### PR TITLE
chore: Refactored import and export svc methods for modularity

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/exports/ActionCollectionExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/exports/ActionCollectionExportableServiceCEImpl.java
@@ -36,8 +36,11 @@ public class ActionCollectionExportableServiceCEImpl implements ExportableServic
         this.actionPermission = actionPermission;
     }
 
+    // Requires pageIdToNameMap, pluginMap.
+    // Updates collectionId to name map in exportable resources. Also directly updates required collection information
+    // in application json
     @Override
-    public Mono<List<ActionCollection>> getExportableEntities(
+    public Mono<Void> getExportableEntities(
             ExportingMetaDTO exportingMetaDTO,
             MappedExportableResourcesDTO mappedExportableResourcesDTO,
             Mono<Application> applicationMono,
@@ -94,7 +97,8 @@ public class ActionCollectionExportableServiceCEImpl implements ExportableServic
                             .put(FieldName.ACTION_COLLECTION_LIST, updatedActionCollectionSet);
 
                     return actionCollections;
-                });
+                })
+                .then();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/imports/ActionCollectionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/imports/ActionCollectionImportableServiceCEImpl.java
@@ -44,8 +44,11 @@ public class ActionCollectionImportableServiceCEImpl implements ImportableServic
         this.repository = repository;
     }
 
+    // Requires pageNameMap, pageNameToOldNameMap, pluginMap and actionResultDTO to be present in importable resources.
+    // Updates actionCollectionResultDTO in importable resources.
+    // Also directly updates required information in DB
     @Override
-    public Mono<List<ActionCollection>> importEntities(
+    public Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
@@ -61,7 +64,7 @@ public class ActionCollectionImportableServiceCEImpl implements ImportableServic
 
         return importActionCollectionMono
                 .doOnNext(mappedImportableResourcesDTO::setActionCollectionResultDTO)
-                .thenReturn(List.of());
+                .then();
     }
 
     private Mono<ImportActionCollectionResultDTO> createImportActionCollectionMono(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/imports/DatasourceImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/imports/DatasourceImportableServiceCEImpl.java
@@ -52,8 +52,11 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
         this.sequenceService = sequenceService;
     }
 
+    // Requires pluginMap to be present in importable resources.
+    // Updates datasourceNameToIdMap in importable resources.
+    // Also directly updates required information in DB
     @Override
-    public Mono<List<Datasource>> importEntities(
+    public Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
@@ -74,10 +77,9 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
                     importingMetaDTO,
                     mappedImportableResourcesDTO);
 
