### PR TITLE
fix: Revert "chore: Refactoring multiple environments to use editorId instead of appId"

### DIFF
--- a/app/client/src/ce/actions/applicationActions.ts
+++ b/app/client/src/ce/actions/applicationActions.ts
@@ -219,18 +219,9 @@ export const setIsReconnectingDatasourcesModalOpen = (payload: {
   payload,
 });
 
-export const setWorkspaceIdForImport = ({
-  editorId = "",
-  workspaceId,
-}: {
-  editorId: string;
-  workspaceId?: string;
-}) => ({
+export const setWorkspaceIdForImport = (workspaceId?: string) => ({
   type: ReduxActionTypes.SET_WORKSPACE_ID_FOR_IMPORT,
-  payload: {
-    workspaceId,
-    editorId,
-  },
+  payload: workspaceId,
 });
 
 export const setPageIdForImport = (pageId?: string) => ({

--- a/app/client/src/ce/actions/environmentAction.ts
+++ b/app/client/src/ce/actions/environmentAction.ts
@@ -8,15 +8,10 @@ export const setCurrentEditingEnvironmentID = (currentEditingId: string) => ({
 });
 
 // Redux action to fetch environments
-export const fetchingEnvironmentConfigs = ({
-  editorId,
+export const fetchingEnvironmentConfigs = (
+  workspaceId: string,
   fetchDatasourceMeta = false,
-  workspaceId,
-}: {
-  editorId: string;
-  fetchDatasourceMeta: boolean;
-  workspaceId: string;
-}) => ({
+) => ({
   type: "",
-  payload: { workspaceId, editorId, fetchDatasourceMeta },
+  payload: { workspaceId, fetchDatasourceMeta },
 });

--- a/app/client/src/ce/components/SwitchEnvironment/index.tsx
+++ b/app/client/src/ce/components/SwitchEnvironment/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "@appsmith/selectors/rampSelectors";
 import { isDatasourceInViewMode } from "selectors/ui";
 import { matchDatasourcePath, matchSAASGsheetsPath } from "constants/routes";
+import { useLocation } from "react-router";
 import {
   RAMP_NAME,
   RampFeature,
@@ -47,8 +48,6 @@ const StyledIcon = styled(Icon)`
 
 interface Props {
   viewMode?: boolean;
-  editorId: string;
-  onChangeEnv?: () => void;
 }
 
 interface EnvironmentType {
@@ -75,8 +74,7 @@ const TooltipLink = styled(Link)`
 `;
 
 export default function SwitchEnvironment({}: Props) {
-  const [disableSwitchEnvironment, setDisableSwitchEnvironment] =
-    useState(false);
+  const [diableSwitchEnvironment, setDiableSwitchEnvironment] = useState(false);
   // Fetching feature flags from the store and checking if the feature is enabled
   const showRampSelector = showProductRamps(RAMP_NAME.MULTIPLE_ENV, true);
   const canShowRamp = useSelector(showRampSelector);
@@ -85,14 +83,14 @@ export default function SwitchEnvironment({}: Props) {
     feature: RampFeature.MultipleEnv,
   });
   const rampLink = useSelector(rampLinkSelector);
-
+  const location = useLocation();
   //listen to url change and disable switch environment if datasource page is open
   useEffect(() => {
-    setDisableSwitchEnvironment(
+    setDiableSwitchEnvironment(
       !!matchDatasourcePath(window.location.pathname) ||
         !!matchSAASGsheetsPath(window.location.pathname),
     );
-  }, [window.location.pathname]);
+  }, [location.pathname]);
   //URL for datasource edit and review page is same
   //this parameter helps us to differentiate between the two.
   const isDatasourceViewMode = useSelector(isDatasourceInViewMode);
@@ -127,7 +125,7 @@ export default function SwitchEnvironment({}: Props) {
 
   return (
     <Wrapper
-      aria-disabled={disableSwitchEnvironment && !isDatasourceViewMode}
+      aria-disabled={diableSwitchEnvironment && !isDatasourceViewMode}
       data-testid="t--switch-env"
     >
       <Select
@@ -135,7 +133,7 @@ export default function SwitchEnvironment({}: Props) {
         dropdownClassName="select_environemnt_dropdown"
         getPopupContainer={(triggerNode) => triggerNode.parentNode.parentNode}
         isDisabled={
-          (disableSwitchEnvironment && !isDatasourceViewMode) ||
+          (diableSwitchEnvironment && !isDatasourceViewMode) ||
           environmentList.length === 1
         }
         listHeight={400}

--- a/app/client/src/ce/constants/routes/appRoutes.ts
+++ b/app/client/src/ce/constants/routes/appRoutes.ts
@@ -1,9 +1,6 @@
 // Leaving this require here. The path-to-regexp module has a commonJS version and an ESM one.
 // We are loading the correct one with the typings with our compilerOptions property "moduleResolution" set to "node". Ref: https://stackoverflow.com/questions/59013618/unable-to-find-module-path-to-regexp
 // All solutions from closed issues on their repo have been tried. Ref: https://github.com/pillarjs/path-to-regexp/issues/193
-
-import { matchPath } from "react-router";
-
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { match } = require("path-to-regexp");
 
@@ -72,19 +69,12 @@ export const APP_STATE_PATH = `/:appState`;
 
 export const matchApiBasePath = match(API_EDITOR_BASE_PATH);
 export const matchApiPath = match(API_EDITOR_ID_PATH);
-export const matchDatasourcePath = (pathname: string) =>
-  matchPath(pathname, {
-    path: [`${BUILDER_PATH}${DATA_SOURCES_EDITOR_ID_PATH}`],
-    strict: false,
-    exact: false,
-  });
-
-export const matchSAASGsheetsPath = (pathname: string) =>
-  matchPath(pathname, {
-    path: [`${BUILDER_PATH}${SAAS_GSHEET_EDITOR_ID_PATH}`],
-    strict: false,
-    exact: false,
-  });
+export const matchDatasourcePath = match(
+  `${BUILDER_PATH}${DATA_SOURCES_EDITOR_ID_PATH}`,
+);
+export const matchSAASGsheetsPath = match(
+  `${BUILDER_PATH}${SAAS_GSHEET_EDITOR_ID_PATH}`,
+);
 export const matchQueryBasePath = match(QUERIES_EDITOR_BASE_PATH);
 export const matchQueryPath = match(QUERIES_EDITOR_ID_PATH);
 export const matchQueryBuilderPath = match(

--- a/app/client/src/ce/pages/Applications/CreateNewAppsOption.tsx
+++ b/app/client/src/ce/pages/Applications/CreateNewAppsOption.tsx
@@ -226,13 +226,7 @@ const CreateNewAppsOption = ({
     dispatch(fetchPlugins());
     dispatch(fetchMockDatasources());
     if (application?.workspaceId) {
-      dispatch(
-        fetchingEnvironmentConfigs({
-          editorId: application.id,
-          fetchDatasourceMeta: true,
-          workspaceId: application?.workspaceId,
-        }),
-      );
+      dispatch(fetchingEnvironmentConfigs(application?.workspaceId, true));
     }
     setUseType(START_WITH_TYPE.DATA);
   };

--- a/app/client/src/ce/reducers/uiReducers/applicationsReducer.tsx
+++ b/app/client/src/ce/reducers/uiReducers/applicationsReducer.tsx
@@ -644,11 +644,11 @@ export const handlers = {
   }),
   [ReduxActionTypes.SET_WORKSPACE_ID_FOR_IMPORT]: (
     state: ApplicationsReduxState,
-    action: ReduxAction<{ workspaceId: string }>,
+    action: ReduxAction<string>,
   ) => {
     return {
       ...state,
-      workspaceIdForImport: action.payload.workspaceId,
+      workspaceIdForImport: action.payload,
     };
   },
   [ReduxActionTypes.SET_PAGE_ID_FOR_IMPORT]: (

--- a/app/client/src/ce/sagas/ApplicationSagas.tsx
+++ b/app/client/src/ce/sagas/ApplicationSagas.tsx
@@ -317,7 +317,6 @@ export function* fetchAppAndPagesSaga(
         type: ReduxActionTypes.SET_CURRENT_WORKSPACE_ID,
         payload: {
           workspaceId: response.data.workspaceId,
-          editorId: response.data.application?.id,
         },
       });
 
@@ -736,7 +735,6 @@ export function* forkApplicationSaga(
         type: ReduxActionTypes.SET_CURRENT_WORKSPACE_ID,
         payload: {
           workspaceId: action.payload.workspaceId,
-          editorId: application.id,
         },
       });
 
@@ -801,7 +799,7 @@ export function* showReconnectDatasourcesModalSaga(
     setUnconfiguredDatasourcesDuringImport(unConfiguredDatasourceList || []),
   );
 
-  yield put(setWorkspaceIdForImport({ editorId: application.id, workspaceId }));
+  yield put(setWorkspaceIdForImport(workspaceId));
   yield put(setPageIdForImport(pageId));
   yield put(setIsReconnectingDatasourcesModalOpen({ isOpen: true }));
 }

--- a/app/client/src/ce/sagas/PageSagas.tsx
+++ b/app/client/src/ce/sagas/PageSagas.tsx
@@ -202,7 +202,6 @@ export function* fetchPageListSaga(
         type: ReduxActionTypes.SET_CURRENT_WORKSPACE_ID,
         payload: {
           workspaceId,
-          editorId: applicationId,
         },
       });
       yield put({

--- a/app/client/src/components/BottomBar/index.tsx
+++ b/app/client/src/components/BottomBar/index.tsx
@@ -6,27 +6,12 @@ import ManualUpgrades from "./ManualUpgrades";
 import { Button } from "design-system";
 import SwitchEnvironment from "@appsmith/components/SwitchEnvironment";
 import { Container, Wrapper } from "./components";
-import { useSelector } from "react-redux";
-import { getCurrentApplicationId } from "selectors/editorSelectors";
-import { useDispatch } from "react-redux";
-import { softRefreshActions } from "actions/pluginActionActions";
 
 export default function BottomBar({ viewMode }: { viewMode: boolean }) {
-  const appId = useSelector(getCurrentApplicationId) || "";
-  const dispatch = useDispatch();
-
-  const onChangeEnv = () => {
-    dispatch(softRefreshActions());
-  };
-
   return (
     <Container>
       <Wrapper>
-        <SwitchEnvironment
-          editorId={appId}
-          onChangeEnv={onChangeEnv}
-          viewMode={viewMode}
-        />
+        <SwitchEnvironment viewMode={viewMode} />
         {!viewMode && <QuickGitActions />}
       </Wrapper>
       {!viewMode && (

--- a/app/client/src/pages/Applications/ImportApplicationModal.tsx
+++ b/app/client/src/pages/Applications/ImportApplicationModal.tsx
@@ -204,7 +204,7 @@ function ImportApplicationModal(props: ImportApplicationModalProps) {
     dispatch({
       type: ReduxActionTypes.GIT_INFO_INIT,
     });
-    dispatch(setWorkspaceIdForImport({ editorId: appId || "", workspaceId }));
+    dispatch(setWorkspaceIdForImport(workspaceId));
 
     dispatch(
       setIsGitSyncModalOpen({

--- a/app/client/src/pages/Editor/gitSync/GitSyncModal/GitSyncModalV1.tsx
+++ b/app/client/src/pages/Editor/gitSync/GitSyncModal/GitSyncModalV1.tsx
@@ -29,7 +29,6 @@ import {
   IMPORT_FROM_GIT_REPOSITORY,
 } from "@appsmith/constants/messages";
 import { GitSyncModalTab } from "entities/GitSync";
-import { getCurrentApplicationId } from "selectors/editorSelectors";
 
 const ModalContentContainer = styled(ModalContent)`
   min-height: 650px;
@@ -68,13 +67,10 @@ function GitSyncModalV1(props: { isImport?: boolean }) {
   const isGitConnected = useSelector(getIsGitConnected);
 
   const activeTabKey = useSelector(getActiveGitSyncModalTab);
-  const appId = useSelector(getCurrentApplicationId);
 
   const handleClose = useCallback(() => {
     dispatch(setIsGitSyncModalOpen({ isOpen: false }));
-    dispatch(
-      setWorkspaceIdForImport({ editorId: appId || "", workspaceId: "" }),
-    );
+    dispatch(setWorkspaceIdForImport(""));
   }, [dispatch, setIsGitSyncModalOpen]);
 
   const setActiveTabKey = useCallback(

--- a/app/client/src/pages/Editor/gitSync/GitSyncModal/GitSyncModalV2.tsx
+++ b/app/client/src/pages/Editor/gitSync/GitSyncModal/GitSyncModalV2.tsx
@@ -32,7 +32,6 @@ import ConnectionSuccess from "../Tabs/ConnectionSuccess";
 import styled from "styled-components";
 import ReconnectSSHError from "../components/ReconnectSSHError";
 import { getCurrentAppGitMetaData } from "@appsmith/selectors/applicationSelectors";
-import { getCurrentApplicationId } from "selectors/editorSelectors";
 
 const StyledModalContent = styled(ModalContent)`
   &&& {
@@ -54,7 +53,6 @@ function GitSyncModalV2({ isImport = false }: GitSyncModalV2Props) {
   const isModalOpen = useSelector(getIsGitSyncModalOpen);
   const isGitConnected = useSelector(getIsGitConnected);
   const isDeploying = useSelector(getIsDeploying);
-  const appId = useSelector(getCurrentApplicationId);
 
   const menuOptions = [
     {
@@ -115,9 +113,7 @@ function GitSyncModalV2({ isImport = false }: GitSyncModalV2Props) {
 
   const handleClose = useCallback(() => {
     dispatch(setIsGitSyncModalOpen({ isOpen: false }));
-    dispatch(
-      setWorkspaceIdForImport({ editorId: appId || "", workspaceId: "" }),
-    );
+    dispatch(setWorkspaceIdForImport(""));
   }, [dispatch, setIsGitSyncModalOpen]);
 
   return (

--- a/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
@@ -348,12 +348,7 @@ function ReconnectDatasourceModal() {
             (app: any) => app.id === queryAppId,
           );
           if (application) {
-            dispatch(
-              setWorkspaceIdForImport({
-                editorId: appId || "",
-                workspaceId: workspace.id,
-              }),
-            );
+            dispatch(setWorkspaceIdForImport(workspace.id));
             dispatch(setIsReconnectingDatasourcesModalOpen({ isOpen: true }));
             const defaultPageId = getDefaultPageId(application.pages);
             if (pageIdForImport) {
@@ -433,9 +428,7 @@ function ReconnectDatasourceModal() {
   const onClose = () => {
     localStorage.setItem("importedAppPendingInfo", "null");
     dispatch(setIsReconnectingDatasourcesModalOpen({ isOpen: false }));
-    dispatch(
-      setWorkspaceIdForImport({ editorId: appId || "", workspaceId: "" }),
-    );
+    dispatch(setWorkspaceIdForImport(""));
     dispatch(setPageIdForImport(""));
     dispatch(resetDatasourceConfigForImportFetchedFlag());
     setSelectedDatasourceId("");

--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnectionV2/ChooseGitProvider.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnectionV2/ChooseGitProvider.tsx
@@ -42,7 +42,6 @@ import {
   createMessage,
 } from "@appsmith/constants/messages";
 import AnalyticsUtil from "utils/AnalyticsUtil";
-import { getCurrentApplicationId } from "selectors/editorSelectors";
 
 const WellInnerContainer = styled.div`
   padding-left: 16px;
@@ -71,7 +70,6 @@ function ChooseGitProvider({
   onChange = noop,
   value = {},
 }: ChooseGitProviderProps) {
-  const appId = useSelector(getCurrentApplicationId);
   const workspace = useSelector(getCurrentAppWorkspace);
   const isMobile = useIsMobileDevice();
 
@@ -82,12 +80,7 @@ function ChooseGitProvider({
     dispatch({
       type: ReduxActionTypes.GIT_INFO_INIT,
     });
-    dispatch(
-      setWorkspaceIdForImport({
-        editorId: appId || "",
-        workspaceId: workspace.id,
-      }),
-    );
+    dispatch(setWorkspaceIdForImport(workspace.id));
 
     dispatch(
       setIsGitSyncModalOpen({

--- a/app/client/src/utils/storage.ts
+++ b/app/client/src/utils/storage.ts
@@ -116,29 +116,10 @@ export const getCopiedWidgets = async () => {
   return [];
 };
 
-export const updateCurrentEnvironmentDetails = async () => {
-  try {
-    const currentEnvDetails = await getSavedCurrentEnvironmentDetails(false);
-    if (currentEnvDetails.appId) {
-      await store.setItem(STORAGE_KEYS.CURRENT_ENV, {
-        envId: currentEnvDetails.envId,
-        editorId: currentEnvDetails.appId,
-      });
-    }
-    return true;
-  } catch (error) {
-    log.error("An error occurred when updating current env: ", error);
-    return false;
-  }
-};
-
 // Function to save the current environment and the appId in indexedDB
-export const saveCurrentEnvironment = async (
-  envId: string,
-  editorId: string,
-) => {
+export const saveCurrentEnvironment = async (envId: string, appId: string) => {
   try {
-    await store.setItem(STORAGE_KEYS.CURRENT_ENV, { envId, editorId });
+    await store.setItem(STORAGE_KEYS.CURRENT_ENV, { envId, appId });
     return true;
   } catch (error) {
     log.error("An error occurred when storing current env: ", error);
@@ -147,28 +128,22 @@ export const saveCurrentEnvironment = async (
 };
 
 // Function to fetch the current environment and related appId from indexedDB
-export const getSavedCurrentEnvironmentDetails = async (
-  callUpdate = true,
-): Promise<{
+export const getSavedCurrentEnvironmentDetails = async (): Promise<{
   envId: string;
-  editorId: string;
-  appId?: string;
+  appId: string;
 }> => {
   try {
-    if (callUpdate) {
-      await updateCurrentEnvironmentDetails();
-    }
     return (
       (await store.getItem(STORAGE_KEYS.CURRENT_ENV)) || {
         envId: "",
-        editorId: "",
+        appId: "",
       }
     );
   } catch (error) {
     log.error("An error occurred when fetching current env: ", error);
     return {
       envId: "",
-      editorId: "",
+      appId: "",
     };
   }
 };


### PR DESCRIPTION
Reverts appsmithorg/appsmith#29873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the action and payload structures for setting workspace IDs across various components and sagas.
  - Streamlined environment configuration fetching and workspace ID management.
  - Removed unnecessary editor ID references and updated related components to align with the new logic.
  - Enhanced code clarity in routing by using direct matching functions.

- **Bug Fixes**
  - Fixed a typo in the state variable within the `SwitchEnvironment` component.

- **Chores**
  - Cleaned up unused imports and variables related to application and editor IDs.

- **Style**
  - No visible style changes to report.

- **Documentation, Tests, Revert**
  - No changes in these categories to report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->