### PR TITLE
fix: Fix backend failing to start when running with a custom PORT

### DIFF
--- a/deploy/docker/fs/opt/appsmith/run-java.sh
+++ b/deploy/docker/fs/opt/appsmith/run-java.sh
@@ -54,7 +54,7 @@ if [[ $proxy_configured == 1 ]]; then
 fi
 
 # Wait until RTS started and listens on port 8091
-while ! curl --fail --silent localhost/rts-api/v1/health-check; do
+while ! curl --fail --silent localhost:"${APPSMITH_RTS_PORT:-8091}"/rts-api/v1/health-check; do
   echo 'Waiting for RTS to start ...'
   sleep 1
 done


### PR DESCRIPTION
When running with a custom `PORT` env variable, NGINX server will be listening on this port. In the backend's startup script, `run-java.sh`, we're checking for RTS being up or not, at `localhost`. So when the port is not 80, then this will never succeed, because it'll be looking for NGINX at the wrong port.

Instead, the fix here will make the backend startup script hit RTS _directly_ on RTS server's own port, instead of going via NGINX. This means it's independent of both the `PORT` env variable and the NGINX server, and only dependent on RTS being up, which is really what we want here.
