### PR TITLE
ci: Updating actions/checkout to v4 and defaulting to fetch-depth 1 instead of 0

### DIFF
--- a/.github/workflows/CypressAddKnownfailedtests.yml
+++ b/.github/workflows/CypressAddKnownfailedtests.yml
@@ -9,12 +9,11 @@ jobs:
     if: (github.event.action == 'opened' || github.event.action == 'reopened') && contains( github.event.issue.labels.*.name, 'CI impacted')
     runs-on: ubuntu-latest
     permissions:
-        issues: write
+      issues: write
     steps:
       - name: Checkout the merged commit from PR and base branch
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
       - name: View issue information
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -33,12 +32,11 @@ jobs:
     if: github.event.action == 'closed' && contains( github.event.issue.labels.*.name, 'CI impacted')
     runs-on: ubuntu-latest
     permissions:
-        issues: write
-    steps:     
+      issues: write
+    steps:
       - name: Checkout the merged commit from PR and base branch
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
       - name: View issue information
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/ad-hoc-deploy-preview.yml
+++ b/.github/workflows/ad-hoc-deploy-preview.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       # Check out merge commit
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -142,7 +142,7 @@ jobs:
     if: success()
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -196,5 +196,3 @@ jobs:
           --data ' {
                   "status": "FAILED"
           }'
-
-

--- a/.github/workflows/appsmithctl.yml
+++ b/.github/workflows/appsmithctl.yml
@@ -39,17 +39,14 @@ jobs:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}
@@ -96,7 +93,6 @@ jobs:
         run: |
           echo "appsmithctl_run_result=failed" >> $GITHUB_OUTPUT > ~/appsmithctl_run_result
           exit 1;
-
 
       # Set status = success
       - name: Save the status of the run

--- a/.github/workflows/build-chromatic.yml
+++ b/.github/workflows/build-chromatic.yml
@@ -1,34 +1,32 @@
-name: 'Build Storybook - UI Tests with Chromatic'
+name: "Build Storybook - UI Tests with Chromatic"
 
 on:
   push:
     branches:
       - release
     paths:
-      - 'app/client/packages/design-system/**'
-      - 'app/client/packages/storybook/**'
+      - "app/client/packages/design-system/**"
+      - "app/client/packages/storybook/**"
   pull_request:
     paths:
-      - 'app/client/packages/design-system/**'
-      - 'app/client/packages/storybook/**'
+      - "app/client/packages/design-system/**"
+      - "app/client/packages/storybook/**"
 
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
-   
+
     steps:
       - name: Checkout PR if pull_request event
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Checkout PR if push event
         if: github.event_name == 'push'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: release
 
       - name: Use Node.js
@@ -39,7 +37,7 @@ jobs:
       - name: Install Dependencies
         working-directory: ./app/client/packages/storybook
         run: yarn install --immutable
-        
+
       - name: Publish to Chromatic
         id: chromatic-publish
         uses: chromaui/action@v1

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -24,9 +24,7 @@ jobs:
       matrix_count: ${{steps.matrix.outputs.matrix_count}}
     steps:
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Set matrix jobs
         id: matrix

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -26,17 +26,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Download the client build artifact
         if: steps.run_result.outputs.run_result != 'success'

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -1,34 +1,32 @@
-name: 'Build Storybook - Docs with Chromatic'
+name: "Build Storybook - Docs with Chromatic"
 
 on:
   push:
     branches:
       - release
     paths:
-      - 'app/client/packages/design-system/**'
-      - 'app/client/packages/storybook/**'
+      - "app/client/packages/design-system/**"
+      - "app/client/packages/storybook/**"
   pull_request:
     paths:
-      - 'app/client/packages/design-system/**'
-      - 'app/client/packages/storybook/**'
+      - "app/client/packages/design-system/**"
+      - "app/client/packages/storybook/**"
 
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
-   
+
     steps:
       - name: Checkout PR if pull_request event
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Checkout PR if push event
         if: github.event_name == 'push'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: release
 
       - name: Use Node.js
@@ -39,7 +37,7 @@ jobs:
       - name: Install Dependencies
         working-directory: ./app/client/packages/storybook
         run: yarn install --immutable
-        
+
       - name: Publish to Chromatic
         id: chromatic-publish
         uses: chromaui/action@v1

--- a/.github/workflows/ci-debugging.yml
+++ b/.github/workflows/ci-debugging.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'Run id to download artifacts:'
+        description: "Run id to download artifacts:"
         required: true
-        type: number      
+        type: number
 
 jobs:
   ci-debugger:
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [ 0 ]
+        job: [0]
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -40,9 +40,7 @@ jobs:
         uses: depot/setup-action@v1
 
       - name: Checkout the head commit of the branch
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Download Docker image artifact
         uses: dawidd6/action-download-artifact@v2
