### PR TITLE
chore: Remove ff4j dependency from pom.xml

### DIFF
--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -16,7 +16,6 @@
     <description>This is the API server for the Appsmith project</description>
 
     <properties>
-        <ff4j.version>2.0.0</ff4j.version>
         <jmh.version>1.35</jmh.version>
         <org.modelmapper.version>2.4.4</org.modelmapper.version>
     </properties>
@@ -402,12 +401,6 @@
             <version>1.10.0</version>
         </dependency>
 
-        <!-- Dependencies for feature flagging -->
-        <dependency>
-            <groupId>org.ff4j</groupId>
-            <artifactId>ff4j-core</artifactId>
-            <version>${ff4j.version}</version>
-        </dependency>
         <dependency>
             <groupId>com.appsmith</groupId>
             <artifactId>reactiveCaching</artifactId>


### PR DESCRIPTION
### Description
As the code references for ff4j is already removed, this PR removes the entry from dependency list.