-            return datasourceMapMono.map(datasourceMap -> {
-                mappedImportableResourcesDTO.setDatasourceNameToIdMap(datasourceMap);
-                return List.of();
-            });
+            return datasourceMapMono
+                    .doOnNext(mappedImportableResourcesDTO::setDatasourceNameToIdMap)
+                    .then();
         });
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/exportable/ExportableServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/exportable/ExportableServiceCE.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 public interface ExportableServiceCE<T extends BaseDomain> {
 
-    Mono<List<T>> getExportableEntities(
+    Mono<Void> getExportableEntities(
             ExportingMetaDTO exportingMetaDTO,
             MappedExportableResourcesDTO mappedExportableResourcesDTO,
             Mono<Application> applicationMono,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportApplicationServiceCEImpl.java
@@ -143,35 +143,16 @@ public class ExportApplicationServiceCEImpl implements ExportApplicationServiceC
 
                     exportingMetaDTO.setUnpublishedPages(unpublishedPages);
 
-                    return pluginExportableService
-                            .getExportableEntities(
-                                    exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson)
-                            .then(themeExportableService.getExportableEntities(
-                                    exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson))
-                            .then(newPageExportableService.getExportableEntities(
-                                    exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson))
-                            .then(datasourceExportableService.getExportableEntities(
-                                    exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson))
-                            .then(actionCollectionExportableService.getExportableEntities(
-                                    exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson))
-                            .then(newActionExportableService.getExportableEntities(
-                                    exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson))
-                            .then(customJSLibExportableService.getExportableEntities(
-                                    exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson))
-                            .map(newActions -> {
-                                datasourceExportableService.sanitizeEntities(
-                                        exportingMetaDTO, mappedResourcesDTO, applicationJson, serialiseFor);
-
-                                newPageExportableService.sanitizeEntities(
-                                        exportingMetaDTO, mappedResourcesDTO, applicationJson, serialiseFor);
-
+                    return getExportableEntities(exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson)
+                            .then(sanitizeEntities(serialiseFor, applicationJson, mappedResourcesDTO, exportingMetaDTO))
+                            .then(Mono.fromCallable(() -> {
                                 application.makePristine();
                                 application.sanitiseToExportDBObject();
                                 // Disable exporting the application with datasource config once imported in destination
                                 // instance
                                 application.setExportWithConfiguration(null);
                                 return applicationJson;
-                            });
+                            }));
                 })
                 .then(sessionUserService.getCurrentUser())
                 .map(user -> {
@@ -196,6 +177,96 @@ public class ExportApplicationServiceCEImpl implements ExportApplicationServiceC
                 .then(applicationMono)
                 .map(application -> sendImportExportApplicationAnalyticsEvent(application, AnalyticsEvents.EXPORT))
                 .thenReturn(applicationJson);
+    }
+
+    private Mono<Void> sanitizeEntities(
+            SerialiseApplicationObjective serialiseFor,
+            ApplicationJson applicationJson,
+            MappedExportableResourcesDTO mappedResourcesDTO,
+            ExportingMetaDTO exportingMetaDTO) {
+        datasourceExportableService.sanitizeEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationJson, serialiseFor);
+
+        newPageExportableService.sanitizeEntities(exportingMetaDTO, mappedResourcesDTO, applicationJson, serialiseFor);
+
+        return Mono.empty().then();
+    }
+
+    private Mono<Void> getExportableEntities(
+            ExportingMetaDTO exportingMetaDTO,
+            MappedExportableResourcesDTO mappedResourcesDTO,
+            Mono<Application> applicationMono,
+            ApplicationJson applicationJson) {
+
+        // The idea with both these methods is that any amount of overriding should take care of whether they want to
+        // zip the additional exportables along with these or sequence them, or combine them using any other logic
+        return Mono.zip(
+                        getPageIndependentExportables(
+                                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson),
+                        objects -> objects)
+                .then(Mono.zip(
+                        getPageDependentExportables(
+                                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson),
+                        objects -> objects))
+                .then();
+    }
+
+    protected List<Mono<Void>> getPageIndependentExportables(
+            ExportingMetaDTO exportingMetaDTO,
+            MappedExportableResourcesDTO mappedResourcesDTO,
+            Mono<Application> applicationMono,
+            ApplicationJson applicationJson) {
+        // Updates plugin map in exportable resources
+        Mono<Void> pluginExportablesMono = pluginExportableService.getExportableEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson);
+
+        // Directly updates required theme information in application json
+        Mono<Void> themeExportablesMono = themeExportableService.getExportableEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson);
+
+        // Updates pageId to name map in exportable resources.
+        // Also directly updates required pages information in application json
+        Mono<Void> newPageExportablesMono = newPageExportableService.getExportableEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson);
+
+        // Updates datasourceId to name map in exportable resources.
+        // Also directly updates required datasources information in application json
+        Mono<Void> datasourceExportablesMono = datasourceExportableService.getExportableEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson);
+
+        // Directly sets required custom JS lib information in application JSON
+        Mono<Void> customJsLibsExportablesMono = customJSLibExportableService.getExportableEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson);
+
+        return List.of(
+                pluginExportablesMono,
+                datasourceExportablesMono,
+                themeExportablesMono,
+                newPageExportablesMono,
+                customJsLibsExportablesMono);
+    }
+
+    protected List<Mono<Void>> getPageDependentExportables(
+            ExportingMetaDTO exportingMetaDTO,
+            MappedExportableResourcesDTO mappedResourcesDTO,
+            Mono<Application> applicationMono,
+            ApplicationJson applicationJson) {
+
+        // Requires pageIdToNameMap, pluginMap.
+        // Updates collectionId to name map in exportable resources.
+        // Also directly updates required collection information in application json
+        Mono<Void> actionCollectionExportablesMono = actionCollectionExportableService.getExportableEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson);
+
+        // Requires datasourceIdToNameMap, pageIdToNameMap, pluginMap, collectionIdToNameMap
+        // Updates actionId to name map in exportable resources.
+        // Also directly updates required collection information in application json
+        Mono<Void> newActionExportablesMono = newActionExportableService.getExportableEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationMono, applicationJson);
+
+        Mono<Void> combinedActionExportablesMono = actionCollectionExportablesMono.then(newActionExportablesMono);
+
+        return List.of(combinedActionExportablesMono);
     }
 
     public Mono<ApplicationJson> exportApplicationById(String applicationId, String branchName) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/ImportableServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/ImportableServiceCE.java
