### PR TITLE
fix: Add anvil sizes to WDS Checkbox and WDS Table widgets

### DIFF
--- a/app/client/src/widgets/wds/WDSCheckboxWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCheckboxWidget/widget/index.tsx
@@ -8,6 +8,7 @@ import * as config from "./../config";
 import BaseWidget from "widgets/BaseWidget";
 import type { CheckboxWidgetProps } from "./types";
 import type { WidgetState } from "widgets/BaseWidget";
+import type { AnvilConfig } from "WidgetProvider/constants";
 
 class WDSCheckboxWidget extends BaseWidget<CheckboxWidgetProps, WidgetState> {
   static type = "WDS_CHECKBOX_WIDGET";
@@ -30,6 +31,17 @@ class WDSCheckboxWidget extends BaseWidget<CheckboxWidgetProps, WidgetState> {
 
   static getAutoLayoutConfig() {
     return {};
+  }
+
+  static getAnvilConfig(): AnvilConfig | null {
+    return {
+      widgetSize: {
+        maxHeight: {},
+        maxWidth: {},
+        minHeight: { base: "40px" },
+        minWidth: { base: "120px" },
+      },
+    };
   }
 
   static getAutocompleteDefinitions() {

--- a/app/client/src/widgets/wds/WDSTableWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSTableWidget/widget/index.tsx
@@ -122,6 +122,7 @@ import { getMemoiseTransformDataWithEditableCell } from "./reactTableUtils/trans
 import type { ExtraDef } from "utils/autocomplete/dataTreeTypeDefCreator";
 import { generateTypeDef } from "utils/autocomplete/dataTreeTypeDefCreator";
 import type {
+  AnvilConfig,
   AutocompletionDefinitions,
   PropertyUpdates,
   SnipingModeProperty,
@@ -370,6 +371,17 @@ export class WDSTableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           },
         },
       ],
+    };
+  }
+
+  static getAnvilConfig(): AnvilConfig | null {
+    return {
+      widgetSize: {
+        maxHeight: {},
+        maxWidth: {},
+        minHeight: { base: "300px" },
+        minWidth: { base: "280px" },
+      },
     };
   }
 


### PR DESCRIPTION
## Description
- Anvil needs a minHeight for widgets that occupy all of the parent's height.
- This way the bounding box assigned to the widget will be appropriate in height.

#### PR fixes following issue(s)
Fixes #28313

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

