### PR TITLE
fix: re-fix for issue 23456

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -49,6 +49,14 @@ public class DataUtils {
 
     public static String FIELD_API_CONTENT_TYPE = "apiContentType";
 
+    /**
+     * this Gson builder has three parameters for creating a gson instances which is required to maintain the JSON as received
+     * setLenient() : allows parsing of JSONs which don't strictly adhere to RFC4627 (our older implementation is also more permissive)
+     * setObjectToNumberStrategy(): How to parse numbers which comes as a part of JSON objects
+     * i.e. [4, 5.5, 7] --> [4, 5.5, 7] (with lazily parsed numbers), default was [4.0, 5.5, 7.0]
+     * setNumberToNumberStrategy() : same as above but only applies to number json
+     * 4 -> 4,  4.7 --> 4.7
+     */
     private static final Gson gson = new GsonBuilder()
             .setLenient()
             .setObjectToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER)

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -322,6 +322,13 @@ public class DataUtils {
             return null;
         }
 
+        // For both list and Map type we have used fallback parsing strategies, First GSON tries to parse
+        // the jsonString (we've used gson because the native jsonObject gson uses to parse JSON is implemented on top
+        // of linkedHashMaps, which preserves the order of attributes),
+        // however if gson encounters any errors, which could arise due to a lenient jsonString
+        // i.e. { "a" : "one", "b" : "two",} (Notice the comma at the end), this is not a valid json according to
+        // RFC4627. GSON would fail here, however JsonParser from net.minidev would parse this in permissive mode.
+
         if (type.equals(List.class)) {
             return parseJsonIntoListWithOrderedObjects(jsonString, gson, jsonParser);
         } else {

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -69,6 +69,7 @@ import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtil
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -2434,6 +2435,163 @@ public class RestApiPluginTest {
                     assertEquals(
                             actionExecutionResult.getStatusCode(),
                             AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR.getAppErrorCode());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void test_setObjectToNumberPolicy_fromGson() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        String baseUrl = String.format("http://%s:%s", mockEndpoint.getHostName(), mockEndpoint.getPort());
+        dsConfig.setUrl(baseUrl);
+        mockEndpoint.enqueue(new MockResponse().setBody("{}").addHeader("Content-Type", "application/json"));
+        ActionConfiguration actionConfig = new ActionConfiguration();
+        final List<Property> headers = List.of(new Property("content-type", "application/json"));
+        actionConfig.setHeaders(headers);
+        actionConfig.setHttpMethod(HttpMethod.POST);
+        String requestBody =
+                "{\"a\":\"1\",\"x\":[1,2.5,6.0],\"b\":[\"1\",\"5\",\"7\"],\"y\":\"value\",\"z\":\"value\"}";
+        actionConfig.setBody(requestBody);
+
+        Mono<ActionExecutionResult> resultMono =
+                pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+
+                    try {
+                        final RecordedRequest recordedRequest = mockEndpoint.takeRequest(30, TimeUnit.SECONDS);
+                        assert recordedRequest != null;
+                        final Buffer recordedRequestBody = recordedRequest.getBody();
+                        byte[] bodyBytes = new byte[(int) recordedRequestBody.size()];
+
+                        recordedRequestBody.readFully(bodyBytes);
+                        recordedRequestBody.close();
+                        assertEquals(requestBody, new String(bodyBytes));
+                    } catch (EOFException | InterruptedException e) {
+                        assert false : e.getMessage();
+                    }
+
+                    final ActionExecutionRequest request = result.getRequest();
+                    assertEquals(HttpMethod.POST, request.getHttpMethod());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void test_numberToNumberPolicy_fromGson() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        String baseUrl = String.format("http://%s:%s", mockEndpoint.getHostName(), mockEndpoint.getPort());
+        dsConfig.setUrl(baseUrl);
+
+        mockEndpoint.enqueue(new MockResponse().setBody("{}").addHeader("Content-Type", "application/json"));
+
+        ActionConfiguration actionConfig = new ActionConfiguration();
+        final List<Property> headers = List.of(new Property("content-type", "application/json"));
+        actionConfig.setHeaders(headers);
+        actionConfig.setHttpMethod(HttpMethod.POST);
+        String requestBody = "1";
+        actionConfig.setBody(requestBody);
+
+        Mono<ActionExecutionResult> resultMono =
+                pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+
+                    try {
+                        final RecordedRequest recordedRequest = mockEndpoint.takeRequest(30, TimeUnit.SECONDS);
+                        assert recordedRequest != null;
+                        final Buffer recordedRequestBody = recordedRequest.getBody();
+                        byte[] bodyBytes = new byte[(int) recordedRequestBody.size()];
+
+                        recordedRequestBody.readFully(bodyBytes);
+                        recordedRequestBody.close();
+                        assertEquals(requestBody, new String(bodyBytes));
+                    } catch (EOFException | InterruptedException e) {
+                        assert false : e.getMessage();
+                    }
+
+                    final ActionExecutionRequest request = result.getRequest();
+                    assertEquals(HttpMethod.POST, request.getHttpMethod());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void test_DifferentialParsingStrategy_fromGson() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        String baseUrl = String.format("http://%s:%s", mockEndpoint.getHostName(), mockEndpoint.getPort());
+        dsConfig.setUrl(baseUrl);
+
+        mockEndpoint.enqueue(new MockResponse().setBody("{}").addHeader("Content-Type", "application/json"));
+
+        ActionConfiguration actionConfig = new ActionConfiguration();
+        final List<Property> headers = List.of(new Property("content-type", "application/json"));
+        actionConfig.setHeaders(headers);
+        actionConfig.setHttpMethod(HttpMethod.POST);
+        String requestBody =
+                "{\"outerAttribute\":{\"c\":\"value-1\",\"a\":\"random-value\"},\"body\":\"invalid json text\"}";
+        actionConfig.setBody(requestBody);
+
+        Mono<ActionExecutionResult> resultMono =
+                pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+
+                    try {
+                        final RecordedRequest recordedRequest = mockEndpoint.takeRequest(30, TimeUnit.SECONDS);
+                        assert recordedRequest != null;
+                        final Buffer recordedRequestBody = recordedRequest.getBody();
+                        byte[] bodyBytes = new byte[(int) recordedRequestBody.size()];
+
+                        recordedRequestBody.readFully(bodyBytes);
+                        recordedRequestBody.close();
+                        assertEquals(requestBody, new String(bodyBytes));
+                    } catch (EOFException | InterruptedException e) {
+                        assert false : e.getMessage();
+                    }
+
+                    final ActionExecutionRequest request = result.getRequest();
+                    assertEquals(HttpMethod.POST, request.getHttpMethod());
+                })
+                .verifyComplete();
+
+        // This only has an added comma over it.
+        String requestBody2 =
+                "{\"outerAttribute\":{\"c\":\"value-1\",\"a\":\"random-value\"},\"body\":\"invalid json text\",}";
+        String bodySent =
+                "{\"outerAttribute\":{\"a\":\"random-value\",\"c\":\"value-1\"},\"body\":\"invalid json text\"}";
+        actionConfig.setBody(requestBody2);
+
+        mockEndpoint.enqueue(new MockResponse().setBody("{}").addHeader("Content-Type", "application/json"));
+
+        StepVerifier.create(pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig))
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+
+                    try {
+                        final RecordedRequest recordedRequest = mockEndpoint.takeRequest(30, TimeUnit.SECONDS);
+                        assert recordedRequest != null;
+                        final Buffer recordedRequestBody = recordedRequest.getBody();
+                        byte[] bodyBytes = new byte[(int) recordedRequestBody.size()];
+
+                        recordedRequestBody.readFully(bodyBytes);
+                        recordedRequestBody.close();
+                        // the bodyByte would differ from the requestBody
+                        assertNotEquals(requestBody, new String(bodyBytes));
+                        assertEquals(bodySent, new String(bodyBytes));
+                    } catch (EOFException | InterruptedException e) {
+                        assert false : e.getMessage();
+                    }
+
+                    final ActionExecutionRequest request = result.getRequest();
+                    assertEquals(HttpMethod.POST, request.getHttpMethod());
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -1363,7 +1363,7 @@ public class RestApiPluginTest {
                         recordedRequestBody.close();
 
                         assertEquals(
-                                "{\"headers\":{\"X-RANDOM-HEADER\":\"random-value\",\"Content-Type\":\"application/json\"},\"body\":\"invalid json text\"}",
+                                "{\"headers\":{\"Content-Type\":\"application/json\",\"X-RANDOM-HEADER\":\"random-value\"},\"body\":\"invalid json text\"}",
                                 new String(bodyBytes));
 
                         String contentType = recordedRequest.getHeaders().get("Content-Type");


### PR DESCRIPTION
## Description
> Now JSON is rendered in ordered format 

- When JSON used to be parsed, the order of the keys were randomly/alphabetically ordered. some users needed these to be unmodified for sending checksum as headers, the previous fix for issue #23456 only dealt with first order trees.
In this Pr we have used the Gson to parse the JSONs. GSON natively used linkedHashMaps for their JSONObjects, which preserves their keys order. One downside for this is that GSON is a strict parser which parses json only according to RFC4627. 

- If GSON fails to parse the json (may happen because of invalid json) we will fallback to older parsing strategy which is lenient in parsing JSONs.    

#### PR fixes following issue(s)
Fixes #23456

#### How Has This Been Tested?
- [x] Manual
- [x] JUnit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON parsing to ensure the order of keys is preserved, improving data consistency.
	- Introduced support for new data types in the API plugin.

- **Refactor**
	- Updated JSON handling logic for better performance and reliability.

- **Tests**
	- Modified tests to align with the updated JSON parsing and header order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->