### PR TITLE
test:Cypress - added tag- @tag.Binding

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/ConnectToWidget_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/ConnectToWidget_spec.ts
@@ -17,90 +17,100 @@ import PageList from "../../../../../support/Pages/PageList";
 
 const oneClickBinding = new OneClickBinding();
 
-describe("JSONForm widget one click binding feature", () => {
-  let datasourceName: string;
+describe(
+  "JSONForm widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    let datasourceName: string;
 
-  it("1.Connect to a table widget", () => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 200, 200);
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
+    it("1.Connect to a table widget", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 200, 200);
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
 
-    dataSources.CreateDataSource("Postgres");
+      dataSources.CreateDataSource("Postgres");
 
-    cy.get("@dsName").then((dsName) => {
-      datasourceName = dsName as unknown as string;
+      cy.get("@dsName").then((dsName) => {
+        datasourceName = dsName as unknown as string;
 
-      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+        EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
 
-      oneClickBinding.ChooseAndAssertForm(
-        `${datasourceName}`,
-        datasourceName,
-        "public.employees",
-        {
-          searchableColumn: "first_name",
-        },
+        oneClickBinding.ChooseAndAssertForm(
+          `${datasourceName}`,
+          datasourceName,
+          "public.employees",
+          {
+            searchableColumn: "first_name",
+          },
+        );
+      });
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
+
+      agHelper.GetNClick(oneClickBindingLocator.datasourceDropdownSelector);
+      agHelper.GetNClick(
+        oneClickBindingLocator.datasourceQuerySelector("Table1"),
+      );
+
+      agHelper.Sleep(2000);
+
+      table.SelectTableRow(0, 1, true, "v2");
+
+      table.ReadTableRowColumnData(0, 1, "v2").then((cellData) => {
+        agHelper
+          .GetText(locators._jsonFormInputField("last_name"), "val")
+          .should("be.equal", cellData);
+      });
+
+      agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
+
+      agHelper.AssertElementVisibility(locators._toastMsg);
+      agHelper.AssertElementVisibility(
+        locators._specificToast(
+          "onSubmit event is not configured for JSONForm1",
+        ),
       );
     });
 
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
+    it("Connect to a list widget", () => {
+      PageList.AddNewPage("New blank page");
 
-    assertHelper.AssertNetworkStatus("@postExecute");
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.LIST_V2, 200, 200);
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
 
-    agHelper.Sleep(2000);
+      agHelper.GetNClick(oneClickBindingLocator.datasourceDropdownSelector);
+      agHelper.GetNClick(
+        oneClickBindingLocator.datasourceQuerySelector("List1"),
+      );
 
-    EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
+      agHelper.Sleep(2000);
 
-    agHelper.GetNClick(oneClickBindingLocator.datasourceDropdownSelector);
-    agHelper.GetNClick(
-      oneClickBindingLocator.datasourceQuerySelector("Table1"),
-    );
+      EditorNavigation.SelectEntityByName("List1", EntityType.Widget);
 
-    agHelper.Sleep(2000);
+      propPane.UpdatePropertyFieldValue("Default selected item", "001");
 
-    table.SelectTableRow(0, 1, true, "v2");
-
-    table.ReadTableRowColumnData(0, 1, "v2").then((cellData) => {
       agHelper
-        .GetText(locators._jsonFormInputField("last_name"), "val")
-        .should("be.equal", cellData);
-    });
-
-    agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
-
-    agHelper.AssertElementVisibility(locators._toastMsg);
-    agHelper.AssertElementVisibility(
-      locators._specificToast("onSubmit event is not configured for JSONForm1"),
-    );
-  });
-
-  it("Connect to a list widget", () => {
-    PageList.AddNewPage("New blank page");
-
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.LIST_V2, 200, 200);
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
-
-    agHelper.GetNClick(oneClickBindingLocator.datasourceDropdownSelector);
-    agHelper.GetNClick(oneClickBindingLocator.datasourceQuerySelector("List1"));
-
-    agHelper.Sleep(2000);
-
-    EditorNavigation.SelectEntityByName("List1", EntityType.Widget);
-
-    propPane.UpdatePropertyFieldValue("Default selected item", "001");
-
-    agHelper
-      .GetText(locators._jsonFormInputField("name"), "val")
-      .then((text) => {
-        agHelper.Sleep(500);
-        agHelper.GetText(".t--widget-textwidget span", "text").then((val) => {
-          expect(val).to.eq(text);
+        .GetText(locators._jsonFormInputField("name"), "val")
+        .then((text) => {
+          agHelper.Sleep(500);
+          agHelper.GetText(".t--widget-textwidget span", "text").then((val) => {
+            expect(val).to.eq(text);
+          });
         });
-      });
 
-    agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
+      agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
 
-    agHelper.AssertElementVisibility(locators._toastMsg);
-    agHelper.AssertElementVisibility(
-      locators._specificToast("onSubmit event is not configured for JSONForm1"),
-    );
-  });
-});
+      agHelper.AssertElementVisibility(locators._toastMsg);
+      agHelper.AssertElementVisibility(
+        locators._specificToast(
+          "onSubmit event is not configured for JSONForm1",
+        ),
+      );
+    });
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/FieldConfigModal_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/FieldConfigModal_spec.ts
@@ -13,60 +13,64 @@ import EditorNavigation, {
 
 const oneClickBinding = new OneClickBinding();
 
-describe("JSONForm widget one click binding feature", () => {
-  it("1.tests select/unselect fields for json form widget", () => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 450, 200);
+describe(
+  "JSONForm widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    it("1.tests select/unselect fields for json form widget", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 450, 200);
 
-    dataSources.CreateDataSource("Postgres");
+      dataSources.CreateDataSource("Postgres");
 
-    cy.get("@dsName").then((dsName) => {
-      EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
+      cy.get("@dsName").then((dsName) => {
+        EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
 
-      oneClickBinding.ChooseAndAssertForm(
-        `${dsName}`,
-        dsName,
-        "public.employees",
+        oneClickBinding.ChooseAndAssertForm(
+          `${dsName}`,
+          dsName,
+          "public.employees",
+        );
+      });
+
+      // Open the column selector modal
+      agHelper.GetNClick(oneClickBindingLocator.columnSelectorModalTrigger);
+
+      // Assert that the primary column is unchecked
+      agHelper.AssertAttribute(
+        oneClickBindingLocator.checkBox,
+        "data-checked",
+        "false",
       );
+
+      // Deselect some columns
+      const deselectColumns = ["title_of_courtesy", "birth_date", "hire_date"];
+
+      deselectColumns.forEach((column) => {
+        agHelper.GetNClick(
+          oneClickBindingLocator.columnSelectorField(column),
+          0,
+          true,
+        );
+      });
+
+      // Save the column selection
+      agHelper.GetNClick(oneClickBindingLocator.columnselectorModalSaveBtn);
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      agHelper.Sleep(2000);
+
+      const selectedColumns = ["last_name", "first_name", "title"];
+
+      // Assert that the selected columns are present in the form
+      selectedColumns.forEach((column) => {
+        agHelper.AssertElementExist(locators._draggableFieldConfig(column));
+      });
+
+      // Assert that the deselected columns are not present in the form
+      deselectColumns.forEach((column) => {
+        agHelper.AssertElementAbsence(locators._draggableFieldConfig(column));
+      });
     });
-
-    // Open the column selector modal
-    agHelper.GetNClick(oneClickBindingLocator.columnSelectorModalTrigger);
-
-    // Assert that the primary column is unchecked
-    agHelper.AssertAttribute(
-      oneClickBindingLocator.checkBox,
-      "data-checked",
-      "false",
-    );
-
-    // Deselect some columns
-    const deselectColumns = ["title_of_courtesy", "birth_date", "hire_date"];
-
-    deselectColumns.forEach((column) => {
-      agHelper.GetNClick(
-        oneClickBindingLocator.columnSelectorField(column),
-        0,
-        true,
-      );
-    });
-
-    // Save the column selection
-    agHelper.GetNClick(oneClickBindingLocator.columnselectorModalSaveBtn);
-
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
-
-    agHelper.Sleep(2000);
-
-    const selectedColumns = ["last_name", "first_name", "title"];
-
-    // Assert that the selected columns are present in the form
-    selectedColumns.forEach((column) => {
-      agHelper.AssertElementExist(locators._draggableFieldConfig(column));
-    });
-
-    // Assert that the deselected columns are not present in the form
-    deselectColumns.forEach((column) => {
-      agHelper.AssertElementAbsence(locators._draggableFieldConfig(column));
-    });
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/mongoDb_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/mongoDb_spec.ts
@@ -16,15 +16,76 @@ import PageList from "../../../../../support/Pages/PageList";
 
 const oneClickBinding = new OneClickBinding();
 
-describe("JSONForm widget one click binding feature", () => {
-  let datasourceName: string;
-  it("1.Create flow: should check that queries are created and bound to jsonform widget properly", () => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 450, 200);
+describe(
+  "JSONForm widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    let datasourceName: string;
+    it("1.Create flow: should check that queries are created and bound to jsonform widget properly", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 450, 200);
 
-    dataSources.CreateDataSource("Mongo");
+      dataSources.CreateDataSource("Mongo");
 
-    cy.get("@dsName").then((dsName) => {
-      datasourceName = dsName as unknown as string;
+      cy.get("@dsName").then((dsName) => {
+        datasourceName = dsName as unknown as string;
+
+        EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
+
+        oneClickBinding.ChooseAndAssertForm(
+          `${datasourceName}`,
+          datasourceName,
+          "netflix",
+          {
+            formType: "Create records",
+          },
+        );
+      });
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      agHelper.Sleep(2000);
+
+      const columns = [
+        "contentRating",
+        "contentType",
+        "creator",
+        "description",
+        "director",
+        "genre",
+        "name",
+        "numberOfSeasons",
+        "releasedDate",
+        "seasonStartDate",
+        "url",
+      ];
+
+      columns.forEach((column) => {
+        agHelper.AssertElementExist(locators._draggableFieldConfig(column));
+      });
+    });
+
+    it("2.Update flow: should check that queries are created and bound to table jsonform widget properly ", () => {
+      PageList.AddNewPage("New blank page");
+
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 200, 200);
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
+
+      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+
+      oneClickBinding.ChooseAndAssertForm(
+        `${datasourceName}`,
+        datasourceName,
+        "netflix",
+        {
+          searchableColumn: "creator",
+        },
+      );
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
 
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
 
@@ -33,103 +94,46 @@ describe("JSONForm widget one click binding feature", () => {
         datasourceName,
         "netflix",
         {
-          formType: "Create records",
+          formType: "Edit records",
+          defaultValues: "Table1",
+          dataIdentifier: "id",
         },
       );
-    });
 
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
 
-    agHelper.Sleep(2000);
+      assertHelper.AssertNetworkStatus("@postExecute");
 
-    const columns = [
-      "contentRating",
-      "contentType",
-      "creator",
-      "description",
-      "director",
-      "genre",
-      "name",
-      "numberOfSeasons",
-      "releasedDate",
-      "seasonStartDate",
-      "url",
-    ];
+      agHelper.Sleep(2000);
 
-    columns.forEach((column) => {
-      agHelper.AssertElementExist(locators._draggableFieldConfig(column));
-    });
-  });
+      table.SelectTableRow(0, 3, true, "v2");
 
-  it("2.Update flow: should check that queries are created and bound to table jsonform widget properly ", () => {
-    PageList.AddNewPage("New blank page");
+      table.ReadTableRowColumnData(0, 3, "v2").then((cellData) => {
+        agHelper
+          .GetText(locators._jsonFormInputField("creator"), "val")
+          .should("be.equal", cellData);
+      });
 
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 200, 200);
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
-
-    EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
-
-    oneClickBinding.ChooseAndAssertForm(
-      `${datasourceName}`,
-      datasourceName,
-      "netflix",
-      {
-        searchableColumn: "creator",
-      },
-    );
-
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
-
-    oneClickBinding.ChooseAndAssertForm(
-      `${datasourceName}`,
-      datasourceName,
-      "netflix",
-      {
-        formType: "Edit records",
-        defaultValues: "Table1",
-        dataIdentifier: "id",
-      },
-    );
-
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    table.SelectTableRow(0, 3, true, "v2");
-
-    table.ReadTableRowColumnData(0, 3, "v2").then((cellData) => {
+      agHelper
+        .GetElement(locators._jsonFormInputField("creator"))
+        .clear()
+        .type("Doe");
       agHelper
         .GetText(locators._jsonFormInputField("creator"), "val")
-        .should("be.equal", cellData);
+        .should("be.equal", "Doe");
+
+      agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
+
+      agHelper.Sleep(2000);
+
+      // reloading because we don't create select query with json form, so we need to reload the page to get the updated data
+      cy.reload();
+
+      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+
+      table.ReadTableRowColumnData(0, 3, "v2").then((cellData) => {
+        expect(cellData).to.eq("Doe");
+      });
     });
-
-    agHelper
-      .GetElement(locators._jsonFormInputField("creator"))
-      .clear()
-      .type("Doe");
-    agHelper
-      .GetText(locators._jsonFormInputField("creator"), "val")
-      .should("be.equal", "Doe");
-
-    agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
-
-    agHelper.Sleep(2000);
-
-    // reloading because we don't create select query with json form, so we need to reload the page to get the updated data
-    cy.reload();
-
-    EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
-
-    table.ReadTableRowColumnData(0, 3, "v2").then((cellData) => {
-      expect(cellData).to.eq("Doe");
-    });
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/postgres_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/postgres_spec.ts
@@ -16,15 +16,71 @@ import PageList from "../../../../../support/Pages/PageList";
 
 const oneClickBinding = new OneClickBinding();
 
-describe("JSONForm widget one click binding feature", () => {
-  let datasourceName: string;
-  it("1.Create flow: should check that queries are created and bound to table jsonform widget properly ", () => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 450, 200);
+describe(
+  "JSONForm widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    let datasourceName: string;
+    it("1.Create flow: should check that queries are created and bound to table jsonform widget properly ", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 450, 200);
 
-    dataSources.CreateDataSource("Postgres");
+      dataSources.CreateDataSource("Postgres");
 
-    cy.get("@dsName").then((dsName) => {
-      datasourceName = dsName as unknown as string;
+      cy.get("@dsName").then((dsName) => {
+        datasourceName = dsName as unknown as string;
+
+        EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
+
+        oneClickBinding.ChooseAndAssertForm(
+          `${datasourceName}`,
+          datasourceName,
+          "public.employees",
+          {
+            formType: "Create records",
+          },
+        );
+      });
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      agHelper.Sleep(2000);
+
+      const columns = [
+        "last_name",
+        "first_name",
+        "title",
+        "title_of_courtesy",
+        "birth_date",
+        "hire_date",
+      ];
+
+      columns.forEach((column) => {
+        agHelper.AssertElementExist(locators._draggableFieldConfig(column));
+      });
+    });
+
+    it("2.Update flow: should check that queries are created and bound to table jsonform widget properly ", () => {
+      PageList.AddNewPage("New blank page");
+
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 200, 200);
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
+
+      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+
+      oneClickBinding.ChooseAndAssertForm(
+        `${datasourceName}`,
+        datasourceName,
+        "public.employees",
+        {
+          searchableColumn: "first_name",
+        },
+      );
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
 
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
 
@@ -33,98 +89,46 @@ describe("JSONForm widget one click binding feature", () => {
         datasourceName,
         "public.employees",
         {
-          formType: "Create records",
+          formType: "Edit records",
+          defaultValues: "Table1",
+          dataIdentifier: "id",
         },
       );
-    });
 
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
 
-    agHelper.Sleep(2000);
+      assertHelper.AssertNetworkStatus("@postExecute");
 
-    const columns = [
-      "last_name",
-      "first_name",
-      "title",
-      "title_of_courtesy",
-      "birth_date",
-      "hire_date",
-    ];
+      agHelper.Sleep(2000);
 
-    columns.forEach((column) => {
-      agHelper.AssertElementExist(locators._draggableFieldConfig(column));
-    });
-  });
+      table.SelectTableRow(0, 1, true, "v2");
 
-  it("2.Update flow: should check that queries are created and bound to table jsonform widget properly ", () => {
-    PageList.AddNewPage("New blank page");
+      table.ReadTableRowColumnData(0, 1, "v2").then((cellData) => {
+        agHelper
+          .GetText(locators._jsonFormInputField("last_name"), "val")
+          .should("be.equal", cellData);
+      });
 
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 200, 200);
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 600, 400);
-
-    EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
-
-    oneClickBinding.ChooseAndAssertForm(
-      `${datasourceName}`,
-      datasourceName,
-      "public.employees",
-      {
-        searchableColumn: "first_name",
-      },
-    );
-
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
-
-    oneClickBinding.ChooseAndAssertForm(
-      `${datasourceName}`,
-      datasourceName,
-      "public.employees",
-      {
-        formType: "Edit records",
-        defaultValues: "Table1",
-        dataIdentifier: "id",
-      },
-    );
-
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    table.SelectTableRow(0, 1, true, "v2");
-
-    table.ReadTableRowColumnData(0, 1, "v2").then((cellData) => {
+      agHelper
+        .GetElement(locators._jsonFormInputField("last_name"))
+        .clear()
+        .type("Doe");
       agHelper
         .GetText(locators._jsonFormInputField("last_name"), "val")
-        .should("be.equal", cellData);
+        .should("be.equal", "Doe");
+
+      agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
+
+      agHelper.Sleep(2000);
+
+      // reloading because we don't create select query with json form, so we need to reload the page to get the updated data
+      cy.reload();
+
+      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+
+      table.ReadTableRowColumnData(0, 1, "v2").then((cellData) => {
+        expect(cellData).to.eq("Doe");
+      });
     });
-
-    agHelper
-      .GetElement(locators._jsonFormInputField("last_name"))
-      .clear()
-      .type("Doe");
-    agHelper
-      .GetText(locators._jsonFormInputField("last_name"), "val")
-      .should("be.equal", "Doe");
-
-    agHelper.GetNClick(locators._jsonFormSubmitBtn, 0, true);
-
-    agHelper.Sleep(2000);
-
-    // reloading because we don't create select query with json form, so we need to reload the page to get the updated data
-    cy.reload();
-
-    EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
-
-    table.ReadTableRowColumnData(0, 1, "v2").then((cellData) => {
-      expect(cellData).to.eq("Doe");
-    });
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/mongoDB_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/mongoDB_spec.ts
@@ -16,80 +16,84 @@ import EditorNavigation, {
 
 const oneClickBinding = new OneClickBinding();
 
-describe("Table widget one click binding feature", () => {
-  it("should check that queries are created and bound to table widget properly", () => {
-    entityExplorer.DragDropWidgetNVerify(
-      draggableWidgets.MULTISELECT,
-      450,
-      200,
-    );
+describe(
+  "Table widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    it("should check that queries are created and bound to table widget properly", () => {
+      entityExplorer.DragDropWidgetNVerify(
+        draggableWidgets.MULTISELECT,
+        450,
+        200,
+      );
 
-    dataSources.CreateDataSource("Mongo");
+      dataSources.CreateDataSource("Mongo");
 
-    cy.get("@dsName").then((dsName) => {
-      EditorNavigation.SelectEntityByName("MultiSelect1", EntityType.Widget);
+      cy.get("@dsName").then((dsName) => {
+        EditorNavigation.SelectEntityByName("MultiSelect1", EntityType.Widget);
 
-      oneClickBinding.ChooseAndAssertForm(`${dsName}`, dsName, "netflix", {
-        label: "name",
-        value: "director",
+        oneClickBinding.ChooseAndAssertForm(`${dsName}`, dsName, "netflix", {
+          label: "name",
+          value: "director",
+        });
       });
-    });
 
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
 
-    assertHelper.AssertNetworkStatus("@postExecute");
+      assertHelper.AssertNetworkStatus("@postExecute");
 
-    agHelper.Sleep(2000);
+      agHelper.Sleep(2000);
 
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
 
-    propPane.UpdatePropertyFieldValue(
-      "Text",
-      `{{MultiSelect1.selectedOptionLabels.toString()}}:{{MultiSelect1.selectedOptionValues.toString()}}`,
-    );
+      propPane.UpdatePropertyFieldValue(
+        "Text",
+        `{{MultiSelect1.selectedOptionLabels.toString()}}:{{MultiSelect1.selectedOptionValues.toString()}}`,
+      );
 
-    [
-      {
-        label: "I Care a Lot",
-        text: "I Care a Lot:J Blakeson",
-      },
-      {
-        label: "tick, tick...BOOM!",
-        text: "I Care a Lot,tick, tick...BOOM!:J Blakeson,Lin-Manuel Miranda",
-      },
-      {
-        label: "Munich – The Edge of War",
-        text: "I Care a Lot,tick, tick...BOOM!,Munich – The Edge of War:J Blakeson,Lin-Manuel Miranda,Christian Schwochow",
-      },
-    ].forEach((d) => {
-      cy.get(formWidgetsPage.multiSelectWidget)
-        .find(".rc-select-selector")
-        .click({
+      [
+        {
+          label: "I Care a Lot",
+          text: "I Care a Lot:J Blakeson",
+        },
+        {
+          label: "tick, tick...BOOM!",
+          text: "I Care a Lot,tick, tick...BOOM!:J Blakeson,Lin-Manuel Miranda",
+        },
+        {
+          label: "Munich – The Edge of War",
+          text: "I Care a Lot,tick, tick...BOOM!,Munich – The Edge of War:J Blakeson,Lin-Manuel Miranda,Christian Schwochow",
+        },
+      ].forEach((d) => {
+        cy.get(formWidgetsPage.multiSelectWidget)
+          .find(".rc-select-selector")
+          .click({
+            force: true,
+          });
+
+        cy.get(".rc-select-item").contains(d.label).click({
           force: true,
         });
-
-      cy.get(".rc-select-item").contains(d.label).click({
-        force: true,
+        cy.get(commonlocators.TextInside).first().should("have.text", d.text);
       });
-      cy.get(commonlocators.TextInside).first().should("have.text", d.text);
+
+      agHelper.Sleep(2000);
+
+      cy.get(formWidgetsPage.multiselectWidgetv2search)
+        .first()
+        .focus({ force: true } as any)
+        .type("Haunting", { force: true });
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      cy.get(
+        ".rc-select-item-option:contains('The Haunting of Hill House')",
+      ).should("have.length", 1);
+      cy.get(".rc-select-item")
+        .contains("The Haunting of Hill House")
+        .should("exist");
     });
-
-    agHelper.Sleep(2000);
-
-    cy.get(formWidgetsPage.multiselectWidgetv2search)
-      .first()
-      .focus({ force: true } as any)
-      .type("Haunting", { force: true });
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    cy.get(
-      ".rc-select-item-option:contains('The Haunting of Hill House')",
-    ).should("have.length", 1);
-    cy.get(".rc-select-item")
-      .contains("The Haunting of Hill House")
-      .should("exist");
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/postgres_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/postgres_spec.ts
@@ -16,79 +16,83 @@ import EditorNavigation, {
 
 const oneClickBinding = new OneClickBinding();
 
-describe("Table widget one click binding feature", () => {
-  it("should check that queries are created and bound to table widget properly", () => {
-    entityExplorer.DragDropWidgetNVerify(
-      draggableWidgets.MULTISELECT,
-      450,
-      200,
-    );
-
-    dataSources.CreateDataSource("Postgres");
-
-    cy.get("@dsName").then((dsName) => {
-      EditorNavigation.SelectEntityByName("MultiSelect1", EntityType.Widget);
-
-      oneClickBinding.ChooseAndAssertForm(
-        `${dsName}`,
-        dsName,
-        "public.employees",
-        {
-          label: "first_name",
-          value: "last_name",
-        },
+describe(
+  "Table widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    it("should check that queries are created and bound to table widget properly", () => {
+      entityExplorer.DragDropWidgetNVerify(
+        draggableWidgets.MULTISELECT,
+        450,
+        200,
       );
-    });
 
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
+      dataSources.CreateDataSource("Postgres");
 
-    assertHelper.AssertNetworkStatus("@postExecute");
+      cy.get("@dsName").then((dsName) => {
+        EditorNavigation.SelectEntityByName("MultiSelect1", EntityType.Widget);
 
-    agHelper.Sleep(2000);
+        oneClickBinding.ChooseAndAssertForm(
+          `${dsName}`,
+          dsName,
+          "public.employees",
+          {
+            label: "first_name",
+            value: "last_name",
+          },
+        );
+      });
 
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
 
-    propPane.UpdatePropertyFieldValue(
-      "Text",
-      `{{MultiSelect1.selectedOptionLabels.toString()}}:{{MultiSelect1.selectedOptionValues.toString()}}`,
-    );
+      assertHelper.AssertNetworkStatus("@postExecute");
 
-    [
-      {
-        label: "Andrew",
-        text: "Andrew:Fuller",
-      },
-      {
-        label: "Janet",
-        text: "Andrew,Janet:Fuller,Leverling",
-      },
-      {
-        label: "Margaret",
-        text: "Andrew,Janet,Margaret:Fuller,Leverling,Peacock",
-      },
-    ].forEach((d) => {
-      cy.get(formWidgetsPage.multiSelectWidget)
-        .find(".rc-select-selector")
-        .click({
+      agHelper.Sleep(2000);
+
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
+
+      propPane.UpdatePropertyFieldValue(
+        "Text",
+        `{{MultiSelect1.selectedOptionLabels.toString()}}:{{MultiSelect1.selectedOptionValues.toString()}}`,
+      );
+
+      [
+        {
+          label: "Andrew",
+          text: "Andrew:Fuller",
+        },
+        {
+          label: "Janet",
+          text: "Andrew,Janet:Fuller,Leverling",
+        },
+        {
+          label: "Margaret",
+          text: "Andrew,Janet,Margaret:Fuller,Leverling,Peacock",
+        },
+      ].forEach((d) => {
+        cy.get(formWidgetsPage.multiSelectWidget)
+          .find(".rc-select-selector")
+          .click({
+            force: true,
+          });
+
+        cy.get(".rc-select-item").contains(d.label).click({
           force: true,
         });
+        cy.get(commonlocators.TextInside).first().should("have.text", d.text);
+      });
 
-      cy.get(".rc-select-item").contains(d.label).click({
+      agHelper.Sleep(2000);
+
+      cy.get(formWidgetsPage.multiSelectWidgetSearch).type("Anne", {
         force: true,
       });
-      cy.get(commonlocators.TextInside).first().should("have.text", d.text);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      cy.get(".rc-select-item").contains("Anne").should("exist");
     });
-
-    agHelper.Sleep(2000);
-
-    cy.get(formWidgetsPage.multiSelectWidgetSearch).type("Anne", {
-      force: true,
-    });
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    cy.get(".rc-select-item").contains("Anne").should("exist");
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/mongoDB_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/mongoDB_spec.ts
@@ -17,81 +17,85 @@ import EditorNavigation, {
 
 const oneClickBinding = new OneClickBinding();
 
-describe("Table widget one click binding feature", () => {
-  it("should check that queries are created and bound to table widget properly", () => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.SELECT, 450, 200);
+describe(
+  "Table widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    it("should check that queries are created and bound to table widget properly", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.SELECT, 450, 200);
 
-    dataSources.CreateDataSource("Mongo");
+      dataSources.CreateDataSource("Mongo");
 
-    cy.get("@dsName").then((dsName) => {
-      EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
+      cy.get("@dsName").then((dsName) => {
+        EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
 
-      oneClickBinding.ChooseAndAssertForm(`${dsName}`, dsName, "netflix", {
-        label: "name",
-        value: "director",
+        oneClickBinding.ChooseAndAssertForm(`${dsName}`, dsName, "netflix", {
+          label: "name",
+          value: "director",
+        });
       });
-    });
 
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
 
-    assertHelper.AssertNetworkStatus("@postExecute");
+      assertHelper.AssertNetworkStatus("@postExecute");
 
-    agHelper.Sleep(2000);
+      agHelper.Sleep(2000);
 
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
 
-    propPane.UpdatePropertyFieldValue(
-      "Text",
-      `{{Select1.selectedOptionLabel}}:{{Select1.selectedOptionValue}}`,
-    );
+      propPane.UpdatePropertyFieldValue(
+        "Text",
+        `{{Select1.selectedOptionLabel}}:{{Select1.selectedOptionValue}}`,
+      );
 
-    [
-      {
-        label: "I Care a Lot",
-        text: "I Care a Lot:J Blakeson",
-      },
-      {
-        label: "tick, tick...BOOM!",
-        text: "tick, tick...BOOM!:Lin-Manuel Miranda",
-      },
-      {
-        label: "Munich – The Edge of War",
-        text: "Munich – The Edge of War:Christian Schwochow",
-      },
-    ].forEach((d) => {
+      [
+        {
+          label: "I Care a Lot",
+          text: "I Care a Lot:J Blakeson",
+        },
+        {
+          label: "tick, tick...BOOM!",
+          text: "tick, tick...BOOM!:Lin-Manuel Miranda",
+        },
+        {
+          label: "Munich – The Edge of War",
+          text: "Munich – The Edge of War:Christian Schwochow",
+        },
+      ].forEach((d) => {
+        cy.get(formWidgetsPage.selectWidget)
+          .find(widgetsPage.dropdownSingleSelect)
+          .click({
+            force: true,
+          });
+
+        cy.get(commonlocators.singleSelectWidgetMenuItem)
+          .contains(d.label)
+          .click({
+            force: true,
+          });
+
+        cy.get(commonlocators.TextInside).first().should("have.text", d.text);
+      });
+
       cy.get(formWidgetsPage.selectWidget)
         .find(widgetsPage.dropdownSingleSelect)
         .click({
           force: true,
         });
 
-      cy.get(commonlocators.singleSelectWidgetMenuItem)
-        .contains(d.label)
-        .click({
-          force: true,
-        });
+      cy.get(commonlocators.selectInputSearch).type("I Care a Lot");
 
-      cy.get(commonlocators.TextInside).first().should("have.text", d.text);
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      cy.get(".select-popover-wrapper .menu-item-link")
+        .children()
+        .should("have.length", 1);
+
+      agHelper.AssertElementExist(
+        commonlocators.singleSelectWidgetMenuItem + `:contains(I Care a Lot)`,
+      );
     });
-
-    cy.get(formWidgetsPage.selectWidget)
-      .find(widgetsPage.dropdownSingleSelect)
-      .click({
-        force: true,
-      });
-
-    cy.get(commonlocators.selectInputSearch).type("I Care a Lot");
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    cy.get(".select-popover-wrapper .menu-item-link")
-      .children()
-      .should("have.length", 1);
-
-    agHelper.AssertElementExist(
-      commonlocators.singleSelectWidgetMenuItem + `:contains(I Care a Lot)`,
-    );
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/postgres_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/postgres_spec.ts
@@ -17,86 +17,90 @@ import EditorNavigation, {
 
 const oneClickBinding = new OneClickBinding();
 
-describe("Table widget one click binding feature", () => {
-  it("should check that queries are created and bound to table widget properly", () => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.SELECT, 450, 200);
+describe(
+  "Table widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    it("should check that queries are created and bound to table widget properly", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.SELECT, 450, 200);
 
-    dataSources.CreateDataSource("Postgres");
+      dataSources.CreateDataSource("Postgres");
 
-    cy.get("@dsName").then((dsName) => {
-      EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
+      cy.get("@dsName").then((dsName) => {
+        EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
 
-      oneClickBinding.ChooseAndAssertForm(
-        `${dsName}`,
-        dsName,
-        "public.employees",
-        {
-          label: "first_name",
-          value: "last_name",
-        },
+        oneClickBinding.ChooseAndAssertForm(
+          `${dsName}`,
+          dsName,
+          "public.employees",
+          {
+            label: "first_name",
+            value: "last_name",
+          },
+        );
+      });
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
+
+      propPane.UpdatePropertyFieldValue(
+        "Text",
+        `{{Select1.selectedOptionLabel}}:{{Select1.selectedOptionValue}}`,
       );
-    });
 
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
+      [
+        {
+          label: "Andrew",
+          text: "Andrew:Fuller",
+        },
+        {
+          label: "Janet",
+          text: "Janet:Leverling",
+        },
+        {
+          label: "Margaret",
+          text: "Margaret:Peacock",
+        },
+      ].forEach((d) => {
+        cy.get(formWidgetsPage.selectWidget)
+          .find(widgetsPage.dropdownSingleSelect)
+          .click({
+            force: true,
+          });
 
-    assertHelper.AssertNetworkStatus("@postExecute");
+        cy.get(commonlocators.singleSelectWidgetMenuItem)
+          .contains(d.label)
+          .click({
+            force: true,
+          });
 
-    agHelper.Sleep(2000);
+        cy.get(commonlocators.TextInside).first().should("have.text", d.text);
+      });
 
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 450, 500);
-
-    propPane.UpdatePropertyFieldValue(
-      "Text",
-      `{{Select1.selectedOptionLabel}}:{{Select1.selectedOptionValue}}`,
-    );
-
-    [
-      {
-        label: "Andrew",
-        text: "Andrew:Fuller",
-      },
-      {
-        label: "Janet",
-        text: "Janet:Leverling",
-      },
-      {
-        label: "Margaret",
-        text: "Margaret:Peacock",
-      },
-    ].forEach((d) => {
       cy.get(formWidgetsPage.selectWidget)
         .find(widgetsPage.dropdownSingleSelect)
         .click({
           force: true,
         });
 
-      cy.get(commonlocators.singleSelectWidgetMenuItem)
-        .contains(d.label)
-        .click({
-          force: true,
-        });
+      cy.get(commonlocators.selectInputSearch).type("Anne");
 
-      cy.get(commonlocators.TextInside).first().should("have.text", d.text);
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      cy.get(".select-popover-wrapper .menu-item-link")
+        .children()
+        .should("have.length", 1);
+
+      agHelper.AssertElementExist(
+        commonlocators.singleSelectWidgetMenuItem + `:contains(Anne)`,
+      );
     });
-
-    cy.get(formWidgetsPage.selectWidget)
-      .find(widgetsPage.dropdownSingleSelect)
-      .click({
-        force: true,
-      });
-
-    cy.get(commonlocators.selectInputSearch).type("Anne");
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    cy.get(".select-popover-wrapper .menu-item-link")
-      .children()
-      .should("have.length", 1);
-
-    agHelper.AssertElementExist(
-      commonlocators.singleSelectWidgetMenuItem + `:contains(Anne)`,
-    );
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/index_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/index_spec.ts
@@ -4,16 +4,20 @@ import EditorNavigation, {
   EntityType,
 } from "../../../../../support/Pages/EditorNavigation";
 
-describe("Table widget one click binding feature", () => {
-  it("1.should check that connect data overlay is shown on the table", () => {
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE);
-    _.agHelper.AssertElementExist(_.table._connectDataHeader);
-    _.agHelper.AssertElementExist(_.table._connectDataButton);
-    // should check that tableData one click property control"
-    EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+describe(
+  "Table widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    it("1.should check that connect data overlay is shown on the table", () => {
+      _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE);
+      _.agHelper.AssertElementExist(_.table._connectDataHeader);
+      _.agHelper.AssertElementExist(_.table._connectDataButton);
+      // should check that tableData one click property control"
+      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
 
-    _.agHelper.AssertElementExist(
-      oneClickBindingLocator.datasourceDropdownSelector,
-    );
-  });
-});
+      _.agHelper.AssertElementExist(
+        oneClickBindingLocator.datasourceDropdownSelector,
+      );
+    });
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/mongoDB_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/mongoDB_spec.ts
@@ -14,86 +14,90 @@ import EditorNavigation, {
 
 const oneClickBinding = new OneClickBinding();
 
-describe("one click binding mongodb datasource", function () {
-  before(() => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 450, 200);
-  });
+describe(
+  "one click binding mongodb datasource",
+  { tags: ["@tag.Binding"] },
+  function () {
+    before(() => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 450, 200);
+    });
 
-  it("1. test connect datasource", () => {
-    //#region bind to mongoDB datasource
-    dataSources.CreateDataSource("Mongo");
+    it("1. test connect datasource", () => {
+      //#region bind to mongoDB datasource
+      dataSources.CreateDataSource("Mongo");
 
-    cy.get("@dsName").then((dsName) => {
-      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+      cy.get("@dsName").then((dsName) => {
+        EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
 
-      oneClickBinding.ChooseAndAssertForm(`${dsName}`, dsName, "netflix", {
-        searchableColumn: "creator",
+        oneClickBinding.ChooseAndAssertForm(`${dsName}`, dsName, "netflix", {
+          searchableColumn: "creator",
+        });
       });
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+      //#endregion
+
+      //#region validate search through table is working
+      const rowWithAValidText = "Mike Flanagan";
+      //enter a search text
+      agHelper.TypeText(table._searchInput, rowWithAValidText);
+      agHelper.Sleep();
+      // check if the table rows are present for the given search entry
+      agHelper.GetNAssertContains(
+        oneClickBindingLocator.validTableRowData,
+        rowWithAValidText,
+      );
+      //#endregion
+
+      //#region table update operation is working
+      const someColumnIndex = 1;
+      const someUUID = Cypress._.random(0, 1e6);
+      const enteredSomeValue = "123" + someUUID;
+
+      //update the first value of the row
+      table.EditTableCell(0, someColumnIndex, enteredSomeValue);
+      agHelper.Sleep();
+      //commit that update
+      (cy as any).saveTableRow(12, 0);
+
+      agHelper.Sleep();
+
+      // check if the updated value is present
+      (cy as any).readTableV2data(0, someColumnIndex).then((cellData: any) => {
+        expect(cellData).to.equal(enteredSomeValue);
+      });
+      //#endregion
+
+      //#region check if the table insert operation works
+      //clear input
+      table.ResetSearch();
+
+      //lets create a new row and check to see the insert operation is working
+      table.AddNewRow();
+
+      const someText = "new row " + Cypress._.random(0, 1e6);
+      const searchColumnIndex = 3;
+      table.EditTableCell(0, searchColumnIndex, someText);
+      (cy as any).saveTableCellValue(searchColumnIndex, 0);
+      // save a row with some random text
+      agHelper.GetNClick(table._saveNewRow, 0, true);
+
+      agHelper.Sleep(2000);
+
+      //search the table for a row having the text used to create a new row
+      agHelper.ClearNType(table._searchInput, someText);
+      agHelper.Sleep();
+
+      //check if that row is present
+      agHelper.GetNAssertContains(
+        oneClickBindingLocator.validTableRowData,
+        someText,
+      );
+      //#endregion
     });
-
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-    //#endregion
-
-    //#region validate search through table is working
-    const rowWithAValidText = "Mike Flanagan";
-    //enter a search text
-    agHelper.TypeText(table._searchInput, rowWithAValidText);
-    agHelper.Sleep();
-    // check if the table rows are present for the given search entry
-    agHelper.GetNAssertContains(
-      oneClickBindingLocator.validTableRowData,
-      rowWithAValidText,
-    );
-    //#endregion
-
-    //#region table update operation is working
-    const someColumnIndex = 1;
-    const someUUID = Cypress._.random(0, 1e6);
-    const enteredSomeValue = "123" + someUUID;
-
-    //update the first value of the row
-    table.EditTableCell(0, someColumnIndex, enteredSomeValue);
-    agHelper.Sleep();
-    //commit that update
-    (cy as any).saveTableRow(12, 0);
-
-    agHelper.Sleep();
-
-    // check if the updated value is present
-    (cy as any).readTableV2data(0, someColumnIndex).then((cellData: any) => {
-      expect(cellData).to.equal(enteredSomeValue);
-    });
-    //#endregion
-
-    //#region check if the table insert operation works
-    //clear input
-    table.ResetSearch();
-
-    //lets create a new row and check to see the insert operation is working
-    table.AddNewRow();
-
-    const someText = "new row " + Cypress._.random(0, 1e6);
-    const searchColumnIndex = 3;
-    table.EditTableCell(0, searchColumnIndex, someText);
-    (cy as any).saveTableCellValue(searchColumnIndex, 0);
-    // save a row with some random text
-    agHelper.GetNClick(table._saveNewRow, 0, true);
-
-    agHelper.Sleep(2000);
-
-    //search the table for a row having the text used to create a new row
-    agHelper.ClearNType(table._searchInput, someText);
-    agHelper.Sleep();
-
-    //check if that row is present
-    agHelper.GetNAssertContains(
-      oneClickBindingLocator.validTableRowData,
-      someText,
-    );
-    //#endregion
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/postgres_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/postgres_spec.ts
@@ -14,112 +14,116 @@ import EditorNavigation, {
 
 const oneClickBinding = new OneClickBinding();
 
-describe("Table widget one click binding feature", () => {
-  it("should check that queries are created and bound to table widget properly", () => {
-    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 450, 200);
+describe(
+  "Table widget one click binding feature",
+  { tags: ["@tag.Binding"] },
+  () => {
+    it("should check that queries are created and bound to table widget properly", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 450, 200);
 
-    dataSources.CreateDataSource("Postgres");
+      dataSources.CreateDataSource("Postgres");
 
-    cy.get("@dsName").then((dsName) => {
-      EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
+      cy.get("@dsName").then((dsName) => {
+        EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
 
-      oneClickBinding.ChooseAndAssertForm(
-        `${dsName}`,
-        dsName,
-        "public.employees",
-        {
-          searchableColumn: "first_name",
-        },
-      );
+        oneClickBinding.ChooseAndAssertForm(
+          `${dsName}`,
+          dsName,
+          "public.employees",
+          {
+            searchableColumn: "first_name",
+          },
+        );
+      });
+
+      agHelper.GetNClick(oneClickBindingLocator.connectData);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      [
+        "employee_id",
+        "last_name",
+        "first_name",
+        "title",
+        "title_of_courtesy",
+        "birth_date",
+        "hire_date",
+      ].forEach((column) => {
+        agHelper.AssertElementExist(table._headerCell(column));
+      });
+
+      agHelper.AssertElementExist(table._showPageItemsCount);
+
+      table.AddNewRow();
+
+      //const randomNumber = Cypress._.random(10, 100, false);
+      //cy.log("randomeNumber: " + randomNumber);
+
+      // table.EditTableCell(0, 0, randomNumber.toString(), false);//Bug 24623 - since 2 digit id is not typed properly
+      table.UpdateTableCell(0, 1, "_");
+      table.UpdateTableCell(0, 2, "appsmith_");
+
+      agHelper.GetNClick(oneClickBindingLocator.dateInput, 0, true);
+      agHelper.GetNClick(oneClickBindingLocator.dayViewFromDate, 0, true);
+
+      agHelper.GetNClick(oneClickBindingLocator.dateInput, 1, true);
+      agHelper.GetNClick(oneClickBindingLocator.dayViewFromDate, 0, true);
+
+      table.UpdateTableCell(0, 16, "1");
+
+      agHelper.Sleep(2000);
+
+      agHelper.GetNClick(table._saveNewRow, 0, true);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.TypeText(table._searchInput, "appsmith_");
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.AssertElementExist(table._bodyCell("appsmith_"));
+
+      agHelper.Sleep();
+
+      //(cy as any).editTableCell(1, 0);
+
+      agHelper.Sleep(500);
+
+      table.EditTableCell(0, 2, "cypress");
+
+      //(cy as any).enterTableCellValue(1, 0, "automation@appsmith{enter}");
+
+      agHelper.Sleep();
+
+      (cy as any).AssertTableRowSavable(18, 0);
+
+      (cy as any).saveTableRow(18, 0);
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(500);
+      agHelper.ClearNType(table._searchInput, "cypress");
+
+      assertHelper.AssertNetworkStatus("@postExecute");
+
+      agHelper.Sleep(2000);
+
+      agHelper.AssertElementExist(table._bodyCell("cypress"));
+
+      //TODO: Commenting out until cypress double click issue is resolved.
+      // agHelper.ClearTextField(table._searchInput);
+
+      // agHelper.TypeText(table._searchInput, "appsmith_");
+
+      // assertHelper.AssertNetworkStatus("@postExecute");
+
+      // agHelper.Sleep(2000);
+
+      // agHelper.AssertElementAbsence(table._bodyCell("appsmith_"));
     });
-
-    agHelper.GetNClick(oneClickBindingLocator.connectData);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    [
-      "employee_id",
-      "last_name",
-      "first_name",
-      "title",
-      "title_of_courtesy",
-      "birth_date",
-      "hire_date",
-    ].forEach((column) => {
-      agHelper.AssertElementExist(table._headerCell(column));
-    });
-
-    agHelper.AssertElementExist(table._showPageItemsCount);
-
-    table.AddNewRow();
-
-    //const randomNumber = Cypress._.random(10, 100, false);
-    //cy.log("randomeNumber: " + randomNumber);
-
-    // table.EditTableCell(0, 0, randomNumber.toString(), false);//Bug 24623 - since 2 digit id is not typed properly
-    table.UpdateTableCell(0, 1, "_");
-    table.UpdateTableCell(0, 2, "appsmith_");
-
-    agHelper.GetNClick(oneClickBindingLocator.dateInput, 0, true);
-    agHelper.GetNClick(oneClickBindingLocator.dayViewFromDate, 0, true);
-
-    agHelper.GetNClick(oneClickBindingLocator.dateInput, 1, true);
-    agHelper.GetNClick(oneClickBindingLocator.dayViewFromDate, 0, true);
-
-    table.UpdateTableCell(0, 16, "1");
-
-    agHelper.Sleep(2000);
-
-    agHelper.GetNClick(table._saveNewRow, 0, true);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.TypeText(table._searchInput, "appsmith_");
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.AssertElementExist(table._bodyCell("appsmith_"));
-
-    agHelper.Sleep();
-
-    //(cy as any).editTableCell(1, 0);
-
-    agHelper.Sleep(500);
-
-    table.EditTableCell(0, 2, "cypress");
-
-    //(cy as any).enterTableCellValue(1, 0, "automation@appsmith{enter}");
-
-    agHelper.Sleep();
-
-    (cy as any).AssertTableRowSavable(18, 0);
-
-    (cy as any).saveTableRow(18, 0);
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(500);
-    agHelper.ClearNType(table._searchInput, "cypress");
-
-    assertHelper.AssertNetworkStatus("@postExecute");
-
-    agHelper.Sleep(2000);
-
-    agHelper.AssertElementExist(table._bodyCell("cypress"));
-
-    //TODO: Commenting out until cypress double click issue is resolved.
-    // agHelper.ClearTextField(table._searchInput);
-
-    // agHelper.TypeText(table._searchInput, "appsmith_");
-
-    // assertHelper.AssertNetworkStatus("@postExecute");
-
-    // agHelper.Sleep(2000);
-
-    // agHelper.AssertElementAbsence(table._bodyCell("appsmith_"));
-  });
-});
+  },
+);


### PR DESCRIPTION
## Description
> Added tags to cases in 
- cypress/e2e/Regression/ClientSide/OneClickBinding

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
> /ok-to-test tags="@tag.Binding"

#### How Has This Been Tested?
- [ ] Manual
- [ ] Cypress


## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced end-to-end test coverage with new test cases and tags for better organization.
  - Improved existing test cases for the JSONForm and Table widgets, including additional assertions and interactions.
  - Synchronized test execution with application behavior through added waits.
  - Expanded test scenarios for one-click binding features across various widgets and data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->