### PR TITLE
ci: Adding fetch-depth 0 to chromatic Github workflow 

### DIFF
--- a/.github/workflows/build-chromatic.yml
+++ b/.github/workflows/build-chromatic.yml
@@ -21,12 +21,14 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Checkout PR if push event
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: release
 
       - name: Use Node.js

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -21,12 +21,14 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Checkout PR if push event
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: release
 
       - name: Use Node.js


### PR DESCRIPTION
Full git history is required by the chromatic plugin to work properly & publish the site. Hence adding `fetch-depth: 0` back into the Chromatic workflow



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to fetch the full Git history for more accurate CI/CD operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->