### PR TITLE
chore: consolidated API: return AppsmithAiPlugin's editor config by default 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConsolidatedAPIServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConsolidatedAPIServiceImpl.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.appsmith.external.constants.PluginConstants.PackageName.APPSMITH_AI_PLUGIN;
 import static com.appsmith.external.constants.PluginConstants.PackageName.GRAPHQL_PLUGIN;
 import static com.appsmith.external.constants.PluginConstants.PackageName.REST_API_PLUGIN;
 import static com.appsmith.server.constants.OtlpSpanNames.ACTIONS_SPAN;
@@ -571,9 +572,13 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                                 .filter(datasource -> !isBlank(datasource.getPluginId()))
                                 .forEach(datasource -> setOfAllPluginIdsToGetFormConfig.add(datasource.getPluginId()));
 
+                        /**
+                         * There are some plugins that allow query to be created without creating a datasource. For
+                         * such datasources, editor config is required to display any queries that may have been
+                         * created or in case user wants to create a query without creating a datasource first.
+                         */
                         pluginList.stream()
-                                .filter(plugin -> REST_API_PLUGIN.equals(plugin.getPackageName())
-                                        || GRAPHQL_PLUGIN.equals(plugin.getPackageName()))
+                                .filter(this::isPossibleToCreateQueryWithoutDatasource)
                                 .forEach(plugin -> setOfAllPluginIdsToGetFormConfig.add(plugin.getId()));
 
                         return setOfAllPluginIdsToGetFormConfig;
@@ -664,5 +669,11 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                 return consolidatedAPIResponseDTO;
             });
         }
+    }
+
+    private boolean isPossibleToCreateQueryWithoutDatasource(Plugin plugin) {
+        return REST_API_PLUGIN.equals(plugin.getPackageName())
+                || GRAPHQL_PLUGIN.equals(plugin.getPackageName())
+                || APPSMITH_AI_PLUGIN.equals(plugin.getPackageName());
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ConsolidatedAPIServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ConsolidatedAPIServiceImplTest.java
@@ -47,6 +47,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.appsmith.external.constants.PluginConstants.PackageName.APPSMITH_AI_PLUGIN;
+import static com.appsmith.external.constants.PluginConstants.PackageName.GRAPHQL_PLUGIN;
+import static com.appsmith.external.constants.PluginConstants.PackageName.REST_API_PLUGIN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -420,7 +423,20 @@ public class ConsolidatedAPIServiceImplTest {
 
         Plugin samplePlugin = new Plugin();
         samplePlugin.setName("samplePlugin");
-        when(mockPluginService.get(any())).thenReturn(Flux.just(samplePlugin));
+        Plugin sampleRestApiPlugin = new Plugin();
+        sampleRestApiPlugin.setName("sampleRestApiPlugin");
+        sampleRestApiPlugin.setId("sampleRestApiPluginId");
+        sampleRestApiPlugin.setPackageName(REST_API_PLUGIN);
+        Plugin sampleGraphqlPlugin = new Plugin();
+        sampleGraphqlPlugin.setName("sampleGraphqlPlugin");
+        sampleGraphqlPlugin.setId("sampleGraphqlPluginId");
+        sampleGraphqlPlugin.setPackageName(GRAPHQL_PLUGIN);
+        Plugin sampleAiPlugin = new Plugin();
+        sampleAiPlugin.setName("sampleAiPlugin");
+        sampleAiPlugin.setId("sampleAiPluginId");
+        sampleAiPlugin.setPackageName(APPSMITH_AI_PLUGIN);
+        when(mockPluginService.get(any()))
+                .thenReturn(Flux.just(samplePlugin, sampleRestApiPlugin, sampleGraphqlPlugin, sampleAiPlugin));
 
         Datasource sampleDatasource = new Datasource();
         sampleDatasource.setName("sampleDatasource");
@@ -563,18 +579,17 @@ public class ConsolidatedAPIServiceImplTest {
 
                     assertNotNull(consolidatedAPIResponseDTO.getPlugins());
                     assertEquals(
-                            1, consolidatedAPIResponseDTO.getPlugins().getData().size());
-                    assertEquals(
-                            "samplePlugin",
-                            consolidatedAPIResponseDTO
-                                    .getPlugins()
-                                    .getData()
-                                    .get(0)
-                                    .getName());
+                            4, consolidatedAPIResponseDTO.getPlugins().getData().size());
+                    List<String> pluginPackageNameList = consolidatedAPIResponseDTO.getPlugins().getData().stream()
+                            .map(Plugin::getPackageName)
+                            .toList();
+                    assertTrue(pluginPackageNameList.contains(REST_API_PLUGIN));
+                    assertTrue(pluginPackageNameList.contains(GRAPHQL_PLUGIN));
+                    assertTrue(pluginPackageNameList.contains(APPSMITH_AI_PLUGIN));
 
                     assertNotNull(consolidatedAPIResponseDTO.getPluginFormConfigs());
                     assertEquals(
-                            1,
+                            4,
                             consolidatedAPIResponseDTO
                                     .getPluginFormConfigs()
                                     .getData()
@@ -584,6 +599,18 @@ public class ConsolidatedAPIServiceImplTest {
                             .getPluginFormConfigs()
                             .getData()
                             .containsKey("samplePluginId"));
+                    assertTrue(consolidatedAPIResponseDTO
+                            .getPluginFormConfigs()
+                            .getData()
+                            .containsKey("sampleRestApiPluginId"));
+                    assertTrue(consolidatedAPIResponseDTO
+                            .getPluginFormConfigs()
+                            .getData()
+                            .containsKey("sampleGraphqlPluginId"));
+                    assertTrue(consolidatedAPIResponseDTO
+                            .getPluginFormConfigs()
+                            .getData()
+                            .containsKey("sampleAiPluginId"));
 
                     assertNotNull(consolidatedAPIResponseDTO.getMockDatasources());
                     assertEquals(


### PR DESCRIPTION
## Description
- return AppsmithAiPlugin's editor config by default 
  - There are some plugins that allow query to be created without creating a datasource. For such datasources, editor config is required to display any queries that may have been created or in case user wants to create a query without creating a datasource first.	

Fixes #30552 

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [x] JUnit

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
