### PR TITLE
fix: `learn more` button on community templates

### DIFF
--- a/app/client/src/constants/TemplatesConstants.ts
+++ b/app/client/src/constants/TemplatesConstants.ts
@@ -1,0 +1,3 @@
+export const COMMUNITY_PORTAL = {
+  BASE_URL: "https://community.appsmith.com",
+};

--- a/app/client/src/pages/Editor/CommunityTemplates/Modals/CommunityTemplatesPublishInfo.tsx
+++ b/app/client/src/pages/Editor/CommunityTemplates/Modals/CommunityTemplatesPublishInfo.tsx
@@ -94,7 +94,14 @@ const UnPublishedAppInstructions = ({
         </Text>
       </InfoContainer>
       <InfoFooter>
-        <Button endIcon="link" kind="tertiary" size="md">
+        <Button
+          endIcon="link"
+          href="https://community.appsmith.com/library"
+          kind="tertiary"
+          renderAs="a"
+          size="md"
+          target="_blank"
+        >
           {createMessage(LEARN_MORE)}
         </Button>
         <Button

--- a/app/client/src/pages/Editor/CommunityTemplates/Modals/CommunityTemplatesPublishInfo.tsx
+++ b/app/client/src/pages/Editor/CommunityTemplates/Modals/CommunityTemplatesPublishInfo.tsx
@@ -9,6 +9,7 @@ import { Button, Icon, Text } from "design-system";
 import React, { useCallback, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
+import { COMMUNITY_PORTAL } from "constants/TemplatesConstants";
 
 interface Props {
   onPublishClick: () => void;
@@ -40,13 +41,12 @@ const CommunityTemplatesPublishInfo = ({
 };
 
 export default CommunityTemplatesPublishInfo;
-const COMMUNITY_PORTAL_BASE_URL = "https://community.appsmith.com";
 
 const PublishedAppInstructions = () => {
   const currentApplication = useSelector(getCurrentApplication);
   const onVisitTemplateClick = useCallback(() => {
     openUrlInNewPage(
-      `${COMMUNITY_PORTAL_BASE_URL}/template/${currentApplication?.id}`,
+      `${COMMUNITY_PORTAL.BASE_URL}/template/${currentApplication?.id}`,
     );
   }, [currentApplication?.id]);
 
@@ -96,7 +96,7 @@ const UnPublishedAppInstructions = ({
       <InfoFooter>
         <Button
           endIcon="link"
-          href="https://community.appsmith.com/library"
+          href={`${COMMUNITY_PORTAL.BASE_URL}/library`}
           kind="tertiary"
           renderAs="a"
           size="md"
@@ -131,7 +131,7 @@ const InfoContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
-  min-height: 250px;
+  min-height: 75px;
   padding-top: var(--ads-v2-spaces-2);
 `;
 const InfoFooter = styled.footer`


### PR DESCRIPTION
## Description
Adds link for `learn more` buttton in publish to community template modal.
#### PR fixes following issue(s)
Fixes #28218
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
![Screenshot 2023-10-19 at 1 16 18 PM](https://github.com/appsmithorg/appsmith/assets/6761673/fd981fb0-659b-4234-b195-dd33d21aabd6)


#### Type of change
- Bug fix (non-breaking change which fixes an issue)
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
