### PR TITLE
chore: Update embedded MongoDB Schema version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ ENV PATH /opt/appsmith/utils/node_modules/.bin:/opt/java/bin:/opt/node/bin:$PATH
 
 RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd - \
   && chmod 0644 /etc/cron.d/* \
-  && chmod +x entrypoint.sh renew-certificate.sh healthcheck.sh templates/nginx-app.conf.sh /watchtower-hooks/*.sh \
+  && chmod +x *.sh templates/nginx-app.conf.sh /watchtower-hooks/*.sh \
   # Disable setuid/setgid bits for the files inside container.
   && find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true \
   && node prepare-image.mjs

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -167,6 +167,8 @@ init_mongodb() {
       openssl rand -base64 756 > "$MONGO_DB_KEY"
     fi
     use-mongodb-key "$MONGO_DB_KEY"
+
+    ./mongodb-fixer.sh &
   fi
 }
 

--- a/deploy/docker/fs/opt/appsmith/mongodb-fixer.sh
+++ b/deploy/docker/fs/opt/appsmith/mongodb-fixer.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+{
+
+while [[ ! -S "$TMP/supervisor.sock" ]]; do
+  sleep 1
+done
+echo "supervisor.sock found"
+
+while supervisorctl status mongodb | grep -q RUNNING; do
+  sleep 1
+done
+echo "MongoDB is RUNNING"
+
+for _ in {1..60}; do
+  if mongosh --quiet "$APPSMITH_MONGODB_URI" --eval '
+    parseFloat(db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version) < 5 &&
+      db.adminCommand({setFeatureCompatibilityVersion: "5.0"})
+  '; then
+    echo "MongoDB version set to 5.0"
+    break
+  fi
+  sleep 1
+done
+
+echo Done
+
+} | sed -u 's/^/mongodb-fixer: /'


### PR DESCRIPTION
Tests:
```
root@3d74d52465e2:/opt/appsmith# mongo --version
MongoDB shell version v4.4.18
Build Info: {
    "version": "4.4.18",
    "gitVersion": "8ed32b5c2c68ebe7f8ae2ebe8d23f36037a17dea",
    "openSSLVersion": "OpenSSL 1.1.1f  31 Mar 2020",
    "modules": [],
    "allocator": "tcmalloc",
    "environment": {
        "distmod": "ubuntu2004",
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}
root@3d74d52465e2:/opt/appsmith# mongo --host mongodb://appsmith:yCPaeoA3wx2JR@localhost:27017/appsmith
MongoDB shell version v4.4.18
connecting to: mongodb://localhost:27017/appsmith?compressors=disabled&gssapiServiceName=mongodb
Implicit session: session { "id" : UUID("fd2d11fd-f5f6-457b-a16d-8437ba2d9872") }
MongoDB server version: 4.4.18
---
The server generated these startup warnings when booting:
        2023-10-16T07:22:42.439+00:00: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine. See http://dochub.mongodb.org/core/prodnotes-filesystem
        2023-10-16T07:22:44.592+00:00: You are running this process as the root user, which is not recommended
---
---
        Enable MongoDB's free cloud-based monitoring service, which will then receive and display
        metrics about your deployment (disk utilization, CPU, operation statistics, etc).

        The monitoring data will be available on a MongoDB website with a unique URL accessible to you
        and anyone you share the URL with. MongoDB may use this information to make product
        improvements and to suggest MongoDB products and deployment options to you.

        To enable free monitoring, run the following command: db.enableFreeMonitoring()
        To permanently disable this reminder, run the following command: db.disableFreeMonitoring()
---
mr1:PRIMARY> db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )
{
	"featureCompatibilityVersion" : {
		"version" : "4.4"
	},
	"ok" : 1,
	"$clusterTime" : {
		"clusterTime" : Timestamp(1697441234, 1),
		"signature" : {
			"hash" : BinData(0,"kE03Du6dOgqbmSE+f9AK/ef14hI="),
			"keyId" : NumberLong("7290453392910974981")
		}
	},
	"operationTime" : Timestamp(1697441234, 1)
}
root@3d74d52465e2:/opt/appsmith# exit
root@ip-172-31-43-3:~/gp# docker ps -a
CONTAINER ID   IMAGE                              COMMAND                  CREATED         STATUS                   PORTS                                                                                                                 NAMES
3d74d52465e2   appsmith/appsmith-ce:v1.8.15       "/opt/appsmith/entry…"   5 minutes ago   Up 5 minutes (healthy)   443/tcp, 0.0.0.0:9000->80/tcp, :::9000->80/tcp                                                                        appsmith_temp


v1.9.2

================
Welcome to the MongoDB shell.
For interactive help, type "help".
For more comprehensive documentation, see
    https://docs.mongodb.com/
Questions? Try the MongoDB Developer Community Forums
    https://community.mongodb.com
---
The server generated these startup warnings when booting:
        2023-10-16T07:36:10.753+00:00: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine. See http://dochub.mongodb.org/core/prodnotes-filesystem
        2023-10-16T07:36:11.962+00:00: You are running this process as the root user, which is not recommended
        2023-10-16T07:36:12.257+00:00: ** WARNING: The default write concern may change when upgrading to 5.0. Use setDefaultRWConcern to set a cluster-wide default write concern that won't change.
---
---
        Enable MongoDB's free cloud-based monitoring service, which will then receive and display
        metrics about your deployment (disk utilization, CPU, operation statistics, etc).

        The monitoring data will be available on a MongoDB website with a unique URL accessible to you
        and anyone you share the URL with. MongoDB may use this information to make product
        improvements and to suggest MongoDB products and deployment options to you.

        To enable free monitoring, run the following command: db.enableFreeMonitoring()
        To permanently disable this reminder, run the following command: db.disableFreeMonitoring()
---
mr1:PRIMARY> db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )
{
    "featureCompatibilityVersion" : {
        "version" : "4.4"
    },
    "ok" : 1,
    "$clusterTime" : {
        "clusterTime" : Timestamp(1697441882, 1),
        "signature" : {
            "hash" : BinData(0,"QwBRaNinV9TP0BI0mJz/hdoJZ3E="),
            "keyId" : NumberLong("7290453392910974981")
        }
    },
    "operationTime" : Timestamp(1697441882, 1)
}
mr1:PRIMARY>
bye
root@a7a1740d5336:/opt/appsmith# exit

root@ip-172-31-43-3:~# docker ps -a
CONTAINER ID   IMAGE                              COMMAND                  CREATED              STATUS                          PORTS                                                                                                                 NAMES
f1aac0c2bfff   appsmith/appsmith-dp:ce-27985      "/opt/appsmith/entry…"   About a minute ago   Up About a minute (unhealthy)   443/tcp, 0.0.0.0:9000->80/tcp, :::9000->80/tcp                                                                        appsmith_temp
f5f00dc1f060   appsmith/appsmith-ee:latest        "/opt/appsmith/entry…"   6 days ago           Up 6 days (healthy)             0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp, 0.0.0.0:9001->9001/tcp, :::9001->9001/tcp   appsmith
a10a2ad71ebc   containrrr/watchtower:latest-dev   "/watchtower --sched…"   7 weeks ago          Up 7 weeks                                                                                                                                            appsmith_auto_update_1
root@ip-172-31-43-3:~# ls
gp  snap
root@ip-172-31-43-3:~# cd gp/
root@ip-172-31-43-3:~/gp# docker-compose exec appsmith bash
root@f1aac0c2bfff:/opt/appsmith# mongo --host mongodb://appsmith:yCPaeoA3wx2JR@localhost:27017/appsmith
MongoDB shell version v5.0.21
connecting to: mongodb://localhost:27017/appsmith?compressors=disabled&gssapiServiceName=mongodb
Implicit session: session { "id" : UUID("cde5e952-8167-48cd-b653-2fb4dd8a58f2") }
MongoDB server version: 5.0.21
================
Warning: the "mongo" shell has been superseded by "mongosh",
which delivers improved usability and compatibility.The "mongo" shell has been deprecated and will be removed in
an upcoming release.
For installation instructions, see
https://docs.mongodb.com/mongodb-shell/install/
================
Welcome to the MongoDB shell.
For interactive help, type "help".
For more comprehensive documentation, see
    https://docs.mongodb.com/
Questions? Try the MongoDB Developer Community Forums
    https://community.mongodb.com
---
The server generated these startup warnings when booting:
        2023-10-16T07:43:12.006+00:00: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine. See http://dochub.mongodb.org/core/prodnotes-filesystem
        2023-10-16T07:43:13.614+00:00: You are running this process as the root user, which is not recommended
        2023-10-16T07:43:13.964+00:00: ** WARNING: The default write concern may change when upgrading to 5.0. Use setDefaultRWConcern to set a cluster-wide default write concern that won't change.
---
mr1:PRIMARY> db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )
{
    "featureCompatibilityVersion" : {
        "version" : "5.0"
    },
    "ok" : 1,
    "$clusterTime" : {
        "clusterTime" : Timestamp(1697442314, 1),
        "signature" : {
            "hash" : BinData(0,"PADM6j1czeTo0BcUv/Ho+Gi5WA0="),
            "keyId" : NumberLong("7290453392910974981")
        }
    },
    "operationTime" : Timestamp(1697442314, 1)
}
mr1:PRIMARY>
```