### PR TITLE
chore: Remove retrieveById

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
@@ -696,7 +696,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
                             .flatMap(actionCollectionRepository::setUserPermissionsInObject));
 
             Flux<BaseDomain> workspaceFlux = Flux.from(workspaceRepository
-                    .retrieveById(targetWorkspaceId)
+                    .findById(targetWorkspaceId)
                     .flatMap(workspaceRepository::setUserPermissionsInObject));
 
             Mono<Set<String>> permissionGroupIdsMono =

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
@@ -202,7 +202,7 @@ public class UserUtilsCE {
                 .flatMap(instanceConfig -> {
                     JSONObject config = instanceConfig.getConfig();
                     String defaultPermissionGroup = (String) config.getOrDefault(DEFAULT_PERMISSION_GROUP, "");
-                    return permissionGroupRepository.retrieveById(defaultPermissionGroup);
+                    return permissionGroupRepository.findById(defaultPermissionGroup);
                 });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepository.java
@@ -11,17 +11,9 @@ import java.util.Collection;
 public interface BaseRepository<T, ID extends Serializable> extends ReactiveMongoRepository<T, ID> {
 
     /**
-     * This function should be used to get an object from the DB without applying any ACL rules
-     *
-     * @param id The identifier for this type
-     * @return Mono<T>
-     */
-    Mono<T> retrieveById(ID id);
-
-    /**
      * This function sets the deleted flag to true and then saves the modified document.
      *
-     * @param T The entity which needs to be archived
+     * @param entity The entity which needs to be archived
      * @return Mono<T>
      */
     Mono<T> archive(T entity);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
@@ -89,22 +89,6 @@ public class BaseRepositoryImpl<T extends BaseDomain, ID extends Serializable>
     @Override
     public Mono<T> findById(ID id) {
         Assert.notNull(id, "The given id must not be null!");
-        return ReactiveSecurityContextHolder.getContext()
-                .map(ctx -> ctx.getAuthentication())
-                .map(auth -> auth.getPrincipal())
-                .flatMap(principal -> {
-                    Query query = new Query(getIdCriteria(id));
-                    query.addCriteria(notDeleted());
-                    return mongoOperations
-                            .query(entityInformation.getJavaType())
-                            .inCollection(entityInformation.getCollectionName())
-                            .matching(query)
-                            .one();
-                });
-    }
-
-    @Override
-    public Mono<T> retrieveById(ID id) {
         Query query = new Query(getIdCriteria(id));
         query.addCriteria(notDeleted());
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
@@ -227,7 +227,7 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
                                 // Fetch the tenant again from DB to make sure the downstream chain is consuming the
                                 // latest
                                 // DB object and not the modified one because of the client pertinent changes
-                                .then(repository.retrieveById(tenant.getId()))
+                                .then(repository.findById(tenant.getId()))
                                 .flatMap(this::checkAndExecuteMigrationsForTenantFeatureFlags);
                     }
                     return Mono.error(
@@ -240,7 +240,7 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
         if (!StringUtils.hasLength(id)) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ID));
         }
-        return repository.retrieveById(id);
+        return repository.findById(id);
     }
 
     /**


### PR DESCRIPTION
Replaced by `findById`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the data retrieval process by standardizing the use of `findById` method across various services.
  
- **Chores**
  - Removed outdated `retrieveById` method to streamline repository interactions.

- **Documentation**
  - Updated Javadoc to reflect changes in the repository interface methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->