### PR TITLE
chore: Remove unneeded exposing of 9001 port

### DIFF
--- a/.github/workflows/ci-debugging.yml
+++ b/.github/workflows/ci-debugging.yml
@@ -74,7 +74,7 @@ jobs:
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3001:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \

--- a/.github/workflows/ci-sanity.yml
+++ b/.github/workflows/ci-sanity.yml
@@ -140,7 +140,7 @@ jobs:
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3001:3000 -p 6001:6001 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -140,7 +140,7 @@ jobs:
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3001:3000 -p 6001:6001 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -28,7 +28,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'repository_dispatch' ||
-      github.event_name == 'schedule' 
+      github.event_name == 'schedule'
     defaults:
       run:
         shell: bash
@@ -175,7 +175,7 @@ jobs:
             -e LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY=$LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY \
             appsmith/cloud-services:release
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \
@@ -212,7 +212,7 @@ jobs:
         run: |
             echo 'tags_to_exclude=airgap' >> "$GITHUB_ENV"
             echo "CYPRESS_grepTags=${{ inputs.tags }}" >> $GITHUB_ENV
-        
+
       - name: Print the tags
         run: |
           echo "tags_to_exclude: ${{ env.tags_to_exclude }}"

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -201,7 +201,7 @@ jobs:
             -e LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY=$LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY \
             appsmith/cloud-services:release
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \

--- a/.github/workflows/ci-test-with-documentdb.yml
+++ b/.github/workflows/ci-test-with-documentdb.yml
@@ -282,7 +282,7 @@ jobs:
             -e ENTERPRISE_ADMIN_PASSWORD=ent_admin_password \
             appsmith/cloud-services:release
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -181,7 +181,7 @@ jobs:
             -e FLAGSMITH_SERVER_KEY_BUSINESS_FEATURES=dummykeybusinessfeatures \
             appsmith/cloud-services:release
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \

--- a/.github/workflows/perf-test-on-documentdb.yml
+++ b/.github/workflows/perf-test-on-documentdb.yml
@@ -131,7 +131,7 @@ jobs:
           APPSMITH_MONGODB_URI: ${{ secrets.INTERNAL_CI_DOC_DB_URI }}
         working-directory: "."
         run: |
-          timestamp=$(date +%s) 
+          timestamp=$(date +%s)
           hash=$(echo -n "$timestamp" | sha1sum | awk '{print $1}')
           current_date=$(date -d "@$timestamp" +"%d-%m")
           DB_NAME="ci${hash:1:3}-${current_date}"
@@ -141,7 +141,7 @@ jobs:
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3000:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
@@ -154,7 +154,7 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: ./app/client/packages/rts
         run: |
-          cp .env.example .env        
+          cp .env.example .env
           ./start-server.sh &
 
       - name: Setting up the perf tests

--- a/.github/workflows/perf-test-v2.yml
+++ b/.github/workflows/perf-test-v2.yml
@@ -129,7 +129,7 @@ jobs:
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3000:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
@@ -141,7 +141,7 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: ./app/client/packages/rts
         run: |
-          cp .env.example .env        
+          cp .env.example .env
           ./start-server.sh &
 
       - name: Setting up the perf tests

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -128,7 +128,7 @@ jobs:
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3000:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+          docker run -d --name appsmith -p 80:80 \
             -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
@@ -140,7 +140,7 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: ./app/client/packages/rts
         run: |
-          cp .env.example .env        
+          cp .env.example .env
           ./start-server.sh &
 
       - name: Setting up the perf tests

--- a/app/server/appsmith-server/src/main/resources/docker-compose.yml
+++ b/app/server/appsmith-server/src/main/resources/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "9001:9001"
     volumes:
       - ./stacks:/appsmith-stacks
     labels:

