### PR TITLE
fix: interchanged primary btn to gen crud from new query

### DIFF
--- a/app/client/src/ce/hooks/datasourceEditorHooks.tsx
+++ b/app/client/src/ce/hooks/datasourceEditorHooks.tsx
@@ -27,6 +27,8 @@ import {
 import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { ActionParentEntityType } from "@appsmith/entities/Engine/actionHelpers";
+import { isEnabledForPreviewData } from "utils/editorContextUtils";
+import { getPlugin } from "@appsmith/selectors/entitiesSelector";
 
 export interface HeaderActionProps {
   datasource: Datasource | ApiDatasourceForm | undefined;
@@ -55,6 +57,13 @@ export const useHeaderActions = (
   const showGenerateButton = useShowPageGenerationOnHeader(
     datasource as Datasource,
   );
+
+  const plugin = useSelector((state: AppState) =>
+    getPlugin(state, datasource?.pluginId || ""),
+  );
+
+  const isPluginAllowedToPreviewData =
+    !!plugin && isEnabledForPreviewData(datasource as Datasource, plugin);
 
   if (editorType === EditorNames.APPLICATION) {
     const canCreateDatasourceActions = hasCreateDSActionPermissionInApp({
@@ -90,6 +99,7 @@ export const useHeaderActions = (
         datasource={datasource as Datasource}
         disabled={!canCreateDatasourceActions || !isPluginAuthorized}
         eventFrom="datasource-pane"
+        isNewQuerySecondaryButton={!!isPluginAllowedToPreviewData}
         pluginType={pluginType}
       />
     );

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -62,7 +62,10 @@ import SaveOrDiscardDatasourceModal from "./SaveOrDiscardDatasourceModal";
 import { toast, Callout } from "design-system";
 import styled from "styled-components";
 import CloseEditor from "components/editorComponents/CloseEditor";
-import { isDatasourceAuthorizedForQueryCreation } from "utils/editorContextUtils";
+import {
+  isDatasourceAuthorizedForQueryCreation,
+  isEnabledForPreviewData,
+} from "utils/editorContextUtils";
 import Debugger, {
   ResizerContentContainer,
   ResizerMainContainer,
@@ -95,7 +98,6 @@ import {
   selectFeatureFlags,
 } from "@appsmith/selectors/featureFlagsSelectors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
-import { DATASOURCES_ALLOWED_FOR_PREVIEW_MODE } from "constants/QueryEditorConstants";
 import { setCurrentEditingEnvironmentID } from "@appsmith/actions/environmentAction";
 import { getCurrentEnvironmentDetails } from "@appsmith/selectors/environmentSelectors";
 import { isGACEnabled } from "@appsmith/utils/planHelpers";
@@ -1154,8 +1156,7 @@ const mapStateToProps = (state: AppState, props: any): ReduxStateProps => {
 
   // should plugin be able to preview data
   const isPluginAllowedToPreviewData =
-    DATASOURCES_ALLOWED_FOR_PREVIEW_MODE.includes(plugin?.name || "") ||
-    (plugin?.name === PluginName.MONGO && !!(datasource as Datasource)?.isMock);
+    !!plugin && isEnabledForPreviewData(datasource as Datasource, plugin);
 
   const isAppSidebarEnabled = getIsAppSidebarEnabled(state);
   const isPagePaneSegmentsEnabled = selectFeatureFlagCheck(

--- a/app/client/src/pages/Editor/DatasourceInfo/DatasourceViewModeSchema.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/DatasourceViewModeSchema.tsx
@@ -278,7 +278,7 @@ const DatasourceViewModeSchema = (props: Props) => {
           <Button
             className="t--datasource-generate-page"
             key="datasource-generate-page"
-            kind="secondary"
+            kind="primary"
             onClick={generatePageAction}
             size="md"
           >

--- a/app/client/src/pages/Editor/DatasourceInfo/GoogleSheetSchema.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/GoogleSheetSchema.tsx
@@ -499,7 +499,7 @@ function GoogleSheetSchema(props: Props) {
           <Button
             className="t--datasource-generate-page"
             key="datasource-generate-page"
-            kind="secondary"
+            kind="primary"
             onClick={onGsheetGeneratePage}
             size="md"
           >

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -39,6 +39,7 @@ import EntityNotFoundPane from "../EntityNotFoundPane";
 import type { Plugin } from "api/PluginApi";
 import {
   isDatasourceAuthorizedForQueryCreation,
+  isEnabledForPreviewData,
   isGoogleSheetPluginDS,
 } from "utils/editorContextUtils";
 import type { PluginType } from "entities/Action";
@@ -128,6 +129,7 @@ interface StateProps extends JSONtoFormProps {
   requiredFields: Record<string, ControlProps>;
   configDetails: Record<string, string>;
   isPluginAuthFailed: boolean;
+  isPluginAllowedToPreviewData: boolean;
 }
 interface DatasourceFormFunctions {
   discardTempDatasource: () => void;
@@ -517,14 +519,8 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
   };
 
   shouldShowTabs = () => {
-    const { datasource, isPluginAuthorized, pluginPackageName } = this.props;
-
-    const isGoogleSheetPlugin = isGoogleSheetPluginDS(pluginPackageName);
-
-    const isGoogleSheetSchemaAvailable =
-      isGoogleSheetPlugin && isPluginAuthorized;
-
-    return isGoogleSheetSchemaAvailable && datasource;
+    const { isPluginAllowedToPreviewData, isPluginAuthorized } = this.props;
+    return isPluginAllowedToPreviewData && isPluginAuthorized;
   };
 
   renderTabsForViewMode = () => {
@@ -814,6 +810,10 @@ const mapStateToProps = (state: AppState, props: any) => {
   const currentApplicationIdForCreateNewApp =
     getCurrentApplicationIdForCreateNewApp(state);
 
+  // should plugin be able to preview data
+  const isPluginAllowedToPreviewData =
+    !!plugin && isEnabledForPreviewData(datasource as Datasource, plugin);
+
   return {
     datasource,
     datasourceButtonConfiguration,
@@ -852,6 +852,7 @@ const mapStateToProps = (state: AppState, props: any) => {
     scopeValue,
     isPluginAuthFailed,
     featureFlags: state.ui.users.featureFlag.data,
+    isPluginAllowedToPreviewData,
   };
 };
 

--- a/app/client/src/utils/editorContextUtils.ts
+++ b/app/client/src/utils/editorContextUtils.ts
@@ -19,6 +19,7 @@ import store from "store";
 import { getPlugin } from "@appsmith/selectors/entitiesSelector";
 import type { AppState } from "@appsmith/reducers";
 import {
+  DATASOURCES_ALLOWED_FOR_PREVIEW_MODE,
   MOCK_DB_TABLE_NAMES,
   SQL_DATASOURCES,
 } from "constants/QueryEditorConstants";
@@ -286,3 +287,17 @@ export function getDefaultTemplateActionConfig(
     return null;
   }
 }
+
+export const isEnabledForPreviewData = (
+  datasource: Datasource,
+  plugin: Plugin,
+) => {
+  const isGoogleSheetPlugin = isGoogleSheetPluginDS(plugin?.packageName);
+
+  return (
+    DATASOURCES_ALLOWED_FOR_PREVIEW_MODE.includes(plugin?.name || "") ||
+    (plugin?.name === PluginName.MONGO &&
+      !!(datasource as Datasource)?.isMock) ||
+    isGoogleSheetPlugin
+  );
+};


### PR DESCRIPTION
## Description
Earlier the `New query` button was primary and `Generate New Page` button was secondary button but now this PR interchanges the UI for both only for the preview data supported datasources i.e. Google sheet, Mysql, Postgres, Mongo Mock db.

#### PR fixes following issue(s)
Fixes #29599 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to preview data within the data source editor for supported plugins.

- **Enhancements**
  - Improved user interface by changing certain buttons from secondary to primary, enhancing visibility and interaction.

- **Refactor**
  - Streamlined the logic for determining if a data source plugin supports data preview.

- **Style**
  - Updated button styles for a more consistent and prominent user interface in the data source editor sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->