### PR TITLE
chore: restrict use of deleted boolean field

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -5,6 +5,7 @@ import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.annotations.QueryTransient;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -55,10 +56,19 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     @JsonView(Views.Public.class)
     protected String modifiedBy;
 
-    // Deprecating this so we can move on to using `deletedAt` for all domain models.
+    /** @deprecated to rely only on `deletedAt` for all domain models.
+     * This field only exists here because its removal will cause a huge diff on all entities in git-connected
+     * applications. So, instead, we keep it, deprecated, transient (no read/write to DB), query-transient (no
+     * corresponding field in Q* class, no getter/setter methods) and only use it for the git sync implementation.
+     * For all practical purposes, this field doesn't exist.
+     */
     @Deprecated(forRemoval = true)
-    @JsonView(Views.Public.class)
-    protected Boolean deleted = false;
+    @JsonView(Views.Internal.class)
+    @Transient
+    @QueryTransient
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    protected final Boolean deleted = false; // TODO: can objects be loaded from the DB if this field is final?
 
     @JsonView(Views.Public.class)
     protected Instant deletedAt = null;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -68,7 +68,7 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     @QueryTransient
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
-    protected final Boolean deleted = false; // TODO: can objects be loaded from the DB if this field is final?
+    protected final Boolean deleted = false;
 
     @JsonView(Views.Public.class)
     protected Instant deletedAt = null;


### PR DESCRIPTION
Instead of removing the `deleted` field, we restrict its use, so it doesn't grow again.

More details in comments in cod.
