### PR TITLE
fix: gsheet invalid ds query redirect issue fixed

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -108,7 +108,7 @@ public enum AppsmithPluginError implements BasePluginError {
             "{0}",
             "{1}"),
     PLUGIN_DATASOURCE_AUTHENTICATION_ERROR(
-            500,
+            401,
             AppsmithPluginErrorCode.PLUGIN_DATASOURCE_AUTHENTICATION_ERROR.getCode(),
             "Invalid authentication credentials. Please check datasource configuration.",
             AppsmithErrorAction.DEFAULT,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -99,7 +99,7 @@ public enum AppsmithPluginError implements BasePluginError {
             "{1}",
             "{2}"),
     PLUGIN_AUTHENTICATION_ERROR(
-            500,
+            401,
             AppsmithPluginErrorCode.PLUGIN_AUTHENTICATION_ERROR.getCode(),
             "Invalid authentication credentials. Please check datasource configuration.",
             AppsmithErrorAction.DEFAULT,
@@ -108,7 +108,7 @@ public enum AppsmithPluginError implements BasePluginError {
             "{0}",
             "{1}"),
     PLUGIN_DATASOURCE_AUTHENTICATION_ERROR(
-            400,
+            500,
             AppsmithPluginErrorCode.PLUGIN_DATASOURCE_AUTHENTICATION_ERROR.getCode(),
             "Invalid authentication credentials. Please check datasource configuration.",
             AppsmithErrorAction.DEFAULT,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -99,7 +99,7 @@ public enum AppsmithPluginError implements BasePluginError {
             "{1}",
             "{2}"),
     PLUGIN_AUTHENTICATION_ERROR(
-            401,
+            500,
             AppsmithPluginErrorCode.PLUGIN_AUTHENTICATION_ERROR.getCode(),
             "Invalid authentication credentials. Please check datasource configuration.",
             AppsmithErrorAction.DEFAULT,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -98,7 +98,7 @@ public class OAuth2 extends AuthenticationDTO {
     @Override
     public Mono<Boolean> hasExpired() {
         if (this.authenticationResponse == null) {
-            return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR));
+            return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_DATASOURCE_AUTHENTICATION_ERROR));
         }
 
         if (this.authenticationResponse.expiresAt == null) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -98,7 +98,7 @@ public class OAuth2 extends AuthenticationDTO {
     @Override
     public Mono<Boolean> hasExpired() {
         if (this.authenticationResponse == null) {
-            return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_DATASOURCE_AUTHENTICATION_ERROR));
+            return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR));
         }
 
         if (this.authenticationResponse.expiresAt == null) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
@@ -233,7 +233,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler
     @ResponseBody
     public Mono<ResponseDTO<ErrorDTO>> catchPluginException(AppsmithPluginException e, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.resolve(e.getHttpStatus()));
+        AppsmithError appsmithError = AppsmithError.INTERNAL_SERVER_ERROR;
+        exchange.getResponse().setStatusCode(HttpStatus.resolve(appsmithError.getHttpErrorCode()));
         doLog(e);
         String urlPath = exchange.getRequest().getPath().toString();
         ResponseDTO<ErrorDTO> response = new ResponseDTO<>(


### PR DESCRIPTION
## Description

When we have google sheet datasource with invalid authorisation and if we create a query on it, it redirects us back to login page. This PR fixes that issue.

`Root cause:`
The issue occurred because when datasource has invalid authorisation, authenticationResponse property inside a datasourceConfig object is null, which results in exception being thrown by the API. This exception has status code of 401. Whenever client receives a response with 401 error code, it logs out the user and redirects them back to login page.

`Fix:`
In this PR, that exception status code is changed from 401 to 500, so that error is thrown but logout and redirection does not happen.

#### PR fixes following issue(s)
Fixes #28988 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
1. Created a new app in a new workspace, added a new GSheets DS - did not authorize. Created a query with this DS. User is not logged out. Remains on Query page [Tried for Selected and All Gsheets.]
2. Imported an application with GSheets DS into a new workspace- did not authorize - skipped to application. Checked existing queries and Created a query with this DS. User is not logged out. Remains on Query page
3. Forked above application into a new workspace -  did not authorize - skipped to application. Checked existing queries and Created a query with this DS. User is not logged out. Remains on Query page
4. Created a new app in a new workspace, added a new GSheets DS - All GSheets permissions - Saved/Authorized/Created a Query - Sheets are displayed and query runs fine. 
5. Created a new app in a new workspace, added a new GSheets DS - Selected GSheets permissions - Saved/Authorized/Created a Query - Sheets are displayed and query runs fine. 
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [x] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
