### PR TITLE
fix: autocomplete for widget specific properties in action selector form fields

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -258,6 +258,7 @@ const ActionCreator = React.forwardRef(
         <div className="flex flex-col gap-[2px]" ref={ref}>
           {Object.entries(actions).map(([id, value], index) => (
             <Action
+              additionalAutoComplete={props.additionalAutoComplete}
               code={value}
               dataTreePath={props.dataTreePath}
               id={id}

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionSelector.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionSelector.tsx
@@ -19,6 +19,7 @@ import { getCodeFromMoustache, getSelectedFieldFromValue } from "../../utils";
 
 export default function ActionSelector(props: {
   action: TActionBlock;
+  additionalAutoComplete?: AdditionalDynamicDataTree;
   children: React.ReactNode;
   open: boolean;
   id: string;
@@ -47,6 +48,7 @@ export default function ActionSelector(props: {
       content={
         <ActionSelectorForm
           action={action}
+          additionalAutoComplete={props.additionalAutoComplete}
           dataTreePath={props.dataTreePath}
           onChange={props.onChange}
         />

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.tsx
@@ -12,6 +12,7 @@ import ActionSelector from "./ActionSelector";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { getActionTypeLabel } from "../ActionBlockTree/utils";
 import classNames from "classnames";
+import type { AdditionalDynamicDataTree } from "utils/autocomplete/customTreeTypeDefCreator";
 
 const CallbackBlockContainer = styled.div<{
   isSelected: boolean;
@@ -44,6 +45,7 @@ const EMPTY_ACTION_BLOCK: TActionBlock = {
 
 export default function ActionTree(props: {
   actionBlock: TActionBlock;
+  additionalAutoComplete?: AdditionalDynamicDataTree;
   onChange: (actionBlock: TActionBlock) => void;
   className?: string;
   id: string;
@@ -176,6 +178,7 @@ export default function ActionTree(props: {
     <div className={props.className}>
       <ActionSelector
         action={actionBlock}
+        additionalAutoComplete={props.additionalAutoComplete}
         dataTreePath={props.dataTreePath}
         id={id}
         level={props.level}

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/index.tsx
@@ -3,6 +3,7 @@ import ActionTree from "./ActionTree";
 import { useApisQueriesAndJsActionOptions } from "../../helpers";
 import type { TActionBlock } from "../../types";
 import { actionToCode, codeToAction } from "../../utils";
+import type { AdditionalDynamicDataTree } from "utils/autocomplete/customTreeTypeDefCreator";
 
 interface TRootActionProps {
   code: string;
@@ -13,6 +14,7 @@ interface TRootActionProps {
   widgetName: string;
   widgetType: string;
   dataTreePath: string | undefined;
+  additionalAutoComplete?: AdditionalDynamicDataTree;
 }
 
 export default function Action(props: TRootActionProps) {
@@ -41,6 +43,7 @@ export default function Action(props: TRootActionProps) {
   return (
     <ActionTree
       actionBlock={action}
+      additionalAutoComplete={props.additionalAutoComplete}
       className={`${props.index === 0 ? "mt-1" : "mt-2"}`}
       dataTreePath={props.dataTreePath}
       id={id}


### PR DESCRIPTION
## Description
> Pass down props from ActionSelector control all the way to action selector form component to render widget specific fields like currentRow, currentIndex etc in autocomplete in ActionSelector.
>
#### PR fixes following issue(s)
Fixes #29049 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
## Testing
>
#### How Has This Been Tested?
- [x] Manual
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
