### PR TITLE
fix: Check for parent widget existence to render drop target (#28275)

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_NestedList_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_NestedList_spec.ts
@@ -1,3 +1,4 @@
+import { WIDGET } from "../../../../../locators/WidgetLocators";
 import {
   agHelper,
   entityExplorer,
@@ -13,6 +14,14 @@ describe("Nested List widget V2 ", () => {
   });
 
   it("1. Verify only 3 levels of nesting is allowed", () => {
+    agHelper.AssertContains(
+      "Oops, Something went wrong.",
+      "not.exist",
+      locators._widgetInCanvas(WIDGET.LIST_V2),
+    );
+    agHelper
+      .GetElement(locators._widgetInCanvas(WIDGET.LIST_V2))
+      .should("have.length", 5);
     entityExplorer.SelectEntityByName("List1", "Widgets");
     entityExplorer.SelectEntityByName("Container1", "List1");
     entityExplorer.SelectEntityByName("List2", "Container1");

--- a/app/client/cypress/fixtures/listV2NestedDsl.json
+++ b/app/client/cypress/fixtures/listV2NestedDsl.json
@@ -1238,7 +1238,7 @@
                     }
                 ],
                 "displayName": "List",
-                "bottomRow": 48,
+                "bottomRow": 88,
                 "parentRowSpace": 10,
                 "hideCard": false,
                 "templateBottomRow": 16,

--- a/app/client/src/layoutSystems/common/dropTarget/DropTargetComponentWrapper.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/DropTargetComponentWrapper.tsx
@@ -3,6 +3,10 @@ import type { DropTargetComponentProps } from "layoutSystems/common/dropTarget/D
 import type { ReactNode } from "react";
 import { memo } from "react";
 import React from "react";
+import { useSelector } from "react-redux";
+import { getWidget } from "sagas/selectors";
+import type { AppState } from "@appsmith/reducers";
+import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 
 interface DropTargetComponentWrapperProps {
   dropTargetProps: DropTargetComponentProps;
@@ -22,7 +26,11 @@ export const DropTargetComponentWrapper = memo(
     dropDisabled,
     dropTargetProps,
   }: DropTargetComponentWrapperProps) => {
-    if (dropDisabled) {
+    // This code block is added exclusively to handle List Widget Meta Canvas Widget which is generated via template.
+    const widget = useSelector((state: AppState) =>
+      getWidget(state, dropTargetProps.parentId || MAIN_CONTAINER_WIDGET_ID),
+    );
+    if ((dropTargetProps.parentId && !widget) || dropDisabled) {
       //eslint-disable-next-line
       return <>{children}</>;
     }


### PR DESCRIPTION
In the legacy architecture, List Widget meta first item was rendering in edit mode allowing DnD, resize, etc while the rest of the items were rendering in view mode restricting any editing experience. The first item was being used as a template to decide what the template was going to be for rest of the items.
However after the overhaul of BaseWidget and CanvasWidget render mode is always EDIT or VIEW for all widgets so DropTarget had to render a meta canvas widget which it was not written to handle. so have added checks to make sure DropTarget does not render and wrap widgets that do not have a parent.

Ideally this should have been caught in the CI, there are tests already but the checks were happening to check if List widget was allowed inside another List widget but the other items that were rendering in view mode were not being asserted.
I have added tests to check if all nested widgets are properly rendered and there is no "Oops, something went wrong" error. This should make sure this issue does not get past CI in the future.

(cherry picked from commit 6355e7a697da9b0eaebe583c47dc752c5449b718)

> Pull Request Template
>
> Use this template to quickly create a well written pull request. Delete all quotes before creating the pull request.
>
## Description
> Add a TL;DR when description is extra long (helps content team)
>
> Please include a summary of the changes and which issue has been fixed. Please also include relevant motivation
> and context. List any dependencies that are required for this change
>
> Links to Notion, Figma or any other documents that might be relevant to the PR
>
>
#### PR fixes following issue(s)
Fixes # (issue number)
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
