### PR TITLE
fix: Only consider non-public apps and workspaces when searching entities in home page

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCE.java
@@ -7,8 +7,6 @@ import com.appsmith.server.dtos.ApplicationAccessDTO;
 import com.appsmith.server.dtos.GitAuthDTO;
 import com.appsmith.server.services.CrudService;
 import com.mongodb.client.result.UpdateResult;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.codec.multipart.Part;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -107,11 +105,4 @@ public interface ApplicationServiceCE extends CrudService<Application, String> {
     Mono<Boolean> isApplicationConnectedToGit(String applicationId);
 
     Mono<Void> updateProtectedBranches(String applicationId, List<String> protectedBranches);
-
-    Flux<Application> filterByEntityFields(
-            List<String> searchableEntityFields,
-            String searchString,
-            Pageable pageable,
-            Sort sort,
-            AclPermission permission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
@@ -27,6 +27,14 @@ public interface AppsmithRepository<T> {
 
     Flux<T> queryAll(List<Criteria> criterias, AclPermission permission, Sort sort);
 
+    Flux<T> queryAllWithStrictPermissionGroups(
+            List<Criteria> criterias,
+            Optional<List<String>> includeFields,
+            Optional<AclPermission> permission,
+            Sort sort,
+            int limit,
+            int skip);
+
     Flux<T> queryAll(List<Criteria> criterias, List<String> includeFields, AclPermission permission, Sort sort);
 
     Mono<T> setUserPermissionsInObject(T obj, Set<String> permissionGroups);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -502,6 +502,21 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
                 criterias, includeFields, permission, sort, permissionGroups, limit, NO_SKIP));
     }
 
+    public Flux<T> queryAllWithStrictPermissionGroups(
+            List<Criteria> criterias,
+            Optional<List<String>> includeFields,
+            Optional<AclPermission> permission,
+            Sort sort,
+            int limit,
+            int skip) {
+        Mono<Set<String>> permissionGroupsMono = ReactiveSecurityContextHolder.getContext()
+                .map(ctx -> ctx.getAuthentication())
+                .map(auth -> auth.getPrincipal())
+                .flatMap(principal -> getStrictPermissionGroupsForUser((User) principal));
+        return permissionGroupsMono.flatMapMany(permissionGroups -> queryAllWithPermissionGroups(
+                criterias, includeFields, permission, Optional.of(sort), permissionGroups, limit, skip));
+    }
+
     public Flux<T> queryAll(
             List<Criteria> criterias,
             Optional<List<String>> includeFields,
@@ -625,6 +640,28 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
                     return permissionGroups;
                 });
+    }
+
+    /**
+     * 1. Get all the user groups associated with the user
+     * 2. Get all the permission groups associated with anonymous user
+     * 3. Return the set of all the permission groups.
+     *
+     * @param user
+     * @return
+     */
+    protected Mono<Set<String>> getStrictPermissionGroupsForUser(User user) {
+
+        Mono<User> userMono = Mono.just(user);
+        if (user.getTenantId() == null) {
+            userMono = cacheableRepositoryHelper.getDefaultTenantId().map(tenantId -> {
+                user.setTenantId(tenantId);
+                return user;
+            });
+        }
+
+        return userMono.flatMap(cacheableRepositoryHelper::getPermissionGroupsOfUser)
+                .map(HashSet::new);
     }
 
     protected Mono<Set<String>> getAnonymousUserPermissionGroups() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/searchentities/SearchEntitySolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/searchentities/SearchEntitySolutionCEImpl.java