@@ -8,11 +8,9 @@ import com.appsmith.server.dtos.ImportingMetaDTO;
 import com.appsmith.server.dtos.MappedImportableResourcesDTO;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
-
 public interface ImportableServiceCE<T extends BaseDomain> {
 
-    Mono<List<T>> importEntities(
+    Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exports/CustomJSLibExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exports/CustomJSLibExportableServiceCEImpl.java
@@ -63,7 +63,6 @@ public class CustomJSLibExportableServiceCEImpl implements ExportableServiceCE<C
                                 .map(lib -> lib.getUidString())
                                 .collect(Collectors.toSet());
                     }
-
                     applicationJson.getUpdatedResources().put(FieldName.CUSTOM_JS_LIB_LIST, updatedCustomJSLibSet);
 
                     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exports/CustomJSLibExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exports/CustomJSLibExportableServiceCEImpl.java
@@ -26,8 +26,9 @@ public class CustomJSLibExportableServiceCEImpl implements ExportableServiceCE<C
         this.customJSLibService = customJSLibService;
     }
 
+    // Directly sets required custom JS lib information in application JSON
     @Override
-    public Mono<List<CustomJSLib>> getExportableEntities(
+    public Mono<Void> getExportableEntities(
             ExportingMetaDTO exportingMetaDTO,
             MappedExportableResourcesDTO mappedExportableResourcesDTO,
             Mono<Application> applicationMono,
@@ -73,6 +74,7 @@ public class CustomJSLibExportableServiceCEImpl implements ExportableServiceCE<C
                     Collections.sort(unpublishedCustomJSLibList, Comparator.comparing(CustomJSLib::getUidString));
                     applicationJson.setCustomJSLibList(unpublishedCustomJSLibList);
                     return unpublishedCustomJSLibList;
-                });
+                })
+                .then();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/imports/CustomJSLibImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/imports/CustomJSLibImportableServiceCEImpl.java
@@ -24,8 +24,9 @@ public class CustomJSLibImportableServiceCEImpl implements ImportableServiceCE<C
         this.customJSLibService = customJSLibService;
     }
 
+    // Persists relevant information and updates mapped resources
     @Override
-    public Mono<List<CustomJSLib>> importEntities(
+    public Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
@@ -46,15 +47,10 @@ public class CustomJSLibImportableServiceCEImpl implements ImportableServiceCE<C
                     return customJSLibService.persistCustomJSLibMetaDataIfDoesNotExistAndGetDTO(customJSLib, false);
                 })
                 .collectList()
-                .map(customJSLibApplicationDTOS -> {
-                    mappedImportableResourcesDTO.setInstalledJsLibsList(customJSLibApplicationDTOS);
-                    return List.<CustomJSLib>of();
-                })
+                .doOnNext(mappedImportableResourcesDTO::setInstalledJsLibsList)
                 .elapsed()
