### PR TITLE
chore: Show commit SHA instead of SNAPSHOT version

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -81,12 +81,10 @@ jobs:
           REACT_APP_ENVIRONMENT: "PRODUCTION"
           REACT_APP_FUSIONCHARTS_LICENSE_KEY: "${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }}"
           REACT_APP_SEGMENT_CE_KEY: "${{ secrets.APPSMITH_SEGMENT_CE_KEY }}"
-          REACT_APP_VERSION_ID: "${{ needs.prelude.outputs.tag }}"
           REACT_APP_INTERCOM_APP_ID: "${{ secrets.APPSMITH_INTERCOM_ID }}"
           REACT_APP_VERSION_EDITION: "Community"
         run: |
-          REACT_APP_VERSION_RELEASE_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-            yarn build
+          yarn build
           ls -l build
 
       - name: Pack the client build directory

--- a/app/client/jest.config.js
+++ b/app/client/jest.config.js
@@ -107,6 +107,7 @@ module.exports = {
       cloudHosting: "CLOUD_HOSTING",
       appVersion: {
         id: parseConfig("__APPSMITH_VERSION_ID__"),
+        sha: parseConfig("__APPSMITH_VERSION_SHA__"),
         releaseDate: parseConfig("__APPSMITH_VERSION_RELEASE_DATE__"),
       },
       intercomAppID: "APP_ID",

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -296,6 +296,7 @@
         cloudHosting: CLOUD_HOSTING,
         appVersion: {
           id: parseConfig("__APPSMITH_VERSION_ID__"),
+          sha: parseConfig("__APPSMITH_VERSION_SHA__"),
           releaseDate: parseConfig("__APPSMITH_VERSION_RELEASE_DATE__"),
         },
         intercomAppID: INTERCOM_APP_ID,

--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -39,6 +39,7 @@ export interface INJECTED_CONFIGS {
   logLevel: "debug" | "error";
   appVersion: {
     id: string;
+    sha: string;
     releaseDate: string;
     edition: string;
   };
@@ -106,8 +107,9 @@ export const getConfigsFromEnvVars = (): INJECTED_CONFIGS => {
       ? process.env.REACT_APP_CLOUD_HOSTING.length > 0
       : false,
     appVersion: {
-      id: process.env.REACT_APP_VERSION_ID || "",
-      releaseDate: process.env.REACT_APP_VERSION_RELEASE_DATE || "",
+      id: "",
+      sha: "",
+      releaseDate: "",
       edition: process.env.REACT_APP_VERSION_EDITION || "",
     },
     intercomAppID: process.env.REACT_APP_INTERCOM_APP_ID || "",
@@ -291,14 +293,9 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
     logLevel:
       ENV_CONFIG.logLevel || APPSMITH_FEATURE_CONFIGS?.logLevel || false,
     appVersion: {
-      id:
-        APPSMITH_FEATURE_CONFIGS?.appVersion?.id ||
-        ENV_CONFIG.appVersion?.id ||
-        "",
-      releaseDate:
-        APPSMITH_FEATURE_CONFIGS?.appVersion?.releaseDate ||
-        ENV_CONFIG.appVersion?.releaseDate ||
-        "",
+      id: APPSMITH_FEATURE_CONFIGS?.appVersion?.id || "",
+      sha: APPSMITH_FEATURE_CONFIGS?.appVersion?.sha || "",
+      releaseDate: APPSMITH_FEATURE_CONFIGS?.appVersion?.releaseDate || "",
       edition:
         ENV_CONFIG.appVersion?.edition ||
         APPSMITH_FEATURE_CONFIGS?.appVersion?.edition ||

--- a/app/client/src/ce/configs/types.ts
+++ b/app/client/src/ce/configs/types.ts
@@ -2,6 +2,7 @@ import type { LogLevelDesc } from "loglevel";
 
 export interface AppVersionData {
   id: string;
+  sha: string;
   releaseDate: string;
   edition: string;
 }

--- a/app/client/src/pages/common/SearchBar/HomepageHeaderAction.tsx
+++ b/app/client/src/pages/common/SearchBar/HomepageHeaderAction.tsx
@@ -165,7 +165,7 @@ const HomepageHeaderAction = ({
                       APPSMITH_DISPLAY_VERSION,
                       appVersion.edition,
                       appVersion.id.endsWith("-SNAPSHOT")
-                        ? appVersion.sha
+                        ? appVersion.sha.substring(0, 8)
                         : appVersion.id,
                     )}
                   </div>

--- a/app/client/src/pages/common/SearchBar/HomepageHeaderAction.tsx
+++ b/app/client/src/pages/common/SearchBar/HomepageHeaderAction.tsx
@@ -164,7 +164,9 @@ const HomepageHeaderAction = ({
                     {createMessage(
                       APPSMITH_DISPLAY_VERSION,
                       appVersion.edition,
-                      appVersion.id,
+                      appVersion.id.endsWith("-SNAPSHOT")
+                        ? appVersion.sha
+                        : appVersion.id,
                     )}
                   </div>
                   {howMuchTimeBefore !== "" && (

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -165,6 +165,7 @@ function finalizeIndexHtml() {
   const info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
   const extraEnv = {
     APPSMITH_VERSION_ID: info.version ?? "",
+    APPSMITH_VERSION_SHA: info.commitSha ?? "",
     APPSMITH_VERSION_RELEASE_DATE: info.imageBuiltAt ?? "",
   }
 


### PR DESCRIPTION
Show the commit SHA in the version popup, instead of a snapshot version number like `v1.11-SNAPSHOT`. But if the version number doesn't have a `-SNAPSHOT` at the end, we show the version number as is. So if it's `v1.12`, we show that instead of the commit SHA.

![shot-2024-02-02-02-09-14](https://github.com/appsmithorg/appsmith/assets/120119/c0fe70f7-5c49-4191-8cb8-262e6c7710bc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced version SHA display in the app, enhancing version tracking and troubleshooting capabilities.
- **Bug Fixes**
	- Fixed an issue with version release date not being set correctly during the build process.
- **Refactor**
	- Streamlined version information handling across the app for better clarity and maintenance.
- **Chores**
	- Updated deployment scripts to include version SHA as an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->