### PR TITLE
fix: resource deleted if imported in same app

### DIFF
--- a/app/server/.run/AppsmithServer.run.xml
+++ b/app/server/.run/AppsmithServer.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="AppsmithServer" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="$PROJECT_DIR$/../java/jdk-17.0.2.jdk/Contents/Home" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="DEBUG_MODE" value="true" />
+    <module name="server" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.appsmith.server.ServerApplication" />
+    <option name="VM_PARAMETERS" value="-Dpf4j.mode=development -Dpf4j.pluginsDir=appsmith-plugins" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/app/server" />
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="true" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+        <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="app/server/.env" />
+      </ENTRIES>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/imports/ActionCollectionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/imports/ActionCollectionImportableServiceCEImpl.java
@@ -53,7 +53,8 @@ public class ActionCollectionImportableServiceCEImpl implements ImportableServic
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson) {
+            ApplicationJson applicationJson,
+            boolean isPartialImport) {
         List<ActionCollection> importedActionCollectionList =
                 CollectionUtils.isEmpty(applicationJson.getActionCollectionList())
                         ? new ArrayList<>()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/imports/DatasourceImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/imports/DatasourceImportableServiceCEImpl.java
@@ -61,7 +61,8 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson) {
+            ApplicationJson applicationJson,
+            boolean isPartialImport) {
         return workspaceMono.flatMap(workspace -> {
             final Flux<Datasource> existingDatasourceFlux = datasourceService
                     .getAllByWorkspaceIdWithStorages(workspace.getId(), Optional.empty())

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/ImportableServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/ImportableServiceCE.java
@@ -15,12 +15,14 @@ public interface ImportableServiceCE<T extends BaseDomain> {
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson);
+            ApplicationJson applicationJson,
+            boolean isPartialImport);
 
     default Mono<Void> updateImportedEntities(
             Application application,
             ImportingMetaDTO importingMetaDTO,
-            MappedImportableResourcesDTO mappedImportableResourcesDTO) {
+            MappedImportableResourcesDTO mappedImportableResourcesDTO,
+            boolean isPartialImport) {
         return null;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportApplicationServiceCEImpl.java
@@ -554,9 +554,9 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 .then(importedApplicationMono)
                 .flatMap(application -> {
                     return newActionImportableService
-                            .updateImportedEntities(application, importingMetaDTO, mappedImportableResourcesDTO)
+                            .updateImportedEntities(application, importingMetaDTO, mappedImportableResourcesDTO, false)
                             .then(newPageImportableService.updateImportedEntities(
-                                    application, importingMetaDTO, mappedImportableResourcesDTO))
+                                    application, importingMetaDTO, mappedImportableResourcesDTO, false))
                             .thenReturn(application);
                 })
                 .flatMap(application -> {
@@ -663,7 +663,8 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                false);
 
         // Directly updates required theme information in DB
         Mono<Void> importedThemesMono = themeImportableService.importEntities(
@@ -671,7 +672,8 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                false);
 
         // Updates pageNametoIdMap and pageNameMap in importable resources.
         // Also directly updates required information in DB
@@ -680,7 +682,8 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                false);
 
         // Requires pluginMap to be present in importable resources.
         // Updates datasourceNameToIdMap in importable resources.
@@ -690,7 +693,8 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson));
+                applicationJson,
+                false));
 
         return List.of(importedDatasourcesMono, importedPagesMono, importedThemesMono);
     }
@@ -711,7 +715,8 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                false);
 
         // Requires pageNameMap, pageNameToOldNameMap, pluginMap and actionResultDTO to be present in importable
         // resources.
@@ -722,7 +727,8 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                false);
 
         Mono<Void> combinedActionExportablesMono = importedNewActionsMono.then(importedActionCollectionsMono);
         return List.of(combinedActionExportablesMono);
@@ -734,7 +740,7 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
             MappedImportableResourcesDTO mappedImportableResourcesDTO) {
         // Persists relevant information and updates mapped resources
         Mono<Void> installedJsLibsMono = customJSLibImportableService.importEntities(
-                importingMetaDTO, mappedImportableResourcesDTO, null, null, applicationJson);
+                importingMetaDTO, mappedImportableResourcesDTO, null, null, applicationJson, false);
         return installedJsLibsMono;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/PartialImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/PartialImportServiceCEImpl.java
