### PR TITLE
chore: Split related changes for export mi

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
@@ -60,7 +60,7 @@ public interface ActionCollectionServiceCE extends CrudService<ActionCollection,
 
     Flux<ActionCollection> findByPageId(String pageId);
 
-    Flux<ActionCollection> findByListOfPageIds(List<String> pageIds, Optional<AclPermission> permission);
+    Flux<ActionCollection> findByPageIds(List<String> pageIds, Optional<AclPermission> permission);
 
     Mono<ActionCollection> findByBranchNameAndDefaultCollectionId(
             String branchName, String defaultCollectionId, AclPermission permission);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -488,8 +488,8 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
     }
 
     @Override
-    public Flux<ActionCollection> findByListOfPageIds(List<String> pageIds, Optional<AclPermission> permission) {
-        return repository.findByListOfPageIds(pageIds, permission);
+    public Flux<ActionCollection> findByPageIds(List<String> pageIds, Optional<AclPermission> permission) {
+        return repository.findByPageIds(pageIds, permission);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/exports/ActionCollectionExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/exports/ActionCollectionExportableServiceCEImpl.java
@@ -49,7 +49,7 @@ public class ActionCollectionExportableServiceCEImpl implements ExportableServic
         Optional<AclPermission> optionalPermission = Optional.ofNullable(actionPermission.getExportPermission(
                 exportingMetaDTO.getIsGitSync(), exportingMetaDTO.getExportWithConfiguration()));
         Flux<ActionCollection> actionCollectionFlux =
-                actionCollectionService.findByListOfPageIds(exportingMetaDTO.getUnpublishedPages(), optionalPermission);
+                actionCollectionService.findByPageIds(exportingMetaDTO.getUnpublishedPages(), optionalPermission);
         return actionCollectionFlux
                 .collectList()
                 .map(actionCollectionList -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ApplicationJson.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ApplicationJson.java
@@ -1,116 +1,14 @@
 package com.appsmith.server.dtos;
 
-import com.appsmith.external.models.DatasourceStorage;
-import com.appsmith.external.models.DatasourceStorageStructure;
-import com.appsmith.external.models.DecryptedSensitiveFields;
-import com.appsmith.external.models.InvisibleActionFields;
-import com.appsmith.external.views.Views;
-import com.appsmith.server.domains.ActionCollection;
-import com.appsmith.server.domains.Application;
-import com.appsmith.server.domains.CustomJSLib;
-import com.appsmith.server.domains.NewAction;
-import com.appsmith.server.domains.NewPage;
-import com.appsmith.server.domains.Theme;
-import com.fasterxml.jackson.annotation.JsonView;
+import com.appsmith.server.dtos.ce.ApplicationJsonCE;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.data.annotation.Transient;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
- * A DTO class to hold complete information about an application, which will then be serialized to a file so as to
- * export that application into a file.
+ * A DTO class to hold complete information about an application,
+ * which will then be serialized to a file,
+ * to export that application into a file.
  */
 @Getter
 @Setter
-public class ApplicationJson {
-
-    // To convey the schema version of the client and will be used to check if the imported file is compatible with
-    // current DSL schema
-    @Transient
-    @JsonView({Views.Public.class, Views.Export.class})
-    Integer clientSchemaVersion;
-
-    // To convey the schema version of the server and will be used to check if the imported file is compatible with
-    // current DB schema
-    @Transient
-    @JsonView({Views.Public.class, Views.Export.class})
-    Integer serverSchemaVersion;
-
-    @JsonView({Views.Public.class, Views.Export.class})
-    Application exportedApplication;
-
-    @JsonView(Views.Public.class)
-    List<DatasourceStorage> datasourceList;
-
-    @JsonView(Views.Public.class)
-    List<DatasourceStorageStructure> datasourceConfigurationStructureList;
-
-    @JsonView({Views.Public.class, Views.Export.class})
-    List<CustomJSLib> customJSLibList;
-
-    @JsonView({Views.Public.class, Views.Export.class})
-    List<NewPage> pageList;
-
-    @Deprecated
-    @JsonView(Views.Public.class)
-    List<String> pageOrder;
-
-    @Deprecated
-    @JsonView(Views.Public.class)
-    List<String> publishedPageOrder;
-
-    @Deprecated
-    @JsonView(Views.Public.class)
-    String publishedDefaultPageName;
-
-    @Deprecated
-    @JsonView(Views.Public.class)
-    String unpublishedDefaultPageName;
-
-    @JsonView(Views.Public.class)
-    List<NewAction> actionList;
-
-    @JsonView(Views.Public.class)
-    List<ActionCollection> actionCollectionList;
-
-    /**
-     * This field will be used to store map of files to be updated in local file system by comparing the recent
-     * changes in database and the last local git commit.
-     * This field can be used while saving resources to local file system and only update the resource files which
-     * are updated in the database.
-     */
-    @JsonView(Views.Internal.class)
-    Map<String, Set<String>> updatedResources;
-
-    // TODO remove the plain text fields during the export once we have a way to address sample apps DB authentication
-    @JsonView(Views.Public.class)
-    Map<String, DecryptedSensitiveFields> decryptedFields;
-
-    @Deprecated
-    @JsonView(Views.Public.class)
-    Map<String, InvisibleActionFields> invisibleActionFields;
-
-    @JsonView({Views.Public.class, Views.Export.class})
-    Theme editModeTheme;
-
-    @JsonView({Views.Public.class, Views.Export.class})
-    Theme publishedTheme;
-
-    /**
-     * Mapping mongoEscapedWidgets with layoutId
-     */
-    @Deprecated
-    @JsonView(Views.Public.class)
-    Map<String, Set<String>> publishedLayoutmongoEscapedWidgets;
-
-    @Deprecated
-    @JsonView(Views.Public.class)
-    Map<String, Set<String>> unpublishedLayoutmongoEscapedWidgets;
-
-    @JsonView({Views.Public.class, Views.Export.class})
-    String widgets;
-}
+public class ApplicationJson extends ApplicationJsonCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/ApplicationJsonCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/ApplicationJsonCE.java
@@ -1,0 +1,117 @@
+package com.appsmith.server.dtos.ce;
+
+import com.appsmith.external.models.DatasourceStorage;
+import com.appsmith.external.models.DatasourceStorageStructure;
+import com.appsmith.external.models.DecryptedSensitiveFields;
+import com.appsmith.external.models.InvisibleActionFields;
+import com.appsmith.external.views.Views;
+import com.appsmith.server.domains.ActionCollection;
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.domains.CustomJSLib;
+import com.appsmith.server.domains.NewAction;
+import com.appsmith.server.domains.NewPage;
+import com.appsmith.server.domains.Theme;
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Transient;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A DTO class to hold complete information about an application,
+ * which will then be serialized to a file,
+ * to export that application into a file.
+ */
+@Getter
+@Setter
+public class ApplicationJsonCE {
+
+    // To convey the schema version of the client and will be used to check if the imported file is compatible with
+    // current DSL schema
+    @Transient
+    @JsonView({Views.Public.class, Views.Export.class})
+    Integer clientSchemaVersion;
+
+    // To convey the schema version of the server and will be used to check if the imported file is compatible with
+    // current DB schema
+    @Transient
+    @JsonView({Views.Public.class, Views.Export.class})
+    Integer serverSchemaVersion;
+
+    @JsonView({Views.Public.class, Views.Export.class})
+    Application exportedApplication;
+
+    @JsonView(Views.Public.class)
+    List<DatasourceStorage> datasourceList;
+
+    @JsonView(Views.Public.class)
+    List<DatasourceStorageStructure> datasourceConfigurationStructureList;
+
+    @JsonView({Views.Public.class, Views.Export.class})
+    List<CustomJSLib> customJSLibList;
+
+    @JsonView({Views.Public.class, Views.Export.class})
+    List<NewPage> pageList;
+
+    @Deprecated
+    @JsonView(Views.Public.class)
+    List<String> pageOrder;
+
+    @Deprecated
+    @JsonView(Views.Public.class)
+    List<String> publishedPageOrder;
+
+    @Deprecated
+    @JsonView(Views.Public.class)
+    String publishedDefaultPageName;
+
+    @Deprecated
+    @JsonView(Views.Public.class)
+    String unpublishedDefaultPageName;
+
+    @JsonView(Views.Public.class)
+    List<NewAction> actionList;
+
+    @JsonView(Views.Public.class)
+    List<ActionCollection> actionCollectionList;
+
+    /**
+     * This field will be used to store map of files to be updated in local file system by comparing the recent
+     * changes in database and the last local git commit.
+     * This field can be used while saving resources to local file system and only update the resource files which
+     * are updated in the database.
+     */
+    @JsonView(Views.Internal.class)
+    Map<String, Set<String>> updatedResources;
+
+    // TODO remove the plain text fields during the export once we have a way to address sample apps DB authentication
+    @JsonView(Views.Public.class)
+    Map<String, DecryptedSensitiveFields> decryptedFields;
+
+    @Deprecated
+    @JsonView(Views.Public.class)
+    Map<String, InvisibleActionFields> invisibleActionFields;
+
+    @JsonView({Views.Public.class, Views.Export.class})
+    Theme editModeTheme;
+
+    @JsonView({Views.Public.class, Views.Export.class})
+    Theme publishedTheme;
+
+    /**
+     * Mapping mongoEscapedWidgets with layoutId
+     */
+    @Deprecated
+    @JsonView(Views.Public.class)
+    Map<String, Set<String>> publishedLayoutmongoEscapedWidgets;
+
+    @Deprecated
+    @JsonView(Views.Public.class)
+    Map<String, Set<String>> unpublishedLayoutmongoEscapedWidgets;
+
+    @JsonView({Views.Public.class, Views.Export.class})
+    String widgets;
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportApplicationServiceCEImpl.java
@@ -39,6 +39,7 @@ import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,7 +60,7 @@ public class ExportApplicationServiceCEImpl implements ExportApplicationServiceC
     private final ExportableService<Datasource> datasourceExportableService;
     private final ExportableService<Plugin> pluginExportableService;
     private final ExportableService<NewPage> newPageExportableService;
-    private final ExportableService<NewAction> newActionExportableService;
+    protected final ExportableService<NewAction> newActionExportableService;
     private final ExportableService<ActionCollection> actionCollectionExportableService;
     private final ExportableService<Theme> themeExportableService;
     private final ExportableService<CustomJSLib> customJSLibExportableService;
@@ -182,7 +183,7 @@ public class ExportApplicationServiceCEImpl implements ExportApplicationServiceC
                 .thenReturn(applicationJson);
     }
 
-    private Mono<Void> sanitizeEntities(
+    protected Mono<Void> sanitizeEntities(
             SerialiseApplicationObjective serialiseFor,
             ApplicationJson applicationJson,
             MappedExportableResourcesDTO mappedResourcesDTO,
@@ -191,6 +192,9 @@ public class ExportApplicationServiceCEImpl implements ExportApplicationServiceC
                 exportingMetaDTO, mappedResourcesDTO, applicationJson, serialiseFor);
 
         newPageExportableService.sanitizeEntities(exportingMetaDTO, mappedResourcesDTO, applicationJson, serialiseFor);
+
+        newActionExportableService.sanitizeEntities(
+                exportingMetaDTO, mappedResourcesDTO, applicationJson, serialiseFor);
 
         return Mono.empty().then();
     }
@@ -265,7 +269,9 @@ public class ExportApplicationServiceCEImpl implements ExportApplicationServiceC
 
         Mono<Void> combinedActionExportablesMono = actionCollectionExportablesMono.then(newActionExportablesMono);
 
-        return List.of(combinedActionExportablesMono);
+        List<Mono<Void>> monos = new ArrayList<>();
+        monos.add(combinedActionExportablesMono);
+        return monos;
     }
 
     public Mono<ApplicationJson> exportApplicationById(String applicationId, String branchName) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -329,13 +329,13 @@ public class GitFileUtils {
     }
 
     protected Stream<Field> getAllFields(ApplicationJson applicationJson) {
-        Optional<Class<?>> currentType = Optional.of(applicationJson.getClass());
+        Class<?> currentType = applicationJson.getClass();
 
         Set<Class<?>> classes = new HashSet<>();
 
-        while (currentType.isPresent()) {
-            classes.add(currentType.get());
-            currentType = Optional.ofNullable(currentType.get().getSuperclass());
+        while (currentType != null) {
+            classes.add(currentType);
+            currentType = currentType.getSuperclass();
         }
 
         return classes.stream().flatMap(currentClass -> Arrays.stream(currentClass.getDeclaredFields()));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -45,10 +45,13 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.appsmith.external.constants.GitConstants.NAME_SEPARATOR;
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
@@ -159,7 +162,7 @@ public class GitFileUtils {
         applicationJson.setPublishedTheme(null);
 
         // Pass metadata
-        Iterable<String> keys = Arrays.stream(applicationJson.getClass().getDeclaredFields())
+        Iterable<String> keys = getAllFields(applicationJson)
                 .map(Field::getName)
                 .filter(name -> !blockedMetadataFields.contains(name))
                 .collect(Collectors.toList());
@@ -323,6 +326,19 @@ public class GitFileUtils {
         resourceMap.clear();
 
         return applicationReference;
+    }
+
+    protected Stream<Field> getAllFields(ApplicationJson applicationJson) {
+        Optional<Class<?>> currentType = Optional.of(applicationJson.getClass());
+
+        Set<Class<?>> classes = new HashSet<>();
+
+        while (currentType.isPresent()) {
+            classes.add(currentType.get());
+            currentType = Optional.ofNullable(currentType.get().getSuperclass());
+        }
+
+        return classes.stream().flatMap(currentClass -> Arrays.stream(currentClass.getDeclaredFields()));
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportApplicationServiceCEImpl.java
@@ -730,8 +730,8 @@ public class ImportApplicationServiceCEImpl implements ImportApplicationServiceC
                 applicationJson,
                 false);
 
-        Mono<Void> combinedActionExportablesMono = importedNewActionsMono.then(importedActionCollectionsMono);
-        return List.of(combinedActionExportablesMono);
+        Mono<Void> combinedActionImportablesMono = importedNewActionsMono.then(importedActionCollectionsMono);
+        return List.of(combinedActionImportablesMono);
     }
 
     private Mono<Void> applicationSpecificImportedEntities(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exports/CustomJSLibExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exports/CustomJSLibExportableServiceCEImpl.java
@@ -38,12 +38,7 @@ public class CustomJSLibExportableServiceCEImpl implements ExportableServiceCE<C
          * Since we are exporting for git, we only consider unpublished JS libraries
          * Ref: https://theappsmith.slack.com/archives/CGBPVEJ5C/p1672225134025919
          */
-        return customJSLibService
-                .getAllJSLibsInContext(
-                        exportingMetaDTO.getApplicationId(),
-                        CreatorContextType.APPLICATION,
-                        exportingMetaDTO.getBranchName(),
-                        false)
+        return getAllJSLibsInContext(exportingMetaDTO)
                 .map(jsLibList -> {
                     jsLibList.forEach(CustomJSLib::sanitiseToExportDBObject);
                     return jsLibList;
@@ -80,5 +75,13 @@ public class CustomJSLibExportableServiceCEImpl implements ExportableServiceCE<C
                     return unpublishedCustomJSLibList;
                 })
                 .then();
+    }
+
+    protected Mono<List<CustomJSLib>> getAllJSLibsInContext(ExportingMetaDTO exportingMetaDTO) {
+        return customJSLibService.getAllJSLibsInContext(
+                exportingMetaDTO.getApplicationId(),
+                CreatorContextType.APPLICATION,
+                exportingMetaDTO.getBranchName(),
+                false);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -136,7 +136,7 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
 
     Flux<PluginTypeAndCountDTO> countActionsByPluginType(String applicationId);
 
-    Flux<NewAction> findByListOfPageIds(List<String> unpublishedPages, Optional<AclPermission> optionalPermission);
+    Flux<NewAction> findByPageIds(List<String> unpublishedPages, Optional<AclPermission> optionalPermission);
 
     Flux<NewAction> findAllActionsByContextIdAndContextTypeAndViewMode(
             String contextId,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -1750,9 +1750,8 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
     }
 
     @Override
-    public Flux<NewAction> findByListOfPageIds(
-            List<String> unpublishedPages, Optional<AclPermission> optionalPermission) {
-        return repository.findByListOfPageIds(unpublishedPages, optionalPermission);
+    public Flux<NewAction> findByPageIds(List<String> unpublishedPages, Optional<AclPermission> optionalPermission) {
+        return repository.findByPageIds(unpublishedPages, optionalPermission);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exports/NewActionExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exports/NewActionExportableServiceCEImpl.java
@@ -51,7 +51,7 @@ public class NewActionExportableServiceCEImpl implements ExportableServiceCE<New
                 exportingMetaDTO.getIsGitSync(), exportingMetaDTO.getExportWithConfiguration()));
 
         Flux<NewAction> actionFlux =
-                newActionService.findByListOfPageIds(exportingMetaDTO.getUnpublishedPages(), optionalPermission);
+                newActionService.findByPageIds(exportingMetaDTO.getUnpublishedPages(), optionalPermission);
 
         return actionFlux
                 .collectList()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/imports/NewActionImportableServiceCEImpl.java
@@ -23,7 +23,7 @@ import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.repositories.NewActionRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -101,7 +101,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                     // attached to the application:
                     // Delete the invalid resources (which are not the part of applicationJsonDTO) in
                     // the git flow only
-                    if (!StringUtils.isEmpty(importingMetaDTO.getApplicationId())
+                    if (StringUtils.hasText(importingMetaDTO.getApplicationId())
                             && !importingMetaDTO.getAppendToApp()
                             && CollectionUtils.isNotEmpty(importActionResultDTO.getExistingActions())) {
                         // Remove unwanted actions
@@ -162,7 +162,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                     // attached to the application:
                     // Delete the invalid resources (which are not the part of applicationJsonDTO) in
                     // the git flow only
-                    if (!StringUtils.isEmpty(importingMetaDTO.getApplicationId())
+                    if (StringUtils.hasText(importingMetaDTO.getApplicationId())
                             && !importingMetaDTO.getAppendToApp()
                             && Boolean.FALSE.equals(isPartialImport)) {
                         // Remove unwanted action collections
@@ -262,7 +262,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
 
                                 for (NewAction newAction : importedNewActionList) {
                                     if (newAction.getUnpublishedAction() == null
-                                            || !org.springframework.util.StringUtils.hasLength(newAction
+                                            || !StringUtils.hasLength(newAction
                                                     .getUnpublishedAction()
                                                     .getPageId())) {
                                         continue;
@@ -291,8 +291,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
 
                                     if (publishedAction != null && publishedAction.getValidName() != null) {
                                         publishedAction.setId(newAction.getId());
-                                        if (!org.springframework.util.StringUtils.hasLength(
-                                                publishedAction.getPageId())) {
+                                        if (!StringUtils.hasLength(publishedAction.getPageId())) {
                                             publishedAction.setPageId(fallbackParentPageId);
                                         }
                                         NewPage publishedActionPage = updatePageInAction(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
@@ -46,9 +46,9 @@ public interface CustomActionCollectionRepositoryCE extends AppsmithRepository<A
     Mono<ActionCollection> findByGitSyncIdAndDefaultApplicationId(
             String defaultApplicationId, String gitSyncId, Optional<AclPermission> permission);
 
-    Flux<ActionCollection> findByListOfPageIds(List<String> pageIds, AclPermission permission);
+    Flux<ActionCollection> findByPageIds(List<String> pageIds, AclPermission permission);
 
-    Flux<ActionCollection> findByListOfPageIds(List<String> pageIds, Optional<AclPermission> permission);
+    Flux<ActionCollection> findByPageIds(List<String> pageIds, Optional<AclPermission> permission);
 
     Mono<List<InsertManyResult>> bulkInsert(List<ActionCollection> newActions);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -210,7 +210,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
     }
 
     @Override
-    public Flux<ActionCollection> findByListOfPageIds(List<String> pageIds, AclPermission permission) {
+    public Flux<ActionCollection> findByPageIds(List<String> pageIds, AclPermission permission) {
         Criteria pageIdCriteria = where(fieldName(QActionCollection.actionCollection.unpublishedCollection) + "."
                         + fieldName(QActionCollection.actionCollection.unpublishedCollection.pageId))
                 .in(pageIds);
@@ -218,7 +218,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
     }
 
     @Override
-    public Flux<ActionCollection> findByListOfPageIds(List<String> pageIds, Optional<AclPermission> permission) {
+    public Flux<ActionCollection> findByPageIds(List<String> pageIds, Optional<AclPermission> permission) {
         Criteria pageIdCriteria = where(fieldName(QActionCollection.actionCollection.unpublishedCollection) + "."
                         + fieldName(QActionCollection.actionCollection.unpublishedCollection.pageId))
                 .in(pageIds);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
@@ -64,9 +64,9 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
     Mono<NewAction> findByGitSyncIdAndDefaultApplicationId(
             String defaultApplicationId, String gitSyncId, Optional<AclPermission> permission);
 
-    Flux<NewAction> findByListOfPageIds(List<String> pageIds, AclPermission permission);
+    Flux<NewAction> findByPageIds(List<String> pageIds, AclPermission permission);
 
-    Flux<NewAction> findByListOfPageIds(List<String> pageIds, Optional<AclPermission> permission);
+    Flux<NewAction> findByPageIds(List<String> pageIds, Optional<AclPermission> permission);
 
     Flux<NewAction> findNonJsActionsByApplicationIdAndViewMode(
             String applicationId, Boolean viewMode, AclPermission aclPermission);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -413,7 +413,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     }
 
     @Override
-    public Flux<NewAction> findByListOfPageIds(List<String> pageIds, AclPermission permission) {
+    public Flux<NewAction> findByPageIds(List<String> pageIds, AclPermission permission) {
 
         Criteria pageIdCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "."
                         + fieldName(QNewAction.newAction.unpublishedAction.pageId))
@@ -423,7 +423,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     }
 
     @Override
-    public Flux<NewAction> findByListOfPageIds(List<String> pageIds, Optional<AclPermission> permission) {
+    public Flux<NewAction> findByPageIds(List<String> pageIds, Optional<AclPermission> permission) {
         Criteria pageIdCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "."
                         + fieldName(QNewAction.newAction.unpublishedAction.pageId))
                 .in(pageIds);


### PR DESCRIPTION
Splits app json type and a few other refactors as comments from [this PR](https://github.com/appsmithorg/appsmith-ee/pull/3054)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed methods for consistency and clarity in action collection services.
  - Streamlined the inheritance and structure of application JSON classes.
  - Improved access modifiers for export services to enhance extensibility.
  - Updated variable naming for clarity in import services.
  - Enhanced method signatures in repositories to better handle permissions.

- **Documentation**
  - Updated method names and parameters in documentation to reflect refactoring changes.

- **Chores**
  - Cleaned up deprecated fields and updated method calls to align with the new method names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->