### PR TITLE
fix: improve query add url split

### DIFF
--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/hooks.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/hooks.ts
@@ -3,8 +3,6 @@ import history from "utils/history";
 import { LIST_PATH } from "@appsmith/constants/routes/appRoutes";
 import { useLocation } from "react-router";
 import { FocusEntity, identifyEntityFromPath } from "navigation/FocusEntity";
-import { useCurrentEditorState } from "pages/Editor/IDE/hooks";
-import { EditorEntityTabState } from "@appsmith/entities/IDE/constants";
 import { useSelector } from "react-redux";
 import { useFilteredFileOperations } from "components/editorComponents/GlobalSearch/GlobalSearchHooks";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
@@ -19,14 +17,11 @@ import { getQueryAddUrl } from "./utils";
 export const useQueryAdd = () => {
   const location = useLocation();
   const currentEntityInfo = identifyEntityFromPath(location.pathname);
-  const { segmentMode } = useCurrentEditorState();
 
   const addButtonClickHandler = useCallback(() => {
-    if (segmentMode === EditorEntityTabState.Edit) {
-      const url = getQueryAddUrl(currentEntityInfo);
-      history.push(url);
-    }
-  }, [currentEntityInfo.id, segmentMode]);
+    const url = getQueryAddUrl(currentEntityInfo);
+    history.push(url);
+  }, [currentEntityInfo.id]);
 
   return addButtonClickHandler;
 };

--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/hooks.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/hooks.ts
@@ -5,12 +5,6 @@ import { useLocation } from "react-router";
 import { FocusEntity, identifyEntityFromPath } from "navigation/FocusEntity";
 import { useCurrentEditorState } from "pages/Editor/IDE/hooks";
 import { EditorEntityTabState } from "@appsmith/entities/IDE/constants";
-import {
-  apiEditorIdURL,
-  queryAddURL,
-  queryEditorIdURL,
-  saasEditorApiIdURL,
-} from "@appsmith/RouteBuilder";
 import { useSelector } from "react-redux";
 import { useFilteredFileOperations } from "components/editorComponents/GlobalSearch/GlobalSearchHooks";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
@@ -20,7 +14,7 @@ import { getHasCreateActionPermission } from "@appsmith/utils/BusinessFeatures/p
 import type { ActionOperation } from "components/editorComponents/GlobalSearch/utils";
 import { SEARCH_ITEM_TYPES } from "components/editorComponents/GlobalSearch/utils";
 import { createMessage, EDITOR_PANE_TEXTS } from "@appsmith/constants/messages";
-import { getQueryType, QueryType } from "./utils";
+import { getQueryAddUrl } from "./utils";
 
 export const useQueryAdd = () => {
   const location = useLocation();
@@ -28,27 +22,11 @@ export const useQueryAdd = () => {
   const { segmentMode } = useCurrentEditorState();
 
   const addButtonClickHandler = useCallback(() => {
-    let url = queryAddURL({});
     if (segmentMode === EditorEntityTabState.Edit) {
-      switch (getQueryType(currentEntityInfo)) {
-        case QueryType.QUERY:
-          url = queryEditorIdURL({ queryId: currentEntityInfo.id, add: true });
-          break;
-        case QueryType.API:
-          url = apiEditorIdURL({ apiId: currentEntityInfo.id, add: true });
-          break;
-        case QueryType.SAAS:
-          if (currentEntityInfo.params.pluginPackageName) {
-            url = saasEditorApiIdURL({
-              apiId: currentEntityInfo.id,
-              pluginPackageName: currentEntityInfo.params.pluginPackageName,
-              add: true,
-            });
-          }
-      }
+      const url = getQueryAddUrl(currentEntityInfo);
+      history.push(url);
     }
-    history.push(url);
-  }, [currentEntityInfo.id, location, segmentMode]);
+  }, [currentEntityInfo.id, segmentMode]);
 
   return addButtonClickHandler;
 };

--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/utils.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/utils.ts
@@ -1,6 +1,12 @@
 import type { EntityItem } from "@appsmith/entities/IDE/constants";
 import { getActionConfig } from "pages/Editor/Explorer/Actions/helpers";
 import type { FocusEntityInfo } from "navigation/FocusEntity";
+import {
+  apiEditorIdURL,
+  queryAddURL,
+  queryEditorIdURL,
+  saasEditorApiIdURL,
+} from "@appsmith/RouteBuilder";
 
 export const getQueryEntityItemUrl = (
   item: EntityItem,
@@ -13,20 +19,25 @@ export const getQueryEntityItemUrl = (
   return config.getURL(pageId, item.key, item.type);
 };
 
-export enum QueryType {
-  API = "API",
-  SAAS = "SAAS",
-  QUERY = "QUERY",
-}
-
-export const getQueryType = (item: FocusEntityInfo): QueryType | undefined => {
+export const getQueryAddUrl = (item: FocusEntityInfo): string => {
   if (item.params.apiId) {
     if (item.params.pluginPackageName) {
-      return QueryType.SAAS;
+      return saasEditorApiIdURL({
+        pluginPackageName: item.params.pluginPackageName,
+        apiId: item.params.apiId,
+        add: true,
+      });
     } else {
-      return QueryType.API;
+      return apiEditorIdURL({
+        apiId: item.params.apiId,
+        add: true,
+      });
     }
   } else if (item.params.queryId) {
-    return QueryType.QUERY;
+    return queryEditorIdURL({
+      queryId: item.params.queryId,
+      add: true,
+    });
   }
+  return queryAddURL({});
 };


### PR DESCRIPTION
improve upon the query add url fix by splitting it for extensibility with EE

We will now extend a utility function `getQueryAddUrl` on EE to add EE cases instead of rewriting the implementation as it does today

fixes: #30764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced URL construction method for adding queries in the Editor Pane to improve navigation and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->