### PR TITLE
fix: Full support for inline SVG images and animations

### DIFF
--- a/app/client/src/widgets/ImageWidget/widget/index.tsx
+++ b/app/client/src/widgets/ImageWidget/widget/index.tsx
@@ -299,7 +299,17 @@ class ImageWidget extends BaseWidget<ImageWidgetProps, WidgetState> {
   }
 
   getWidgetView() {
-    const { maxZoomLevel, objectFit } = this.props;
+    const { image, maxZoomLevel, objectFit } = this.props;
+
+    // Special case for inline SVG images. They're special because it's the only image format that can be represented
+    // in UTF8 readable text. But special characters in the image text like `#` or `"` cause the image to not render.
+    let imageUrl = image;
+    if (imageUrl?.startsWith("data:image/svg+xml;utf8,")) {
+      imageUrl =
+        "data:image/svg+xml;base64," +
+        window.btoa(imageUrl.replace("data:image/svg+xml;utf8,", ""));
+    }
+
     return (
       <ImageComponent
         borderRadius={this.props.borderRadius}
@@ -310,7 +320,7 @@ class ImageWidget extends BaseWidget<ImageWidgetProps, WidgetState> {
         }}
         enableDownload={this.props.enableDownload}
         enableRotation={this.props.enableRotation}
-        imageUrl={this.props.image}
+        imageUrl={imageUrl}
         isLoading={this.props.isLoading}
         maxZoomLevel={maxZoomLevel}
         objectFit={objectFit}


### PR DESCRIPTION
This fixes support for inline SVGs that contain special characters like `"` for SVG attribute values, or `#` for colors in the SVG objects. Both of which make the SVG render incorrectly.

For example, drop an image widget, and use this as the src:

```
data:image/svg+xml;utf8,<svg viewBox="0 0 10 10" xmlns='http://www.w3.org/2000/svg'><circle cx='50%' cy='50%' r='2' stroke-width='1' stroke='black' fill='none'/></svg>
```

This won't render, but if we change the `"` to `'`:

```
data:image/svg+xml;utf8,<svg viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'><circle cx='50%' cy='50%' r='2' stroke-width='1' stroke='black' fill='none'/></svg>
```

It works fine.

Similarly, if we change the `stroke` from `black` to `#F09` or some such hex color, the image again fails to render.

```
data:image/svg+xml;utf8,<svg viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'><circle cx='50%' cy='50%' r='2' stroke-width='1' stroke='#F09' fill='none'/></svg>
```

This PR fixes for both of these, and any other special characters that can form part of an SVG.
