### PR TITLE
chore: add try catch for signup recaptcha

### DIFF
--- a/app/client/src/pages/UserAuth/SignUp.tsx
+++ b/app/client/src/pages/UserAuth/SignUp.tsx
@@ -20,6 +20,7 @@ import {
   ALREADY_HAVE_AN_ACCOUNT,
   createMessage,
   SIGNUP_PAGE_SUBTITLE,
+  GOOGLE_RECAPTCHA_KEY_ERROR,
 } from "@appsmith/constants/messages";
 import FormTextField from "components/utils/ReduxFormTextField";
 import ThirdPartyAuth from "pages/UserAuth/ThirdPartyAuth";
@@ -52,6 +53,7 @@ import Helmet from "react-helmet";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
 import { getHTMLPageTitle } from "@appsmith/utils/BusinessFeatures/brandingPageHelpers";
+import log from "loglevel";
 
 declare global {
   interface Window {
@@ -145,17 +147,24 @@ export function SignUp(props: SignUpFormProps) {
       googleRecaptchaSiteKey.enabled &&
       recaptchaStatus === ScriptStatus.READY
     ) {
-      window.grecaptcha
-        .execute(googleRecaptchaSiteKey.apiKey, {
-          action: "submit",
-        })
-        .then(function (token: any) {
-          if (formElement) {
-            signupURL.searchParams.append("recaptchaToken", token);
-            formElement.setAttribute("action", signupURL.toString());
-            formElement.submit();
-          }
-        });
+      try {
+        window.grecaptcha
+          .execute(googleRecaptchaSiteKey.apiKey, {
+            action: "submit",
+          })
+          .then(function (token: any) {
+            if (formElement) {
+              signupURL.searchParams.append("recaptchaToken", token);
+              formElement.setAttribute("action", signupURL.toString());
+              formElement.submit();
+            }
+          })
+          .catch(() => {
+            log.error(createMessage(GOOGLE_RECAPTCHA_KEY_ERROR));
+          });
+      } catch (e) {
+        log.error(e);
+      }
     } else {
       formElement && formElement.submit();
     }


### PR DESCRIPTION
## Description
Adds a try catch around the recaptcha code on signup page. This is handled similarly else where in the code base. https://github.com/appsmithorg/appsmith/blob/release/app/client/src/widgets/ButtonWidget/component/index.tsx#L361.

The intention here is to catch the [timeout](https://github.com/appsmithorg/appsmith/issues/20764) error and not log to sentry as it isn't really crashing the app. There is a lot of sentry logs for this originating from the signup page. 

Fixes https://github.com/appsmithorg/appsmith/issues/20764


#### Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## Testing
#### How Has This Been Tested?

- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
