### PR TITLE
fix: WDS PhoneInput input area displays “+” & country code in different lines

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/TextInput/stories/TextInput.stories.mdx
+++ b/app/client/packages/design-system/widgets/src/components/TextInput/stories/TextInput.stories.mdx
@@ -67,7 +67,7 @@ TextInput is a component that allows users to input text.
   name="Prefix"
   args={{
     placeholder: "Start Visual",
-    startIcon: "+11",
+    startIcon: "$",
   }}
 >
   {Template.bind({})}

--- a/app/client/packages/design-system/widgets/src/components/TextInput/stories/TextInput.stories.mdx
+++ b/app/client/packages/design-system/widgets/src/components/TextInput/stories/TextInput.stories.mdx
@@ -67,7 +67,7 @@ TextInput is a component that allows users to input text.
   name="Prefix"
   args={{
     placeholder: "Start Visual",
-    startIcon: "$",
+    startIcon: "+11",
   }}
 >
   {Template.bind({})}

--- a/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
+++ b/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
@@ -111,11 +111,11 @@
   * START ICON AND END ICON
   *-----------------------------------------------------------------------------
   */
-  & [data-field-input-start-icon] {
+  & [data-field-input-start-icon] div {
     width: max-content;
   }
 
-  & [data-field-input-end-icon] {
+  & [data-field-input-end-icon] div {
     width: max-content;
   }
 }


### PR DESCRIPTION
Fixes #29362 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `TextInput` component documentation to reflect the new `startIcon` property change.

- **Style**
  - Adjusted CSS selectors for improved targeting of start and end icons within text input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->