### PR TITLE
fix: Allow incoming TLS traffic without restricting the domain

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -31,8 +31,6 @@ if (CUSTOM_DOMAIN !== "") {
 
 }
 
-const tlsConfig = certLocation == null ? "" : `tls ${certLocation}/fullchain.pem ${certLocation}/privkey.pem`
-
 const frameAncestorsPolicy = (process.env.APPSMITH_ALLOWED_FRAME_ANCESTORS || "'self'")
   .replace(/;.*$/, "")
 
@@ -128,13 +126,27 @@ parts.push(`
 `)
 
 if (CUSTOM_DOMAIN !== "") {
-  // If no custom domain, no extra routing needed.
+  if (certLocation) {
+    // There's a custom certificate, don't bind to any exact domain.
+    parts.push(`
+    https:// {
+      import all-config
+      tls ${certLocation}/fullchain.pem ${certLocation}/privkey.pem
+    }
+    `)
+
+  } else {
+    // No custom certificate, bind to the custom domain explicitly, so Caddy can auto-provision the cert.
+    parts.push(`
+    https://${CUSTOM_DOMAIN} {
+      import all-config
+    }
+    `)
+
+  }
+
   // We have to own the http-to-https redirect, since we need to remove the `Server` header from the response.
   parts.push(`
-  https:// {
-    import all-config
-    ${tlsConfig}
-  }
   http://${CUSTOM_DOMAIN} {
     redir https://{host}{uri}
     header -Server

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -131,7 +131,7 @@ if (CUSTOM_DOMAIN !== "") {
   // If no custom domain, no extra routing needed.
   // We have to own the http-to-https redirect, since we need to remove the `Server` header from the response.
   parts.push(`
-  https://${CUSTOM_DOMAIN} {
+  https:// {
     import all-config
     ${tlsConfig}
   }

--- a/deploy/docker/route-tests/entrypoint.sh
+++ b/deploy/docker/route-tests/entrypoint.sh
@@ -74,6 +74,7 @@ new-spec "Spec 2: With a custom domain, cert obtained (because of internal CA)"
 export APPSMITH_CUSTOM_DOMAIN=custom-domain.com
 node /caddy-reconfigure.mjs
 #sed -i '2i acme_ca https://acme-staging-v02.api.letsencrypt.org/directory' "$TMP/Caddyfile"
+# The domain being present is a necceary thing here, since otherwise Caddy won't know what domain to provision a cert for.
 sed -i '/https:\/\/'"$APPSMITH_CUSTOM_DOMAIN"' {$/a tls internal' "$TMP/Caddyfile"
 reload-caddy
 run-hurl --variable ca_issuer="CN = Caddy Local Authority - ECC Intermediate" \


### PR DESCRIPTION
This is a fix for a user's problem. They have custom domain set, a custom cert in the `stacks/ssl` folder, but because a different team operates a reverse-proxy, they aren't sure which _host_ is actually used by the reverse proxy. And the way we bind to port 443 requires that that puzzle be solved, for very little extra value.

This change makes it so that we accept any incoming TLS connections, if a custom domain is set, which should be much more convenient.

[Slack Thread](https://theappsmith.slack.com/archives/C0341RERY4R/p1705700120412079).

Already deployed on users' system, and they've confirmed its working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved `https` URL routing to automatically adapt based on custom certificate availability.
- **Documentation**
	- Added explanatory comments for domain requirements in TLS configuration.
- **Refactor**
	- Enhanced server response header management for better security compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->