### PR TITLE
chore: Added context type handling for isNameAllowed

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/refactors/applications/RefactoringSolutionCE.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.refactors.applications;
 
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.server.dtos.LayoutDTO;
 import com.appsmith.server.dtos.RefactorEntityNameDTO;
 import reactor.core.publisher.Mono;
@@ -8,5 +9,5 @@ public interface RefactoringSolutionCE {
 
     Mono<LayoutDTO> refactorEntityName(RefactorEntityNameDTO refactorEntityNameDTO, String branchName);
 
-    Mono<Boolean> isNameAllowed(String pageId, String layoutId, String newName);
+    Mono<Boolean> isNameAllowed(String contextId, CreatorContextType contextType, String layoutId, String newName);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.external.helpers.AppsmithEventContext;
 import com.appsmith.external.helpers.AppsmithEventContextType;
 import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DefaultResources;
 import com.appsmith.server.acl.AclPermission;
@@ -409,7 +410,9 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
         return pageMono.flatMap(page -> {
                     Layout layout = page.getUnpublishedPage().getLayouts().get(0);
                     String name = action.getValidName();
-                    return refactoringSolution.isNameAllowed(page.getId(), layout.getId(), name);
+                    CreatorContextType contextType =
+                            action.getContextType() == null ? CreatorContextType.PAGE : action.getContextType();
+                    return refactoringSolution.isNameAllowed(page.getId(), contextType, layout.getId(), name);
                 })
                 .flatMap(nameAllowed -> {
                     // If the name is allowed, return pageMono for further processing

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services.ce;
 
 import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.DefaultResources;
 import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.constants.FieldName;
@@ -92,8 +93,11 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
         // If the collection name is unique, the action name will be guaranteed to be unique within that collection
         return pageMono.flatMap(page -> {
                     Layout layout = page.getUnpublishedPage().getLayouts().get(0);
+                    CreatorContextType contextType =
+                            collection.getContextType() == null ? CreatorContextType.PAGE : collection.getContextType();
                     // Check against widget names and action names
-                    return refactoringSolution.isNameAllowed(page.getId(), layout.getId(), collection.getName());
+                    return refactoringSolution.isNameAllowed(
+                            page.getId(), contextType, layout.getId(), collection.getName());
                 })
                 .flatMap(isNameAllowed -> {
                     // If the name is allowed, return list of actionDTOs for further processing

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/RefactoringSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/RefactoringSolutionTest.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.refactors;
 
 import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.PluginType;
 import com.appsmith.server.actioncollections.base.ActionCollectionService;
@@ -249,7 +250,10 @@ public class RefactoringSolutionTest {
                 .thenReturn(Flux.just(mockActionCollectionDTO));
 
         Mono<Boolean> nameAllowedMono = refactoringSolution.isNameAllowed(
-                testPage.getId(), testPage.getLayouts().get(0).getId(), "testCollection");
+                testPage.getId(),
+                CreatorContextType.PAGE,
+                testPage.getLayouts().get(0).getId(),
+                "testCollection");
 
         StepVerifier.create(nameAllowedMono).assertNext(Assertions::assertFalse).verifyComplete();
     }
@@ -281,7 +285,10 @@ public class RefactoringSolutionTest {
                 .thenReturn(Flux.just(mockActionCollectionDTO));
 
         Mono<Boolean> nameAllowedMono = refactoringSolution.isNameAllowed(
-                testPage.getId(), testPage.getLayouts().get(0).getId(), "testCollection.bar");
+                testPage.getId(),
+                CreatorContextType.PAGE,
+                testPage.getLayouts().get(0).getId(),
+                "testCollection.bar");
 
         StepVerifier.create(nameAllowedMono).assertNext(Assertions::assertTrue).verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -234,7 +234,7 @@ public class ActionCollectionServiceImplTest {
         final NewPage newPage = objectMapper.convertValue(jsonNode.get("newPage"), NewPage.class);
         Mockito.when(newPageService.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(newPage));
-        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(false));
 
         Mockito.when(actionCollectionRepository.findAllActionCollectionsByNamePageIdsViewModeAndBranch(
@@ -275,7 +275,7 @@ public class ActionCollectionServiceImplTest {
 
         Mockito.when(newPageService.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(newPage));
-        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(true));
 
         Mockito.when(actionCollectionRepository.findAllActionCollectionsByNamePageIdsViewModeAndBranch(
@@ -340,7 +340,7 @@ public class ActionCollectionServiceImplTest {
 
         Mockito.when(newPageService.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(newPage));
-        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(refactoringSolution.isNameAllowed(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(true));
 
         Mockito.when(actionCollectionRepository.findAllActionCollectionsByNamePageIdsViewModeAndBranch(


### PR DESCRIPTION
Added `contextType` as a param for `isNameAllowed` method so that the method can be reused for other contexts as well.