### PR TITLE
fix: UX issue in delete of Query / API / JS from context menu

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Actions/MoreActionsMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/MoreActionsMenu.tsx
@@ -71,6 +71,10 @@ export function MoreActionsMenu(props: EntityContextMenuProps) {
   const deleteActionFromPage = useCallback(
     (actionId: string, actionName: string) => {
       dispatch(deleteAction({ id: actionId, name: actionName }));
+      // Reset the delete confirmation state because it can navigate to another action
+      // which will not remount this component
+      setConfirmDelete(false);
+      toggleMenuOpen(false);
     },
     [dispatch],
   );

--- a/app/client/src/pages/Editor/JSEditor/AppJSEditorContextMenu.tsx
+++ b/app/client/src/pages/Editor/JSEditor/AppJSEditorContextMenu.tsx
@@ -85,8 +85,10 @@ export function AppJSEditorContextMenu({
     [dispatch],
   );
   const deleteJSCollectionFromPage = useCallback(
-    (actionId: string, actionName: string) =>
-      dispatch(deleteJSCollection({ id: actionId, name: actionName })),
+    (actionId: string, actionName: string) => {
+      dispatch(deleteJSCollection({ id: actionId, name: actionName }));
+      setConfirmDelete(false);
+    },
     [dispatch],
   );
 


### PR DESCRIPTION
## Description

On Delete using the context menu, the redirect now happens to another entity of the same type and hence states are not getting reset. This PR will reset the states on delete for consistent UX


#### PR fixes following issue(s)
Fixes #30696

#### Media

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user experience in the Editor by improving the delete action flow, ensuring smoother navigation and interaction without unnecessary component remounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->