### PR TITLE
fix: Remove "No action"  cue in action selector

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -118,7 +118,7 @@ describe("Table widget - Select column type functionality", () => {
       ]}}
     `,
     );
-    cy.get(".t--property-control-filterable input").click();
+    cy.get(".t--property-control-filterable input").click({ force: true });
     cy.editTableSelectCell(0, 0);
     cy.get(".select-popover-wrapper .bp3-input-group input").should("exist");
     cy.get(".select-popover-wrapper .bp3-input-group input").type("1", {

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -15,8 +15,6 @@ import { useApisQueriesAndJsActionOptions } from "./helpers";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { getActionTypeLabel } from "./viewComponents/ActionBlockTree/utils";
 import { AppsmithFunction } from "./constants";
-import { isEmpty } from "lodash";
-import styled from "styled-components";
 
 export const ActionCreatorContext = React.createContext<{
   label: string;
@@ -254,19 +252,6 @@ const ActionCreator = React.forwardRef(
       () => ({ label: props.action, selectedBlockId, selectBlock }),
       [selectedBlockId, props.action, selectBlock],
     );
-
-    const EmptyState = styled.div`
-      padding: var(--ads-v2-spaces-3);
-      border-radius: var(--ads-v2-border-radius);
-      border: solid 0 var(--ads-v2-color-gray-300);
-      background-color: var(--ads-v2-color-gray-100);
-      color: var(--ads-v2-color-gray-400);
-      font-size: 14px;
-    `;
-
-    if (isEmpty(actions)) {
-      return <EmptyState className="mt-1">No action</EmptyState>;
-    }
 
     return (
       <ActionCreatorContext.Provider value={contextValue}>


### PR DESCRIPTION
## Description
This PR reverts the"No action"  cue in action selector
#### PR fixes following issue(s)
Fixes #29013 

#### Media
<img width="286" alt="Screenshot 2023-11-21 at 23 02 32" src="https://github.com/appsmithorg/appsmith/assets/46670083/19054602-8a28-42c5-9dff-91e8dfb29092">
<br/>
<img width="282" alt="Screenshot 2023-11-21 at 23 03 20" src="https://github.com/appsmithorg/appsmith/assets/46670083/c2020b75-a990-4003-b9ff-5acb27d94580">


#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
