### PR TITLE
ci: Print failed tests to Action Summary

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -184,7 +184,8 @@ jobs:
           if ! mvn test "${args[@]}"; then
             if [[ -s failed-server-tests.txt ]]; then
               {
-                echo "Failed tests:"
+                echo "## Failed tests"
+                echo
                 sed 's/^/- /' 'failed-server-tests.txt'
               } >> "$GITHUB_STEP_SUMMARY"
             fi

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -181,7 +181,15 @@ jobs:
             args+=("-DfailIfNoTests=false" "-Dtest=${failed_tests}")
           fi
           args+=("-DtestResultFile=$PWD/failed-server-tests.txt")
-          mvn test "${args[@]}"
+          if ! mvn test "${args[@]}"; then
+            if [[ -s failed-server-tests.txt ]]; then
+              {
+                echo "Failed tests:"
+                sed 's/^/- /' 'failed-server-tests.txt'
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+            exit 1
+          fi
 
       # Set status = failedtest
       - name: Set fail if there are test failures


### PR DESCRIPTION
This should show the failed test list in the GitHub actions summary so we don't have to load the _extremely large_ full log file of the server tests, just to see the list of tests that failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved CI workflow by appending a summary of failed tests for GitHub actions, enhancing error visibility for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->