### PR TITLE
fix: Update FileParser.ts to parse xlsx files properly

### DIFF
--- a/app/client/src/widgets/FilePickerWidgetV2/widget/FileParser.ts
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/FileParser.ts
@@ -114,7 +114,9 @@ function parseXLSFile(data: Blob): Promise<ExcelSheetData[]> {
       workbook.SheetNames.forEach((sheetName) => {
         const sheetData: ExcelSheetData = { name: "", data: [] };
         try {
-          const data = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName]);
+          const data = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName], {
+            defval: null
+          });
           sheetData["name"] = sheetName;
           sheetData["data"] = data;
           sheetsData.push(sheetData);

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/FileParser.ts
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/FileParser.ts
@@ -114,9 +114,7 @@ function parseXLSFile(data: Blob): Promise<ExcelSheetData[]> {
       workbook.SheetNames.forEach((sheetName) => {
         const sheetData: ExcelSheetData = { name: "", data: [] };
         try {
-          const data = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName], {
-            header: 1,
-          });
+          const data = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName]);
           sheetData["name"] = sheetName;
           sheetData["data"] = data;
           sheetsData.push(sheetData);


### PR DESCRIPTION
## Description
In filepicker widget if we upload xlsx file, the data output is an array of array instead of array of objects. The change we make is to simply remove the header prop from `XLSX.utils.sheet_to_json` API

#### PR fixes following issue(s)
Fixes #27888

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

#### Test Plan
nil

#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
