### PR TITLE
chore: Fluent interface for queryAll method

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
@@ -1,6 +1,8 @@
 package com.appsmith.server.repositories;
 
+import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.repositories.ce.params.QueryAllParams;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.result.InsertManyResult;
 import org.springframework.data.domain.Sort;
@@ -13,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public interface AppsmithRepository<T> {
+public interface AppsmithRepository<T extends BaseDomain> {
 
     Mono<T> findById(String id, AclPermission permission);
 
@@ -23,9 +25,7 @@ public interface AppsmithRepository<T> {
 
     Mono<T> updateById(String id, T resource, AclPermission permission);
 
-    Flux<T> queryAll(List<Criteria> criterias, AclPermission permission);
-
-    Flux<T> queryAll(List<Criteria> criterias, AclPermission permission, Sort sort);
+    QueryAllParams<T> queryAll();
 
     Flux<T> queryAllWithStrictPermissionGroups(
             List<Criteria> criterias,
@@ -34,8 +34,6 @@ public interface AppsmithRepository<T> {
             Sort sort,
             int limit,
             int skip);
-
-    Flux<T> queryAll(List<Criteria> criterias, List<String> includeFields, AclPermission permission, Sort sort);
 
     Mono<T> setUserPermissionsInObject(T obj, Set<String> permissionGroups);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -9,6 +9,7 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
+import com.appsmith.server.repositories.ce.params.QueryAllParams;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.bulk.BulkWriteResult;
@@ -78,9 +79,9 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
     protected final CacheableRepositoryHelper cacheableRepositoryHelper;
 
-    protected static final int NO_RECORD_LIMIT = -1;
+    public static final int NO_RECORD_LIMIT = -1;
 
-    protected static final int NO_SKIP = 0;
+    public static final int NO_SKIP = 0;
 
     @Autowired
     @SuppressWarnings("unchecked")
@@ -437,71 +438,6 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         return count(criteriaList, Optional.empty());
     }
 
-    @Deprecated
-    public Flux<T> queryAll(List<Criteria> criterias, AclPermission aclPermission) {
-        return queryAll(
-                criterias, Optional.empty(), Optional.ofNullable(aclPermission), Optional.empty(), NO_RECORD_LIMIT);
-    }
-
-    public Flux<T> queryAll(List<Criteria> criterias, Optional<AclPermission> permission) {
-        return queryAll(criterias, permission, Optional.empty());
-    }
-
-    @Deprecated
-    public Flux<T> queryAll(List<Criteria> criterias, AclPermission aclPermission, Sort sort) {
-        return queryAll(
-                criterias,
-                Optional.empty(),
-                Optional.ofNullable(aclPermission),
-                Optional.ofNullable(sort),
-                NO_RECORD_LIMIT);
-    }
-
-    public Flux<T> queryAll(List<Criteria> criterias, Optional<AclPermission> permission, Optional<Sort> sort) {
-        return queryAll(criterias, Optional.empty(), permission, sort, NO_RECORD_LIMIT);
-    }
-
-    @Deprecated
-    public Flux<T> queryAll(
-            List<Criteria> criterias, List<String> includeFields, AclPermission aclPermission, Sort sort) {
-        return queryAll(
-                criterias,
-                Optional.ofNullable(includeFields),
-                Optional.ofNullable(aclPermission),
-                Optional.ofNullable(sort),
-                NO_RECORD_LIMIT);
-    }
-
-    public Flux<T> queryAll(
-            List<Criteria> criterias,
-            Optional<List<String>> includeFields,
-            Optional<AclPermission> aclPermission,
-            Optional<Sort> sort) {
-        return queryAll(criterias, includeFields, aclPermission, sort, NO_RECORD_LIMIT);
-    }
-
-    @Deprecated
-    public Flux<T> queryAll(
-            List<Criteria> criterias, List<String> includeFields, AclPermission aclPermission, Sort sort, int limit) {
-        return queryAll(
-                criterias,
-                Optional.ofNullable(includeFields),
-                Optional.ofNullable(aclPermission),
-                Optional.ofNullable(sort),
-                limit);
-    }
-
-    public Flux<T> queryAll(
-            List<Criteria> criterias,
-            Optional<List<String>> includeFields,
-            Optional<AclPermission> permission,
-            Optional<Sort> sort,
-            int limit) {
-        Mono<Set<String>> permissionGroupsMono = getCurrentUserPermissionGroupsIfRequired(permission);
-        return permissionGroupsMono.flatMapMany(permissionGroups -> queryAllWithPermissionGroups(
-                criterias, includeFields, permission, sort, permissionGroups, limit, NO_SKIP));
-    }
-
     public Flux<T> queryAllWithStrictPermissionGroups(
             List<Criteria> criterias,
             Optional<List<String>> includeFields,
@@ -513,53 +449,30 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
                 .map(ctx -> ctx.getAuthentication())
                 .map(auth -> auth.getPrincipal())
                 .flatMap(principal -> getStrictPermissionGroupsForUser((User) principal));
-        return permissionGroupsMono.flatMapMany(permissionGroups -> queryAllWithPermissionGroups(
-                criterias, includeFields, permission, Optional.of(sort), permissionGroups, limit, skip));
+        return permissionGroupsMono.flatMapMany(permissionGroups -> queryAll()
+                .criteria(criterias)
+                .fields(includeFields.orElse(null))
+                .permission(permission.orElse(null))
+                .permissionGroups(permissionGroups)
+                .sort(sort)
+                .limit(limit)
+                .skip(skip)
+                .submit());
     }
 
-    public Flux<T> queryAll(
-            List<Criteria> criterias,
-            Optional<List<String>> includeFields,
-            Optional<AclPermission> permission,
-            Sort sort,
-            int limit,
-            int skip) {
-        Mono<Set<String>> permissionGroupsMono = getCurrentUserPermissionGroupsIfRequired(permission);
-        return permissionGroupsMono.flatMapMany(permissionGroups -> queryAllWithPermissionGroups(
-                criterias, includeFields, permission, Optional.of(sort), permissionGroups, limit, skip));
-    }
-
-    @Deprecated
     public Flux<T> queryAllWithPermissionGroups(
             List<Criteria> criterias,
             List<String> includeFields,
             AclPermission aclPermission,
             Sort sort,
             Set<String> permissionGroups,
-            int limit) {
-        return queryAllWithPermissionGroups(
-                criterias,
-                Optional.ofNullable(includeFields),
-                Optional.ofNullable(aclPermission),
-                Optional.ofNullable(sort),
-                permissionGroups,
-                limit,
-                NO_SKIP);
-    }
-
-    public Flux<T> queryAllWithPermissionGroups(
-            List<Criteria> criterias,
-            Optional<List<String>> includeFields,
-            Optional<AclPermission> aclPermission,
-            Optional<Sort> sortOptional,
-            Set<String> permissionGroups,
             int limit,
             int skip) {
         final ArrayList<Criteria> criteriaList = new ArrayList<>(criterias);
         Query query = new Query();
-        includeFields.ifPresent(fields -> {
-            fields.forEach(field -> query.fields().include(field));
-        });
+        if (!CollectionUtils.isEmpty(includeFields)) {
+            query.fields().include(includeFields.toArray(new String[0]));
+        }
         if (skip > NO_SKIP) {
             query.skip(skip);
         }
@@ -568,15 +481,35 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         }
         Criteria andCriteria = new Criteria();
         criteriaList.add(notDeleted());
-        userAcl(permissionGroups, aclPermission).ifPresent(criteria -> criteriaList.add(criteria));
+        userAcl(permissionGroups, Optional.ofNullable(aclPermission)).ifPresent(criteria -> criteriaList.add(criteria));
         andCriteria.andOperator(criteriaList.toArray(new Criteria[0]));
         query.addCriteria(andCriteria);
-        sortOptional.ifPresent(sort -> query.with(sort));
+        if (sort != null) {
+            query.with(sort);
+        }
         return mongoOperations
                 .query(this.genericDomain)
                 .matching(query.cursorBatchSize(10000))
                 .all()
                 .flatMap(obj -> setUserPermissionsInObject(obj, permissionGroups));
+    }
+
+    public QueryAllParams<T> queryAll() {
+        return new QueryAllParams<>(this);
+    }
+
+    public Flux<T> queryAllExecute(QueryAllParams<T> params) {
+        return Mono.justOrEmpty(params.getPermissionGroups())
+                .switchIfEmpty(Mono.defer(
+                        () -> getCurrentUserPermissionGroupsIfRequired(Optional.ofNullable(params.getPermission()))))
+                .flatMapMany(permissionGroups1 -> queryAllWithPermissionGroups(
+                        params.getCriteria(),
+                        params.getFields(),
+                        params.getPermission(),
+                        params.getSort(),
+                        permissionGroups1,
+                        params.getLimit(),
+                        params.getSkip()));
     }
 
     public Mono<T> setUserPermissionsInObject(T obj) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -40,7 +40,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
                 .is(applicationId);
 
         return queryAll()
-                .criteria(List.of(applicationCriteria))
+                .criteria(applicationCriteria)
                 .permission(aclPermission)
                 .sort(sort)
                 .submit();
@@ -180,10 +180,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
                 .orOperator(
                         where(unpublishedPage).is(pageId), where(publishedPage).is(pageId));
 
-        return queryAll()
-                .criteria(List.of(pageCriteria))
-                .permission(aclPermission)
-                .submit();
+        return queryAll().criteria(pageCriteria).permission(aclPermission).submit();
     }
 
     @Override
@@ -225,7 +222,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria defaultAppIdCriteria =
                 where(defaultResources + "." + FieldName.APPLICATION_ID).is(defaultApplicationId);
         return queryAll()
-                .criteria(List.of(defaultAppIdCriteria))
+                .criteria(defaultAppIdCriteria)
                 .permission(permission.orElse(null))
                 .submit();
     }
