### PR TITLE
ci: Skip TBD for every push on release branch

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -7,7 +7,7 @@ on:
   # This line enables manual triggering of this workflow.
   workflow_dispatch:
 
-  # trigger for pushes to release and master
+  # trigger for pushes to master
   push:
     branches: [master]
     paths:

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -9,7 +9,7 @@ on:
 
   # trigger for pushes to release and master
   push:
-    branches: [release]
+    branches: [master]
     paths:
       - "app/client/**"
       - "app/server/**"


### PR DESCRIPTION
## Description
- Skipping TBD for every push on release branch
- TBD will run once a day on the scheduled cron
- People can still run TBD on-demand

#### Type of change
- Workflow Change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the CI/CD workflow to trigger Docker image builds on pushes to the "master" branch instead of the "release" branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->