### PR TITLE
chore: WDS `fgNeutralSubtle` fine-tuning

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -642,7 +642,7 @@ export class DarkModeTheme implements ColorModeTheme {
   private get fgNeutralSubtle() {
     const color = this.fgNeutral.clone();
 
-    color.oklch.l -= 0.3;
+    color.oklch.l -= 0.15;
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -670,7 +670,7 @@ export class LightModeTheme implements ColorModeTheme {
   private get fgNeutralSubtle() {
     const color = this.fgNeutral.clone();
 
-    color.oklch.l += 0.3;
+    color.oklch.l += 0.1;
 
     return color;
   }

--- a/app/client/packages/design-system/widgets/src/styles/src/textInputStyles.ts
+++ b/app/client/packages/design-system/widgets/src/styles/src/textInputStyles.ts
@@ -78,6 +78,7 @@ export const textInputStyles = css<HeadlessTextInputProps>`
 */
   & [data-field-input] :is(input, textarea)::placeholder {
     color: var(--color-fg-neutral-subtle);
+    opacity: 1;
   }
 
   & [data-field-input] :is(input, textarea):placeholder-shown {


### PR DESCRIPTION
Closes #26854

Increased contrast by lowering lightness shift, increasing opacity of placeholder element to 100%. Current on the right
<img width="2560" alt="Screenshot 2023-09-20 at 13 20 39" src="https://github.com/appsmithorg/appsmith/assets/80973/6ce1605e-f102-4a62-bce5-efaecd92d152">
<img width="2559" alt="Screenshot 2023-09-20 at 13 20 55" src="https://github.com/appsmithorg/appsmith/assets/80973/c80df4e6-1635-4928-bade-0511dfb3e650">
