### PR TITLE
fix: widget icon in debugger

### DIFF
--- a/app/client/src/ce/components/editorComponents/Debugger/ErrorLogs/getLogIconForEntity.tsx
+++ b/app/client/src/ce/components/editorComponents/Debugger/ErrorLogs/getLogIconForEntity.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import type { Plugin } from "api/PluginApi";
+import type { LogItemProps } from "components/editorComponents/Debugger/ErrorLogs/ErrorLogItem";
+import { PluginType } from "entities/Action";
+import WidgetIcon from "pages/Editor/Explorer/Widgets/WidgetIcon";
+import {
+  ApiMethodIcon,
+  EntityIcon,
+  JsFileIconV2,
+} from "pages/Editor/Explorer/ExplorerIcons";
+import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
+import { ENTITY_TYPE_VALUE } from "entities/DataTree/dataTreeFactory";
+
+export const getIconForEntity: Record<
+  string,
+  (props: LogItemProps, pluginGroups: Record<string, Plugin>) => any
+> = {
+  [ENTITY_TYPE_VALUE.WIDGET]: (props) => {
+    if (props.source?.pluginType) {
+      return (
+        <WidgetIcon height={16} type={props.source.pluginType} width={16} />
+      );
+    }
+  },
+  [ENTITY_TYPE_VALUE.JSACTION]: () => {
+    return JsFileIconV2(16, 16, true, true);
+  },
+  [ENTITY_TYPE_VALUE.ACTION]: (props, pluginGroups) => {
+    const { iconId, source } = props;
+    if (source?.pluginType === PluginType.API && source.httpMethod) {
+      // If the source is an API action.
+      return ApiMethodIcon(source.httpMethod, "16px", "32px", 50);
+    } else if (iconId && pluginGroups[iconId]) {
+      // If the source is a Datasource action.
+      return (
+        <EntityIcon height={"16px"} noBackground noBorder width={"16px"}>
+          <img
+            alt="entityIcon"
+            src={getAssetUrl(pluginGroups[iconId].iconLocation)}
+          />
+        </EntityIcon>
+      );
+    }
+    return <img alt="icon" />;
+  },
+};

