### PR TITLE
chore: Fixes imported action refs getting reset to null in layouts

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/imports/ActionCollectionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/imports/ActionCollectionImportableServiceCEImpl.java
@@ -77,6 +77,7 @@ public class ActionCollectionImportableServiceCEImpl implements ImportableServic
         if (importingMetaDTO.getAppendToApp()) {
             importedActionCollectionMono = importedActionCollectionMono.map(importedActionCollectionList1 -> {
                 List<NewPage> importedNewPages = mappedImportableResourcesDTO.getPageNameMap().values().stream()
+                        .distinct()
                         .toList();
                 Map<String, String> newToOldNameMap = mappedImportableResourcesDTO.getNewPageNameToOldPageNameMap();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
@@ -74,6 +74,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
         if (Boolean.TRUE.equals(importingMetaDTO.getAppendToApp())) {
             importedNewActionMono = importedNewActionMono.map(importedNewActionList1 -> {
                 List<NewPage> importedNewPages = mappedImportableResourcesDTO.getPageNameMap().values().stream()
+                        .distinct()
                         .toList();
                 Map<String, String> newToOldNameMap = mappedImportableResourcesDTO.getNewPageNameToOldPageNameMap();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/imports/NewPageImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/imports/NewPageImportableServiceCEImpl.java
@@ -119,8 +119,9 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
                 mappedImportableResourcesDTO.getActionAndCollectionMapsDTO();
 
         ImportActionResultDTO importActionResultDTO = mappedImportableResourcesDTO.getActionResultDTO();
-        List<NewPage> newPages =
-                mappedImportableResourcesDTO.getPageNameMap().values().stream().toList();
+        List<NewPage> newPages = mappedImportableResourcesDTO.getPageNameMap().values().stream()
+                .distinct()
+                .toList();
         return Flux.fromIterable(newPages)
                 .flatMap(newPage -> {
                     if (newPage.getDefaultResources() != null) {
@@ -566,65 +567,57 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
             Map<String, List<String>> unpublishedActionIdToCollectionIdsMap,
             Map<String, List<String>> publishedActionIdToCollectionIdsMap) {
 
-        return Mono.just(newPage)
-                .flatMap(page -> {
-                    return newActionService
-                            .findAllById(getLayoutOnLoadActionsForPage(
-                                    page,
-                                    actionIdMap,
-                                    unpublishedActionIdToCollectionIdsMap,
-                                    publishedActionIdToCollectionIdsMap))
-                            .map(newAction -> {
-                                final String defaultActionId =
-                                        newAction.getDefaultResources().getActionId();
-                                if (page.getUnpublishedPage().getLayouts() != null) {
-                                    final String defaultCollectionId = newAction
-                                            .getUnpublishedAction()
-                                            .getDefaultResources()
-                                            .getCollectionId();
-                                    page.getUnpublishedPage().getLayouts().forEach(layout -> {
-                                        if (layout.getLayoutOnLoadActions() != null) {
-                                            layout.getLayoutOnLoadActions()
-                                                    .forEach(onLoadAction -> onLoadAction.stream()
-                                                            .filter(actionDTO -> StringUtils.equals(
-                                                                    actionDTO.getId(), newAction.getId()))
-                                                            .forEach(actionDTO -> {
-                                                                actionDTO.setDefaultActionId(defaultActionId);
-                                                                actionDTO.setDefaultCollectionId(defaultCollectionId);
-                                                            }));
-                                        }
-                                    });
-                                }
+        Set<String> layoutOnLoadActionsForPage = getLayoutOnLoadActionsForPage(
+                newPage, actionIdMap, unpublishedActionIdToCollectionIdsMap, publishedActionIdToCollectionIdsMap);
 
-                                if (page.getPublishedPage() != null
-                                        && page.getPublishedPage().getLayouts() != null) {
-                                    page.getPublishedPage().getLayouts().forEach(layout -> {
-                                        if (layout.getLayoutOnLoadActions() != null) {
-                                            layout.getLayoutOnLoadActions()
-                                                    .forEach(onLoadAction -> onLoadAction.stream()
-                                                            .filter(actionDTO -> StringUtils.equals(
-                                                                    actionDTO.getId(), newAction.getId()))
-                                                            .forEach(actionDTO -> {
-                                                                actionDTO.setDefaultActionId(defaultActionId);
-                                                                if (newAction.getPublishedAction() != null
-                                                                        && newAction
-                                                                                        .getPublishedAction()
-                                                                                        .getDefaultResources()
-                                                                                != null) {
-                                                                    actionDTO.setDefaultCollectionId(newAction
-                                                                            .getPublishedAction()
-                                                                            .getDefaultResources()
-                                                                            .getCollectionId());
-                                                                }
-                                                            }));
-                                        }
-                                    });
-                                }
-                                return newAction;
-                            })
-                            .collectList()
-                            .thenReturn(page);
+        return newActionService
+                .findAllById(layoutOnLoadActionsForPage)
+                .map(newAction -> {
+                    final String defaultActionId =
+                            newAction.getDefaultResources().getActionId();
+                    if (newPage.getUnpublishedPage().getLayouts() != null) {
+                        final String defaultCollectionId = newAction
+                                .getUnpublishedAction()
+                                .getDefaultResources()
+                                .getCollectionId();
+                        newPage.getUnpublishedPage().getLayouts().forEach(layout -> {
+                            if (layout.getLayoutOnLoadActions() != null) {
+                                layout.getLayoutOnLoadActions().forEach(onLoadAction -> onLoadAction.stream()
+                                        .filter(actionDTO -> StringUtils.equals(actionDTO.getId(), newAction.getId()))
+                                        .forEach(actionDTO -> {
+                                            actionDTO.setDefaultActionId(defaultActionId);
+                                            actionDTO.setDefaultCollectionId(defaultCollectionId);
+                                        }));
+                            }
+                        });
+                    }
+
+                    if (newPage.getPublishedPage() != null
+                            && newPage.getPublishedPage().getLayouts() != null) {
+                        newPage.getPublishedPage().getLayouts().forEach(layout -> {
+                            if (layout.getLayoutOnLoadActions() != null) {
+                                layout.getLayoutOnLoadActions().forEach(onLoadAction -> onLoadAction.stream()
+                                        .filter(actionDTO -> StringUtils.equals(actionDTO.getId(), newAction.getId()))
+                                        .forEach(actionDTO -> {
+                                            actionDTO.setDefaultActionId(defaultActionId);
+                                            if (newAction.getPublishedAction() != null
+                                                    && newAction
+                                                                    .getPublishedAction()
+                                                                    .getDefaultResources()
+                                                            != null) {
+                                                actionDTO.setDefaultCollectionId(newAction
+                                                        .getPublishedAction()
+                                                        .getDefaultResources()
+                                                        .getCollectionId());
+                                            }
+                                        }));
+                            }
+                        });
+                    }
+                    return newAction;
                 })
+                .collectList()
+                .thenReturn(newPage)
                 .onErrorResume(error -> {
                     log.error("Error while updating action collection id in page layout", error);
                     return Mono.error(error);
@@ -643,7 +636,8 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
                 if (layout.getLayoutOnLoadActions() != null) {
                     layout.getLayoutOnLoadActions()
                             .forEach(onLoadAction -> onLoadAction.forEach(actionDTO -> {
-                                actionDTO.setId(actionIdMap.get(actionDTO.getId()));
+                                String oldActionDTOId = actionDTO.getId();
+                                actionDTO.setId(actionIdMap.get(oldActionDTOId));
                                 if (!CollectionUtils.sizeIsEmpty(unpublishedActionIdToCollectionIdsMap)
                                         && !CollectionUtils.isEmpty(
                                                 unpublishedActionIdToCollectionIdsMap.get(actionDTO.getId()))) {
@@ -663,7 +657,8 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
                 if (layout.getLayoutOnLoadActions() != null) {
                     layout.getLayoutOnLoadActions()
                             .forEach(onLoadAction -> onLoadAction.forEach(actionDTO -> {
-                                actionDTO.setId(actionIdMap.get(actionDTO.getId()));
+                                String oldActionDTOId = actionDTO.getId();
+                                actionDTO.setId(actionIdMap.get(oldActionDTOId));
                                 if (!CollectionUtils.sizeIsEmpty(publishedActionIdToCollectionIdsMap)
                                         && !CollectionUtils.isEmpty(
                                                 publishedActionIdToCollectionIdsMap.get(actionDTO.getId()))) {


### PR DESCRIPTION
Since pageMap contains duplicates from unpublished and published pages, any computation done on top of it needs to use only the distinct list from the value set of this map. This fix ensures we use distinct object references only.


Fixes #28377 