### PR TITLE
chore: Remove autogeneration of feature flag if the same is not present in `FF4J` context

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/FeatureFlagConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/FeatureFlagConfig.java
@@ -8,8 +8,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class FeatureFlagConfig {
 
+    // Since we rely on cloud services to retrieve the most up-to-date flags, we avoid automatically generating the same
+    // flag in the FF4J context.
     @Bean
     public FF4j ff4j() {
-        return new FF4j(new XmlParser(), "features/init-flags.xml").audit(true).autoCreate(true);
+        return new FF4j(new XmlParser(), "features/init-flags.xml").audit(true).autoCreate(false);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
@@ -96,7 +96,7 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
         try {
             return ff4j.check(featureName, new FlippingExecutionContext(Map.of(FieldName.USER, user)));
         } catch (Exception e) {
-            // We configure FF4J not to auto-generate a flag if it's not present in init-flags.xml
+            // FF4J is configured not to auto-generate a flag if it's not present in init-flags.xml
             // (see FeatureFlagConfig.java).
             // Consequently, we anticipate that the flag may not exist in the FF4J context and need to handle any
             // related exceptions silently.


### PR DESCRIPTION
## Description
PR for updating the FF4J configuration to avoid auto-creating the feature flags for FF4J if the same is not present in the FF4J context. 

We are planning to remove the FF4J dependency but with this change the flakiness we are seeing in EE codebase will be fixed. This is because with auto-creation enabled FF4J tries to add the flag to the feature store. This ends up in ConcurrentModification exceptions for the `LinkedHashmap` which is being used under the hood.    

Ref thread: https://theappsmith.slack.com/archives/CPQNLFHTN/p1697109849578459

Fixes https://github.com/appsmithorg/appsmith-ee/issues/2635

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
