### PR TITLE
test: Cypress | DB specs flaky fixes

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/MySQL_Datatypes/Basic_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/MySQL_Datatypes/Basic_Spec.ts
@@ -44,18 +44,6 @@ describe("MySQL Datatype tests", function () {
     dataSources.CreateQueryFromOverlay(dsName, query, "createTable"); //Creating query from EE overlay
     dataSources.RunQuery();
 
-    //Creating SELECT query
-    dataSources.createQueryWithDatasourceSchemaTemplate(
-      dsName,
-      inputData.tableName,
-      "Select",
-    );
-    agHelper.RenameWithInPane("selectRecords");
-    dataSources.RunQuery();
-    agHelper
-      .GetText(dataSources._noRecordFound)
-      .then(($noRecMsg) => expect($noRecMsg).to.eq("No data records to show"));
-
     //Other queries
     query = inputData.query.insertRecord;
     dataSources.createQueryWithDatasourceSchemaTemplate(
@@ -74,6 +62,18 @@ describe("MySQL Datatype tests", function () {
     );
     agHelper.RenameWithInPane("dropTable");
     dataSources.EnterQuery(query);
+
+    //Creating SELECT query
+    dataSources.createQueryWithDatasourceSchemaTemplate(
+      dsName,
+      inputData.tableName,
+      "Select",
+    );
+    agHelper.RenameWithInPane("selectRecords");
+    dataSources.RunQuery();
+    agHelper
+      .GetText(dataSources._noRecordFound)
+      .then(($noRecMsg) => expect($noRecMsg).to.eq("No data records to show"));
   });
 
   //Insert valid/true values into datasource

--- a/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Array_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Array_Spec.ts
@@ -40,18 +40,6 @@ describe("Array Datatype tests", function () {
     agHelper.RenameWithInPane("createTable");
     dataSources.RunQuery();
 
-    //Creating SELECT query - arraytypes + Bug 14493
-    dataSources.createQueryWithDatasourceSchemaTemplate(
-      dsName,
-      "public.arraytypes",
-      "Select",
-    );
-    agHelper.RenameWithInPane("selectRecords");
-    dataSources.RunQuery();
-    agHelper
-      .GetText(dataSources._noRecordFound)
-      .then(($noRecMsg) => expect($noRecMsg).to.eq("No data records to show"));
-
     //Creating other queries
     query = `INSERT INTO arraytypes ("name", "pay_by_quarter", "schedule")  VALUES ('{{Insertname.text}}', ARRAY{{Insertpaybyquarter.text.split(',').map(Number)}}, ARRAY[['{{Insertschedule.text.split(',').slice(0,2).toString()}}'],['{{Insertschedule.text.split(',').slice(2,4).toString()}}']]);`;
 
@@ -72,6 +60,18 @@ describe("Array Datatype tests", function () {
 
     query = `DROP table public."arraytypes"`;
     dataSources.CreateQueryFromOverlay(dsName, query, "dropTable"); //Creating query from EE overlay
+
+    //Creating SELECT query - arraytypes + Bug 14493
+    dataSources.createQueryWithDatasourceSchemaTemplate(
+      dsName,
+      "public.arraytypes",
+      "Select",
+    );
+    agHelper.RenameWithInPane("selectRecords");
+    dataSources.RunQuery();
+    agHelper
+      .GetText(dataSources._noRecordFound)
+      .then(($noRecMsg) => expect($noRecMsg).to.eq("No data records to show"));
 
     entityExplorer.ExpandCollapseEntity("Queries/JS", false);
   });

--- a/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
@@ -39,18 +39,6 @@ describe("Boolean & Enum Datatype tests", function () {
     dataSources.CreateQueryFromOverlay(dsName, query, "createTable");
     dataSources.RunQuery();
 
-    //Select query:
-    dataSources.createQueryWithDatasourceSchemaTemplate(
-      dsName,
-      "public.boolenumtypes",
-      "Select",
-    );
-    agHelper.RenameWithInPane("selectRecords");
-    dataSources.RunQuery();
-    agHelper
-      .GetText(dataSources._noRecordFound)
-      .then(($noRecMsg) => expect($noRecMsg).to.eq("No data records to show"));
-
     //Other queries
     query = `INSERT INTO public."boolenumtypes" ("workingday", "areweworking") VALUES ({{Insertworkingday.selectedOptionValue}}, {{Insertareweworking.isSwitchedOn}})`;
     dataSources.CreateQueryFromOverlay(dsName, query, "insertRecord");
@@ -72,6 +60,18 @@ describe("Boolean & Enum Datatype tests", function () {
 
     query = `drop type weekdays`;
     dataSources.CreateQueryFromOverlay(dsName, query, "dropEnum");
+
+    //Select query:
+    dataSources.createQueryWithDatasourceSchemaTemplate(
+      dsName,
+      "public.boolenumtypes",
+      "Select",
+    );
+    agHelper.RenameWithInPane("selectRecords");
+    dataSources.RunQuery();
+    agHelper
+      .GetText(dataSources._noRecordFound)
+      .then(($noRecMsg) => expect($noRecMsg).to.eq("No data records to show"));
 
     entityExplorer.ExpandCollapseEntity("Queries/JS", false);
   });

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,8 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+#cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/MySQL_Datatypes/Basic_Spec.ts
+cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Array_Spec.ts
+cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
 
 
 # For running all specs - uncomment below:

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -397,7 +397,7 @@ Cypress.Commands.add("DeletepageFromSideBar", () => {
 });
 
 Cypress.Commands.add("LogOut", (toCheckgetPluginForm = true) => {
-  agHelper.WaitUntilAllToastsDisappear();
+  // agHelper.WaitUntilAllToastsDisappear();
   //Since these are coming in every self-hosted 1st time login, commenting for CI runs
   // agHelper.AssertElementAbsence(
   //   locators._specificToast("There was an unexpected error"),


### PR DESCRIPTION
## Description
- This PR fixes below flaky specs:
- cypress/e2e/Regression/ServerSide/MySQL_Datatypes/Basic_Spec.ts
- cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Array_Spec.ts
- cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [X] Cypress CI runs

## Checklist:
#### QA activity:
- [X] Added `Test Plan Approved` label after Cypress tests were reviewed