@@ -235,10 +232,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria pageIdCriteria = where(fieldName(QActionCollection.actionCollection.unpublishedCollection) + "."
                         + fieldName(QActionCollection.actionCollection.unpublishedCollection.pageId))
                 .in(pageIds);
-        return queryAll()
-                .criteria(List.of(pageIdCriteria))
-                .permission(permission)
-                .submit();
+        return queryAll().criteria(pageIdCriteria).permission(permission).submit();
     }
 
     @Override
@@ -247,7 +241,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
                         + fieldName(QActionCollection.actionCollection.unpublishedCollection.pageId))
                 .in(pageIds);
         return queryAll()
-                .criteria(List.of(pageIdCriteria))
+                .criteria(pageIdCriteria)
                 .permission(permission.orElse(null))
                 .submit();
     }
@@ -268,7 +262,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria contextIdAndContextTypeCriteria =
                 where(contextIdPath).is(contextId).and(contextTypePath).is(contextType);
         return queryAll()
-                .criteria(List.of(contextIdAndContextTypeCriteria))
+                .criteria(contextIdAndContextTypeCriteria)
                 .permission(Optional.ofNullable(permission).orElse(null))
                 .submit();
     }
@@ -283,7 +277,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria contextIdAndContextTypeCriteria =
                 where(contextIdPath).is(contextId).and(contextTypePath).is(contextType);
         return queryAll()
-                .criteria(List.of(contextIdAndContextTypeCriteria))
+                .criteria(contextIdAndContextTypeCriteria)
                 .permission(Optional.ofNullable(permission).orElse(null))
                 .submit();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -39,7 +39,11 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria applicationCriteria = where(fieldName(QActionCollection.actionCollection.applicationId))
                 .is(applicationId);
 
-        return queryAll(List.of(applicationCriteria), aclPermission, sort);
+        return queryAll()
+                .criteria(List.of(applicationCriteria))
+                .permission(aclPermission)
+                .sort(sort)
+                .submit();
     }
 
     @Override
@@ -49,7 +53,11 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria applicationCriteria = where(fieldName(QActionCollection.actionCollection.applicationId))
                 .is(applicationId);
 
-        return queryAll(List.of(applicationCriteria), aclPermission, sort);
+        return queryAll()
+                .criteria(applicationCriteria)
+                .permission(aclPermission.orElse(null))
+                .sort(sort.orElse(null))
+                .submit();
     }
 
     protected List<Criteria> getCriteriaForFindByApplicationIdAndViewMode(String applicationId, boolean viewMode) {
@@ -76,7 +84,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
 
         List<Criteria> criteria = this.getCriteriaForFindByApplicationIdAndViewMode(applicationId, viewMode);
 
-        return queryAll(criteria, aclPermission);
+        return queryAll().criteria(criteria).permission(aclPermission).submit();
     }
 
     protected List<Criteria> getCriteriaForFindAllActionCollectionsByNameDefaultPageIdsViewModeAndBranch(
@@ -154,7 +162,11 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         List<Criteria> criteriaList = this.getCriteriaForFindAllActionCollectionsByNameDefaultPageIdsViewModeAndBranch(
                 branchName, viewMode, name, pageIds);
 
-        return queryAll(criteriaList, aclPermission, sort);
+        return queryAll()
+                .criteria(criteriaList)
+                .permission(aclPermission)
+                .sort(sort)
+                .submit();
     }
 
     @Override
