### PR TITLE
fix: Context switching bug for queries

### DIFF
--- a/app/client/src/navigation/FocusSelectors.ts
+++ b/app/client/src/navigation/FocusSelectors.ts
@@ -65,9 +65,8 @@ export const getSelectedQueryId = (path: string): QueryListState => {
   ]);
   if (!match) return undefined;
   const { apiId, pluginPackageName, queryId } = match.params;
-  if (!queryId || !apiId) {
-    return undefined;
-  }
+  const id = apiId ? apiId : queryId;
+  if (!id) return undefined;
   let type: PluginType = PluginType.API;
   if (pluginPackageName) {
     type = PluginType.SAAS;
@@ -76,7 +75,7 @@ export const getSelectedQueryId = (path: string): QueryListState => {
   }
   return {
     type,
-    id: apiId || queryId,
+    id,
     pluginPackageName,
   };
 };


### PR DESCRIPTION
## Description

This PR fixes the context switching bug in queries page.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/29201

#### Type of change

- Bug fix (non-breaking change which fixes an issue)


## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
