### PR TITLE
chore: junit test added for catchPluginException to assert http status

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/exceptions/GlobalExceptionHandlerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,41 @@
+package com.appsmith.server.exceptions;
+
+import com.appsmith.external.exceptions.ErrorDTO;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.server.dtos.ResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.util.LinkedMultiValueMap;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GlobalExceptionHandlerTest {
+    // Refer issue: https://github.com/appsmithorg/appsmith/pull/29009 for more context
+    @Test
+    public void testCatchPluginException_onAppsmithPluginException_throwsInternalServerError() {
+        LinkedMultiValueMap<String, String> mockHeaders = new LinkedMultiValueMap<>(1);
+        mockHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        MockServerHttpRequest httpRequest =
+                MockServerHttpRequest.get("").headers(mockHeaders).build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(httpRequest);
+
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(null, null, null, null);
+        Mono<ResponseDTO<ErrorDTO>> exceptionHandlerMono = handler.catchPluginException(
+                new AppsmithPluginException(AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR), exchange);
+        StepVerifier.create(exceptionHandlerMono)
+                .assertNext(response1 -> {
+                    // This asserts internal status code of the response
+                    assertEquals(response1.getResponseMeta().getStatus(), 401);
+
+                    // This asserts main/external http status code of the response
+                    assertEquals(exchange.getResponse().getStatusCode().is5xxServerError(), true);
+                })
+                .verifyComplete();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/exceptions/GlobalExceptionHandlerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/exceptions/GlobalExceptionHandlerTest.java
@@ -5,11 +5,8 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.server.dtos.ResponseDTO;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
-import org.springframework.util.LinkedMultiValueMap;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -19,10 +16,7 @@ public class GlobalExceptionHandlerTest {
     // Refer issue: https://github.com/appsmithorg/appsmith/pull/29009 for more context
     @Test
     public void testCatchPluginException_onAppsmithPluginException_throwsInternalServerError() {
-        LinkedMultiValueMap<String, String> mockHeaders = new LinkedMultiValueMap<>(1);
-        mockHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-        MockServerHttpRequest httpRequest =
-                MockServerHttpRequest.get("").headers(mockHeaders).build();
+        MockServerHttpRequest httpRequest = MockServerHttpRequest.get("").build();
         MockServerWebExchange exchange = MockServerWebExchange.from(httpRequest);
 
         GlobalExceptionHandler handler = new GlobalExceptionHandler(null, null, null, null);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/exceptions/GlobalExceptionHandlerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/exceptions/GlobalExceptionHandlerTest.java
@@ -13,7 +13,13 @@ import reactor.test.StepVerifier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GlobalExceptionHandlerTest {
-    // Refer issue: https://github.com/appsmithorg/appsmith/pull/29009 for more context
+    /*
+     * test case to ensure that whenever there is appsmithPluginException on server,
+     * we never expose the plugin status code directly,
+     * instead we use generic 500 internal server error.
+     * The actual plugin status code is visible inside response.status
+     * https://github.com/appsmithorg/appsmith/pull/29009 for more context
+     */
     @Test
     public void testCatchPluginException_onAppsmithPluginException_throwsInternalServerError() {
         MockServerHttpRequest httpRequest = MockServerHttpRequest.get("").build();


### PR DESCRIPTION
## Description

This PR adds junit test case to ensure that whenever there is appsmithPluginException on server, we never expose the plugin status code directly, instead we use generic 500 internal server error. The actual plugin status code is visible inside `response.status`.

#### PR fixes following issue(s)
Fixes #29037 
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [x] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