-                .map(objects -> {
-                    log.debug("time to import custom jslibs: {}", objects.getT1());
-                    return objects.getT2();
-                })
+                .doOnNext(objects -> log.debug("time to import custom jslibs: {}", objects.getT1()))
+                .then()
                 .onErrorResume(e -> {
                     log.error("Error importing custom jslibs", e);
                     return Mono.error(e);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exports/NewActionExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exports/NewActionExportableServiceCEImpl.java
@@ -37,8 +37,11 @@ public class NewActionExportableServiceCEImpl implements ExportableServiceCE<New
         this.actionPermission = actionPermission;
     }
 
+    // Requires datasourceIdToNameMap, pageIdToNameMap, pluginMap, collectionIdToNameMap
+    // Updates actionId to name map in exportable resources. Also directly updates required collection information in
+    // application json
     @Override
-    public Mono<List<NewAction>> getExportableEntities(
+    public Mono<Void> getExportableEntities(
             ExportingMetaDTO exportingMetaDTO,
             MappedExportableResourcesDTO mappedExportableResourcesDTO,
             Mono<Application> applicationMono,
@@ -101,7 +104,8 @@ public class NewActionExportableServiceCEImpl implements ExportableServiceCE<New
                             .removeIf(datasource -> !dbNamesUsedInActions.contains(datasource.getName()));
 
                     return actionList;
-                });
+                })
+                .then();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
@@ -56,8 +56,12 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
         this.actionCollectionService = actionCollectionService;
     }
 
+    // Requires pageNameMap, pageNameToOldNameMap, pluginMap and datasourceNameToIdMap to be present in importable
+    // resources.
+    // Updates actionResultDTO in importable resources.
+    // Also directly updates required information in DB
     @Override
-    public Mono<List<NewAction>> importEntities(
+    public Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
@@ -124,7 +128,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                     log.error("Error while importing actions and deleting unused ones", throwable);
                     return Mono.error(throwable);
                 })
-                .thenReturn(List.of());
+                .then();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/exports/NewPageExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/exports/NewPageExportableServiceCEImpl.java
@@ -17,7 +17,6 @@ import org.apache.commons.collections.CollectionUtils;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -111,11 +110,8 @@ public class NewPageExportableServiceCEImpl implements ExportableServiceCE<NewPa
                         newPage.sanitiseToExportDBObject();
                     });
                     applicationJson.setPageList(newPageList);
-                    applicationJson.setUpdatedResources(new HashMap<>() {
-                        {
-                            put(FieldName.PAGE_LIST, updatedPageSet);
-                        }
-                    });
+                    applicationJson.getUpdatedResources().put(FieldName.PAGE_LIST, updatedPageSet);
+
                     return newPageList;
                 })
                 .then();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/exports/NewPageExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/exports/NewPageExportableServiceCEImpl.java
@@ -37,8 +37,10 @@ public class NewPageExportableServiceCEImpl implements ExportableServiceCE<NewPa
         this.pagePermission = pagePermission;
     }
 
+    // Updates pageId to name map in exportable resources. Also directly updates required pages information in
+    // application json
     @Override
-    public Mono<List<NewPage>> getExportableEntities(
+    public Mono<Void> getExportableEntities(
             ExportingMetaDTO exportingMetaDTO,
             MappedExportableResourcesDTO mappedExportableResourcesDTO,
             Mono<Application> applicationMono,
@@ -115,7 +117,8 @@ public class NewPageExportableServiceCEImpl implements ExportableServiceCE<NewPa
                         }
                     });
                     return newPageList;
-                });
+                })
+                .then();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/imports/NewPageImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/imports/NewPageImportableServiceCEImpl.java
@@ -60,8 +60,10 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
         this.newActionService = newActionService;
     }
 
+    // Updates pageNametoIdMap and pageNameMap in importable resources.
+    // Also directly updates required information in DB
     @Override
-    public Mono<List<NewPage>> importEntities(
+    public Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
@@ -104,7 +106,7 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
                         mappedImportableResourcesDTO)
                 .cache();
 
