### PR TITLE
chore: Update doc for skipping tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,6 @@ app/client/tsconfig.path.json @KelvinOm
 
 # App viewers pod
 app/client/src/widgets/* @appsmithorg/app-viewers
-app/client/cypress/e2e/Regression/ClientSide/Widgets/* @rajatagrawal
 app/client/src/components/propertyControls/* @appsmithorg/app-viewers
 app/client/src/sagas/OneClickBindingSaga.ts @sbalaji1192
 app/client/src/WidgetQueryGenerators/* @sbalaji1192

--- a/contributions/ServerSetup.md
+++ b/contributions/ServerSetup.md
@@ -134,7 +134,7 @@ With the prerequisites met, let's build the code.
 7. Run the following command to create the final JAR for the Appsmith server:
 
     ```console
-    ./build.sh -DskipTests
+    ./build.sh -Dmaven.test.skip
     ```
     - This command will create a `dist` folder which contains the final packaged jar along with multiple jars for plugins as well.
     - If you want to run the tests, you can remove `-DskipTests` flag from the build cmd.


### PR DESCRIPTION
This PR updates the README for server setup to exclude test compilation.

The earlier command flag `-DskipTests` skipped only the exeuction of the tests.

`-Dmaven.test.skip` will also skip compilation of tests. This will help developers to compile code faster without worrying about unrelated compilation failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated code ownership assignments for better maintainability.

- **Documentation**
  - Revised server setup instructions to refine the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->