### PR TITLE
fix: remove hotkey shortcuts for Entity Explorer and Preview mode

### DIFF
--- a/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.test.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.test.tsx
@@ -36,7 +36,6 @@ import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import * as widgetActions from "actions/widgetActions";
 import * as uiSelectors from "selectors/ui";
 import { NavigationMethod } from "../../../utils/history";
-import { setExplorerPinnedAction } from "actions/explorerActions";
 
 jest.mock("constants/routes", () => {
   return {
@@ -530,76 +529,5 @@ describe("cmd + s hotkey", () => {
         component.getByText(createMessage(SAVE_HOTKEY_TOASTER_MESSAGE)),
       ).toBeDefined();
     });
-  });
-});
-
-describe("mod + / hotkey", () => {
-  it("Should dispatch pin/unpin explorer on mod + /", async () => {
-    const dispatchSpy = jest.spyOn(store, "dispatch");
-    const component = render(
-      <GlobalHotKeys
-        getMousePosition={() => {
-          return { x: 0, y: 0 };
-        }}
-      >
-        <div />
-      </GlobalHotKeys>,
-    );
-    dispatchSpy.mockClear();
-
-    dispatchTestKeyboardEventWithCode(
-      component.container,
-      "keydown",
-      "/",
-      191,
-      false,
-      true,
-    );
-
-    expect(dispatchSpy).toBeCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenNthCalledWith(
-      1,
-      setExplorerPinnedAction(false),
-    );
-  });
-
-  it("Shouldn't dispatch pin/unpin explorer on mod + / when signposting is enabled", async () => {
-    const dispatchSpy = jest.spyOn(store, "dispatch");
-    const state: any = {
-      entities: {
-        pageList: {
-          applicationId: "1",
-        },
-      },
-      ui: {
-        onBoarding: {
-          firstTimeUserOnboardingApplicationIds: ["1"],
-        },
-      },
-    };
-    const component = render(
-      <GlobalHotKeys
-        getMousePosition={() => {
-          return { x: 0, y: 0 };
-        }}
-      >
-        <div />
-      </GlobalHotKeys>,
-      {
-        initialState: state,
-      },
-    );
-    dispatchSpy.mockClear();
-
-    dispatchTestKeyboardEventWithCode(
-      component.container,
-      "keydown",
-      "/",
-      191,
-      false,
-      true,
-    );
-
-    expect(dispatchSpy).toBeCalledTimes(0);
   });
 });

--- a/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.tsx
@@ -36,10 +36,6 @@ import {
   createMessage,
   SAVE_HOTKEY_TOASTER_MESSAGE,
 } from "@appsmith/constants/messages";
-import { setPreviewModeInitAction } from "actions/editorActions";
-import { previewModeSelector } from "selectors/editorSelectors";
-import { getExplorerPinned } from "selectors/explorerSelector";
-import { setExplorerPinnedAction } from "actions/explorerActions";
 import { setIsGitSyncModalOpen } from "actions/gitSyncActions";
 import { GitSyncModalTab } from "entities/GitSync";
 import { matchBuilderPath } from "constants/routes";
@@ -74,10 +70,7 @@ interface Props {
   appMode?: APP_MODE;
   isPreviewMode: boolean;
   isProtectedMode: boolean;
-  setPreviewModeInitAction: (shouldSet: boolean) => void;
-  isExplorerPinned: boolean;
   isSignpostingEnabled: boolean;
-  setExplorerPinnedAction: (shouldPinned: boolean) => void;
   showCommitModal: () => void;
   getMousePosition: () => { x: number; y: number };
   hideInstaller: () => void;
@@ -264,7 +257,6 @@ class GlobalHotKeys extends React.Component<Props> {
             this.props.closeProppane();
             this.props.closeTableFilterProppane();
             e.preventDefault();
-            this.props.setPreviewModeInitAction(false);
           }}
         />
         <Hotkey
@@ -333,24 +325,6 @@ class GlobalHotKeys extends React.Component<Props> {
           stopPropagation
         />
         <Hotkey
-          combo="p"
-          global
-          label="Preview Mode"
-          onKeyDown={() => {
-            this.props.setPreviewModeInitAction(!this.props.isPreviewMode);
-          }}
-        />
-        <Hotkey
-          combo="mod + /"
-          disabled={this.props.isSignpostingEnabled}
-          global
-          label="Pin/Unpin Entity Explorer"
-          onKeyDown={() => {
-            this.props.setExplorerPinnedAction(!this.props.isExplorerPinned);
-            this.props.hideInstaller();
-          }}
-        />
-        <Hotkey
           combo="ctrl + shift + g"
           global
           label="Show git commit modal"
@@ -372,9 +346,7 @@ const mapStateToProps = (state: AppState) => ({
   selectedWidgets: getSelectedWidgets(state),
   isDebuggerOpen: showDebuggerFlag(state),
   appMode: getAppMode(state),
-  isPreviewMode: previewModeSelector(state),
   isProtectedMode: protectedModeSelector(state),
-  isExplorerPinned: getExplorerPinned(state),
   isSignpostingEnabled: getIsFirstTimeUserOnboardingEnabled(state),
 });
 
@@ -399,10 +371,6 @@ const mapDispatchToProps = (dispatch: any) => {
     executeAction: () => dispatch(runActionViaShortcut()),
     undo: () => dispatch(undoAction()),
     redo: () => dispatch(redoAction()),
-    setPreviewModeInitAction: (shouldSet: boolean) =>
-      dispatch(setPreviewModeInitAction(shouldSet)),
-    setExplorerPinnedAction: (shouldSet: boolean) =>
-      dispatch(setExplorerPinnedAction(shouldSet)),
     showCommitModal: () =>
       dispatch(
         setIsGitSyncModalOpen({

--- a/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.tsx
@@ -36,6 +36,7 @@ import {
   createMessage,
   SAVE_HOTKEY_TOASTER_MESSAGE,
 } from "@appsmith/constants/messages";
+import { previewModeSelector } from "selectors/editorSelectors";
 import { setIsGitSyncModalOpen } from "actions/gitSyncActions";
 import { GitSyncModalTab } from "entities/GitSync";
 import { matchBuilderPath } from "constants/routes";
@@ -346,6 +347,7 @@ const mapStateToProps = (state: AppState) => ({
   selectedWidgets: getSelectedWidgets(state),
   isDebuggerOpen: showDebuggerFlag(state),
   appMode: getAppMode(state),
+  isPreviewMode: previewModeSelector(state),
   isProtectedMode: protectedModeSelector(state),
   isSignpostingEnabled: getIsFirstTimeUserOnboardingEnabled(state),
 });


### PR DESCRIPTION
Removes hotkey for Pinning Entity Explorer as it is not used anymore. 
Removes hotkey for preview mode as it ill designed and causes problems with new users