### PR TITLE
fix: fix modal position and styles

### DIFF
--- a/app/client/packages/design-system/headless/src/components/Popover/src/types.ts
+++ b/app/client/packages/design-system/headless/src/components/Popover/src/types.ts
@@ -47,6 +47,12 @@ export interface PopoverProps {
   triggerRef?: MutableRefObject<HTMLElement | null>;
   /** Which element to initially focus. Can be either a number (tabbable index as specified by the order) or a ref.  */
   initialFocus?: number | MutableRefObject<HTMLElement | null>;
+  /** Determines whether clickOutside is work or not.
+   * @default false
+   */
+  dismissClickOutside?: boolean;
+  /** Selectors that are clicked on do not close the popup. */
+  dismissCloseSelectors?: string | string[];
 }
 
 export interface PopoverContentProps {

--- a/app/client/packages/design-system/headless/src/components/Popover/src/types.ts
+++ b/app/client/packages/design-system/headless/src/components/Popover/src/types.ts
@@ -51,8 +51,6 @@ export interface PopoverProps {
    * @default false
    */
   dismissClickOutside?: boolean;
-  /** Selectors that are clicked on do not close the popup. */
-  dismissCloseSelectors?: string | string[];
 }
 
 export interface PopoverContentProps {

--- a/app/client/packages/design-system/headless/src/components/Popover/src/usePopover.ts
+++ b/app/client/packages/design-system/headless/src/components/Popover/src/usePopover.ts
@@ -18,7 +18,6 @@ const DEFAULT_POPOVER_OFFSET = 10;
 export function usePopover({
   defaultOpen = false,
   dismissClickOutside = false,
-  dismissCloseSelectors,
   duration = 0,
   initialFocus,
   isOpen: controlledOpen,
@@ -63,18 +62,10 @@ export function usePopover({
     outsidePress: (event) => {
       if (dismissClickOutside) return false;
 
-      const target = event?.target as HTMLElement;
-
-      if (typeof dismissCloseSelectors === "string") {
-        return !Boolean(target.closest(dismissCloseSelectors));
-      } else {
-        dismissCloseSelectors?.forEach(
-          (elem: string) => !Boolean(target.closest(elem)),
-        );
-      }
-
       // By default, click to close popup only work inside the provider
-      return Boolean(target.closest("[data-theme-provider]"));
+      return Boolean(
+        (event?.target as HTMLElement).closest("[data-theme-provider]"),
+      );
     },
   });
   const role = useRole(context);

--- a/app/client/packages/design-system/headless/src/components/Popover/src/usePopover.ts
+++ b/app/client/packages/design-system/headless/src/components/Popover/src/usePopover.ts
@@ -56,7 +56,10 @@ export function usePopover({
   const click = useClick(context, {
     enabled: controlledOpen == null,
   });
-  const dismiss = useDismiss(context);
+  const dismiss = useDismiss(context, {
+    outsidePress: (event) =>
+      Boolean((event?.target as HTMLElement).closest("[data-theme-provider]")),
+  });
   const role = useRole(context);
   const interactions = useInteractions([click, dismiss, role]);
 

--- a/app/client/packages/design-system/headless/src/components/Popover/src/usePopover.ts
+++ b/app/client/packages/design-system/headless/src/components/Popover/src/usePopover.ts
@@ -17,6 +17,8 @@ const DEFAULT_POPOVER_OFFSET = 10;
 
 export function usePopover({
   defaultOpen = false,
+  dismissClickOutside = false,
+  dismissCloseSelectors,
   duration = 0,
   initialFocus,
   isOpen: controlledOpen,
@@ -57,8 +59,23 @@ export function usePopover({
     enabled: controlledOpen == null,
   });
   const dismiss = useDismiss(context, {
-    outsidePress: (event) =>
-      Boolean((event?.target as HTMLElement).closest("[data-theme-provider]")),
+    escapeKey: !dismissClickOutside,
+    outsidePress: (event) => {
+      if (dismissClickOutside) return false;
+
+      const target = event?.target as HTMLElement;
+
+      if (typeof dismissCloseSelectors === "string") {
+        return !Boolean(target.closest(dismissCloseSelectors));
+      } else {
+        dismissCloseSelectors?.forEach(
+          (elem: string) => !Boolean(target.closest(elem)),
+        );
+      }
+
+      // By default, click to close popup only work inside the provider
+      return Boolean(target.closest("[data-theme-provider]"));
+    },
   });
   const role = useRole(context);
   const interactions = useInteractions([click, dismiss, role]);

--- a/app/client/packages/design-system/widgets/src/components/Modal/src/ModalFooter.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/ModalFooter.tsx
@@ -7,7 +7,7 @@ import type { ModalFooterProps } from "./types";
 
 export const ModalFooter = (props: ModalFooterProps) => {
   const { closeText = "Close", onSubmit, submitText = "Submit" } = props;
-  const { onClose, setOpen } = usePopoverContext();
+  const { setOpen } = usePopoverContext();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSubmit = async () => {
@@ -19,14 +19,9 @@ export const ModalFooter = (props: ModalFooterProps) => {
     }
   };
 
-  const closeHandler = () => {
-    onClose && onClose();
-    setOpen(false);
-  };
-
   return (
     <Flex alignItems="center" gap="spacing-4" justifyContent="end">
-      <Button onPress={closeHandler} variant="ghost">
+      <Button onPress={() => setOpen(false)} variant="ghost">
         {closeText}
       </Button>
 

--- a/app/client/packages/design-system/widgets/src/components/Modal/src/ModalHeader.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/ModalHeader.tsx
@@ -10,7 +10,7 @@ import type { ModalHeaderProps } from "./types";
 
 export const ModalHeader = (props: ModalHeaderProps) => {
   const { title } = props;
-  const { onClose, setLabelId, setOpen } = usePopoverContext();
+  const { setLabelId, setOpen } = usePopoverContext();
   const id = useId();
 
   // Only sets `aria-labelledby` on the Dialog root element
@@ -20,17 +20,12 @@ export const ModalHeader = (props: ModalHeaderProps) => {
     return () => setLabelId(undefined);
   }, [id, setLabelId]);
 
-  const closeHandler = () => {
-    onClose && onClose();
-    setOpen(false);
-  };
-
   return (
     <Flex alignItems="center" gap="spacing-4" justifyContent="space-between">
       <Text id={id} lineClamp={1} title={title} variant="caption">
         {title}
       </Text>
-      <IconButton icon="x" onPress={closeHandler} variant="ghost" />
+      <IconButton icon="x" onPress={() => setOpen(false)} variant="ghost" />
     </Flex>
   );
 };

--- a/app/client/packages/design-system/widgets/src/components/Modal/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/styles.module.css
@@ -11,8 +11,8 @@
   background: var(--color-bg);
   border-radius: var(--border-radius-1);
   box-shadow: var(--box-shadow-1);
-  max-width: calc(100vw - var(--outer-spacing-8));
-  max-height: calc(100vh - var(--outer-spacing-8));
+  max-width: calc(var(--provider-width) - var(--outer-spacing-8));
+  max-height: calc(var(--provider-width) - var(--outer-spacing-8));
   outline: none;
   display: flex;
   flex-direction: column;

--- a/app/client/packages/design-system/widgets/src/components/Modal/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/styles.module.css
@@ -1,18 +1,18 @@
 .overlay {
-  /* Redefining the overlay positioning so that the dialog is centered relative to the provider, not the viewport */
-  position: absolute !important;
   background: var(--color-bg-neutral-opacity);
   display: grid;
   place-items: center;
   z-index: var(--z-index-99);
+  max-width: var(--provider-width);
+  margin: 0 auto;
 }
 
 .content {
   background: var(--color-bg);
   border-radius: var(--border-radius-1);
   box-shadow: var(--box-shadow-1);
-  max-width: calc(100vw - var(--outer-spacing-6));
-  max-height: calc(100vh - var(--outer-spacing-6));
+  max-width: calc(100vw - var(--outer-spacing-8));
+  max-height: calc(100vh - var(--outer-spacing-8));
   outline: none;
   display: flex;
   flex-direction: column;
@@ -38,7 +38,7 @@
 }
 
 [data-size="large"] .content {
-  width: calc(var(--provider-width) - var(--outer-spacing-6));
+  width: calc(var(--provider-width) - var(--outer-spacing-8));
   height: 100%;
 }
 

--- a/app/client/packages/design-system/widgets/src/components/Modal/src/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/types.ts
@@ -14,7 +14,6 @@ export interface ModalProps
       | "triggerRef"
       | "initialFocus"
       | "dismissClickOutside"
-      | "dismissCloseSelectors"
     >,
     Pick<PopoverModalContentProps, "overlayClassName"> {
   /** Size of the Modal

--- a/app/client/packages/design-system/widgets/src/components/Modal/src/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/types.ts
@@ -8,7 +8,13 @@ import type { SIZES } from "../../../shared";
 export interface ModalProps
   extends Pick<
       PopoverProps,
-      "isOpen" | "setOpen" | "onClose" | "triggerRef" | "initialFocus"
+      | "isOpen"
+      | "setOpen"
+      | "onClose"
+      | "triggerRef"
+      | "initialFocus"
+      | "dismissClickOutside"
+      | "dismissCloseSelectors"
     >,
     Pick<PopoverModalContentProps, "overlayClassName"> {
   /** Size of the Modal

--- a/app/client/src/ce/selectors/featureFlagsSelectors.ts
+++ b/app/client/src/ce/selectors/featureFlagsSelectors.ts
@@ -1,8 +1,11 @@
 import type { AppState } from "@appsmith/reducers";
 import type { FeatureFlag } from "@appsmith/entities/FeatureFlag";
 
-export const selectFeatureFlags = (state: AppState) =>
-  state.ui.users.featureFlag.data;
+export const selectFeatureFlags = (state: AppState) => ({
+  ...state.ui.users.featureFlag.data,
+  ab_wds_enabled: true,
+  release_anvil_enabled: true,
+});
 
 // React hooks should not be placed in a selectors file.
 export const selectFeatureFlagCheck = (

--- a/app/client/src/ce/selectors/featureFlagsSelectors.ts
+++ b/app/client/src/ce/selectors/featureFlagsSelectors.ts
@@ -1,11 +1,8 @@
 import type { AppState } from "@appsmith/reducers";
 import type { FeatureFlag } from "@appsmith/entities/FeatureFlag";
 
-export const selectFeatureFlags = (state: AppState) => ({
-  ...state.ui.users.featureFlag.data,
-  ab_wds_enabled: true,
-  release_anvil_enabled: true,
-});
+export const selectFeatureFlags = (state: AppState) =>
+  state.ui.users.featureFlag.data;
 
 // React hooks should not be placed in a selectors file.
 export const selectFeatureFlagCheck = (

--- a/app/client/src/components/editorComponents/ErrorBoundry.tsx
+++ b/app/client/src/components/editorComponents/ErrorBoundry.tsx
@@ -11,11 +11,6 @@ interface State {
   hasError: boolean;
 }
 
-const ErrorBoundaryContainer = styled.div`
-  height: 100%;
-  width: 100%;
-`;
-
 const RetryLink = styled.span`
   color: ${(props) => props.theme.colors.primaryDarkest};
   cursor: pointer;
@@ -39,7 +34,7 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   render() {
     return (
-      <ErrorBoundaryContainer className="error-boundary">
+      <div className="error-boundary">
         {this.state.hasError ? (
           <p>
             Oops, Something went wrong.
@@ -51,7 +46,7 @@ class ErrorBoundary extends React.Component<Props, State> {
         ) : (
           this.props.children
         )}
-      </ErrorBoundaryContainer>
+      </div>
     );
   }
 }

--- a/app/client/src/components/editorComponents/ErrorBoundry.tsx
+++ b/app/client/src/components/editorComponents/ErrorBoundry.tsx
@@ -1,15 +1,22 @@
-import type { ReactNode } from "react";
 import React from "react";
 import styled from "styled-components";
 import * as Sentry from "@sentry/react";
 import * as log from "loglevel";
 
+import type { ReactNode, CSSProperties } from "react";
+
 interface Props {
   children: ReactNode;
+  style?: CSSProperties;
 }
 interface State {
   hasError: boolean;
 }
+
+const ErrorBoundaryContainer = styled.div`
+  height: 100%;
+  width: 100%;
+`;
 
 const RetryLink = styled.span`
   color: ${(props) => props.theme.colors.primaryDarkest};
@@ -34,7 +41,10 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   render() {
     return (
-      <div className="error-boundary">
+      <ErrorBoundaryContainer
+        className="error-boundary"
+        style={this.props.style}
+      >
         {this.state.hasError ? (
           <p>
             Oops, Something went wrong.
@@ -46,7 +56,7 @@ class ErrorBoundary extends React.Component<Props, State> {
         ) : (
           this.props.children
         )}
-      </div>
+      </ErrorBoundaryContainer>
     );
   }
 }

--- a/app/client/src/layoutSystems/anvil/canvas/styles.css
+++ b/app/client/src/layoutSystems/anvil/canvas/styles.css
@@ -3,8 +3,3 @@
   width: 100%;
   height: 100%;
 }
-
-.main-anvil-canvas {
-  height: calc(100% - 1rem);
-  overflow-y: auto;
-}

--- a/app/client/src/layoutSystems/anvil/common/widgetComponent/AnvilWidgetComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/common/widgetComponent/AnvilWidgetComponent.tsx
@@ -22,7 +22,8 @@ export const AnvilWidgetComponent = (props: BaseWidgetProps) => {
   if (!detachFromLayout) return props.children;
 
   return (
-    <ErrorBoundary>
+    // delete style as soon as we switch to Anvil layout completely
+    <ErrorBoundary style={{ height: "auto", width: "auto" }}>
       <WidgetComponentBoundary widgetType={type}>
         {props.children}
       </WidgetComponentBoundary>

--- a/app/client/src/layoutSystems/anvil/utils/AnvilDSLTransformer.ts
+++ b/app/client/src/layoutSystems/anvil/utils/AnvilDSLTransformer.ts
@@ -22,7 +22,6 @@ export function anvilDSLTransformer(dsl: DSLWidget) {
         layoutStyle: {
           border: "none",
           height: "100%",
-          minHeight: "var(--canvas-height)",
           padding: "spacing-1",
         },
         isDropTarget: true,

--- a/app/client/src/layoutSystems/anvil/utils/layouts/renderUtils.tsx
+++ b/app/client/src/layoutSystems/anvil/utils/layouts/renderUtils.tsx
@@ -125,7 +125,6 @@ export function renderWidgetsInAlignedRow(
   > = {
     alignSelf: "stretch",
     canvasId,
-    columnGap: "4px",
     direction: "row",
     flexBasis: { base: "auto", [`${MOBILE_BREAKPOINT}px`]: "0%" },
     flexGrow: 1,

--- a/app/client/src/layoutSystems/common/mainContainerResizer/MainContainerResizer.tsx
+++ b/app/client/src/layoutSystems/common/mainContainerResizer/MainContainerResizer.tsx
@@ -70,6 +70,7 @@ export function MainContainerResizer({
   const appLayout = useSelector(getCurrentApplicationLayout);
   const ref = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
+  const topHeaderHeight = "48px";
   useEffect(() => {
     const ele: HTMLElement | null = document.getElementById(CANVAS_VIEWPORT);
 
@@ -170,8 +171,8 @@ export function MainContainerResizer({
       }}
       ref={ref}
       style={{
-        top: isPreview ? "48px" : "0",
-        height: isPreview ? "calc(100% - 48px)" : "100%",
+        top: isPreview ? topHeaderHeight : "0",
+        height: isPreview ? `calc(100% - ${topHeaderHeight})` : "100%",
       }}
     >
       <div className="canvas-resizer-icon">

--- a/app/client/src/layoutSystems/common/mainContainerResizer/MainContainerResizer.tsx
+++ b/app/client/src/layoutSystems/common/mainContainerResizer/MainContainerResizer.tsx
@@ -13,13 +13,12 @@ const CanvasResizerIcon = importSvg(
 );
 
 const AutoLayoutCanvasResizer = styled.div`
-  position: sticky;
+  position: relative;
   z-index: var(--on-canvas-ui-z-index);
   cursor: col-resize;
   user-select: none;
   -webkit-user-select: none;
   width: 2px;
-  height: 100%;
   display: flex;
   background: var(--ads-v2-color-border);
   align-items: center;
@@ -59,12 +58,9 @@ const AutoLayoutCanvasResizer = styled.div`
 export function MainContainerResizer({
   currentPageId,
   enableMainCanvasResizer,
-  heightWithTopMargin,
   isPageInitiated,
   isPreview,
-  shouldHaveTopMargin,
 }: {
-  heightWithTopMargin: string;
   isPageInitiated: boolean;
   shouldHaveTopMargin: boolean;
   isPreview: boolean;
@@ -174,8 +170,8 @@ export function MainContainerResizer({
       }}
       ref={ref}
       style={{
-        top: "100%",
-        height: shouldHaveTopMargin ? heightWithTopMargin : "100vh",
+        top: isPreview ? "48px" : "0",
+        height: isPreview ? "calc(100% - 48px)" : "100%",
       }}
     >
       <div className="canvas-resizer-icon">

--- a/app/client/src/pages/AppViewer/AppPage.tsx
+++ b/app/client/src/pages/AppViewer/AppPage.tsx
@@ -71,10 +71,7 @@ export function AppPage(props: AppPageProps) {
     >
       <PageView className="t--app-viewer-page" width={width}>
         {props.widgetsStructure.widgetId &&
-          renderAppsmithCanvas({
-            ...props.widgetsStructure,
-            classList: isAnvilLayout ? ["main-anvil-canvas"] : [],
-          } as WidgetProps)}
+          renderAppsmithCanvas(props.widgetsStructure as WidgetProps)}
       </PageView>
     </PageViewWrapper>
   );

--- a/app/client/src/pages/Editor/Canvas.tsx
+++ b/app/client/src/pages/Editor/Canvas.tsx
@@ -18,8 +18,6 @@ import { getIsAppSettingsPaneWithNavigationTabOpen } from "selectors/appSettings
 import { CANVAS_ART_BOARD } from "constants/componentClassNameConstants";
 import { renderAppsmithCanvas } from "layoutSystems/CanvasFactory";
 import type { WidgetProps } from "widgets/BaseWidget";
-import { LayoutSystemTypes } from "layoutSystems/types";
-import { getLayoutSystemType } from "selectors/layoutSystemSelectors";
 import { getAppThemeSettings } from "@appsmith/selectors/applicationSelectors";
 
 interface CanvasProps {
@@ -33,6 +31,7 @@ const Wrapper = styled.section<{
   width: number;
   $enableMainCanvasResizer: boolean;
 }>`
+  flex: 1;
   background: ${({ background }) => background};
   width: ${({ $enableMainCanvasResizer, width }) =>
     $enableMainCanvasResizer ? `100%` : `${width}px`};
@@ -45,7 +44,6 @@ const Canvas = (props: CanvasProps) => {
   );
   const selectedTheme = useSelector(getSelectedAppTheme);
   const isWDSEnabled = useFeatureFlag("ab_wds_enabled");
-  const layoutSystemType: LayoutSystemTypes = useSelector(getLayoutSystemType);
 
   const themeSetting = useSelector(getAppThemeSettings);
   const themeProps = {
@@ -82,14 +80,12 @@ const Canvas = (props: CanvasProps) => {
     : `mx-auto`;
   const paddingBottomClass = props.enableMainCanvasResizer ? "" : "pb-52";
 
-  const height = layoutSystemType === LayoutSystemTypes.ANVIL ? "h-full" : "";
-
   const renderChildren = () => {
     return (
       <Wrapper
         $enableMainCanvasResizer={!!props.enableMainCanvasResizer}
         background={isWDSEnabled ? "" : backgroundForCanvas}
-        className={`relative t--canvas-artboard ${height} ${paddingBottomClass} transition-all duration-400  ${marginHorizontalClass} ${getViewportClassName(
+        className={`relative t--canvas-artboard ${paddingBottomClass} transition-all duration-400  ${marginHorizontalClass} ${getViewportClassName(
           canvasWidth,
         )}`}
         data-testid={"t--canvas-artboard"}
@@ -98,13 +94,7 @@ const Canvas = (props: CanvasProps) => {
         width={canvasWidth}
       >
         {props.widgetsStructure.widgetId &&
-          renderAppsmithCanvas({
-            ...props.widgetsStructure,
-            classList:
-              layoutSystemType === LayoutSystemTypes.ANVIL
-                ? ["main-anvil-canvas"]
-                : [],
-          } as WidgetProps)}
+          renderAppsmithCanvas(props.widgetsStructure as WidgetProps)}
       </Wrapper>
     );
   };
@@ -112,7 +102,12 @@ const Canvas = (props: CanvasProps) => {
   try {
     if (isWDSEnabled) {
       return (
-        <WDSThemeProvider theme={theme}>{renderChildren()}</WDSThemeProvider>
+        <WDSThemeProvider
+          style={{ minHeight: "100%", display: "flex" }}
+          theme={theme}
+        >
+          {renderChildren()}
+        </WDSThemeProvider>
       );
     }
 

--- a/app/client/src/pages/Editor/Canvas.tsx
+++ b/app/client/src/pages/Editor/Canvas.tsx
@@ -26,6 +26,11 @@ interface CanvasProps {
   enableMainCanvasResizer?: boolean;
 }
 
+const StyledWDSThemeProvider = styled(WDSThemeProvider)`
+  min-height: 100%;
+  display: flex;
+`;
+
 const Wrapper = styled.section<{
   background: string;
   width: number;
@@ -102,12 +107,9 @@ const Canvas = (props: CanvasProps) => {
   try {
     if (isWDSEnabled) {
       return (
-        <WDSThemeProvider
-          style={{ minHeight: "100%", display: "flex" }}
-          theme={theme}
-        >
+        <StyledWDSThemeProvider theme={theme}>
           {renderChildren()}
-        </WDSThemeProvider>
+        </StyledWDSThemeProvider>
       );
     }
 

--- a/app/client/src/pages/Editor/WidgetsEditor/MainContainerWrapper.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/MainContainerWrapper.tsx
@@ -210,7 +210,7 @@ function MainContainerWrapper(props: MainCanvasWrapperProps) {
         isPreviewingNavigation={isPreviewingNavigation}
         navigationHeight={navigationHeight}
         style={{
-          height: isPreviewMode ? `calc(100% - ${headerHeight})` : "100%",
+          height: isPreviewMode ? `calc(100% - ${headerHeight})` : "auto",
           fontFamily: fontFamily,
           pointerEvents: isAutoCanvasResizing ? "none" : "auto",
         }}

--- a/app/client/src/pages/Editor/WidgetsEditor/MainContainerWrapper.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/MainContainerWrapper.tsx
@@ -138,6 +138,7 @@ function MainContainerWrapper(props: MainCanvasWrapperProps) {
     useMainContainerResizer();
   const layoutSystemType: LayoutSystemTypes = useSelector(getLayoutSystemType);
   const isAnvilLayout = layoutSystemType === LayoutSystemTypes.ANVIL;
+  const headerHeight = "40px";
 
   useEffect(() => {
     return () => {
@@ -209,7 +210,7 @@ function MainContainerWrapper(props: MainCanvasWrapperProps) {
         isPreviewingNavigation={isPreviewingNavigation}
         navigationHeight={navigationHeight}
         style={{
-          height: isPreviewMode ? `calc(100% - 40px)` : "100%",
+          height: isPreviewMode ? `calc(100% - ${headerHeight})` : "100%",
           fontFamily: fontFamily,
           pointerEvents: isAutoCanvasResizing ? "none" : "auto",
         }}

--- a/app/client/src/pages/Editor/WidgetsEditor/index.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/index.tsx
@@ -9,6 +9,8 @@ import {
   getCurrentPageName,
   previewModeSelector,
 } from "selectors/editorSelectors";
+import { LayoutSystemTypes } from "../../../layoutSystems/types";
+import { getLayoutSystemType } from "../../../selectors/layoutSystemSelectors";
 import NavigationPreview from "./NavigationPreview";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import PerformanceTracker, {
@@ -86,6 +88,9 @@ function WidgetsEditor() {
   const [enableOverlayCanvas] = checkLayoutSystemFeatures([
     LayoutSystemFeatures.ENABLE_CANVAS_OVERLAY_FOR_EDITOR_UI,
   ]);
+
+  const layoutSystemType: LayoutSystemTypes = useSelector(getLayoutSystemType);
+  const isAnvilLayout = layoutSystemType === LayoutSystemTypes.ANVIL;
 
   useEffect(() => {
     if (navigationPreviewRef?.current) {
@@ -176,7 +181,7 @@ function WidgetsEditor() {
   PerformanceTracker.stopTracking();
   return (
     <EditorContextProvider renderMode="CANVAS">
-      <div className="relative flex flex-row w-full overflow-hidden">
+      <div className="relative flex flex-row h-full w-full overflow-hidden">
         <div
           className={classNames({
             "relative flex flex-col w-full overflow-hidden": true,
@@ -189,7 +194,7 @@ function WidgetsEditor() {
           )}
           <AnonymousDataPopup />
           <div
-            className="relative flex flex-row w-full overflow-hidden"
+            className="relative flex flex-row h-full w-full overflow-hidden"
             data-testid="widgets-editor"
             draggable
             id="widgets-editor"
@@ -218,9 +223,20 @@ function WidgetsEditor() {
               isPreview={isPreviewMode || isProtectedMode}
               isPublished={isPublished}
               sidebarWidth={isPreviewingNavigation ? sidebarWidth : 0}
+              style={
+                isAnvilLayout
+                  ? {
+                      //This is necessary in order to place WDS modal with position: fixed; relatively to the canvas.
+                      transform: "scale(1)",
+                    }
+                  : {}
+              }
             >
               {shouldShowSnapShotBanner && (
-                <div className="absolute top-0 z-1 w-full">
+                <div
+                  className="absolute top-0 w-full"
+                  style={{ zIndex: "calc(var(--on-canvas-ui-z-index) + 1)" }}
+                >
                   <SnapShotBannerCTA />
                 </div>
               )}

--- a/app/client/src/pages/Editor/WidgetsEditor/index.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/index.tsx
@@ -9,6 +9,7 @@ import {
   getCurrentPageName,
   previewModeSelector,
 } from "selectors/editorSelectors";
+import styled from "styled-components";
 import { LayoutSystemTypes } from "../../../layoutSystems/types";
 import { getLayoutSystemType } from "../../../selectors/layoutSystemSelectors";
 import NavigationPreview from "./NavigationPreview";
@@ -50,6 +51,10 @@ import {
 } from "layoutSystems/common/useLayoutSystemFeatures";
 import OverlayCanvasContainer from "layoutSystems/common/WidgetNamesCanvas";
 import { protectedModeSelector } from "selectors/gitSyncSelectors";
+
+const BannerWrapper = styled.div`
+  z-index: calc(var(--on-canvas-ui-z-index) + 1);
+`;
 
 function WidgetsEditor() {
   const dispatch = useDispatch();
@@ -233,12 +238,9 @@ function WidgetsEditor() {
               }
             >
               {shouldShowSnapShotBanner && (
-                <div
-                  className="absolute top-0 w-full"
-                  style={{ zIndex: "calc(var(--on-canvas-ui-z-index) + 1)" }}
-                >
+                <BannerWrapper className="absolute top-0 w-full">
                   <SnapShotBannerCTA />
-                </div>
+                </BannerWrapper>
               )}
               <MainContainerWrapper
                 canvasWidth={canvasWidth}

--- a/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
@@ -15,7 +15,6 @@ import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { ModalBody } from "@design-system/widgets";
 import { WDS_MODAL_WIDGET_CLASSNAME } from "widgets/wds/constants";
-import { WIDGET_NAME_CANVAS } from "layoutSystems/common/WidgetNamesCanvas/WidgetNameConstants";
 import type { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
 import type {
   CopiedWidgetData,
@@ -120,8 +119,6 @@ class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
 
     return (
       <Modal
-        // don't close modal by clicking on the widget name
-        dismissCloseSelectors={`#${WIDGET_NAME_CANVAS}`}
         isOpen={this.state.isVisible as boolean}
         onClose={this.onModalClose}
         setOpen={(val) => this.setState({ isVisible: val })}

--- a/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
@@ -15,6 +15,7 @@ import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { ModalBody } from "@design-system/widgets";
 import { WDS_MODAL_WIDGET_CLASSNAME } from "widgets/wds/constants";
+import { WIDGET_NAME_CANVAS } from "layoutSystems/common/WidgetNamesCanvas/WidgetNameConstants";
 import type { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
 import type {
   CopiedWidgetData,
@@ -119,6 +120,8 @@ class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
 
     return (
       <Modal
+        // don't close modal by clicking on the widget name
+        dismissCloseSelectors={`#${WIDGET_NAME_CANVAS}`}
         isOpen={this.state.isVisible as boolean}
         onClose={this.onModalClose}
         setOpen={(val) => this.setState({ isVisible: val })}

--- a/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
@@ -24,14 +24,16 @@ import type {
 import { call } from "redux-saga/effects";
 import { pasteWidgetsIntoMainCanvas } from "layoutSystems/anvil/utils/paste/mainCanvasPasteUtils";
 
-const modalBodyStyles: React.CSSProperties = {
-  minHeight: "var(--sizing-16)",
-  maxHeight:
-    "calc(var(--canvas-height) - var(--outer-spacing-4) - var(--outer-spacing-4) - var(--outer-spacing-4) - 100px)",
-};
-
 class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
   static type = "WDS_MODAL_WIDGET";
+
+  constructor(props: ModalWidgetProps) {
+    super(props);
+
+    this.state = {
+      isVisible: this.getModalVisibility(),
+    };
+  }
 
   static getConfig() {
     return config.metaConfig;
@@ -117,16 +119,14 @@ class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
 
     return (
       <Modal
-        isOpen={this.getModalVisibility()}
+        isOpen={this.state.isVisible as boolean}
         onClose={this.onModalClose}
+        setOpen={(val) => this.setState({ isVisible: val })}
         size={this.props.size}
       >
         <ModalContent className={this.props.className}>
           {this.props.showHeader && <ModalHeader title={this.props.title} />}
-          <ModalBody
-            className={WDS_MODAL_WIDGET_CLASSNAME}
-            style={modalBodyStyles}
-          >
+          <ModalBody className={WDS_MODAL_WIDGET_CLASSNAME}>
             <LayoutProvider {...this.props} />
           </ModalBody>
           {this.props.showFooter && (


### PR DESCRIPTION
## Description
Fixes for the modal widget:
1. Added support for clickOutside. The modal is closed only by clicking on the backdrop overlay. A click on the widget name has been added to the exceptions for close event.
2. Fixed the positioning of the modal. Now it is located in the center of the provider. 
3. For the correct positioning of the modal, it was necessary to make fixes for canvas height. The fixes also affect fixed and autolayout.

#### PR fixes following issue(s)
Fixes #30788

Also fixed this https://www.notion.so/appsmith/Canvas-gets-cut-off-on-preview-mode-525b95f26c6e4644bf5ab7389c02e434

#### Media

https://github.com/appsmithorg/appsmith/assets/11555074/6db9ecde-595b-4fa4-a21b-9ed08930d58f


#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [x] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Popover and Modal components now support dismissing by clicking outside. Custom logic and selectors can be specified to control this behavior.
- **Enhancements**
	- Simplified logic for closing Modals by directly setting open state.
	- Enhanced Modal styling options, allowing for better customization of width and height.
	- ErrorBoundary component now supports custom styles.
- **Refactor**
	- Removed redundant code and unused properties across various components and layout systems.
	- Simplified state management and styling adjustments in editor components.
- **Style**
	- Updated Modal component styles for improved layout and responsiveness.
- **Chores**
	- Codebase cleanup including removal of unused classes, variables, and adjustments for more efficient layout rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->