### PR TITLE
fix: Fix version name's `v` prefix in info.json

### DIFF
--- a/scripts/generate_info_json.sh
+++ b/scripts/generate_info_json.sh
@@ -9,7 +9,7 @@ commit_sha="$(git rev-parse HEAD)"
 base_url="$(git remote get-url origin | sed 's,^git@github\.com:,https://github.com/,; s/\.git$//')"
 
 if [[ "${GITHUB_REF-}" =~ ^refs/tags/v ]]; then
-  version="${GITHUB_REF#refs/tags/v}"
+  version="${GITHUB_REF#refs/tags/}"
 else
   latest_released_version="$(git ls-remote --tags --sort=-v:refname "$(git remote | head -1)" 'v*' | awk -F/ '{print $NF; exit}')"
   echo "latest_released_version = $latest_released_version" >&2


### PR DESCRIPTION
Fixes #29506.

The version in `info.json` never had the `v` prefix, but we never used it for anything significant, so we never noticed it. Until in `v1.9.51`.
