### PR TITLE
chore: fix TypeError during dev

### DIFF
--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -112,12 +112,10 @@ module.exports = {
       ignoreWarnings: [
         function ignoreSourcemapsloaderWarnings(warning) {
           return (
-            (warning.module &&
-            warning.module.resource.includes("node_modules") &&
-            warning.details &&
-            warning.details.includes("source-map-loader")) ||
-            warning.module.resource.includes("/node_modules/@babel/standalone/babel.js")
-          );
+            (warning.module?.resource.includes("node_modules") &&
+            warning.details?.includes("source-map-loader")) ||
+            warning.module?.resource.includes("/node_modules/@babel/standalone/babel.js")
+          ) ?? false;
         },
       ],
       plugins: [


### PR DESCRIPTION
I see the below error when I do `yarn start`. This change helps, and shouldn't have an impact on underlying functionality.

![shot-2024-01-16-05-42-24](https://github.com/appsmithorg/appsmith/assets/120119/65f9f050-38b2-425f-8482-26a8ab5f1612)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved configuration file logic for enhanced stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->