### PR TITLE
fix: Route for HTTP-01 challenge, instead of redirecting

### DIFF
--- a/deploy/docker/fs/opt/appsmith/templates/nginx-app.conf.sh
+++ b/deploy/docker/fs/opt/appsmith/templates/nginx-app.conf.sh
@@ -48,7 +48,14 @@ if [[ $use_https == 1 ]]; then
   echo "
   listen 80;
   server_name $custom_domain;
-  return 301 https://\$host\$request_uri;
+
+  location /.well-known/acme-challenge/ {
+    root /appsmith-stacks/data/certificate/certbot;
+  }
+
+  location / {
+    return 301 https://\$host\$request_uri;
+  }
 }
 
 server {


### PR DESCRIPTION
In the NGINX configuration we generate, we're redirecting _all_ HTTP requests to HTTPS, when HTTPS is enabled. But the HTTP-01 challenge works on port 80 and is getting redirected to 443.

This usually fine, as Let's Encrypt respects that redirect and completes the challenge on port 443. But, if port 443 is blocked to outside access, the cert renewal will fail. This PR fixes that.

Tested on a server with port 80 open and 443 closed to outside Internet. Cert renewal fails without this PR's changes, and works with this PR's changes.