### PR TITLE
use page id instead of application id in action view controller

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ActionControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ActionControllerCE.java
@@ -130,18 +130,10 @@ public class ActionControllerCE {
             @RequestParam(required = false) String applicationId,
             @RequestParam(required = false) String pageId,
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
-        if (pageId != null) {
-            // If pageId is present, applicationId is optional
-            return newActionService
-                    .getActionsForViewModeForPage(pageId, branchName)
-                    .collectList()
-                    .map(actions -> new ResponseDTO<>(HttpStatus.OK.value(), actions, null));
-        } else {
-            return newActionService
-                    .getActionsForViewMode(applicationId, branchName)
-                    .collectList()
-                    .map(actions -> new ResponseDTO<>(HttpStatus.OK.value(), actions, null));
-        }
+        return newActionService
+                .getActionsForViewMode(applicationId, pageId, branchName)
+                .collectList()
+                .map(actions -> new ResponseDTO<>(HttpStatus.OK.value(), actions, null));
     }
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ActionControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ActionControllerCE.java
@@ -127,12 +127,21 @@ public class ActionControllerCE {
     @JsonView(Views.Public.class)
     @GetMapping("/view")
     public Mono<ResponseDTO<List<ActionViewDTO>>> getActionsForViewMode(
-            @RequestParam String applicationId,
+            @RequestParam(required = false) String applicationId,
+            @RequestParam(required = false) String pageId,
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
-        return newActionService
-                .getActionsForViewMode(applicationId, branchName)
-                .collectList()
-                .map(actions -> new ResponseDTO<>(HttpStatus.OK.value(), actions, null));
+        if (pageId != null) {
+            // If pageId is present, applicationId is optional
+            return newActionService
+                    .getActionsForViewModeForPage(pageId, branchName)
+                    .collectList()
+                    .map(actions -> new ResponseDTO<>(HttpStatus.OK.value(), actions, null));
+        } else {
+            return newActionService
+                    .getActionsForViewMode(applicationId, branchName)
+                    .collectList()
+                    .map(actions -> new ResponseDTO<>(HttpStatus.OK.value(), actions, null));
+        }
     }
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -74,6 +74,8 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
 
     Flux<ActionViewDTO> getActionsForViewMode(String defaultApplicationId, String branchName);
 
+    Flux<ActionViewDTO> getActionsForViewModeForPage(String pageId, String branchName);
+
     Mono<ActionDTO> deleteUnpublishedAction(String id);
 
     Flux<ActionDTO> getUnpublishedActions(MultiValueMap<String, String> params, Boolean includeJsActions);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -70,11 +70,9 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
     Flux<NewAction> findAllByApplicationIdAndViewMode(
             String applicationId, Boolean viewMode, Optional<AclPermission> permission, Optional<Sort> sort);
 
-    Flux<ActionViewDTO> getActionsForViewMode(String applicationId);
+    Flux<ActionViewDTO> getActionsForViewModeForApplication(String applicationId);
 
-    Flux<ActionViewDTO> getActionsForViewMode(String defaultApplicationId, String branchName);
-
-    Flux<ActionViewDTO> getActionsForViewModeForPage(String pageId, String branchName);
+    Flux<ActionViewDTO> getActionsForViewMode(String defaultApplicationId, String pageId, String branchName);
 
     Mono<ActionDTO> deleteUnpublishedAction(String id);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -759,6 +759,16 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 .flatMapMany(this::addMissingPluginDetailsIntoAllActions);
     }
 
+    public Flux<ActionViewDTO> getActionsForViewModeForPage(String pageId, String branchName) {
+        Mono<NewPage> pageMono = newPageService.findById(pageId, pagePermission.getReadPermission());
+
+        return pageMono.flatMapMany(page -> {
+            String applicationId = page.getApplicationId();
+
+            return getActionsForViewMode(applicationId, branchName);
+        });
+    }
+
     @Override
     public Flux<ActionViewDTO> getActionsForViewMode(String defaultApplicationId, String branchName) {
         return applicationService

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -733,7 +733,9 @@ public class ActionServiceCE_Test {
                 .then(layoutActionService.createSingleAction(action1, Boolean.FALSE))
                 .then(layoutActionService.createSingleAction(action2, Boolean.FALSE))
                 .then(applicationPageService.publish(testPage.getApplicationId(), true))
-                .then(newActionService.getActionsForViewMode(testApp.getId()).collectList());
+                .then(newActionService
+                        .getActionsForViewModeForApplication(testApp.getId())
+                        .collectList());
 
         StepVerifier.create(actionsListMono)
                 .assertNext(actionsList -> {
@@ -789,7 +791,9 @@ public class ActionServiceCE_Test {
         Mono<List<ActionViewDTO>> actionViewModeListMono = createActionMono
                 // Publish the application before fetching the action in view mode
                 .then(applicationPageService.publish(testApp.getId(), true))
-                .then(newActionService.getActionsForViewMode(testApp.getId()).collectList());
+                .then(newActionService
+                        .getActionsForViewModeForApplication(testApp.getId())
+                        .collectList());
 
         StepVerifier.create(actionViewModeListMono)
                 .assertNext(actions -> {


### PR DESCRIPTION
We have the page id as soon as the main bundle is initialized.
We can not make these essential API calls unless we have the application ID. We depend on another API to get the application id making the first meaningful paint slower by 2*(300-600)ms.

In this PR, we are adding another check for fetching the ActionList via pageId. the existing clients continue to work with application id, if page Id is sent, it will take precedence

#### PR fixes following issue(s)
Fixes # (issue number)
> https://github.com/appsmithorg/appsmith/issues/28708
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
