### PR TITLE
feat: Support running as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,10 @@ RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd 
   && chmod +x *.sh templates/nginx-app.conf.sh /watchtower-hooks/*.sh \
   # Disable setuid/setgid bits for the files inside container.
   && find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true \
-  && node prepare-image.mjs
+  && node prepare-image.mjs \
+  && mkdir -p /.mongodb/mongosh /appsmith-stacks \
+  && chmod ugo+w /etc /appsmith-stacks \
+  && chmod -R ugo+w /var/lib/nginx /var/log/nginx /var/run /usr/sbin/cron /.mongodb /etc/ssl /usr/local/share
 
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+echo "Running as: $(id)"
+
 stacks_path=/appsmith-stacks
 
 export SUPERVISORD_CONF_TARGET="$TMP/supervisor-conf.d/"  # export for use in supervisord.conf
@@ -68,7 +70,7 @@ init_env_file() {
   TEMPLATES_PATH="/opt/appsmith/templates"
 
   # Build an env file with current env variables. We single-quote the values, as well as escaping any single-quote characters.
-  printenv | grep -E '^APPSMITH_|^MONGO_' | sed "s/'/'\\\''/g; s/=/='/; s/$/'/" > "$TEMPLATES_PATH/pre-define.env"
+  printenv | grep -E '^APPSMITH_|^MONGO_' | sed "s/'/'\\\''/g; s/=/='/; s/$/'/" > "$TMP/pre-define.env"
 
   echo "Initialize .env file"
   if ! [[ -e "$ENV_PATH" ]]; then
@@ -99,7 +101,7 @@ init_env_file() {
   echo "Load environment configuration"
   set -o allexport
   . "$ENV_PATH"
-  . "$TEMPLATES_PATH/pre-define.env"
+  . "$TMP/pre-define.env"
   set +o allexport
 }
 
@@ -345,7 +347,9 @@ configure_supervisord() {
       mkdir -p "$stacks_path/data/redis"
     fi
     if ! [[ -e "/appsmith-stacks/ssl/fullchain.pem" ]] || ! [[ -e "/appsmith-stacks/ssl/privkey.pem" ]]; then
-      cp "$supervisord_conf_source/cron.conf" "$SUPERVISORD_CONF_TARGET"
+      if [[ -n "${APPSMITH_CUSTOM_DOMAIN-}" ]]; then
+        cp "$supervisord_conf_source/cron.conf" "$SUPERVISORD_CONF_TARGET"
+      fi
     fi
     if [[ $runEmbeddedPostgres -eq 1 ]]; then
       cp "$supervisord_conf_source/postgres.conf" "$SUPERVISORD_CONF_TARGET"

--- a/deploy/docker/fs/opt/appsmith/renew-certificate.sh
+++ b/deploy/docker/fs/opt/appsmith/renew-certificate.sh
@@ -3,7 +3,7 @@
 set -e
 
 ENV_PATH="/appsmith-stacks/configuration/docker.env"
-PRE_DEFINED_ENV_PATH="/opt/appsmith/templates/pre-define.env"
+PRE_DEFINED_ENV_PATH="$TMP/pre-define.env"
 if [[ -f /appsmith-stacks/configuration/docker.env ]]; then
   echo 'Load environment configuration'
   set -o allexport

--- a/deploy/docker/fs/opt/appsmith/run-with-env.sh
+++ b/deploy/docker/fs/opt/appsmith/run-with-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ENV_PATH="/appsmith-stacks/configuration/docker.env"
-PRE_DEFINED_ENV_PATH="/opt/appsmith/templates/pre-define.env"
+PRE_DEFINED_ENV_PATH="$TMP/pre-define.env"
 echo 'Load environment configuration'
 set -o allexport
 . "$ENV_PATH"

--- a/deploy/docker/fs/opt/appsmith/templates/supervisord/cron.conf
+++ b/deploy/docker/fs/opt/appsmith/templates/supervisord/cron.conf
@@ -1,6 +1,5 @@
 [program:cron]
 command=/usr/sbin/cron -f
-user=root
 priority=35
 autostart=true
 autorestart=true


### PR DESCRIPTION
Running an Appsmith as a non-root user:

```sh
docker run --name appsmith --user 70:70
```

The `70:70` figures are the UID and GID respectively. It can mostly be any number, safe to user figures are 70 to 79, or anything above 200 and below 65000. The important bit, is that it shouldn't change on restart or manual updates etc.

No product functionality should be affected when running as a non-root user.
