### PR TITLE
fix: App sidebar context switching with page

### DIFF
--- a/app/client/src/sagas/ContextSwitchingSaga.ts
+++ b/app/client/src/sagas/ContextSwitchingSaga.ts
@@ -260,7 +260,7 @@ function* getEntitiesForSet(
     state?.invokedBy === NavigationMethod.AppSidebar
   ) {
     const currentAppId: string = yield select(getCurrentApplicationId);
-    const key = `${currentEntityInfo.appState}.${currentAppId}#${branch}`;
+    const key = `${currentEntityInfo.appState}.${currentAppId}.${currentEntityInfo.pageId}#${branch}`;
     entities.push({
       key,
       entityInfo: {


### PR DESCRIPTION
Fixes a context switching issue where app sidebar navigation does not retain the current page canvas 

fixes #29614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the context switching mechanism to include page-specific data, enhancing the app's responsiveness and accuracy when users switch between different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->