### PR TITLE
fix: Admin setting radio button issue

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -108,7 +108,7 @@
     "cypress-log-to-output": "^1.1.2",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",
-    "design-system": "npm:@appsmithorg/design-system@2.1.30",
+    "design-system": "npm:@appsmithorg/design-system@2.1.31",
     "design-system-old": "npm:@appsmithorg/design-system-old@1.1.14",
     "downloadjs": "^1.4.7",
     "echarts": "^5.4.2",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -13359,7 +13359,7 @@ __metadata:
     cypress-xpath: ^1.6.0
     dayjs: ^1.10.6
     deep-diff: ^1.0.2
-    design-system: "npm:@appsmithorg/design-system@2.1.30"
+    design-system: "npm:@appsmithorg/design-system@2.1.31"
     design-system-old: "npm:@appsmithorg/design-system-old@1.1.14"
     diff: ^5.0.0
     dotenv: ^8.1.0
@@ -17407,9 +17407,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"design-system@npm:@appsmithorg/design-system@2.1.30":
-  version: 2.1.30
-  resolution: "@appsmithorg/design-system@npm:2.1.30"
+"design-system@npm:@appsmithorg/design-system@2.1.31":
+  version: 2.1.31
+  resolution: "@appsmithorg/design-system@npm:2.1.31"
   dependencies:
     "@radix-ui/react-dialog": ^1.0.2
     "@radix-ui/react-dropdown-menu": ^2.0.4
@@ -17439,7 +17439,7 @@ __metadata:
     react-dom: ^17.0.2
     react-router-dom: ^5.0.0
     styled-components: ^5.3.6
-  checksum: b41c9a2f85db6c7ed59c74cabfb874a27d9df9fdaa11dd2e33a687be5df653c3d8f6547e332af625f7061b168ae1375068255535d8e31642b69ea8c0ca8e415e
+  checksum: 4fc89bbb7f4403a9583960dd410c722ed3469e22c3e3d3bc256b3024ce6a7288f46308ef89386d931c264e9179cf22141f673f1c0ed9675dc60e8401c3845be8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Issue: Admin settings embedded setting tag was rendering a radio button inside.
Cause: In design system, while styling the radio button, it was only looking for child span. This means any span comes inside the Radio button children, will be considered as the radio part.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/28889


#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
