### PR TITLE
fix: MySQL plugin: add check for null column value for JSON column type

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -557,7 +557,7 @@ public class MySqlPlugin extends BasePlugin {
                     columnValue = DateTimeFormatter.ISO_TIME.format(row.get(columnName, LocalTime.class));
                 } else if (java.time.Year.class.toString().equalsIgnoreCase(javaTypeName) && columnValue != null) {
                     columnValue = row.get(columnName, LocalDate.class).getYear();
-                } else if (JSON_DB_TYPE.equals(sqlColumnType)) {
+                } else if (columnValue != null && JSON_DB_TYPE.equals(sqlColumnType)) {
                     /**
                      * In case of MySQL the JSON DB type is stored as a binary object in the DB. This is different from
                      * MariaDB where it is stored as a text.Since we currently use MariaDB driver for MySQL plugin as

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -836,8 +836,7 @@ public class MySqlPluginTest {
         String query_create_table_json_data_type = "create table test_json_type (id INTEGER, c_json JSON);";
         String query_insert_json_data_type_1 =
                 "insert into test_json_type values (1, '{\"key1\": \"value1\", \"key2\": " + "\"value2\"}');";
-        String query_insert_json_data_type_2 =
-            "insert into test_json_type values (2, NULL);";
+        String query_insert_json_data_type_2 = "insert into test_json_type values (2, NULL);";
 
         String query_create_table_geometry_types =
                 "create table test_geometry_types (c_geometry GEOMETRY, c_point " + "POINT);";
@@ -863,7 +862,8 @@ public class MySqlPluginTest {
                 + "\"c_blob\":\"dGVzdA==\",\"c_mediumblob\":\"dGVzdA==\",\"c_longblob\":\"dGVzdA==\",\"c_tinytext\":\"test\","
                 + "\"c_text\":\"test\",\"c_mediumtext\":\"test\",\"c_longtext\":\"test\",\"c_enum\":\"ONE\",\"c_set\":\"a\"}]";
 
-        String expected_json_result_1 = "[{\"c_json\":\"{\\\"key1\\\": \\\"value1\\\", \\\"key2\\\": \\\"value2\\\"}\"}]";
+        String expected_json_result_1 =
+                "[{\"c_json\":\"{\\\"key1\\\": \\\"value1\\\", \\\"key2\\\": \\\"value2\\\"}\"}]";
         String expected_json_result_2 = "[{\"c_json\":null}]";
 
         String expected_geometry_types_result = "[{\"c_geometry\":\"AAAAAAEBAAAAAAAAAAAA8D8AAAAAAADwPw==\","

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -833,9 +833,11 @@ public class MySqlPluginTest {
         String query_insert_data_types = "insert into test_data_types values ('test', 'test', 'a\\0\\t', 'a\\0\\t', "
                 + "'test', 'test', 'test', 'test',  'test', 'test', 'test', 'test', 'ONE', 'a');";
 
-        String query_create_table_json_data_type = "create table test_json_type (c_json JSON);";
-        String query_insert_json_data_type =
-                "insert into test_json_type values ('{\"key1\": \"value1\", \"key2\": " + "\"value2\"}');";
+        String query_create_table_json_data_type = "create table test_json_type (id INTEGER, c_json JSON);";
+        String query_insert_json_data_type_1 =
+                "insert into test_json_type values (1, '{\"key1\": \"value1\", \"key2\": " + "\"value2\"}');";
+        String query_insert_json_data_type_2 =
+            "insert into test_json_type values (2, NULL);";
 
         String query_create_table_geometry_types =
                 "create table test_geometry_types (c_geometry GEOMETRY, c_point " + "POINT);";
@@ -844,7 +846,8 @@ public class MySqlPluginTest {
 
         String query_select_from_test_numeric_types = "select * from test_numeric_types;";
         String query_select_from_test_date_time_types = "select * from test_date_time_types;";
-        String query_select_from_test_json_data_type = "select * from test_json_type;";
+        String query_select_from_test_json_data_type_1 = "select c_json from test_json_type where id=1;";
+        String query_select_from_test_json_data_type_2 = "select c_json from test_json_type where id=2;";
         String query_select_from_test_data_types = "select * from test_data_types;";
         String query_select_from_test_geometry_types = "select * from test_geometry_types;";
 
@@ -860,7 +863,8 @@ public class MySqlPluginTest {
                 + "\"c_blob\":\"dGVzdA==\",\"c_mediumblob\":\"dGVzdA==\",\"c_longblob\":\"dGVzdA==\",\"c_tinytext\":\"test\","
                 + "\"c_text\":\"test\",\"c_mediumtext\":\"test\",\"c_longtext\":\"test\",\"c_enum\":\"ONE\",\"c_set\":\"a\"}]";
 
-        String expected_json_result = "[{\"c_json\":\"{\\\"key1\\\": \\\"value1\\\", \\\"key2\\\": \\\"value2\\\"}\"}]";
+        String expected_json_result_1 = "[{\"c_json\":\"{\\\"key1\\\": \\\"value1\\\", \\\"key2\\\": \\\"value2\\\"}\"}]";
+        String expected_json_result_2 = "[{\"c_json\":null}]";
 
         String expected_geometry_types_result = "[{\"c_geometry\":\"AAAAAAEBAAAAAAAAAAAA8D8AAAAAAADwPw==\","
                 + "\"c_point\":\"AAAAAAEBAAAAAAAAAAAA8D8AAAAAAABZQA==\"}]";
@@ -874,7 +878,8 @@ public class MySqlPluginTest {
                             .add(query_create_table_date_time_types)
                             .add(query_insert_into_table_date_time_types)
                             .add(query_create_table_json_data_type)
-                            .add(query_insert_json_data_type)
+                            .add(query_insert_json_data_type_1)
+                            .add(query_insert_json_data_type_2)
                             .add(query_create_table_data_types)
                             .add(query_insert_data_types)
                             .add(query_create_table_geometry_types)
@@ -890,7 +895,8 @@ public class MySqlPluginTest {
         /* Test data types */
         testExecute(query_select_from_test_data_types, expected_data_types_result);
         /* Test json type */
-        testExecute(query_select_from_test_json_data_type, expected_json_result);
+        testExecute(query_select_from_test_json_data_type_1, expected_json_result_1);
+        testExecute(query_select_from_test_json_data_type_2, expected_json_result_2);
         /* Test geometry types */
         testExecute(query_select_from_test_geometry_types, expected_geometry_types_result);
 


### PR DESCRIPTION
## Description
- Add check for column value being `null` when column type is `JSON`. This check was mistakenly not added before. Adding it now as part of this PR. 
- Add JUnit TC. 

#### PR fixes following issue(s)
Fixes #27645 

#### Media
![Screenshot 2023-10-17 at 2 25 04 PM](https://github.com/appsmithorg/appsmith/assets/1757421/afb5ef2e-a128-4e6b-9fe1-6b4e1b7f4643)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [x] JUnit
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