-        return updatedApplicationMono.then(importedNewPagesMono).map(Tuple2::getT1);
+        return updatedApplicationMono.then(importedNewPagesMono).then();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onpageload/internal/PageLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onpageload/internal/PageLoadExecutablesUtilCEImpl.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -102,7 +101,7 @@ public class PageLoadExecutablesUtilCEImpl implements PageLoadExecutablesUtilCE 
 
         Set<String> onPageLoadExecutableSetRef = new HashSet<>();
         Set<String> explicitUserSetOnLoadExecutablesRef = new HashSet<>();
-        Set<String> bindingsFromExecutablesRef = ConcurrentHashMap.newKeySet();
+        Set<String> bindingsFromExecutablesRef = new HashSet<>();
 
         // Function `extractAndSetExecutableBindingsInGraphEdges` updates this map to keep a track of all the
         // executables which
@@ -856,8 +855,9 @@ public class PageLoadExecutablesUtilCEImpl implements PageLoadExecutablesUtilCE 
         }
 
         // All executables found from possibleExecutableNames set would add their dependencies in the following set for
-        // further walk to find more executables recursively.
-        Set<String> newBindings = ConcurrentHashMap.newKeySet();
+        // further
+        // walk to find more executables recursively.
+        Set<String> newBindings = new HashSet<>();
 
         // First fetch all the executables in the page whose name matches the words found in all the dynamic bindings
         Mono<List<EntityDependencyNode>> findAndAddExecutablesInBindingsMono = getPossibleEntityReferences(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onpageload/internal/PageLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onpageload/internal/PageLoadExecutablesUtilCEImpl.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -101,7 +102,7 @@ public class PageLoadExecutablesUtilCEImpl implements PageLoadExecutablesUtilCE 
 
         Set<String> onPageLoadExecutableSetRef = new HashSet<>();
         Set<String> explicitUserSetOnLoadExecutablesRef = new HashSet<>();
-        Set<String> bindingsFromExecutablesRef = new HashSet<>();
+        Set<String> bindingsFromExecutablesRef = ConcurrentHashMap.newKeySet();
 
         // Function `extractAndSetExecutableBindingsInGraphEdges` updates this map to keep a track of all the
         // executables which
@@ -855,9 +856,8 @@ public class PageLoadExecutablesUtilCEImpl implements PageLoadExecutablesUtilCE 
         }
 
         // All executables found from possibleExecutableNames set would add their dependencies in the following set for
-        // further
-        // walk to find more executables recursively.
-        Set<String> newBindings = new HashSet<>();
+        // further walk to find more executables recursively.
+        Set<String> newBindings = ConcurrentHashMap.newKeySet();
 
         // First fetch all the executables in the page whose name matches the words found in all the dynamic bindings
         Mono<List<EntityDependencyNode>> findAndAddExecutablesInBindingsMono = getPossibleEntityReferences(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/exports/PluginExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/exports/PluginExportableServiceCEImpl.java
@@ -27,8 +27,9 @@ public class PluginExportableServiceCEImpl implements ExportableServiceCE<Plugin
         this.workspaceService = workspaceService;
     }
 
+    // Updates plugin map in exportable resources
     @Override
-    public Mono<List<Plugin>> getExportableEntities(
+    public Mono<Void> getExportableEntities(
             ExportingMetaDTO exportingMetaDTO,
             MappedExportableResourcesDTO mappedExportableResourcesDTO,
             Mono<Application> applicationMono,
@@ -49,6 +50,7 @@ public class PluginExportableServiceCEImpl implements ExportableServiceCE<Plugin
                                     plugin.getPluginName() == null ? plugin.getPackageName() : plugin.getPluginName());
                     return plugin;
                 })
-                .collectList();
+                .collectList()
+                .then();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/imports/PluginImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/imports/PluginImportableServiceCEImpl.java
@@ -26,8 +26,9 @@ public class PluginImportableServiceCEImpl implements ImportableServiceCE<Plugin
         this.pluginService = pluginService;
     }
 
+    // Updates plugin map in importable resources
     @Override
-    public Mono<List<Plugin>> importEntities(
+    public Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
@@ -50,9 +51,7 @@ public class PluginImportableServiceCEImpl implements ImportableServiceCE<Plugin
                 })
                 .collectList()
                 .elapsed()