--- a/app/client/src/ce/utils/getEntityPayloadInfo.ts
+++ b/app/client/src/ce/utils/getEntityPayloadInfo.ts
@@ -14,7 +14,7 @@ export const getEntityPayloadInfo: Record<
   (entityConfig: EntityConfig) => {
     iconId: string;
     id: string;
-    pluginType?: PluginType;
+    pluginType?: PluginType | string;
   }
 > = {
   [ENTITY_TYPE_VALUE.WIDGET]: (entityConfig) => {
@@ -22,6 +22,7 @@ export const getEntityPayloadInfo: Record<
     return {
       iconId: config.widgetId,
       id: config.widgetId,
+      pluginType: config.type,
     };
   },
   [ENTITY_TYPE_VALUE.JSACTION]: (entityConfig) => {

--- a/app/client/src/components/editorComponents/Debugger/ErrorLogs/components/LogEntityLink.tsx
+++ b/app/client/src/components/editorComponents/Debugger/ErrorLogs/components/LogEntityLink.tsx
@@ -16,6 +16,7 @@ import { getPlugins } from "@appsmith/selectors/entitiesSelector";
 import EntityLink from "../../EntityLink";
 import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
 import { DebuggerLinkUI } from "components/editorComponents/Debugger/DebuggerEntityLink";
+import type { Plugin } from "api/PluginApi";
 
 const EntityLinkWrapper = styled.div`
   display: flex;
@@ -36,48 +37,49 @@ const IconWrapper = styled.span`
   margin-right: 4px;
 `;
 
+// This function is used to fetch the icon component for the entity link.
+const getIcon = (props: LogItemProps, pluginGroups: Record<string, Plugin>) => {
+  if (props.source) {
+    // If the source is a widget.
+    if (props.source.type === ENTITY_TYPE.WIDGET && props.source.pluginType) {
+      return (
+        <WidgetIcon height={16} type={props.source.pluginType} width={16} />
+      );
+    }
+    // If the source is a JS action.
+    else if (props.source.type === ENTITY_TYPE.JSACTION) {
+      return JsFileIconV2(16, 16, true, true);
+    } else if (props.source.type === ENTITY_TYPE.ACTION) {
+      // If the source is an API action.
+      if (
+        props.source.pluginType === PluginType.API &&
+        props.source.httpMethod
+      ) {
+        return ApiMethodIcon(props.source.httpMethod, "16px", "32px", 50);
+      }
+      // If the source is a Datasource action.
+      else if (props.iconId && pluginGroups[props.iconId]) {
+        return (
+          <EntityIcon height={"16px"} noBackground noBorder width={"16px"}>
+            <img
+              alt="entityIcon"
+              src={getAssetUrl(pluginGroups[props.iconId].iconLocation)}
+            />
+          </EntityIcon>
+        );
+      }
+    }
+  }
+  // If the source is not defined then return an empty icon.
+  // this case is highly unlikely to happen.
+  return <img alt="icon" src={undefined} />;
+};
+
 // This component is used to render the entity link in the error logs.
 export default function LogEntityLink(props: LogItemProps) {
   const plugins = useSelector(getPlugins);
   const pluginGroups = useMemo(() => keyBy(plugins, "id"), [plugins]);
 
-  // This function is used to fetch the icon component for the entity link.
-  const getIcon = () => {
-    if (props.source) {
-      // If the source is a widget.
-      if (props.source.type === ENTITY_TYPE.WIDGET && props.source.pluginType) {
-        return (
-          <WidgetIcon height={16} type={props.source.pluginType} width={16} />
-        );
-      }
-      // If the source is a JS action.
-      else if (props.source.type === ENTITY_TYPE.JSACTION) {
-        return JsFileIconV2(16, 16, true, true);
-      } else if (props.source.type === ENTITY_TYPE.ACTION) {
-        // If the source is an API action.
-        if (
-          props.source.pluginType === PluginType.API &&
-          props.source.httpMethod
-        ) {
-          return ApiMethodIcon(props.source.httpMethod, "16px", "32px", 50);
-        }
-        // If the source is a Datasource action.
-        else if (props.iconId && pluginGroups[props.iconId]) {
-          return (
-            <EntityIcon height={"16px"} noBackground noBorder width={"16px"}>
-              <img
-                alt="entityIcon"
-                src={getAssetUrl(pluginGroups[props.iconId].iconLocation)}
-              />
-            </EntityIcon>
-          );
-        }
-      }
-    }
-    // If the source is not defined then return an empty icon.
-    // this case is highly unlikely to happen.
-    return <img alt="icon" src={undefined} />;
-  };
   const plugin = props.iconId ? pluginGroups[props.iconId] : undefined;
   return (
     <div>
@@ -89,7 +91,7 @@ export default function LogEntityLink(props: LogItemProps) {
             lineHeight: "14px",
           }}
         >
-          <IconWrapper>{getIcon()}</IconWrapper>
+          <IconWrapper>{getIcon(props, pluginGroups)}</IconWrapper>
           <EntityLink
             appsmithErrorCode={props.pluginErrorDetails?.appsmithErrorCode}
             errorSubType={props.messages && props.messages[0].message.name}

--- a/app/client/src/components/editorComponents/Debugger/ErrorLogs/components/LogEntityLink.tsx
+++ b/app/client/src/components/editorComponents/Debugger/ErrorLogs/components/LogEntityLink.tsx
@@ -4,18 +4,10 @@ import { useSelector } from "react-redux";
 import { keyBy } from "lodash";
 import type { LogItemProps } from "../ErrorLogItem";
 import { Colors } from "constants/Colors";
-import WidgetIcon from "pages/Editor/Explorer/Widgets/WidgetIcon";
-import {
-  ApiMethodIcon,
-  EntityIcon,
-  JsFileIconV2,
-} from "pages/Editor/Explorer/ExplorerIcons";
-import { ENTITY_TYPE } from "entities/AppsmithConsole";
-import { PluginType } from "entities/Action";
 import { getPlugins } from "@appsmith/selectors/entitiesSelector";
 import EntityLink from "../../EntityLink";
-import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
 import { DebuggerLinkUI } from "components/editorComponents/Debugger/DebuggerEntityLink";
+import { getIconForEntity } from "@appsmith/components/editorComponents/Debugger/ErrorLogs/getLogIconForEntity";
 import type { Plugin } from "api/PluginApi";
 
 const EntityLinkWrapper = styled.div`
@@ -39,40 +31,12 @@ const IconWrapper = styled.span`
 
 // This function is used to fetch the icon component for the entity link.
 const getIcon = (props: LogItemProps, pluginGroups: Record<string, Plugin>) => {
-  if (props.source) {
-    // If the source is a widget.
-    if (props.source.type === ENTITY_TYPE.WIDGET && props.source.pluginType) {
-      return (
-        <WidgetIcon height={16} type={props.source.pluginType} width={16} />
-      );
-    }
-    // If the source is a JS action.
-    else if (props.source.type === ENTITY_TYPE.JSACTION) {
-      return JsFileIconV2(16, 16, true, true);
-    } else if (props.source.type === ENTITY_TYPE.ACTION) {
-      // If the source is an API action.
-      if (
-        props.source.pluginType === PluginType.API &&
-        props.source.httpMethod
-      ) {
-        return ApiMethodIcon(props.source.httpMethod, "16px", "32px", 50);
-      }
-      // If the source is a Datasource action.
-      else if (props.iconId && pluginGroups[props.iconId]) {
-        return (
-          <EntityIcon height={"16px"} noBackground noBorder width={"16px"}>
-            <img
-              alt="entityIcon"
-              src={getAssetUrl(pluginGroups[props.iconId].iconLocation)}
-            />
-          </EntityIcon>
-        );
-      }
-    }
+  const entityType = props.source?.type;
+  let icon = null;
+  if (entityType) {
+    icon = getIconForEntity[entityType](props, pluginGroups);
   }
-  // If the source is not defined then return an empty icon.
-  // this case is highly unlikely to happen.
-  return <img alt="icon" src={undefined} />;
+  return icon || <img alt="icon" src={undefined} />;
 };
 
 // This component is used to render the entity link in the error logs.

--- a/app/client/src/ee/components/editorComponents/Debugger/ErrorLogs/getLogIconForEntity.tsx
+++ b/app/client/src/ee/components/editorComponents/Debugger/ErrorLogs/getLogIconForEntity.tsx
@@ -1,0 +1,1 @@
+export * from "ce/components/editorComponents/Debugger/ErrorLogs/getLogIconForEntity";

--- a/app/client/src/entities/AppsmithConsole/index.ts
+++ b/app/client/src/entities/AppsmithConsole/index.ts
@@ -71,8 +71,8 @@ export interface SourceEntity {
   id: string;
   // property path of the child
   propertyPath?: string;
-  // plugin type of the action
-  pluginType?: PluginType;
+  // plugin type of the action or type of widget
+  pluginType?: PluginType | string;
   // http method of the api. (Only for api actions)
   httpMethod?: HTTP_METHOD;
 }


### PR DESCRIPTION
## Description

- Fix the widget icon in debugger 
- Makes the LogEntityLink component extendable 

#### PR fixes following issue(s)
Fixes #29144

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
