### PR TITLE
fix: Fix backup command getting version

### DIFF
--- a/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
@@ -98,8 +98,9 @@ async function getLastBackupErrorMailSentInMilliSec() {
 }
 
 async function getCurrentAppsmithVersion() {
-  const content = await fsPromises.readFile('/opt/appsmith/rts/version.js', { encoding: 'utf8' });
-  return content.match(/\bexports\.VERSION\s*=\s*["']([^"]+)["']/)[1];
+  const githubRef = JSON.parse(await fsPromises.readFile("/opt/appsmith/info.json", "utf8")).githubRef;
+  // This will be of the form "refs/tags/v1.2.3".
+  return githubRef.split("/").pop();
 }
 
 function preprocessMongoDBURI(uri /* string */) {


### PR DESCRIPTION
This broke when we changed the way RTS stores version information. This was never the right way to get the version in the `backup` command and this PR fixes it, by getting the version from `info.json`.
