### PR TITLE
chore: increment minor number for snapshot versions

### DIFF
--- a/.github/release-drafter-template.yml
+++ b/.github/release-drafter-template.yml
@@ -26,7 +26,7 @@ version-resolver:
   patch:
     labels:
       - "Patch"
-  default: patch
+  default: minor
 
 template: |
   ## What's new?

--- a/scripts/generate_info_json.sh
+++ b/scripts/generate_info_json.sh
@@ -13,7 +13,7 @@ if [[ "${GITHUB_REF-}" =~ ^refs/tags/v ]]; then
 else
   latest_released_version="$(git ls-remote --tags --sort=-v:refname "$(git remote | head -1)" 'v*' | awk -F/ '{print $NF; exit}')"
   echo "latest_released_version = $latest_released_version" >&2
-  next_version="$(echo "$latest_released_version" | awk -F. -v OFS=. '{ $3++; print }')"
+  next_version="$(echo "$latest_released_version" | awk -F. -v OFS=. '{ $2++; $3 = 0; print }')"
   echo "next_version = $next_version" >&2
   version="$next_version-SNAPSHOT"
 fi


### PR DESCRIPTION
We've always wanted to increment minor versions instead of patch versions for new releases, as it's more semantic. This PR will change the snapshot version calculation to increment the minor number instead of the patch number.

Came up from [this Slack thread](https://theappsmith.slack.com/archives/CGBPVEJ5C/p1705674928122129?thread_ts=1704793408.986219&cid=CGBPVEJ5C).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the versioning strategy to increment the minor version instead of the patch version for new releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->