### PR TITLE
chore: Install NodeJS manually instead of with the deprecated script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,17 +23,14 @@ RUN apt-get update \
   && apt-get remove --yes git python3-pip python3-venv \
   && apt-get autoremove --yes
 
-# Install MongoDB v5.0.14, Redis, NodeJS - Service Layer, PostgreSQL v13
+# Install MongoDB v5.0.14, Redis, PostgreSQL v13
 RUN curl --silent --show-error --location https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
   && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
-  && curl --silent --show-error --location https://deb.nodesource.com/setup_18.x | bash - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/lsb-release | grep CODENAME | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
-  && apt-get install --no-install-recommends --yes mongodb-org nodejs redis postgresql-13 \
-  && apt-get clean \
-  # This is to get semver 7.5.2, for a CVE fix, might be able to remove it with later versions on NodeJS.
-  && npm install -g npm@9.7.2
+  && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 \
+  && apt-get clean
 
 # Install Java
 RUN set -o xtrace \
@@ -42,6 +39,12 @@ RUN set -o xtrace \
   && version="$(curl --write-out '%{redirect_url}' 'https://github.com/adoptium/temurin17-binaries/releases/latest' | sed 's,.*jdk-,,')" \
   && curl --location --output /tmp/java.tar.gz "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$version/OpenJDK17U-jdk_$(uname -m | sed s/x86_64/x64/)_linux_hotspot_$(echo $version | tr + _).tar.gz" \
   && tar -xzf /tmp/java.tar.gz -C /opt/java --strip-components 1
+
+# Install NodeJS
+RUN set -o xtrace \
+  && mkdir -p /opt/node \
+  && file="$(curl -sS 'https://nodejs.org/dist/latest-v18.x/' | awk -F\" '$2 ~ /linux-'"$(uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/')"'.tar.gz/ {print $2}')" \
+  && curl "https://nodejs.org/dist/latest-v18.x/$file" | tar -xz -C /opt/node --strip-components 1
 
 # Clean up cache file - Service layer
 RUN rm -rf \
@@ -85,14 +88,14 @@ COPY ./app/client/build editor/
 # Add RTS - Application Layer
 COPY ./app/client/packages/rts/dist rts/
 
+ENV PATH /opt/appsmith/utils/node_modules/.bin:/opt/java/bin:/opt/node/bin:$PATH
+
 RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd - \
   && chmod 0644 /etc/cron.d/* \
   && chmod +x entrypoint.sh renew-certificate.sh healthcheck.sh templates/nginx-app.conf.sh /watchtower-hooks/*.sh \
   # Disable setuid/setgid bits for the files inside container.
   && find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true \
   && node prepare-image.mjs
-
-ENV PATH /opt/appsmith/utils/node_modules/.bin:/opt/java/bin:$PATH
 
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 # Install MongoDB v5.0.14, Redis, PostgreSQL v13
 RUN curl --silent --show-error --location https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
   && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt $(cat /etc/lsb-release | grep CODENAME | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 \


### PR DESCRIPTION
Fixes #26891.