@@ -147,9 +147,9 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
                                 }
                                 return newActionImportableService
                                         .updateImportedEntities(
-                                                application, importingMetaDTO, mappedImportableResourcesDTO)
+                                                application, importingMetaDTO, mappedImportableResourcesDTO, true)
                                         .then(newPageImportableService.updateImportedEntities(
-                                                application, importingMetaDTO, mappedImportableResourcesDTO))
+                                                application, importingMetaDTO, mappedImportableResourcesDTO, true))
                                         .thenReturn(application);
                             });
                 })
@@ -209,17 +209,19 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                true);
 
         Mono<Void> datasourceMono = datasourceImportableService.importEntities(
                 importingMetaDTO,
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                true);
 
         Mono<Void> customJsLibMono = customJSLibImportableService.importEntities(
-                importingMetaDTO, mappedImportableResourcesDTO, null, null, applicationJson);
+                importingMetaDTO, mappedImportableResourcesDTO, null, null, applicationJson, true);
 
         return pluginMono.then(datasourceMono).then(customJsLibMono).then();
     }
@@ -235,14 +237,16 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                true);
 
         Mono<Void> actionCollectionMono = actionCollectionImportableService.importEntities(
                 importingMetaDTO,
                 mappedImportableResourcesDTO,
                 workspaceMono,
                 importedApplicationMono,
-                applicationJson);
+                applicationJson,
+                true);
 
         return actionMono.then(actionCollectionMono).then();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/imports/CustomJSLibImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/imports/CustomJSLibImportableServiceCEImpl.java
