### PR TITLE
fix: Can't switch back to System Default

### DIFF
--- a/app/client/src/pages/Editor/WDSThemePropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/WDSThemePropertyPane/index.tsx
@@ -128,7 +128,10 @@ function WDSThemePropertyPane() {
             }}
             value={theme.fontFamily}
           >
-            {Object.keys(FONT_METRICS)
+            {Object.keys({
+              "System Default": "System Default",
+              ...FONT_METRICS,
+            })
               .filter((item) => {
                 return (
                   ["-apple-system", "BlinkMacSystemFont", "Segoe UI"].includes(


### PR DESCRIPTION
Fixes #30715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added "System Default" as a font option in the theme property pane for more customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->