### PR TITLE
chore: Removing styles from instance admin emails to avoid keeping it a scrollable input

### DIFF
--- a/app/client/src/pages/AdminSettings/FormGroup/TagInputField.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/TagInputField.tsx
@@ -5,19 +5,6 @@ import { TagInput } from "design-system-old";
 import { FormGroup } from "./Common";
 import type { Intent } from "constants/DefaultTheme";
 import type { Setting } from "@appsmith/pages/AdminSettings/config/types";
-import styled from "styled-components";
-
-const StyledTagInput = styled(TagInput)`
-  .bp3-tag-input-values {
-    flex-wrap: nowrap;
-    width: 100%;
-    overflow: auto;
-
-    &::-webkit-scrollbar {
-      height: 0px;
-    }
-  }
-`;
 
 const renderComponent = (
   componentProps: TagListFieldProps & {
@@ -33,7 +20,7 @@ const renderComponent = (
       }`}
       setting={setting}
     >
-      <StyledTagInput {...componentProps} />
+      <TagInput {...componentProps} />
     </FormGroup>
   );
 };


### PR DESCRIPTION
## Description

Removing styles from instance admin emails to avoid keeping it a scrollable input

#### PR fixes following issue(s)
Fixes # (issue number)

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
