### PR TITLE
chore: Use version from info.json directly

### DIFF
--- a/app/client/packages/rts/src/version.js
+++ b/app/client/packages/rts/src/version.js
@@ -3,6 +3,6 @@ import * as fs from "fs";
 export const VERSION = (() => {
     try {
         return JSON.parse(fs.readFileSync("/opt/appsmith/info.json")).version;
-    } catch (_) {
+    } catch {
     }
 })() || "SNAPSHOT"

--- a/app/client/packages/rts/src/version.js
+++ b/app/client/packages/rts/src/version.js
@@ -1,1 +1,8 @@
-export const VERSION = "SNAPSHOT";
+import * as fs from "fs";
+
+export const VERSION = (() => {
+    try {
+        return JSON.parse(fs.readFileSync("/opt/appsmith/info.json")).version;
+    } catch (_) {
+    }
+})() || "SNAPSHOT"

--- a/app/client/packages/rts/src/version.js
+++ b/app/client/packages/rts/src/version.js
@@ -1,8 +1,8 @@
 import * as fs from "fs";
 
-export const VERSION = (() => {
+export const VERSION =
+  (() => {
     try {
-        return JSON.parse(fs.readFileSync("/opt/appsmith/info.json")).version;
-    } catch {
-    }
-})() || "SNAPSHOT"
+      return JSON.parse(fs.readFileSync("/opt/appsmith/info.json")).version;
+    } catch {}
+  })() || "SNAPSHOT";


### PR DESCRIPTION
This will bring us one step closer to the `info.json` being the one source of truth for the version information. We shouldn't need the step to overwrite the contents of the `version.js` file during build in CI.
