### PR TITLE
fix: Split changes to allow access to all entities when refactoring something

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceCEImpl.java
@@ -15,7 +15,6 @@ import com.appsmith.server.helpers.DslUtils;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.entities.EntityRefactoringServiceCE;
 import com.appsmith.server.services.AstService;
-import com.appsmith.server.solutions.PagePermission;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -47,7 +46,6 @@ public class WidgetRefactoringServiceCEImpl implements EntityRefactoringServiceC
     private final NewPageService newPageService;
     private final AstService astService;
     private final ObjectMapper objectMapper;
-    private final PagePermission pagePermission;
 
     @Override
     public AnalyticsEvents getRefactorAnalyticsEvent(EntityType entityType) {
@@ -117,7 +115,7 @@ public class WidgetRefactoringServiceCEImpl implements EntityRefactoringServiceC
             String contextId, CreatorContextType contextType, String layoutId, boolean viewMode) {
         return newPageService
                 // fetch the unpublished page
-                .findPageById(contextId, pagePermission.getReadPermission(), viewMode)
+                .findPageById(contextId, null, viewMode)
                 .flatMapMany(page -> {
                     List<Layout> layouts = page.getLayouts();
                     for (Layout layout : layouts) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceImpl.java
@@ -4,7 +4,6 @@ import com.appsmith.server.domains.Layout;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.refactors.entities.EntityRefactoringService;
 import com.appsmith.server.services.AstService;
-import com.appsmith.server.solutions.PagePermission;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 
@@ -12,10 +11,7 @@ import org.springframework.stereotype.Service;
 public class WidgetRefactoringServiceImpl extends WidgetRefactoringServiceCEImpl
         implements EntityRefactoringService<Layout> {
     public WidgetRefactoringServiceImpl(
-            NewPageService newPageService,
-            AstService astService,
-            ObjectMapper objectMapper,
-            PagePermission pagePermission) {
-        super(newPageService, astService, objectMapper, pagePermission);
+            NewPageService newPageService, AstService astService, ObjectMapper objectMapper) {
+        super(newPageService, astService, objectMapper);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/widgets/refactors/WidgetRefactoringServiceCEImplTest.java
@@ -4,7 +4,6 @@ import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.services.AstService;
 import com.appsmith.server.solutions.ActionPermission;
-import com.appsmith.server.solutions.PagePermission;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -34,9 +33,6 @@ class WidgetRefactoringServiceCEImplTest {
     private final String postWord = ")\\b";
 
     @Autowired
-    PagePermission pagePermission;
-
-    @Autowired
     ActionPermission actionPermission;
 
     @MockBean
@@ -54,8 +50,7 @@ class WidgetRefactoringServiceCEImplTest {
 
     @BeforeEach
     public void setUp() {
-        widgetRefactoringServiceCE =
-                new WidgetRefactoringServiceCEImpl(newPageService, astService, mapper, pagePermission);
+        widgetRefactoringServiceCE = new WidgetRefactoringServiceCEImpl(newPageService, astService, mapper);
     }
 
     @Test


### PR DESCRIPTION
Widgets will no longer need permission to refactor. Actions and collections are a TODO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved widget refactoring service for better performance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->