### PR TITLE
test: Cypress | Skip MsSQL_Basic_Spec.ts spec in CI

### DIFF
--- a/app/client/cypress_ci_custom.config.ts
+++ b/app/client/cypress_ci_custom.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
       "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
       "cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts",
       "cypress/e2e/Regression/ClientSide/Widgets/Others/MapWidget_Spec.ts",
+      "cypress/e2e/Sanity/Datasources/MsSQL_Basic_Spec.ts",
     ],
   },
 });


### PR DESCRIPTION
## Description
- This PR skips MsSQL_Basic_Spe.ts from CI runs since its runing out of memory in multiple CI runs
- Until this is added to TED or we find other ways - will be run locally during regression

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Checklist:
#### QA activity:
- [X] Added `Test Plan Approved` label after changes were reviewed