### PR TITLE
chore: Refactored is name allowed

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/refactors/ActionCollectionRefactoringServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/refactors/ActionCollectionRefactoringServiceCEImpl.java
@@ -2,8 +2,10 @@ package com.appsmith.server.actioncollections.refactors;
 
 import com.appsmith.external.constants.AnalyticsEvents;
 import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.MustacheBindingToken;
 import com.appsmith.server.actioncollections.base.ActionCollectionService;
+import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.EntityType;
@@ -15,6 +17,8 @@ import com.appsmith.server.services.AstService;
 import com.appsmith.server.solutions.ActionPermission;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -137,5 +141,16 @@ public class ActionCollectionRefactoringServiceCEImpl implements EntityRefactori
                             actionCollectionService.update(branchedActionCollection.getId(), branchedActionCollection));
                 })
                 .then();
+    }
+
+    @Override
+    public Flux<String> getExistingEntityNames(String contextId, CreatorContextType contextType, String layoutId) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        if (contextId != null) {
+            params.add(FieldName.PAGE_ID, contextId);
+        }
+        return actionCollectionService
+                .getActionCollectionsByViewMode(params, false)
+                .map(ActionCollectionDTO::getName);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/refactors/ActionCollectionRefactoringServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/refactors/ActionCollectionRefactoringServiceCEImpl.java
@@ -146,7 +146,7 @@ public class ActionCollectionRefactoringServiceCEImpl implements EntityRefactori
     @Override
     public Flux<String> getExistingEntityNames(String contextId, CreatorContextType contextType, String layoutId) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        if (contextId != null) {
+        if (StringUtils.hasText(contextId)) {
             params.add(FieldName.PAGE_ID, contextId);
         }
         return actionCollectionService

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/LayoutController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/LayoutController.java
@@ -2,8 +2,8 @@ package com.appsmith.server.controllers;
 
 import com.appsmith.server.constants.Url;
 import com.appsmith.server.controllers.ce.LayoutControllerCE;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
-import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.services.LayoutService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,9 +16,8 @@ public class LayoutController extends LayoutControllerCE {
 
     public LayoutController(
             LayoutService layoutService,
-            LayoutActionService layoutActionService,
+            UpdateLayoutService updateLayoutService,
             RefactoringSolution refactoringSolution) {
-
-        super(layoutService, layoutActionService, refactoringSolution);
+        super(layoutService, updateLayoutService, refactoringSolution);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
@@ -9,8 +9,8 @@ import com.appsmith.server.dtos.LayoutDTO;
 import com.appsmith.server.dtos.RefactorEntityNameDTO;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.dtos.UpdateMultiplePageLayoutDTO;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
-import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.services.LayoutService;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.validation.Valid;
@@ -32,17 +32,16 @@ import reactor.core.publisher.Mono;
 public class LayoutControllerCE {
 
     private final LayoutService service;
-    private final LayoutActionService layoutActionService;
-
+    private final UpdateLayoutService updateLayoutService;
     private final RefactoringSolution refactoringSolution;
 
     @Autowired
     public LayoutControllerCE(
             LayoutService layoutService,
-            LayoutActionService layoutActionService,
+            UpdateLayoutService updateLayoutService,
             RefactoringSolution refactoringSolution) {
         this.service = layoutService;
-        this.layoutActionService = layoutActionService;
+        this.updateLayoutService = updateLayoutService;
         this.refactoringSolution = refactoringSolution;
     }
 
@@ -73,7 +72,7 @@ public class LayoutControllerCE {
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName,
             @RequestBody @Valid UpdateMultiplePageLayoutDTO request) {
         log.debug("update multiple layout received for application {} branch {}", applicationId, branchName);
-        return layoutActionService
+        return updateLayoutService
                 .updateMultipleLayouts(applicationId, branchName, request)
                 .map(updatedCount -> new ResponseDTO<>(HttpStatus.OK.value(), updatedCount, null));
     }
@@ -87,7 +86,7 @@ public class LayoutControllerCE {
             @RequestBody Layout layout,
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
         log.debug("update layout received for page {}", pageId);
-        return layoutActionService
+        return updateLayoutService
                 .updateLayout(pageId, applicationId, layoutId, layout, branchName)
                 .map(created -> new ResponseDTO<>(HttpStatus.OK.value(), created, null));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutService.java
@@ -1,0 +1,3 @@
+package com.appsmith.server.layouts;
+
+public interface UpdateLayoutService extends UpdateLayoutServiceCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceCE.java
@@ -1,0 +1,19 @@
+package com.appsmith.server.layouts;
+
+import com.appsmith.server.domains.Layout;
+import com.appsmith.server.dtos.LayoutDTO;
+import com.appsmith.server.dtos.UpdateMultiplePageLayoutDTO;
+import net.minidev.json.JSONObject;
+import reactor.core.publisher.Mono;
+
+public interface UpdateLayoutServiceCE {
+    Mono<LayoutDTO> updateLayout(String pageId, String applicationId, String layoutId, Layout layout);
+
+    Mono<LayoutDTO> updateLayout(
+            String defaultPageId, String defaultApplicationId, String layoutId, Layout layout, String branchName);
+
+    Mono<Integer> updateMultipleLayouts(
+            String defaultApplicationId, String branchName, UpdateMultiplePageLayoutDTO updateMultiplePageLayoutDTO);
+
+    JSONObject unescapeMongoSpecialCharacters(Layout layout);
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceCEImpl.java
@@ -1,0 +1,526 @@
+package com.appsmith.server.layouts;
+
+import com.appsmith.external.constants.AnalyticsEvents;
+import com.appsmith.external.dtos.DslExecutableDTO;
+import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
+import com.appsmith.external.exceptions.ErrorDTO;
+import com.appsmith.external.helpers.MustacheHelper;
+import com.appsmith.external.models.CreatorContextType;
+import com.appsmith.external.models.Executable;
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.ExecutableDependencyEdge;
+import com.appsmith.server.domains.Layout;
+import com.appsmith.server.domains.NewPage;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.LayoutDTO;
+import com.appsmith.server.dtos.UpdateMultiplePageLayoutDTO;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.helpers.WidgetSpecificUtils;
+import com.appsmith.server.newpages.base.NewPageService;
+import com.appsmith.server.onload.internal.OnLoadExecutablesUtil;
+import com.appsmith.server.services.AnalyticsService;
+import com.appsmith.server.services.ApplicationService;
+import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.solutions.PagePermission;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONObject;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.appsmith.server.services.ce.ApplicationPageServiceCEImpl.EVALUATION_VERSION;
+import static java.lang.Boolean.FALSE;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UpdateLayoutServiceCEImpl implements UpdateLayoutServiceCE {
+
+    private final OnLoadExecutablesUtil onLoadExecutablesUtil;
+    private final SessionUserService sessionUserService;
+    private final NewPageService newPageService;
+    private final AnalyticsService analyticsService;
+    private final ResponseUtils responseUtils;
+    private final PagePermission pagePermission;
+    private final ApplicationService applicationService;
+
+    private final ObjectMapper objectMapper;
+
+    private final String layoutOnLoadActionErrorToastMessage =
+            "A cyclic dependency error has been encountered on current page, \nqueries on page load will not run. \n Please check debugger and Appsmith documentation for more information";
+
+    private Mono<Boolean> sendUpdateLayoutAnalyticsEvent(
+            String creatorId,
+            String layoutId,
+            JSONObject dsl,
+            boolean isSuccess,
+            Throwable error,
+            CreatorContextType creatorType) {
+        return Mono.zip(sessionUserService.getCurrentUser(), newPageService.getById(creatorId))
+                .flatMap(tuple -> {
+                    User t1 = tuple.getT1();
+                    NewPage t2 = tuple.getT2();
+
+                    final Map<String, Object> data = Map.of(
+                            "username",
+                            t1.getUsername(),
+                            "appId",
+                            t2.getApplicationId(),
+                            "creatorId",
+                            creatorId,
+                            "creatorType",
+                            creatorType,
+                            "layoutId",
+                            layoutId,
+                            "isSuccessfulExecution",
+                            isSuccess,
+                            "error",
+                            error == null ? "" : error.getMessage());
+
+                    return analyticsService
+                            .sendObjectEvent(AnalyticsEvents.UPDATE_LAYOUT, t2, data)
+                            .thenReturn(isSuccess);
+                })
+                .onErrorResume(e -> {
+                    log.warn("Error sending action execution data point", e);
+                    return Mono.just(isSuccess);
+                });
+    }
+
+    private Mono<LayoutDTO> updateLayoutDsl(
+            String creatorId,
+            String layoutId,
+            Layout layout,
+            Integer evaluatedVersion,
+            CreatorContextType creatorType) {
+        JSONObject dsl = layout.getDsl();
+        if (dsl == null) {
+            // There is no DSL here. No need to process anything. Return as is.
+            return Mono.just(generateResponseDTO(layout));
+        }
+
+        Set<String> widgetNames = new HashSet<>();
+        Map<String, Set<String>> widgetDynamicBindingsMap = new HashMap<>();
+        Set<String> escapedWidgetNames = new HashSet<>();
+        try {
+            dsl = extractAllWidgetNamesAndDynamicBindingsFromDSL(
+                    dsl, widgetNames, widgetDynamicBindingsMap, creatorId, layoutId, escapedWidgetNames, creatorType);
+        } catch (Throwable t) {
+            return sendUpdateLayoutAnalyticsEvent(creatorId, layoutId, dsl, false, t, creatorType)
+                    .then(Mono.error(t));
+        }
+
+        layout.setWidgetNames(widgetNames);
+
+        if (!escapedWidgetNames.isEmpty()) {
+            layout.setMongoEscapedWidgetNames(escapedWidgetNames);
+        }
+
+        Set<String> executableNames = new HashSet<>();
+        Set<ExecutableDependencyEdge> edges = new HashSet<>();
+        Set<String> executablesUsedInDSL = new HashSet<>();
+        List<Executable> flatmapOnLoadExecutables = new ArrayList<>();
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        AtomicReference<Boolean> validOnLoadExecutables = new AtomicReference<>(Boolean.TRUE);
+
+        // setting the layoutOnLoadActionActionErrors to empty to remove the existing errors before new DAG calculation.
+        layout.setLayoutOnLoadActionErrors(new ArrayList<>());
+
+        Mono<List<Set<DslExecutableDTO>>> allOnLoadExecutablesMono = onLoadExecutablesUtil
+                .findAllOnLoadExecutables(
+                        creatorId,
+                        evaluatedVersion,
+                        widgetNames,
+                        edges,
+                        widgetDynamicBindingsMap,
+                        flatmapOnLoadExecutables,
+                        executablesUsedInDSL,
+                        creatorType)
+                .onErrorResume(AppsmithException.class, error -> {
+                    log.info(error.getMessage());
+                    validOnLoadExecutables.set(FALSE);
+                    layout.setLayoutOnLoadActionErrors(List.of(new ErrorDTO(
+                            error.getAppErrorCode(),
+                            error.getErrorType(),
+                            layoutOnLoadActionErrorToastMessage,
+                            error.getMessage(),
+                            error.getTitle())));
+                    return Mono.just(new ArrayList<>());
+                });
+
+        // First update the actions and set execute on load to true
+        JSONObject finalDsl = dsl;
+        return allOnLoadExecutablesMono
+                .flatMap(allOnLoadExecutables -> {
+                    // If there has been an error (e.g. cyclical dependency), then don't update any actions.
+                    // This is so that unnecessary updates don't happen to actions while the page is in invalid state.
+                    if (!validOnLoadExecutables.get()) {
+                        return Mono.just(allOnLoadExecutables);
+                    }
+                    // Update these executables to be executed on load, unless the user has touched the executeOnLoad
+                    // setting for this
+                    return onLoadExecutablesUtil
+                            .updateExecutablesExecuteOnLoad(
+                                    flatmapOnLoadExecutables, creatorId, executableUpdatesRef, messagesRef, creatorType)
+                            .thenReturn(allOnLoadExecutables);
+                })
+                // Now update the page layout with the page load executables and the graph.
+                .flatMap(onLoadExecutables -> {
+                    layout.setLayoutOnLoadActions(onLoadExecutables);
+                    layout.setAllOnPageLoadActionNames(executableNames);
+                    layout.setActionsUsedInDynamicBindings(executablesUsedInDSL);
+                    // The below field is to ensure that we record if the page load actions computation was
+                    // valid when last stored in the database.
+                    layout.setValidOnPageLoadActions(validOnLoadExecutables.get());
+
+                    return onLoadExecutablesUtil.findAndUpdateLayout(creatorId, creatorType, layoutId, layout);
+                })
+                .map(savedLayout -> {
+                    savedLayout.setDsl(this.unescapeMongoSpecialCharacters(savedLayout));
+                    return savedLayout;
+                })
+                .flatMap(savedLayout -> {
+                    LayoutDTO layoutDTO = generateResponseDTO(savedLayout);
+                    layoutDTO.setActionUpdates(executableUpdatesRef);
+                    layoutDTO.setMessages(messagesRef);
+
+                    return sendUpdateLayoutAnalyticsEvent(creatorId, layoutId, finalDsl, true, null, creatorType)
+                            .thenReturn(layoutDTO);
+                });
+    }
+
+    @Override
+    public Mono<LayoutDTO> updateLayout(String pageId, String applicationId, String layoutId, Layout layout) {
+        return applicationService
+                .findById(applicationId)
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION_ID, applicationId)))
+                .flatMap(application -> {
+                    Integer evaluationVersion = application.getEvaluationVersion();
+                    if (evaluationVersion == null) {
+                        evaluationVersion = EVALUATION_VERSION;
+                    }
+                    return updateLayoutDsl(pageId, layoutId, layout, evaluationVersion, CreatorContextType.PAGE);
+                });
+    }
+
+    @Override
+    public Mono<LayoutDTO> updateLayout(
+            String defaultPageId, String defaultApplicationId, String layoutId, Layout layout, String branchName) {
+        if (!StringUtils.hasLength(branchName)) {
+            return updateLayout(defaultPageId, defaultApplicationId, layoutId, layout);
+        }
+        return newPageService
+                .findByBranchNameAndDefaultPageId(branchName, defaultPageId, pagePermission.getEditPermission())
+                .flatMap(branchedPage ->
+                        updateLayout(branchedPage.getId(), branchedPage.getApplicationId(), layoutId, layout))
+                .map(responseUtils::updateLayoutDTOWithDefaultResources);
+    }
+
+    @Override
+    public Mono<Integer> updateMultipleLayouts(
+            String defaultApplicationId, String branchName, UpdateMultiplePageLayoutDTO updateMultiplePageLayoutDTO) {
+        List<Mono<LayoutDTO>> monoList = new ArrayList<>();
+        for (UpdateMultiplePageLayoutDTO.UpdatePageLayoutDTO pageLayout :
+                updateMultiplePageLayoutDTO.getPageLayouts()) {
+            Mono<LayoutDTO> updatedLayoutMono = this.updateLayout(
+                    pageLayout.getPageId(),
+                    defaultApplicationId,
+                    pageLayout.getLayoutId(),
+                    pageLayout.getLayout(),
+                    branchName);
+            monoList.add(updatedLayoutMono);
+        }
+        return Flux.merge(monoList).then(Mono.just(monoList.size()));
+    }
+
+    private LayoutDTO generateResponseDTO(Layout layout) {
+
+        LayoutDTO layoutDTO = new LayoutDTO();
+
+        layoutDTO.setId(layout.getId());
+        layoutDTO.setDsl(layout.getDsl());
+        layoutDTO.setScreen(layout.getScreen());
+        layoutDTO.setLayoutOnLoadActions(layout.getLayoutOnLoadActions());
+        layoutDTO.setLayoutOnLoadActionErrors(layout.getLayoutOnLoadActionErrors());
+        layoutDTO.setUserPermissions(layout.getUserPermissions());
+
+        return layoutDTO;
+    }
+
+    @Override
+    public JSONObject unescapeMongoSpecialCharacters(Layout layout) {
+        Set<String> mongoEscapedWidgetNames = layout.getMongoEscapedWidgetNames();
+
+        if (mongoEscapedWidgetNames == null || mongoEscapedWidgetNames.isEmpty()) {
+            return layout.getDsl();
+        }
+
+        JSONObject dsl = layout.getDsl();
+
+        // Unescape specific widgets
+        dsl = unEscapeDslKeys(dsl, layout.getMongoEscapedWidgetNames());
+
+        return dsl;
+    }
+
+    private JSONObject unEscapeDslKeys(JSONObject dsl, Set<String> escapedWidgetNames) {
+
+        String widgetName = (String) dsl.get(FieldName.WIDGET_NAME);
+
+        if (widgetName == null) {
+            // This isnt a valid widget configuration. No need to traverse further.
+            return dsl;
+        }
+
+        if (escapedWidgetNames.contains(widgetName)) {
+            // We should escape the widget keys
+            String widgetType = dsl.getAsString(FieldName.WIDGET_TYPE);
+            if (widgetType.equals(FieldName.TABLE_WIDGET)) {
+                // UnEscape Table widget keys
+                // Since this is a table widget, it wouldnt have children. We can safely return from here with updated
+                // dsl
+                return WidgetSpecificUtils.unEscapeTableWidgetPrimaryColumns(dsl);
+            }
+        }
+
+        // Fetch the children of the current node in the DSL and recursively iterate over them to extract bindings
+        ArrayList<Object> children = (ArrayList<Object>) dsl.get(FieldName.CHILDREN);
+        ArrayList<Object> newChildren = new ArrayList<>();
+        if (children != null) {
+            for (int i = 0; i < children.size(); i++) {
+                Map data = (Map) children.get(i);
+                JSONObject object = new JSONObject();
+                // If the children tag exists and there are entries within it
+                if (!CollectionUtils.isEmpty(data)) {
+                    object.putAll(data);
+                    JSONObject child = unEscapeDslKeys(object, escapedWidgetNames);
+                    newChildren.add(child);
+                }
+            }
+            dsl.put(FieldName.CHILDREN, newChildren);
+        }
+
+        return dsl;
+    }
+
+    /**
+     * Walks the DSL and extracts all the widget names from it.
+     * A widget is expected to have a few properties defining its own behaviour, with any mustache bindings present
+     * in them aggregated in the field dynamicBindingsPathList.
+     * A widget may also have other widgets as children, each of which will follow the same structure
+     * Refer to FieldName.DEFAULT_PAGE_LAYOUT for a template
+     *
+     * @param dsl
+     * @param widgetNames
+     * @param widgetDynamicBindingsMap
+     * @param creatorId
+     * @param layoutId
+     * @param escapedWidgetNames
+     * @return
+     */
+    private JSONObject extractAllWidgetNamesAndDynamicBindingsFromDSL(
+            JSONObject dsl,
+            Set<String> widgetNames,
+            Map<String, Set<String>> widgetDynamicBindingsMap,
+            String creatorId,
+            String layoutId,
+            Set<String> escapedWidgetNames,
+            CreatorContextType creatorType)
+            throws AppsmithException {
+        if (dsl.get(FieldName.WIDGET_NAME) == null) {
+            // This isn't a valid widget configuration. No need to traverse this.
+            return dsl;
+        }
+
+        String widgetName = dsl.getAsString(FieldName.WIDGET_NAME);
+        String widgetId = dsl.getAsString(FieldName.WIDGET_ID);
+        String widgetType = dsl.getAsString(FieldName.WIDGET_TYPE);
+
+        // Since we are parsing this widget in this, add it to the global set of widgets found so far in the DSL.
+        widgetNames.add(widgetName);
+
+        // Start by picking all fields where we expect to find dynamic bindings for this particular widget
+        ArrayList<Object> dynamicallyBoundedPathList = (ArrayList<Object>) dsl.get(FieldName.DYNAMIC_BINDING_PATH_LIST);
+
+        // Widgets will not have FieldName.DYNAMIC_BINDING_PATH_LIST if there are no bindings in that widget.
+        // Hence we skip over the extraction of the bindings from that widget.
+        if (dynamicallyBoundedPathList != null) {
+            // Each of these might have nested structures, so we iterate through them to find the leaf node for each
+            for (Object x : dynamicallyBoundedPathList) {
+                final String fieldPath = String.valueOf(((Map) x).get(FieldName.KEY));
+                String[] fields = fieldPath.split("[].\\[]");
+                // For nested fields, the parent dsl to search in would shift by one level every iteration
+                Object parent = dsl;
+                Iterator<String> fieldsIterator = Arrays.stream(fields)
+                        .filter(fieldToken -> !fieldToken.isBlank())
+                        .iterator();
+                boolean isLeafNode = false;
+                Object oldParent;
+                // This loop will end at either a leaf node, or the last identified JSON field (by throwing an
+                // exception)
+                // Valid forms of the fieldPath for this search could be:
+                // root.field.list[index].childField.anotherList.indexWithDotOperator.multidimensionalList[index1][index2]
+                while (fieldsIterator.hasNext()) {
+                    oldParent = parent;
+                    String nextKey = fieldsIterator.next();
+                    if (parent instanceof JSONObject) {
+                        parent = ((JSONObject) parent).get(nextKey);
+                    } else if (parent instanceof Map) {
+                        parent = ((Map<String, ?>) parent).get(nextKey);
+                    } else if (parent instanceof List) {
+                        if (Pattern.matches(Pattern.compile("[0-9]+").toString(), nextKey)) {
+                            try {
+                                parent = ((List) parent).get(Integer.parseInt(nextKey));
+                            } catch (IndexOutOfBoundsException e) {
+                                // The index being referred does not exist. Hence the path would not exist.
+                                throw new AppsmithException(
+                                        AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
+                                        widgetType,
+                                        widgetName,
+                                        widgetId,
+                                        fieldPath,
+                                        creatorId,
+                                        layoutId,
+                                        oldParent,
+                                        nextKey,
+                                        "Index out of bounds for list",
+                                        creatorType);
+                            }
+                        } else {
+                            throw new AppsmithException(
+                                    AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
+                                    widgetType,
+                                    widgetName,
+                                    widgetId,
+                                    fieldPath,
+                                    creatorId,
+                                    layoutId,
+                                    oldParent,
+                                    nextKey,
+                                    "Child of list is not in an indexed path",
+                                    creatorType);
+                        }
+                    }
+                    // After updating the parent, check for the types
+                    if (parent == null) {
+                        throw new AppsmithException(
+                                AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
+                                widgetType,
+                                widgetName,
+                                widgetId,
+                                fieldPath,
+                                creatorId,
+                                layoutId,
+                                oldParent,
+                                nextKey,
+                                "New element is null",
+                                creatorType);
+                    } else if (parent instanceof String) {
+                        // If we get String value, then this is a leaf node
+                        isLeafNode = true;
+                    }
+
+                    // Only extract mustache keys from leaf nodes
+                    if (isLeafNode) {
+
+                        // We found the path. But if the path does not have any mustache bindings, throw the error
+                        if (!MustacheHelper.laxIsBindingPresentInString((String) parent)) {
+                            try {
+                                String bindingAsString = objectMapper.writeValueAsString(parent);
+                                throw new AppsmithException(
+                                        AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
+                                        widgetType,
+                                        widgetName,
+                                        widgetId,
+                                        fieldPath,
+                                        creatorId,
+                                        layoutId,
+                                        bindingAsString,
+                                        nextKey,
+                                        "Binding path has no mustache bindings",
+                                        creatorType);
+                            } catch (JsonProcessingException e) {
+                                throw new AppsmithException(AppsmithError.JSON_PROCESSING_ERROR, parent);
+                            }
+                        }
+
+                        // Stricter extraction of dynamic bindings
+                        Set<String> mustacheKeysFromFields =
+                                MustacheHelper.extractMustacheKeysFromFields(parent).stream()
+                                        .map(token -> token.getValue())
+                                        .collect(Collectors.toSet());
+
+                        String completePath = widgetName + "." + fieldPath;
+                        if (widgetDynamicBindingsMap.containsKey(completePath)) {
+                            Set<String> mustacheKeysForWidget = widgetDynamicBindingsMap.get(completePath);
+                            mustacheKeysFromFields.addAll(mustacheKeysForWidget);
+                        }
+                        widgetDynamicBindingsMap.put(completePath, mustacheKeysFromFields);
+                    }
+                }
+            }
+        }
+
+        // Escape the widget keys if required and update dsl and escapedWidgetNames
+        removeSpecialCharactersFromKeys(dsl, escapedWidgetNames);
+
+        // Fetch the children of the current node in the DSL and recursively iterate over them to extract bindings
+        ArrayList<Object> children = (ArrayList<Object>) dsl.get(FieldName.CHILDREN);
+        ArrayList<Object> newChildren = new ArrayList<>();
+        if (children != null) {
+            for (int i = 0; i < children.size(); i++) {
+                Map data = (Map) children.get(i);
+                JSONObject object = new JSONObject();
+                // If the children tag exists and there are entries within it
+                if (!CollectionUtils.isEmpty(data)) {
+                    object.putAll(data);
+                    JSONObject child = extractAllWidgetNamesAndDynamicBindingsFromDSL(
+                            object,
+                            widgetNames,
+                            widgetDynamicBindingsMap,
+                            creatorId,
+                            layoutId,
+                            escapedWidgetNames,
+                            creatorType);
+                    newChildren.add(child);
+                }
+            }
+            dsl.put(FieldName.CHILDREN, newChildren);
+        }
+
+        return dsl;
+    }
+
+    private JSONObject removeSpecialCharactersFromKeys(JSONObject dsl, Set<String> escapedWidgetNames) {
+        String widgetType = dsl.getAsString(FieldName.WIDGET_TYPE);
+
+        // Only Table widget has this behaviour.
+        if (widgetType != null && widgetType.equals(FieldName.TABLE_WIDGET)) {
+            return WidgetSpecificUtils.escapeTableWidgetPrimaryColumns(dsl, escapedWidgetNames);
+        }
+
+        return dsl;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceImpl.java
@@ -1,0 +1,35 @@
+package com.appsmith.server.layouts;
+
+import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.newpages.base.NewPageService;
+import com.appsmith.server.onload.internal.OnLoadExecutablesUtil;
+import com.appsmith.server.services.AnalyticsService;
+import com.appsmith.server.services.ApplicationService;
+import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.solutions.PagePermission;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdateLayoutServiceImpl extends UpdateLayoutServiceCEImpl implements UpdateLayoutService {
+
+    public UpdateLayoutServiceImpl(
+            OnLoadExecutablesUtil onLoadExecutablesUtil,
+            SessionUserService sessionUserService,
+            NewPageService newPageService,
+            AnalyticsService analyticsService,
+            ResponseUtils responseUtils,
+            PagePermission pagePermission,
+            ApplicationService applicationService,
+            ObjectMapper objectMapper) {
+        super(
+                onLoadExecutablesUtil,
+                sessionUserService,
+                newPageService,
+                analyticsService,
+                responseUtils,
+                pagePermission,
+                applicationService,
+                objectMapper);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/refactors/NewActionRefactoringServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/refactors/NewActionRefactoringServiceCEImpl.java
@@ -3,9 +3,11 @@ package com.appsmith.server.newactions.refactors;
 import com.appsmith.external.constants.AnalyticsEvents;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.MustacheBindingToken;
 import com.appsmith.external.models.PluginType;
 import com.appsmith.server.configurations.InstanceConfig;
+import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.dtos.EntityType;
 import com.appsmith.server.dtos.RefactorEntityNameDTO;
@@ -20,6 +22,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -125,6 +129,37 @@ public class NewActionRefactoringServiceCEImpl implements EntityRefactoringServi
                     return newActionService.updateUnpublishedAction(action.getId(), action);
                 })
                 .then();
+    }
+
+    @Override
+    public Flux<String> getExistingEntityNames(String contextId, CreatorContextType contextType, String layoutId) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        if (contextId != null) {
+            params.add(FieldName.PAGE_ID, contextId);
+        }
+
+        return newActionService
+                .getUnpublishedActions(params)
+                .flatMap(actionDTO -> {
+                    /*
+                       This is unexpected. Every action inside a JS collection should have a collectionId.
+                       But there are a few documents found for plugin type JS inside newAction collection that don't have any collectionId.
+                       The reason could be due to the lack of transactional behaviour when multiple inserts/updates that take place
+                       during JS action creation. A detailed RCA is documented here
+                       https://www.notion.so/appsmith/RCA-JSObject-name-already-exists-Please-use-a-different-name-e09c407f0ddb4653bd3974f3703408e6
+                    */
+                    if (actionDTO.getPluginType().equals(PluginType.JS)
+                            && !StringUtils.hasLength(actionDTO.getCollectionId())) {
+                        log.debug(
+                                "JS Action with Id: {} doesn't have any collection Id under pageId: {}",
+                                actionDTO.getId(),
+                                contextId);
+                        return Mono.empty();
+                    } else {
+                        return Mono.just(actionDTO);
+                    }
+                })
+                .map(ActionDTO::getValidName);
     }
 
     private Mono<Set<String>> refactorNameInAction(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionCE.java
@@ -7,4 +7,6 @@ import reactor.core.publisher.Mono;
 public interface RefactoringSolutionCE {
 
     Mono<LayoutDTO> refactorEntityName(RefactorEntityNameDTO refactorEntityNameDTO, String branchName);
+
+    Mono<Boolean> isNameAllowed(String pageId, String layoutId, String newName);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionCEImpl.java
@@ -13,11 +13,11 @@ import com.appsmith.server.dtos.RefactoringMetaDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.entities.EntityRefactoringService;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.ApplicationService;
-import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.solutions.PagePermission;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +43,7 @@ import static com.appsmith.server.services.ce.ApplicationPageServiceCEImpl.EVALU
 public class RefactoringSolutionCEImpl implements RefactoringSolutionCE {
     private final NewPageService newPageService;
     private final ResponseUtils responseUtils;
-    private final LayoutActionService layoutActionService;
+    private final UpdateLayoutService updateLayoutService;
     private final ApplicationService applicationService;
     private final PagePermission pagePermission;
     private final AnalyticsService analyticsService;
@@ -112,8 +112,8 @@ public class RefactoringSolutionCEImpl implements RefactoringSolutionCE {
                 List<Layout> layouts = page.getLayouts();
                 for (Layout layout : layouts) {
                     if (layoutId.equals(layout.getId())) {
-                        layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
-                        return layoutActionService
+                        layout.setDsl(updateLayoutService.unescapeMongoSpecialCharacters(layout));
+                        return updateLayoutService
                                 .updateLayout(page.getId(), page.getApplicationId(), layout.getId(), layout)
                                 .zipWith(Mono.just(updatedBindingPaths));
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionImpl.java
@@ -4,11 +4,11 @@ import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.domains.Layout;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.entities.EntityRefactoringService;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.ApplicationService;
-import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.solutions.PagePermission;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +22,7 @@ public class RefactoringSolutionImpl extends RefactoringSolutionCEImpl implement
     public RefactoringSolutionImpl(
             NewPageService newPageService,
             ResponseUtils responseUtils,
-            LayoutActionService layoutActionService,
+            UpdateLayoutService updateLayoutService,
             ApplicationService applicationService,
             PagePermission pagePermission,
             AnalyticsService analyticsService,
@@ -35,7 +35,7 @@ public class RefactoringSolutionImpl extends RefactoringSolutionCEImpl implement
         super(
                 newPageService,
                 responseUtils,
-                layoutActionService,
+                updateLayoutService,
                 applicationService,
                 pagePermission,
                 analyticsService,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/entities/EntityRefactoringServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/entities/EntityRefactoringServiceCE.java
@@ -1,9 +1,11 @@
 package com.appsmith.server.refactors.entities;
 
 import com.appsmith.external.constants.AnalyticsEvents;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.server.dtos.EntityType;
 import com.appsmith.server.dtos.RefactorEntityNameDTO;
 import com.appsmith.server.dtos.RefactoringMetaDTO;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface EntityRefactoringServiceCE<T> {
@@ -21,4 +23,8 @@ public interface EntityRefactoringServiceCE<T> {
             RefactorEntityNameDTO refactorEntityNameDTO, RefactoringMetaDTO refactoringMetaDTO);
 
     Mono<Void> updateRefactoredEntity(RefactorEntityNameDTO refactorEntityNameDTO, String branchName);
+
+    default Flux<String> getExistingEntityNames(String contextId, CreatorContextType contextType, String layoutId) {
+        return Flux.empty();
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.acl.PolicyGenerator;
 import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.repositories.ActionCollectionRepository;
@@ -33,6 +34,7 @@ public class ApplicationPageServiceImpl extends ApplicationPageServiceCEImpl imp
             SessionUserService sessionUserService,
             WorkspaceRepository workspaceRepository,
             LayoutActionService layoutActionService,
+            UpdateLayoutService updateLayoutService,
             AnalyticsService analyticsService,
             PolicyGenerator policyGenerator,
             ApplicationRepository applicationRepository,
@@ -53,13 +55,13 @@ public class ApplicationPageServiceImpl extends ApplicationPageServiceCEImpl imp
             NewPageRepository newPageRepository,
             DatasourceRepository datasourceRepository,
             DatasourcePermission datasourcePermission) {
-
         super(
                 workspaceService,
                 applicationService,
                 sessionUserService,
                 workspaceRepository,
                 layoutActionService,
+                updateLayoutService,
                 analyticsService,
                 policyGenerator,
                 applicationRepository,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -1,11 +1,11 @@
 package com.appsmith.server.services;
 
-import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.onload.internal.OnLoadExecutablesUtil;
+import com.appsmith.server.refactors.applications.RefactoringSolution;
 import com.appsmith.server.services.ce.LayoutActionServiceCEImpl;
 import com.appsmith.server.solutions.ActionPermission;
 import com.appsmith.server.solutions.PagePermission;
@@ -16,30 +16,28 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class LayoutActionServiceImpl extends LayoutActionServiceCEImpl implements LayoutActionService {
-
     public LayoutActionServiceImpl(
             ObjectMapper objectMapper,
             AnalyticsService analyticsService,
             NewPageService newPageService,
             NewActionService newActionService,
-            OnLoadExecutablesUtil pageLoadActionsUtil,
+            OnLoadExecutablesUtil onLoadExecutablesUtil,
             SessionUserService sessionUserService,
-            ActionCollectionService actionCollectionService,
+            RefactoringSolution refactoringSolution,
             CollectionService collectionService,
             ApplicationService applicationService,
             ResponseUtils responseUtils,
             DatasourceService datasourceService,
             PagePermission pagePermission,
             ActionPermission actionPermission) {
-
         super(
                 objectMapper,
                 analyticsService,
                 newPageService,
                 newActionService,
-                pageLoadActionsUtil,
+                onLoadExecutablesUtil,
                 sessionUserService,
-                actionCollectionService,
+                refactoringSolution,
                 collectionService,
                 applicationService,
                 responseUtils,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -2,44 +2,38 @@ package com.appsmith.server.services;
 
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
-import com.appsmith.server.onload.internal.OnLoadExecutablesUtil;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
 import com.appsmith.server.services.ce.LayoutActionServiceCEImpl;
 import com.appsmith.server.solutions.ActionPermission;
 import com.appsmith.server.solutions.PagePermission;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
 public class LayoutActionServiceImpl extends LayoutActionServiceCEImpl implements LayoutActionService {
+
     public LayoutActionServiceImpl(
-            ObjectMapper objectMapper,
             AnalyticsService analyticsService,
             NewPageService newPageService,
             NewActionService newActionService,
-            OnLoadExecutablesUtil onLoadExecutablesUtil,
-            SessionUserService sessionUserService,
             RefactoringSolution refactoringSolution,
             CollectionService collectionService,
-            ApplicationService applicationService,
+            UpdateLayoutService updateLayoutService,
             ResponseUtils responseUtils,
             DatasourceService datasourceService,
             PagePermission pagePermission,
             ActionPermission actionPermission) {
         super(
-                objectMapper,
                 analyticsService,
                 newPageService,
                 newActionService,
-                onLoadExecutablesUtil,
-                sessionUserService,
                 refactoringSolution,
                 collectionService,
-                applicationService,
+                updateLayoutService,
                 responseUtils,
                 datasourceService,
                 pagePermission,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutCollectionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutCollectionServiceImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
+import com.appsmith.server.refactors.applications.RefactoringSolution;
 import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.services.ce.LayoutCollectionServiceCEImpl;
 import com.appsmith.server.solutions.ActionPermission;
@@ -18,6 +19,7 @@ public class LayoutCollectionServiceImpl extends LayoutCollectionServiceCEImpl i
     public LayoutCollectionServiceImpl(
             NewPageService newPageService,
             LayoutActionService layoutActionService,
+            RefactoringSolution refactoringSolution,
             ActionCollectionService actionCollectionService,
             NewActionService newActionService,
             AnalyticsService analyticsService,
@@ -28,6 +30,7 @@ public class LayoutCollectionServiceImpl extends LayoutCollectionServiceCEImpl i
         super(
                 newPageService,
                 layoutActionService,
+                refactoringSolution,
                 actionCollectionService,
                 newActionService,
                 analyticsService,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutCollectionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutCollectionServiceImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services;
 
 import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
@@ -19,6 +20,7 @@ public class LayoutCollectionServiceImpl extends LayoutCollectionServiceCEImpl i
     public LayoutCollectionServiceImpl(
             NewPageService newPageService,
             LayoutActionService layoutActionService,
+            UpdateLayoutService updateLayoutService,
             RefactoringSolution refactoringSolution,
             ActionCollectionService actionCollectionService,
             NewActionService newActionService,
@@ -30,6 +32,7 @@ public class LayoutCollectionServiceImpl extends LayoutCollectionServiceCEImpl i
         super(
                 newPageService,
                 layoutActionService,
+                updateLayoutService,
                 refactoringSolution,
                 actionCollectionService,
                 newActionService,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -36,6 +36,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.helpers.UserPermissionUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.migrations.ApplicationVersion;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
@@ -97,6 +98,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
     private final SessionUserService sessionUserService;
     private final WorkspaceRepository workspaceRepository;
     private final LayoutActionService layoutActionService;
+    private final UpdateLayoutService updateLayoutService;
 
     private final AnalyticsService analyticsService;
     private final PolicyGenerator policyGenerator;
@@ -251,7 +253,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                     || layout.getMongoEscapedWidgetNames().isEmpty()) {
                 continue;
             }
-            layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
+            layout.setDsl(updateLayoutService.unescapeMongoSpecialCharacters(layout));
         }
         page.setLayouts(layouts);
         return page;
@@ -777,8 +779,8 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
 
                     return Flux.fromIterable(layouts)
                             .flatMap(layout -> {
-                                layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
-                                return layoutActionService.updateLayout(
+                                layout.setDsl(updateLayoutService.unescapeMongoSpecialCharacters(layout));
+                                return updateLayoutService.updateLayout(
                                         savedPage.getId(), savedPage.getApplicationId(), layout.getId(), layout);
                             })
                             .collectList()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCE.java
@@ -23,8 +23,6 @@ public interface LayoutActionServiceCE {
 
     Mono<ActionDTO> moveAction(ActionMoveDTO actionMoveDTO, String branchName);
 
-    Mono<Boolean> isNameAllowed(String pageId, String layoutId, String newName);
-
     Mono<ActionDTO> updateAction(String id, ActionDTO action);
 
     Mono<ActionDTO> updateSingleAction(String id, ActionDTO action);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCE.java
@@ -2,22 +2,10 @@ package com.appsmith.server.services.ce;
 
 import com.appsmith.external.helpers.AppsmithEventContext;
 import com.appsmith.external.models.ActionDTO;
-import com.appsmith.server.domains.Layout;
 import com.appsmith.server.dtos.ActionMoveDTO;
-import com.appsmith.server.dtos.LayoutDTO;
-import com.appsmith.server.dtos.UpdateMultiplePageLayoutDTO;
-import net.minidev.json.JSONObject;
 import reactor.core.publisher.Mono;
 
 public interface LayoutActionServiceCE {
-
-    Mono<LayoutDTO> updateLayout(String pageId, String applicationId, String layoutId, Layout layout);
-
-    Mono<LayoutDTO> updateLayout(
-            String defaultPageId, String defaultApplicationId, String layoutId, Layout layout, String branchName);
-
-    Mono<Integer> updateMultipleLayouts(
-            String defaultApplicationId, String branchName, UpdateMultiplePageLayoutDTO updateMultiplePageLayoutDTO);
 
     Mono<ActionDTO> moveAction(ActionMoveDTO actionMoveDTO);
 
@@ -34,8 +22,6 @@ public interface LayoutActionServiceCE {
     Mono<ActionDTO> setExecuteOnLoad(String id, Boolean isExecuteOnLoad);
 
     Mono<ActionDTO> setExecuteOnLoad(String defaultActionId, String branchName, Boolean isExecuteOnLoad);
-
-    JSONObject unescapeMongoSpecialCharacters(Layout layout);
 
     Mono<ActionDTO> createAction(ActionDTO action);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -1,70 +1,38 @@
 package com.appsmith.server.services.ce;
 
-import com.appsmith.external.constants.AnalyticsEvents;
-import com.appsmith.external.dtos.DslExecutableDTO;
-import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
-import com.appsmith.external.exceptions.ErrorDTO;
 import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.external.helpers.AppsmithEventContext;
 import com.appsmith.external.helpers.AppsmithEventContextType;
-import com.appsmith.external.helpers.MustacheHelper;
 import com.appsmith.external.models.ActionDTO;
-import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DefaultResources;
-import com.appsmith.external.models.Executable;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.datasources.base.DatasourceService;
-import com.appsmith.server.domains.ExecutableDependencyEdge;
 import com.appsmith.server.domains.Layout;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
-import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.ActionMoveDTO;
-import com.appsmith.server.dtos.LayoutDTO;
-import com.appsmith.server.dtos.UpdateMultiplePageLayoutDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.DefaultResourcesUtils;
 import com.appsmith.server.helpers.ResponseUtils;
-import com.appsmith.server.helpers.WidgetSpecificUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
-import com.appsmith.server.onload.internal.OnLoadExecutablesUtil;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
 import com.appsmith.server.services.AnalyticsService;
-import com.appsmith.server.services.ApplicationService;
 import com.appsmith.server.services.CollectionService;
-import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.solutions.ActionPermission;
 import com.appsmith.server.solutions.PagePermission;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.minidev.json.JSONObject;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import static com.appsmith.server.services.ce.ApplicationPageServiceCEImpl.EVALUATION_VERSION;
-import static java.lang.Boolean.FALSE;
 import static java.util.stream.Collectors.toSet;
 
 @Slf4j
@@ -72,22 +40,16 @@ import static java.util.stream.Collectors.toSet;
 @Service
 public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
 
-    private final ObjectMapper objectMapper;
     private final AnalyticsService analyticsService;
     private final NewPageService newPageService;
     private final NewActionService newActionService;
-    private final OnLoadExecutablesUtil onLoadExecutablesUtil;
-    private final SessionUserService sessionUserService;
     private final RefactoringSolution refactoringSolution;
     private final CollectionService collectionService;
-    private final ApplicationService applicationService;
+    private final UpdateLayoutService updateLayoutService;
     private final ResponseUtils responseUtils;
     private final DatasourceService datasourceService;
     private final PagePermission pagePermission;
     private final ActionPermission actionPermission;
-
-    private final String layoutOnLoadActionErrorToastMessage =
-            "A cyclic dependency error has been encountered on current page, \nqueries on page load will not run. \n Please check debugger and Appsmith documentation for more information";
 
     /**
      * Called by Action controller to create Action
@@ -209,8 +171,9 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                                     // 2. Run updateLayout on the old page
                                     return Flux.fromIterable(page.getLayouts())
                                             .flatMap(layout -> {
-                                                layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
-                                                return updateLayout(
+                                                layout.setDsl(
+                                                        updateLayoutService.unescapeMongoSpecialCharacters(layout));
+                                                return updateLayoutService.updateLayout(
                                                         page.getId(), page.getApplicationId(), layout.getId(), layout);
                                             })
                                             .collect(toSet());
@@ -228,8 +191,9 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                                     // 3. Run updateLayout on the new page.
                                     return Flux.fromIterable(page.getLayouts())
                                             .flatMap(layout -> {
-                                                layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
-                                                return updateLayout(
+                                                layout.setDsl(
+                                                        updateLayoutService.unescapeMongoSpecialCharacters(layout));
+                                                return updateLayoutService.updateLayout(
                                                         page.getId(), page.getApplicationId(), layout.getId(), layout);
                                             })
                                             .collect(toSet());
@@ -263,205 +227,6 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                     return moveAction(actionMoveDTO);
                 })
                 .map(responseUtils::updateActionDTOWithDefaultResources);
-    }
-
-    /**
-     * Walks the DSL and extracts all the widget names from it.
-     * A widget is expected to have a few properties defining its own behaviour, with any mustache bindings present
-     * in them aggregated in the field dynamicBindingsPathList.
-     * A widget may also have other widgets as children, each of which will follow the same structure
-     * Refer to FieldName.DEFAULT_PAGE_LAYOUT for a template
-     *
-     * @param dsl
-     * @param widgetNames
-     * @param widgetDynamicBindingsMap
-     * @param creatorId
-     * @param layoutId
-     * @param escapedWidgetNames
-     * @return
-     */
-    private JSONObject extractAllWidgetNamesAndDynamicBindingsFromDSL(
-            JSONObject dsl,
-            Set<String> widgetNames,
-            Map<String, Set<String>> widgetDynamicBindingsMap,
-            String creatorId,
-            String layoutId,
-            Set<String> escapedWidgetNames,
-            CreatorContextType creatorType)
-            throws AppsmithException {
-        if (dsl.get(FieldName.WIDGET_NAME) == null) {
-            // This isn't a valid widget configuration. No need to traverse this.
-            return dsl;
-        }
-
-        String widgetName = dsl.getAsString(FieldName.WIDGET_NAME);
-        String widgetId = dsl.getAsString(FieldName.WIDGET_ID);
-        String widgetType = dsl.getAsString(FieldName.WIDGET_TYPE);
-
-        // Since we are parsing this widget in this, add it to the global set of widgets found so far in the DSL.
-        widgetNames.add(widgetName);
-
-        // Start by picking all fields where we expect to find dynamic bindings for this particular widget
-        ArrayList<Object> dynamicallyBoundedPathList = (ArrayList<Object>) dsl.get(FieldName.DYNAMIC_BINDING_PATH_LIST);
-
-        // Widgets will not have FieldName.DYNAMIC_BINDING_PATH_LIST if there are no bindings in that widget.
-        // Hence we skip over the extraction of the bindings from that widget.
-        if (dynamicallyBoundedPathList != null) {
-            // Each of these might have nested structures, so we iterate through them to find the leaf node for each
-            for (Object x : dynamicallyBoundedPathList) {
-                final String fieldPath = String.valueOf(((Map) x).get(FieldName.KEY));
-                String[] fields = fieldPath.split("[].\\[]");
-                // For nested fields, the parent dsl to search in would shift by one level every iteration
-                Object parent = dsl;
-                Iterator<String> fieldsIterator = Arrays.stream(fields)
-                        .filter(fieldToken -> !fieldToken.isBlank())
-                        .iterator();
-                boolean isLeafNode = false;
-                Object oldParent;
-                // This loop will end at either a leaf node, or the last identified JSON field (by throwing an
-                // exception)
-                // Valid forms of the fieldPath for this search could be:
-                // root.field.list[index].childField.anotherList.indexWithDotOperator.multidimensionalList[index1][index2]
-                while (fieldsIterator.hasNext()) {
-                    oldParent = parent;
-                    String nextKey = fieldsIterator.next();
-                    if (parent instanceof JSONObject) {
-                        parent = ((JSONObject) parent).get(nextKey);
-                    } else if (parent instanceof Map) {
-                        parent = ((Map<String, ?>) parent).get(nextKey);
-                    } else if (parent instanceof List) {
-                        if (Pattern.matches(Pattern.compile("[0-9]+").toString(), nextKey)) {
-                            try {
-                                parent = ((List) parent).get(Integer.parseInt(nextKey));
-                            } catch (IndexOutOfBoundsException e) {
-                                // The index being referred does not exist. Hence the path would not exist.
-                                throw new AppsmithException(
-                                        AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
-                                        widgetType,
-                                        widgetName,
-                                        widgetId,
-                                        fieldPath,
-                                        creatorId,
-                                        layoutId,
-                                        oldParent,
-                                        nextKey,
-                                        "Index out of bounds for list",
-                                        creatorType);
-                            }
-                        } else {
-                            throw new AppsmithException(
-                                    AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
-                                    widgetType,
-                                    widgetName,
-                                    widgetId,
-                                    fieldPath,
-                                    creatorId,
-                                    layoutId,
-                                    oldParent,
-                                    nextKey,
-                                    "Child of list is not in an indexed path",
-                                    creatorType);
-                        }
-                    }
-                    // After updating the parent, check for the types
-                    if (parent == null) {
-                        throw new AppsmithException(
-                                AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
-                                widgetType,
-                                widgetName,
-                                widgetId,
-                                fieldPath,
-                                creatorId,
-                                layoutId,
-                                oldParent,
-                                nextKey,
-                                "New element is null",
-                                creatorType);
-                    } else if (parent instanceof String) {
-                        // If we get String value, then this is a leaf node
-                        isLeafNode = true;
-                    }
-
-                    // Only extract mustache keys from leaf nodes
-                    if (isLeafNode) {
-
-                        // We found the path. But if the path does not have any mustache bindings, throw the error
-                        if (!MustacheHelper.laxIsBindingPresentInString((String) parent)) {
-                            try {
-                                String bindingAsString = objectMapper.writeValueAsString(parent);
-                                throw new AppsmithException(
-                                        AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE,
-                                        widgetType,
-                                        widgetName,
-                                        widgetId,
-                                        fieldPath,
-                                        creatorId,
-                                        layoutId,
-                                        bindingAsString,
-                                        nextKey,
-                                        "Binding path has no mustache bindings",
-                                        creatorType);
-                            } catch (JsonProcessingException e) {
-                                throw new AppsmithException(AppsmithError.JSON_PROCESSING_ERROR, parent);
-                            }
-                        }
-
-                        // Stricter extraction of dynamic bindings
-                        Set<String> mustacheKeysFromFields =
-                                MustacheHelper.extractMustacheKeysFromFields(parent).stream()
-                                        .map(token -> token.getValue())
-                                        .collect(Collectors.toSet());
-
-                        String completePath = widgetName + "." + fieldPath;
-                        if (widgetDynamicBindingsMap.containsKey(completePath)) {
-                            Set<String> mustacheKeysForWidget = widgetDynamicBindingsMap.get(completePath);
-                            mustacheKeysFromFields.addAll(mustacheKeysForWidget);
-                        }
-                        widgetDynamicBindingsMap.put(completePath, mustacheKeysFromFields);
-                    }
-                }
-            }
-        }
-
-        // Escape the widget keys if required and update dsl and escapedWidgetNames
-        removeSpecialCharactersFromKeys(dsl, escapedWidgetNames);
-
-        // Fetch the children of the current node in the DSL and recursively iterate over them to extract bindings
-        ArrayList<Object> children = (ArrayList<Object>) dsl.get(FieldName.CHILDREN);
-        ArrayList<Object> newChildren = new ArrayList<>();
-        if (children != null) {
-            for (int i = 0; i < children.size(); i++) {
-                Map data = (Map) children.get(i);
-                JSONObject object = new JSONObject();
-                // If the children tag exists and there are entries within it
-                if (!CollectionUtils.isEmpty(data)) {
-                    object.putAll(data);
-                    JSONObject child = extractAllWidgetNamesAndDynamicBindingsFromDSL(
-                            object,
-                            widgetNames,
-                            widgetDynamicBindingsMap,
-                            creatorId,
-                            layoutId,
-                            escapedWidgetNames,
-                            creatorType);
-                    newChildren.add(child);
-                }
-            }
-            dsl.put(FieldName.CHILDREN, newChildren);
-        }
-
-        return dsl;
-    }
-
-    private JSONObject removeSpecialCharactersFromKeys(JSONObject dsl, Set<String> escapedWidgetNames) {
-        String widgetType = dsl.getAsString(FieldName.WIDGET_TYPE);
-
-        // Only Table widget has this behaviour.
-        if (widgetType != null && widgetType.equals(FieldName.TABLE_WIDGET)) {
-            return WidgetSpecificUtils.escapeTableWidgetPrimaryColumns(dsl, escapedWidgetNames);
-        }
-
-        return dsl;
     }
 
     /**
@@ -566,269 +331,13 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                         return Mono.empty();
                     }
                     return Flux.fromIterable(page.getLayouts()).flatMap(layout -> {
-                        layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
-                        return updateLayout(page.getId(), page.getApplicationId(), layout.getId(), layout);
+                        layout.setDsl(updateLayoutService.unescapeMongoSpecialCharacters(layout));
+                        return updateLayoutService.updateLayout(
+                                page.getId(), page.getApplicationId(), layout.getId(), layout);
                     });
                 })
                 .collectList()
                 .then(Mono.just(pageId));
-    }
-
-    private Mono<Boolean> sendUpdateLayoutAnalyticsEvent(
-            String creatorId,
-            String layoutId,
-            JSONObject dsl,
-            boolean isSuccess,
-            Throwable error,
-            CreatorContextType creatorType) {
-        return Mono.zip(sessionUserService.getCurrentUser(), newPageService.getById(creatorId))
-                .flatMap(tuple -> {
-                    User t1 = tuple.getT1();
-                    NewPage t2 = tuple.getT2();
-
-                    final Map<String, Object> data = Map.of(
-                            "username",
-                            t1.getUsername(),
-                            "appId",
-                            t2.getApplicationId(),
-                            "creatorId",
-                            creatorId,
-                            "creatorType",
-                            creatorType,
-                            "layoutId",
-                            layoutId,
-                            "isSuccessfulExecution",
-                            isSuccess,
-                            "error",
-                            error == null ? "" : error.getMessage());
-
-                    return analyticsService
-                            .sendObjectEvent(AnalyticsEvents.UPDATE_LAYOUT, t2, data)
-                            .thenReturn(isSuccess);
-                })
-                .onErrorResume(e -> {
-                    log.warn("Error sending action execution data point", e);
-                    return Mono.just(isSuccess);
-                });
-    }
-
-    private Mono<LayoutDTO> updateLayoutDsl(
-            String creatorId,
-            String layoutId,
-            Layout layout,
-            Integer evaluatedVersion,
-            CreatorContextType creatorType) {
-        JSONObject dsl = layout.getDsl();
-        if (dsl == null) {
-            // There is no DSL here. No need to process anything. Return as is.
-            return Mono.just(generateResponseDTO(layout));
-        }
-
-        Set<String> widgetNames = new HashSet<>();
-        Map<String, Set<String>> widgetDynamicBindingsMap = new HashMap<>();
-        Set<String> escapedWidgetNames = new HashSet<>();
-        try {
-            dsl = extractAllWidgetNamesAndDynamicBindingsFromDSL(
-                    dsl, widgetNames, widgetDynamicBindingsMap, creatorId, layoutId, escapedWidgetNames, creatorType);
-        } catch (Throwable t) {
-            return sendUpdateLayoutAnalyticsEvent(creatorId, layoutId, dsl, false, t, creatorType)
-                    .then(Mono.error(t));
-        }
-
-        layout.setWidgetNames(widgetNames);
-
-        if (!escapedWidgetNames.isEmpty()) {
-            layout.setMongoEscapedWidgetNames(escapedWidgetNames);
-        }
-
-        Set<String> executableNames = new HashSet<>();
-        Set<ExecutableDependencyEdge> edges = new HashSet<>();
-        Set<String> executablesUsedInDSL = new HashSet<>();
-        List<Executable> flatmapOnLoadExecutables = new ArrayList<>();
-        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
-        List<String> messagesRef = new ArrayList<>();
-
-        AtomicReference<Boolean> validOnLoadExecutables = new AtomicReference<>(Boolean.TRUE);
-
-        // setting the layoutOnLoadActionActionErrors to empty to remove the existing errors before new DAG calculation.
-        layout.setLayoutOnLoadActionErrors(new ArrayList<>());
-
-        Mono<List<Set<DslExecutableDTO>>> allOnLoadExecutablesMono = onLoadExecutablesUtil
-                .findAllOnLoadExecutables(
-                        creatorId,
-                        evaluatedVersion,
-                        widgetNames,
-                        edges,
-                        widgetDynamicBindingsMap,
-                        flatmapOnLoadExecutables,
-                        executablesUsedInDSL,
-                        creatorType)
-                .onErrorResume(AppsmithException.class, error -> {
-                    log.info(error.getMessage());
-                    validOnLoadExecutables.set(FALSE);
-                    layout.setLayoutOnLoadActionErrors(List.of(new ErrorDTO(
-                            error.getAppErrorCode(),
-                            error.getErrorType(),
-                            layoutOnLoadActionErrorToastMessage,
-                            error.getMessage(),
-                            error.getTitle())));
-                    return Mono.just(new ArrayList<>());
-                });
-
-        // First update the actions and set execute on load to true
-        JSONObject finalDsl = dsl;
-        return allOnLoadExecutablesMono
-                .flatMap(allOnLoadExecutables -> {
-                    // If there has been an error (e.g. cyclical dependency), then don't update any actions.
-                    // This is so that unnecessary updates don't happen to actions while the page is in invalid state.
-                    if (!validOnLoadExecutables.get()) {
-                        return Mono.just(allOnLoadExecutables);
-                    }
-                    // Update these executables to be executed on load, unless the user has touched the executeOnLoad
-                    // setting for this
-                    return onLoadExecutablesUtil
-                            .updateExecutablesExecuteOnLoad(
-                                    flatmapOnLoadExecutables, creatorId, executableUpdatesRef, messagesRef, creatorType)
-                            .thenReturn(allOnLoadExecutables);
-                })
-                // Now update the page layout with the page load executables and the graph.
-                .flatMap(onLoadExecutables -> {
-                    layout.setLayoutOnLoadActions(onLoadExecutables);
-                    layout.setAllOnPageLoadActionNames(executableNames);
-                    layout.setActionsUsedInDynamicBindings(executablesUsedInDSL);
-                    // The below field is to ensure that we record if the page load actions computation was
-                    // valid when last stored in the database.
-                    layout.setValidOnPageLoadActions(validOnLoadExecutables.get());
-
-                    return onLoadExecutablesUtil.findAndUpdateLayout(creatorId, creatorType, layoutId, layout);
-                })
-                .map(savedLayout -> {
-                    savedLayout.setDsl(this.unescapeMongoSpecialCharacters(savedLayout));
-                    return savedLayout;
-                })
-                .flatMap(savedLayout -> {
-                    LayoutDTO layoutDTO = generateResponseDTO(savedLayout);
-                    layoutDTO.setActionUpdates(executableUpdatesRef);
-                    layoutDTO.setMessages(messagesRef);
-
-                    return sendUpdateLayoutAnalyticsEvent(creatorId, layoutId, finalDsl, true, null, creatorType)
-                            .thenReturn(layoutDTO);
-                });
-    }
-
-    @Override
-    public Mono<LayoutDTO> updateLayout(String pageId, String applicationId, String layoutId, Layout layout) {
-        return applicationService
-                .findById(applicationId)
-                .switchIfEmpty(Mono.error(new AppsmithException(
-                        AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION_ID, applicationId)))
-                .flatMap(application -> {
-                    Integer evaluationVersion = application.getEvaluationVersion();
-                    if (evaluationVersion == null) {
-                        evaluationVersion = EVALUATION_VERSION;
-                    }
-                    return updateLayoutDsl(pageId, layoutId, layout, evaluationVersion, CreatorContextType.PAGE);
-                });
-    }
-
-    @Override
-    public Mono<LayoutDTO> updateLayout(
-            String defaultPageId, String defaultApplicationId, String layoutId, Layout layout, String branchName) {
-        if (!StringUtils.hasLength(branchName)) {
-            return updateLayout(defaultPageId, defaultApplicationId, layoutId, layout);
-        }
-        return newPageService
-                .findByBranchNameAndDefaultPageId(branchName, defaultPageId, pagePermission.getEditPermission())
-                .flatMap(branchedPage ->
-                        updateLayout(branchedPage.getId(), branchedPage.getApplicationId(), layoutId, layout))
-                .map(responseUtils::updateLayoutDTOWithDefaultResources);
-    }
-
-    @Override
-    public Mono<Integer> updateMultipleLayouts(
-            String defaultApplicationId, String branchName, UpdateMultiplePageLayoutDTO updateMultiplePageLayoutDTO) {
-        List<Mono<LayoutDTO>> monoList = new ArrayList<>();
-        for (UpdateMultiplePageLayoutDTO.UpdatePageLayoutDTO pageLayout :
-                updateMultiplePageLayoutDTO.getPageLayouts()) {
-            Mono<LayoutDTO> updatedLayoutMono = this.updateLayout(
-                    pageLayout.getPageId(),
-                    defaultApplicationId,
-                    pageLayout.getLayoutId(),
-                    pageLayout.getLayout(),
-                    branchName);
-            monoList.add(updatedLayoutMono);
-        }
-        return Flux.merge(monoList).then(Mono.just(monoList.size()));
-    }
-
-    private LayoutDTO generateResponseDTO(Layout layout) {
-
-        LayoutDTO layoutDTO = new LayoutDTO();
-
-        layoutDTO.setId(layout.getId());
-        layoutDTO.setDsl(layout.getDsl());
-        layoutDTO.setScreen(layout.getScreen());
-        layoutDTO.setLayoutOnLoadActions(layout.getLayoutOnLoadActions());
-        layoutDTO.setLayoutOnLoadActionErrors(layout.getLayoutOnLoadActionErrors());
-        layoutDTO.setUserPermissions(layout.getUserPermissions());
-
-        return layoutDTO;
-    }
-
-    @Override
-    public JSONObject unescapeMongoSpecialCharacters(Layout layout) {
-        Set<String> mongoEscapedWidgetNames = layout.getMongoEscapedWidgetNames();
-
-        if (mongoEscapedWidgetNames == null || mongoEscapedWidgetNames.isEmpty()) {
-            return layout.getDsl();
-        }
-
-        JSONObject dsl = layout.getDsl();
-
-        // Unescape specific widgets
-        dsl = unEscapeDslKeys(dsl, layout.getMongoEscapedWidgetNames());
-
-        return dsl;
-    }
-
-    private JSONObject unEscapeDslKeys(JSONObject dsl, Set<String> escapedWidgetNames) {
-
-        String widgetName = (String) dsl.get(FieldName.WIDGET_NAME);
-
-        if (widgetName == null) {
-            // This isnt a valid widget configuration. No need to traverse further.
-            return dsl;
-        }
-
-        if (escapedWidgetNames.contains(widgetName)) {
-            // We should escape the widget keys
-            String widgetType = dsl.getAsString(FieldName.WIDGET_TYPE);
-            if (widgetType.equals(FieldName.TABLE_WIDGET)) {
-                // UnEscape Table widget keys
-                // Since this is a table widget, it wouldnt have children. We can safely return from here with updated
-                // dsl
-                return WidgetSpecificUtils.unEscapeTableWidgetPrimaryColumns(dsl);
-            }
-        }
-
-        // Fetch the children of the current node in the DSL and recursively iterate over them to extract bindings
-        ArrayList<Object> children = (ArrayList<Object>) dsl.get(FieldName.CHILDREN);
-        ArrayList<Object> newChildren = new ArrayList<>();
-        if (children != null) {
-            for (int i = 0; i < children.size(); i++) {
-                Map data = (Map) children.get(i);
-                JSONObject object = new JSONObject();
-                // If the children tag exists and there are entries within it
-                if (!CollectionUtils.isEmpty(data)) {
-                    object.putAll(data);
-                    JSONObject child = unEscapeDslKeys(object, escapedWidgetNames);
-                    newChildren.add(child);
-                }
-            }
-            dsl.put(FieldName.CHILDREN, newChildren);
-        }
-
-        return dsl;
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -15,6 +15,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.DefaultResourcesUtils;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
@@ -49,6 +50,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
 
     private final NewPageService newPageService;
     private final LayoutActionService layoutActionService;
+    private final UpdateLayoutService updateLayoutService;
     private final RefactoringSolution refactoringSolution;
     private final ActionCollectionService actionCollectionService;
     private final NewActionService newActionService;
@@ -332,8 +334,8 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
                                 // 2. Run updateLayout on the old page
                                 return Flux.fromIterable(page.getLayouts())
                                         .flatMap(layout -> {
-                                            layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
-                                            return layoutActionService.updateLayout(
+                                            layout.setDsl(updateLayoutService.unescapeMongoSpecialCharacters(layout));
+                                            return updateLayoutService.updateLayout(
                                                     page.getId(), page.getApplicationId(), layout.getId(), layout);
                                         })
                                         .collect(toSet());
@@ -351,8 +353,8 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
                                 // 3. Run updateLayout on the new page.
                                 return Flux.fromIterable(page.getLayouts())
                                         .flatMap(layout -> {
-                                            layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
-                                            return layoutActionService.updateLayout(
+                                            layout.setDsl(updateLayoutService.unescapeMongoSpecialCharacters(layout));
+                                            return updateLayoutService.updateLayout(
                                                     page.getId(), page.getApplicationId(), layout.getId(), layout);
                                         })
                                         .collect(toSet());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -17,6 +17,7 @@ import com.appsmith.server.helpers.DefaultResourcesUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
+import com.appsmith.server.refactors.applications.RefactoringSolution;
 import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.LayoutActionService;
@@ -48,6 +49,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
 
     private final NewPageService newPageService;
     private final LayoutActionService layoutActionService;
+    private final RefactoringSolution refactoringSolution;
     private final ActionCollectionService actionCollectionService;
     private final NewActionService newActionService;
     private final AnalyticsService analyticsService;
@@ -89,7 +91,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
         return pageMono.flatMap(page -> {
                     Layout layout = page.getUnpublishedPage().getLayouts().get(0);
                     // Check against widget names and action names
-                    return layoutActionService.isNameAllowed(page.getId(), layout.getId(), collection.getName());
+                    return refactoringSolution.isNameAllowed(page.getId(), layout.getId(), collection.getName());
                 })
                 .flatMap(isNameAllowed -> {
                     // If the name is allowed, return list of actionDTOs for further processing

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolutionImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolutionImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.services.AnalyticsService;
@@ -19,12 +20,12 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class CreateDBTablePageSolutionImpl extends CreateDBTablePageSolutionCEImpl
         implements CreateDBTablePageSolution {
-
     public CreateDBTablePageSolutionImpl(
             DatasourceService datasourceService,
             DatasourceStorageService datasourceStorageService,
             NewPageService newPageService,
             LayoutActionService layoutActionService,
+            UpdateLayoutService updateLayoutService,
             ApplicationPageService applicationPageService,
             ApplicationService applicationService,
             PluginService pluginService,
@@ -42,6 +43,7 @@ public class CreateDBTablePageSolutionImpl extends CreateDBTablePageSolutionCEIm
                 datasourceStorageService,
                 newPageService,
                 layoutActionService,
+                updateLayoutService,
                 applicationPageService,
                 applicationService,
                 pluginService,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -31,6 +31,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.migrations.JsonSchemaMigration;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.plugins.base.PluginService;
@@ -80,6 +81,7 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
     private final DatasourceStorageService datasourceStorageService;
     private final NewPageService newPageService;
     private final LayoutActionService layoutActionService;
+    private final UpdateLayoutService updateLayoutService;
     private final ApplicationPageService applicationPageService;
     private final ApplicationService applicationService;
     private final PluginService pluginService;
@@ -405,7 +407,7 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
 
                     log.debug("Going to update layout for page {} and layout {}", savedPageId, layoutId);
                     return sanitizeTemplateInfoMono
-                            .then(layoutActionService.updateLayout(
+                            .then(updateLayoutService.updateLayout(
                                     savedPageId, page.getApplicationId(), layoutId, layout))
                             .then(Mono.zip(
                                     Mono.just(datasourceStorage),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.domains.Layout;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.entities.EntityRefactoringService;
 import com.appsmith.server.services.AstService;
+import com.appsmith.server.solutions.PagePermission;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +12,10 @@ import org.springframework.stereotype.Service;
 public class WidgetRefactoringServiceImpl extends WidgetRefactoringServiceCEImpl
         implements EntityRefactoringService<Layout> {
     public WidgetRefactoringServiceImpl(
-            NewPageService newPageService, AstService astService, ObjectMapper objectMapper) {
-        super(newPageService, astService, objectMapper);
+            NewPageService newPageService,
+            AstService astService,
+            ObjectMapper objectMapper,
+            PagePermission pagePermission) {
+        super(newPageService, astService, objectMapper, pagePermission);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/RefactoringSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/RefactoringSolutionTest.java
@@ -15,6 +15,7 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.exports.internal.ExportApplicationService;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.imports.internal.ImportApplicationService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
@@ -79,6 +80,9 @@ public class RefactoringSolutionTest {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     RefactoringSolution refactoringSolution;
@@ -175,7 +179,7 @@ public class RefactoringSolutionTest {
 
         layout.setDsl(dsl);
         layout.setPublishedDsl(dsl);
-        layoutActionService
+        updateLayoutService
                 .updateLayout(pageId, testApp.getId(), layout.getId(), layout)
                 .block();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/RefactoringSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/RefactoringSolutionTest.java
@@ -1,0 +1,284 @@
+package com.appsmith.server.refactors;
+
+import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.Datasource;
+import com.appsmith.external.models.PluginType;
+import com.appsmith.server.actioncollections.base.ActionCollectionService;
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.domains.GitApplicationMetadata;
+import com.appsmith.server.domains.Layout;
+import com.appsmith.server.domains.Plugin;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.domains.Workspace;
+import com.appsmith.server.dtos.ActionCollectionDTO;
+import com.appsmith.server.dtos.PageDTO;
+import com.appsmith.server.exports.internal.ExportApplicationService;
+import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.imports.internal.ImportApplicationService;
+import com.appsmith.server.newactions.base.NewActionService;
+import com.appsmith.server.newpages.base.NewPageService;
+import com.appsmith.server.refactors.applications.RefactoringSolution;
+import com.appsmith.server.repositories.NewActionRepository;
+import com.appsmith.server.repositories.PluginRepository;
+import com.appsmith.server.services.ApplicationPageService;
+import com.appsmith.server.services.ApplicationService;
+import com.appsmith.server.services.LayoutActionService;
+import com.appsmith.server.services.LayoutCollectionService;
+import com.appsmith.server.services.UserService;
+import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.ApplicationPermission;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.appsmith.server.acl.AclPermission.READ_PAGES;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Slf4j
+public class RefactoringSolutionTest {
+
+    @SpyBean
+    NewActionService newActionService;
+
+    @Autowired
+    ApplicationPageService applicationPageService;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    WorkspaceService workspaceService;
+
+    @Autowired
+    PluginRepository pluginRepository;
+
+    @MockBean
+    PluginExecutorHelper pluginExecutorHelper;
+
+    @Autowired
+    LayoutActionService layoutActionService;
+
+    @Autowired
+    RefactoringSolution refactoringSolution;
+
+    @Autowired
+    LayoutCollectionService layoutCollectionService;
+
+    @SpyBean
+    NewPageService newPageService;
+
+    @Autowired
+    NewActionRepository actionRepository;
+
+    @SpyBean
+    ActionCollectionService actionCollectionService;
+
+    @Autowired
+    ApplicationService applicationService;
+
+    @Autowired
+    ImportApplicationService importApplicationService;
+
+    @Autowired
+    ExportApplicationService exportApplicationService;
+
+    @Autowired
+    ApplicationPermission applicationPermission;
+
+    Application testApp = null;
+
+    PageDTO testPage = null;
+
+    Application gitConnectedApp = null;
+
+    PageDTO gitConnectedPage = null;
+
+    Datasource datasource;
+
+    String workspaceId;
+
+    String branchName;
+
+    Datasource jsDatasource;
+
+    Plugin installed_plugin;
+
+    Plugin installedJsPlugin;
+
+    @BeforeEach
+    public void setup() {
+        newPageService.deleteAll();
+        User apiUser = userService.findByEmail("api_user").block();
+        Workspace toCreate = new Workspace();
+        toCreate.setName("LayoutActionServiceTest");
+
+        Workspace workspace =
+                workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
+        workspaceId = workspace.getId();
+
+        // Create application and page which will be used by the tests to create actions for.
+        Application application = new Application();
+        application.setName(UUID.randomUUID().toString());
+        testApp = applicationPageService
+                .createApplication(application, workspace.getId())
+                .block();
+
+        final String pageId = testApp.getPages().get(0).getId();
+
+        testPage = newPageService.findPageById(pageId, READ_PAGES, false).block();
+
+        Layout layout = testPage.getLayouts().get(0);
+        JSONObject dsl = new JSONObject();
+        dsl.put("widgetName", "firstWidget");
+        JSONArray temp = new JSONArray();
+        temp.addAll(List.of(new JSONObject(Map.of("key", "testField")), new JSONObject(Map.of("key", "testField2"))));
+        dsl.put("dynamicBindingPathList", temp);
+        dsl.put("testField", "{{ query1.data }}");
+        dsl.put("testField2", "{{jsObject.jsFunction.data}}");
+
+        JSONObject dsl2 = new JSONObject();
+        dsl2.put("widgetName", "Table1");
+        dsl2.put("type", "TABLE_WIDGET");
+        Map<String, Object> primaryColumns = new HashMap<>();
+        JSONObject jsonObject = new JSONObject(Map.of("key", "value"));
+        primaryColumns.put("_id", "{{ query1.data }}");
+        primaryColumns.put("_class", jsonObject);
+        dsl2.put("primaryColumns", primaryColumns);
+        final ArrayList<Object> objects = new ArrayList<>();
+        JSONArray temp2 = new JSONArray();
+        temp2.add(new JSONObject(Map.of("key", "primaryColumns._id")));
+        dsl2.put("dynamicBindingPathList", temp2);
+        objects.add(dsl2);
+        dsl.put("children", objects);
+
+        layout.setDsl(dsl);
+        layout.setPublishedDsl(dsl);
+        layoutActionService
+                .updateLayout(pageId, testApp.getId(), layout.getId(), layout)
+                .block();
+
+        testPage = newPageService.findPageById(pageId, READ_PAGES, false).block();
+
+        Application newApp = new Application();
+        newApp.setName(UUID.randomUUID().toString());
+        GitApplicationMetadata gitData = new GitApplicationMetadata();
+        gitData.setBranchName("actionServiceTest");
+        newApp.setGitApplicationMetadata(gitData);
+        gitConnectedApp = applicationPageService
+                .createApplication(newApp, workspaceId)
+                .flatMap(application1 -> {
+                    application1.getGitApplicationMetadata().setDefaultApplicationId(application1.getId());
+                    return applicationService
+                            .save(application1)
+                            .zipWhen(application11 -> exportApplicationService.exportApplicationById(
+                                    application11.getId(), gitData.getBranchName()));
+                })
+                // Assign the branchName to all the resources connected to the application
+                .flatMap(tuple -> importApplicationService.importApplicationInWorkspaceFromGit(
+                        workspaceId, tuple.getT2(), tuple.getT1().getId(), gitData.getBranchName()))
+                .block();
+
+        gitConnectedPage = newPageService
+                .findPageById(gitConnectedApp.getPages().get(0).getId(), READ_PAGES, false)
+                .block();
+
+        branchName = gitConnectedApp.getGitApplicationMetadata().getBranchName();
+
+        workspaceId = workspace.getId();
+        datasource = new Datasource();
+        datasource.setName("Default Database");
+        datasource.setWorkspaceId(workspaceId);
+        installed_plugin =
+                pluginRepository.findByPackageName("installed-plugin").block();
+        datasource.setPluginId(installed_plugin.getId());
+
+        jsDatasource = new Datasource();
+        jsDatasource.setName("Default JS Database");
+        jsDatasource.setWorkspaceId(workspaceId);
+        installedJsPlugin =
+                pluginRepository.findByPackageName("installed-js-plugin").block();
+        assert installedJsPlugin != null;
+        jsDatasource.setPluginId(installedJsPlugin.getId());
+    }
+
+    @AfterEach
+    public void cleanup() {
+        List<Application> deletedApplications = applicationService
+                .findByWorkspaceId(workspaceId, applicationPermission.getDeletePermission())
+                .flatMap(remainingApplication -> applicationPageService.deleteApplication(remainingApplication.getId()))
+                .collectList()
+                .block();
+        Workspace deletedWorkspace = workspaceService.archiveById(workspaceId).block();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testIsNameAllowed_withRepeatedActionCollectionName_throwsError() {
+        Mockito.doReturn(Flux.empty()).when(newActionService).getUnpublishedActions(Mockito.any());
+
+        ActionCollectionDTO mockActionCollectionDTO = new ActionCollectionDTO();
+        mockActionCollectionDTO.setName("testCollection");
+
+        Mockito.when(actionCollectionService.getActionCollectionsByViewMode(Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(Flux.just(mockActionCollectionDTO));
+
+        Mono<Boolean> nameAllowedMono = refactoringSolution.isNameAllowed(
+                testPage.getId(), testPage.getLayouts().get(0).getId(), "testCollection");
+
+        StepVerifier.create(nameAllowedMono).assertNext(Assertions::assertFalse).verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void jsActionWithoutCollectionIdShouldBeIgnoredDuringNameChecking() {
+        ActionDTO firstAction = new ActionDTO();
+        firstAction.setPluginType(PluginType.JS);
+        firstAction.setName("foo");
+        firstAction.setFullyQualifiedName("testCollection.foo");
+        firstAction.setCollectionId("collectionId");
+
+        ActionDTO secondAction = new ActionDTO();
+        secondAction.setPluginType(PluginType.JS);
+        secondAction.setName("bar");
+        secondAction.setFullyQualifiedName("testCollection.bar");
+        secondAction.setCollectionId(null);
+
+        Mockito.doReturn(Flux.just(firstAction, secondAction))
+                .when(newActionService)
+                .getUnpublishedActions(Mockito.any());
+
+        ActionCollectionDTO mockActionCollectionDTO = new ActionCollectionDTO();
+        mockActionCollectionDTO.setName("testCollection");
+        mockActionCollectionDTO.setActions(List.of(firstAction, secondAction));
+
+        Mockito.when(actionCollectionService.getActionCollectionsByViewMode(Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(Flux.just(mockActionCollectionDTO));
+
+        Mono<Boolean> nameAllowedMono = refactoringSolution.isNameAllowed(
+                testPage.getId(), testPage.getLayouts().get(0).getId(), "testCollection.bar");
+
+        StepVerifier.create(nameAllowedMono).assertNext(Assertions::assertTrue).verifyComplete();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -21,6 +21,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ObjectMapperUtils;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
@@ -83,6 +84,9 @@ public class ActionCollectionServiceImplTest {
     LayoutActionService layoutActionService;
 
     @MockBean
+    UpdateLayoutService updateLayoutService;
+
+    @MockBean
     RefactoringSolution refactoringSolution;
 
     @MockBean
@@ -141,6 +145,7 @@ public class ActionCollectionServiceImplTest {
         layoutCollectionService = new LayoutCollectionServiceImpl(
                 newPageService,
                 layoutActionService,
+                updateLayoutService,
                 refactoringSolution,
                 actionCollectionService,
                 newActionService,
@@ -791,10 +796,10 @@ public class ActionCollectionServiceImplTest {
         jsonObject.put("key", "value");
         layout.setDsl(jsonObject);
 
-        Mockito.when(layoutActionService.unescapeMongoSpecialCharacters(Mockito.any()))
+        Mockito.when(updateLayoutService.unescapeMongoSpecialCharacters(Mockito.any()))
                 .thenReturn(jsonObject);
 
-        Mockito.when(layoutActionService.updateLayout(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(updateLayoutService.updateLayout(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(layout));
 
         Mockito.when(actionCollectionRepository.setUserPermissionsInObject(Mockito.any()))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -23,6 +23,7 @@ import com.appsmith.server.helpers.ObjectMapperUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
+import com.appsmith.server.refactors.applications.RefactoringSolution;
 import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.solutions.ActionPermission;
 import com.appsmith.server.solutions.ActionPermissionImpl;
@@ -82,6 +83,9 @@ public class ActionCollectionServiceImplTest {
     LayoutActionService layoutActionService;
 
     @MockBean
+    RefactoringSolution refactoringSolution;
+
+    @MockBean
     ActionCollectionRepository actionCollectionRepository;
 
     @MockBean
@@ -137,6 +141,7 @@ public class ActionCollectionServiceImplTest {
         layoutCollectionService = new LayoutCollectionServiceImpl(
                 newPageService,
                 layoutActionService,
+                refactoringSolution,
                 actionCollectionService,
                 newActionService,
                 analyticsService,
@@ -224,7 +229,7 @@ public class ActionCollectionServiceImplTest {
         final NewPage newPage = objectMapper.convertValue(jsonNode.get("newPage"), NewPage.class);
         Mockito.when(newPageService.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(newPage));
-        Mockito.when(layoutActionService.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(false));
 
         Mockito.when(actionCollectionRepository.findAllActionCollectionsByNamePageIdsViewModeAndBranch(
@@ -265,7 +270,7 @@ public class ActionCollectionServiceImplTest {
 
         Mockito.when(newPageService.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(newPage));
-        Mockito.when(layoutActionService.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(true));
 
         Mockito.when(actionCollectionRepository.findAllActionCollectionsByNamePageIdsViewModeAndBranch(
@@ -330,7 +335,7 @@ public class ActionCollectionServiceImplTest {
 
         Mockito.when(newPageService.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(newPage));
-        Mockito.when(layoutActionService.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(true));
 
         Mockito.when(actionCollectionRepository.findAllActionCollectionsByNamePageIdsViewModeAndBranch(

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -17,7 +17,6 @@ import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
-import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.EntityType;
 import com.appsmith.server.dtos.LayoutDTO;
 import com.appsmith.server.dtos.PageDTO;
@@ -43,7 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -622,23 +620,6 @@ public class LayoutActionServiceTest {
                             .containsAll(Set.of(FieldName.MONGO_ESCAPE_ID, FieldName.MONGO_ESCAPE_CLASS));
                 })
                 .verifyComplete();
-    }
-
-    @Test
-    @WithUserDetails(value = "api_user")
-    public void testIsNameAllowed_withRepeatedActionCollectionName_throwsError() {
-        Mockito.doReturn(Flux.empty()).when(newActionService).getUnpublishedActions(Mockito.any());
-
-        ActionCollectionDTO mockActionCollectionDTO = new ActionCollectionDTO();
-        mockActionCollectionDTO.setName("testCollection");
-
-        Mockito.when(actionCollectionService.getActionCollectionsByViewMode(Mockito.any(), Mockito.anyBoolean()))
-                .thenReturn(Flux.just(mockActionCollectionDTO));
-
-        Mono<Boolean> nameAllowedMono = layoutActionService.isNameAllowed(
-                testPage.getId(), testPage.getLayouts().get(0).getId(), "testCollection");
-
-        StepVerifier.create(nameAllowedMono).assertNext(Assertions::assertFalse).verifyComplete();
     }
 
     @Test
@@ -1336,38 +1317,6 @@ public class LayoutActionServiceTest {
         assertNotNull(changedLayoutDTO);
         assertNotNull(changedLayoutDTO.getLayoutOnLoadActionErrors());
         assertEquals(0, changedLayoutDTO.getLayoutOnLoadActionErrors().size());
-    }
-
-    @Test
-    @WithUserDetails(value = "api_user")
-    public void jsActionWithoutCollectionIdShouldBeIgnoredDuringNameChecking() {
-        ActionDTO firstAction = new ActionDTO();
-        firstAction.setPluginType(PluginType.JS);
-        firstAction.setName("foo");
-        firstAction.setFullyQualifiedName("testCollection.foo");
-        firstAction.setCollectionId("collectionId");
-
-        ActionDTO secondAction = new ActionDTO();
-        secondAction.setPluginType(PluginType.JS);
-        secondAction.setName("bar");
-        secondAction.setFullyQualifiedName("testCollection.bar");
-        secondAction.setCollectionId(null);
-
-        Mockito.doReturn(Flux.just(firstAction, secondAction))
-                .when(newActionService)
-                .getUnpublishedActions(Mockito.any());
-
-        ActionCollectionDTO mockActionCollectionDTO = new ActionCollectionDTO();
-        mockActionCollectionDTO.setName("testCollection");
-        mockActionCollectionDTO.setActions(List.of(firstAction, secondAction));
-
-        Mockito.when(actionCollectionService.getActionCollectionsByViewMode(Mockito.any(), Mockito.anyBoolean()))
-                .thenReturn(Flux.just(mockActionCollectionDTO));
-
-        Mono<Boolean> nameAllowedMono = layoutActionService.isNameAllowed(
-                testPage.getId(), testPage.getLayouts().get(0).getId(), "testCollection.bar");
-
-        StepVerifier.create(nameAllowedMono).assertNext(Assertions::assertTrue).verifyComplete();
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -28,6 +28,7 @@ import com.appsmith.server.exports.internal.ExportApplicationService;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.imports.internal.ImportApplicationService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
@@ -103,6 +104,9 @@ public class LayoutActionServiceTest {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     RefactoringSolution refactoringSolution;
@@ -201,7 +205,7 @@ public class LayoutActionServiceTest {
 
         layout.setDsl(dsl);
         layout.setPublishedDsl(dsl);
-        layoutActionService
+        updateLayoutService
                 .updateLayout(pageId, testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -454,7 +458,7 @@ public class LayoutActionServiceTest {
                 layoutActionService.createSingleAction(action2, Boolean.FALSE).block();
 
         Mono<LayoutDTO> updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(updatedLayout -> {
@@ -490,7 +494,7 @@ public class LayoutActionServiceTest {
         layout.setDsl(dsl);
 
         updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(updatedLayout -> {
@@ -598,7 +602,7 @@ public class LayoutActionServiceTest {
         Layout layout = testPage.getLayouts().get(0);
         layout.setDsl(dsl);
 
-        Mono<LayoutDTO> updateLayoutMono = layoutActionService
+        Mono<LayoutDTO> updateLayoutMono = updateLayoutService
                 .updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout)
                 .cache();
 
@@ -737,7 +741,7 @@ public class LayoutActionServiceTest {
                 layoutActionService.createSingleAction(action2, Boolean.FALSE).block();
 
         Mono<LayoutDTO> updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(updatedLayout -> {
@@ -855,7 +859,7 @@ public class LayoutActionServiceTest {
                 .block();
 
         Mono<LayoutDTO> updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(updatedLayout -> {
@@ -948,7 +952,7 @@ public class LayoutActionServiceTest {
                 layoutActionService.createSingleAction(action2, Boolean.FALSE).block();
 
         Mono<LayoutDTO> updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(updatedLayout -> {
@@ -987,7 +991,7 @@ public class LayoutActionServiceTest {
         layout.setDsl(parentDsl);
 
         Mono<LayoutDTO> updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(layoutDTO -> {
@@ -1027,7 +1031,7 @@ public class LayoutActionServiceTest {
                 newPageService.findPageById(testPage.getId(), READ_PAGES, false),
                 newPageService.findPageById(secondPage.getId(), READ_PAGES, false));
 
-        Mono<Tuple2<PageDTO, PageDTO>> updateAndGetPagesMono = layoutActionService
+        Mono<Tuple2<PageDTO, PageDTO>> updateAndGetPagesMono = updateLayoutService
                 .updateMultipleLayouts(testApp.getId(), null, multiplePageLayoutDTO)
                 .then(pagesMono);
 
@@ -1120,7 +1124,7 @@ public class LayoutActionServiceTest {
                 .thenReturn(newActionFlux);
 
         Mono<LayoutDTO> updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(updatedLayout -> {
@@ -1192,7 +1196,7 @@ public class LayoutActionServiceTest {
                 .thenReturn(newActionFlux);
 
         Mono<LayoutDTO> updateLayoutMono =
-                layoutActionService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
+                updateLayoutService.updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout);
 
         StepVerifier.create(updateLayoutMono)
                 .assertNext(updatedLayout -> {
@@ -1261,7 +1265,7 @@ public class LayoutActionServiceTest {
         mainDsl.put("children", objects);
         layout.setDsl(mainDsl);
 
-        LayoutDTO firstLayout = layoutActionService
+        LayoutDTO firstLayout = updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -1311,7 +1315,7 @@ public class LayoutActionServiceTest {
 
         layout.setDsl(mainDsl);
 
-        LayoutDTO changedLayoutDTO = layoutActionService
+        LayoutDTO changedLayoutDTO = updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
         assertNotNull(changedLayoutDTO);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
@@ -20,6 +20,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
@@ -71,6 +72,9 @@ public class LayoutServiceTest {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     ApplicationPageService applicationPageService;
@@ -251,7 +255,7 @@ public class LayoutServiceTest {
         Layout startLayout =
                 layoutService.createLayout(page.getId(), testLayout).block();
 
-        Mono<LayoutDTO> updatedLayoutMono = layoutActionService.updateLayout(
+        Mono<LayoutDTO> updatedLayoutMono = updateLayoutService.updateLayout(
                 "random-impossible-id-page", page.getApplicationId(), startLayout.getId(), updateLayout);
 
         StepVerifier.create(updatedLayoutMono)
@@ -287,7 +291,7 @@ public class LayoutServiceTest {
         Layout startLayout =
                 layoutService.createLayout(page.getId(), testLayout).block();
 
-        Mono<LayoutDTO> updatedLayoutMono = layoutActionService.updateLayout(
+        Mono<LayoutDTO> updatedLayoutMono = updateLayoutService.updateLayout(
                 page.getId(), "random-impossible-id-app", startLayout.getId(), updateLayout);
 
         StepVerifier.create(updatedLayoutMono)
@@ -326,7 +330,7 @@ public class LayoutServiceTest {
             PageDTO page = tuple.getT1();
             Layout startLayout = tuple.getT2();
             startLayout.setDsl(obj1);
-            return layoutActionService.updateLayout(
+            return updateLayoutService.updateLayout(
                     page.getId(), page.getApplicationId(), startLayout.getId(), startLayout);
         });
 
@@ -623,7 +627,7 @@ public class LayoutServiceTest {
                     obj.put("dynamicBindingPathList", dynamicBindingsPathList);
                     newLayout.setDsl(obj);
 
-                    return layoutActionService.updateLayout(
+                    return updateLayoutService.updateLayout(
                             page1.getId(), page1.getApplicationId(), layout.getId(), newLayout);
                 });
 
@@ -832,7 +836,7 @@ public class LayoutServiceTest {
                     obj.put("dynamicBindingPathList", dynamicBindingsPathList);
                     newLayout.setDsl(obj);
 
-                    return layoutActionService.updateLayout(
+                    return updateLayoutService.updateLayout(
                             page1.getId(), page1.getApplicationId(), layout.getId(), newLayout);
                 });
 
@@ -1285,7 +1289,7 @@ public class LayoutServiceTest {
                     obj.put("dynamicBindingPathList", dynamicBindingsPathList);
                     newLayout.setDsl(obj);
 
-                    return layoutActionService.updateLayout(
+                    return updateLayoutService.updateLayout(
                             page1.getId(), page1.getApplicationId(), layout.getId(), newLayout);
                 });
 
@@ -1371,7 +1375,7 @@ public class LayoutServiceTest {
                     obj.put("dynamicBindingPathList", dynamicBindingsPathList);
                     newLayout.setDsl(obj);
 
-                    return layoutActionService.updateLayout(
+                    return updateLayoutService.updateLayout(
                             page1.getId(), page1.getApplicationId(), layout.getId(), newLayout);
                 });
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -34,6 +34,7 @@ import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.helpers.TextUtils;
 import com.appsmith.server.imports.internal.ImportApplicationService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.repositories.PermissionGroupRepository;
@@ -121,6 +122,9 @@ public class PageServiceTest {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     LayoutCollectionService layoutCollectionService;
@@ -615,7 +619,7 @@ public class PageServiceTest {
 
         action.setPageId(page.getId());
 
-        final LayoutDTO layoutDTO = layoutActionService
+        final LayoutDTO layoutDTO = updateLayoutService
                 .updateLayout(page.getId(), page.getApplicationId(), layout.getId(), layout)
                 .block();
 
@@ -825,7 +829,7 @@ public class PageServiceTest {
 
         layoutActionService.createSingleAction(action, Boolean.FALSE).block();
 
-        final LayoutDTO layoutDTO = layoutActionService
+        final LayoutDTO layoutDTO = updateLayoutService
                 .updateLayout(page.getId(), page.getApplicationId(), layout.getId(), layout)
                 .block();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -37,6 +37,7 @@ import com.appsmith.server.exports.internal.ExportApplicationService;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.imports.internal.ImportApplicationService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.plugins.base.PluginService;
@@ -136,6 +137,9 @@ public class ActionServiceCE_Test {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     LayoutService layoutService;
@@ -1248,7 +1252,7 @@ public class ActionServiceCE_Test {
                     obj.put("dynamicBindingPathList", dynamicBindingsPathList);
                     newLayout.setDsl(obj);
 
-                    return layoutActionService.updateLayout(
+                    return updateLayoutService.updateLayout(
                             page1.getId(), page1.getApplicationId(), layout.getId(), newLayout);
                 });
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
@@ -48,6 +48,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.helpers.TextUtils;
 import com.appsmith.server.imports.internal.ImportApplicationService;
 import com.appsmith.server.jslibs.base.CustomJSLibService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.migrations.ApplicationVersion;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
@@ -206,6 +207,9 @@ public class ApplicationServiceCETest {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     LayoutCollectionService layoutCollectionService;
@@ -2129,7 +2133,7 @@ public class ApplicationServiceCETest {
                     return Mono.zip(
                             layoutCollectionService.createCollection(actionCollectionDTO),
                             layoutActionService.createSingleAction(action, Boolean.FALSE),
-                            layoutActionService.updateLayout(
+                            updateLayoutService.updateLayout(
                                     testPage.getId(), testPage.getApplicationId(), layout.getId(), layout),
                             Mono.just(application));
                 })
@@ -2500,7 +2504,7 @@ public class ApplicationServiceCETest {
                     return Mono.zip(
                             Mono.just(tuple.getT1()),
                             Mono.just(tuple.getT2()),
-                            layoutActionService.updateLayout(
+                            updateLayoutService.updateLayout(
                                     testPage.getId(), testPage.getApplicationId(), layout.getId(), layout),
                             Mono.just(tuple.getT3()));
                 })

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/GitServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/GitServiceCETest.java
@@ -45,6 +45,7 @@ import com.appsmith.server.helpers.GitCloudServicesUtils;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.migrations.JsonSchemaMigration;
 import com.appsmith.server.migrations.JsonSchemaVersions;
 import com.appsmith.server.newactions.base.NewActionService;
@@ -172,6 +173,9 @@ public class GitServiceCETest {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     NewPageService newPageService;
@@ -1233,7 +1237,7 @@ public class GitServiceCETest {
                     return Mono.zip(
                                     layoutActionService
                                             .createSingleAction(action, Boolean.FALSE)
-                                            .then(layoutActionService.updateLayout(
+                                            .then(updateLayoutService.updateLayout(
                                                     testPage.getId(),
                                                     testPage.getApplicationId(),
                                                     layout.getId(),
@@ -2558,7 +2562,7 @@ public class GitServiceCETest {
                     return Mono.zip(
                                     layoutActionService
                                             .createSingleActionWithBranch(action, null)
-                                            .then(layoutActionService.updateLayout(
+                                            .then(updateLayoutService.updateLayout(
                                                     testPage.getId(),
                                                     testPage.getApplicationId(),
                                                     layout.getId(),

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
@@ -44,6 +44,7 @@ import com.appsmith.server.fork.internal.ApplicationForkingService;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.imports.internal.ImportApplicationService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.repositories.ApplicationRepository;
@@ -157,6 +158,9 @@ public class ApplicationForkingServiceTests {
 
     @Autowired
     private LayoutActionService layoutActionService;
+
+    @Autowired
+    private UpdateLayoutService updateLayoutService;
 
     @Autowired
     private NewPageService newPageService;
@@ -337,7 +341,7 @@ public class ApplicationForkingServiceTests {
         Layout layout = testPage.getLayouts().get(0);
         layout.setDsl(parentDsl);
 
-        layoutActionService
+        updateLayoutService
                 .updateLayout(testPage.getId(), testPage.getApplicationId(), layout.getId(), layout)
                 .block();
         return app1.getId();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportApplicationServiceTests.java
@@ -49,6 +49,7 @@ import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.imports.internal.ImportApplicationService;
 import com.appsmith.server.jslibs.base.CustomJSLibService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.migrations.ApplicationVersion;
 import com.appsmith.server.migrations.JsonSchemaMigration;
 import com.appsmith.server.migrations.JsonSchemaVersions;
@@ -180,6 +181,9 @@ public class ImportApplicationServiceTests {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     LayoutCollectionService layoutCollectionService;
@@ -561,7 +565,7 @@ public class ImportApplicationServiceTests {
                             .createCollection(actionCollectionDTO1)
                             .then(layoutActionService.createSingleAction(action, Boolean.FALSE))
                             .then(layoutActionService.createSingleAction(action2, Boolean.FALSE))
-                            .then(layoutActionService.updateLayout(
+                            .then(updateLayoutService.updateLayout(
                                     testPage.getId(), testPage.getApplicationId(), layout.getId(), layout))
                             .then(exportApplicationService.exportApplicationById(testApp.getId(), ""));
                 })
@@ -2777,7 +2781,7 @@ public class ImportApplicationServiceTests {
                             .createCollection(actionCollectionDTO1)
                             .then(layoutActionService.createSingleAction(action, Boolean.FALSE))
                             .then(layoutActionService.createSingleAction(action2, Boolean.FALSE))
-                            .then(layoutActionService.updateLayout(
+                            .then(updateLayoutService.updateLayout(
                                     testPage.getId(), testPage.getApplicationId(), layout.getId(), layout))
                             .then(exportApplicationService.exportApplicationById(testApp.getId(), ""));
                 })

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
@@ -16,6 +16,7 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.RefactorEntityNameDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.applications.RefactoringSolutionCEImpl;
@@ -23,7 +24,6 @@ import com.appsmith.server.refactors.entities.EntityRefactoringService;
 import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.ApplicationService;
-import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.solutions.ActionPermission;
 import com.appsmith.server.solutions.PagePermission;
@@ -73,7 +73,7 @@ class RefactoringSolutionCEImplTest {
     private ResponseUtils responseUtils;
 
     @MockBean
-    private LayoutActionService layoutActionService;
+    private UpdateLayoutService updateLayoutService;
 
     @MockBean
     private ApplicationService applicationService;
@@ -110,7 +110,7 @@ class RefactoringSolutionCEImplTest {
         refactoringSolutionCE = new RefactoringSolutionCEImpl(
                 newPageService,
                 responseUtils,
-                layoutActionService,
+                updateLayoutService,
                 applicationService,
                 pagePermission,
                 analyticsService,
@@ -182,7 +182,7 @@ class RefactoringSolutionCEImplTest {
         Mockito.when(newActionService.findByPageIdAndViewMode(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any()))
                 .thenReturn(Flux.empty());
 
-        Mockito.when(layoutActionService.updateLayout(
+        Mockito.when(updateLayoutService.updateLayout(
                         Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any()))
                 .thenReturn(Mono.just(layout));
 
@@ -319,7 +319,7 @@ class RefactoringSolutionCEImplTest {
         Mockito.when(responseUtils.updateLayoutDTOWithDefaultResources(Mockito.any()))
                 .thenReturn(layout);
 
-        Mockito.when(layoutActionService.updateLayout(
+        Mockito.when(updateLayoutService.updateLayout(
                         Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any()))
                 .thenReturn(Mono.just(layout));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
@@ -141,9 +141,6 @@ class RefactoringSolutionCEImplTest {
         oldUnpublishedCollection.setDefaultResources(setDefaultResources(oldUnpublishedCollection));
         oldActionCollection.setDefaultResources(setDefaultResources(oldActionCollection));
 
-        Mockito.when(refactoringSolutionCE.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Mono.just(true));
-
         LayoutDTO layout = new LayoutDTO();
         final JSONObject jsonObject = new JSONObject();
         jsonObject.put("key", "value");
@@ -186,6 +183,10 @@ class RefactoringSolutionCEImplTest {
                         Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any()))
                 .thenReturn(Mono.just(layout));
 
+        Mockito.doReturn(Flux.just(oldUnpublishedCollection.getName()))
+                .when(actionCollectionEntityRefactoringService)
+                .getExistingEntityNames(Mockito.anyString(), Mockito.any(), Mockito.anyString());
+
         final Mono<LayoutDTO> layoutDTOMono =
                 refactoringSolutionCE.refactorEntityName(refactorActionCollectionNameDTO, null);
 
@@ -219,20 +220,24 @@ class RefactoringSolutionCEImplTest {
         duplicateUnpublishedCollection.setName("newName");
         duplicateActionCollection.setUnpublishedCollection(duplicateUnpublishedCollection);
 
-        Mockito.when(actionCollectionRepository.findAllActionCollectionsByNamePageIdsViewModeAndBranch(
-                        Mockito.any(),
-                        Mockito.any(),
-                        Mockito.anyBoolean(),
-                        Mockito.any(),
-                        Mockito.any(),
-                        Mockito.any()))
-                .thenReturn(Flux.just(oldActionCollection, duplicateActionCollection));
-
-        Mockito.when(refactoringSolutionCE.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Mono.just(false));
+        Mockito.doReturn(Flux.just("oldName", "newName"))
+                .when(actionCollectionEntityRefactoringService)
+                .getExistingEntityNames(Mockito.anyString(), Mockito.any(), Mockito.anyString());
 
         NewPage newPage = new NewPage();
         newPage.setId("testPageId");
+        PageDTO pageDTO = new PageDTO();
+        pageDTO.setId("testPageId");
+        pageDTO.setApplicationId("testAppId");
+        Layout layout1 = new Layout();
+        layout1.setId("testLayoutId");
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key", "value");
+        layout1.setDsl(jsonObject);
+        pageDTO.setLayouts(List.of(layout1));
+        newPage.setUnpublishedPage(pageDTO);
+        Mockito.when(newPageService.findPageById(Mockito.anyString(), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(pageDTO));
         Mockito.when(newPageService.getById(Mockito.anyString())).thenReturn(Mono.just(newPage));
 
         final Mono<LayoutDTO> layoutDTOMono =
@@ -264,9 +269,6 @@ class RefactoringSolutionCEImplTest {
         oldActionCollection.setUnpublishedCollection(oldUnpublishedCollection);
         oldActionCollection.setDefaultResources(setDefaultResources(oldActionCollection));
         oldUnpublishedCollection.setDefaultResources(setDefaultResources(oldUnpublishedCollection));
-
-        Mockito.when(refactoringSolutionCE.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(Mono.just(true));
 
         Mockito.when(newActionService.findActionDTObyIdAndViewMode(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
                 .thenReturn(Mono.just(new ActionDTO()));
@@ -322,6 +324,10 @@ class RefactoringSolutionCEImplTest {
         Mockito.when(updateLayoutService.updateLayout(
                         Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any()))
                 .thenReturn(Mono.just(layout));
+
+        Mockito.doReturn(Flux.just(oldUnpublishedCollection.getName()))
+                .when(actionCollectionEntityRefactoringService)
+                .getExistingEntityNames(Mockito.anyString(), Mockito.any(), Mockito.anyString());
 
         final Mono<LayoutDTO> layoutDTOMono =
                 refactoringSolutionCE.refactorEntityName(refactorActionCollectionNameDTO, null);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
@@ -141,7 +141,7 @@ class RefactoringSolutionCEImplTest {
         oldUnpublishedCollection.setDefaultResources(setDefaultResources(oldUnpublishedCollection));
         oldActionCollection.setDefaultResources(setDefaultResources(oldActionCollection));
 
-        Mockito.when(layoutActionService.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolutionCE.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(true));
 
         LayoutDTO layout = new LayoutDTO();
@@ -228,7 +228,7 @@ class RefactoringSolutionCEImplTest {
                         Mockito.any()))
                 .thenReturn(Flux.just(oldActionCollection, duplicateActionCollection));
 
-        Mockito.when(layoutActionService.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolutionCE.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(false));
 
         NewPage newPage = new NewPage();
@@ -265,7 +265,7 @@ class RefactoringSolutionCEImplTest {
         oldActionCollection.setDefaultResources(setDefaultResources(oldActionCollection));
         oldUnpublishedCollection.setDefaultResources(setDefaultResources(oldUnpublishedCollection));
 
-        Mockito.when(layoutActionService.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolutionCE.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(true));
 
         Mockito.when(newActionService.findActionDTObyIdAndViewMode(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCETest.java
@@ -27,6 +27,7 @@ import com.appsmith.server.exports.internal.ExportApplicationService;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.imports.internal.ImportApplicationService;
+import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.applications.RefactoringSolution;
@@ -100,6 +101,9 @@ class RefactoringSolutionCETest {
 
     @Autowired
     LayoutActionService layoutActionService;
+
+    @Autowired
+    UpdateLayoutService updateLayoutService;
 
     @Autowired
     RefactoringSolution refactoringSolution;
@@ -195,7 +199,7 @@ class RefactoringSolutionCETest {
 
         layout.setDsl(dsl);
         layout.setPublishedDsl(dsl);
-        layoutActionService
+        updateLayoutService
                 .updateLayout(pageId, testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -291,7 +295,7 @@ class RefactoringSolutionCETest {
         ActionDTO createdAction =
                 layoutActionService.createSingleAction(action, Boolean.FALSE).block();
 
-        LayoutDTO firstLayout = layoutActionService
+        LayoutDTO firstLayout = updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -367,7 +371,7 @@ class RefactoringSolutionCETest {
         ActionDTO createdAction =
                 layoutActionService.createSingleAction(action, Boolean.FALSE).block();
 
-        LayoutDTO firstLayout = layoutActionService
+        LayoutDTO firstLayout = updateLayoutService
                 .updateLayout(gitConnectedPage.getId(), testApp.getId(), layout.getId(), layout, null)
                 .block();
 
@@ -434,8 +438,8 @@ class RefactoringSolutionCETest {
         ActionDTO firstAction =
                 layoutActionService.createSingleAction(action, Boolean.FALSE).block();
 
-        layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
-        LayoutDTO firstLayout = layoutActionService
+        layout.setDsl(updateLayoutService.unescapeMongoSpecialCharacters(layout));
+        LayoutDTO firstLayout = updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -495,7 +499,7 @@ class RefactoringSolutionCETest {
         ActionDTO createdAction =
                 layoutActionService.createSingleAction(action, Boolean.FALSE).block();
 
-        LayoutDTO firstLayout = layoutActionService
+        LayoutDTO firstLayout = updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -569,7 +573,7 @@ class RefactoringSolutionCETest {
         // Now save this action directly in the repo to create a duplicate action name scenario
         actionRepository.save(duplicateNameCompleteAction).block();
 
-        LayoutDTO firstLayout = layoutActionService
+        LayoutDTO firstLayout = updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -622,7 +626,7 @@ class RefactoringSolutionCETest {
         Layout layout = testPage.getLayouts().get(0);
         layout.setDsl(dsl);
 
-        layoutActionService
+        updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -672,7 +676,7 @@ class RefactoringSolutionCETest {
         Layout layout = testPage.getLayouts().get(0);
         layout.setDsl(dsl);
 
-        layoutActionService
+        updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -725,7 +729,7 @@ class RefactoringSolutionCETest {
         Layout layout = testPage.getLayouts().get(0);
         layout.setDsl(dsl);
 
-        layoutActionService
+        updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 
@@ -762,7 +766,7 @@ class RefactoringSolutionCETest {
         Layout layout = testPage.getLayouts().get(0);
         layout.setDsl(dsl);
 
-        layoutActionService
+        updateLayoutService
                 .updateLayout(testPage.getId(), testApp.getId(), layout.getId(), layout)
                 .block();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceCEImplTest.java
@@ -54,7 +54,8 @@ class WidgetRefactoringServiceCEImplTest {
 
     @BeforeEach
     public void setUp() {
-        widgetRefactoringServiceCE = new WidgetRefactoringServiceCEImpl(newPageService, astService, mapper);
+        widgetRefactoringServiceCE =
+                new WidgetRefactoringServiceCEImpl(newPageService, astService, mapper, pagePermission);
     }
 
     @Test


### PR DESCRIPTION
Refactored `isNameAllowed` to allow extending the number of checks that need to be applied for figuring out invalid names that already exist in context.

`isNameAllowed` should be a refactoringService method, moved it to be there. `updateLayout` now belongs to a service of its own. All other changes to accommodate dependencies among beans.