### PR TITLE
fix: Include loopback by default in NO_PROXY

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -108,6 +108,16 @@ init_env_file() {
 setup_proxy_variables() {
   export NO_PROXY="${NO_PROXY-localhost,127.0.0.1}"
 
+  # Ensure `localhost` and `127.0.0.1` are in always present in `NO_PROXY`.
+  local no_proxy_lines
+  no_proxy_lines="$(echo "$NO_PROXY" | tr , \\n)"
+  if ! echo "$no_proxy_lines" | grep -q '^localhost$'; then
+    export NO_PROXY="localhost,$NO_PROXY"
+  fi
+  if ! echo "$no_proxy_lines" | grep -q '^127.0.0.1$'; then
+    export NO_PROXY="127.0.0.1,$NO_PROXY"
+  fi
+
   # If one of HTTPS_PROXY or https_proxy are set, copy it to the other. If both are set, prefer HTTPS_PROXY.
   if [[ -n ${HTTPS_PROXY-} ]]; then
     export https_proxy="$HTTPS_PROXY"


### PR DESCRIPTION
Fixes https://github.com/appsmithorg/appsmith/issues/21900

Recently surfaced with a customer. [Relevant Slack conversation](https://theappsmith.slack.com/archives/C0341RERY4R/p1705066329009749?thread_ts=1702568797.080409&cid=C0341RERY4R).

# Tests
![shot-2024-01-12-15-34-11](https://github.com/appsmithorg/appsmith/assets/120119/66076399-304e-45f1-9030-60176cedf913)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured `localhost` and `127.0.0.1` are consistently recognized in proxy exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->