### PR TITLE
fix: Adding multiple certs in ca-certs folder

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -318,7 +318,8 @@ setup-custom-ca-certificates() (
 
   # Add the custom CA certificates to the store.
   find "$stacks_ca_certs_path" -maxdepth 1 -type f -name '*.crt' \
-    -exec keytool -import -noprompt -keystore "$store" -file '{}' -storepass changeit ';'
+    -print \
+    -exec keytool -import -alias '{}' -noprompt -keystore "$store" -file '{}' -storepass changeit ';'
 
   {
     echo "-Djavax.net.ssl.trustStore=$store"


### PR DESCRIPTION
Fix issue with alias names clashing in `keytool -import` command, when there's more than one cert file in the `ca-certs` folder.

The fix is to explicitly set the alias for each `keytool -import` run, to the file itself, so clashes don't happen.
