### PR TITLE
chore: Remove deprecated fields in Policy

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Policy.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Policy.java
@@ -21,14 +21,6 @@ public class Policy implements Serializable {
 
     String permission;
 
-    @Deprecated
-    @Builder.Default
-    Set<String> users = new HashSet<>();
-
-    @Deprecated
-    @Builder.Default
-    Set<String> groups = new HashSet<>();
-
     @Builder.Default
     Set<String> permissionGroups = new HashSet<>();
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/SeedMongoData.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/SeedMongoData.java
@@ -74,80 +74,52 @@ public class SeedMongoData {
         final String ADMIN_USER_EMAIL = "admin@solutiontest.com";
         final String DEV_USER_EMAIL = "developer@solutiontest.com";
 
-        Policy manageAppPolicy = Policy.builder()
-                .permission(MANAGE_APPLICATIONS.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy manageAppPolicy =
+                Policy.builder().permission(MANAGE_APPLICATIONS.getValue()).build();
 
-        Policy readAppPolicy = Policy.builder()
-                .permission(READ_APPLICATIONS.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy readAppPolicy =
+                Policy.builder().permission(READ_APPLICATIONS.getValue()).build();
 
         Policy manageWorkspaceAppPolicy = Policy.builder()
                 .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .users(Set.of(API_USER_EMAIL))
                 .build();
 
         Policy exportWorkspaceAppPolicy = Policy.builder()
                 .permission(WORKSPACE_EXPORT_APPLICATIONS.getValue())
-                .users(Set.of(API_USER_EMAIL))
                 .build();
 
-        Policy userManageWorkspacePolicy = Policy.builder()
-                .permission(USER_MANAGE_WORKSPACES.getValue())
-                .users(Set.of(API_USER_EMAIL, TEST_USER_EMAIL, ADMIN_USER_EMAIL, DEV_USER_EMAIL))
-                .build();
+        Policy userManageWorkspacePolicy =
+                Policy.builder().permission(USER_MANAGE_WORKSPACES.getValue()).build();
 
-        Policy inviteUserWorkspacePolicy = Policy.builder()
-                .permission(WORKSPACE_INVITE_USERS.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy inviteUserWorkspacePolicy =
+                Policy.builder().permission(WORKSPACE_INVITE_USERS.getValue()).build();
 
-        Policy managePagePolicy = Policy.builder()
-                .permission(MANAGE_PAGES.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy managePagePolicy =
+                Policy.builder().permission(MANAGE_PAGES.getValue()).build();
 
-        Policy readPagePolicy = Policy.builder()
-                .permission(READ_PAGES.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy readPagePolicy =
+                Policy.builder().permission(READ_PAGES.getValue()).build();
 
-        Policy readWorkspacePolicy = Policy.builder()
-                .permission(READ_WORKSPACES.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy readWorkspacePolicy =
+                Policy.builder().permission(READ_WORKSPACES.getValue()).build();
 
-        Policy manageWorkspacePolicy = Policy.builder()
-                .permission(MANAGE_WORKSPACES.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy manageWorkspacePolicy =
+                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
 
-        Policy readApiUserPolicy = Policy.builder()
-                .permission(READ_USERS.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy readApiUserPolicy =
+                Policy.builder().permission(READ_USERS.getValue()).build();
 
-        Policy manageApiUserPolicy = Policy.builder()
-                .permission(MANAGE_USERS.getValue())
-                .users(Set.of(API_USER_EMAIL))
-                .build();
+        Policy manageApiUserPolicy =
+                Policy.builder().permission(MANAGE_USERS.getValue()).build();
 
-        Policy readTestUserPolicy = Policy.builder()
-                .permission(READ_USERS.getValue())
-                .users(Set.of(TEST_USER_EMAIL))
-                .build();
+        Policy readTestUserPolicy =
+                Policy.builder().permission(READ_USERS.getValue()).build();
 
-        Policy readAdminUserPolicy = Policy.builder()
-                .permission(READ_USERS.getValue())
-                .users(Set.of(ADMIN_USER_EMAIL))
-                .build();
+        Policy readAdminUserPolicy =
+                Policy.builder().permission(READ_USERS.getValue()).build();
 
-        Policy readDevUserPolicy = Policy.builder()
-                .permission(READ_USERS.getValue())
-                .users(Set.of(DEV_USER_EMAIL))
-                .build();
+        Policy readDevUserPolicy =
+                Policy.builder().permission(READ_USERS.getValue()).build();
 
         Object[][] userData = {
             {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -925,7 +925,6 @@ public class DatasourceServiceTest {
                                         page.setApplicationId(application1.getId());
                                         page.setPolicies(new HashSet<>(Set.of(Policy.builder()
                                                 .permission(READ_PAGES.getValue())
-                                                .users(Set.of("api_user"))
                                                 .build())));
                                         return applicationPageService.createPage(page);
                                     }));
@@ -1007,7 +1006,6 @@ public class DatasourceServiceTest {
                                         page.setApplicationId(application1.getId());
                                         page.setPolicies(new HashSet<>(Set.of(Policy.builder()
                                                 .permission(READ_PAGES.getValue())
-                                                .users(Set.of("api_user"))
                                                 .build())));
                                         return applicationPageService.createPage(page);
                                     }));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
@@ -587,13 +587,6 @@ public class WorkspaceServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void inValidupdateWorkspaceEmptyName() {
-        Policy manageWorkspaceAppPolicy = Policy.builder()
-                .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .build();
-
-        Policy manageWorkspacePolicy =
-                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
-
         Workspace workspace = new Workspace();
         workspace.setName("Test Update Name");
         workspace.setDomain("example.com");
@@ -615,13 +608,6 @@ public class WorkspaceServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void validUpdateWorkspaceValidEmail() {
-        Policy manageWorkspaceAppPolicy = Policy.builder()
-                .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .build();
-
-        Policy manageWorkspacePolicy =
-                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
-
         String[] validEmails = {"valid@email.com", "valid@email.co.in", "valid@email-assoc.co.in"};
         for (String validEmail : validEmails) {
             Workspace workspace = new Workspace();
@@ -646,13 +632,6 @@ public class WorkspaceServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void validUpdateWorkspaceInvalidEmail() {
-        Policy manageWorkspaceAppPolicy = Policy.builder()
-                .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .build();
-
-        Policy manageWorkspacePolicy =
-                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
-
         String[] invalidEmails = {"invalid@.com", "@invalid.com"};
         for (String invalidEmail : invalidEmails) {
             Workspace workspace = new Workspace();
@@ -677,13 +656,6 @@ public class WorkspaceServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void validUpdateWorkspaceValidWebsite() {
-        Policy manageWorkspaceAppPolicy = Policy.builder()
-                .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .build();
-
-        Policy manageWorkspacePolicy =
-                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
-
         String[] validWebsites = {
             "https://www.valid.website.com",
             "http://www.valid.website.com",
@@ -727,13 +699,6 @@ public class WorkspaceServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void validUpdateWorkspaceInvalidWebsite() {
-        Policy manageWorkspaceAppPolicy = Policy.builder()
-                .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .build();
-
-        Policy manageWorkspacePolicy =
-                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
-
         String[] invalidWebsites = {
             "htp://www.invalid.website.com", "htp://invalid.website.com", "htp://www", "www", "www."
         };

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
@@ -589,13 +589,10 @@ public class WorkspaceServiceTest {
     public void inValidupdateWorkspaceEmptyName() {
         Policy manageWorkspaceAppPolicy = Policy.builder()
                 .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .users(Set.of("api_user"))
                 .build();
 
-        Policy manageWorkspacePolicy = Policy.builder()
-                .permission(MANAGE_WORKSPACES.getValue())
-                .users(Set.of("api_user"))
-                .build();
+        Policy manageWorkspacePolicy =
+                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
 
         Workspace workspace = new Workspace();
         workspace.setName("Test Update Name");
@@ -620,13 +617,10 @@ public class WorkspaceServiceTest {
     public void validUpdateWorkspaceValidEmail() {
         Policy manageWorkspaceAppPolicy = Policy.builder()
                 .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .users(Set.of("api_user"))
                 .build();
 
-        Policy manageWorkspacePolicy = Policy.builder()
-                .permission(MANAGE_WORKSPACES.getValue())
-                .users(Set.of("api_user"))
-                .build();
+        Policy manageWorkspacePolicy =
+                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
 
         String[] validEmails = {"valid@email.com", "valid@email.co.in", "valid@email-assoc.co.in"};
         for (String validEmail : validEmails) {
@@ -654,13 +648,10 @@ public class WorkspaceServiceTest {
     public void validUpdateWorkspaceInvalidEmail() {
         Policy manageWorkspaceAppPolicy = Policy.builder()
                 .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .users(Set.of("api_user"))
                 .build();
 
-        Policy manageWorkspacePolicy = Policy.builder()
-                .permission(MANAGE_WORKSPACES.getValue())
-                .users(Set.of("api_user"))
-                .build();
+        Policy manageWorkspacePolicy =
+                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
 
         String[] invalidEmails = {"invalid@.com", "@invalid.com"};
         for (String invalidEmail : invalidEmails) {
@@ -688,13 +679,10 @@ public class WorkspaceServiceTest {
     public void validUpdateWorkspaceValidWebsite() {
         Policy manageWorkspaceAppPolicy = Policy.builder()
                 .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .users(Set.of("api_user"))
                 .build();
 
-        Policy manageWorkspacePolicy = Policy.builder()
-                .permission(MANAGE_WORKSPACES.getValue())
-                .users(Set.of("api_user"))
-                .build();
+        Policy manageWorkspacePolicy =
+                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
 
         String[] validWebsites = {
             "https://www.valid.website.com",
@@ -741,13 +729,10 @@ public class WorkspaceServiceTest {
     public void validUpdateWorkspaceInvalidWebsite() {
         Policy manageWorkspaceAppPolicy = Policy.builder()
                 .permission(WORKSPACE_MANAGE_APPLICATIONS.getValue())
-                .users(Set.of("api_user"))
                 .build();
 
-        Policy manageWorkspacePolicy = Policy.builder()
-                .permission(MANAGE_WORKSPACES.getValue())
-                .users(Set.of("api_user"))
-                .build();
+        Policy manageWorkspacePolicy =
+                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
 
         String[] invalidWebsites = {
             "htp://www.invalid.website.com", "htp://invalid.website.com", "htp://www", "www", "www."
@@ -1666,14 +1651,10 @@ public class WorkspaceServiceTest {
     public void delete_WithoutManagePermission_ThrowsException() {
         Workspace workspace = new Workspace();
         workspace.setName("Test org to test delete org");
-        Policy readWorkspacePolicy = Policy.builder()
-                .permission(READ_WORKSPACES.getValue())
-                .users(Set.of("api_user", "test_user@example.com"))
-                .build();
-        Policy manageWorkspacePolicy = Policy.builder()
-                .permission(MANAGE_WORKSPACES.getValue())
-                .users(Set.of("test_user@example.com"))
-                .build();
+        Policy readWorkspacePolicy =
+                Policy.builder().permission(READ_WORKSPACES.getValue()).build();
+        Policy manageWorkspacePolicy =
+                Policy.builder().permission(MANAGE_WORKSPACES.getValue()).build();
 
         // api user has read org permission but no manage org permission
         workspace.setPolicies(new HashSet<>(Set.of(readWorkspacePolicy, manageWorkspacePolicy)));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
@@ -590,14 +590,10 @@ public class ApplicationServiceCETest {
                 // Fetch the unpublished pages by applicationId
                 .flatMapMany(application -> newPageService.findByApplicationId(application.getId(), READ_PAGES, false));
 
-        Policy managePagePolicy = Policy.builder()
-                .permission(MANAGE_PAGES.getValue())
-                .users(Set.of("api_user"))
-                .build();
-        Policy readPagePolicy = Policy.builder()
-                .permission(READ_PAGES.getValue())
-                .users(Set.of("api_user"))
-                .build();
+        Policy managePagePolicy =
+                Policy.builder().permission(MANAGE_PAGES.getValue()).build();
+        Policy readPagePolicy =
+                Policy.builder().permission(READ_PAGES.getValue()).build();
 
         StepVerifier.create(pagesFlux)
                 .assertNext(page -> {


### PR DESCRIPTION
This PR removes the `Policy.users` and `Policy.groups` fields, that aren't used, and are deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified policy management by removing deprecated user and group sets.
  
- **Chores**
  - Updated tests to align with the new policy management approach.

- **Bug Fixes**
  - Ensured consistent policy creation across various services without specifying explicit user sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->