### PR TITLE
ci: Fix version calculation in workflows

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -220,7 +220,7 @@ jobs:
           fi
           # Since this is an unreleased build, we set the version to incremented version number with
           # a `-SNAPSHOT` suffix.
-          latest_released_version="$(git tag --list 'v*' --sort=-version:refname | head -1)"
+          latest_released_version="$(git ls-remote --tags --sort=-v:refname "$(git remote | head -1)" 'v*' | awk -F/ '{print $NF; exit}')"
           echo "latest_released_version = $latest_released_version"
           next_version="$(echo "$latest_released_version" | awk -F. -v OFS=. '{ $NF++; print }')"
           echo "next_version = $next_version"

--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           # Since this is an unreleased build, we set the version to incremented version number with a
           # `-SNAPSHOT` suffix.
-          latest_released_version="$(git tag --list 'v*' --sort=-version:refname | head -1)"
+          latest_released_version="$(git ls-remote --tags --sort=-v:refname "$(git remote | head -1)" 'v*' | awk -F/ '{print $NF; exit}')"
           echo "latest_released_version = $latest_released_version"
           next_version="$(echo "$latest_released_version" | awk -F. -v OFS=. '{ $3++; print }')"
           echo "next_version = $next_version"

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           # Since this is an unreleased build, we set the version to incremented version number with a
           # `-SNAPSHOT` suffix.
-          latest_released_version="$(git tag --list 'v*' --sort=-version:refname | head -1)"
+          latest_released_version="$(git ls-remote --tags --sort=-v:refname "$(git remote | head -1)" 'v*' | awk -F/ '{print $NF; exit}')"
           echo "latest_released_version = $latest_released_version"
           next_version="$(echo "$latest_released_version" | awk -F. -v OFS=. '{ $NF++; print }')"
           echo "next_version = $next_version"
@@ -147,7 +147,7 @@ jobs:
             -DnewVersion=${{ steps.vars.outputs.version }} \
             -DgenerateBackupPoms=false \
             -DprocessAllModules=true \
-            -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.outputFile="./junit-report.xml" 
+            -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.outputFile="./junit-report.xml"
           ./build.sh $args
 
       # Restore the previous built bundle if present. If not push the newly built into the cache


### PR DESCRIPTION
This code is duplicated from generate_info_json.sh script, but that's temporary. We'll be moving towards not having the version computation in the workflows at all, and all components getting version information from `info.json` alone. Essentially treating `info.json` as the source of truth for this.