@@ -168,7 +180,10 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
                 .orOperator(
                         where(unpublishedPage).is(pageId), where(publishedPage).is(pageId));
 
-        return queryAll(List.of(pageCriteria), aclPermission);
+        return queryAll()
+                .criteria(List.of(pageCriteria))
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override
@@ -209,7 +224,10 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         final String defaultResources = fieldName(QBranchAwareDomain.branchAwareDomain.defaultResources);
         Criteria defaultAppIdCriteria =
                 where(defaultResources + "." + FieldName.APPLICATION_ID).is(defaultApplicationId);
-        return queryAll(List.of(defaultAppIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(defaultAppIdCriteria))
+                .permission(permission.orElse(null))
+                .submit();
     }
 
     @Override
@@ -217,7 +235,10 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria pageIdCriteria = where(fieldName(QActionCollection.actionCollection.unpublishedCollection) + "."
                         + fieldName(QActionCollection.actionCollection.unpublishedCollection.pageId))
                 .in(pageIds);
-        return queryAll(List.of(pageIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(pageIdCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
@@ -225,13 +246,16 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         Criteria pageIdCriteria = where(fieldName(QActionCollection.actionCollection.unpublishedCollection) + "."
                         + fieldName(QActionCollection.actionCollection.unpublishedCollection.pageId))
                 .in(pageIds);
-        return queryAll(List.of(pageIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(pageIdCriteria))
+                .permission(permission.orElse(null))
+                .submit();
     }
 
     @Override
     public Flux<ActionCollection> findAllByApplicationIds(List<String> applicationIds, List<String> includeFields) {
         Criteria applicationCriteria = Criteria.where(FieldName.APPLICATION_ID).in(applicationIds);
-        return queryAll(List.of(applicationCriteria), includeFields, null, null, NO_RECORD_LIMIT);
+        return queryAll().criteria(applicationCriteria).fields(includeFields).submit();
     }
 
     @Override
@@ -243,7 +267,10 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
                 + fieldName(QActionCollection.actionCollection.unpublishedCollection.contextType);
         Criteria contextIdAndContextTypeCriteria =
                 where(contextIdPath).is(contextId).and(contextTypePath).is(contextType);
-        return queryAll(List.of(contextIdAndContextTypeCriteria), Optional.ofNullable(permission));
+        return queryAll()
+                .criteria(List.of(contextIdAndContextTypeCriteria))
+                .permission(Optional.ofNullable(permission).orElse(null))
+                .submit();
     }
 
     @Override
@@ -255,7 +282,10 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
                 + fieldName(QActionCollection.actionCollection.publishedCollection.contextType);
         Criteria contextIdAndContextTypeCriteria =
                 where(contextIdPath).is(contextId).and(contextTypePath).is(contextType);
-        return queryAll(List.of(contextIdAndContextTypeCriteria), Optional.ofNullable(permission));
+        return queryAll()
+                .criteria(List.of(contextIdAndContextTypeCriteria))
+                .permission(Optional.ofNullable(permission).orElse(null))
+                .submit();
     }
 
     @Override
@@ -284,6 +314,6 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
                     .is(null);
             criteria.add(deletedCriteria);
         }
