### PR TITLE
fix: NPE during import when ApplicationJson has no action collection

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -1944,6 +1944,13 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                     Application application = tuple.getT1();
                     stopwatch.stopTimer();
                     stopwatch.stopAndLogTimeInMillis();
+                    int jsObjectCount = CollectionUtils.isEmpty(applicationJson.getActionCollectionList())
+                            ? 0
+                            : applicationJson.getActionCollectionList().size();
+                    int actionCount = CollectionUtils.isEmpty(applicationJson.getActionList())
+                            ? 0
+                            : applicationJson.getActionList().size();
+
                     final Map<String, Object> data = Map.of(
                             FieldName.APPLICATION_ID,
                             application.getId(),
@@ -1952,9 +1959,9 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                             "pageCount",
                             applicationJson.getPageList().size(),
                             "actionCount",
-                            applicationJson.getActionList().size(),
+                            actionCount,
                             "JSObjectCount",
-                            applicationJson.getActionCollectionList().size(),
+                            jsObjectCount,
                             FieldName.FLOW_NAME,
                             stopwatch.getFlow(),
                             "executionTime",

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-without-action-collection.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-without-action-collection.json
@@ -530,7 +530,6 @@
       "new": false
     }
   ],
-  "actionCollectionList": [],
   "decryptedFields": {
     "db-auth": {
       "password": "CreativePassword",


### PR DESCRIPTION
## Description
This fixes the NPE when the user is trying to import an application JSON that has no action collection.

#### PR fixes following issue(s)
Fixes #27646

#### Media
N/A
#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

>
#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
