### PR TITLE
chore: move MySQL datasource validation tests to a separate file

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySQLDatasourceValidationTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySQLDatasourceValidationTest.java
@@ -10,8 +10,11 @@ import com.appsmith.external.models.SSHPrivateKey;
 import com.appsmith.external.models.SSLDetails;
 import com.appsmith.external.models.UploadedFile;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import static com.appsmith.external.exceptions.pluginExceptions.BasePluginErrorMessages.DS_INVALID_SSH_HOSTNAME_ERROR_MSG;
@@ -24,13 +27,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MySQLDatasourceValidationTest {
     static MySqlPlugin.MySqlPluginExecutor pluginExecutor = new MySqlPlugin.MySqlPluginExecutor();
 
-    private DatasourceConfiguration getDatasourceConfigurationWithSSHConnectionMethod() {
+    private DatasourceConfiguration getDatasourceConfigurationWithStandardConnectionMethod() {
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
 
         /* Set connection method toggle */
         ArrayList<Property> properties = new ArrayList<>();
         properties.add(null);
-        properties.add(new Property("Connection method", "SSH"));
+        properties.add(new Property("Connection method", "STANDARD"));
         datasourceConfiguration.setProperties(properties);
 
         /* Set connection mode */
@@ -42,6 +45,25 @@ public class MySQLDatasourceValidationTest {
         mysqlEndpoints.add(new Endpoint("mysqlHost", 3306L));
         datasourceConfiguration.setEndpoints(mysqlEndpoints);
 
+        /* Set DB username and password */
+        datasourceConfiguration.setAuthentication(new DBAuth(null, "username", "password", "dbname"));
+
+        /* Set ssl mode */
+        datasourceConfiguration.getConnection().setSsl(new SSLDetails());
+        datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.DEFAULT);
+
+        return datasourceConfiguration;
+    }
+
+    private DatasourceConfiguration getDatasourceConfigurationWithSSHConnectionMethod() {
+        DatasourceConfiguration datasourceConfiguration = getDatasourceConfigurationWithStandardConnectionMethod();
+
+        /* Set connection method toggle */
+        ArrayList<Property> properties = new ArrayList<>();
+        properties.add(null);
+        properties.add(new Property("Connection method", "SSH"));
+        datasourceConfiguration.setProperties(properties);
+
         /* Set SSH endpoints */
         ArrayList<Endpoint> sshEndpoints = new ArrayList<>();
         sshEndpoints.add(new Endpoint("sshHost", 22L));
@@ -52,13 +74,6 @@ public class MySQLDatasourceValidationTest {
         sshConnection.setUsername("sshUser");
         sshConnection.setPrivateKey(new SSHPrivateKey(new UploadedFile("key", "base64Key"), null));
         datasourceConfiguration.setSshProxy(sshConnection);
-
-        /* Set DB username and password */
-        datasourceConfiguration.setAuthentication(new DBAuth(null, "username", "password", "dbname"));
-
-        /* Set ssl mode */
-        datasourceConfiguration.getConnection().setSsl(new SSLDetails());
-        datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.DEFAULT);
 
         return datasourceConfiguration;
     }
@@ -110,5 +125,68 @@ public class MySQLDatasourceValidationTest {
         Set<String> validationErrors = pluginExecutor.validateDatasource(sshDatasourceConfiguration);
         assertTrue(validationErrors.size() > 0);
         assertTrue(validationErrors.contains(DS_MISSING_SSH_KEY_ERROR_MSG), validationErrors::toString);
+    }
+
+    @Test
+    public void testValidateDatasourceNullCredentials() {
+        DatasourceConfiguration dsConfig = getDatasourceConfigurationWithStandardConnectionMethod();
+        dsConfig.setConnection(new com.appsmith.external.models.Connection());
+        DBAuth auth = (DBAuth) dsConfig.getAuthentication();
+        auth.setUsername(null);
+        auth.setPassword(null);
+        auth.setDatabaseName("someDbName");
+        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.contains("Missing username for authentication."));
+        assertTrue(output.contains("Missing password for authentication."));
+    }
+
+    @Test
+    public void testValidateDatasourceMissingDBName() {
+        DatasourceConfiguration dsConfig = getDatasourceConfigurationWithStandardConnectionMethod();
+        ((DBAuth) dsConfig.getAuthentication()).setDatabaseName("");
+        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.stream().anyMatch(error -> error.contains("Missing database name.")));
+    }
+
+    @Test
+    public void testValidateDatasourceNullEndpoint() {
+        DatasourceConfiguration dsConfig = getDatasourceConfigurationWithStandardConnectionMethod();
+        dsConfig.setEndpoints(null);
+        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.stream().anyMatch(error -> error.contains("Missing endpoint and url")));
+    }
+
+    @Test
+    public void testValidateDatasource_NullHost() {
+        DatasourceConfiguration dsConfig = getDatasourceConfigurationWithStandardConnectionMethod();
+        dsConfig.setEndpoints(List.of(new Endpoint()));
+        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.stream().anyMatch(error -> error.contains("Host value cannot be empty")));
+    }
+
+    @Test
+    public void testValidateDatasourceInvalidEndpoint() {
+        DatasourceConfiguration dsConfig = getDatasourceConfigurationWithStandardConnectionMethod();
+        String hostname = "r2dbc:mysql://localhost";
+        dsConfig.getEndpoints().get(0).setHost(hostname);
+        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.contains("Host value cannot contain `/` or `:` characters. Found `" + hostname + "`."));
+    }
+
+    @Test
+    public void testSslToggleMissingError() {
+        DatasourceConfiguration datasourceConfiguration = getDatasourceConfigurationWithStandardConnectionMethod();
+        datasourceConfiguration.getConnection().getSsl().setAuthType(null);
+
+        Mono<Set<String>> invalidsMono =
+                Mono.just(pluginExecutor).map(executor -> executor.validateDatasource(datasourceConfiguration));
+
+        StepVerifier.create(invalidsMono)
+                .assertNext(invalids -> {
+                    String expectedError = "Appsmith server has failed to fetch SSL configuration from datasource "
+                            + "configuration form. Please reach out to Appsmith customer support to resolve this.";
+                    assertTrue(invalids.stream().anyMatch(error -> expectedError.equals(error)));
+                })
+                .verifyComplete();
     }
 }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -484,52 +484,6 @@ public class MySqlPluginTest {
     }
 
     @Test
