### PR TITLE
chore: fix the jgit version updates in other places

### DIFF
--- a/app/server/appsmith-git/pom.xml
+++ b/app/server/appsmith-git/pom.xml
@@ -29,15 +29,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
-            <version>5.13.0.202109080827-r</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.junit.ssh -->
-        <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit.junit.ssh</artifactId>
-            <version>6.4.0.202211300538-r</version>
-            <scope>test</scope>
+            <version>6.6.1.202309021850-r</version>
         </dependency>
 
         <dependency>

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/SshTransportConfigCallback.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/SshTransportConfigCallback.java
@@ -4,11 +4,11 @@ import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import org.eclipse.jgit.api.TransportConfigCallback;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig;
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.Transport;
+import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.ssh.jsch.OpenSshConfig;
 import org.eclipse.jgit.util.FS;
 
 /**


### PR DESCRIPTION
Should resolve the following CVE reports:

1. https://github.com/appsmithorg/appsmith/security/dependabot/263
1. https://github.com/appsmithorg/appsmith/security/dependabot/264