--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -110,9 +110,9 @@ On your development machine, please ensure that:
   ```
 
 - In order to run cypress tests which use datasources/rest api, you will need to have TED (Test Event Driver) container running: (It bundles multiple services together along with fake data for testing)
-  ``` 
+  ```
   docker pull appsmith/test-event-driver
-  
+
   docker run --name appsmithted -d -p 2222:22 -p 5001:5001 -p 3306:3306 -p 28017:27017 -p 5432:5432 -p 25:25 -p 5000:5000 -p 3000:3000 -v `pwd`/git-server/keys:/git-server/keys -v `pwd`/git-server/repos:/git-server/repo appsmith/test-event-driver
   ```
 
@@ -134,15 +134,15 @@ On your development machine, please ensure that:
 
             docker pull appsmith/appsmith-ce
 
-            docker run -d --name appsmith -p 8000:80 -p 9001:9001 appsmith/appsmith-ce:latest;
+            docker run -d --name appsmith -p 8000:80 appsmith/appsmith-ce:latest;
 
             docker logs -f appsmith;
 
-            ./start-https.sh http://localhost:8000 // if nginx is installed locally 
+            ./start-https.sh http://localhost:8000 // if nginx is installed locally
             ./start-https.sh http://host.docker.internal:8000 // if nginx is running on docker
-            
+
             ```
-    
+
 
         1. Create docker image from local source code
 
@@ -151,15 +151,15 @@ On your development machine, please ensure that:
             ./scripts/local_testing.sh -l # This builds a fat docker image of local backend and frontend
             # The docker image created above will show up in your docker desktop application
 
-            docker run -d --name appsmith -p 8000:80 -p 9001:9001 appsmith/appsmith-ce:local-testing;
-            
-            ./start-https.sh http://localhost:8000 // if nginx is installed locally 
+            docker run -d --name appsmith -p 8000:80 appsmith/appsmith-ce:local-testing;
+
+            ./start-https.sh http://localhost:8000 // if nginx is installed locally
             ./start-https.sh http://host.docker.internal:8000 // if nginx is running on docker
 
             ```
 - Please check out our [Testing Contribution](docs/TestAutomation.md) guide for more details on setting up & troubleshooting Cypress runs on your machine.
 
-   
+
 ### Running Unit Tests
 
 - To run the Jest unit tests, run:
@@ -172,10 +172,10 @@ On your development machine, please ensure that:
 - To run a single jest test,
   ```bash
     cd app/client
-    
+
     # Run either command below to run a test
     npx jest <file_path/file_name>
-    
+
     # or
 
     yarn jest src/widgets/<filepath>/<filename>.test.ts --silent=false

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -45,7 +45,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "9001:9001"
     volumes:
       - ./stacks:/appsmith-stacks
     restart: unless-stopped
@@ -96,7 +95,7 @@ To make Appsmith available on a custom domain, please update your domain's DNS r
 ## Custom SSL Certificate
 
 In our container, we support to generate a free SSL certificate If you have your owned certificate, please follow these steps to use it inside the container.
-- Firstly, please rename your certificate file as `fullchain.pem` and key file as `privkey.pem` 
+- Firstly, please rename your certificate file as `fullchain.pem` and key file as `privkey.pem`
 - Then, copy these files into the sub-directory `<mounting-directory>/ssl/` (*Note: Please change `<mounting-directory>` by the mounting volume directory in the `docker-compose.yml`. Default is `./stacks`*)
 - Restart the container using `docker restart appsmith`
 

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -75,9 +75,6 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
-            - name: supervisord
-              containerPort: 9001
-              protocol: TCP
           {{- $probes := .Values.probes | default dict }}
           startupProbe:
             # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.


### PR DESCRIPTION
We're already using `/supervisor` for this, and don't expect anyone to hit the port directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow configurations to refine Docker container setup and networking.
	- Adjusted performance test workflows for better resource allocation.

- **Documentation**
	- Updated client setup guide and Docker deployment instructions to reflect changes in port configurations and command syntax.
	- Improved clarity in the "Custom SSL Certificate" section of the Docker deployment documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->