### PR TITLE
chore: Don't query on `deleted` field directly

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -281,11 +281,6 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
                         + fieldName(QApplication.application.gitApplicationMetadata.defaultApplicationId))
                 .is(defaultApplicationId));
         query.addCriteria(notDeleted());
-        query.equals(where("this." + gitApplicationMetadata + "."
-                        + fieldName(QApplication.application.gitApplicationMetadata.branchName))
-                .equals("this." + gitApplicationMetadata + "."
-                        + fieldName(QApplication.application.gitApplicationMetadata.defaultBranchName)));
-
         return mongoOperations.findOne(query, Application.class);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -216,9 +216,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
         Criteria applicationIdCriteria = where(gitApplicationMetadata + "."
                         + fieldName(QApplication.application.gitApplicationMetadata.defaultApplicationId))
                 .is(defaultApplicationId);
-        Criteria deletionCriteria =
-                where(fieldName(QApplication.application.deleted)).ne(true);
-        return queryAll(List.of(applicationIdCriteria, deletionCriteria), permission);
+        return queryAll(List.of(applicationIdCriteria), permission);
     }
 
     /**
@@ -282,7 +280,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
         query.addCriteria(where(gitApplicationMetadata + "."
                         + fieldName(QApplication.application.gitApplicationMetadata.defaultApplicationId))
                 .is(defaultApplicationId));
-        query.addCriteria(where(fieldName(QApplication.application.deleted)).ne(true));
+        query.addCriteria(notDeleted());
         query.equals(where("this." + gitApplicationMetadata + "."
                         + fieldName(QApplication.application.gitApplicationMetadata.branchName))
                 .equals("this." + gitApplicationMetadata + "."

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -627,7 +627,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 group(fieldName(QNewAction.newAction.pluginType)).count().as("count");
         MatchOperation filterStates = match(where(fieldName(QNewAction.newAction.applicationId))
                 .is(applicationId)
-                .andCriteria(notDeleted()));
+                .andOperator(notDeleted()));
         ProjectionOperation projectionOperation = project("count").and("_id").as("pluginType");
         Aggregation aggregation = newAggregation(filterStates, countByPluginType, projectionOperation);
         return mongoOperations.aggregate(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -627,8 +627,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 group(fieldName(QNewAction.newAction.pluginType)).count().as("count");
         MatchOperation filterStates = match(where(fieldName(QNewAction.newAction.applicationId))
                 .is(applicationId)
-                .and(fieldName(QNewAction.newAction.deleted))
-                .ne(Boolean.TRUE));
+                .andCriteria(notDeleted()));
         ProjectionOperation projectionOperation = project("count").and("_id").as("pluginType");
         Aggregation aggregation = newAggregation(filterStates, countByPluginType, projectionOperation);
         return mongoOperations.aggregate(


### PR DESCRIPTION
Use the `notDeleted` query builder function instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for querying applications by introducing more efficient criteria handling.
  - Enhanced the filtering process to more accurately exclude deleted records from aggregation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->