### PR TITLE
chore: changes to pinpoint errors in ApplicationServiceCETest

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services;
 
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.WithMockAppsmithUser;
 import com.appsmith.server.domains.LoginSource;
 import com.appsmith.server.domains.User;
@@ -12,9 +13,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -26,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(properties = {"signup.disabled = true", "admin.emails = dummy_admin@appsmith.com,dummy2@appsmith.com"})
-@DirtiesContext
+@SpringBootTest
 public class UserServiceWithDisabledSignupTest {
 
     @Autowired
@@ -48,11 +49,17 @@ public class UserServiceWithDisabledSignupTest {
     @Autowired
     PermissionGroupRepository permissionGroupRepository;
 
+    @SpyBean
+    CommonConfig commonConfig;
+
     Mono<User> userMono;
 
     @BeforeEach
     public void setup() {
         userMono = userService.findByEmail("usertest@usertest.com");
+        Mockito.when(commonConfig.isSignupDisabled()).thenReturn(Boolean.TRUE);
+        Mockito.when(commonConfig.getAdminEmails())
+                .thenReturn(Set.of("dummy_admin@appsmith.com", "dummy2@appsmith.com"));
     }
 
     @Test


### PR DESCRIPTION
## Description
> ApplicationServiceCETest is flaky in the setup, so breaking down the setup into multiple steps to pinpoint the failure.

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
