### PR TITLE
fix: Incorrect status code for missing static files

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -84,7 +84,10 @@ parts.push(`
     import file_server
     skip_log
   }
-  error /static/* 404
+
+  handle /static/* {
+   error 404
+  }
 
   handle /info {
     root * /opt/appsmith


### PR DESCRIPTION
I think the route precedence in Caddy is different when using `handle` directive, vs when directly using the `error` directive.

This is causing the file `handle {` route, which is a catch-all route is handling `/static/*` requests that don't have a corresponding file. This handler however, doesn't respond with 404 status, it responds with 200 status for missing files, and render the `index.html` for our SPA behaviour.

Now, the CDN we have on release.app.appsmith.com caches responses from upstream when the status is 200. If it is 404, it won't cache and retry next time. This is why it's essential that we respond with 404 for files that don't exist, irrespective of the content of the response.

When the container is starting up, Caddy doesn't have all the information yet, and may have responded with not-found for one of the assets. But since this went out with 200 status, our CDN cached it, and once the file _was_ available with Caddy, the CDN wouldn't retry ever.

This fix will ensure we get 404 status code for requests to `/static/*` that point to files that don't exist.
