### PR TITLE
ci: Add perf v2 job to perf test command

### DIFF
--- a/.github/workflows/perf-tests-command.yml
+++ b/.github/workflows/perf-tests-command.yml
@@ -60,3 +60,13 @@ jobs:
     secrets: inherit
     with:
       pr: ${{ github.event.client_payload.pull_request.number }}
+
+  perf-test-v2:
+    needs: [ build-docker-image ]
+    # Only run if the build step is successful
+    if: success()
+    name: perf-test-v2
+    uses: ./.github/workflows/perf-test-v2.yml
+    secrets: inherit
+    with:
+      pr: ${{ github.event.client_payload.pull_request.number }}


### PR DESCRIPTION
## Description
-  Run perf tests in parallel
- Remove v2 from /perf-test workflow as we can run v2 by passing the ref

#### PR fixes following issue(s)
Fixes #23791
 
#### Type of change
 - Chore (housekeeping or task changes that don't impact user perception)
 
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
 
