### PR TITLE
fix: Postgres permission error in creating the stats folder

### DIFF
--- a/deploy/docker/fs/opt/appsmith/run-postgres.sh
+++ b/deploy/docker/fs/opt/appsmith/run-postgres.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 rm -f /appsmith-stacks/data/postgres/main/core.*
-mkdir -p "$TMP/postgres-stats"
-exec /usr/lib/postgresql/13/bin/postgres -D "/appsmith-stacks/data/postgres/main" -c listen_addresses=127.0.0.1 -c stats_temp_directory="$TMP/postgres-stats"
+exec /usr/lib/postgresql/13/bin/postgres -D "/appsmith-stacks/data/postgres/main" -c listen_addresses=127.0.0.1


### PR DESCRIPTION
When PostgreSQL starts, we see the following errors in the logs:

```
mkdir: 
cannot create directory ‘/tmp/appsmith/postgres-stats’
: Permission denied
```

And then this over and over again:

```
postgres stdout | 2023-09-19 15:34:34.504 UTC [1759] LOG:  could not open temporary statistics file "/tmp/appsmith/postgres-stats/global.tmp": No such file or directory
```

The problem is that in `postgres.conf`, we set `user=postgres`, which doesn't have access to create things in `/tmp`.

This PR removes this configuration and lets the default be, which will be a temp folders _under_ the data directory.
