### PR TITLE
fix: Multiple bindings from same entity should get replaced

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Executable.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Executable.java
@@ -3,6 +3,7 @@ package com.appsmith.external.models;
 import com.appsmith.external.dtos.DslExecutableDTO;
 import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.data.annotation.Transient;
 
 import java.time.Instant;
 import java.util.List;
@@ -46,6 +47,7 @@ public interface Executable {
     String getValidName();
 
     @JsonIgnore
+    @Transient
     String getExecutableName();
 
     EntityReferenceType getEntityReferenceType();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DslUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DslUtils.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -47,7 +48,11 @@ public class DslUtils {
         if (dslWalkResponse != null && dslWalkResponse.isLeafNode) {
             final StringBuilder oldValue = new StringBuilder(((TextNode) dslWalkResponse.currentNode).asText());
 
-            for (MustacheBindingToken mustacheBindingToken : replacementMap.keySet()) {
+            final List<MustacheBindingToken> tokens = replacementMap.keySet().stream()
+                    .sorted((token1, token2) -> token2.getStartIndex() - token1.getStartIndex())
+                    .toList();
+
+            for (MustacheBindingToken mustacheBindingToken : tokens) {
                 String tokenValue = mustacheBindingToken.getValue();
                 int endIndex = mustacheBindingToken.getStartIndex() + tokenValue.length();
                 if (oldValue.length() >= endIndex

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -91,7 +91,7 @@ import java.util.stream.Collectors;
 import static com.appsmith.external.constants.spans.ActionSpan.GET_ACTION_REPOSITORY_CALL;
 import static com.appsmith.external.constants.spans.ActionSpan.GET_UNPUBLISHED_ACTION;
 import static com.appsmith.external.constants.spans.ActionSpan.GET_VIEW_MODE_ACTION;
-import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNewFieldValuesIntoOldObject;
+import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
 import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInFormData;
 import static com.appsmith.server.acl.AclPermission.EXECUTE_DATASOURCES;
 import static java.lang.Boolean.FALSE;
@@ -286,7 +286,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
 
         this.validateCreatorId(action);
 
-        if (!isValidActionName(action)) {
+        if (!this.isValidActionName(action)) {
             action.setIsValid(false);
             invalids.add(AppsmithError.INVALID_ACTION_NAME.getMessage());
         }
@@ -607,7 +607,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.ACTION, id)))
                 .map(dbAction -> {
                     final ActionDTO unpublishedAction = dbAction.getUnpublishedAction();
-                    copyNewFieldValuesIntoOldObject(action, unpublishedAction);
+                    copyNestedNonNullProperties(action, unpublishedAction);
                     return dbAction;
                 })
                 .flatMap(this::extractAndSetNativeQueryFromFormData)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/DslUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/DslUtilsTest.java
@@ -86,13 +86,14 @@ class DslUtilsTest {
     void replaceValuesInSpecificDynamicBindingPath_withSuccessfulMultipleReplacements() {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode dsl = mapper.createObjectNode();
-        dsl.put("existingPath", "oldFieldValue1 oldFieldValue2");
+        dsl.put("existingPath", "oldFieldValue1 oldFieldValue2 oldFieldValue1 oldFieldValue2");
         HashMap<MustacheBindingToken, String> replacementMap = new HashMap<>();
-        replacementMap.put(new MustacheBindingToken("oldFieldValue1", 0, false), "newFieldValue1");
-        replacementMap.put(new MustacheBindingToken("oldFieldValue2", 15, false), "newFieldValue2");
+        replacementMap.put(new MustacheBindingToken("oldFieldValue1", 0, false), "newishFieldValue1");
+        replacementMap.put(new MustacheBindingToken("oldFieldValue2", 15, false), "newerFieldValue2");
+        replacementMap.put(new MustacheBindingToken("oldFieldValue1", 30, false), "newishFieldValue1");
+        replacementMap.put(new MustacheBindingToken("oldFieldValue2", 45, false), "newerFieldValue2");
         JsonNode replacedDsl = DslUtils.replaceValuesInSpecificDynamicBindingPath(dsl, "existingPath", replacementMap);
-        ObjectNode newDsl = mapper.createObjectNode();
-        newDsl.put("existingPath", "newFieldValue1 newFieldValue2");
-        Assertions.assertThat(replacedDsl).isEqualTo(dsl);
+        Assertions.assertThat(replacedDsl.get("existingPath").asText())
+                .isEqualTo("newishFieldValue1 newerFieldValue2 newishFieldValue1 newerFieldValue2");
     }
 }


### PR DESCRIPTION
Contains changes to make sure that a binding with multiple references to the same entity gets replaced properly. This is ensured now because we start from the last binding, and changes in sizes do not affect the start index of tokens before that point.