### PR TITLE
fix: Removing saas integrations section on datasources page for airgap

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx
@@ -37,6 +37,7 @@ import Debugger, {
 import { showDebuggerFlag } from "selectors/debuggerSelectors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { DatasourceCreateEntryPoints } from "constants/Datasource";
+import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 
 const HeaderFlex = styled.div`
   font-size: 20px;
@@ -219,6 +220,7 @@ function CreateNewSaasIntegration({
 }: any) {
   const newSaasAPIRef = useRef<HTMLDivElement>(null);
   const isMounted = useRef(false);
+  const isAirgappedInstance = isAirgapped();
 
   useEffect(() => {
     if (active && newSaasAPIRef.current) {
@@ -233,7 +235,7 @@ function CreateNewSaasIntegration({
       isMounted.current = true;
     }
   }, [active]);
-  return (
+  return !isAirgappedInstance ? (
     <div id="new-saas-api" ref={newSaasAPIRef}>
       <Text type={TextType.H2}>Saas Integrations</Text>
       <NewApiScreen
@@ -245,7 +247,7 @@ function CreateNewSaasIntegration({
         showUnsupportedPluginDialog={showUnsupportedPluginDialog}
       />
     </div>
-  );
+  ) : null;
 }
 
 function CreateNewDatasource({


### PR DESCRIPTION
## Description

Removing saas integrations section on the datasources page for airgap, as it is not supported.

#### PR fixes following issue(s)
Fixes [#27544](https://github.com/appsmithorg/appsmith/issues/27544)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
