### PR TITLE
fix: Enabled add widget button in list view of editor pane

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/UI/List.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/UI/List.tsx
@@ -16,7 +16,6 @@ import { EmptyState } from "../components/EmptyState";
 import history from "utils/history";
 import { builderURL } from "@appsmith/RouteBuilder";
 import styled from "styled-components";
-import { getIsSideBySideEnabled } from "selectors/ideSelectors";
 
 const ListContainer = styled(Flex)`
   & .t--entity-item {
@@ -32,7 +31,6 @@ const ListWidgets = () => {
   const widgets = useSelector(selectWidgetsForCurrentPage);
   const pagePermissions = useSelector(getPagePermissions);
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
-  const isSideBySideEnabled = useSelector(getIsSideBySideEnabled);
 
   const canManagePages = getHasManagePagePermission(
     isFeatureEnabled,
@@ -68,7 +66,7 @@ const ListWidgets = () => {
           icon={"widgets-v3"}
           onClick={canManagePages ? addButtonClickHandler : undefined}
         />
-      ) : canManagePages && !isSideBySideEnabled ? (
+      ) : canManagePages ? (
         /* We show the List Add button when side by side is not enabled  */
         <Flex flexDirection="column" px="spaces-3">
           <Button


### PR DESCRIPTION
## Description

Add widget button was not enabled in editor pane until and unless canvas is selected. This PR will enable the "Add widget" button irrelevant of canvas selected state.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/30712

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
