### PR TITLE
feat: add copy paste functionality for modal widget

### DIFF
--- a/app/client/src/layoutSystems/anvil/integrations/sagas/pasteSagas.ts
+++ b/app/client/src/layoutSystems/anvil/integrations/sagas/pasteSagas.ts
@@ -41,6 +41,8 @@ function* pasteWidgetSagas() {
     const selectedWidget: FlattenedWidgetProps =
       yield getSelectedWidgetWhenPasting();
 
+    if (!selectedWidget) return;
+
     let allWidgets: CanvasWidgetsReduxState = yield select(getWidgets);
 
     const destinationInfo: PasteDestinationInfo = yield call(

--- a/app/client/src/layoutSystems/anvil/layoutComponents/presets/ModalPreset.tsx
+++ b/app/client/src/layoutSystems/anvil/layoutComponents/presets/ModalPreset.tsx
@@ -13,6 +13,7 @@ export const modalPreset = (): LayoutProps[] => {
       layoutStyle: {
         border: "none",
         height: "100%",
+        minHeight: "sizing-16",
         padding: "spacing-1",
       },
       isDropTarget: true,

--- a/app/client/src/layoutSystems/anvil/utils/constants.ts
+++ b/app/client/src/layoutSystems/anvil/utils/constants.ts
@@ -33,7 +33,8 @@ export const SELECT_ANVIL_WIDGET_CUSTOM_EVENT =
 
 export const widgetHierarchy: Record<string, number> = {
   MAIN_CANVAS: 0,
-  [anvilWidgets.SECTION_WIDGET]: 1,
-  [anvilWidgets.ZONE_WIDGET]: 2,
-  OTHER: 3,
+  WDS_MODAL_WIDGET: 1,
+  [anvilWidgets.SECTION_WIDGET]: 2,
+  [anvilWidgets.ZONE_WIDGET]: 3,
+  OTHER: 4,
 };

--- a/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
@@ -15,6 +15,14 @@ import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { ModalBody } from "@design-system/widgets";
 import { WDS_MODAL_WIDGET_CLASSNAME } from "widgets/wds/constants";
+import type { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
+import type {
+  CopiedWidgetData,
+  PasteDestinationInfo,
+  PastePayload,
+} from "layoutSystems/anvil/utils/paste/types";
+import { call } from "redux-saga/effects";
+import { pasteWidgetsIntoMainCanvas } from "layoutSystems/anvil/utils/paste/mainCanvasPasteUtils";
 
 const modalBodyStyles: React.CSSProperties = {
   minHeight: "var(--sizing-16)",
@@ -43,6 +51,24 @@ class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
 
   static getPropertyPaneStyleConfig() {
     return config.propertyPaneStyleConfig;
+  }
+
+  static *performPasteOperation(
+    allWidgets: CanvasWidgetsReduxState,
+    copiedWidgets: CopiedWidgetData[],
+    destinationInfo: PasteDestinationInfo,
+    widgetIdMap: Record<string, string>,
+    reverseWidgetIdMap: Record<string, string>,
+  ) {
+    const res: PastePayload = yield call(
+      pasteWidgetsIntoMainCanvas,
+      allWidgets,
+      copiedWidgets,
+      destinationInfo,
+      widgetIdMap,
+      reverseWidgetIdMap,
+    );
+    return res;
   }
 
   onModalClose = () => {


### PR DESCRIPTION
## Description

1. Add copy paste functionality for Modal. The behaviour has to be similar to MainCanvas.
2. Introduce a min-height for modal preset for easy DnD of widgets.

#### Media


https://github.com/appsmithorg/appsmith/assets/5424788/dc68aec6-b966-46a8-a3a1-1500088b3832



#### Type of change
- New feature (non-breaking change which adds functionality)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
