### PR TITLE
fix: add fg and bg colors for inheritance in child components

### DIFF
--- a/app/client/packages/design-system/theming/src/hooks/src/useCssTokens.tsx
+++ b/app/client/packages/design-system/theming/src/hooks/src/useCssTokens.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { cssRule, getTypographyClassName } from "../../utils";
 
 import type { Theme } from "../../theme";
-import type { FontFamily, Typography } from "../../token";
+import type { FontFamily, ThemeToken, Typography } from "../../token";
 
 const fontFamilyCss = (fontFamily?: FontFamily) => {
   const fontFamilyCss =
@@ -42,18 +42,36 @@ const getTypographyCss = (typography: Typography) => {
   `;
 };
 
+const getColorCss = (color: ThemeToken["color"]) => {
+  return css`
+    background: var(--color-bg);
+    color: var(--color-fg);
+    ${cssRule({ color })};
+  `;
+};
+
 interface UseCssTokensProps extends Theme {
   width: number | null;
 }
 
 export function useCssTokens(props: UseCssTokensProps) {
-  const { colorMode, fontFamily, typography, width, ...restTokens } = props;
+  const { color, colorMode, fontFamily, typography, width, ...restTokens } =
+    props;
 
-  const [typographyClassname, setTypographyClassName] = useState<string>();
-  const [widthClassName, setWidthClassName] = useState<string>();
-  const [fontFamilyClassName, setFontFamilyClassName] = useState<string>();
+  const [colorClassName, setColorClassName] = useState<string>();
   const [colorModeClassName, setColorModeClassName] = useState<string>();
+  const [fontFamilyClassName, setFontFamilyClassName] = useState<string>();
+  const [typographyClassName, setTypographyClassName] = useState<string>();
+  const [widthClassName, setWidthClassName] = useState<string>();
   const [providerClassName, setProviderClassName] = useState<string>();
+
+  useEffect(() => {
+    if (color != null) {
+      setColorClassName(css`
+        ${getColorCss(color)}
+      `);
+    }
+  }, [color]);
 
   useEffect(() => {
     if (typography != null) {
@@ -94,10 +112,11 @@ export function useCssTokens(props: UseCssTokensProps) {
   }, [colorMode]);
 
   return {
-    typographyClassname,
-    widthClassName,
-    fontFamilyClassName,
+    colorClassName,
     colorModeClassName,
+    fontFamilyClassName,
+    typographyClassName,
+    widthClassName,
     providerClassName,
   };
 }

--- a/app/client/packages/design-system/theming/src/theme/src/ThemeProvider.tsx
+++ b/app/client/packages/design-system/theming/src/theme/src/ThemeProvider.tsx
@@ -22,10 +22,11 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
   );
 
   const {
+    colorClassName,
     colorModeClassName,
     fontFamilyClassName,
     providerClassName,
-    typographyClassname,
+    typographyClassName,
     widthClassName,
   } = useCssTokens({ ...theme, width });
 
@@ -34,10 +35,11 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
       <div
         className={clsx(
           className,
+          colorClassName,
           colorModeClassName,
           fontFamilyClassName,
           providerClassName,
-          typographyClassname,
+          typographyClassName,
           widthClassName,
         )}
         data-theme-provider=""

--- a/app/client/packages/storybook/.storybook/decorators/theming.tsx
+++ b/app/client/packages/storybook/.storybook/decorators/theming.tsx
@@ -11,8 +11,6 @@ const StyledThemeProvider = styled(ThemeProvider)`
   padding: 16px;
   align-items: center;
   justify-content: center;
-  background: var(--color-bg);
-  color: var(--color-fg);
 `;
 
 export const theming = (Story, args) => {


### PR DESCRIPTION
## Description
Add fg and bg colors to provier for inheritance in child components

Before:
![Снимок экрана 2023-12-07 в 18 55 30](https://github.com/appsmithorg/appsmith/assets/11555074/db0b73bd-d7fb-4b89-9b84-1d3769749175)

After:
![Снимок экрана 2023-12-07 в 18 55 37](https://github.com/appsmithorg/appsmith/assets/11555074/226e4ab6-06de-4bf4-aa56-aa19724e082f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new theming capability to dynamically adjust color schemes.
  
- **Refactor**
  - Enhanced theming logic to improve responsiveness to color mode changes.

- **Style**
  - Updated visual styling to ensure consistency across different themes.

- **Documentation**
  - Adjusted documentation to reflect new theming functions and usage.

- **Chores**
  - Streamlined theming properties for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->