### PR TITLE
chore: SQL hinter automated test

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.test.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.test.ts
@@ -1,5 +1,29 @@
-import { bindingHintHelper } from "components/editorComponents/CodeEditor/hintHelpers";
+import {
+  bindingHintHelper,
+  SqlHintHelper,
+} from "components/editorComponents/CodeEditor/hintHelpers";
 import { MockCodemirrorEditor } from "../../../../test/__mocks__/CodeMirrorEditorMock";
+import { random } from "lodash";
+import "codemirror/addon/hint/sql-hint";
+import { MAX_NUMBER_OF_SQL_HINTS } from "./utils/sqlHint";
+
+jest.mock("./codeEditorUtils", () => {
+  const actualExports = jest.requireActual("./codeEditorUtils");
+  return {
+    __esModule: true,
+    ...actualExports,
+    isCursorOnEmptyToken: jest.fn(() => false),
+  };
+});
+
+function generateRandomTable() {
+  const table: Record<string, string> = {};
+  for (let i = 0; i < 500; i++) {
+    table[`T${random(0, 1000)}`] = "string";
+  }
+
+  return table;
+}
 
 describe("hint helpers", () => {
   describe("binding hint helper", () => {
@@ -82,6 +106,41 @@ describe("hint helpers", () => {
       ).length;
       expect(MockCodemirrorEditor.closeHint).toHaveBeenCalledTimes(
         closeHintCount,
+      );
+    });
+  });
+
+  describe("SQL hinter", () => {
+    const hinter = new SqlHintHelper();
+    const randomTable = generateRandomTable();
+    hinter.setDatasourceTableKeys(randomTable);
+    jest.spyOn(hinter, "getCompletions").mockImplementation(() => ({
+      from: { line: 1, ch: 1 },
+      to: { line: 1, ch: 1 },
+      list: Object.keys(randomTable),
+    }));
+
+    it("returns no hint when not in SQL mode", () => {
+      jest.spyOn(hinter, "isSqlMode").mockImplementationOnce(() => false);
+      // @ts-expect-error: actual editor is not required
+      const response = hinter.handleCompletions({});
+
+      expect(response.completions).toBe(null);
+    });
+
+    it("returns hints when in SQL mode", () => {
+      jest.spyOn(hinter, "isSqlMode").mockImplementationOnce(() => true);
+      // @ts-expect-error: actual editor is not required
+      const response = hinter.handleCompletions({});
+      expect(response.completions?.list).toBeTruthy();
+    });
+
+    it("Doesn't return hints greater than the threshold", () => {
+      jest.spyOn(hinter, "isSqlMode").mockImplementationOnce(() => true);
+      // @ts-expect-error: actual editor is not required
+      const response = hinter.handleCompletions({});
+      expect(response.completions?.list.length).toBeLessThanOrEqual(
+        MAX_NUMBER_OF_SQL_HINTS,
       );
     });
   });

--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
@@ -76,7 +76,7 @@ type HandleCompletions = (
   | { showHints: false; completions: null }
   | { showHints: true; completions: Hints };
 
-class SqlHintHelper {
+export class SqlHintHelper {
   datasourceTableKeys: NonNullable<
     ReturnType<typeof getAllDatasourceTableKeys>
   > = {};
@@ -88,6 +88,7 @@ class SqlHintHelper {
     this.addCustomAttributesToCompletions =
       this.addCustomAttributesToCompletions.bind(this);
     this.generateTables = this.generateTables.bind(this);
+    this.getCompletions = this.getCompletions.bind(this);
   }
 
   setDatasourceTableKeys(
@@ -155,13 +156,18 @@ class SqlHintHelper {
     return completions;
   }
 
+  getCompletions(editor: CodeMirror.Editor) {
+    // @ts-expect-error: No types available
+    const completions: Hints = CodeMirror.hint.sql(editor, {
+      tables: this.tables,
+    });
+    return completions;
+  }
+
   handleCompletions(editor: CodeMirror.Editor): ReturnType<HandleCompletions> {
     const noHints = { showHints: false, completions: null } as const;
     if (isCursorOnEmptyToken(editor) || !this.isSqlMode(editor)) return noHints;
-    // @ts-expect-error: No types available
-    let completions: Hints = CodeMirror.hint.sql(editor, {
-      tables: this.tables,
-    });
+    let completions: Hints = this.getCompletions(editor);
     if (isEmpty(completions.list)) return noHints;
     completions = filterCompletions(completions);
     return {

--- a/app/client/src/components/editorComponents/CodeEditor/utils/sqlHint.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/utils/sqlHint.ts
@@ -48,7 +48,7 @@ export function getHintDetailsFromClassName(
 
 // Beyond 270 hints, the main thread task for rendering the hint tooltip becomes greater than 50ms
 // 50ms is the limit beyond which a task is considered a long task
-const MAX_NUMBER_OF_SQL_HINTS = 270;
+export const MAX_NUMBER_OF_SQL_HINTS = 270;
 
 export function filterCompletions(completions: Hints) {
   completions.list = completions.list.slice(0, MAX_NUMBER_OF_SQL_HINTS);


### PR DESCRIPTION
## Description

This PR adds unit tests for the SQL hinter class. It tests that the number of hints shown is never greater than the threshold set[ here](https://github.com/appsmithorg/appsmith/pull/27329)

#### PR fixes following issue(s)
Fixes #27757 


#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)
- 
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [x] Jest
- [ ] Cypress

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
