### PR TITLE
chore: Fix `equals` on `TenantConfiguration`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/TenantConfiguration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/TenantConfiguration.java
@@ -2,6 +2,8 @@ package com.appsmith.server.domains;
 
 import com.appsmith.server.domains.ce.TenantConfigurationCE;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class TenantConfiguration extends TenantConfigurationCE {}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/domains/EqualityTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/domains/EqualityTest.java
@@ -1,0 +1,78 @@
+package com.appsmith.server.domains;
+
+import lombok.Data;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.reflections.Reflections;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class EqualityTest {
+
+    private final Set<Class<?>> TESTED_CLASSES = Set.of(
+            // Note: Adding a class here means that we have a test for its equality in this file.
+            ApplicationDetail.class, TenantConfiguration.class);
+
+    @SneakyThrows
+    @Test
+    void testAffirmation() {
+        // Test that all classes we suspect equality screw-up in, are accounted for in the TESTED_CLASSES set.
+        final Set<Class<?>> classes = new Reflections("com.appsmith").getTypesAnnotatedWith(Document.class);
+        final Set<Class<?>> fieldClasses = new HashSet<>();
+
+        for (final Class<?> cls : classes) {
+            Field[] fields = cls.getDeclaredFields();
+            for (Field field : fields) {
+                final Class<?> fieldCls = field.getType();
+                if (!fieldCls.isEnum()
+                        && fieldCls.getPackageName().startsWith("com.appsmith.")
+                        && !fieldCls.isAnnotationPresent(Document.class)
+                        && !fieldCls.getSuperclass().equals(Object.class)
+                        && !fieldCls.isAnnotationPresent(Data.class)
+                        && !TESTED_CLASSES.contains(fieldCls)) {
+                    fieldClasses.add(fieldCls);
+                }
+            }
+        }
+
+        assertThat(fieldClasses).isEmpty();
+    }
+
+    @Test
+    void testTenantConfiguration() {
+        TenantConfiguration c1 = new TenantConfiguration();
+        c1.setEmailVerificationEnabled(true);
+        TenantConfiguration c2 = new TenantConfiguration();
+        c2.setEmailVerificationEnabled(true);
+        TenantConfiguration c3 = new TenantConfiguration();
+        c3.setEmailVerificationEnabled(false);
+        assertThat(c1).isEqualTo(c2).isNotEqualTo(c3);
+    }
+
+    @Test
+    void testApplicationDetail() {
+        Application.AppPositioning p1 = new Application.AppPositioning();
+        p1.setType(Application.AppPositioning.Type.AUTO);
+        Application.AppPositioning p2 = new Application.AppPositioning();
+        p2.setType(Application.AppPositioning.Type.AUTO);
+        Application.AppPositioning p3 = new Application.AppPositioning();
+        p3.setType(Application.AppPositioning.Type.FIXED);
+        assertThat(p1).isEqualTo(p2).isNotEqualTo(p3);
+
+        ApplicationDetail d1 = new ApplicationDetail();
+        d1.setAppPositioning(p1);
+        ApplicationDetail d2 = new ApplicationDetail();
+        d2.setAppPositioning(p2);
+        ApplicationDetail d3 = new ApplicationDetail();
+        d3.setAppPositioning(p3);
+        assertThat(d1).isEqualTo(d2);
+        assertThat(d1).isNotEqualTo(d3);
+    }
+}


### PR DESCRIPTION
Lack of checking fields in parent's class meant that the `.equals()` method from `@Data` annotation in `TenantConfiguration` never compared the values of fields in parent class. This meant that some part of Hibernate's dirty-checking is getting thrown off, and changes to TenantConfiguration aren't getting saved to database in Postgres.

Lombok even warns about this exact thing, but it's unfortunate we don't take warnings as seriously as errors.
![shot-2024-01-30-13-11-41](https://github.com/appsmithorg/appsmith/assets/120119/fe3ba2c5-949d-47d0-ac81-8fe5a08c988c)

So instead, I added a test which would fail when this annotation is missing in cases like this.
