### PR TITLE
chore: Fixed flatmapping cs req

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PluginScheduledTaskCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PluginScheduledTaskCEImpl.java
@@ -35,7 +35,7 @@ public class PluginScheduledTaskCEImpl implements PluginScheduledTaskCE {
         configService
                 .getByName(FieldName.REMOTE_PLUGINS)
                 .onErrorReturn(new Config())
-                .map(config -> {
+                .flatMap(config -> {
                     JSONObject config1 = config.getConfig();
                     Instant lastUpdatedAt = null;
 


### PR DESCRIPTION
In order to not skip plugin init