@@ -82,7 +80,7 @@ jobs:
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
             --add-host=host.docker.internal:host-gateway \
             cicontainer
-            
+
       - name: Execute access to ci-debug.sh
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: "."

--- a/.github/workflows/ci-sanity.yml
+++ b/.github/workflows/ci-sanity.yml
@@ -43,17 +43,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -43,17 +43,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -119,17 +119,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -53,17 +53,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0 || github.event_name == 'schedule'
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -80,17 +80,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/ci-test-with-documentdb.yml
+++ b/.github/workflows/ci-test-with-documentdb.yml
@@ -115,17 +115,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -53,17 +53,14 @@ jobs:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/cleanup-dp.yml
+++ b/.github/workflows/cleanup-dp.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       # Checkout the code
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Install mongosh
         run: |

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -54,24 +54,21 @@ jobs:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Check out the specified branch in case this workflow is called by another workflow
       - name: Checkout the specified branch
         if: inputs.pr == 0 && inputs.branch != ''
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0 && inputs.branch == ''
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       # get all the files changes in the cypress/e2e folder
       - name: Get added files in cypress/e2e folder

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -56,6 +56,7 @@ jobs:
         if: inputs.pr != 0
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Check out the specified branch in case this workflow is called by another workflow
@@ -63,12 +64,14 @@ jobs:
         if: inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
           ref: ${{ inputs.branch }}
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0 && inputs.branch == ''
         uses: actions/checkout@v4
+          fetch-tags: true
 
       # get all the files changes in the cypress/e2e folder
       - name: Get added files in cypress/e2e folder

--- a/.github/workflows/client-lint.yml
+++ b/.github/workflows/client-lint.yml
@@ -33,9 +33,8 @@ jobs:
 
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # In case this is second attempt try restoring status of the prior attempt from cache

--- a/.github/workflows/client-prettier.yml
+++ b/.github/workflows/client-prettier.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ inputs.pr }}/merge
 

--- a/.github/workflows/client-unit-tests.yml
+++ b/.github/workflows/client-unit-tests.yml
@@ -33,9 +33,8 @@ jobs:
 
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # In case this is second attempt try restoring status of the prior attempt from cache

--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout the head commit of the branch
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -53,9 +53,7 @@ jobs:
 
     steps:
       # Checkout the code
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -114,15 +112,13 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies
@@ -163,9 +159,7 @@ jobs:
 
     steps:
       # Checkout the code
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -216,7 +210,7 @@ jobs:
 
     steps:
       - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -22,9 +22,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
 
@@ -121,7 +121,7 @@ jobs:
     steps:
       # Check out merge commit
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
 
@@ -201,10 +201,9 @@ jobs:
     if: success()
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
-          fetch-depth: 0
 
       - name: Print versions of tools
         run: |

--- a/.github/workflows/packer-ami-build.yml
+++ b/.github/workflows/packer-ami-build.yml
@@ -1,6 +1,4 @@
-
 ---
-
 name: Ami Packer Build
 
 on:
@@ -9,13 +7,12 @@ on:
 
 jobs:
   packer:
-
     runs-on: ubuntu-latest
     name: ami-packer-build
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -27,11 +24,11 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install ansible
         run: pip install ansible
-      
+
       - name: Install Packer
         run: |
           sudo apt-get update; sudo apt-get install -y curl gnupg software-properties-common ;
@@ -40,6 +37,6 @@ jobs:
           sudo apt-get update && sudo apt-get install -y packer;
 
       - name: Build artifacts
-        run : |
+        run: |
           cd deploy/packer;
           packer build -var vpc_id=${{ secrets.APPSMITH_AWS_VPC_PROD }} -var subnet_id=${{ secrets.APPSMITH_AWS_PROD_SUBNET }} -var token=${{ secrets.DO_TOKEN }} template.json.pkr.hcl

--- a/.github/workflows/perf-test-on-documentdb.yml
+++ b/.github/workflows/perf-test-on-documentdb.yml
@@ -43,17 +43,14 @@ jobs:
     steps:
       - name: Checkout the merged commit from PR and base branch
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}
@@ -115,7 +112,7 @@ jobs:
         working-directory: "."
         run: |
           mkdir -p cicontainerlocal/stacks/configuration/
-      
+
       - name: Set up SSH key for tunnel
         env:
           SSH_PRIVATE_KEY: ${{ secrets.APPSMITH_CI_TUNNEL_PRIVATE_KEY }}
@@ -126,7 +123,7 @@ jobs:
       - name: Setup SSH tunnel to AWS DocumentDB instance
         run: |
           ssh -4 -o StrictHostKeyChecking=no -o ServerAliveInterval=180 -o ServerAliveCountMax=5 -i "ssh_key.pem" -L 0.0.0.0:27010:docdb-ansible-test-cluster.cluster-cz8diybf9wdj.ap-south-1.docdb.amazonaws.com:27017 ubuntu@65.1.106.35 -N -f