@@ -62,7 +62,7 @@ public class SearchEntitySolutionCEImpl implements SearchEntitySolutionCE {
         Mono<List<Workspace>> workspacesMono = Mono.just(new ArrayList<>());
         if (shouldSearchEntity(Workspace.class, entities)) {
             workspacesMono = workspaceService
-                    .filterByEntityFields(
+                    .filterByEntityFieldsWithoutPublicAccess(
                             List.of(FieldName.NAME),
                             searchString,
                             pageable,
@@ -74,7 +74,7 @@ public class SearchEntitySolutionCEImpl implements SearchEntitySolutionCE {
         Mono<List<Application>> applicationsMono = Mono.just(new ArrayList<>());
         if (shouldSearchEntity(Application.class, entities)) {
             applicationsMono = applicationService
-                    .filterByEntityFields(
+                    .filterByEntityFieldsWithoutPublicAccess(
                             List.of(FieldName.NAME),
                             searchString,
                             pageable,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -211,6 +212,39 @@ public abstract class BaseService<
                 .toList();
         Criteria criteria = new Criteria().orOperator(criteriaList);
         Flux<T> result = repository.queryAll(List.of(criteria), permission, sort);
+        if (pageable != null) {
+            return result.skip(pageable.getOffset()).take(pageable.getPageSize());
+        }
+        return result;
+    }
+
+    /**
+     * This function is used to filter the entities based on the entity fields and the search string.
+     * The search is performed with contains operator on the entity fields and is case-insensitive.
+     * @param searchableEntityFields  The list of entity fields to search for. If null or empty, all entities are searched.
+     * @param searchString  The string to search for in the entity fields.
+     * @param pageable      The page number of the results to return.
+     * @param sort          The sort order of the results to return.
+     * @param permission    The permission to check for the entity.
+     * @return  A Flux of entities.
+     */
+    public Flux<T> filterByEntityFieldsWithoutPublicAccess(
+            List<String> searchableEntityFields,
+            String searchString,
+            Pageable pageable,
+            Sort sort,
+            AclPermission permission) {
+
+        if (searchableEntityFields == null || searchableEntityFields.isEmpty()) {
+            return Flux.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, ENTITY_FIELDS));
+        }
+        List<Criteria> criteriaList = searchableEntityFields.stream()
+                .map(fieldName -> Criteria.where(fieldName).regex(".*" + Pattern.quote(searchString) + ".*", "i"))
+                .toList();
+        Criteria criteria = new Criteria().orOperator(criteriaList);
+
+        Flux<T> result = repository.queryAllWithStrictPermissionGroups(
+                List.of(criteria), Optional.empty(), Optional.ofNullable(permission), sort, -1, 0);
         if (pageable != null) {
             return result.skip(pageable.getOffset()).take(pageable.getPageSize());
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CrudService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CrudService.java
@@ -1,10 +1,14 @@
 package com.appsmith.server.services;
 
 import com.appsmith.external.models.BaseDomain;
+import com.appsmith.server.acl.AclPermission;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Map;
 
 public interface CrudService<T extends BaseDomain, ID> {
@@ -28,4 +32,18 @@ public interface CrudService<T extends BaseDomain, ID> {
     }
 
     Map<String, Object> getAnalyticsProperties(T savedResource);
+
+    Flux<T> filterByEntityFields(
+            List<String> searchableEntityFields,
+            String searchString,
+            Pageable pageable,
+            Sort sort,
+            AclPermission permission);
+
+    Flux<T> filterByEntityFieldsWithoutPublicAccess(
+            List<String> searchableEntityFields,
+            String searchString,
+            Pageable pageable,
+            Sort sort,
+            AclPermission permission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
@@ -5,8 +5,6 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.PermissionGroupInfoDTO;
 import com.appsmith.server.services.CrudService;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.codec.multipart.Part;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -46,11 +44,4 @@ public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
     Mono<Workspace> archiveById(String s);
 
     Mono<String> getDefaultEnvironmentId(String workspaceId, AclPermission aclPermission);
-
-    Flux<Workspace> filterByEntityFields(
-            List<String> searchableEntityFields,
-            String searchString,
-            Pageable pageable,
-            Sort sort,
-            AclPermission permission);
 }


### PR DESCRIPTION
Search options should not show results for stuff that is public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method for querying all entities with strict permission groups, enhancing security and data access control.
- **Refactor**
	- Streamlined entity filtering methods across services, focusing on improved performance and accuracy in data retrieval.
- **Chores**
	- Removed unused imports and methods related to entity filtering, aligning with the refactor strategy for efficiency and code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->