### PR TITLE
ci: Schedule TBP workflow to run 4 times a day with 3hrs interval

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -86,7 +86,7 @@ jobs:
   ci-test:
     needs: [setup, build-docker-image]
     # Only run if the build step is successful
-    if: success() && github.event_name != 'push'
+    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master' )
     name: ci-test
     uses: ./.github/workflows/ci-test-custom-script.yml
     secrets: inherit
@@ -98,7 +98,7 @@ jobs:
   server-unit-tests:
     name: server-unit-tests
     needs: [build-docker-image]
-    if: success() && github.event_name != 'push'
+    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master' )
     uses: ./.github/workflows/server-build.yml
     secrets: inherit
     with:
@@ -108,7 +108,7 @@ jobs:
   client-unit-tests:
     name: client-unit-tests
     needs: [build-docker-image]
-    if: success() && github.event_name != 'push'
+    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master' )
     uses: ./.github/workflows/client-unit-tests.yml
     secrets: inherit
     with:
@@ -119,6 +119,7 @@ jobs:
     if: always() &&
       (github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
+      ( github.event_name != 'push' || github.ref == 'refs/heads/master' ) ||
       (github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       github.event.pull_request.head.repo.full_name == github.repository))

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -1,9 +1,9 @@
 name: Test, build and push Docker Image
 
 on:
-  # This workflow will run everyday at 06:00 AM IST (12:30 AM UTC) on weekdays
+  # This workflow will run everyday at 7:00AM, 10:00AM, 1:00PM, 4:00PM IST on weekdays
   schedule:
-    - cron: "30 00 * * 1-5"
+    - cron: "30 1-12/3 * * 1-5"
   # This line enables manual triggering of this workflow.
   workflow_dispatch:
     inputs:
@@ -86,7 +86,7 @@ jobs:
   ci-test:
     needs: [setup, build-docker-image]
     # Only run if the build step is successful
-    if: success()
+    if: success() && github.event_name != 'push'
     name: ci-test
     uses: ./.github/workflows/ci-test-custom-script.yml
     secrets: inherit
@@ -98,6 +98,7 @@ jobs:
   server-unit-tests:
     name: server-unit-tests
     needs: [build-docker-image]
+    if: success() && github.event_name != 'push'
     uses: ./.github/workflows/server-build.yml
     secrets: inherit
     with:
@@ -107,6 +108,7 @@ jobs:
   client-unit-tests:
     name: client-unit-tests
     needs: [build-docker-image]
+    if: success() && github.event_name != 'push'
     uses: ./.github/workflows/client-unit-tests.yml
     secrets: inherit
     with:
@@ -116,7 +118,6 @@ jobs:
     needs: [ci-test, client-unit-tests, server-unit-tests]
     if: always() &&
       (github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&


### PR DESCRIPTION
## Description
- Scheduled TBP workflow to run 4 times a day with 3hrs interval
- Made changes in TBP workflow to run all the steps only while running with schedule or manual workflow trigger
- Added condition to run ci-test and ci-test-result only during schedule or manual workflow run.

#### Type of change
- Workflow changes
## Testing
>
#### How Has This Been Tested?
- [x] CI Run
>
>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the workflow schedule for Docker image build tests to run at new times: 7:00 AM, 10:00 AM, 1:00 PM, and 4:00 PM IST on weekdays.
	- Modified conditional triggers in the CI pipeline to exclude jobs from running on push events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->