-      
+
       - name: Run docker image
         if: steps.run_result.outputs.run_result != 'success'
         env:
@@ -198,7 +195,7 @@ jobs:
           echo ref=$ref >> $GITHUB_OUTPUT
 
       - name: Checkout Performance Infra code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: appsmithorg/performance-infra
           token: ${{ secrets.APPSMITH_PERF_INFRA_REPO_PAT }}

--- a/.github/workflows/perf-test-v2.yml
+++ b/.github/workflows/perf-test-v2.yml
@@ -25,10 +25,6 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'repository_dispatch'
-    defaults:
-      run:
-        working-directory: app/client
-        shell: bash
 
     strategy:
       fail-fast: false

--- a/.github/workflows/perf-test-v2.yml
+++ b/.github/workflows/perf-test-v2.yml
@@ -29,7 +29,7 @@ jobs:
       run:
         working-directory: app/client
         shell: bash
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -51,17 +51,14 @@ jobs:
     steps:
       - name: Checkout the merged commit from PR and base branch
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}
@@ -189,7 +186,7 @@ jobs:
           echo ref=$ref >> $GITHUB_OUTPUT
 
       - name: Checkout Performance Infra code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: appsmithorg/performance-infra
           token: ${{ secrets.APPSMITH_PERF_INFRA_REPO_PAT }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -46,17 +46,14 @@ jobs:
     steps:
       - name: Checkout the merged commit from PR and base branch
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}
@@ -184,7 +181,7 @@ jobs:
           echo ref=$ref >> $GITHUB_OUTPUT
 
       - name: Checkout Performance Infra code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: appsmithorg/performance-infra
           token: ${{ secrets.APPSMITH_PERF_INFRA_REPO_PAT }}

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
-    
+
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -84,7 +84,15 @@ jobs:
 
   qc-result:
     name: qc-result
-    needs: [server-spotless, server-unit-tests, client-build, client-prettier, client-unit-tests, client-lint]
+    needs:
+      [
+        server-spotless,
+        server-unit-tests,
+        client-build,
+        client-prettier,
+        client-unit-tests,
+        client-lint,
+      ]
     if: always()
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -50,6 +50,7 @@ jobs:
         if: inputs.pr != 0
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Check out the specified branch in case this workflow is called by another workflow
@@ -57,12 +58,15 @@ jobs:
         if: inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
           ref: ${{ inputs.branch }}
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0 && inputs.branch == ''
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}

--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -48,25 +48,21 @@ jobs:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
         if: inputs.pr != 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Check out the specified branch in case this workflow is called by another workflow
       - name: Checkout the specified branch
         if: inputs.pr == 0 && inputs.branch != ''
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0 && inputs.branch == ''
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -44,25 +44,22 @@ jobs:
 
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Check out merged commit from PR and base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: inputs.pr != 0
         with:
-          fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Check out the specified branch in case this workflow is called by another workflow
       - name: Checkout the specified branch
         if: inputs.pr == 0 && inputs.branch != ''
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-  
+
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Check out the head commit of the branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: inputs.pr == 0 && inputs.branch == ''
-        with:
-          fetch-depth: 0
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}
@@ -92,8 +89,8 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v4
         if: inputs.pr != 0
         with:
+          fetch-tags: true
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Check out the specified branch in case this workflow is called by another workflow
@@ -54,12 +55,15 @@ jobs:
         if: inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
           ref: ${{ inputs.branch }}
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Check out the head commit of the branch
         uses: actions/checkout@v4
         if: inputs.pr == 0 && inputs.branch == ''
+        with:
+          fetch-tags: true
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}

--- a/.github/workflows/server-spotless.yml
+++ b/.github/workflows/server-spotless.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ inputs.pr }}/merge
 
@@ -28,8 +28,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       # Run maven step for spotless check
       - name: Run spotless check

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -188,7 +188,7 @@ jobs:
     steps:
       - name: Checkout the head commit of the branch
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download the react build artifact
         uses: actions/download-artifact@v3
@@ -263,7 +263,7 @@ jobs:
     steps:
       - name: Checkout the head commit of the branch
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download the react build artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to use `actions/checkout@v4` for improved performance and reliability.
  - Removed `fetch-depth` parameter to simplify checkout steps across various workflows.
  - Standardized quote usage for consistency in workflow files.

- **Documentation**
  - Adjusted formatting and descriptions in workflow files for better clarity and readability.

- **Refactor**
  - Aligned multiple workflow files to follow a consistent structure and naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fetch-depth 0 causes the Github workflow to checkout the entire Git history. This is not required. We only need to check out the head of the commit. By default, actions/checkout has fetch-depth=1, hence removing it from the workflow completely for simplicity.