### PR TITLE
fix: Fixed Layout system: Main container background underflow

### DIFF
--- a/app/client/src/pages/Editor/Canvas.tsx
+++ b/app/client/src/pages/Editor/Canvas.tsx
@@ -37,7 +37,6 @@ const Wrapper = styled.section<{
   background: ${({ background }) => background};
   width: ${({ $enableMainCanvasResizer, width }) =>
     $enableMainCanvasResizer ? `100%` : `${width}px`};
-  height: 100%;
 `;
 const Canvas = (props: CanvasProps) => {
   const { canvasWidth } = props;
@@ -83,12 +82,14 @@ const Canvas = (props: CanvasProps) => {
     : `mx-auto`;
   const paddingBottomClass = props.enableMainCanvasResizer ? "" : "pb-52";
 
+  const height = layoutSystemType === LayoutSystemTypes.ANVIL ? "h-full" : "";
+
   const renderChildren = () => {
     return (
       <Wrapper
         $enableMainCanvasResizer={!!props.enableMainCanvasResizer}
         background={isWDSEnabled ? "" : backgroundForCanvas}
-        className={`relative t--canvas-artboard ${paddingBottomClass} transition-all duration-400  ${marginHorizontalClass} ${getViewportClassName(
+        className={`relative t--canvas-artboard ${height} ${paddingBottomClass} transition-all duration-400  ${marginHorizontalClass} ${getViewportClassName(
           canvasWidth,
         )}`}
         data-testid={"t--canvas-artboard"}


### PR DESCRIPTION
## Description
- In the fixed layout system, the background of the canvas fell short of the bottom most widget.
- This was due to an unnecessary `height: 100%` applied to the Fixed layout system.
- Changed the code so that the `height: 100%' is only applied in the Anvil layout system
#### PR fixes following issue(s)
Fixes # (issue number)
#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress PENDING

#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
