### PR TITLE
feat: Introduce support for non-reactive method to bifurcate the implementation based on feature flag status

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
@@ -3,7 +3,9 @@ package com.appsmith.server.aspect;
 import com.appsmith.server.annotations.FeatureFlagged;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.featureflags.CachedFeatures;
 import com.appsmith.server.featureflags.FeatureFlagEnum;
+import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.services.FeatureFlagService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,10 +65,7 @@ public class FeatureFlaggedMethodInvokerAspect {
         }
         // For non-reactive methods with feature flagging annotation we will have to convert featureFlagMono to
         // synchronous call using .block()
-        String errorMessage = "Only reactive objects Mono and Flux are supported";
-        AppsmithException exception = getInvalidAnnotationUsageException(method, errorMessage);
-        log.error(exception.getMessage());
-        throw exception;
+        return invokeMethod(isFeatureFlagEnabled(flagName), joinPoint, method);
     }
 
     private Object invokeMethod(Boolean isFeatureSupported, ProceedingJoinPoint joinPoint, Method method) {
@@ -102,5 +101,12 @@ public class FeatureFlaggedMethodInvokerAspect {
                 method.getDeclaringClass().getSimpleName(),
                 method.getName(),
                 error);
+    }
+
+    boolean isFeatureFlagEnabled(FeatureFlagEnum flagName) {
+        CachedFeatures cachedFeatures = featureFlagService.getCachedTenantFeatureFlags();
+        return cachedFeatures != null
+                && !CollectionUtils.isNullOrEmpty(cachedFeatures.getFeatures())
+                && Boolean.TRUE.equals(cachedFeatures.getFeatures().get(flagName.name()));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
@@ -63,8 +63,8 @@ public class FeatureFlaggedMethodInvokerAspect {
         } else if (Flux.class.isAssignableFrom(returnType)) {
             return featureFlagMono.flatMapMany(isSupported -> (Flux<?>) invokeMethod(isSupported, joinPoint, method));
         }
-        // For non-reactive methods with feature flagging annotation we will have to convert featureFlagMono to
-        // synchronous call using .block()
+        // For non-reactive methods with feature flagging annotation we will be using the in memory feature flag cache
+        // which is getting updated whenever the tenant feature flags are updated.
         return invokeMethod(isFeatureFlagEnabled(flagName), joinPoint, method);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
@@ -12,6 +12,8 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static java.lang.Boolean.TRUE;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -28,7 +30,7 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
 
         Mono<Void> registrationAndRtsCheckMono = configService
                 .getByName(Appsmith.APPSMITH_REGISTERED)
-                .filter(config -> Boolean.TRUE.equals(config.getConfig().get("value")))
+                .filter(config -> TRUE.equals(config.getConfig().get("value")))
                 .switchIfEmpty(Mono.defer(() -> instanceConfigHelper.registerInstance()))
                 .onErrorResume(errorSignal -> {
                     log.debug("Instance registration failed with error: \n{}", errorSignal.getMessage());
@@ -44,7 +46,18 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
                 // Prefill the server cache with anonymous user permission group ids.
                 .then(cacheableRepositoryHelper.preFillAnonymousUserPermissionGroupIdsCache())
                 // Add cold publisher as we have dependency on the instance registration
-                .then(Mono.defer(instanceConfigHelper::isLicenseValid));
+                // TODO Update implementation to fetch license status for all the tenants once multi-tenancy is
+                //  introduced
+                .then(Mono.defer(instanceConfigHelper::isLicenseValid)
+                        // Ensure that the tenant feature flags are refreshed with the latest values after completing
+                        // the
+                        // license verification process.
+                        .flatMap(isValid -> {
+                            log.debug(
+                                    "License verification completed with status: {}",
+                                    TRUE.equals(isValid) ? "valid" : "invalid");
+                            return instanceConfigHelper.updateCacheForTenantFeatureFlags();
+                        }));
 
         try {
             startupProcess.block();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/InstanceConfigHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/InstanceConfigHelperImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.configurations.CloudServicesConfig;
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.helpers.ce.InstanceConfigHelperCEImpl;
 import com.appsmith.server.services.ConfigService;
+import com.appsmith.server.services.FeatureFlagService;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.stereotype.Component;
@@ -15,7 +16,14 @@ public class InstanceConfigHelperImpl extends InstanceConfigHelperCEImpl impleme
             CloudServicesConfig cloudServicesConfig,
             CommonConfig commonConfig,
             ApplicationContext applicationContext,
-            ReactiveMongoTemplate reactiveMongoTemplate) {
-        super(configService, cloudServicesConfig, commonConfig, applicationContext, reactiveMongoTemplate);
+            ReactiveMongoTemplate reactiveMongoTemplate,
+            FeatureFlagService featureFlagService) {
+        super(
+                configService,
+                cloudServicesConfig,
+                commonConfig,
+                applicationContext,
+                reactiveMongoTemplate,
+                featureFlagService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/InstanceConfigHelperCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/InstanceConfigHelperCE.java
@@ -18,4 +18,6 @@ public interface InstanceConfigHelperCE {
     Mono<Boolean> isLicenseValid();
 
     Mono<String> checkMongoDBVersion();
+
+    Mono<Void> updateCacheForTenantFeatureFlags();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/InstanceConfigHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/InstanceConfigHelperCEImpl.java
@@ -8,6 +8,7 @@ import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.services.ConfigService;
+import com.appsmith.server.services.FeatureFlagService;
 import com.appsmith.util.WebClientUtils;
 import joptsimple.internal.Strings;
 import lombok.RequiredArgsConstructor;
@@ -39,9 +40,11 @@ public class InstanceConfigHelperCEImpl implements InstanceConfigHelperCE {
 
     private final ApplicationContext applicationContext;
 
-    private boolean isRtsAccessible = false;
-
     private final ReactiveMongoTemplate reactiveMongoTemplate;
+
+    private final FeatureFlagService featureFlagService;
+
+    private boolean isRtsAccessible = false;
 
     @Override
     public Mono<? extends Config> registerInstance() {
@@ -193,5 +196,10 @@ public class InstanceConfigHelperCEImpl implements InstanceConfigHelperCE {
                             error);
                     return Mono.just(Strings.EMPTY);
                 });
+    }
+
+    @Override
+    public Mono<Void> updateCacheForTenantFeatureFlags() {
+        return featureFlagService.getTenantFeatures().then();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCE.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services.ce;
 
 import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.featureflags.CachedFeatures;
 import com.appsmith.server.featureflags.FeatureFlagEnum;
 import reactor.core.publisher.Mono;
 
@@ -50,4 +51,6 @@ public interface FeatureFlagServiceCE {
     Mono<Map<String, Boolean>> getTenantFeatures();
 
     Mono<Tenant> checkAndExecuteMigrationsForTenantFeatureFlags(Tenant tenant);
+
+    CachedFeatures getCachedTenantFeatureFlags();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
@@ -46,6 +46,8 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
     private final FeatureFlagMigrationHelper featureFlagMigrationHelper;
     private static final long FEATURE_FLAG_CACHE_TIME_MIN = 120;
 
+    private CachedFeatures cachedTenantFeatureFlags;
+
     private Mono<Boolean> checkAll(String featureName, User user) {
         Boolean check = check(featureName, user);
 
@@ -206,7 +208,10 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
         return tenantService
                 .getDefaultTenantId()
                 .flatMap(cacheableFeatureFlagHelper::fetchCachedTenantFeatures)
-                .map(CachedFeatures::getFeatures);
+                .map(cachedFeatures -> {
+                    cachedTenantFeatureFlags = cachedFeatures;
+                    return cachedFeatures.getFeatures();
+                });
     }
 
     /**
@@ -217,5 +222,10 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
     @Override
     public Mono<Tenant> checkAndExecuteMigrationsForTenantFeatureFlags(Tenant tenant) {
         return tenantService.checkAndExecuteMigrationsForTenantFeatureFlags(tenant);
+    }
+
+    @Override
+    public CachedFeatures getCachedTenantFeatureFlags() {
+        return this.cachedTenantFeatureFlags;
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspectTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspectTest.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.aspect;
 
 import com.appsmith.server.aspect.component.TestComponent;
+import com.appsmith.server.featureflags.CachedFeatures;
 import com.appsmith.server.featureflags.FeatureFlagEnum;
 import com.appsmith.server.services.FeatureFlagService;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 
 @SpringBootTest
@@ -89,5 +93,20 @@ class FeatureFlaggedMethodInvokerAspectTest {
     void ceEeDiffMethodReturnsFlux_ceImplTest() {
         Flux<String> resultFlux = testComponent.ceEeDiffMethodReturnsFlux();
         StepVerifier.create(resultFlux).expectNext("ce", "impl", "method").verifyComplete();
+    }
+
+    @Test
+    void ceEeSyncMethod_eeImplTest() {
+        CachedFeatures cachedFeatures = new CachedFeatures();
+        cachedFeatures.setFeatures(Map.of(FeatureFlagEnum.TENANT_TEST_FEATURE.name(), Boolean.TRUE));
+        Mockito.when(featureFlagService.getCachedTenantFeatureFlags()).thenReturn(cachedFeatures);
+        String result = testComponent.ceEeSyncMethod("arg_");
+        assertEquals("arg_ee_impl_method", result);
+    }
+
+    @Test
+    void ceEeSyncMethod_ceImplTest() {
+        String result = testComponent.ceEeSyncMethod("arg_");
+        assertEquals("arg_ce_impl_method", result);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponentImpl.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponentImpl.java
@@ -35,4 +35,10 @@ public class TestComponentImpl extends TestComponentCECompatibleImpl implements 
         List<String> result = List.of("ee", "impl", "method");
         return Flux.fromIterable(result);
     }
+
+    @Override
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.TENANT_TEST_FEATURE)
+    public String ceEeSyncMethod(String arg) {
+        return arg + "ee_impl_method";
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCE.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCE.java
@@ -12,4 +12,6 @@ public interface TestComponentCE {
     Mono<String> ceEeDiffMethod();
 
     Flux<String> ceEeDiffMethodReturnsFlux();
+
+    String ceEeSyncMethod(String arg);
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCEImpl.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCEImpl.java
@@ -25,4 +25,9 @@ public class TestComponentCEImpl implements TestComponentCE {
         List<String> result = List.of("ce", "impl", "method");
         return Flux.fromIterable(result);
     }
+
+    @Override
+    public String ceEeSyncMethod(String arg) {
+        return arg + "ce_impl_method";
+    }
 }


### PR DESCRIPTION
## Description
In the current implementation, only reactive methods can be bifurcated based on feature flag status. This limitation arises from the fact that the method invoker aspect class relies on `featureFlagService.check`, which operates in a reactive manner. With the introduction of this PR, we're addressing this limitation by introducing a new class-level variable. This variable is updated each time tenant-level flags are retrieved. For reactive methods, we continue to utilize the reactive `featureFlagService.check` functionality, preserving the option to explore user-level flag experimentation.      

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/27450


#### Type of change
- New feature (non-breaking change which adds functionality)

## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [x] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
