### PR TITLE
fix: current workspace getting set incorrectly issue fixed

### DIFF
--- a/app/client/src/ce/sagas/ApplicationSagas.tsx
+++ b/app/client/src/ce/sagas/ApplicationSagas.tsx
@@ -35,6 +35,7 @@ import { all, call, put, select, take } from "redux-saga/effects";
 
 import { validateResponse } from "sagas/ErrorSagas";
 import {
+  getCurrentApplicationIdForCreateNewApp,
   getDeletingMultipleApps,
   getUserApplicationsWorkspacesList,
 } from "@appsmith/selectors/applicationSelectors";
@@ -214,6 +215,9 @@ export function* getAllApplicationSaga() {
       selectFeatureFlagCheck,
       FEATURE_FLAG.ab_create_new_apps_enabled,
     );
+    const isOnboardingApplicationId: string = yield select(
+      getCurrentApplicationIdForCreateNewApp,
+    );
     const isValidResponse: boolean = yield validateResponse(response);
     if (isValidResponse) {
       const workspaceApplication: WorkspaceApplicationObject[] =
@@ -239,7 +243,12 @@ export function* getAllApplicationSaga() {
         payload: workspaceApplication,
       });
 
-      if (isEnabledForCreateNew && workspaceApplication.length > 0) {
+      // This will initialise the current workspace to first only during onboarding
+      if (
+        isEnabledForCreateNew &&
+        workspaceApplication.length > 0 &&
+        !!isOnboardingApplicationId
+      ) {
         yield put({
           type: ReduxActionTypes.SET_CURRENT_WORKSPACE,
           payload: workspaceApplication[0]?.workspace,


### PR DESCRIPTION
## Description

This PR fixes issue of user getting logged out on testing the datasource configuration during import export flow.

**RCA**:
In onboarding initiative of start with data, we wanted to set current workspace object in the redux state during onboarding so that the same can be used throughout the start with data flow. In this [PR](https://github.com/appsmithorg/appsmith/pull/28763/files) changes were made to set current workspace to the first one based on the feature flag and workspaces available. The function where we call the action to set current workspace object as first is also being reused whenever we create a new workspace, hence every time we would create new workspace, current workspace object was getting set to first one in the array. 

During import export datasource test configuration, we would pick up the workspace id from this current workspace object and pass it to test API, hence always id of the first workspace was getting passed even though we were importing application in newly created workspace.

This issue was observed only in EE repo, because EE repo has multiple environments feature and during test we ensure that environment is correctly mapped to workspace id, that's where the issue occurred.

**Impact**
This would affect all users who have `ab_create_new_apps_enabled` flag enabled. This flag is currently enabled for:
- All appsmith users (`@appsmith`)
- All integration appsmith users (`@integration-appsmith`)
- 50% of new users (As this flag is split 50-50 across new users)

#### PR fixes following issue(s)
Fixes #29373 

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a new process to identify the current application during the onboarding process for a smoother user experience.

- **Refactor**
  - Improved the logic in the application retrieval process to better support new users during initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->