-        return queryAll(criteria, permission);
+        return queryAll().criteria(criteria).permission(permission).submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -77,14 +77,20 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     public Flux<Application> findByWorkspaceId(String workspaceId, AclPermission permission) {
         Criteria workspaceIdCriteria =
                 where(fieldName(QApplication.application.workspaceId)).is(workspaceId);
-        return queryAll(List.of(workspaceIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(workspaceIdCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
     public Flux<Application> findByMultipleWorkspaceIds(Set<String> workspaceIds, AclPermission permission) {
         Criteria workspaceIdCriteria =
                 where(fieldName(QApplication.application.workspaceId)).in(workspaceIds);
-        return queryAll(List.of(workspaceIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(workspaceIdCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
@@ -104,15 +110,20 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
 
         return currentUserWithTenantMono
                 .flatMap(cacheableRepositoryHelper::getPermissionGroupsOfUser)
-                .flatMapMany(permissionGroups -> queryAllWithPermissionGroups(
-                        List.of(), null, permission, null, permissionGroups, NO_RECORD_LIMIT));
+                .flatMapMany(permissionGroups -> queryAll()
+                        .permission(permission)
+                        .permissionGroups(permissionGroups)
+                        .submit());
     }
 
     @Override
     public Flux<Application> findByClonedFromApplicationId(String applicationId, AclPermission permission) {
         Criteria clonedFromCriteria = where(fieldName(QApplication.application.clonedFromApplicationId))
                 .is(applicationId);
-        return queryAll(List.of(clonedFromCriteria), permission);
+        return queryAll()
+                .criteria(List.of(clonedFromCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
@@ -216,7 +227,10 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
         Criteria applicationIdCriteria = where(gitApplicationMetadata + "."
                         + fieldName(QApplication.application.gitApplicationMetadata.defaultApplicationId))
                 .is(defaultApplicationId);
-        return queryAll(List.of(applicationIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(applicationIdCriteria))
+                .permission(permission)
+                .submit();
     }
 
     /**
@@ -268,8 +282,11 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
                 .exists(Boolean.TRUE);
         Criteria workspaceIdCriteria =
                 where(fieldName(QApplication.application.workspaceId)).is(workspaceId);
-        return queryAll(
-                List.of(workspaceIdCriteria, repoCriteria, gitAuthCriteria), applicationPermission.getEditPermission());
+        AclPermission aclPermission = applicationPermission.getEditPermission();
+        return queryAll()
+                .criteria(List.of(workspaceIdCriteria, repoCriteria, gitAuthCriteria))
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -77,20 +77,14 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     public Flux<Application> findByWorkspaceId(String workspaceId, AclPermission permission) {
         Criteria workspaceIdCriteria =
                 where(fieldName(QApplication.application.workspaceId)).is(workspaceId);
-        return queryAll()
-                .criteria(List.of(workspaceIdCriteria))
-                .permission(permission)
-                .submit();
+        return queryAll().criteria(workspaceIdCriteria).permission(permission).submit();
     }
 
     @Override
     public Flux<Application> findByMultipleWorkspaceIds(Set<String> workspaceIds, AclPermission permission) {
         Criteria workspaceIdCriteria =
                 where(fieldName(QApplication.application.workspaceId)).in(workspaceIds);
-        return queryAll()
-                .criteria(List.of(workspaceIdCriteria))
-                .permission(permission)
-                .submit();
+        return queryAll().criteria(workspaceIdCriteria).permission(permission).submit();
     }
 
     @Override
@@ -120,10 +114,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     public Flux<Application> findByClonedFromApplicationId(String applicationId, AclPermission permission) {
         Criteria clonedFromCriteria = where(fieldName(QApplication.application.clonedFromApplicationId))
                 .is(applicationId);
-        return queryAll()
-                .criteria(List.of(clonedFromCriteria))
-                .permission(permission)
-                .submit();
+        return queryAll().criteria(clonedFromCriteria).permission(permission).submit();
     }
 
     @Override
@@ -227,10 +218,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
         Criteria applicationIdCriteria = where(gitApplicationMetadata + "."
                         + fieldName(QApplication.application.gitApplicationMetadata.defaultApplicationId))
                 .is(defaultApplicationId);
-        return queryAll()
-                .criteria(List.of(applicationIdCriteria))
-                .permission(permission)
-                .submit();
+        return queryAll().criteria(applicationIdCriteria).permission(permission).submit();
     }
 
     /**
@@ -284,7 +272,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
                 where(fieldName(QApplication.application.workspaceId)).is(workspaceId);
         AclPermission aclPermission = applicationPermission.getEditPermission();
         return queryAll()
-                .criteria(List.of(workspaceIdCriteria, repoCriteria, gitAuthCriteria))
+                .criteria(workspaceIdCriteria, repoCriteria, gitAuthCriteria)
                 .permission(aclPermission)
                 .submit();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
@@ -33,15 +33,23 @@ public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl
     public Flux<Datasource> findAllByWorkspaceId(String workspaceId, AclPermission permission) {
         Criteria workspaceIdCriteria =
                 where(fieldName(QDatasource.datasource.workspaceId)).is(workspaceId);
-        return queryAll(List.of(workspaceIdCriteria), permission, Sort.by(fieldName(QDatasource.datasource.name)));
+        Sort sort = Sort.by(fieldName(QDatasource.datasource.name));
+        return queryAll()
+                .criteria(List.of(workspaceIdCriteria))
+                .permission(permission)
+                .sort(sort)
+                .submit();
     }
 
     @Override
     public Flux<Datasource> findAllByWorkspaceId(String workspaceId, Optional<AclPermission> permission) {
         Criteria workspaceIdCriteria =
                 where(fieldName(QDatasource.datasource.workspaceId)).is(workspaceId);
-        return queryAll(
-                List.of(workspaceIdCriteria), permission, Optional.of(Sort.by(fieldName(QDatasource.datasource.name))));
+        return queryAll()
+                .criteria(workspaceIdCriteria)
+                .permission(permission.orElse(null))
+                .sort(Sort.by(fieldName(QDatasource.datasource.name)))
+                .submit();
     }
 
     @Override
@@ -65,17 +73,12 @@ public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl
     @Override
     public Flux<Datasource> findAllByIds(Set<String> ids, AclPermission permission) {
         Criteria idcriteria = where(fieldName(QDatasource.datasource.id)).in(ids);
-        return queryAll(List.of(idcriteria), permission);
+        return queryAll().criteria(idcriteria).permission(permission).submit();
     }
 
     @Override
     public Flux<Datasource> findAllByIdsWithoutPermission(Set<String> ids, List<String> includeFields) {
         Criteria idCriteria = where(fieldName(QDatasource.datasource.id)).in(ids);
-        return queryAll(
-                List.of(idCriteria),
-                Optional.ofNullable(includeFields),
-                Optional.empty(),
-                Optional.empty(),
-                NO_RECORD_LIMIT);
+        return queryAll().criteria(idCriteria).fields(includeFields).submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
@@ -35,7 +35,7 @@ public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl
                 where(fieldName(QDatasource.datasource.workspaceId)).is(workspaceId);
         Sort sort = Sort.by(fieldName(QDatasource.datasource.name));
         return queryAll()
-                .criteria(List.of(workspaceIdCriteria))
+                .criteria(workspaceIdCriteria)
                 .permission(permission)
                 .sort(sort)
                 .submit();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.repositories.ce;
 
-import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.CustomJSLib;
 import com.appsmith.server.domains.QCustomJSLib;
 import com.appsmith.server.dtos.CustomJSLibContextDTO;
@@ -13,7 +12,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,9 +44,6 @@ public class CustomJSLibRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Cust
         Criteria criteria =
                 Criteria.where(fieldName(QCustomJSLib.customJSLib.uidString)).in(uidStrings);
 
-        return queryAll()
-                .criteria(List.of(criteria))
-                .permission(Optional.<AclPermission>empty().orElse(null))
-                .submit();
+        return queryAll().criteria(List.of(criteria)).submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
@@ -44,6 +44,6 @@ public class CustomJSLibRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Cust
         Criteria criteria =
                 Criteria.where(fieldName(QCustomJSLib.customJSLib.uidString)).in(uidStrings);
 
-        return queryAll().criteria(List.of(criteria)).submit();
+        return queryAll().criteria(criteria).submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.repositories.ce;
 
+import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.CustomJSLib;
 import com.appsmith.server.domains.QCustomJSLib;
 import com.appsmith.server.dtos.CustomJSLibContextDTO;
@@ -45,6 +46,9 @@ public class CustomJSLibRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Cust
         Criteria criteria =
                 Criteria.where(fieldName(QCustomJSLib.customJSLib.uidString)).in(uidStrings);
 
-        return this.queryAll(List.of(criteria), Optional.empty());
+        return queryAll()
+                .criteria(List.of(criteria))
+                .permission(Optional.<AclPermission>empty().orElse(null))
+                .submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -62,14 +62,21 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     @Override
     public Flux<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission) {
         Criteria applicationIdCriteria = this.getCriterionForFindByApplicationId(applicationId);
-        return queryAll(List.of(applicationIdCriteria), aclPermission);
+        return queryAll()
+                .criteria(List.of(applicationIdCriteria))
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override
     public Flux<NewAction> findByApplicationId(
             String applicationId, Optional<AclPermission> aclPermission, Optional<Sort> sort) {
         Criteria applicationIdCriteria = this.getCriterionForFindByApplicationId(applicationId);
-        return queryAll(List.of(applicationIdCriteria), aclPermission, sort);
+        return queryAll()
+                .criteria(applicationIdCriteria)
+                .permission(aclPermission.orElse(null))
+                .sort(sort.orElse(null))
+                .submit();
     }
 
     @Override
@@ -100,7 +107,10 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .orOperator(
                         where(unpublishedPage).is(pageId), where(publishedPage).is(pageId));
 
-        return queryAll(List.of(pageCriteria), aclPermission);
+        return queryAll()
+                .criteria(List.of(pageCriteria))
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override
@@ -114,7 +124,10 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .orOperator(
                         where(unpublishedPage).is(pageId), where(publishedPage).is(pageId));
 
-        return queryAll(List.of(pageCriteria), aclPermission);
+        return queryAll()
+                .criteria(List.of(pageCriteria))
+                .permission(aclPermission.orElse(null))
+                .submit();
     }
 
     @Override
@@ -150,7 +163,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                     .is(null);
             criteria.add(deletedCriteria);
         }
-        return queryAll(criteria, aclPermission);
+        return queryAll().criteria(criteria).permission(aclPermission).submit();
     }
 
     @Override
@@ -180,7 +193,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         Criteria httpMethodCriteria = where(httpMethodQueryKey).is(httpMethod);
         List<Criteria> criterias = List.of(namesCriteria, pageCriteria, httpMethodCriteria, userSetOnLoadCriteria);
 
-        return queryAll(criterias, aclPermission);
+        return queryAll().criteria(criterias).permission(aclPermission).submit();
     }
 
     @Override
@@ -189,7 +202,11 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         List<Criteria> criteriaList =
                 this.getCriteriaForFindAllActionsByNameAndPageIdsAndViewMode(name, pageIds, viewMode);
 
-        return queryAll(criteriaList, aclPermission, sort);
+        return queryAll()
+                .criteria(criteriaList)
+                .permission(aclPermission)
+                .sort(sort)
+                .submit();
     }
 
     protected List<Criteria> getCriteriaForFindAllActionsByNameAndPageIdsAndViewMode(
@@ -272,7 +289,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .is(null);
         criteriaList.add(deletedCriteria);
 
-        return queryAll(criteriaList, permission);
+        return queryAll().criteria(criteriaList).permission(permission).submit();
     }
 
     @Override
@@ -301,7 +318,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .is(null);
         criteriaList.add(deletedCriteria);
 
-        return queryAll(criteriaList, permission);
+        return queryAll().criteria(criteriaList).permission(permission).submit();
     }
 
     @Override
@@ -331,7 +348,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .is(null);
         criteriaList.add(deletedCriteria);
 
-        return queryAll(criteriaList, permission);
+        return queryAll().criteria(criteriaList).permission(permission).submit();
     }
 
     @Override
@@ -339,7 +356,11 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
         Criteria applicationCriteria = this.getCriterionForFindByApplicationId(applicationId);
 
-        return queryAll(List.of(applicationCriteria), aclPermission, sort);
+        return queryAll()
+                .criteria(List.of(applicationCriteria))
+                .permission(aclPermission)
+                .sort(sort)
+                .submit();
     }
 
     protected Criteria getCriterionForFindByApplicationId(String applicationId) {
@@ -354,7 +375,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
         List<Criteria> criteria = this.getCriteriaForFindByApplicationIdAndViewMode(applicationId, viewMode);
 
-        return queryAll(criteria, aclPermission);
+        return queryAll().criteria(criteria).permission(aclPermission).submit();
     }
 
     protected List<Criteria> getCriteriaForFindByApplicationIdAndViewMode(String applicationId, Boolean viewMode) {
@@ -426,7 +447,10 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                         + fieldName(QNewAction.newAction.unpublishedAction.pageId))
                 .in(pageIds);
 
-        return queryAll(List.of(pageIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(pageIdCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
@@ -435,7 +459,10 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                         + fieldName(QNewAction.newAction.unpublishedAction.pageId))
                 .in(pageIds);
 
-        return queryAll(List.of(pageIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(pageIdCriteria))
+                .permission(permission.orElse(null))
+                .submit();
     }
 
     @Override
@@ -444,7 +471,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         List<Criteria> criteria =
                 this.getCriteriaForFindNonJsActionsByApplicationIdAndViewMode(applicationId, viewMode);
 
-        return queryAll(criteria, aclPermission);
+        return queryAll().criteria(criteria).permission(aclPermission).submit();
     }
 
     protected List<Criteria> getCriteriaForFindNonJsActionsByApplicationIdAndViewMode(
@@ -475,7 +502,11 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         List<Criteria> criteriaList =
                 this.getCriteriaForFindAllNonJsActionsByNameAndPageIdsAndViewMode(name, pageIds, viewMode);
 
-        return queryAll(criteriaList, aclPermission, sort);
+        return queryAll()
+                .criteria(criteriaList)
+                .permission(aclPermission)
+                .sort(sort)
+                .submit();
     }
 
     protected List<Criteria> getCriteriaForFindAllNonJsActionsByNameAndPageIdsAndViewMode(
@@ -536,7 +567,10 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         final String defaultResources = fieldName(QBranchAwareDomain.branchAwareDomain.defaultResources);
         Criteria defaultAppIdCriteria =
                 where(defaultResources + "." + FieldName.APPLICATION_ID).is(defaultApplicationId);
-        return queryAll(List.of(defaultAppIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(defaultAppIdCriteria))
+                .permission(permission.orElse(null))
+                .submit();
     }
 
     @Override
@@ -608,7 +642,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     public Flux<NewAction> findAllByApplicationIdsWithoutPermission(
             List<String> applicationIds, List<String> includeFields) {
         Criteria applicationCriteria = Criteria.where(FieldName.APPLICATION_ID).in(applicationIds);
-        return queryAll(List.of(applicationCriteria), includeFields, null, null, NO_RECORD_LIMIT);
+        return queryAll().criteria(applicationCriteria).fields(includeFields).submit();
     }
 
     @Override
@@ -633,7 +667,10 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
             criteriaList.add(jsInclusionOrExclusionCriteria);
         }
 
-        return queryAll(criteriaList, Optional.ofNullable(permission));
+        return queryAll()
+                .criteria(criteriaList)
+                .permission(Optional.ofNullable(permission).orElse(null))
+                .submit();
     }
 
     @Override
@@ -658,6 +695,9 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
         criteriaList.add(jsInclusionOrExclusionCriteria);
 
-        return queryAll(criteriaList, Optional.ofNullable(permission));
+        return queryAll()
+                .criteria(criteriaList)
+                .permission(Optional.ofNullable(permission).orElse(null))
+                .submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -63,7 +63,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     public Flux<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission) {
         Criteria applicationIdCriteria = this.getCriterionForFindByApplicationId(applicationId);
         return queryAll()
-                .criteria(List.of(applicationIdCriteria))
+                .criteria(applicationIdCriteria)
                 .permission(aclPermission)
                 .submit();
     }
@@ -107,10 +107,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .orOperator(
                         where(unpublishedPage).is(pageId), where(publishedPage).is(pageId));
 
-        return queryAll()
-                .criteria(List.of(pageCriteria))
-                .permission(aclPermission)
-                .submit();
+        return queryAll().criteria(pageCriteria).permission(aclPermission).submit();
     }
 
     @Override
@@ -125,7 +122,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                         where(unpublishedPage).is(pageId), where(publishedPage).is(pageId));
 
         return queryAll()
-                .criteria(List.of(pageCriteria))
+                .criteria(pageCriteria)
                 .permission(aclPermission.orElse(null))
                 .submit();
     }
@@ -357,7 +354,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         Criteria applicationCriteria = this.getCriterionForFindByApplicationId(applicationId);
 
         return queryAll()
-                .criteria(List.of(applicationCriteria))
+                .criteria(applicationCriteria)
                 .permission(aclPermission)
                 .sort(sort)
                 .submit();
@@ -447,10 +444,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                         + fieldName(QNewAction.newAction.unpublishedAction.pageId))
                 .in(pageIds);
 
-        return queryAll()
-                .criteria(List.of(pageIdCriteria))
-                .permission(permission)
-                .submit();
+        return queryAll().criteria(pageIdCriteria).permission(permission).submit();
     }
 
     @Override
@@ -460,7 +454,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .in(pageIds);
 
         return queryAll()
-                .criteria(List.of(pageIdCriteria))
+                .criteria(pageIdCriteria)
                 .permission(permission.orElse(null))
                 .submit();
     }
@@ -568,7 +562,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         Criteria defaultAppIdCriteria =
                 where(defaultResources + "." + FieldName.APPLICATION_ID).is(defaultApplicationId);
         return queryAll()
-                .criteria(List.of(defaultAppIdCriteria))
+                .criteria(defaultAppIdCriteria)
                 .permission(permission.orElse(null))
                 .submit();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -49,14 +49,20 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
     public Flux<NewPage> findByApplicationId(String applicationId, AclPermission aclPermission) {
         Criteria applicationIdCriteria =
                 where(fieldName(QNewPage.newPage.applicationId)).is(applicationId);
-        return queryAll(List.of(applicationIdCriteria), aclPermission);
+        return queryAll()
+                .criteria(List.of(applicationIdCriteria))
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override
     public Flux<NewPage> findByApplicationId(String applicationId, Optional<AclPermission> permission) {
         Criteria applicationIdCriteria =
                 where(fieldName(QNewPage.newPage.applicationId)).is(applicationId);
-        return queryAll(List.of(applicationIdCriteria), permission);
+        return queryAll()
+                .criteria(List.of(applicationIdCriteria))
+                .permission(permission.orElse(null))
+                .submit();
     }
 
     @Override
@@ -68,7 +74,10 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         Criteria activeEditModeCriteria = where(fieldName(QNewPage.newPage.unpublishedPage) + "."
                         + fieldName(QNewPage.newPage.unpublishedPage.deletedAt))
                 .is(null);
-        return queryAll(List.of(applicationIdCriteria, activeEditModeCriteria), aclPermission);
+        return queryAll()
+                .criteria(List.of(applicationIdCriteria, activeEditModeCriteria))
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override
@@ -171,7 +180,11 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
 
         Criteria idsCriterion = where("id").in(ids);
 
-        return this.queryAll(new ArrayList<>(List.of(idsCriterion)), includedFields, aclPermission, null);
+        return this.queryAll()
+                .criteria(idsCriterion)
+                .fields(includedFields)
+                .permission(aclPermission)
+                .submit();
     }
 
     private Criteria getNameCriterion(String name, Boolean viewMode) {
@@ -230,16 +243,16 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
                 fieldName(QNewPage.newPage.publishedPage), fieldName(QNewPage.newPage.publishedPage.customSlug));
         String applicationIdFieldPath = fieldName(QNewPage.newPage.applicationId);
 
-        return queryAll(
-                List.of(applicationIdCriteria),
-                List.of(
+        return queryAll()
+                .criteria(applicationIdCriteria)
+                .fields(
                         unpublishedSlugFieldPath,
                         unpublishedCustomSlugFieldPath,
                         publishedSlugFieldPath,
                         publishedCustomSlugFieldPath,
-                        applicationIdFieldPath),
-                aclPermission,
-                null);
+                        applicationIdFieldPath)
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override
@@ -294,6 +307,6 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
     public Flux<NewPage> findAllByApplicationIdsWithoutPermission(
             List<String> applicationIds, List<String> includeFields) {
         Criteria applicationCriteria = Criteria.where(FieldName.APPLICATION_ID).in(applicationIds);
-        return queryAll(List.of(applicationCriteria), includeFields, null, null, NO_RECORD_LIMIT);
+        return queryAll().criteria(applicationCriteria).fields(includeFields).submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -50,7 +50,7 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         Criteria applicationIdCriteria =
                 where(fieldName(QNewPage.newPage.applicationId)).is(applicationId);
         return queryAll()
-                .criteria(List.of(applicationIdCriteria))
+                .criteria(applicationIdCriteria)
                 .permission(aclPermission)
                 .submit();
     }
@@ -60,7 +60,7 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         Criteria applicationIdCriteria =
                 where(fieldName(QNewPage.newPage.applicationId)).is(applicationId);
         return queryAll()
-                .criteria(List.of(applicationIdCriteria))
+                .criteria(applicationIdCriteria)
                 .permission(permission.orElse(null))
                 .submit();
     }
@@ -75,7 +75,7 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
                         + fieldName(QNewPage.newPage.unpublishedPage.deletedAt))
                 .is(null);
         return queryAll()
-                .criteria(List.of(applicationIdCriteria, activeEditModeCriteria))
+                .criteria(applicationIdCriteria, activeEditModeCriteria)
                 .permission(aclPermission)
                 .submit();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
@@ -44,8 +44,10 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
                 .is(workspaceId);
         Criteria defaultDomainTypeCriteria = where(fieldName(QPermissionGroup.permissionGroup.defaultDomainType))
                 .is(Workspace.class.getSimpleName());
-        return queryAll(
-                List.of(assignedToUserIdCriteria, defaultWorkspaceIdCriteria, defaultDomainTypeCriteria), permission);
+        return queryAll()
+                .criteria(List.of(assignedToUserIdCriteria, defaultWorkspaceIdCriteria, defaultDomainTypeCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
@@ -63,7 +65,10 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
                 .is(workspaceId);
         Criteria defaultDomainTypeCriteria = where(fieldName(QPermissionGroup.permissionGroup.defaultDomainType))
                 .is(Workspace.class.getSimpleName());
-        return queryAll(List.of(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria), permission);
+        return queryAll()
+                .criteria(List.of(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
@@ -72,7 +77,10 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
                 .in(workspaceIds);
         Criteria defaultDomainTypeCriteria = where(fieldName(QPermissionGroup.permissionGroup.defaultDomainType))
                 .is(Workspace.class.getSimpleName());
-        return queryAll(List.of(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria), permission);
+        return queryAll()
+                .criteria(List.of(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria))
+                .permission(permission)
+                .submit();
     }
 
     @Override
@@ -100,7 +108,10 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
             Set<String> userIds, Optional<List<String>> includeFields, Optional<AclPermission> permission) {
         Criteria assignedToUserIdCriteria = where(fieldName(QPermissionGroup.permissionGroup.assignedToUserIds))
                 .in(userIds);
-        return queryAll(
-                List.of(assignedToUserIdCriteria), includeFields, permission, Optional.empty(), NO_RECORD_LIMIT);
+        return queryAll()
+                .criteria(assignedToUserIdCriteria)
+                .fields(includeFields.orElse(null))
+                .permission(permission.orElse(null))
+                .submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
@@ -45,7 +45,7 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
         Criteria defaultDomainTypeCriteria = where(fieldName(QPermissionGroup.permissionGroup.defaultDomainType))
                 .is(Workspace.class.getSimpleName());
         return queryAll()
-                .criteria(List.of(assignedToUserIdCriteria, defaultWorkspaceIdCriteria, defaultDomainTypeCriteria))
+                .criteria(assignedToUserIdCriteria, defaultWorkspaceIdCriteria, defaultDomainTypeCriteria)
                 .permission(permission)
                 .submit();
     }
@@ -66,7 +66,7 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
         Criteria defaultDomainTypeCriteria = where(fieldName(QPermissionGroup.permissionGroup.defaultDomainType))
                 .is(Workspace.class.getSimpleName());
         return queryAll()
-                .criteria(List.of(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria))
+                .criteria(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria)
                 .permission(permission)
                 .submit();
     }
@@ -78,7 +78,7 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
         Criteria defaultDomainTypeCriteria = where(fieldName(QPermissionGroup.permissionGroup.defaultDomainType))
                 .is(Workspace.class.getSimpleName());
         return queryAll()
-                .criteria(List.of(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria))
+                .criteria(defaultWorkspaceIdCriteria, defaultDomainTypeCriteria)
                 .permission(permission)
                 .submit();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
@@ -10,7 +10,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -33,17 +32,12 @@ public class CustomPluginRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Plu
                 fieldName(QPlugin.plugin.name),
                 fieldName(QPlugin.plugin.packageName),
                 fieldName(QPlugin.plugin.iconLocation));
-        return this.queryAll(List.of(criteria), projections, null, null);
+        return queryAll().criteria(criteria).fields(projections).submit();
     }
 
     @Override
     public Flux<Plugin> findAllByIdsWithoutPermission(Set<String> ids, List<String> includeFields) {
         Criteria idCriteria = where(fieldName(QPlugin.plugin.id)).in(ids);
-        return queryAll(
-                List.of(idCriteria),
-                Optional.ofNullable(includeFields),
-                Optional.empty(),
-                Optional.empty(),
-                NO_RECORD_LIMIT);
+        return queryAll().criteria(idCriteria).fields(includeFields).submit();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -39,7 +39,7 @@ public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Them
         Criteria systemThemeCriteria =
                 Criteria.where(fieldName(QTheme.theme.isSystemTheme)).is(Boolean.TRUE);
         Criteria criteria = new Criteria().orOperator(appThemeCriteria, systemThemeCriteria);
-        return queryAll().criteria(List.of(criteria)).permission(aclPermission).submit();
+        return queryAll().criteria(criteria).permission(aclPermission).submit();
     }
 
     @Override
@@ -47,7 +47,7 @@ public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Them
         Criteria systemThemeCriteria =
                 Criteria.where(fieldName(QTheme.theme.isSystemTheme)).is(Boolean.TRUE);
         return queryAll()
-                .criteria(List.of(systemThemeCriteria))
+                .criteria(systemThemeCriteria)
                 .permission(AclPermission.READ_THEMES)
                 .submit();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -39,14 +39,17 @@ public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Them
         Criteria systemThemeCriteria =
                 Criteria.where(fieldName(QTheme.theme.isSystemTheme)).is(Boolean.TRUE);
         Criteria criteria = new Criteria().orOperator(appThemeCriteria, systemThemeCriteria);
-        return queryAll(List.of(criteria), aclPermission);
+        return queryAll().criteria(List.of(criteria)).permission(aclPermission).submit();
     }
 
     @Override
     public Flux<Theme> getSystemThemes() {
         Criteria systemThemeCriteria =
                 Criteria.where(fieldName(QTheme.theme.isSystemTheme)).is(Boolean.TRUE);
-        return queryAll(List.of(systemThemeCriteria), AclPermission.READ_THEMES);
+        return queryAll()
+                .criteria(List.of(systemThemeCriteria))
+                .permission(AclPermission.READ_THEMES)
+                .submit();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -19,7 +19,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -68,9 +67,10 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
     public Flux<UserData> findPhotoAssetsByUserIds(Iterable<String> userId) {
         // need to convert from Iterable to ArrayList because the "in" method of criteria takes a collection as input
         Criteria criteria = where(fieldName(QUserData.userData.userId)).in(Lists.newArrayList(userId));
-        List<String> fieldsToInclude =
-                List.of(fieldName(QUserData.userData.profilePhotoAssetId), fieldName(QUserData.userData.userId));
-        return queryAll(List.of(criteria), Optional.of(fieldsToInclude), Optional.empty(), Optional.empty());
+        return queryAll()
+                .criteria(criteria)
+                .fields(fieldName(QUserData.userData.profilePhotoAssetId), fieldName(QUserData.userData.userId))
+                .submit();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
@@ -50,7 +50,11 @@ public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         Criteria tenantIdCriteria =
                 where(fieldName(QWorkspace.workspace.tenantId)).is(tenantId);
 
-        return queryAll(List.of(workspaceIdCriteria, tenantIdCriteria), aclPermission, sort);
+        return queryAll()
+                .criteria(List.of(workspaceIdCriteria, tenantIdCriteria))
+                .permission(aclPermission)
+                .sort(sort)
+                .submit();
     }
 
     @Override
@@ -73,7 +77,10 @@ public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         return sessionUserService.getCurrentUser().flatMapMany(user -> {
             Criteria tenantIdCriteria =
                     where(fieldName(QWorkspace.workspace.tenantId)).is(user.getTenantId());
-            return queryAll(List.of(tenantIdCriteria), permission);
+            return queryAll()
+                    .criteria(List.of(tenantIdCriteria))
+                    .permission(permission)
+                    .submit();
         });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
@@ -51,7 +51,7 @@ public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 where(fieldName(QWorkspace.workspace.tenantId)).is(tenantId);
 
         return queryAll()
-                .criteria(List.of(workspaceIdCriteria, tenantIdCriteria))
+                .criteria(workspaceIdCriteria, tenantIdCriteria)
                 .permission(aclPermission)
                 .sort(sort)
                 .submit();
@@ -77,10 +77,7 @@ public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         return sessionUserService.getCurrentUser().flatMapMany(user -> {
             Criteria tenantIdCriteria =
                     where(fieldName(QWorkspace.workspace.tenantId)).is(user.getTenantId());
-            return queryAll()
-                    .criteria(List.of(tenantIdCriteria))
-                    .permission(permission)
-                    .submit();
+            return queryAll().criteria(tenantIdCriteria).permission(permission).submit();
         });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -1,0 +1,91 @@
+package com.appsmith.server.repositories.ce.params;
+
+import com.appsmith.external.models.BaseDomain;
+import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl;
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.query.Criteria;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.NO_RECORD_LIMIT;
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.NO_SKIP;
+
+@Getter
+public class QueryAllParams<T extends BaseDomain> {
+    // TODO(Shri): There's a cyclic dependency between the repository and this class. Fix it.
+    private final BaseAppsmithRepositoryCEImpl<T> repo;
+    private final List<Criteria> criteria = new ArrayList<>();
+    private final List<String> fields = new ArrayList<>();
+    private AclPermission permission;
+    private Set<String> permissionGroups;
+    private Sort sort;
+    private int limit = NO_RECORD_LIMIT;
+    private int skip = NO_SKIP;
+
+    public QueryAllParams(BaseAppsmithRepositoryCEImpl<T> repo) {
+        this.repo = repo;
+    }
+
+    public Flux<T> submit() {
+        return repo.queryAllExecute(this);
+    }
+
+    public QueryAllParams<T> criteria(Criteria criteria) {
+        if (criteria == null) {
+            return this;
+        }
+        return criteria(Collections.singletonList(criteria));
+    }
+
+    public QueryAllParams<T> criteria(List<Criteria> criterias) {
+        if (criterias == null) {
+            return this;
+        }
+        this.criteria.addAll(criterias);
+        return this;
+    }
+
+    public QueryAllParams<T> fields(String... fields) {
+        return fields(List.of(fields));
+    }
+
+    public QueryAllParams<T> fields(Collection<String> fields) {
+        if (fields == null) {
+            return this;
+        }
+        this.fields.addAll(fields);
+        return this;
+    }
+
+    public QueryAllParams<T> permission(AclPermission permission) {
+        this.permission = permission;
+        return this;
+    }
+
+    public QueryAllParams<T> permissionGroups(Set<String> permissionGroups) {
+        this.permissionGroups = permissionGroups;
+        return this;
+    }
+
+    public QueryAllParams<T> sort(Sort sort) {
+        this.sort = sort;
+        return this;
+    }
+
+    public QueryAllParams<T> limit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public QueryAllParams<T> skip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -10,7 +10,6 @@ import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -37,11 +36,11 @@ public class QueryAllParams<T extends BaseDomain> {
         return repo.queryAllExecute(this);
     }
 
-    public QueryAllParams<T> criteria(Criteria criteria) {
+    public QueryAllParams<T> criteria(Criteria... criteria) {
         if (criteria == null) {
             return this;
         }
-        return criteria(Collections.singletonList(criteria));
+        return criteria(List.of(criteria));
     }
 
     public QueryAllParams<T> criteria(List<Criteria> criterias) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -18,7 +18,7 @@ import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.N
 
 @Getter
 public class QueryAllParams<T extends BaseDomain> {
-    // TODO(Shri): There's a cyclic dependency between the repository and this class. Fix it.
+    // TODO(Shri): There's a cyclic dependency between the repository and this class. Remove it.
     private final BaseAppsmithRepositoryCEImpl<T> repo;
     private final List<Criteria> criteria = new ArrayList<>();
     private final List<String> fields = new ArrayList<>();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -116,7 +116,11 @@ public abstract class BaseService<
                     })
                     .collect(Collectors.toList());
         }
-        return repository.queryAll(criterias, aclPermission);
+        return repository
+                .queryAll()
+                .criteria(criterias)
+                .permission(aclPermission)
+                .submit();
     }
 
     @Override
@@ -211,7 +215,12 @@ public abstract class BaseService<
                 .map(fieldName -> Criteria.where(fieldName).regex(".*" + Pattern.quote(searchString) + ".*", "i"))
                 .toList();
         Criteria criteria = new Criteria().orOperator(criteriaList);
-        Flux<T> result = repository.queryAll(List.of(criteria), permission, sort);
+        Flux<T> result = repository
+                .queryAll()
+                .criteria(criteria)
+                .permission(permission)
+                .sort(sort)
+                .submit();
         if (pageable != null) {
             return result.skip(pageable.getOffset()).take(pageable.getPageSize());
         }


### PR DESCRIPTION
Continuing from https://github.com/appsmithorg/appsmith/pull/30669.

🚨 **DO NOT MERGE. ONLY REVIEW/APPROVE.**

There is ~13 signatures of the `queryAll` method with parameters ranging from 2 to 7, different combinations of the same superset. This is extremely hard to grok and the resulting uses of `queryAll` aren't very readable either. This PR introduces a fluent interface for this method. If this works better for us, I'll look to move more such over-signature-ed methods to a fluent interface.

This sprang from a frustration in trying to understand this method's usages, to port to Postgres, and pulling my hair apart in the process.

Here's an example of the fluent API compared to current API:
![shot-2024-01-27-10-37-57@2x](https://github.com/appsmithorg/appsmith/assets/120119/ed11a4c6-a433-4e92-824c-7db00880a24a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced query flexibility and expressiveness across various repository methods by adopting a more fluent and expressive querying style.
	- Introduced `QueryAllParams` class to streamline the construction and execution of queries with comprehensive parameters including criteria, permissions, and sorting.
- **New Features**
	- Updated method signatures to include `AclPermission` as a parameter, improving access control and permission management in data queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->