### PR TITLE
fix: Show connect your data prompt correctly

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStarterLayoutPrompt.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStarterLayoutPrompt.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   Popover,
   PopoverContent,
@@ -32,6 +32,7 @@ import { INTEGRATION_TABS } from "constants/routes";
 import { Colors } from "constants/Colors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { STARTER_BUILDING_BLOCK_TEMPLATE_NAME } from "constants/TemplatesConstants";
+import { useAppWideAndOtherDatasource } from "@appsmith/pages/Editor/Explorer/hooks";
 
 function DatasourceStarterLayoutPrompt() {
   const dispatch = useDispatch();
@@ -45,12 +46,21 @@ function DatasourceStarterLayoutPrompt() {
   const buildingBlockSourcePageId = useSelector(
     buildingBlocksSourcePageIdSelector,
   );
+  const { appWideDS } = useAppWideAndOtherDatasource();
 
   const disablePrompt = () =>
     dispatch(hideStarterBuildingBlockDatasourcePrompt());
 
-  const showActivePageDatasourcePrompt =
-    buildingBlockSourcePageId === pageId && showDatasourcePrompt;
+  const showActivePageDatasourcePrompt = useMemo(
+    () =>
+      buildingBlockSourcePageId === pageId &&
+      showDatasourcePrompt &&
+      // Here we are checking, if user already has some datasources added to the application
+      // in few cases user go through "start with data" and then "forks a starter building block from canvas"
+      // this condition prevents showing the popup if datasource is already connected.
+      appWideDS.length === 1,
+    [buildingBlockSourcePageId, pageId, showDatasourcePrompt, appWideDS],
+  );
 
   const onClickConnect = useCallback(() => {
     dispatch(hideStarterBuildingBlockDatasourcePrompt());


### PR DESCRIPTION

## Description

**Problem** 
We noticed that some users go through "start with data" option and then "forks a starter building block from canvas", this condition prevents showing the popup if datasource is already connected.

With this PR we add a check, to ensure that if user already has some datasources then it prevents showing the popup if datasource is already connected.

#### PR fixes following issue(s)
Fixes #29680

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for displaying the datasource prompt in the editor to enhance user experience.
  - Optimized data retrieval for app-wide datasources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->