### PR TITLE
chore: Changing OpenAI datasource documentation link

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -107,6 +107,15 @@ public enum AppsmithPluginError implements BasePluginError {
             ErrorType.AUTHENTICATION_ERROR,
             "{0}",
             "{1}"),
+    PLUGIN_DATASOURCE_ERROR(
+            400,
+            AppsmithPluginErrorCode.PLUGIN_DATASOURCE_ERROR.getCode(),
+            "Error with datasource request. Please check datasource configuration.",
+            AppsmithErrorAction.DEFAULT,
+            "Datasource error",
+            ErrorType.BAD_REQUEST,
+            "{0}",
+            "{1}"),
     PLUGIN_IN_MEMORY_FILTERING_ERROR(
             500,
             AppsmithPluginErrorCode.PLUGIN_IN_MEMORY_FILTERING_ERROR.getCode(),

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginErrorCode.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginErrorCode.java
@@ -17,6 +17,7 @@ public enum AppsmithPluginErrorCode {
     PLUGIN_DATASOURCE_TIMEOUT_ERROR("PE-DSE-5004", "Timed out when connecting to datasource"),
     PLUGIN_QUERY_TIMEOUT_ERROR("PE-QRY-5000", "Timed out on query execution"),
     PLUGIN_AUTHENTICATION_ERROR("PE-ATH-5000", "Datasource authentication error"),
+    PLUGIN_DATASOURCE_ERROR("PE-DSE-4000", "Datasource error"),
     PLUGIN_UQI_WHERE_CONDITION_UNKNOWN("PE-UQI-5000", "Where condition could not be parsed"),
     GENERIC_STALE_CONNECTION("PE-STC-5000", "Secondary stale connection error"),
     PLUGIN_EXECUTE_ARGUMENT_ERROR("PE-ARG-5000", "Wrong arguments provided"),

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/OpenAiPlugin.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/OpenAiPlugin.java
@@ -25,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.pf4j.PluginWrapper;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -105,11 +104,17 @@ public class OpenAiPlugin extends BasePlugin {
             return RequestUtils.makeRequest(httpMethod, uri, bearerTokenAuth, BodyInserters.fromValue(openAIRequestDTO))
                     .flatMap(responseEntity -> {
                         HttpStatusCode statusCode = responseEntity.getStatusCode();
-                        HttpHeaders headers = responseEntity.getHeaders();
 
                         ActionExecutionResult actionExecutionResult = new ActionExecutionResult();
                         actionExecutionResult.setRequest(actionExecutionRequest);
                         actionExecutionResult.setStatusCode(statusCode.toString());
+
+                        if (statusCode.isSameCodeAs(HttpStatusCode.valueOf(401))) {
+                            actionExecutionResult.setIsExecutionSuccess(false);
+                            actionExecutionResult.setErrorInfo(
+                                    new AppsmithPluginException(AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR));
+                            return Mono.just(actionExecutionResult);
+                        }
 
                         if (statusCode.is4xxClientError()) {
                             actionExecutionResult.setIsExecutionSuccess(false);
@@ -118,7 +123,7 @@ public class OpenAiPlugin extends BasePlugin {
                                 errorMessage = new String(responseEntity.getBody());
                             }
                             actionExecutionResult.setErrorInfo(new AppsmithPluginException(
-                                    AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR, errorMessage));
+                                    AppsmithPluginError.PLUGIN_DATASOURCE_ERROR, errorMessage));
                             return Mono.just(actionExecutionResult);
                         }
 

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static com.external.plugins.constants.OpenAIConstants.CONTENT;
+import static com.external.plugins.constants.OpenAIConstants.DEFAULT_MAX_TOKEN;
 import static com.external.plugins.constants.OpenAIConstants.ID;
 import static com.external.plugins.constants.OpenAIConstants.IMAGE_TYPE;
 import static com.external.plugins.constants.OpenAIConstants.LABEL;
@@ -178,18 +179,16 @@ public class VisionCommand implements OpenAICommand {
     }
 
     private int getMaxTokenFromFormData(Map<String, Object> formData) {
-        int defaultMaxToken = 1000;
-
         String maxTokenAsString = RequestUtils.extractValueFromFormData(formData, MAX_TOKENS);
 
         if (!StringUtils.hasText(maxTokenAsString)) {
-            return defaultMaxToken;
+            return DEFAULT_MAX_TOKEN;
         }
 
         try {
             return Integer.parseInt(maxTokenAsString);
         } catch (IllegalArgumentException illegalArgumentException) {
-            return defaultMaxToken;
+            return DEFAULT_MAX_TOKEN;
         } catch (Exception exception) {
             throw new AppsmithPluginException(
                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/constants/OpenAIConstants.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/constants/OpenAIConstants.java
@@ -42,6 +42,7 @@ public class OpenAIConstants {
 
     // Other constants
     public static final String BODY = "body";
+    public static final Integer DEFAULT_MAX_TOKEN = 16;
 
     public static final ExchangeStrategies EXCHANGE_STRATEGIES = ExchangeStrategies.builder()
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(/* 10MB */ 10 * 1024 * 1024))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
@@ -15,6 +15,7 @@ public class FieldNameCE {
     public static final String UPDATED_AT = "updatedAt";
     public static final String CURL_CODE = "curlCode";
     public static final String PLUGIN_TYPE = "pluginType";
+    public static final String PACKAGE_NAME = "packageName";
     public static final String COLLECTION_ID = "collectionId";
     public static final String ACTION_ID = "actionId";
     public static String WORKSPACE = "workspace";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration034ChangeOpenAIIntegrationDocumentationLink.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration034ChangeOpenAIIntegrationDocumentationLink.java
@@ -1,0 +1,40 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.external.constants.PluginConstants;
+import com.appsmith.server.constants.ce.FieldNameCE;
+import com.appsmith.server.domains.Plugin;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+@Slf4j
+@ChangeUnit(order = "034", id = "change-open-ai-integration-documentation-link", author = " ")
+public class Migration034ChangeOpenAIIntegrationDocumentationLink {
+
+    private final MongoTemplate mongoTemplate;
+
+    public Migration034ChangeOpenAIIntegrationDocumentationLink(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void rollbackExecution() {}
+
+    @Execution
+    public void changeDocumentationLink() {
+        Query pluginFindQuery = new Query();
+
+        pluginFindQuery.addCriteria(
+                Criteria.where(FieldNameCE.PACKAGE_NAME).is(PluginConstants.PackageName.OPEN_AI_PLUGIN));
+        Plugin openAiPlugin = mongoTemplate.findOne(pluginFindQuery, Plugin.class);
+        if (openAiPlugin == null) {
+            return;
+        }
+        openAiPlugin.setDocumentationLink("https://docs.appsmith.com/connect-data/reference/open-ai");
+        mongoTemplate.save(openAiPlugin);
+    }
+}


### PR DESCRIPTION
## Description
Changing the documentation link to https://docs.appsmith.com/connect-data/reference/open-ai

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
#### How Has This Been Tested?
- [x] Manual

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
