### PR TITLE
fix: Fixed echarts evaluation and validation on page reload

### DIFF
--- a/app/client/src/entities/Widget/utils.ts
+++ b/app/client/src/entities/Widget/utils.ts
@@ -272,14 +272,14 @@ const getAllPathsFromPropertyConfigWithoutMemo = (
         if ("hidden" in controlConfig) {
           isHidden = controlConfig.hidden(widget, basePath);
         }
+        const path = controlConfig.propertyName;
+        const {
+          configBindingPaths,
+          configReactivePaths,
+          configTriggerPaths,
+          configValidationPaths,
+        } = checkPathsInConfig(controlConfig, path);
         if (!isHidden) {
-          const path = controlConfig.propertyName;
-          const {
-            configBindingPaths,
-            configReactivePaths,
-            configTriggerPaths,
-            configValidationPaths,
-          } = checkPathsInConfig(controlConfig, path);
           bindingPaths = {
             ...bindingPaths,
             ...configBindingPaths,
@@ -290,8 +290,8 @@ const getAllPathsFromPropertyConfigWithoutMemo = (
             ...configReactivePaths,
           };
           triggerPaths = { ...triggerPaths, ...configTriggerPaths };
-          validationPaths = { ...validationPaths, ...configValidationPaths };
         }
+        validationPaths = { ...validationPaths, ...configValidationPaths };
         // Has child Panel Config
         if (controlConfig.panelConfig) {
           const resultingPaths = childHasPanelConfig(

--- a/app/client/src/widgets/ChartWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/ChartWidget/widget/propertyConfig.ts
@@ -101,6 +101,7 @@ export const contentConfig = (
             params: {
               default: {},
             },
+            dependentPaths: ["chartType"],
           },
           hidden: (props: ChartWidgetProps) =>
             props.chartType !== "CUSTOM_ECHART",


### PR DESCRIPTION
## Description
PR to fix the validation issue in ECharts. Below is the summary of existing behaviour and how we fixed it.

**Problem**
1. When a chart is configured as type `EChart` with `customEChartConfig` configured, we evaluate/validate the config field and pass it back to the chart as a JS Object.
2. Now when the `chartType` is switched to any other type, the evaluated value of `customEChartConfig` still remains in the system. Switching back the `chartType` to EChart at this point, will work as expected since `customEChartConfig` is evaluated already. 
3. When you reload the page with the `chartType` as `BarChart`, `customEChartConfig` property doesn't get evaluated and remains in the system as a JSON string.
4. Now when the switch is made, the change in `chartType` doesn't trigger an evaluation of `customEChartConfig` property, thereby passing the JSON string to the chart widget and causing it to crash.

**New changes**
1. Added `chartType` as a validation dependency for `customEChartsConfig`
2. Send validationConfig for hidden properties as well.
3. This ensures that the hidden properties that are non dynamic get validated in the first tree creation
>
> Links to Notion, Figma or any other documents that might be relevant to the PR
>
>
#### PR fixes following issue(s)
Fixes # (issue number)
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
