### PR TITLE
fix: Race condition in deleting the loading page

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
@@ -12,6 +12,10 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static java.lang.Boolean.TRUE;
 
 @Slf4j
@@ -25,8 +29,18 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
 
     private final InstanceConfigHelper instanceConfigHelper;
 
+    private static final String WWW_PATH = System.getenv("NGINX_WWW_PATH");
+
     @Override
     public void onApplicationEvent(ApplicationReadyEvent applicationReadyEvent) {
+        if (WWW_PATH != null) {
+            try {
+                // Delete the loading.html file if it exists.
+                Files.deleteIfExists(Path.of(WWW_PATH + "/loading.html"));
+            } catch (IOException e) {
+                log.error("Error deleting loading.html file: {}", e.getMessage());
+            }
+        }
 
         Mono<Void> registrationAndRtsCheckMono = configService
                 .getByName(Appsmith.APPSMITH_REGISTERED)


### PR DESCRIPTION
In addition to the polling loop that waits for backend to be ready to delete the loading page, this PR will make the backend also try and delete the loading page once it's ready to accept incoming requests.

Tested locally.
