### PR TITLE
fix: Remove Server header and allow all on port 80

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -3,8 +3,9 @@ import {dirname} from "path"
 import {spawnSync} from "child_process"
 import {X509Certificate} from "crypto"
 
-// The custom domain is expected to only have the domain. So if it has protocol or trailing slash, we remove it.
-const CUSTOM_DOMAIN = (process.env.APPSMITH_CUSTOM_DOMAIN || "").replace(/^https?:\/\//, "").replace(/\/$/, "")
+// The custom domain is expected to only have the domain. So if it has a protocol, we ignore the whole value.
+// This was the effective behaviour before Caddy.
+const CUSTOM_DOMAIN = (process.env.APPSMITH_CUSTOM_DOMAIN || "").replace(/^https?:\/\/.+$/, "")
 
 const CaddyfilePath = process.env.TMP + "/Caddyfile"
 

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -143,7 +143,7 @@ if (CUSTOM_DOMAIN !== "") {
 }
 
 fs.mkdirSync(dirname(CaddyfilePath), { recursive: true })
-fs.writeFileSync(CaddyfilePath, parts.map(part => part.trim()).join("\n\n"))
+fs.writeFileSync(CaddyfilePath, parts.join("\n"))
 spawnSync("/opt/caddy/caddy", ["fmt", "--overwrite", CaddyfilePath])
 spawnSync("/opt/caddy/caddy", ["reload", "--config", CaddyfilePath])
 

--- a/deploy/docker/route-tests/Dockerfile
+++ b/deploy/docker/route-tests/Dockerfile
@@ -1,23 +1,9 @@
-FROM node
+FROM node:lts-alpine
 
-WORKDIR /opt
-
-RUN set -o xtrace \
-# Install Hurl
-  && v="$(curl -sS --write-out '%{redirect_url}' 'https://github.com/Orange-OpenSource/hurl/releases/latest' | sed 's,.*/,,')" \
-  && curl -LsS "https://github.com/Orange-OpenSource/hurl/releases/download/$v/hurl-$v-$(uname -m)-unknown-linux-gnu.tar.gz" \
-    | tar -xz \
-  && mv hurl* hurl \
-# Install Caddy
-  && mkdir -p caddy \
-  && v="$(curl --write-out '%{redirect_url}' 'https://github.com/caddyserver/caddy/releases/latest' | sed 's,.*/v,,')" \
-  && curl --location "https://github.com/caddyserver/caddy/releases/download/v$v/caddy_${v}_linux_$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/').tar.gz" \
-    | tar -xzC caddy \
-# Install mkcert
-  && v="$(curl --write-out '%{redirect_url}' 'https://github.com/FiloSottile/mkcert/releases/latest' | sed 's,.*/v,,')" \
-  && curl --location "https://github.com/FiloSottile/mkcert/releases/download/v$v/mkcert-v$v-linux-$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" --output mkcert \
-  && chmod +x mkcert \
-  && /opt/mkcert -install
+RUN apk add --no-cache bash caddy \
+  && apk add --no-cache hurl mkcert --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+  && mkcert -install
 
 WORKDIR /code
+
 ENTRYPOINT [ "bash", "entrypoint.sh" ]

--- a/deploy/docker/route-tests/Dockerfile
+++ b/deploy/docker/route-tests/Dockerfile
@@ -1,0 +1,23 @@
+FROM node
+
+WORKDIR /opt
+
+RUN set -o xtrace \
+# Install Hurl
+  && v="$(curl -sS --write-out '%{redirect_url}' 'https://github.com/Orange-OpenSource/hurl/releases/latest' | sed 's,.*/,,')" \
+  && curl -LsS "https://github.com/Orange-OpenSource/hurl/releases/download/$v/hurl-$v-$(uname -m)-unknown-linux-gnu.tar.gz" \
+    | tar -xz \
+  && mv hurl* hurl \
+# Install Caddy
+  && mkdir -p caddy \
+  && v="$(curl --write-out '%{redirect_url}' 'https://github.com/caddyserver/caddy/releases/latest' | sed 's,.*/v,,')" \
+  && curl --location "https://github.com/caddyserver/caddy/releases/download/v$v/caddy_${v}_linux_$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/').tar.gz" \
+    | tar -xzC caddy \
+# Install mkcert
+  && v="$(curl --write-out '%{redirect_url}' 'https://github.com/FiloSottile/mkcert/releases/latest' | sed 's,.*/v,,')" \
+  && curl --location "https://github.com/FiloSottile/mkcert/releases/download/v$v/mkcert-v$v-linux-$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" --output mkcert \
+  && chmod +x mkcert \
+  && /opt/mkcert -install
+
+WORKDIR /code
+ENTRYPOINT [ "bash", "entrypoint.sh" ]

--- a/deploy/docker/route-tests/common-https/forwarded-headers.hurl
+++ b/deploy/docker/route-tests/common-https/forwarded-headers.hurl
@@ -1,0 +1,33 @@
+GET https://custom-domain.com/oauth2/google/authorize
+HTTP 200
+```
+Scheme = 'http'
+X-Forwarded-Proto = 'https'
+Host = 'custom-domain.com'
+X-Forwarded-Host = 'custom-domain.com'
+Forwarded = ''
+```
+
+# This is the CloudRun test. That the `Forwarded` header should be removed when proxying to upstream.
+GET https://custom-domain.com/oauth2/google/authorize
+Forwarded: something something
+HTTP 200
+```
+Scheme = 'http'
+X-Forwarded-Proto = 'https'
+Host = 'custom-domain.com'
+X-Forwarded-Host = 'custom-domain.com'
+Forwarded = ''
+```
+
+GET https://custom-domain.com/oauth2/google/authorize
+X-Forwarded-Proto: http
+X-Forwarded-Host: overridden.com
+HTTP 200
+```
+Scheme = 'http'
+X-Forwarded-Proto = 'http'
+Host = 'custom-domain.com'
+X-Forwarded-Host = 'overridden.com'
+Forwarded = ''
+```

--- a/deploy/docker/route-tests/common/forwarded-headers.hurl
+++ b/deploy/docker/route-tests/common/forwarded-headers.hurl
@@ -1,0 +1,33 @@
+GET http://local.com/oauth2/google/authorize
+HTTP 200
+```
+Scheme = 'http'
+X-Forwarded-Proto = 'http'
+Host = 'local.com'
+X-Forwarded-Host = 'local.com'
+Forwarded = ''
+```
+
+# This is the CloudRun test. That the `Forwarded` header should be removed when proxying to upstream.
+GET http://local.com/oauth2/google/authorize
+Forwarded: something something
+HTTP 200
+```
+Scheme = 'http'
+X-Forwarded-Proto = 'http'
+Host = 'local.com'
+X-Forwarded-Host = 'local.com'
+Forwarded = ''
+```
+
+GET http://local.com/oauth2/google/authorize
+X-Forwarded-Proto: https
+X-Forwarded-Host: overridden.com
+HTTP 200
+```
+Scheme = 'http'
+X-Forwarded-Proto = 'https'
+Host = 'local.com'
+X-Forwarded-Host = 'overridden.com'
+Forwarded = ''
+```

--- a/deploy/docker/route-tests/common/index-html-response.hurl
+++ b/deploy/docker/route-tests/common/index-html-response.hurl
@@ -1,0 +1,41 @@
+GET http://localhost
+HTTP 200
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Server" not exists
+body == "index.html body"
+
+GET http://127.0.0.1
+HTTP 200
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Server" not exists
+body == "index.html body"
+
+GET http://local.com
+HTTP 200
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Server" not exists
+body == "index.html body"
+
+GET http://localhost/some/non/handled/path
+HTTP 200
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Server" not exists
+body == "index.html body"
+
+GET http://127.0.0.1/some/non/handled/path
+HTTP 200
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Server" not exists
+body == "index.html body"
+
+GET http://local.com/some/non/handled/path
+HTTP 200
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Server" not exists
+body == "index.html body"

--- a/deploy/docker/route-tests/common/static-404.hurl
+++ b/deploy/docker/route-tests/common/static-404.hurl
@@ -1,0 +1,14 @@
+GET http://localhost/static/missing
+HTTP 404
+[Asserts]
+header "Server" not exists
+
+GET http://127.0.0.1/static/missing
+HTTP 404
+[Asserts]
+header "Server" not exists
+
+GET http://local.com/static/missing
+HTTP 404
+[Asserts]
+header "Server" not exists

--- a/deploy/docker/route-tests/echo.caddyfile
+++ b/deploy/docker/route-tests/echo.caddyfile
@@ -1,0 +1,12 @@
+{
+  admin off
+}
+
+http://:5050
+
+respond "Scheme = '{scheme}'
+X-Forwarded-Proto = '{header.x-forwarded-proto}'
+Host = '{host}'
+X-Forwarded-Host = '{header.x-forwarded-host}'
+Forwarded = '{header.forwarded}'
+"

--- a/deploy/docker/route-tests/entrypoint.sh
+++ b/deploy/docker/route-tests/entrypoint.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+#set -o xtrace
+
+new-spec() {
+  echo "-----------" "$@" "-----------"
+  unset APPSMITH_CUSTOM_DOMAIN
+  mkdir -p /appsmith-stacks/ssl
+  find /appsmith-stacks/ssl -type f -delete
+}
+
+reload-caddy() {
+  sed -i 's/127.0.0.1:{args\[0]}/127.0.0.1:5050/' "$TMP/Caddyfile"
+  /opt/caddy/caddy fmt --overwrite "$TMP/Caddyfile"
+  /opt/caddy/caddy reload --config "$TMP/Caddyfile"
+  sleep 1
+}
+
+run-hurl() {
+  /opt/hurl/hurl --test \
+    --resolve local.com:80:127.0.0.1 \
+    --resolve custom-domain.com:80:127.0.0.1 \
+    --resolve custom-domain.com:443:127.0.0.1 \
+    "$@"
+}
+
+if [[ "${OPEN_SHELL-}" == 1 ]]; then
+  # Open shell for debugging after this script is done.
+  trap bash EXIT
+fi
+
+echo
+echo "caddy version: $(/opt/caddy/caddy --version)"
+echo "hurl version: $(/opt/hurl/hurl --version)"
+echo "mkcert version: $(/opt/mkcert --version)"
+echo
+
+export TMP=/tmp/appsmith
+export WWW_PATH="$TMP/www"
+
+mkdir -p "$WWW_PATH"
+echo -n 'index.html body' > "$WWW_PATH/index.html"
+
+# Start echo server
+(
+  export XDG_DATA_HOME="$TMP/echo-data"
+  export XDG_CONFIG_HOME="$TMP/echo-conf"
+  mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME"
+  /opt/caddy/caddy start --config echo.caddyfile --adapter caddyfile >> "$TMP/echo-caddy.log" 2>&1
+)
+
+# Start Caddy for use with our config to test
+echo localhost > "$TMP/Caddyfile"
+/opt/caddy/caddy start --config "$TMP/Caddyfile" >> "$TMP/caddy.log" 2>&1
+
+sleep 1
+
+
+new-spec "Spec 1: With no custom domain"
+node /caddy-reconfigure.mjs
+reload-caddy
+run-hurl common/*.hurl
+
+
+new-spec "Spec 2: With a custom domain, cert obtained (because of internal CA)"
+export APPSMITH_CUSTOM_DOMAIN=custom-domain.com
+node /caddy-reconfigure.mjs
+#sed -i '2i acme_ca https://acme-staging-v02.api.letsencrypt.org/directory' "$TMP/Caddyfile"
+sed -i '/^https:\/\//a tls internal' "$TMP/Caddyfile"
+reload-caddy
+run-hurl common/*.hurl common-https/*.hurl spec-2/*.hurl
+
+
+new-spec "Spec 3: With a custom domain, certs given in ssl folder"
+export APPSMITH_CUSTOM_DOMAIN=custom-domain.com
+/opt/mkcert -cert-file "/appsmith-stacks/ssl/fullchain.pem" -key-file "/appsmith-stacks/ssl/privkey.pem" "$APPSMITH_CUSTOM_DOMAIN"
+node /caddy-reconfigure.mjs
+reload-caddy
+run-hurl common/*.hurl spec-3/*.hurl

--- a/deploy/docker/route-tests/entrypoint.sh
+++ b/deploy/docker/route-tests/entrypoint.sh
@@ -14,28 +14,28 @@ new-spec() {
 
 reload-caddy() {
   sed -i 's/127.0.0.1:{args\[0]}/127.0.0.1:5050/' "$TMP/Caddyfile"
-  /opt/caddy/caddy fmt --overwrite "$TMP/Caddyfile"
-  /opt/caddy/caddy reload --config "$TMP/Caddyfile"
+  caddy fmt --overwrite "$TMP/Caddyfile"
+  caddy reload --config "$TMP/Caddyfile"
   sleep 1
 }
 
 run-hurl() {
-  /opt/hurl/hurl --test \
+  hurl --test \
     --resolve local.com:80:127.0.0.1 \
     --resolve custom-domain.com:80:127.0.0.1 \
     --resolve custom-domain.com:443:127.0.0.1 \
     "$@"
 }
 
-if [[ "${OPEN_SHELL-}" == 1 ]]; then
+#if [[ "${OPEN_SHELL-}" == 1 ]]; then
   # Open shell for debugging after this script is done.
   trap bash EXIT
-fi
+#fi
 
 echo
-echo "caddy version: $(/opt/caddy/caddy --version)"
-echo "hurl version: $(/opt/hurl/hurl --version)"
-echo "mkcert version: $(/opt/mkcert --version)"
+echo "caddy version: $(caddy --version)"
+echo "hurl version: $(hurl --version)"
+echo "mkcert version: $(mkcert --version)"
 echo
 
 export TMP=/tmp/appsmith
@@ -43,18 +43,19 @@ export WWW_PATH="$TMP/www"
 
 mkdir -p "$WWW_PATH"
 echo -n 'index.html body' > "$WWW_PATH/index.html"
+mkcert -install
 
 # Start echo server
 (
   export XDG_DATA_HOME="$TMP/echo-data"
   export XDG_CONFIG_HOME="$TMP/echo-conf"
   mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME"
-  /opt/caddy/caddy start --config echo.caddyfile --adapter caddyfile >> "$TMP/echo-caddy.log" 2>&1
+  caddy start --config echo.caddyfile --adapter caddyfile >> "$TMP/echo-caddy.log" 2>&1
 )
 
 # Start Caddy for use with our config to test
 echo localhost > "$TMP/Caddyfile"
-/opt/caddy/caddy start --config "$TMP/Caddyfile" >> "$TMP/caddy.log" 2>&1
+caddy start --config "$TMP/Caddyfile" >> "$TMP/caddy.log" 2>&1
 
 sleep 1
 
@@ -69,14 +70,14 @@ new-spec "Spec 2: With a custom domain, cert obtained (because of internal CA)"
 export APPSMITH_CUSTOM_DOMAIN=custom-domain.com
 node /caddy-reconfigure.mjs
 #sed -i '2i acme_ca https://acme-staging-v02.api.letsencrypt.org/directory' "$TMP/Caddyfile"
-sed -i '/^https:\/\//a tls internal' "$TMP/Caddyfile"
+sed -i '/https:\/\/'"$APPSMITH_CUSTOM_DOMAIN"' {$/a tls internal' "$TMP/Caddyfile"
 reload-caddy
 run-hurl common/*.hurl common-https/*.hurl spec-2/*.hurl
 
 
 new-spec "Spec 3: With a custom domain, certs given in ssl folder"
 export APPSMITH_CUSTOM_DOMAIN=custom-domain.com
-/opt/mkcert -cert-file "/appsmith-stacks/ssl/fullchain.pem" -key-file "/appsmith-stacks/ssl/privkey.pem" "$APPSMITH_CUSTOM_DOMAIN"
+mkcert -cert-file "/appsmith-stacks/ssl/fullchain.pem" -key-file "/appsmith-stacks/ssl/privkey.pem" "$APPSMITH_CUSTOM_DOMAIN"
 node /caddy-reconfigure.mjs
 reload-caddy
 run-hurl common/*.hurl spec-3/*.hurl

--- a/deploy/docker/route-tests/entrypoint.sh
+++ b/deploy/docker/route-tests/entrypoint.sh
@@ -27,10 +27,10 @@ run-hurl() {
     "$@"
 }
 
-#if [[ "${OPEN_SHELL-}" == 1 ]]; then
+if [[ "${OPEN_SHELL-}" == 1 ]]; then
   # Open shell for debugging after this script is done.
   trap bash EXIT
-#fi
+fi
 
 echo
 echo "caddy version: $(caddy --version)"

--- a/deploy/docker/route-tests/run.sh
+++ b/deploy/docker/route-tests/run.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 
 loc="$(dirname "$0")"
-#docker build -f "$loc/Dockerfile" --tag ar "$loc/.."
+docker build -f "$loc/Dockerfile" --tag ar "$loc/.."
 docker run \
   --name ar \
   --rm \

--- a/deploy/docker/route-tests/run.sh
+++ b/deploy/docker/route-tests/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+loc="$(dirname "$0")"
+docker build -f "$loc/Dockerfile" --tag ar "$loc/.."
+docker run \
+  --name ar \
+  --rm \
+  -it \
+  --volume "$loc/../fs/opt/appsmith/caddy-reconfigure.mjs:/caddy-reconfigure.mjs:ro" \
+  --volume "$loc:/code:ro" \
+  ar

--- a/deploy/docker/route-tests/run.sh
+++ b/deploy/docker/route-tests/run.sh
@@ -4,11 +4,13 @@ set -o errexit
 set -o nounset
 
 loc="$(dirname "$0")"
-docker build -f "$loc/Dockerfile" --tag ar "$loc/.."
+#docker build -f "$loc/Dockerfile" --tag ar "$loc/.."
 docker run \
   --name ar \
   --rm \
   -it \
+  --hostname ar \
+  -e OPEN_SHELL=${OPEN_SHELL-} \
   --volume "$loc/../fs/opt/appsmith/caddy-reconfigure.mjs:/caddy-reconfigure.mjs:ro" \
   --volume "$loc:/code:ro" \
   ar

--- a/deploy/docker/route-tests/spec-2/custom-domain.hurl
+++ b/deploy/docker/route-tests/spec-2/custom-domain.hurl
@@ -20,10 +20,8 @@ GET https://custom-domain.com/random/path
 HTTP 200
 [Asserts]
 header "Server" not exists
-#certificate "Issuer" == "CN = Caddy Local Authority - ECC Intermediate"
 
 GET https://custom-domain.com/static/x
 HTTP 404
 [Asserts]
 header "Server" not exists
-#certificate "Issuer" == "CN = Caddy Local Authority - ECC Intermediate"

--- a/deploy/docker/route-tests/spec-2/custom-domain.hurl
+++ b/deploy/docker/route-tests/spec-2/custom-domain.hurl
@@ -1,0 +1,29 @@
+GET http://custom-domain.com
+HTTP 302
+Location: https://custom-domain.com/
+[Asserts]
+header "Server" not exists
+
+GET http://custom-domain.com/random/path
+HTTP 302
+Location: https://custom-domain.com/random/path
+[Asserts]
+header "Server" not exists
+
+GET https://custom-domain.com
+HTTP 200
+[Asserts]
+header "Server" not exists
+certificate "Issuer" == "CN = Caddy Local Authority - ECC Intermediate"
+
+GET https://custom-domain.com/random/path
+HTTP 200
+[Asserts]
+header "Server" not exists
+#certificate "Issuer" == "CN = Caddy Local Authority - ECC Intermediate"
+
+GET https://custom-domain.com/static/x
+HTTP 404
+[Asserts]
+header "Server" not exists
+#certificate "Issuer" == "CN = Caddy Local Authority - ECC Intermediate"

--- a/deploy/docker/route-tests/spec-3/custom-domain.hurl
+++ b/deploy/docker/route-tests/spec-3/custom-domain.hurl
@@ -1,0 +1,31 @@
+GET http://custom-domain.com
+HTTP 302
+Location: https://custom-domain.com/
+Connection: close
+[Asserts]
+header "Server" not exists
+
+GET http://custom-domain.com/random/path
+HTTP 302
+Location: https://custom-domain.com/random/path
+Connection: close
+[Asserts]
+header "Server" not exists
+
+GET https://custom-domain.com
+HTTP 200
+[Asserts]
+header "Server" not exists
+certificate "Issuer" == "O = mkcert development CA, OU = root@buildkitsandbox, CN = mkcert root@buildkitsandbox"
+
+GET https://custom-domain.com/random/path
+HTTP 200
+[Asserts]
+header "Server" not exists
+#certificate "Issuer" == "O = mkcert development CA, OU = root@buildkitsandbox, CN = mkcert root@buildkitsandbox"
+
+GET https://custom-domain.com/static/x
+HTTP 404
+[Asserts]
+header "Server" not exists
+#certificate "Issuer" == "O = mkcert development CA, OU = root@buildkitsandbox, CN = mkcert root@buildkitsandbox"

--- a/deploy/docker/route-tests/spec-3/custom-domain.hurl
+++ b/deploy/docker/route-tests/spec-3/custom-domain.hurl
@@ -16,16 +16,14 @@ GET https://custom-domain.com
 HTTP 200
 [Asserts]
 header "Server" not exists
-certificate "Issuer" == "O = mkcert development CA, OU = root@buildkitsandbox, CN = mkcert root@buildkitsandbox"
+certificate "Issuer" == "O = mkcert development CA, OU = root@ar, CN = mkcert root@ar"
 
 GET https://custom-domain.com/random/path
 HTTP 200
 [Asserts]
 header "Server" not exists
-#certificate "Issuer" == "O = mkcert development CA, OU = root@buildkitsandbox, CN = mkcert root@buildkitsandbox"
 
 GET https://custom-domain.com/static/x
 HTTP 404
 [Asserts]
 header "Server" not exists
-#certificate "Issuer" == "O = mkcert development CA, OU = root@buildkitsandbox, CN = mkcert root@buildkitsandbox"


### PR DESCRIPTION
Another attempt at #29550, which was reverted. Fallback is not happening if cert provisioning fails _despite_ having the correct header. But with the changes in this PR, since we'll listen on `:80`, fallback _will_ happen when cert provisioning fails due to incorrect domain configuration.

We're also adding [Hurl](https://hurl.dev) based tests. They're not run in any CI yet. That'll come in soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved handling of custom domain configurations in the server setup.
	- Enhanced HTTP to HTTPS redirection for custom domains.

- **Chores**
	- Updated environment variable naming for clarity in custom domain setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->