### PR TITLE
chore: Remove `build-essential` by default in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN curl --silent --show-error --location https://www.mongodb.org/static/pgp/ser
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
-  && apt-get install --no-install-recommends --yes mongodb-org nodejs redis build-essential postgresql-13 \
+  && apt-get install --no-install-recommends --yes mongodb-org nodejs redis postgresql-13 \
   && apt-get clean \
   # This is to get semver 7.5.2, for a CVE fix, might be able to remove it with later versions on NodeJS.
   && npm install -g npm@9.7.2

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -315,21 +315,28 @@ configure_supervisord() {
 
 }
 
-# This is a workaround to get Redis working on diffent memory pagesize
+# This is a workaround to get Redis working on different memory pagesize
 # https://github.com/appsmithorg/appsmith/issues/11773
 check_redis_compatible_page_size() {
   local page_size
   page_size="$(getconf PAGE_SIZE)"
   if [[ $page_size -gt 4096 ]]; then
+    curl \
+      --silent \
+      --user "$APPSMITH_SEGMENT_CE_KEY:" \
+      --header 'Content-Type: application/json' \
+      --data '{ "userId": "'"$HOSTNAME"'", "event":"RedisCompile" }' \
+      https://api.segment.io/v1/track \
+      || true
     echo "Compile Redis stable with page size of $page_size"
-    echo "Downloading Redis source..."
-    curl https://download.redis.io/redis-stable.tar.gz -L | tar xvz
-    cd redis-stable/
-    echo "Compiling Redis from source..."
-    make && make install
-    echo "Cleaning up Redis source..."
-    cd ..
-    rm -rf redis-stable/
+    apt-get update
+    apt-get install --yes build-essential
+    curl --location https://download.redis.io/redis-stable.tar.gz | tar -xz -C /tmp
+    pushd /tmp/redis-stable
+    make
+    make install
+    popd
+    rm -rf /tmp/redis-stable
   else
     echo "Redis is compatible with page size of $page_size"
   fi


### PR DESCRIPTION
This removes ~70 medium/low severity CVEs reported on our Docker image, by removing `build-essential` from being installed by default in the Docker image.

We only need it when compiling Redis, which is needed on _some_ ARM systems, that re configured with a page-size of greater than 4096. For example, CentOS 8.
