### PR TITLE
fix: Resolved Incomplete error message for Rating widget 

### DIFF
--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -80,7 +80,7 @@ function validateDefaultRate(value: unknown, props: any, _: any) {
         messages: [
           {
             name: "ValidationError",
-            message: `This value can be a decimal only if 'Allow half' is true`,
+            message: `This value can be a decimal only if 'Allow half stars' is true`,
           },
         ],
       };


### PR DESCRIPTION
Incomplete error message for Rating widget #17654

## Description
> When the Allow Half Stars property is turned off and the user enters a decimal value for the Default Rating, an incomplete error message is displayed.

#### PR fixes following issue(s)
Fixes # 17654

- **Bug Fixes**
	- Updated the error message in the Rate Widget for clearer guidance on allowing half stars.

