### PR TITLE
chore: Add  `LaunchDarkly` configs in CI run to mock feature flags

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -186,6 +186,8 @@ jobs:
 
       - name: Run Appsmith & TED docker image
         if: steps.run_result.outputs.run_result != 'success'
+        env:
+          LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY: ${{ secrets.LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY }}
         working-directory: "."
         run: |
           sudo /etc/init.d/ssh stop ;
@@ -220,9 +222,7 @@ jobs:
             -e ENTERPRISE_USER_PASSWORD=ent_user_password \
             -e ENTERPRISE_ADMIN_NAME=ent-admin@appsmith.com \
             -e ENTERPRISE_ADMIN_PASSWORD=ent_admin_password \
-            -e FLAGSMITH_URL=http://host.docker.internal:5001/flagsmith \
-            -e FLAGSMITH_SERVER_KEY=dummykey \
-            -e FLAGSMITH_SERVER_KEY_BUSINESS_FEATURES=dummykeybusinessfeatures \
+            -e LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY=$LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY \
             appsmith/cloud-services:release
           cd cicontainerlocal
           docker run -d --name appsmith -p 80:80 -p 9001:9001 \

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -222,6 +222,9 @@ jobs:
             -e ENTERPRISE_USER_PASSWORD=ent_user_password \
             -e ENTERPRISE_ADMIN_NAME=ent-admin@appsmith.com \
             -e ENTERPRISE_ADMIN_PASSWORD=ent_admin_password \
+            -e FLAGSMITH_URL=http://host.docker.internal:5001/flagsmith \
+            -e FLAGSMITH_SERVER_KEY=dummykey \
+            -e FLAGSMITH_SERVER_KEY_BUSINESS_FEATURES=dummykeybusinessfeatures \
             -e LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY=$LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY \
             appsmith/cloud-services:release
           cd cicontainerlocal


### PR DESCRIPTION
Note: We have to create `LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY` secret before merging this PR.