@@ -30,7 +30,8 @@ public class CustomJSLibImportableServiceCEImpl implements ImportableServiceCE<C
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson) {
+            ApplicationJson applicationJson,
+            boolean isPartialImport) {
         List<CustomJSLib> customJSLibs = applicationJson.getCustomJSLibList();
         if (customJSLibs == null) {
             customJSLibs = new ArrayList<>();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
@@ -66,7 +66,8 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson) {
+            ApplicationJson applicationJson,
+            boolean isPartialImport) {
 
         List<NewAction> importedNewActionList = applicationJson.getActionList();
 
@@ -105,9 +106,13 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                             && CollectionUtils.isNotEmpty(importActionResultDTO.getExistingActions())) {
                         // Remove unwanted actions
                         Set<String> invalidActionIds = new HashSet<>();
-                        for (NewAction action : importActionResultDTO.getExistingActions()) {
-                            if (!importActionResultDTO.getImportedActionIds().contains(action.getId())) {
-                                invalidActionIds.add(action.getId());
+                        if (Boolean.FALSE.equals(isPartialImport)) {
+                            for (NewAction action : importActionResultDTO.getExistingActions()) {
+                                if (!importActionResultDTO
+                                        .getImportedActionIds()
+                                        .contains(action.getId())) {
+                                    invalidActionIds.add(action.getId());
+                                }
                             }
                         }
                         log.info("Deleting {} actions which are no more used", invalidActionIds.size());
@@ -136,7 +141,8 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
     public Mono<Void> updateImportedEntities(
             Application application,
             ImportingMetaDTO importingMetaDTO,
-            MappedImportableResourcesDTO mappedImportableResourcesDTO) {
+            MappedImportableResourcesDTO mappedImportableResourcesDTO,
+            boolean isPartialImport) {
 
         ImportActionResultDTO importActionResultDTO = mappedImportableResourcesDTO.getActionResultDTO();
         ImportActionCollectionResultDTO importActionCollectionResultDTO =
@@ -157,7 +163,8 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                     // Delete the invalid resources (which are not the part of applicationJsonDTO) in
                     // the git flow only
                     if (!StringUtils.isEmpty(importingMetaDTO.getApplicationId())
-                            && !importingMetaDTO.getAppendToApp()) {
+                            && !importingMetaDTO.getAppendToApp()
+                            && Boolean.FALSE.equals(isPartialImport)) {
                         // Remove unwanted action collections
                         Set<String> invalidCollectionIds = new HashSet<>();
                         for (ActionCollection collection :

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/imports/NewPageImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/imports/NewPageImportableServiceCEImpl.java
@@ -68,7 +68,8 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson) {
+            ApplicationJson applicationJson,
+            boolean isPartialImport) {
 
         List<NewPage> importedNewPageList = applicationJson.getPageList();
 
@@ -113,7 +114,8 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
     public Mono<Void> updateImportedEntities(
             Application application,
             ImportingMetaDTO importingMetaDTO,
-            MappedImportableResourcesDTO mappedImportableResourcesDTO) {
+            MappedImportableResourcesDTO mappedImportableResourcesDTO,
+            boolean isPartialImport) {
 
         ImportedActionAndCollectionMapsDTO actionAndCollectionMapsDTO =
                 mappedImportableResourcesDTO.getActionAndCollectionMapsDTO();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/imports/PluginImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/imports/PluginImportableServiceCEImpl.java
@@ -33,7 +33,8 @@ public class PluginImportableServiceCEImpl implements ImportableServiceCE<Plugin
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson) {
+            ApplicationJson applicationJson,
+            boolean isPartialImport) {
         return workspaceMono
                 .map(workspace -> workspace.getPlugins().stream()
                         .map(WorkspacePlugin::getPluginId)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/imports/ThemeImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/imports/ThemeImportableServiceCEImpl.java
@@ -53,7 +53,8 @@ public class ThemeImportableServiceCEImpl implements ImportableServiceCE<Theme> 
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Mono<Workspace> workspaceMono,
             Mono<Application> applicationMono,
-            ApplicationJson applicationJson) {
+            ApplicationJson applicationJson,
+            boolean isPartialImport) {
         if (Boolean.TRUE.equals(importingMetaDTO.getAppendToApp())) {
             // appending to existing app, theme should not change
             return Mono.empty().then();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ThemeImportableServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ThemeImportableServiceCETest.java
@@ -180,7 +180,8 @@ public class ThemeImportableServiceCETest {
                                 new MappedImportableResourcesDTO(),
                                 null,
                                 Mono.just(application),
-                                applicationJson)
+                                applicationJson,
+                                false)
                         .thenReturn(savedApplication.getId()))
                 .flatMap(applicationId -> applicationRepository.findById(applicationId, MANAGE_APPLICATIONS));
 
@@ -224,7 +225,8 @@ public class ThemeImportableServiceCETest {
                                     new MappedImportableResourcesDTO(),
                                     null,
                                     Mono.just(savedApplication),
-                                    applicationJson)
+                                    applicationJson,
+                                    false)
                             .thenReturn(savedApplication.getId());
                 })
                 .flatMap(applicationId -> applicationRepository.findById(applicationId, MANAGE_APPLICATIONS));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/transactions/ImportApplicationTransactionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/transactions/ImportApplicationTransactionServiceTest.java
@@ -135,7 +135,7 @@ public class ImportApplicationTransactionServiceTest {
         Workspace newWorkspace = new Workspace();
         newWorkspace.setName("Template Workspace");
 
-        Mockito.when(newActionImportableService.importEntities(any(), any(), any(), any(), any()))
+        Mockito.when(newActionImportableService.importEntities(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Mono.error(new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST)));
 
         Workspace createdWorkspace = workspaceService.create(newWorkspace).block();
@@ -166,7 +166,7 @@ public class ImportApplicationTransactionServiceTest {
         Workspace newWorkspace = new Workspace();
         newWorkspace.setName("Template Workspace");
 
-        Mockito.when(newActionImportableService.importEntities(any(), any(), any(), any(), any()))
+        Mockito.when(newActionImportableService.importEntities(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Mono.error(new MongoTransactionException(
                         "Command failed with error 251 (NoSuchTransaction): 'Transaction 1 has been aborted.'")));
 


### PR DESCRIPTION
## Description
This PR fixes the issue where the exported entities are no longer associated with the parent page (from where the entities were imported) if imported in the same application. 
This is handled by adding a boolean value to differentiate normal import flow with partial import. 

#### PR fixes following issue(s)
Fixes #29378 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [ ] Manual

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
