### PR TITLE
fix: put wds theme provider under feature flag

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/AutoLayoutAutoHeight_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/AutoLayoutAutoHeight_spec.ts
@@ -41,7 +41,7 @@ describe("Validating use cases for Auto Dimension", () => {
       .GetWidgetCSSHeight(getWidgetSelector(draggableWidgets.TEXT))
       .then((height) => {
         const textHeight = parseInt(height?.split("px")[0]);
-        expect(textHeight).to.eq(311);
+        expect(textHeight).to.greaterThan(300);
       });
 
     deployMode.DeployApp();

--- a/app/client/src/pages/AppViewer/index.tsx
+++ b/app/client/src/pages/AppViewer/index.tsx
@@ -214,59 +214,66 @@ function AppViewer(props: Props) {
     };
   }, [selectedTheme.properties.fontFamily.appFont]);
 
-  const isWDSV2Enabled = useFeatureFlag("ab_wds_enabled");
-  const backgroundForBody = isWDSV2Enabled
-    ? "var(--color-bg)"
-    : selectedTheme.properties.colors.backgroundColor;
+  const isWDSEnabled = useFeatureFlag("ab_wds_enabled");
 
-  return (
-    <WDSThemeProvider theme={theme}>
-      <ThemeProvider theme={lightTheme}>
-        <EditorContextProvider renderMode="PAGE">
-          {!isWDSV2Enabled && (
-            <WidgetGlobaStyles
-              fontFamily={selectedTheme.properties.fontFamily.appFont}
-              primaryColor={selectedTheme.properties.colors.primaryColor}
-            />
-          )}
-          <HtmlTitle
-            description={pageDescription}
-            name={currentApplicationDetails?.name}
+  const renderChildren = () => {
+    return (
+      <EditorContextProvider renderMode="PAGE">
+        {!isWDSEnabled && (
+          <WidgetGlobaStyles
+            fontFamily={selectedTheme.properties.fontFamily.appFont}
+            primaryColor={selectedTheme.properties.colors.primaryColor}
           />
-          <AppViewerBodyContainer backgroundColor={backgroundForBody}>
-            <AppViewerBody
-              className={CANVAS_SELECTOR}
-              hasPages={pages.length > 1}
-              headerHeight={headerHeight}
-              ref={focusRef}
-              showBottomBar={!!showBottomBar}
-              showGuidedTourMessage={showGuidedTourMessage}
-            >
-              {isInitialized && <AppViewerPageContainer />}
-            </AppViewerBody>
-            {showBottomBar && <BottomBar viewMode />}
-            <div
-              className={`fixed hidden right-8 z-3 md:flex ${
-                showBottomBar ? "bottom-12" : "bottom-4"
-              }`}
-            >
-              {!hideWatermark && (
-                <a
-                  className="hover:no-underline"
-                  href="https://appsmith.com"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  <BrandingBadge />
-                </a>
-              )}
-              <KBViewerFloatingButton />
-            </div>
-          </AppViewerBodyContainer>
-        </EditorContextProvider>
-      </ThemeProvider>
-    </WDSThemeProvider>
-  );
+        )}
+        <HtmlTitle
+          description={pageDescription}
+          name={currentApplicationDetails?.name}
+        />
+        <AppViewerBodyContainer
+          backgroundColor={
+            isWDSEnabled ? "" : selectedTheme.properties.colors.backgroundColor
+          }
+        >
+          <AppViewerBody
+            className={CANVAS_SELECTOR}
+            hasPages={pages.length > 1}
+            headerHeight={headerHeight}
+            ref={focusRef}
+            showBottomBar={!!showBottomBar}
+            showGuidedTourMessage={showGuidedTourMessage}
+          >
+            {isInitialized && <AppViewerPageContainer />}
+          </AppViewerBody>
+          {showBottomBar && <BottomBar viewMode />}
+          <div
+            className={`fixed hidden right-8 z-3 md:flex ${
+              showBottomBar ? "bottom-12" : "bottom-4"
+            }`}
+          >
+            {!hideWatermark && (
+              <a
+                className="hover:no-underline"
+                href="https://appsmith.com"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <BrandingBadge />
+              </a>
+            )}
+            <KBViewerFloatingButton />
+          </div>
+        </AppViewerBodyContainer>
+      </EditorContextProvider>
+    );
+  };
+
+  if (isWDSEnabled) {
+    return (
+      <WDSThemeProvider theme={theme}>{renderChildren()}</WDSThemeProvider>
+    );
+  }
+
+  return <ThemeProvider theme={lightTheme}>{renderChildren()}</ThemeProvider>;
 }
 
 export default withRouter(Sentry.withProfiler(AppViewer));

