### PR TITLE
fix: Allow request headers up to 16KB

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -2,6 +2,8 @@ server.port=${PORT:8080}
 # Allow the Spring context to close all active requests before shutting down the server
 # Please ref: https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/spring-boot-features.html#boot-features-graceful-shutdown
 server.shutdown=graceful
+server.max-http-request-header-size=16KB
+
 spring.lifecycle.timeout-per-shutdown-phase=20s
 
 spring.profiles.active=${ACTIVE_PROFILE:production}


### PR DESCRIPTION
This is so that large headers like JWT tokens can be accepted.

[Relevant Slack conversation](https://theappsmith.slack.com/archives/C023V5Y0STH/p1705472948243609?thread_ts=1705395384.537429&cid=C023V5Y0STH).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased maximum HTTP request header size to 16KB for improved request handling.
	- Adjusted server shutdown phase timeout to 20 seconds for smoother shutdown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->