### PR TITLE
feat: Transform API/Query data based on widget's expected data type after 1-click binding

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug28731_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug28731_Spec.ts
@@ -1,0 +1,41 @@
+import OneClickBindingLocator from "../../../../locators/OneClickBindingLocator";
+import {
+  agHelper,
+  entityExplorer,
+  apiPage,
+  dataManager,
+  draggableWidgets,
+  propPane,
+} from "../../../../support/Objects/ObjectsCore";
+
+describe("transformed one-click binding", function () {
+  before(() => {
+    entityExplorer.NavigateToSwitcher("Explorer");
+  });
+
+  it("Transforms API data to match widget exppected type ", function () {
+    // Create anAPI that mreturns object response
+    apiPage.CreateAndFillApi(
+      dataManager.dsValues[dataManager.defaultEnviorment].mockApiObjectUrl,
+    );
+    apiPage.RunAPI();
+
+    // Table
+    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 300, 300);
+
+    agHelper.GetNClick(OneClickBindingLocator.datasourceDropdownSelector);
+    agHelper.GetNClick(OneClickBindingLocator.datasourceQuerySelector("Api1"));
+    propPane.ToggleJSMode("Table Data", true);
+    agHelper.AssertContains("{{Api1.data.users}}");
+
+    // Select widget
+    entityExplorer.DragDropWidgetNVerify(draggableWidgets.SELECT, 100, 100);
+
+    agHelper.GetNClick(OneClickBindingLocator.datasourceDropdownSelector);
+    agHelper.GetNClick(OneClickBindingLocator.datasourceQuerySelector("Api1"));
+    propPane.ToggleJSMode("Source Data", true);
+    agHelper.AssertContains(
+      "{{Api1.data.users.map( (obj) =>{ return  {'label': obj.address, 'value': obj.avatar } })}}",
+    );
+  });
+});

--- a/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
+++ b/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
@@ -13,7 +13,10 @@ import type { DropdownOptionType } from "../../../types";
 import type { WidgetProps } from "widgets/BaseWidget";
 import { WidgetQueryGeneratorFormContext } from "components/editorComponents/WidgetQueryGeneratorForm";
 import { PluginPackageName } from "entities/Action";
-import type { ActionDataState } from "@appsmith/reducers/entityReducers/actionsReducer";
+import type {
+  ActionData,
+  ActionDataState,
+} from "@appsmith/reducers/entityReducers/actionsReducer";
 
 enum SortingWeights {
   alphabetical = 1,
@@ -60,6 +63,16 @@ function sortQueries(queries: ActionDataState, expectedDatatype: string) {
   });
 }
 
+function getBindingValue(widget: WidgetProps, query: ActionData) {
+  const defaultBindingValue = `{{${query.config.name}.data}}`;
+  const querySuggestedWidgets = query.data?.suggestedWidgets;
+  if (!querySuggestedWidgets) return defaultBindingValue;
+  const suggestedWidget = querySuggestedWidgets.find(
+    (suggestedWidget) => suggestedWidget.type === widget.type,
+  );
+  if (!suggestedWidget) return defaultBindingValue;
+  return `{{${query.config.name}.${suggestedWidget.bindingQuery}}}`;
+}
 interface ConnectToOptionsProps {
   pluginImages: Record<string, string>;
   widget: WidgetProps;
@@ -97,7 +110,7 @@ function useConnectToOptions(props: ConnectToOptionsProps) {
     return sortQueries(filteredQueries, expectedType).map((query) => ({
       id: query.config.id,
       label: query.config.name,
-      value: `{{${query.config.name}.data}}`,
+      value: getBindingValue(widget, query),
       icon: (
         <ImageWrapper>
           <DatasourceImage
@@ -127,7 +140,7 @@ function useConnectToOptions(props: ConnectToOptionsProps) {
         });
       },
     }));
-  }, [filteredQueries, pluginImages, addBinding]);
+  }, [filteredQueries, pluginImages, addBinding, widget]);
 
   const currentPageWidgets = useSelector(getCurrentPageWidgets);
 


### PR DESCRIPTION
## Description

In this PR, transformed API/Query data ( based on the widget's expected data type) is used after 1-click binding. This is aimed at improving 1-click binding success.

#### PR fixes following issue(s)
Fixes #28731 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
