### PR TITLE
fix: Created at field in action is set again during import

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -199,7 +199,16 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         action.setId(newAction.getId());
         action.setUserPermissions(newAction.getUserPermissions());
         action.setPolicies(newAction.getPolicies());
-        action.setCreatedAt(newAction.getCreatedAt());
+        /*
+         * Important: This null check before setting the createdAt field to ActionDTO is temporary.
+         * createdAt is part of exported JSON, and we used to import actions with the same value from JSON.
+         * It's wrong but if we fix this, the existing Git connected applications will show a diff for all actions.
+         * We want to avoid this and hence this null check is there.
+         * We're going to remove the createdAt field from JSON and post that this null check will be removed.
+         */
+        if (action.getCreatedAt() == null) {
+            action.setCreatedAt(newAction.getCreatedAt());
+        }
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportApplicationServiceTests.java
@@ -1077,6 +1077,7 @@ public class ImportApplicationServiceTests {
                         ActionDTO actionDTO = newAction.getUnpublishedAction();
                         assertThat(actionDTO.getPageId())
                                 .isNotEqualTo(pageList.get(0).getName());
+
                         if (StringUtils.equals(actionDTO.getName(), "api_wo_auth")) {
                             ActionDTO publishedAction = newAction.getPublishedAction();
                             assertThat(publishedAction).isNotNull();
@@ -1084,6 +1085,8 @@ public class ImportApplicationServiceTests {
                             // Test the fallback page ID from the unpublishedAction is copied to published version when
                             // published version does not have pageId
                             assertThat(actionDTO.getPageId()).isEqualTo(publishedAction.getPageId());
+                            // check that createAt field is getting populated from JSON
+                            assertThat(actionDTO.getCreatedAt()).isEqualTo("2023-12-13T12:10:02Z");
                         }
 
                         if (!StringUtils.isEmpty(actionDTO.getCollectionId())) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/transactions/ImportApplicationTransactionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/transactions/ImportApplicationTransactionServiceTest.java
@@ -84,6 +84,9 @@ public class ImportApplicationTransactionServiceTest {
     @MockBean
     ImportableService<NewAction> newActionImportableService;
 
+    @Autowired
+    private Gson gson;
+
     Long applicationCount = 0L, pageCount = 0L, actionCount = 0L, actionCollectionCount = 0L;
     private ApplicationJson applicationJson = new ApplicationJson();
 
@@ -123,7 +126,6 @@ public class ImportApplicationTransactionServiceTest {
 
         return stringifiedFile
                 .map(data -> {
-                    Gson gson = new Gson();
                     return gson.fromJson(data, ApplicationJson.class);
                 })
                 .map(JsonSchemaMigration::migrateApplicationToLatestSchema);

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
@@ -519,7 +519,8 @@
         "invalids": [],
         "jsonPathKeys": [],
         "confirmBeforeExecute": false,
-        "userPermissions": []
+        "userPermissions": [],
+        "createdAt": "2023-12-13T12:10:02Z"
       },
       "publishedAction": {
         "name": "api_wo_auth",


### PR DESCRIPTION
## Description
Skips `createdAt` field of unpublished action from being reset when application is imported.

#### PR fixes following issue(s)
Fixes #30178

#### Media
#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented a temporary null check to ensure stability for Git connected applications when setting creation dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->