### PR TITLE
chore: fix airgap explorer test

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Pin_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Pin_spec.js
@@ -109,7 +109,10 @@ describe("Entity explorer tests related to pinning and unpinning", function () {
     function () {
       agHelper.AssertElementVisibility(entityExplorer._entityExplorer);
       entityExplorer.PinUnpinEntityExplorer(true);
-      const menu = Object.keys(ExplorerMenu);
+      // We cannot add libraries on airgap
+      const menu = Object.keys(ExplorerMenu).filter(
+        (menu) => menu !== ExplorerMenu.ADD_LIBRARY,
+      );
 
       Cypress._.times(menu.length - 1, (index) => {
         OpenExplorerMenu(menu[index]);


### PR DESCRIPTION
In the test we were looking for the add js libraries button, but we cannot add js libraries on airgap. So skipping add libraries from the assertion list.