### PR TITLE
fix: Installation of libraries without a default export

### DIFF
--- a/app/client/src/workers/Evaluation/handlers/__tests__/jsLibrary.test.ts
+++ b/app/client/src/workers/Evaluation/handlers/__tests__/jsLibrary.test.ts
@@ -1,4 +1,4 @@
-import { installLibrary, uninstallLibrary } from "../jsLibrary";
+import { flattenModule, installLibrary, uninstallLibrary } from "../jsLibrary";
 import {
   EVAL_WORKER_ASYNC_ACTION,
   EVAL_WORKER_SYNC_ACTION,
@@ -97,5 +97,49 @@ describe("Tests to assert install/uninstall flows", function () {
     });
     expect(res).toEqual({ success: true });
     expect(self.lodash).toBeUndefined();
+  });
+
+  it("Test flatten of ESM module", () => {
+    /** ESM with default and named exports */
+    const library = {
+      default: {
+        method: "Hello",
+      },
+      method: "Hello",
+    };
+
+    const flatLibrary1 = flattenModule(library);
+
+    expect(flatLibrary1).toEqual({
+      method: "Hello",
+    });
+
+    expect(Object.getPrototypeOf(flatLibrary1)).toEqual({
+      method: "Hello",
+    });
+
+    /** ESM with named exports only */
+    const library2 = {
+      method: "Hello",
+    };
+
+    const flatLibrary2 = flattenModule(library2);
+
+    expect(flatLibrary2).toEqual({
+      method: "Hello",
+    });
+
+    /** ESM with default export only */
+    const library3 = {
+      default: {
+        method: "Hello",
+      },
+    };
+
+    const flatLibrary3 = flattenModule(library3);
+
+    expect(flatLibrary3).toEqual({
+      method: "Hello",
+    });
   });
 });

--- a/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
+++ b/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
@@ -327,7 +327,7 @@ function flattenModule(module: Record<string, any>) {
   if (keys.length === 1 && keys[0] === "default") return module.default;
   // If there are keys other than default, return a new object with all the keys
   // and set its prototype of default export.
-  const libModule = Object.create(module.default);
+  const libModule = Object.create(module.default || {});
   for (const key of Object.keys(module)) {
     if (key === "default") continue;
     libModule[key] = module[key];

--- a/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
+++ b/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
@@ -321,7 +321,7 @@ function generateUniqueAccessor(
   throw new Error("Unable to generate a unique accessor");
 }
 
-function flattenModule(module: Record<string, any>) {
+export function flattenModule(module: Record<string, any>) {
   const keys = Object.keys(module);
   // If there are no keys other than default, return default.
   if (keys.length === 1 && keys[0] === "default") return module.default;


### PR DESCRIPTION
## Description
This fixes the installation of libraries in native ESM build which doesn't contain a default export. 

**Root cause**:
ESM builds are flattened and the default export is added to the prototype chain of the library object. When the default export is empty, the installation fails at Object.create (prototype creation) step.
>
>
#### PR fixes following issue(s)
Fixes #28576 
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [x] Jest
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
