### PR TITLE
ci: Removing set-output in CI workflows as it's a deprecated command.

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -30,7 +30,7 @@ jobs:
             echo "No files changed in the specified folder"
             exit 1
           else
-            echo "::set-output name=files_changed_count::$filesChangedCount"            
+            echo "files_changed_count=$filesChangedCount" >> $GITHUB_OUTPUT
           fi
 
       - name: Check if PR is merged

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -133,7 +133,7 @@ jobs:
 
       # Timestamp will be used to create cache key
       - id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M:%S')"
+        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
@@ -389,6 +389,7 @@ jobs:
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_grepTags: ${{ inputs.tags }} # This is a comma separated list of tags to run a subset of the suite
           CYPRESS_SKIP_FLAKY: true
+          DEBUG: "@cypress/grep"
         with:
           browser: ${{ env.BROWSER_PATH }}
           install: false

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -67,7 +67,7 @@ jobs:
 
       # Timestamp will be used to create cache key
       - id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M:%S')"
+        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -437,5 +437,5 @@ jobs:
       # Set status = success
       - name: Save the status of the run
         run: |
-          echo "::set-output name=run_result::success"
+          echo "run_result=success" >> $GITHUB_OUTPUT
           echo "success" > ~/run_result

--- a/.github/workflows/ci-test-with-documentdb.yml
+++ b/.github/workflows/ci-test-with-documentdb.yml
@@ -129,7 +129,7 @@ jobs:
 
       # Timestamp will be used to create cache key
       - id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M:%S')"
+        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -67,7 +67,7 @@ jobs:
 
       # Timestamp will be used to create cache key
       - id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M:%S')"
+        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result


### PR DESCRIPTION
Using `GITHUB_OUTPUT` to save environment variables instead. This is to remove lots of warnings in the CI run and make it easier to read the summary.

Refer: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/