### PR TITLE
fix: move ansible playbooks to default appsmith-ee

### DIFF
--- a/deploy/ansible/appsmith_playbook/roles/setup-appsmith/defaults/main.yml
+++ b/deploy/ansible/appsmith_playbook/roles/setup-appsmith/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
-# Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
-docker_edition: 'ce'
+docker_edition: 'ee'
 docker_package: 'docker-{{ docker_edition }}'
 docker_package_state: present
 

--- a/deploy/ansible/appsmith_playbook/roles/setup-appsmith/defaults/main.yml
+++ b/deploy/ansible/appsmith_playbook/roles/setup-appsmith/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-docker_edition: 'ee'
+# Edition can be one of: 'ce' (Community Edition) or 'ee' (Enterprise Edition).
+docker_edition: 'ce'
 docker_package: 'docker-{{ docker_edition }}'
 docker_package_state: present
 

--- a/deploy/aws_ami/docker-compose.yml
+++ b/deploy/aws_ami/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   appsmith:
-    image: index.docker.io/appsmith/appsmith-ce
+    image: index.docker.io/appsmith/appsmith-ee
     container_name: appsmith
     ports:
       - "80:80"

--- a/deploy/digital_ocean/files/var/lib/cloud/scripts/per-instance/01-onboot
+++ b/deploy/digital_ocean/files/var/lib/cloud/scripts/per-instance/01-onboot
@@ -9,7 +9,7 @@ cd /root/appsmith
 
 # Step 1: Download the templates
 echo "Downloading the Docker Compose file..."
-curl -L https://bit.ly/3AQzII6 -o $PWD/docker-compose.yml
+curl -L https://raw.githubusercontent.com/appsmithorg/appsmith/master/deploy/aws_ami/docker-compose.yml -o $PWD/docker-compose.yml
 
 # Step 2: Pulling the latest container images
 echo ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source URL for Docker Compose file download in the cloud initialization script to a specific GitHub repository for improved reliability and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->