-    public void testValidateDatasourceNullCredentials() {
-        dsConfig.setConnection(new com.appsmith.external.models.Connection());
-        DBAuth auth = (DBAuth) dsConfig.getAuthentication();
-        auth.setUsername(null);
-        auth.setPassword(null);
-        auth.setDatabaseName("someDbName");
-        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
-        assertTrue(output.contains("Missing username for authentication."));
-        assertTrue(output.contains("Missing password for authentication."));
-    }
-
-    @Test
-    public void testValidateDatasourceMissingDBName() {
-        ((DBAuth) dsConfig.getAuthentication()).setDatabaseName("");
-        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
-        assertTrue(output.stream().anyMatch(error -> error.contains("Missing database name.")));
-    }
-
-    @Test
-    public void testValidateDatasourceNullEndpoint() {
-        dsConfig.setEndpoints(null);
-        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
-        assertTrue(output.stream().anyMatch(error -> error.contains("Missing endpoint and url")));
-    }
-
-    @Test
-    public void testValidateDatasource_NullHost() {
-        dsConfig.setEndpoints(List.of(new Endpoint()));
-        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
-        assertTrue(output.stream().anyMatch(error -> error.contains("Host value cannot be empty")));
-
-        Endpoint endpoint = new Endpoint();
-        endpoint.setHost(address);
-        endpoint.setPort(port.longValue());
-        dsConfig.setEndpoints(List.of(endpoint));
-    }
-
-    @Test
-    public void testValidateDatasourceInvalidEndpoint() {
-        String hostname = "r2dbc:mysql://localhost";
-        dsConfig.getEndpoints().get(0).setHost(hostname);
-        Set<String> output = pluginExecutor.validateDatasource(dsConfig);
-        assertTrue(output.contains("Host value cannot contain `/` or `:` characters. Found `" + hostname + "`."));
-    }
-
-    @Test
     public void testAliasColumnNames() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         Mono<ConnectionContext<ConnectionPool>> connectionContextMono = pluginExecutor.datasourceCreate(dsConfig);
@@ -1081,23 +1035,6 @@ public class MySqlPluginTest {
                                         false),
                             },
                             usersTable.getTemplates().toArray());
-                })
-                .verifyComplete();
-    }
-
-    @Test
-    public void testSslToggleMissingError() {
-        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
-        datasourceConfiguration.getConnection().getSsl().setAuthType(null);
-
-        Mono<Set<String>> invalidsMono =
-                Mono.just(pluginExecutor).map(executor -> executor.validateDatasource(datasourceConfiguration));
-
-        StepVerifier.create(invalidsMono)
-                .assertNext(invalids -> {
-                    String expectedError = "Appsmith server has failed to fetch SSL configuration from datasource "
-                            + "configuration form. Please reach out to Appsmith customer support to resolve this.";
-                    assertTrue(invalids.stream().anyMatch(error -> expectedError.equals(error)));
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
- A separate file had been created earlier to segregate all the datasource validation tests for MySQL but only few tests had been moved to it. This PR moves the remaining tests to this file. This should help de-clutter the main test file which has become too lengthy to read. 

#### PR fixes following issue(s)
Fixes #26830

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] JUnit
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
