### PR TITLE
chore: Fix auto heal script crash if curl times out

### DIFF
--- a/deploy/docker/fs/opt/appsmith/auto_heal.sh
+++ b/deploy/docker/fs/opt/appsmith/auto_heal.sh
@@ -32,7 +32,6 @@ do
         then
                 echo "TIMESTAMP=`date "+%Y-%m-%d %H:%M:%S"` backend is unresponsive";
                 supervisorctl restart backend || echo true
-                sleep 60
         else
                 echo "TIMESTAMP=`date "+%Y-%m-%d %H:%M:%S"` backend is responsive";
         fi

--- a/deploy/docker/fs/opt/appsmith/auto_heal.sh
+++ b/deploy/docker/fs/opt/appsmith/auto_heal.sh
@@ -6,16 +6,33 @@ set -o xtrace
 
 sleep 120
 
+echo "time out argument is "
+echo $1
+
+default_timeout="5"
+
+# Check if the first command-line argument is provided
+if [ -z "$1" ]; then
+    # If not provided, assign a default value
+    timeout=$default_timeout
+else
+    # If provided, use the provided value
+    timeout="$1"
+fi
+
+echo "The timeout is: $timeout"
+
 while true;
 do
         ### Get backend state
         echo "auto heal check"
-        appsmith_status="$(curl --write-out %{http_code} --silent --output /dev/null localhost:80/api/v1/tenants/current)"
+        appsmith_status="$(curl --max-time $timeout --write-out %{http_code} --silent --output /dev/null localhost:8080/api/v1/tenants/current || echo 1)"
         echo "TIMESTAMP=`date "+%Y-%m-%d %H:%M:%S"` backend response "$appsmith_status
         if [[ "$appsmith_status" -ne 200 ]];
         then
                 echo "TIMESTAMP=`date "+%Y-%m-%d %H:%M:%S"` backend is unresponsive";
                 supervisorctl restart backend || echo true
+                sleep 60
         else
                 echo "TIMESTAMP=`date "+%Y-%m-%d %H:%M:%S"` backend is responsive";
         fi

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -458,7 +458,7 @@ function setup_auto_heal(){
    if [[ ${APPSMITH_AUTO_HEAL-} = 1 ]]; then
      # By default APPSMITH_AUTO_HEAL=0
      # To enable auto heal set APPSMITH_AUTO_HEAL=1
-     bash /opt/appsmith/auto_heal.sh >> /appsmith-stacks/logs/cron/auto_heal.log 2>&1 &
+     bash /opt/appsmith/auto_heal.sh $APPSMITH_AUTO_HEAL_CURL_TIMEOUT >> /appsmith-stacks/logs/cron/auto_heal.log 2>&1 &
    fi
 }
 


### PR DESCRIPTION
Fixes #29116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Implemented a timeout mechanism for the auto-healing feature to enhance stability.
  - Auto-healing script now supports a customizable timeout through an environment variable.

- **Documentation**
  - Updated the auto-healing process documentation to reflect the new timeout feature and usage of the environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->