### PR TITLE
test: Cypress| fix ButtonWidgets_NavigateTo_Validation_spec.js

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/ButtonWidgets_NavigateTo_validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/ButtonWidgets_NavigateTo_validation_spec.js
@@ -23,7 +23,7 @@ describe("Binding the button Widgets and validating NavigateTo Page functionalit
         cy.get(".t--code-editor-wrapper").type(testdata.externalPage);
       });
     cy.wait(300);
-    //. Button click should take the control to page link validation", function () {
+    // Button click should take the control to page link validation", function () {
     deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.BUTTON));
     cy.wait(2000);
     agHelper.ClickButton("Submit");
@@ -31,8 +31,8 @@ describe("Binding the button Widgets and validating NavigateTo Page functionalit
     agHelper.AssertElementAbsence(
       locators._widgetInDeployed(draggableWidgets.BUTTON),
     );
-    agHelper.AssertElementVisibility(
-      locators._visibleTextSpan("Build the tools"),
-    );
+    cy.url().should("contain", testdata.externalPage);
+
+
   });
 });


### PR DESCRIPTION
## Description
The test failed while navigating to appsmith website where it was asserting text on website, changed it to assert URL instead.

## Testing
>
#### How Has This Been Tested?
locally


