### PR TITLE
fix: Feature/iframe dynamic visibility (2nd attempt)

### DIFF
--- a/app/client/src/widgets/IframeWidget/widget/index.tsx
+++ b/app/client/src/widgets/IframeWidget/widget/index.tsx
@@ -53,6 +53,7 @@ class IframeWidget extends BaseWidget<IframeWidgetProps, WidgetState> {
       widgetName: "Iframe",
       version: 1,
       animateLoading: true,
+      isVisible: true,
       responsiveBehavior: ResponsiveBehavior.Fill,
       flexVerticalAlignment: FlexVerticalAlignment.Top,
     };
@@ -180,6 +181,17 @@ class IframeWidget extends BaseWidget<IframeWidgetProps, WidgetState> {
             label: "Animate loading",
             controlType: "SWITCH",
             helpText: "Controls the loading of the widget",
+            defaultValue: true,
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: { type: ValidationTypes.BOOLEAN },
+          },
+          {
+            propertyName: "isVisible",
+            label: "Visible",
+            controlType: "SWITCH",
+            helpText: "Controls the visibility of the widget",
             defaultValue: true,
             isJSConvertible: true,
             isBindProperty: true,
@@ -359,6 +371,7 @@ class IframeWidget extends BaseWidget<IframeWidgetProps, WidgetState> {
       borderColor,
       borderOpacity,
       borderWidth,
+      isVisible,
       renderMode,
       source,
       srcDoc,
@@ -374,6 +387,7 @@ class IframeWidget extends BaseWidget<IframeWidgetProps, WidgetState> {
         borderRadius={this.props.borderRadius}
         borderWidth={borderWidth}
         boxShadow={this.props.boxShadow}
+        isVisible={isVisible}
         onMessageReceived={this.handleMessageReceive}
         onSrcDocChanged={this.handleSrcDocChange}
         onURLChanged={this.handleUrlChange}


### PR DESCRIPTION

## Description
> This is a second attempt to add an "isVisible" property to the iframe widget. The first attempt (PR: #28243) became too messy due to rebasing. 
>
> In this current PR, an "isVisible" property is added to the iframe widget, consistent with how other widgets work. 
>
>
#### PR fixes following issue(s)
Fixes #27991 
>
>
#### Media

>
![Firefox - My first application - Editor - Appsmith 2023-10-26 at 7 37 25 PM](https://github.com/appsmithorg/appsmith/assets/99446612/c1a49f5b-c7ff-4c0f-a718-c2f0e3110f75)

>
#### Type of change
> Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
>
>
#### Test Plan
>
>
#### Issues raised during DP testing
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
