### PR TITLE
chore: Using retrieve by id for fetching super admin permission group

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
@@ -204,7 +204,7 @@ public class UserUtilsCE {
                 .flatMap(instanceConfig -> {
                     JSONObject config = instanceConfig.getConfig();
                     String defaultPermissionGroup = (String) config.getOrDefault(DEFAULT_PERMISSION_GROUP, "");
-                    return permissionGroupRepository.findById(defaultPermissionGroup);
+                    return permissionGroupRepository.retrieveById(defaultPermissionGroup);
                 });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PACConfigurationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PACConfigurationService.java
@@ -1,0 +1,5 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.services.ce_compatible.PACConfigurationServiceCECompatible;
+
+public interface PACConfigurationService extends PACConfigurationServiceCECompatible {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PACConfigurationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PACConfigurationServiceImpl.java
@@ -1,0 +1,10 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.services.ce_compatible.PACConfigurationServiceCECompatibleImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class PACConfigurationServiceImpl extends PACConfigurationServiceCECompatibleImpl
+        implements PACConfigurationService {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -49,7 +49,8 @@ public class UserServiceImpl extends UserServiceCECompatibleImpl implements User
             UserUtils userUtils,
             EmailVerificationTokenRepository emailVerificationTokenRepository,
             EmailService emailService,
-            RateLimitService rateLimitService) {
+            RateLimitService rateLimitService,
+            PACConfigurationService pacConfigurationService) {
         super(
                 scheduler,
                 validator,
@@ -74,6 +75,7 @@ public class UserServiceImpl extends UserServiceCECompatibleImpl implements User
                 userUtils,
                 emailVerificationTokenRepository,
                 emailService,
-                rateLimitService);
+                rateLimitService,
+                pacConfigurationService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCE.java
@@ -1,0 +1,10 @@
+package com.appsmith.server.services.ce;
+
+import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.UserProfileDTO;
+import reactor.core.publisher.Mono;
+
+public interface PACConfigurationServiceCE {
+    Mono<UserProfileDTO> setRolesAndGroups(
+            UserProfileDTO profile, User user, boolean showUsersAndGroups, boolean isCloudHosting);
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCEImpl.java
@@ -1,0 +1,24 @@
+package com.appsmith.server.services.ce;
+
+import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.UserProfileDTO;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static com.appsmith.server.constants.ce.AccessControlConstantsCE.UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC;
+
+@Service
+public class PACConfigurationServiceCEImpl implements PACConfigurationServiceCE {
+    @Override
+    public Mono<UserProfileDTO> setRolesAndGroups(
+            UserProfileDTO profile, User user, boolean showUsersAndGroups, boolean isCloudHosting) {
+        profile.setRoles(
+                List.of(UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC));
+        profile.setGroups(
+                List.of(UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC));
+
+        return Mono.just(profile);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -37,6 +37,7 @@ import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.BaseService;
 import com.appsmith.server.services.EmailService;
+import com.appsmith.server.services.PACConfigurationService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.TenantService;
@@ -88,7 +89,6 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
-import static com.appsmith.server.constants.AccessControlConstants.UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC;
 import static com.appsmith.server.helpers.RedirectHelper.DEFAULT_REDIRECT_URL;
 import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MAX_LENGTH;
 import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MIN_LENGTH;
@@ -116,6 +116,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
     private final UserUtils userUtils;
     private final EmailService emailService;
     private final RateLimitService rateLimitService;
+    private final PACConfigurationService pacConfigurationService;
 
     private static final WebFilterChain EMPTY_WEB_FILTER_CHAIN = serverWebExchange -> Mono.empty();
     private static final String FORGOT_PASSWORD_CLIENT_URL_FORMAT = "%s/user/resetPassword?token=%s";
@@ -154,7 +155,8 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
             UserUtils userUtils,
             EmailVerificationTokenRepository emailVerificationTokenRepository,
             EmailService emailService,
-            RateLimitService rateLimitService) {
+            RateLimitService rateLimitService,
+            PACConfigurationService pacConfigurationService) {
 
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
         this.workspaceService = workspaceService;
@@ -172,6 +174,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
         this.rateLimitService = rateLimitService;
         this.emailVerificationTokenRepository = emailVerificationTokenRepository;
         this.emailService = emailService;
+        this.pacConfigurationService = pacConfigurationService;
     }
 
     @Override
@@ -756,18 +759,9 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                             commonConfig.isCloudHosting() ? true : userData.isIntercomConsentGiven());
                     profile.setSuperUser(isSuperUser);
                     profile.setConfigurable(!StringUtils.isEmpty(commonConfig.getEnvFilePath()));
-                    return setRolesAndGroups(profile, userFromDb, true, commonConfig.isCloudHosting());
+                    return pacConfigurationService.setRolesAndGroups(
+                            profile, userFromDb, true, commonConfig.isCloudHosting());
                 });
-    }
-
-    protected Mono<UserProfileDTO> setRolesAndGroups(
-            UserProfileDTO profile, User user, boolean showRolesAndGroups, boolean isCloudHosting) {
-        profile.setRoles(
-                List.of(UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC));
-        profile.setGroups(
-                List.of(UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC));
-
-        return Mono.just(profile);
     }
 
     private EmailTokenDTO parseValueFromEncryptedToken(String encryptedToken) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/PACConfigurationServiceCECompatible.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/PACConfigurationServiceCECompatible.java
@@ -1,0 +1,10 @@
+package com.appsmith.server.services.ce_compatible;
+
+import com.appsmith.server.services.ce.PACConfigurationServiceCE;
+
+/**
+ * PACConfigurationService - Controls the configurations for PAC
+ * <br>
+ * - PAC : programmatic access control
+ */
+public interface PACConfigurationServiceCECompatible extends PACConfigurationServiceCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/PACConfigurationServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/PACConfigurationServiceCECompatibleImpl.java
@@ -1,0 +1,10 @@
+package com.appsmith.server.services.ce_compatible;
+
+import com.appsmith.server.services.ce.PACConfigurationServiceCEImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class PACConfigurationServiceCECompatibleImpl extends PACConfigurationServiceCEImpl
+        implements PACConfigurationServiceCECompatible {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/UserServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/UserServiceCECompatibleImpl.java
@@ -12,6 +12,7 @@ import com.appsmith.server.repositories.PasswordResetTokenRepository;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.EmailService;
+import com.appsmith.server.services.PACConfigurationService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.TenantService;
@@ -53,7 +54,8 @@ public class UserServiceCECompatibleImpl extends UserServiceCEImpl implements Us
             UserUtils userUtils,
             EmailVerificationTokenRepository emailVerificationTokenRepository,
             EmailService emailService,
-            RateLimitService rateLimitService) {
+            RateLimitService rateLimitService,
+            PACConfigurationService pacConfigurationService) {
         super(
                 scheduler,
                 validator,
@@ -78,6 +80,7 @@ public class UserServiceCECompatibleImpl extends UserServiceCEImpl implements Us
                 userUtils,
                 emailVerificationTokenRepository,
                 emailService,
-                rateLimitService);
+                rateLimitService,
+                pacConfigurationService);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/PACConfigurationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/PACConfigurationServiceCETest.java
@@ -1,0 +1,42 @@
+package com.appsmith.server.services.ce;
+
+import com.appsmith.server.dtos.UserProfileDTO;
+import com.appsmith.server.services.PACConfigurationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+import static com.appsmith.server.constants.ce.AccessControlConstantsCE.UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class PACConfigurationServiceCETest {
+    @Autowired
+    PACConfigurationService pacConfigurationService;
+
+    @Test
+    public void test_setRolesAndGroups_featureFlagDisabled() {
+        UserProfileDTO userProfileDTO = new UserProfileDTO();
+        Mono<UserProfileDTO> userProfileDTOMono =
+                pacConfigurationService.setRolesAndGroups(userProfileDTO, null, false, false);
+        StepVerifier.create(userProfileDTOMono)
+                .assertNext(userProfileDTO1 -> {
+                    assertThat(userProfileDTO1.getRoles())
+                            .isEqualTo(
+                                    List.of(
+                                            UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC));
+                    assertThat(userProfileDTO1.getGroups())
+                            .isEqualTo(
+                                    List.of(
+                                            UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC));
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Description
Fetching super admin permission group without user context check using retrieveById.


#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

#### How Has This Been Tested?
- [x] Manual
- [x] JUnit

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [x] Added `Test Plan Approved` label after Cypress tests were reviewed
- [x] Added `Test Plan Approved` label after JUnit tests were reviewed
