### PR TITLE
chore: Add traces for measuring data transfer time between worker thread and…

### DIFF
--- a/app/client/src/UITelemetry/generateWebWorkerTraces.ts
+++ b/app/client/src/UITelemetry/generateWebWorkerTraces.ts
@@ -1,59 +1,53 @@
 import { startNestedSpan } from "./generateTraces";
 import type { TimeInput, Attributes, Span } from "@opentelemetry/api";
 
-export interface WebworkerSpan {
+export interface WebworkerSpanData {
   attributes: Attributes;
   spanName: string;
   startTime: TimeInput;
   endTime: TimeInput;
-  endSpan?: () => void;
 }
+
 //this is used in webworkers to generate telemetry data
 //this telemetry data is pushed to the main thread which is converted
 //to regular otlp telemetry data and subsequently exported to our telemetry collector
-export const startSpan = (
+export const newWebWorkerSpanData = (
   spanName: string,
   attributes: Attributes,
-): WebworkerSpan => {
+): WebworkerSpanData => {
   return {
     attributes,
     spanName,
     startTime: Date.now(),
     endTime: Date.now(),
-    endSpan: function () {
-      this.endTime = Date.now();
-    },
   };
 };
 
-export const startSpansInAnEvaluation = () => {
-  return {
-    allSpans: [] as WebworkerSpan[],
-    profileFn: function (
-      spanName: string,
-      attributes: Attributes = {},
-      fun: (...args: any[]) => any,
-    ) {
-      const span = startSpan(spanName, attributes);
-      const res = fun();
-      span.endSpan?.();
-      // delete endSpan since it is not serialisable by webworker's postMessage to main thread
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { endSpan, ...rest } = span;
-      this.allSpans.push(rest);
-      return res;
-    },
-  };
+const addEndTimeForWebWorkerSpanData = (span: WebworkerSpanData) => {
+  span.endTime = Date.now();
+};
+
+export const profileFn = (
+  spanName: string,
+  attributes: Attributes = {},
+  allSpans: Record<string, WebworkerSpanData>,
+  fn: (...args: any[]) => any,
+) => {
+  const span = newWebWorkerSpanData(spanName, attributes);
+  const res = fn();
+  addEndTimeForWebWorkerSpanData(span);
+  allSpans[spanName] = span;
+  return res;
 };
 
 //convert webworker spans to OTLP spans
 export const convertWebworkerSpansToRegularSpans = (
   parentSpan: Span,
-  allSpans?: WebworkerSpan[],
+  allSpans: Record<string, WebworkerSpanData> = {},
 ) => {
-  allSpans?.forEach((v) => {
-    const { attributes, endTime, spanName, startTime } = v;
+  for (const spanData of Object.values(allSpans)) {
+    const { attributes, endTime, spanName, startTime } = spanData;
     const span = startNestedSpan(spanName, parentSpan, attributes, startTime);
     span?.end(endTime);
-  });
+  }
 };

--- a/app/client/src/ce/workers/common/types.ts
+++ b/app/client/src/ce/workers/common/types.ts
@@ -1,3 +1,5 @@
+import type { WebworkerSpanData } from "UITelemetry/generateWebWorkerTraces";
+
 export enum AppsmithWorkers {
   LINT_WORKER = "LINT_WORKER",
   EVALUATION_WORKER = "EVALUATION_WORKER",
@@ -10,4 +12,5 @@ export enum WorkerErrorTypes {
 export interface WorkerRequest<TData, TActions> {
   method: TActions;
   data: TData;
+  webworkerTelemetry: Record<string, WebworkerSpanData>;
 }

--- a/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
+++ b/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
@@ -43,6 +43,7 @@ describe("evaluateSync", () => {
       data: {
         cloudHosting: false,
       },
+      webworkerTelemetry: {},
     });
     resetJSLibraries();
   });

--- a/app/client/src/workers/Evaluation/handlers/__tests__/jsLibrary.test.ts
+++ b/app/client/src/workers/Evaluation/handlers/__tests__/jsLibrary.test.ts
@@ -34,6 +34,7 @@ describe("Tests to assert install/uninstall flows", function () {
         takenNamesMap: {},
       },
       method: EVAL_WORKER_ASYNC_ACTION.INSTALL_LIBRARY,
+      webworkerTelemetry: {},
     });
     //
     expect(self.importScripts).toHaveBeenCalled();
@@ -57,6 +58,7 @@ describe("Tests to assert install/uninstall flows", function () {
         takenNamesMap: {},
       },
       method: EVAL_WORKER_ASYNC_ACTION.INSTALL_LIBRARY,
+      webworkerTelemetry: {},
     });
     expect(res).toEqual({
       success: true,
@@ -77,6 +79,7 @@ describe("Tests to assert install/uninstall flows", function () {
         takenNamesMap: { lodash: true },
       },
       method: EVAL_WORKER_ASYNC_ACTION.INSTALL_LIBRARY,
+      webworkerTelemetry: {},
     });
     expect(res).toEqual({
       success: true,
@@ -94,6 +97,7 @@ describe("Tests to assert install/uninstall flows", function () {
     const res = await uninstallLibrary({
       data: ["lodash"],
       method: EVAL_WORKER_SYNC_ACTION.UNINSTALL_LIBRARY,
+      webworkerTelemetry: {},
     });
     expect(res).toEqual({ success: true });
     expect(self.lodash).toBeUndefined();

--- a/app/client/src/workers/Evaluation/handlers/index.ts
+++ b/app/client/src/workers/Evaluation/handlers/index.ts
@@ -7,7 +7,8 @@ import { EVAL_WORKER_ACTIONS } from "@appsmith/workers/Evaluation/evalWorkerActi
 import type { EvalWorkerSyncRequest, EvalWorkerASyncRequest } from "../types";
 import evalActionBindings from "./evalActionBindings";
 import evalExpression from "./evalExpression";
-import evalTree, {
+import {
+  evalTree,
   clearCache,
   evalTreeTransmissionErrorHandler,
 } from "./evalTree";

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -18,7 +18,7 @@ import type { EvalMetaUpdates } from "@appsmith/workers/common/DataTreeEvaluator
 import type { WorkerRequest } from "@appsmith/workers/common/types";
 import type { DataTreeDiff } from "@appsmith/workers/Evaluation/evaluationUtils";
 import type { APP_MODE } from "entities/App";
-import type { WebworkerSpan } from "UITelemetry/generateWebWorkerTraces";
+import type { WebworkerSpanData } from "UITelemetry/generateWebWorkerTraces";
 
 export type EvalWorkerSyncRequest<T = any> = WorkerRequest<
   T,
@@ -60,7 +60,7 @@ export interface EvalTreeResponseData {
   isNewWidgetAdded: boolean;
   undefinedEvalValuesMap: Record<string, boolean>;
   jsVarsCreatedEvent?: { path: string; type: string }[];
-  webworkerTelemetry?: WebworkerSpan[];
+  webworkerTelemetry?: Record<string, WebworkerSpanData>;
   updates: string;
 }
 


### PR DESCRIPTION
This pull requests instruments traces for evaluations to include data transfer time between main thread and worker thread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced web worker telemetry for improved performance profiling.
  - Added new telemetry data handling in `GracefulWorkerService`.

- **Refactor**
  - Updated web worker span data structure and related functions for better efficiency.
  - Refactored `evalTree` function to include telemetry and profiling enhancements.
  - Reorganized imports for clarity in the evaluation handlers.

- **Bug Fixes**
  - Fixed telemetry span data collection to accurately reflect end times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->