### PR TITLE
fix: using data key for messages in AI plugins

### DIFF
--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
@@ -24,8 +24,6 @@ import static com.external.plugins.constants.AnthropicConstants.CHAT;
 import static com.external.plugins.constants.AnthropicConstants.CHAT_MODEL_SELECTOR;
 import static com.external.plugins.constants.AnthropicConstants.CLOUD_SERVICES;
 import static com.external.plugins.constants.AnthropicConstants.COMMAND;
-import static com.external.plugins.constants.AnthropicConstants.COMPONENT;
-import static com.external.plugins.constants.AnthropicConstants.COMPONENT_DATA;
 import static com.external.plugins.constants.AnthropicConstants.CONTENT;
 import static com.external.plugins.constants.AnthropicConstants.DATA;
 import static com.external.plugins.constants.AnthropicConstants.DEFAULT_MAX_TOKEN;
@@ -130,29 +128,18 @@ public class ChatCommand implements AnthropicCommand {
         }
     }
 
+    /**
+     * When JS is enabled in form component, value is stored in data key only. Difference is if viewType is json,
+     * it's stored as JSON string otherwise it's Java serialized object
+     */
     private List<Map<String, String>> getMessages(Map<String, Object> messages) {
         Type listType = new TypeToken<List<Map<String, String>>>() {}.getType();
-        if (messages.containsKey(VIEW_TYPE)) {
-            if (JSON.equals(messages.get(VIEW_TYPE))) {
-                // data is present in data key as String
-                return gson.fromJson((String) messages.get(DATA), listType);
-            } else if (COMPONENT.equals(messages.get(VIEW_TYPE))) {
-                return (List<Map<String, String>>) messages.get(COMPONENT_DATA);
-            }
+        if (messages.containsKey(VIEW_TYPE) && JSON.equals(messages.get(VIEW_TYPE))) {
+            // data is present in data key as String
+            return gson.fromJson((String) messages.get(DATA), listType);
         }
         // return object stored in data key
         return (List<Map<String, String>>) messages.get(DATA);
-    }
-
-    /**
-     * Finds right data key from formData.messages. If viewType is present and it's json, then use `componentData`key
-     * else use `data` key to find right messages.
-     */
-    private String findDataKey(Map<String, Object> messages) {
-        if (messages.containsKey(VIEW_TYPE) && "json".equals(messages.get(VIEW_TYPE))) {
-            return COMPONENT_DATA;
-        }
-        return DATA;
     }
 
     private int getMaxTokenFromFormData(Map<String, Object> formData) {

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/commands/GenerateContentCommand.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/commands/GenerateContentCommand.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static com.external.plugins.constants.GoogleAIConstants.COMPONENT;
-import static com.external.plugins.constants.GoogleAIConstants.COMPONENT_DATA;
 import static com.external.plugins.constants.GoogleAIConstants.CONTENT;
 import static com.external.plugins.constants.GoogleAIConstants.DATA;
 import static com.external.plugins.constants.GoogleAIConstants.GENERATE_CONTENT_MODEL;
@@ -136,15 +134,15 @@ public class GenerateContentCommand implements GoogleAICommand {
         }
     }
 
+    /**
+     * When JS is enabled in form component, value is stored in data key only. Difference is if viewType is json,
+     * it's stored as JSON string otherwise it's Java serialized object
+     */
     private List<Map<String, String>> getMessages(Map<String, Object> messages) {
         Type listType = new TypeToken<List<Map<String, String>>>() {}.getType();
-        if (messages.containsKey(VIEW_TYPE)) {
-            if (JSON.equals(messages.get(VIEW_TYPE))) {
-                // data is present in data key as String
-                return gson.fromJson((String) messages.get(DATA), listType);
-            } else if (COMPONENT.equals(messages.get(VIEW_TYPE))) {
-                return (List<Map<String, String>>) messages.get(COMPONENT_DATA);
-            }
+        if (messages.containsKey(VIEW_TYPE) && JSON.equals(messages.get(VIEW_TYPE))) {
+            // data is present in data key as String
+            return gson.fromJson((String) messages.get(DATA), listType);
         }
         // return object stored in data key
         return (List<Map<String, String>>) messages.get(DATA);


### PR DESCRIPTION
## Description
There was a misunderstanding between using data/componentData field in `JS` enabled form fields. Now it's clear and we are using `data` key value always.

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [x] Manual

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the message retrieval process to enhance user experience in chat features.
  - Simplified the content generation logic for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->