### PR TITLE
ci: Use a variable for client runner

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -34,7 +34,7 @@ defaults:
 
 jobs:
   client-build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ${{ vars.RUNNER_CLIENT_BUILD }}
     # Only run this workflow for internally triggered events
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||


### PR DESCRIPTION
We should be able to switch back-and-forth faster with this. I've already set the variable on both repos to `ubuntu-latest-8-cores`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build process to use a dynamic execution environment for enhanced flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->