### PR TITLE
feat: fix more than one capital letter in class name start

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.beans.Introspector;
 import java.lang.reflect.Method;
 
 @RequiredArgsConstructor
@@ -88,10 +89,10 @@ public class FeatureFlaggedMethodInvokerAspect {
     }
 
     /**
-     * Method to get default bean name from java classes as per <a href="https://docs.spring.io/spring-framework/docs/3.0.0.M4/reference/html/ch03s03.html#beans-beanname">Spring naming convention</a>
+     * Method to get default bean name from java classes as per <a href="https://docs.spring.io/spring-framework/docs/5.2.3.RELEASE/spring-framework-reference/core.html#beans-beanname">Spring naming convention</a>
      */
     private String getSpringDefaultBeanName(String beanClassName) {
-        return Character.toLowerCase(beanClassName.charAt(0)) + beanClassName.substring(1);
+        return Introspector.decapitalize(beanClassName);
     }
 
     AppsmithException getInvalidAnnotationUsageException(Method method, String error) {


### PR DESCRIPTION

## Description
This Fixes the problem of more than one capital letter in the feature flagged class name start like PACConfigurationService.

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
- [x] Manual
- [x] JUnit
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [x] Added `Test Plan Approved` label after Cypress tests were reviewed
- [x] Added `Test Plan Approved` label after JUnit tests were reviewed
