### PR TITLE
chore: add default value for feature flag on the client side

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -31,6 +31,8 @@ export const FEATURE_FLAG = {
   release_git_branch_protection_enabled:
     "release_git_branch_protection_enabled",
   license_widget_rtl_support_enabled: "license_widget_rtl_support_enabled",
+  ab_onboarding_flow_start_with_data_dev_only_enabled:
+    "ab_onboarding_flow_start_with_data_dev_only_enabled",
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG;
@@ -61,6 +63,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_app_sidebar_enabled: false,
   release_git_branch_protection_enabled: false,
   license_widget_rtl_support_enabled: false,
+  ab_onboarding_flow_start_with_data_dev_only_enabled: false,
 };
 
 export const AB_TESTING_EVENT_KEYS = {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/featureflags/FeatureFlagEnum.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/featureflags/FeatureFlagEnum.java
@@ -29,6 +29,7 @@ public enum FeatureFlagEnum {
     release_embed_hide_share_settings_enabled,
     ab_mock_mongo_schema_enabled,
     rollout_datasource_test_rate_limit_enabled,
+    ab_onboarding_flow_start_with_data_dev_only_enabled,
 
     // Add EE flags below this line, to avoid conflicts.
 }


### PR DESCRIPTION
## Description
- For feature flag `ab_onboarding_flow_start_with_data_dev_only_enabled`:
  - add default value on the client 
  - add it to the list of available feature flags that can be used on the API server. 

#### PR fixes following issue(s)
Fixes #28548 

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
- It seems not possible to add automation test for this change at the moment. 

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
