### PR TITLE
feat: change the subtexts for options to profiling questions

### DIFF
--- a/app/client/src/pages/setup/constants.ts
+++ b/app/client/src/pages/setup/constants.ts
@@ -56,22 +56,22 @@ type OptionTypeWithSubtext = OptionType & {
 export const proficiencyOptions: OptionTypeWithSubtext[] = [
   {
     label: "Brand New",
-    subtext: "Just dipping my toes 🌱 (Brand new to this)",
+    subtext: "I've never written code before.",
     value: "Brand New",
   },
   {
     label: "Novice",
-    subtext: "Novice (Limited to no experience)",
+    subtext: "Learning the ropes. Basic understanding of coding concepts.",
     value: "Novice",
   },
   {
     label: "Intermediate",
-    subtext: "Intermediate (Some coding adventures)",
+    subtext: "Can tackle moderately complex projects.",
     value: "Intermediate",
   },
   {
     label: "Advanced",
-    subtext: "Advanced (Comfortable with programming quests)",
+    subtext: "Mastery in development. Experienced with complex coding tasks.",
     value: "Advanced",
   },
 ];


### PR DESCRIPTION
## Description
With https://github.com/appsmithorg/appsmith/issues/27915 issue, we changed the profiling questions during new user onboarding. However, the subtexts to the options should be changed according to the new [design](https://www.figma.com/file/kbU9xPv44neCfv1FFo9Ndu/User-Activation?type=design&node-id=3134-18334&mode=design&t=m8UYj5Qkl3iBplFk-0).

#### PR fixes following issue(s)
Fixes #28159

#### Type of change
- New feature (non-breaking change which adds functionality)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
