### PR TITLE
fix: frame-ancestors env variable being overridden

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -30,6 +30,9 @@ if (APPSMITH_CUSTOM_DOMAIN != null) {
 
 const tlsConfig = certLocation == null ? "" : `tls ${certLocation}/fullchain.pem ${certLocation}/privkey.pem`
 
+const frameAncestorsPolicy = (process.env.APPSMITH_ALLOWED_FRAME_ANCESTORS || "'self'")
+  .replace(/;.*$/, "")
+
 const parts = []
 
 parts.push(`
@@ -64,7 +67,7 @@ parts.push(`
 
   header {
     -Server
-    Content-Security-Policy "frame-ancestors ${process.env.APPSMITH_ALLOWED_FRAME_ANCESTORS ?? "'self' *"}"
+    Content-Security-Policy "frame-ancestors ${frameAncestorsPolicy}"
     X-Content-Type-Options "nosniff"
   }
 

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -442,14 +442,6 @@ init_loading_pages(){
   export XDG_CONFIG_HOME=/appsmith-stacks/configuration
   mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME"
   cp templates/loading.html "$WWW_PATH"
-  if [[ -z "${APPSMITH_ALLOWED_FRAME_ANCESTORS-}" ]]; then
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-    export APPSMITH_ALLOWED_FRAME_ANCESTORS="'self'"
-  else
-    # Remove any extra rules that may be present in the frame ancestors value. This is to prevent this env variable from
-    # being used to inject more rules to the CSP header. If needed, that should be supported/solved separately.
-    export APPSMITH_ALLOWED_FRAME_ANCESTORS="${APPSMITH_ALLOWED_FRAME_ANCESTORS%;*}"
-  fi
   node caddy-reconfigure.mjs
   /opt/caddy/caddy start --config "$TMP/Caddyfile"
 }


### PR DESCRIPTION
We're setting the default value for `APPSMITH_ALLOWED_FRAME_ANCESTORS` before we initialize env variables from `docker.env`. This make the default value take a higher precedence over the value configured in `docker.env`. And since the value in `docker.env` is the one configured from Admin Settings, it feels like the value configured from the UI is being ignored.

This fixes the problem by moving the check for this env variable to _inside_ the reconfigure script, and so doesn't affect any env variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new policy to enhance the security of frames within the application.

- **Chores**
  - Simplified the configuration of frame ancestors' policy by direct environment variable setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->