--- a/app/client/src/pages/Editor/Canvas.tsx
+++ b/app/client/src/pages/Editor/Canvas.tsx
@@ -68,20 +68,12 @@ const Canvas = (props: CanvasProps) => {
   /**
    * background for canvas
    */
-  let backgroundForCanvas;
+  let backgroundForCanvas: string;
 
   if (isPreviewMode || isAppSettingsPaneWithNavigationTabOpen) {
-    if (isWDSEnabled) {
-      backgroundForCanvas = "var(--color-bg)";
-    } else {
-      backgroundForCanvas = "initial";
-    }
+    backgroundForCanvas = "initial";
   } else {
-    if (isWDSEnabled) {
-      backgroundForCanvas = "var(--color-bg)";
-    } else {
-      backgroundForCanvas = selectedTheme.properties.colors.backgroundColor;
-    }
+    backgroundForCanvas = selectedTheme.properties.colors.backgroundColor;
   }
 
   const focusRef = useWidgetFocus();
@@ -90,31 +82,40 @@ const Canvas = (props: CanvasProps) => {
     ? `mx-0`
     : `mx-auto`;
   const paddingBottomClass = props.enableMainCanvasResizer ? "" : "pb-52";
-  try {
+
+  const renderChildren = () => {
     return (
-      <WDSThemeProvider theme={theme}>
-        <Wrapper
-          $enableMainCanvasResizer={!!props.enableMainCanvasResizer}
-          background={backgroundForCanvas}
-          className={`relative t--canvas-artboard ${paddingBottomClass} transition-all duration-400  ${marginHorizontalClass} ${getViewportClassName(
-            canvasWidth,
-          )}`}
-          data-testid={"t--canvas-artboard"}
-          id={CANVAS_ART_BOARD}
-          ref={isWDSEnabled ? undefined : focusRef}
-          width={canvasWidth}
-        >
-          {props.widgetsStructure.widgetId &&
-            renderAppsmithCanvas({
-              ...props.widgetsStructure,
-              classList:
-                layoutSystemType === LayoutSystemTypes.ANVIL
-                  ? ["main-anvil-canvas"]
-                  : [],
-            } as WidgetProps)}
-        </Wrapper>
-      </WDSThemeProvider>
+      <Wrapper
+        $enableMainCanvasResizer={!!props.enableMainCanvasResizer}
+        background={isWDSEnabled ? "" : backgroundForCanvas}
+        className={`relative t--canvas-artboard ${paddingBottomClass} transition-all duration-400  ${marginHorizontalClass} ${getViewportClassName(
+          canvasWidth,
+        )}`}
+        data-testid={"t--canvas-artboard"}
+        id={CANVAS_ART_BOARD}
+        ref={isWDSEnabled ? undefined : focusRef}
+        width={canvasWidth}
+      >
+        {props.widgetsStructure.widgetId &&
+          renderAppsmithCanvas({
+            ...props.widgetsStructure,
+            classList:
+              layoutSystemType === LayoutSystemTypes.ANVIL
+                ? ["main-anvil-canvas"]
+                : [],
+          } as WidgetProps)}
+      </Wrapper>
     );
+  };
+
+  try {
+    if (isWDSEnabled) {
+      return (
+        <WDSThemeProvider theme={theme}>{renderChildren()}</WDSThemeProvider>
+      );
+    }
+
+    return renderChildren();
   } catch (error) {
     log.error("Error rendering DSL", error);
     Sentry.captureException(error);


### PR DESCRIPTION
## Description
Put WDS theme provider under the feature flag so that WDS don't affect prod anymore.

Also fix this 
![CleanShot 2023-12-15 at 13 50 29@2x](https://github.com/appsmithorg/appsmith/assets/11555074/c1421c67-9605-4912-b8d4-c9203758ac6a)

**How it look like now**

WDS enabled
![Снимок экрана 2023-12-15 в 14 34 54](https://github.com/appsmithorg/appsmith/assets/11555074/3e3d4c05-cc3f-4222-95eb-b90a50e0117f)
![Снимок экрана 2023-12-15 в 14 34 59](https://github.com/appsmithorg/appsmith/assets/11555074/718ab285-8700-41d0-b9bc-e60546592b76)


WDS disabled
![Снимок экрана 2023-12-15 в 14 35 59](https://github.com/appsmithorg/appsmith/assets/11555074/7b7de78f-0b71-4197-bd2e-c42f60fd2b63)
![Снимок экрана 2023-12-15 в 14 36 03](https://github.com/appsmithorg/appsmith/assets/11555074/5c5fe2fa-7547-4f6a-a8f2-bdf193f3b6e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved feature flag naming for clarity in the app viewer settings.
  - Simplified theme background color application in the editor canvas.
  - Centralized rendering logic for editor canvas components for better maintainability.

- **Style**
  - Streamlined the application of themes to ensure consistent background colors across the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->