### PR TITLE
chore: Vendor supervisor_stdout extension

### DIFF
--- a/deploy/docker/fs/etc/supervisor/supervisord.conf
+++ b/deploy/docker/fs/etc/supervisor/supervisord.conf
@@ -38,7 +38,7 @@ files = %(ENV_SUPERVISORD_CONF_TARGET)s/*.conf
 ; and forward to container log using supervisor_stdout
 ; Ref: https://github.com/coderanger/supervisor-stdout
 [eventlistener:stdout]
-command = supervisor_stdout
+command = python3 -m supervisor.appsmith_supervisor_stdout
 buffer_size = 10000
 events = PROCESS_LOG
-result_handler = supervisor_stdout:event_handler
+result_handler = supervisor.appsmith_supervisor_stdout:event_handler

--- a/deploy/docker/fs/etc/supervisor/supervisord.conf
+++ b/deploy/docker/fs/etc/supervisor/supervisord.conf
@@ -34,9 +34,6 @@ serverurl=unix://%(ENV_TMP)s/supervisor.sock ; use a unix:// URL  for a unix soc
 [include]
 files = %(ENV_SUPERVISORD_CONF_TARGET)s/*.conf
 
-; This event listener is used to capture processes log
-; and forward to container log using supervisor_stdout
-; Ref: https://github.com/coderanger/supervisor-stdout
 [eventlistener:stdout]
 command = python3 -m supervisor.appsmith_supervisor_stdout
 buffer_size = 10000

--- a/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
+++ b/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
@@ -1,3 +1,10 @@
+"""
+This is a supervisor event listener, used to capture processes log and forward
+to container log. The `event_handler` function does this work.
+
+Originally taken from https://github.com/coderanger/supervisor-stdout/blob/973ba19967cdaf46d9c1634d1675fc65b9574f6e/supervisor_stdout.py
+"""
+
 import sys
 
 

--- a/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
+++ b/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
@@ -1,0 +1,35 @@
+import sys
+
+
+def write_stdout(s):
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+
+def write_stderr(s):
+    sys.stderr.write(s)
+    sys.stderr.flush()
+
+
+def main():
+    while 1:
+        write_stdout("READY\n")  # transition from ACKNOWLEDGED to READY
+        line = sys.stdin.readline()  # read header line from stdin
+        headers = dict([x.split(":") for x in line.split()])
+        data = sys.stdin.read(int(headers["len"]))  # read the event payload
+        write_stdout(
+            "RESULT %s\n%s" % (len(data.encode("utf-8")), data)
+        )  # transition from READY to ACKNOWLEDGED
+
+
+def event_handler(event, response):
+    response = response.decode()
+    line, data = response.split("\n", 1)
+    headers = dict([x.split(":") for x in line.split()])
+    lines = data.split("\n")
+    prefix = "%s %s | " % (headers["processname"], headers["channel"])
+    print("\n".join([prefix + l for l in lines]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Instead of downloading it from the github repo on every build (in `base.dockerfile`), we vendor the supervisor extension so we can look to fix the buffer overflow problem in supervisor logs.

After this is merged, after a day/two, we'll be removing `git`, `python3-pip` and the supervisor-stdout extension from `base.dockerfile`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the event handling in system processes for improved logging and output management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->