### PR TITLE
fix: gsheet issue with import and redirection fixed

### DIFF
--- a/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
@@ -516,7 +516,10 @@ function ReconnectDatasourceModal() {
             JSON.stringify(appInfo),
           );
         }
-      } else if (appURL && unconfiguredDatasources.length === 0) {
+      }
+      // When datasources are present and pending datasources are 0,
+      // then only we want to update status as success
+      else if (appURL && pending.length === 0 && datasources.length > 0) {
         // open application import successfule
         localStorage.setItem("importApplicationSuccess", "true");
         localStorage.setItem("importedAppPendingInfo", "null");

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -45,12 +45,10 @@ import {
   getPluginByPackageName,
   getDatasourcesUsedInApplicationByActions,
   getEntityExplorerDatasources,
-  getUnconfiguredDatasources,
 } from "@appsmith/selectors/entitiesSelector";
 import {
   addMockDatasourceToWorkspace,
   setDatasourceViewModeFlag,
-  setUnconfiguredDatasourcesDuringImport,
 } from "actions/datasourceActions";
 import type {
   UpdateDatasourceSuccessAction,
@@ -524,14 +522,6 @@ function* updateDatasourceSaga(
       toast.show(createMessage(DATASOURCE_UPDATE, responseData.name), {
         kind: "success",
       });
-
-      const unconfiguredDSList: Datasource[] = yield select(
-        getUnconfiguredDatasources,
-      );
-      const updatedList = unconfiguredDSList.filter(
-        (d: Datasource) => d.id !== datasourcePayload?.id,
-      );
-      yield put(setUnconfiguredDatasourcesDuringImport(updatedList));
 
       const expandDatasourceId = state.ui.datasourcePane.expandDatasourceId;
 


### PR DESCRIPTION
## Description
This PR fixes issue with gsheet import and redirection. When an application containing a couple of datasources like mysql, postgres and gsheet are imported, we are shown reconnect datasource modal, suppose we first configure all datasources except gsheet, lastly we select gsheet datasource and save and authorise, we are not being redirected to authorisation.

The issue occurred because after saving each datasource, that datasource was disappearing from the list of datasources shown on left panel in reconnect datasource modal, so if we configure gsheet datasource at last, it would remove datasource from the list and lose all the context. So the request sent to `/oauth` endpoint would be cancelled.

This PR essentially solves 2 issues:
- datasource disappearing from left panel in reconnect datasource modal
- gsheet datasource not being redirected to authorisation


#### PR fixes following issue(s)
Fixes #27520 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
Covered the following areas manually:
- workspace import with app containing multiple DS
- fork of above imported app into another workspace
- app level import with multiple DS
- importing an app without any datasources

>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [x] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
