### PR TITLE
feat: add readonly mode to input

### DIFF
--- a/app/client/packages/design-system/headless/src/components/Field/src/Field.tsx
+++ b/app/client/packages/design-system/headless/src/components/Field/src/Field.tsx
@@ -31,6 +31,7 @@ const _Field = (props: FieldProps, ref: FieldRef) => {
     helpTextClassName,
     includeNecessityIndicatorInAccessibilityName,
     isDisabled = false,
+    isReadOnly = false,
     isRequired,
     label,
     labelClassName,
@@ -40,6 +41,8 @@ const _Field = (props: FieldProps, ref: FieldRef) => {
     wrapperClassName,
     wrapperProps = {},
   } = props;
+
+  const getDisabledState = () => Boolean(isDisabled) && !Boolean(isReadOnly);
 
   const hasHelpText =
     Boolean(description) ||
@@ -53,7 +56,7 @@ const _Field = (props: FieldProps, ref: FieldRef) => {
         descriptionProps={descriptionProps}
         errorMessage={errorMessage}
         errorMessageProps={errorMessageProps}
-        isDisabled={isDisabled}
+        isDisabled={getDisabledState()}
         validationState={validationState}
       />
     );
@@ -84,9 +87,10 @@ const _Field = (props: FieldProps, ref: FieldRef) => {
     <div
       {...wrapperProps}
       className={wrapperClassName}
-      data-disabled={Boolean(isDisabled) ? "" : undefined}
+      data-disabled={getDisabledState() ? "" : undefined}
       data-field=""
       data-field-type={fieldType}
+      data-readonly={Boolean(isReadOnly) ? "" : undefined}
       ref={ref}
     >
       {labelAndContextualHelp}

--- a/app/client/packages/design-system/headless/src/components/Field/src/Field.tsx
+++ b/app/client/packages/design-system/headless/src/components/Field/src/Field.tsx
@@ -42,6 +42,7 @@ const _Field = (props: FieldProps, ref: FieldRef) => {
     wrapperProps = {},
   } = props;
 
+  // Readonly has a higher priority than disabled.
   const getDisabledState = () => Boolean(isDisabled) && !Boolean(isReadOnly);
 
   const hasHelpText =

--- a/app/client/packages/design-system/headless/src/components/TextInputBase/src/TextInputBase.tsx
+++ b/app/client/packages/design-system/headless/src/components/TextInputBase/src/TextInputBase.tsx
@@ -19,6 +19,7 @@ function TextInputBase(props: TextInputBaseProps, ref: Ref<HTMLDivElement>) {
     inputRef: userInputRef,
     isDisabled = false,
     isLoading = false,
+    isReadOnly = false,
     labelProps,
     multiLine = false,
     onBlur,
@@ -28,7 +29,11 @@ function TextInputBase(props: TextInputBaseProps, ref: Ref<HTMLDivElement>) {
     suffix,
     validationState,
   } = props;
-  const { hoverProps, isHovered } = useHover({ isDisabled });
+  const getDisabledState = () => isDisabled && !isReadOnly;
+
+  const { hoverProps, isHovered } = useHover({
+    isDisabled: getDisabledState(),
+  });
   const domRef = useRef<HTMLDivElement>(null);
   const defaultInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const inputRef = userInputRef ?? defaultInputRef;
@@ -36,7 +41,10 @@ function TextInputBase(props: TextInputBaseProps, ref: Ref<HTMLDivElement>) {
   const ElementType: React.ElementType = Boolean(multiLine)
     ? "textarea"
     : "input";
-  const isInvalid = validationState === "invalid" && !Boolean(isDisabled);
+  const isInvalid =
+    validationState === "invalid" &&
+    !Boolean(isDisabled) &&
+    !Boolean(isReadOnly);
 
   const { focusProps, isFocused, isFocusVisible } = useFocusRing({
     isTextInput: true,
@@ -44,7 +52,7 @@ function TextInputBase(props: TextInputBaseProps, ref: Ref<HTMLDivElement>) {
   });
 
   const { focusableProps } = useFocusable(
-    { isDisabled, onFocus: onFocus, onBlur: onBlur },
+    { isDisabled: getDisabledState(), onFocus: onFocus, onBlur: onBlur },
     inputRef,
   );
 
@@ -56,12 +64,15 @@ function TextInputBase(props: TextInputBaseProps, ref: Ref<HTMLDivElement>) {
   const inputField = (
     <div
       aria-busy={isLoading ? true : undefined}
-      data-disabled={isDisabled ? "" : undefined}
+      data-disabled={getDisabledState() ? "" : undefined}
       data-field-input=""
-      data-focused={isFocusVisible || isFocused ? "" : undefined}
+      data-focused={
+        isFocusVisible || (isFocused && !isReadOnly) ? "" : undefined
+      }
       data-hovered={isHovered ? "" : undefined}
       data-invalid={isInvalid ? "" : undefined}
       data-loading={isLoading ? "" : undefined}
+      data-readonly={isReadOnly ? "" : undefined}
       onClick={focusInput}
       ref={ref}
     >
@@ -71,6 +82,8 @@ function TextInputBase(props: TextInputBaseProps, ref: Ref<HTMLDivElement>) {
       <ElementType
         {...mergeProps(inputProps, hoverProps, focusProps, focusableProps)}
         className={inputClassName}
+        disabled={getDisabledState()}
+        readOnly={isReadOnly}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ref={inputRef as any}
         rows={multiLine ? 1 : undefined}

--- a/app/client/packages/design-system/headless/src/components/TextInputBase/src/TextInputBase.tsx
+++ b/app/client/packages/design-system/headless/src/components/TextInputBase/src/TextInputBase.tsx
@@ -29,6 +29,8 @@ function TextInputBase(props: TextInputBaseProps, ref: Ref<HTMLDivElement>) {
     suffix,
     validationState,
   } = props;
+
+  // Readonly has a higher priority than disabled.
   const getDisabledState = () => isDisabled && !isReadOnly;
 
   const { hoverProps, isHovered } = useHover({

--- a/app/client/packages/design-system/headless/src/components/TextInputBase/src/types.ts
+++ b/app/client/packages/design-system/headless/src/components/TextInputBase/src/types.ts
@@ -20,4 +20,6 @@ export interface TextInputBaseProps
   errorMessageProps?: TextFieldAria["errorMessageProps"];
   /** ref for input component */
   inputRef?: RefObject<HTMLInputElement | HTMLTextAreaElement>;
+  /** Whether the input can be selected but not changed by the user. Readonly has a higher priority than disabled. */
+  isReadOnly?: boolean;
 }

--- a/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
+++ b/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
@@ -1,6 +1,7 @@
 /* NOTE: these input styles are used in text area and text input */
 .text-input {
   & [data-field-input] {
+    position: relative;
     display: flex;
     align-items: center;
     gap: var(--inner-spacing-1);
@@ -19,6 +20,7 @@
     color: var(--color-fg);
     text-overflow: ellipsis;
     width: 100%;
+    padding: 0;
 
     &:autofill,
     &:autofill:hover,
@@ -34,11 +36,32 @@
 
   /**
   * ----------------------------------------------------------------------------
+  * READONLY
+  *-----------------------------------------------------------------------------
+  */
+  & [data-readonly][data-field-input] {
+    box-shadow: none;
+    padding-inline: 0;
+  }
+
+  /**
+  * ----------------------------------------------------------------------------
   * FOCUSSED
   *-----------------------------------------------------------------------------
   */
-  & [data-field-input][data-focused] {
+  & [data-field-input][data-focused]:before {
+    content: "";
+    left: 0;
+    width: 100%;
+    height: 100%;
+    position: absolute;
     box-shadow: 0 0 0 2px var(--color-bd-focus);
+    border-radius: var(--border-radius-1);
+  }
+
+  & [data-readonly][data-field-input][data-focused]:before {
+    left: calc(-0.5 * var(--inner-spacing-1));
+    width: calc(100% + var(--inner-spacing-1));
   }
 
   /**

--- a/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
+++ b/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
@@ -49,6 +49,11 @@
   * FOCUSSED
   *-----------------------------------------------------------------------------
   */
+
+  /**
+  * We use an absolutely positioned pseudo element because
+  * we need to make the focus state in read mode a bit wider than the component width
+  */
   & [data-field-input][data-focused]:before {
     content: "";
     left: 0;

--- a/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
@@ -16,7 +16,6 @@ import {
   ResponsiveBehavior,
 } from "layoutSystems/common/utils/constants";
 import type { FlexProps } from "@design-system/widgets/src/components/Flex/src/types";
-import { WIDGET_PADDING } from "constants/WidgetConstants";
 import { checkIsDropTarget } from "WidgetProvider/factory/helpers";
 import type { AnvilFlexComponentProps } from "../utils/types";
 import {
@@ -131,7 +130,7 @@ export function AnvilFlexComponent(props: AnvilFlexComponentProps) {
       flexShrink: isFillWidget ? 1 : 0,
       flexBasis: isFillWidget ? "0%" : "auto",
       height: "auto",
-      padding: WIDGET_PADDING + "px",
+      padding: "spacing-1",
       width: "auto",
     };
     if (props?.widgetSize) {

--- a/app/client/src/layoutSystems/anvil/utils/AnvilDSLTransformer.ts
+++ b/app/client/src/layoutSystems/anvil/utils/AnvilDSLTransformer.ts
@@ -23,7 +23,7 @@ export function anvilDSLTransformer(dsl: DSLWidget) {
           border: "none",
           height: "100%",
           minHeight: "70vh",
-          padding: "4px 4px 5rem",
+          padding: "spacing-2",
         },
         isDropTarget: true,
         isPermanent: true,

--- a/app/client/src/widgets/wds/WDSBaseInputWidget/component/types.ts
+++ b/app/client/src/widgets/wds/WDSBaseInputWidget/component/types.ts
@@ -20,6 +20,7 @@ export interface BaseInputComponentProps extends ComponentProps {
   isLoading?: boolean;
   placeholder?: string;
   isDisabled?: boolean;
+  isReadOnly?: boolean;
   isRequired?: boolean;
   defaultValue?: string | number;
   onValueChange?: (value: string) => void;

--- a/app/client/src/widgets/wds/WDSBaseInputWidget/widget/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSBaseInputWidget/widget/contentConfig.ts
@@ -104,6 +104,17 @@ export const propertyPaneContentConfig = [
         validation: { type: ValidationTypes.BOOLEAN },
       },
       {
+        helpText:
+          "Whether the input can be selected but not changed by the user. Readonly has a higher priority than disabled.",
+        propertyName: "isReadOnly",
+        label: "Readonly",
+        controlType: "SWITCH",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: { type: ValidationTypes.BOOLEAN },
+      },
+      {
         propertyName: "animateLoading",
         label: "Animate loading",
         controlType: "SWITCH",

--- a/app/client/src/widgets/wds/WDSBaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSBaseInputWidget/widget/index.tsx
@@ -49,6 +49,7 @@ class WDSBaseInputWidget<
       labelStyle: "",
       resetOnSubmit: true,
       isRequired: false,
+      isReadOnly: false,
       isDisabled: false,
       animateLoading: true,
       responsiveBehavior: ResponsiveBehavior.Fill,

--- a/app/client/src/widgets/wds/WDSBaseInputWidget/widget/types.ts
+++ b/app/client/src/widgets/wds/WDSBaseInputWidget/widget/types.ts
@@ -3,6 +3,7 @@ import type { WidgetProps } from "widgets/BaseWidget";
 export interface BaseInputWidgetProps extends WidgetProps {
   text: string;
   isDisabled?: boolean;
+  isReadOnly?: boolean;
   placeholderText?: string;
   isFocused?: boolean;
   autoFocus?: boolean;

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/component/index.tsx
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/component/index.tsx
@@ -15,6 +15,7 @@ export function CurrencyInputComponent(props: CurrencyInputComponentProps) {
       contextualHelp={props.tooltip}
       errorMessage={props.errorMessage}
       isDisabled={props.isDisabled}
+      isReadOnly={props.isReadOnly}
       isRequired={props.isRequired}
       label={props.label}
       onChange={props.onValueChange}

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/config/autocompleteConfig.ts
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/config/autocompleteConfig.ts
@@ -17,6 +17,7 @@ export const autocompleteConfig = {
   isValid: "bool",
   isVisible: DefaultAutocompleteDefinitions.isVisible,
   isDisabled: "bool",
+  isReadOnly: "bool",
   countryCode: {
     "!type": "string",
     "!doc": "Selected country code for Currency",

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/config/settersConfig.ts
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/config/settersConfig.ts
@@ -12,6 +12,10 @@ export const settersConfig = {
       path: "isRequired",
       type: "boolean",
     },
+    setReadOnly: {
+      path: "isReadOnly",
+      type: "boolean",
+    },
     setValue: {
       path: "defaultText",
       type: "string",

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
@@ -277,6 +277,7 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
         errorMessage={validation.errorMessage}
         isDisabled={this.props.isDisabled}
         isLoading={this.props.isLoading}
+        isReadOnly={this.props.isReadOnly}
         isRequired={this.props.isRequired}
         label={this.props.label}
         onCurrencyChange={this.onCurrencyChange}

--- a/app/client/src/widgets/wds/WDSInputWidget/component/index.tsx
+++ b/app/client/src/widgets/wds/WDSInputWidget/component/index.tsx
@@ -95,6 +95,7 @@ function InputComponent(props: InputComponentProps) {
       endIcon={endIcon}
       errorMessage={props.errorMessage}
       isDisabled={props.isDisabled}
+      isReadOnly={props.isReadOnly}
       isRequired={props.isRequired}
       label={props.label}
       max={max}

--- a/app/client/src/widgets/wds/WDSInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSInputWidget/widget/index.tsx
@@ -135,6 +135,7 @@ class WDSInputWidget extends WDSBaseInputWidget<InputWidgetProps, WidgetState> {
       isValid: "bool",
       isVisible: DefaultAutocompleteDefinitions.isVisible,
       isDisabled: "bool",
+      isReadOnly: "bool",
     };
 
     return definitions;
@@ -183,6 +184,10 @@ class WDSInputWidget extends WDSBaseInputWidget<InputWidgetProps, WidgetState> {
         },
         setDisabled: {
           path: "isDisabled",
+          type: "boolean",
+        },
+        setReadOnly: {
+          path: "isReadOnly",
           type: "boolean",
         },
         setRequired: {
@@ -339,6 +344,7 @@ class WDSInputWidget extends WDSBaseInputWidget<InputWidgetProps, WidgetState> {
         inputType={inputType}
         isDisabled={this.props.isDisabled}
         isLoading={this.props.isLoading}
+        isReadOnly={this.props.isReadOnly}
         isRequired={this.props.isRequired}
         label={this.props.label}
         maxChars={this.props.maxChars}

--- a/app/client/src/widgets/wds/WDSInputWidget/widget/propertyPaneConfig/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSInputWidget/widget/propertyPaneConfig/contentConfig.ts
@@ -182,7 +182,7 @@ export const propertyPaneContentConfig = [
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
         hidden: (props: InputWidgetProps) => {
-          //should be shown for only inputWidgetV2 and for email or password input types
+          //should be shown for only inputWidgetV3 and for email or password input types
           return !(
             isInputTypeEmailOrPassword(props?.inputType) &&
             props.type === "INPUT_WIDGET_V3"

--- a/app/client/src/widgets/wds/WDSPhoneInputWidget/component/index.tsx
+++ b/app/client/src/widgets/wds/WDSPhoneInputWidget/component/index.tsx
@@ -16,6 +16,7 @@ export function PhoneInputComponent(props: PhoneInputComponentProps) {
       contextualHelp={props.tooltip}
       errorMessage={props.errorMessage}
       isDisabled={props.isDisabled}
+      isReadOnly={props.isReadOnly}
       label={props.label}
       onChange={props.onValueChange}
       onFocusChange={props.onFocusChange}

--- a/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/config/autocompleteConfig.ts
+++ b/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/config/autocompleteConfig.ts
@@ -17,6 +17,7 @@ export const autocompleteConfig = {
   isValid: "bool",
   isVisible: DefaultAutocompleteDefinitions.isVisible,
   isDisabled: "bool",
+  isReadOnly: "bool",
   countryCode: {
     "!type": "string",
     "!doc": "Selected country code for Phone Number",

--- a/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/config/settersConfig.ts
+++ b/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/config/settersConfig.ts
@@ -8,5 +8,9 @@ export const settersConfig = {
       path: "isDisabled",
       type: "boolean",
     },
+    setReadOnly: {
+      path: "isReadOnly",
+      type: "boolean",
+    },
   },
 };

--- a/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/index.tsx
@@ -268,6 +268,7 @@ class WDSPhoneInputWidget extends WDSBaseInputWidget<
         errorMessage={validation.errorMessage}
         isDisabled={this.props.isDisabled}
         isLoading={this.props.isLoading}
+        isReadOnly={this.props.isReadOnly}
         label={this.props.label}
         onFocusChange={this.onFocusChange}
         onISDCodeChange={this.onISDCodeChange}


### PR DESCRIPTION
## Description
Add readonly mode for input component and widgets

#### PR fixes following issue(s)
Fixes #29145 

#### Media

https://github.com/appsmithorg/appsmith/assets/11555074/2d42a2bf-603b-4b30-a74c-6c1edd408216

![Снимок экрана 2023-12-20 в 20 13 43](https://github.com/appsmithorg/appsmith/assets/11555074/bbb45fee-65ae-4f0b-8681-33713bee079f)

#### Type of change
> Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Read-only" mode for input fields, enabling users to view data without the ability to modify it.

- **Enhancements**
  - Improved input components to respect both disabled and read-only states.
  - Updated widget properties to include read-only configurations.

- **Style Updates**
  - Standardized padding across various components to use spacing variables for consistency.

- **Documentation**
  - Added "Read-only" property documentation to relevant component interfaces and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->