### PR TITLE
ci: Disable perf tests on CI

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -19,7 +19,6 @@ jobs:
             Workflow: `${{ github.workflow }}`.
             Commit: `${{ github.event.client_payload.slash_command.args.named.sha }}`.
             PR: ${{ github.event.client_payload.pull_request.number }}.
-            Perf tests will be available at <https://app.appsmith.com/app/performance-infra-dashboard/pr-details-638dd7cd2913ba43778b915e?pr=${{ github.event.client_payload.pull_request.number }}&runId=${{ github.run_id }}_${{github.run_attempt}}>
 
   server-build:
     name: server-build
@@ -71,18 +70,8 @@ jobs:
     with:
       pr: ${{ github.event.client_payload.pull_request.number }}
 
-  perf-test:
-    needs: [build-docker-image]
-    # Only run if the build step is successful
-    if: success()
-    name: perf-test
-    uses: ./.github/workflows/perf-test.yml
-    secrets: inherit
-    with:
-      pr: ${{ github.event.client_payload.pull_request.number }}
-
   ci-test-result:
-    needs: [ci-test, perf-test]
+    needs: [ci-test]
     # Only run if the ci-test with matrices step is successful
     if: always()
     runs-on: ubuntu-latest
@@ -287,7 +276,7 @@ jobs:
         run: echo "$PAYLOAD_CONTEXT"
 
       - name: Check ci-test set status
-        if: needs.ci-test.result != 'success' || needs.perf-test.result != 'success'
+        if: needs.ci-test.result != 'success'
         run: exit 1
 
   package:

--- a/.github/workflows/integration-tests-with-documentdb-command.yml
+++ b/.github/workflows/integration-tests-with-documentdb-command.yml
@@ -19,7 +19,6 @@ jobs:
             Workflow: `${{ github.workflow }}`.
             Commit: `${{ github.event.client_payload.slash_command.args.named.sha }}`.
             PR: ${{ github.event.client_payload.pull_request.number }}.
-            Perf tests will be available at <https://app.appsmith.com/app/performance-infra-dashboard/pr-details-638dd7cd2913ba43778b915e?pr=${{ github.event.client_payload.pull_request.number }}&runId=${{ github.run_id }}_${{github.run_attempt}}>
 
   server-build:
     name: server-build
@@ -71,18 +70,9 @@ jobs:
     with:
       pr: ${{ github.event.client_payload.pull_request.number }}
 
-  perf-test:
-    needs: [build-docker-image]
-    # Only run if the build step is successful
-    if: success()
-    name: perf-test-on-documentdb
-    uses: ./.github/workflows/perf-test-on-documentdb.yml
-    secrets: inherit
-    with:
-      pr: ${{ github.event.client_payload.pull_request.number }}
 
   ci-test-result:
-    needs: [ci-test, perf-test]
+    needs: [ci-test]
     # Only run if the ci-test with matrices step is successful
     if: always()
     runs-on: ubuntu-latest
@@ -261,7 +251,7 @@ jobs:
         run: echo "$PAYLOAD_CONTEXT"
 
       - name: Check ci-test set status
-        if: needs.ci-test.result != 'success' || needs.perf-test.result != 'success'
+        if: needs.ci-test.result != 'success'
         run: exit 1
 
   package:

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -45,16 +45,6 @@ jobs:
     with:
       pr: 0
 
-  perf-test:
-    needs: [build-docker-image]
-    # Only run if the build step is successful
-    if: success()
-    name: perf-test
-    uses: ./.github/workflows/perf-test.yml
-    secrets: inherit
-    with:
-      pr: 0
-
   ci-test:
     needs: [build-docker-image]
     # Only run if the build step is successful


### PR DESCRIPTION
## Description
Disables automated perf tests on CI that are no longer used. Saves CI costs by about 2.4%

#### PR fixes following issue(s)
Fixes #28510
  
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
