### PR TITLE
ci: Create separate base image so daily CI can cache better and run faster

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -1,0 +1,49 @@
+name: Docker Base Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout the head commit of the branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Get tag
+        id: tag
+        run: |
+          tag="${GITHUB_REF_NAME//\//-}"
+          if [[ "$tag" == master ]]; then
+            tag=nightly
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/docker/base.dockerfile
+          push: true
+          platforms: linux/arm64,linux/amd64
+          tags: |
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:${{ steps.tag.outputs.tag }}

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="tech@appsmith.com"
+
+# Set workdir to /opt/appsmith
+WORKDIR /opt/appsmith
+
+# The env variables are needed for Appsmith server to correctly handle non-roman scripts like Arabic.
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# Update APT packages - Base Layer
+RUN apt-get update \
+  && apt-get upgrade --yes \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
+    supervisor curl cron nfs-common nginx nginx-extras gnupg wget netcat openssh-client \
+    gettext \
+    python3-pip python3-venv git ca-certificates \
+  && pip install --no-cache-dir git+https://github.com/coderanger/supervisor-stdout@973ba19967cdaf46d9c1634d1675fc65b9574f6e \
+  && python3 -m venv --prompt certbot /opt/certbot/venv \
+  && /opt/certbot/venv/bin/pip install --upgrade certbot setuptools pip \
+  && ln -s /opt/certbot/venv/bin/certbot /usr/local/bin \
+  && apt-get remove --yes git python3-pip python3-venv \
+  && apt-get autoremove --yes
+
+# Install MongoDB v5.0.14, Redis, PostgreSQL v13
+RUN curl --silent --show-error --location https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
+  && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
+  && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && apt update \
+  && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 \
+  && apt-get clean
+
+# Install Java
+RUN set -o xtrace \
+  && mkdir -p /opt/java \
+  # Assets from https://github.com/adoptium/temurin17-binaries/releases
+  && version="$(curl --write-out '%{redirect_url}' 'https://github.com/adoptium/temurin17-binaries/releases/latest' | sed 's,.*jdk-,,')" \
+  && curl --location --output /tmp/java.tar.gz "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$version/OpenJDK17U-jdk_$(uname -m | sed s/x86_64/x64/)_linux_hotspot_$(echo $version | tr + _).tar.gz" \
+  && tar -xzf /tmp/java.tar.gz -C /opt/java --strip-components 1
+
+# Install NodeJS
+RUN set -o xtrace \
+  && mkdir -p /opt/node \
+  && file="$(curl -sS 'https://nodejs.org/dist/latest-v18.x/' | awk -F\" '$2 ~ /linux-'"$(uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/')"'.tar.gz/ {print $2}')" \
+  && curl "https://nodejs.org/dist/latest-v18.x/$file" | tar -xz -C /opt/node --strip-components 1
+
+# Clean up cache file - Service layer
+RUN rm -rf \
+  /root/.cache \
+  /root/.npm \
+  /root/.pip \
+  /usr/local/share/doc \
+  /usr/share/doc \
+  /usr/share/man \
+  /var/lib/apt/lists/* \
+  /tmp/*
+
+# Define volumes - Service Layer
+VOLUME [ "/appsmith-stacks" ]
+
+# ------------------------------------------------------------------------
+ENV TMP="/tmp/appsmith"
+ENV NGINX_WWW_PATH="$TMP/www"


### PR DESCRIPTION
The layers in the Dockerfile that depend on downloading large files from external sources, doesn't have to run every day, or at every PR. We tried using Docker's caching configuration, but it's not as reliable as we'd have liked.

A separate base image lends us much more control over the how long we cache the downloaded files and how often we redo this.

This PR only _adds_ the base image. It doesn't change anything in the build of the existing Docker image. That'll happen once we have the base images for `release` and `master` already present on DockerHub.
