### PR TITLE
chore: Bring boolean deleted field back

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -55,6 +55,11 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     @JsonView(Views.Public.class)
     protected String modifiedBy;
 
+    // Deprecating this so we can move on to using `deletedAt` for all domain models.
+    @Deprecated(forRemoval = true)
+    @JsonView(Views.Public.class)
+    protected Boolean deleted = false;
+
     @JsonView(Views.Public.class)
     protected Instant deletedAt = null;
 


### PR DESCRIPTION
Bringing the `deleted` field with the same old default value back, so we don't create a diff for git-connected apps, till we figure this out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated domain models to use `deletedAt` field, deprecating the previous `deleted` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->