### PR TITLE
fix: datasource query schema show condition

### DIFF
--- a/app/client/src/ce/entities/Engine/actionHelpers.ts
+++ b/app/client/src/ce/entities/Engine/actionHelpers.ts
@@ -7,6 +7,7 @@ import type { DependentFeatureFlags } from "@appsmith/selectors/engineSelectors"
 import { fetchDatasources } from "actions/datasourceActions";
 import { fetchPageDSLs } from "actions/pageActions";
 import { fetchPlugins } from "actions/pluginActions";
+import type { Plugin } from "api/PluginApi";
 
 export const CreateNewActionKey = {
   PAGE: "pageId",
@@ -39,4 +40,10 @@ export const getPageDependencyActions = (
     successActions,
     errorActions,
   };
+};
+
+export const doesPluginRequireDatasource = (plugin: Plugin | undefined) => {
+  return !!plugin && plugin.hasOwnProperty("requiresDatasource")
+    ? plugin.requiresDatasource
+    : true;
 };

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -354,11 +354,14 @@ export function EditorJSONtoForm(props: Props) {
     userWorkspacePermissions,
   );
 
+  const doesPluginRequireDatasource =
+    !!plugin && plugin.hasOwnProperty("requiresDatasource")
+      ? plugin.requiresDatasource
+      : true;
+
   const showSchema =
     useShowSchema(currentActionConfig?.pluginId || "") &&
-    (!!plugin && plugin.hasOwnProperty("requiresDatasource")
-      ? plugin.requiresDatasource
-      : true);
+    doesPluginRequireDatasource;
 
   const showRightPane =
     showSchema ||
@@ -624,7 +627,7 @@ export function EditorJSONtoForm(props: Props) {
   // Datasource selection is hidden for Appsmith AI Plugin and for plugins that don't require datasource
   // TODO: @Diljit Remove this condition when knowledge retrieval for Appsmith AI is implemented (Only remove the AI Condition)
   const showDatasourceSelector =
-    !isAppsmithAIPlugin(plugin?.packageName) && !!plugin?.requiresDatasource;
+    !isAppsmithAIPlugin(plugin?.packageName) && doesPluginRequireDatasource;
 
   // when switching between different redux forms, make sure this redux form has been initialized before rendering anything.
   // the initialized prop below comes from redux-form.

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -92,6 +92,7 @@ import QueryResponseTabView from "./QueryResponseView";
 import { setDebuggerSelectedTab, showDebugger } from "actions/debuggerActions";
 import useShowSchema from "components/editorComponents/ActionRightPane/useShowSchema";
 import { isAppsmithAIPlugin } from "utils/editorContextUtils";
+import { doesPluginRequireDatasource } from "@appsmith/entities/Engine/actionHelpers";
 
 const QueryFormContainer = styled.form`
   flex: 1;
@@ -354,14 +355,11 @@ export function EditorJSONtoForm(props: Props) {
     userWorkspacePermissions,
   );
 
-  const doesPluginRequireDatasource =
-    !!plugin && plugin.hasOwnProperty("requiresDatasource")
-      ? plugin.requiresDatasource
-      : true;
+  const pluginRequireDatasource = doesPluginRequireDatasource(plugin);
 
   const showSchema =
     useShowSchema(currentActionConfig?.pluginId || "") &&
-    doesPluginRequireDatasource;
+    pluginRequireDatasource;
 
   const showRightPane =
     showSchema ||
@@ -627,7 +625,7 @@ export function EditorJSONtoForm(props: Props) {
   // Datasource selection is hidden for Appsmith AI Plugin and for plugins that don't require datasource
   // TODO: @Diljit Remove this condition when knowledge retrieval for Appsmith AI is implemented (Only remove the AI Condition)
   const showDatasourceSelector =
-    !isAppsmithAIPlugin(plugin?.packageName) && doesPluginRequireDatasource;
+    !isAppsmithAIPlugin(plugin?.packageName) && pluginRequireDatasource;
 
   // when switching between different redux forms, make sure this redux form has been initialized before rendering anything.
   // the initialized prop below comes from redux-form.

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -356,7 +356,9 @@ export function EditorJSONtoForm(props: Props) {
 
   const showSchema =
     useShowSchema(currentActionConfig?.pluginId || "") &&
-    !!plugin?.requiresDatasource;
+    (!!plugin && plugin.hasOwnProperty("requiresDatasource")
+      ? plugin.requiresDatasource
+      : true);
 
   const showRightPane =
     showSchema ||

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -90,6 +90,7 @@ import {
   getCurrentApplicationIdForCreateNewApp,
 } from "@appsmith/selectors/applicationSelectors";
 import { TEMP_DATASOURCE_ID } from "constants/Datasource";
+import { doesPluginRequireDatasource } from "@appsmith/entities/Engine/actionHelpers";
 
 // Called whenever the query being edited is changed via the URL or query pane
 function* changeQuerySaga(actionPayload: ReduxAction<ChangeQueryPayload>) {
@@ -293,7 +294,7 @@ function* formValueChangeSaga(
       url: "",
     };
 
-    if (plugin?.requiresDatasource) {
+    if (doesPluginRequireDatasource(plugin)) {
       dsConfig = datasourceStorages[currentEnvironment].datasourceConfiguration;
     }
     const postEvalActions =


### PR DESCRIPTION
## Description
With the introduction of new workflow plugin we have added a flag `requiresDatasource` in the plugins which allows users to create a query on a plugin without the datasource. This kind of actions already exist in REST APIs but not for queries. The schema section is to be hidden in case the query doesn't have a parent datasource. But in some cases this flag was not coming causing the condition to fail. This PR fixes the condition fetch and allow schema to be shown by default if the flag is not present.

#### PR fixes following issue(s)
Fixes #30543

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability in the query editor by ensuring the `showSchema` option is correctly determined when a plugin's data source requirement is unspecified.
	- Updated the `actionHelpers.ts` file to include the import of `Plugin` from "api/PluginApi" and the addition of a new function `doesPluginRequireDatasource` that checks if a plugin requires a datasource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->