### PR TITLE
fix: redundant unit tests in templates

### DIFF
--- a/app/client/src/pages/Templates/BuildingBlock/BuildingBlock.test.tsx
+++ b/app/client/src/pages/Templates/BuildingBlock/BuildingBlock.test.tsx
@@ -84,11 +84,4 @@ describe("<BuildingBlock />", () => {
     fireEvent.click(screen.getByText(MOCK_BUILDING_BLOCK_TITLE));
     expect(onForkTemplateClick).not.toHaveBeenCalled();
   });
-
-  // it("opens the fork modal when the fork button is clicked", async () => {
-  //   render(BaseBuildingBlockRender());
-  //   const forkButton = screen.getByTestId("t--fork-building-block");
-  //   fireEvent.click(forkButton);
-  //   expect(screen.getByTestId("t--fork-template-modal")).toBeInTheDocument();
-  // });
 });

--- a/app/client/src/pages/Templates/ForkTemplate.tsx
+++ b/app/client/src/pages/Templates/ForkTemplate.tsx
@@ -57,10 +57,7 @@ function ForkTemplate({
       <Modal onOpenChange={closeModal} open={showForkModal}>
         <ModalContent style={{ width: "640px" }}>
           <ModalHeader>{createMessage(CHOOSE_WHERE_TO_FORK)}</ModalHeader>
-          <ModalBody
-            data-testid="t--fork-template-modal"
-            style={{ overflow: "unset", paddingBottom: "4px" }}
-          >
+          <ModalBody style={{ overflow: "unset", paddingBottom: "4px" }}>
             <Select
               dropdownMatchSelectWidth
               getPopupContainer={(triggerNode) => triggerNode.parentNode}


### PR DESCRIPTION

## Description
Complete the following fixes to tests
1. Remove data-testid from ForkTemplate modal. This is because the test case for that includes this component is going to be removed in another [PR](https://github.com/appsmithorg/appsmith/pull/30160/files).
2. Remove redundant comments from BuildingBlock.test

#### PR fixes following issue(s)
Fixes #30024


#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `ForkTemplate` modal rendering logic.
- **Tests**
  - Removed a test case related to the fork modal interaction.
- **Style**
  - Removed `data-testid` attribute from the `ModalBody` component for cleaner UI code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->