### PR TITLE
fix:lint staged

### DIFF
--- a/app/client/.husky/check-staged-files.sh
+++ b/app/client/.husky/check-staged-files.sh
@@ -7,7 +7,7 @@ is_merge_commit=$(git rev-parse -q --verify MERGE_HEAD)
 
 if [ "$is_merge_commit" ]; then
   echo "Skipping server and client checks for merge commit"
-else 
+else
   if [ "$is_server_change" -ge 1 ]; then
     echo "Running Spotless check ..."
     pushd app/server > /dev/null
@@ -23,7 +23,7 @@ else
 
   if [ "$is_client_change" -ge 1  ]; then
     echo "Running client check ..."
-    npx lint-staged --cwd app/client && git-secrets --scan --untracked && git-secrets --scan -r
+    npx lint-staged --cwd app/client
   else
     echo "Skipping client side check..."
   fi

--- a/app/client/.lintstagedrc.json
+++ b/app/client/.lintstagedrc.json
@@ -1,8 +1,11 @@
 {
-	"src/**/*.{js,ts,tsx}": ["npx eslint --fix"],
-	"src/**/*.{js,ts,tsx,css,md,json}": ["npx prettier --write"],
-	"cypress/**/*.{js,ts}": ["cd ./cypress && npx eslint -c .eslintrc.json --fix"],
-	"cypress/**/*.{js,ts,json}": ["npx prettier --write"],
-	"packages/**/*.{js,ts,tsx}": ["npx eslint --fix"],
-	"packages/**/*.{js,ts,tsx,css,mdx,json}": ["npx prettier --write"]
+  "src/**/*.{js,ts,tsx}": ["eslint --fix --cache"],
+  "src/**/*.{css,md,json}": ["prettier --write --cache"],
+  "cypress/**/*.{js,ts}": [
+    "cd ./cypress && eslint -c .eslintrc.json --fix --cache"
+  ],
+  "cypress/**/*.json": ["prettier --write --cache"],
+  "packages/**/*.{js,ts,tsx}": ["eslint --fix --cache"],
+  "packages/**/*.{css,mdx,json}": ["prettier --write --cache"],
+  "*": ["git-secrets --scan --cached"]
 }


### PR DESCRIPTION
## Description

1. Optimise `lint-staged` scripts so that they are not executed twice. For some patterns, I removed the `prettier` checks since they are executed by`eslint` checks as well.
2. Add caching for all scripts.
3. Optimisation of the `git secrets`, now we check only staged files. Earlier we checked all the files that `git ls-files` returns. [Here more about this.](https://github.com/awslabs/git-secrets#options-for-scan).