### PR TITLE
chore: adding indices to workspace, application and newAction class

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration025AddIndexDeletedInApplication.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration025AddIndexDeletedInApplication.java
@@ -1,0 +1,53 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.Application;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+
+import static com.appsmith.server.migrations.DatabaseChangelog1.dropIndexIfExists;
+import static com.appsmith.server.migrations.DatabaseChangelog1.ensureIndexes;
+import static com.appsmith.server.migrations.DatabaseChangelog1.makeIndex;
+
+@Slf4j
+@ChangeUnit(order = "025", id = "add-index-application-deleted", author = " ")
+public class Migration025AddIndexDeletedInApplication {
+
+    private final MongoTemplate mongoTemplate;
+    private static final String APPLICATION_COMPOUND_INDEX_DELETED = "deleted_compound_index";
+
+    public Migration025AddIndexDeletedInApplication(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    /**
+     * mandatory to declare, but we don't have a use-case for this yet.
+     */
+    @RollbackExecution
+    public void rollbackExecution() {}
+
+    @Execution
+    public void createIndexInApplicationCollection() {
+        dropIndexIfExists(mongoTemplate, Application.class, APPLICATION_COMPOUND_INDEX_DELETED);
+
+        Index deletedAtDeletedIndex =
+                makeIndex(FieldName.DELETED, FieldName.DELETED_AT).named(APPLICATION_COMPOUND_INDEX_DELETED);
+
+        try {
+            ensureIndexes(mongoTemplate, Application.class, deletedAtDeletedIndex);
+        } catch (UncategorizedMongoDbException mongockException) {
+            log.debug(
+                    "An error occurred while creating the index : {}, skipping the addition of index because of {}.",
+                    APPLICATION_COMPOUND_INDEX_DELETED,
+                    mongockException.getMessage());
+        } catch (Exception exception) {
+            log.debug("An error occurred while creating the index : {}", APPLICATION_COMPOUND_INDEX_DELETED);
+            exception.printStackTrace();
+        }
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration026AddIndexTenantAndDeletedInWorkspace.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration026AddIndexTenantAndDeletedInWorkspace.java
@@ -1,0 +1,56 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.Workspace;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+
+import static com.appsmith.server.migrations.DatabaseChangelog1.dropIndexIfExists;
+import static com.appsmith.server.migrations.DatabaseChangelog1.ensureIndexes;
+import static com.appsmith.server.migrations.DatabaseChangelog1.makeIndex;
+
+@Slf4j
+@ChangeUnit(order = "026", id = "add-index-workspace-tenant-deleted", author = " ")
+public class Migration026AddIndexTenantAndDeletedInWorkspace {
+
+    private final MongoTemplate mongoTemplate;
+
+    private static final String WORKSPACE_COMPOUND_INDEX_TENANT = "tenantId_deleted_compound_index";
+    private static final String TENANT_ID = "tenantId";
+
+    public Migration026AddIndexTenantAndDeletedInWorkspace(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    /**
+     * mandatory to declare, but we don't have a use-case for this yet.
+     */
+    @RollbackExecution
+    public void rollbackExecution() {}
+
+    @Execution
+    public void addIndexInWorkspaceCollection() {
+
+        dropIndexIfExists(mongoTemplate, Workspace.class, WORKSPACE_COMPOUND_INDEX_TENANT);
+
+        Index tenantDeletedAtIndex =
+                makeIndex(TENANT_ID, FieldName.DELETED, FieldName.DELETED_AT).named(WORKSPACE_COMPOUND_INDEX_TENANT);
+
+        try {
+            ensureIndexes(mongoTemplate, Workspace.class, tenantDeletedAtIndex);
+        } catch (UncategorizedMongoDbException mongockException) {
+            log.debug(
+                    "An error occurred while creating the index : {}, skipping the addition of index because of {}.",
+                    WORKSPACE_COMPOUND_INDEX_TENANT,
+                    mongockException.getMessage());
+        } catch (Exception exception) {
+            log.debug("An error occurred while creating the index : {}", WORKSPACE_COMPOUND_INDEX_TENANT);
+            exception.printStackTrace();
+        }
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration027AddIndexDatasourceIdAndDeletedInAction.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration027AddIndexDatasourceIdAndDeletedInAction.java
@@ -1,0 +1,56 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.external.models.QDatasource;
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.NewAction;
+import com.appsmith.server.domains.QNewAction;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+
+import static com.appsmith.server.migrations.DatabaseChangelog1.ensureIndexes;
+import static com.appsmith.server.migrations.DatabaseChangelog1.makeIndex;
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.fieldName;
+
+@ChangeUnit(order = "027", id = "new-action-compound-index-datasource-id", author = " ")
+public class Migration027AddIndexDatasourceIdAndDeletedInAction {
+    private final MongoTemplate mongoTemplate;
+
+    private static final String PUBLISHED_ACTION_COMPOUND_INDEX_DATASOURCE_ID =
+            "publishedAction_datasourceId_deleted_compound_index";
+    private static final String UNPUBLISHED_ACTION_COMPOUND_INDEX_DATASOURCE_ID =
+            "unpublishedAction_datasourceId_deleted_compound_index";
+
+    private static final String UNPUBLISHED_ACTION = fieldName(QNewAction.newAction.unpublishedAction);
+    private static final String PUBLISHED_ACTION = fieldName(QNewAction.newAction.publishedAction);
+
+    private static final String PATH_DELIMITER = ".";
+
+    public Migration027AddIndexDatasourceIdAndDeletedInAction(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    /**
+     * mandatory to declare, but we don't have a use-case for this yet.
+     */
+    @RollbackExecution
+    public void rollbackExecution() {}
+
+    @Execution
+    public void addIndexInNewActionCollection() {
+        Index publishedIndex = makeIndex(createFullPathName(PUBLISHED_ACTION), FieldName.DELETED, FieldName.DELETED_AT)
+                .named(PUBLISHED_ACTION_COMPOUND_INDEX_DATASOURCE_ID);
+        Index unpublishedIndex = makeIndex(
+                        createFullPathName(UNPUBLISHED_ACTION), FieldName.DELETED, FieldName.DELETED_AT)
+                .named(UNPUBLISHED_ACTION_COMPOUND_INDEX_DATASOURCE_ID);
+
+        ensureIndexes(mongoTemplate, NewAction.class, publishedIndex);
+        ensureIndexes(mongoTemplate, NewAction.class, unpublishedIndex);
+    }
+
+    private static String createFullPathName(String path) {
+        return path + PATH_DELIMITER + FieldName.DATASOURCE + PATH_DELIMITER + fieldName(QDatasource.datasource.id);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -376,9 +376,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                         fieldName(QNewAction.newAction.publishedAction) + ".datasource._id")
                 .is(new ObjectId(datasourceId));
 
-        Criteria datasourceCriteria = where(FieldName.DELETED_AT)
-                .is(null)
-                .orOperator(unpublishedDatasourceCriteria, publishedDatasourceCriteria);
+        Criteria datasourceCriteria =
+                notDeleted().orOperator(unpublishedDatasourceCriteria, publishedDatasourceCriteria);
 
         Query query = new Query();
         query.addCriteria(datasourceCriteria);


### PR DESCRIPTION
## Description
> Adding indices to classes

### This PR adds indices to three classes as a chore:
- Workspace (`tenantId`, `deleted`, `deletedAt`)
- Application (`deleted`, `deletedAt`)
- NewAction ((`unpublishedAction.datasource._id`, `deleted`, `deletedAt`),  (`publishedAction.datasource._id`, `deleted`, `deletedAt`))

### This PR also modifies the query criteria for counting #actions associated to a datasource.
Fixes #23360 

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)


#### How Has This Been Tested?
- [x] Manual

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag

