### PR TITLE
chore: Cypress wait improvements to code editor focus and cursor checks

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/MaintainContext&Focus_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/MaintainContext&Focus_spec.js
@@ -78,7 +78,7 @@ describe("MaintainContext&Focus", { tags: ["@tag.IDE"] }, function () {
     EditorNavigation.SelectEntityByName("JSObject1", EntityType.JSObject);
 
     cy.wait(1000);
-    cy.focusCodeInput(".js-editor", { ch: 4, line: 4 });
+    cy.focusCodeInput(".js-editor", { ch: 2, line: 4 });
     cy.wait("@saveAction");
 
     EditorNavigation.SelectEntityByName("JSObject2", EntityType.JSObject);

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -516,7 +516,7 @@ Cypress.Commands.add(
       codeMirrorInput.focus();
       cy.wait(200);
       codeMirrorInput.setCursor(cursor);
-      cy.wait(1000); //time for value to set
+      cy.assertCursorOnCodeInput($selector, cursor);
     });
   },
 );

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -516,7 +516,10 @@ Cypress.Commands.add(
       codeMirrorInput.focus();
       cy.wait(200);
       codeMirrorInput.setCursor(cursor);
-      cy.assertCursorOnCodeInput($selector, cursor);
+      cy.wait(200);
+      const editorCursor = codeMirrorInput.getCursor();
+      expect(editorCursor.ch).to.equal(cursor.ch);
+      expect(editorCursor.line).to.equal(cursor.line);
     });
   },
 );


### PR DESCRIPTION
Improves the cypress test method for editor focus and cursor checks removing a wait on focus and asserting instead. This should help in reducing flakiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved cursor positioning logic in code input fields for a more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->