### PR TITLE
fix: Change of error message when Organization name is blank #9912

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1804,7 +1804,7 @@ export const GENERAL_SETTINGS_SECTION_HEADER_DESC = () =>
   "App name, icon and share";
 export const GENERAL_SETTINGS_APP_NAME_LABEL = () => "App name";
 export const GENERAL_SETTINGS_NAME_EMPTY_MESSAGE = () =>
-  "App name cannot be empty";
+  "Please enter valid App Name";
 export const GENERAL_SETTINGS_NAME_SPECIAL_CHARACTER_ERROR = () =>
   "Only alphanumeric or '-()' are allowed";
 export const GENERAL_SETTINGS_APP_ICON_LABEL = () => "App icon";


### PR DESCRIPTION
Change of error message when Organization name is blank #9912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the error message for an empty app name to be more user-friendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->