### PR TITLE
fix: Use user executable names for exported actions and js objects

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/exports/ActionCollectionExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/exports/ActionCollectionExportableServiceCEImpl.java
@@ -73,9 +73,9 @@ public class ActionCollectionExportableServiceCEImpl implements ExportableServic
                         // we've replaced page id with page name in previous step
                         String pageName = actionCollectionDTO.getPageId();
                         boolean isPageUpdated = ImportExportUtils.isPageNameInUpdatedList(applicationJson, pageName);
-                        String actionCollectionName = actionCollectionDTO != null
-                                ? actionCollectionDTO.getName() + NAME_SEPARATOR + actionCollectionDTO.getPageId()
-                                : null;
+                        String actionCollectionName = actionCollectionDTO.getUserExecutableName()
+                                + NAME_SEPARATOR
+                                + actionCollectionDTO.getPageId();
                         Instant actionCollectionUpdatedAt = actionCollection.getUpdatedAt();
                         boolean isActionCollectionUpdated = exportingMetaDTO.isClientSchemaMigrated()
                                 || exportingMetaDTO.isServerSchemaMigrated()
@@ -85,7 +85,7 @@ public class ActionCollectionExportableServiceCEImpl implements ExportableServic
                                 || exportingMetaDTO
                                         .getApplicationLastCommittedAt()
                                         .isBefore(actionCollectionUpdatedAt);
-                        if (isActionCollectionUpdated && actionCollectionName != null) {
+                        if (isActionCollectionUpdated) {
                             updatedActionCollectionSet.add(actionCollectionName);
                         }
                         actionCollection.sanitiseToExportDBObject();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exports/NewActionExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exports/NewActionExportableServiceCEImpl.java
@@ -69,7 +69,7 @@ public class NewActionExportableServiceCEImpl implements ExportableServiceCE<New
                         ActionDTO publishedActionDTO = newAction.getPublishedAction();
                         ActionDTO actionDTO = unpublishedActionDTO != null ? unpublishedActionDTO : publishedActionDTO;
                         String newActionName = actionDTO != null
-                                ? actionDTO.getValidName() + NAME_SEPARATOR + actionDTO.getPageId()
+                                ? actionDTO.getUserExecutableName() + NAME_SEPARATOR + actionDTO.getPageId()
                                 : null;
                         // TODO: check whether resource updated after last commit - move to a function
                         String pageName = actionDTO.getPageId();


### PR DESCRIPTION
Split work from this [PR](https://github.com/appsmithorg/appsmith-ee/pull/3246/files#diff-b7cbbeeca7852f03d5f74e7b307e8a39cb299a7f84dc0bba5563cddba2b76c93). Already reviewed and tested on the other PR, hence force merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved naming conventions for action collections and actions to enhance clarity and consistency in exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->