### PR TITLE
chore: Set client's version in index.html at runtime

### DIFF
--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -310,8 +310,8 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
         ENV_CONFIG.appVersion?.id ||
         "",
       releaseDate:
-        ENV_CONFIG.appVersion?.releaseDate ||
         APPSMITH_FEATURE_CONFIGS?.appVersion?.releaseDate ||
+        ENV_CONFIG.appVersion?.releaseDate ||
         "",
       edition:
         ENV_CONFIG.appVersion?.edition ||

--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -304,8 +304,20 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
       ENV_CONFIG.logLevel || APPSMITH_FEATURE_CONFIGS?.logLevel || false,
     enableTNCPP:
       ENV_CONFIG.enableTNCPP || APPSMITH_FEATURE_CONFIGS?.enableTNCPP || false,
-    appVersion:
-      APPSMITH_FEATURE_CONFIGS?.appVersion || ENV_CONFIG.appVersion || false,
+    appVersion: {
+      id:
+        APPSMITH_FEATURE_CONFIGS?.appVersion?.id ||
+        ENV_CONFIG.appVersion?.id ||
+        "",
+      releaseDate:
+        ENV_CONFIG.appVersion?.releaseDate ||
+        APPSMITH_FEATURE_CONFIGS?.appVersion?.releaseDate ||
+        "",
+      edition:
+        ENV_CONFIG.appVersion?.edition ||
+        APPSMITH_FEATURE_CONFIGS?.appVersion?.edition ||
+        "",
+    },
     intercomAppID:
       ENV_CONFIG.intercomAppID || APPSMITH_FEATURE_CONFIGS?.intercomAppID || "",
     mailEnabled:

--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -305,7 +305,7 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
     enableTNCPP:
       ENV_CONFIG.enableTNCPP || APPSMITH_FEATURE_CONFIGS?.enableTNCPP || false,
     appVersion:
-      ENV_CONFIG.appVersion || APPSMITH_FEATURE_CONFIGS?.appVersion || false,
+      APPSMITH_FEATURE_CONFIGS?.appVersion || ENV_CONFIG.appVersion || false,
     intercomAppID:
       ENV_CONFIG.intercomAppID || APPSMITH_FEATURE_CONFIGS?.intercomAppID || "",
     mailEnabled:

--- a/deploy/docker/fs/opt/appsmith/run-caddy.sh
+++ b/deploy/docker/fs/opt/appsmith/run-caddy.sh
@@ -17,6 +17,7 @@ apply-env-vars() {
   try {
     const info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
     process.env.APPSMITH_VERSION_ID = info.version || ""
+    process.env.APPSMITH_VERSION_RELEASE_DATE = info.imageBuiltAt || ""
   } catch {}
   const content = fs.readFileSync("'"$original"'", "utf8").replace(
     /\b__(APPSMITH_[A-Z0-9_]+)__\b/g,

--- a/deploy/docker/fs/opt/appsmith/run-caddy.sh
+++ b/deploy/docker/fs/opt/appsmith/run-caddy.sh
@@ -14,6 +14,10 @@ apply-env-vars() {
   served="$2"
   node -e '
   const fs = require("fs")
+  try {
+    const info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
+    process.env.APPSMITH_VERSION_ID = info.version || ""
+  } catch {}
   const content = fs.readFileSync("'"$original"'", "utf8").replace(
     /\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
     (placeholder, name) => (process.env[name] || "")


### PR DESCRIPTION
[Slack thread with a lot more details and discussion](https://theappsmith.slack.com/archives/C02MUD8DNUR/p1701759438660509).

This will help us move towards having `info.json` as the one source of truth for Appsmith version.

**Only review, DO NOT MERGE. This PR _will_ cause conflicts in sync.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The app now displays more detailed version information, including the build ID, release date, and edition.

- **Bug Fixes**
  - Improved error handling during environment variable setup to ensure smoother app initialization.

- **Refactor**
  - Updated configuration retrieval logic to enhance the clarity and reliability of version information displayed in the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->