### PR TITLE
chore: Render env vars in caddy-reconfigure script

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -143,10 +143,26 @@ if (CUSTOM_DOMAIN !== "") {
   `)
 }
 
+finalizeIndexHtml()
 fs.mkdirSync(dirname(CaddyfilePath), { recursive: true })
 fs.writeFileSync(CaddyfilePath, parts.join("\n"))
 spawnSync("/opt/caddy/caddy", ["fmt", "--overwrite", CaddyfilePath])
 spawnSync("/opt/caddy/caddy", ["reload", "--config", CaddyfilePath])
+
+function finalizeIndexHtml() {
+  const info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
+  const extraEnv = {
+    APPSMITH_VERSION_ID: info.version ?? "",
+    APPSMITH_VERSION_RELEASE_DATE: info.imageBuiltAt ?? "",
+  }
+
+  const content = fs.readFileSync("/opt/appsmith/editor/index.html", "utf8").replace(
+    /\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
+    (_, name) => (process.env[name] || extraEnv[name] || "")
+  )
+
+  fs.writeFileSync(process.env.WWW_PATH + "/index.html", content)
+}
 
 function isCertExpired(path) {
   const cert = new X509Certificate(fs.readFileSync(path, "utf-8"))

--- a/deploy/docker/fs/opt/appsmith/run-caddy.sh
+++ b/deploy/docker/fs/opt/appsmith/run-caddy.sh
@@ -9,30 +9,11 @@ if [[ -z "${APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX-}" ]]; then
   export APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX="true"
 fi
 
-apply-env-vars() {
-  original="$1"
-  served="$2"
-  node -e '
-  const fs = require("fs")
-  try {
-    const info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
-    process.env.APPSMITH_VERSION_ID = info.version || ""
-    process.env.APPSMITH_VERSION_RELEASE_DATE = info.imageBuiltAt || ""
-  } catch {}
-  const content = fs.readFileSync("'"$original"'", "utf8").replace(
-    /\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
-    (placeholder, name) => (process.env[name] || "")
-  )
-  fs.writeFileSync("'"$served"'", content)
-  '
-  pushd "$(dirname "$served")"
-  gzip --keep --force "$(basename "$served")"
-  popd
-}
-
-apply-env-vars /opt/appsmith/editor/index.html "$WWW_PATH/index.html"
-
 node caddy-reconfigure.mjs
+
+pushd "$(dirname "$WWW_PATH/index.html")"
+gzip --keep --force "$(basename "$WWW_PATH/index.html")"
+popd
 
 # Caddy may already be running for the loading page.
 /opt/caddy/caddy stop --config "$TMP/Caddyfile" || true


### PR DESCRIPTION
Move more logic in managing Caddy into Javascript from the shell script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the web server configuration process for improved performance and reliability.
- **Refactor**
	- Streamlined server setup and environment variable management for efficiency.
- **Chores**
	- Updated server scripts for better maintainability and performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->