### PR TITLE
ci: Remove RTS' computation of snapshot version

### DIFF
--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -109,23 +109,6 @@ jobs:
           restore-keys: |
             v1-yarn3-
 
-      # Here, the GITHUB_REF is of type /refs/head/<branch_name>. We extract branch_name from this by removing the
-      # first 11 characters. This can be used to build images for several branches
-      # Since this is an unreleased build, we get the latest released version number, increment the minor number in it,
-      # append a `-SNAPSHOT` at it's end to prepare the snapshot version number. This is used as the project's version.
-      - name: Get the version to tag the Docker image
-        if: steps.run_result.outputs.run_result != 'success'
-        id: vars
-        run: |
-          # Since this is an unreleased build, we set the version to incremented version number with a
-          # `-SNAPSHOT` suffix.
-          latest_released_version="$(git ls-remote --tags --sort=-v:refname "$(git remote | head -1)" 'v*' | awk -F/ '{print $NF; exit}')"
-          echo "latest_released_version = $latest_released_version"
-          next_version="$(echo "$latest_released_version" | awk -F. -v OFS=. '{ $3++; print }')"
-          echo "next_version = $next_version"
-          echo version=$next_version-SNAPSHOT >> $GITHUB_OUTPUT
-          echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
-
       # Install all the dependencies
       - name: Install dependencies
         if: steps.run_result.outputs.run_result != 'success'
@@ -141,9 +124,6 @@ jobs:
       - name: Build
         if: steps.run_result.outputs.run_result != 'success'
         run: |
-          if ! grep -qF "info.json" src/version.js; then
-            echo 'export const VERSION = "${{ steps.vars.outputs.version }}"' > src/version.js
-          fi
           yarn build
 
       # Set status = failure


### PR DESCRIPTION
RTS is already getting the version from `info.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the build process by removing unnecessary versioning steps.
- **Refactor**
  - Simplified the Docker image tagging process during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->