-                .map(tuples -> {
-                    log.debug("time to get plugin map: {}", tuples.getT1());
-                    return tuples.getT2();
-                });
+                .doOnNext(tuples -> log.debug("time to get plugin map: {}", tuples.getT1()))
+                .then();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/imports/ThemeImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/imports/ThemeImportableServiceCEImpl.java
@@ -16,8 +16,6 @@ import com.appsmith.server.themes.base.ThemeService;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
-
 import static com.appsmith.server.acl.AclPermission.MANAGE_THEMES;
 
 public class ThemeImportableServiceCEImpl implements ImportableServiceCE<Theme> {
@@ -52,7 +50,7 @@ public class ThemeImportableServiceCEImpl implements ImportableServiceCE<Theme> 
      * @return Updated application that has editModeThemeId and publishedModeThemeId set
      */
     @Override
-    public Mono<List<Theme>> importEntities(
+    public Mono<Void> importEntities(
             ImportingMetaDTO importingMetaDTO,
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
@@ -60,7 +58,7 @@ public class ThemeImportableServiceCEImpl implements ImportableServiceCE<Theme> 
             ApplicationJson applicationJson) {
         if (Boolean.TRUE.equals(importingMetaDTO.getAppendToApp())) {
             // appending to existing app, theme should not change
-            return Mono.just(List.of());
+            return Mono.empty().then();
         }
         return applicationMono.flatMap(destinationApp -> {
             Mono<Theme> editModeTheme = updateExistingAppThemeFromJSON(
@@ -86,7 +84,7 @@ public class ThemeImportableServiceCEImpl implements ImportableServiceCE<Theme> 
                                         editModeThemeId,
                                         publishedModeThemeId,
                                         applicationPermission.getEditPermission())
-                                .thenReturn(List.<Theme>of());
+                                .then();
                     })
                     .switchIfEmpty(Mono.error(
                             new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Failed to import theme")));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/imports/ThemeImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/imports/ThemeImportableServiceCEImpl.java
@@ -6,8 +6,6 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.ImportingMetaDTO;
 import com.appsmith.server.dtos.MappedImportableResourcesDTO;
-import com.appsmith.server.exceptions.AppsmithError;
-import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.imports.importable.ImportableServiceCE;
 import com.appsmith.server.repositories.ThemeRepository;
 import com.appsmith.server.services.ApplicationService;
@@ -46,7 +44,7 @@ public class ThemeImportableServiceCEImpl implements ImportableServiceCE<Theme> 
      * - If current theme is a customized one and source theme is system theme, set the current theme to system and delete the old one
      * - If current theme is system theme, update the current theme as per source theme
      *
-     * @param applicationJson     ApplicationJSON from file or Git
+     * @param applicationJson ApplicationJSON from file or Git
      * @return Updated application that has editModeThemeId and publishedModeThemeId set
      */
     @Override
@@ -76,18 +74,13 @@ public class ThemeImportableServiceCEImpl implements ImportableServiceCE<Theme> 
                         destinationApp.setEditModeThemeId(editModeThemeId);
                         destinationApp.setPublishedModeThemeId(publishedModeThemeId);
                         // this will update the theme id in DB
-                        // also returning the updated application object so that theme id are available to the next
-                        // pipeline
-                        return applicationService
-                                .setAppTheme(
-                                        destinationApp.getId(),
-                                        editModeThemeId,
-                                        publishedModeThemeId,
-                                        applicationPermission.getEditPermission())
-                                .then();
+                        return applicationService.setAppTheme(
+                                destinationApp.getId(),
+                                editModeThemeId,
+                                publishedModeThemeId,
+                                applicationPermission.getEditPermission());
                     })
-                    .switchIfEmpty(Mono.error(
-                            new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Failed to import theme")));
+                    .then();
         });
     }
 


### PR DESCRIPTION
Breaks down all the exportable and importable methods into structured calls to parallelize where possible, and enable overriding.