### PR TITLE
chore: Use a single `notDeleted` method

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/mongo/SoftDeletePartTreeMongoQuery.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/mongo/SoftDeletePartTreeMongoQuery.java
@@ -2,7 +2,6 @@ package com.appsmith.server.configurations.mongo;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.repository.query.ConvertingParameterAccessor;
 import org.springframework.data.mongodb.repository.query.ReactiveMongoQueryMethod;
@@ -13,7 +12,7 @@ import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Method;
 
-import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.notDeleted;
 
 @Slf4j
 public class SoftDeletePartTreeMongoQuery extends ReactivePartTreeMongoQuery {
@@ -52,10 +51,5 @@ public class SoftDeletePartTreeMongoQuery extends ReactivePartTreeMongoQuery {
             query.addCriteria(notDeleted());
             return query;
         });
-    }
-
-    private Criteria notDeleted() {
-        return new Criteria()
-                .orOperator(where("deleted").exists(false), where("deleted").is(false));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/MigrationHelperMethods.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/MigrationHelperMethods.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.external.models.InvisibleActionFields;
 import com.appsmith.server.constants.ApplicationConstants;
-import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.constants.ResourceModes;
 import com.appsmith.server.domains.ApplicationPage;
 import com.appsmith.server.domains.CustomJSLib;
@@ -238,25 +237,6 @@ public class MigrationHelperMethods {
         final List<T> domainObject =
                 mongoTemplate.find(query(where(fieldName(path)).is(id)), type);
         return domainObject;
-    }
-
-    /**
-     * The method provides the criteria for any document to qualify as not deleted
-     * @return Criteria
-     */
-    public static Criteria notDeleted() {
-        return new Criteria()
-                .andOperator(
-                        // Older check for deleted
-                        new Criteria()
-                                .orOperator(
-                                        where(FieldName.DELETED).exists(false),
-                                        where(FieldName.DELETED).is(false)),
-                        // New check for deleted
-                        new Criteria()
-                                .orOperator(
-                                        where(FieldName.DELETED_AT).exists(false),
-                                        where(FieldName.DELETED_AT).is(null)));
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration032AddingXmlParserToApplicationLibraries.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration032AddingXmlParserToApplicationLibraries.java
@@ -18,8 +18,8 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
 import static com.appsmith.server.constants.ApplicationConstants.XML_PARSER_LIBRARY_UID;
-import static com.appsmith.server.migrations.MigrationHelperMethods.notDeleted;
 import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.fieldName;
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.notDeleted;
 
 /**
  *  Appsmith provides xmlParser v 3.17.5 and few other customJSLibraries by default, xmlParser has been

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.Collection;
 
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.notDeleted;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 /**
@@ -67,19 +68,6 @@ public class BaseRepositoryImpl<T extends BaseDomain, ID extends Serializable>
         super(entityInformation, mongoOperations);
         this.entityInformation = entityInformation;
         this.mongoOperations = mongoOperations;
-    }
-
-    private Criteria notDeleted() {
-        return new Criteria()
-                .andOperator(
-                        new Criteria()
-                                .orOperator(
-                                        where(FieldName.DELETED).exists(false),
-                                        where(FieldName.DELETED).is(false)),
-                        new Criteria()
-                                .orOperator(
-                                        where(FieldName.DELETED_AT).exists(false),
-                                        where(FieldName.DELETED_AT).is(null)));
     }
 
     private Criteria getIdCriteria(Object id) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -115,10 +115,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
                                         where(FieldName.DELETED).exists(false),
                                         where(FieldName.DELETED).is(false)),
                         // New check for deleted
-                        new Criteria()
-                                .orOperator(
-                                        where(FieldName.DELETED_AT).exists(false),
-                                        where(FieldName.DELETED_AT).is(null)));
+                        where(FieldName.DELETED_AT).isNull());
     }
 
     @Deprecated


### PR DESCRIPTION
This was duplicated four times, and one of them was only checking for the boolean field. :(

There will be conflict in `BaseRepositoryImpl.java`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the internal handling of database queries for improved performance and maintainability.

- **Bug Fixes**
	- Ensured correct handling of custom JavaScript libraries in the application JSON.

- **Chores**
	- Cleaned up the codebase by removing unused import statements and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->