### PR TITLE
fix: Segment default selection failing on git

### DIFF
--- a/app/client/src/selectors/jsPaneSelectors.ts
+++ b/app/client/src/selectors/jsPaneSelectors.ts
@@ -16,8 +16,8 @@ export const getFirstJSObject = (
   const currentJSActions = getJSSegmentItems(state);
   const pageId = getCurrentPageId(state);
   if (currentJSActions.length) {
-    return identifyEntityFromPath(
-      getJSEntityItemUrl(currentJSActions[0], pageId),
-    );
+    const url = getJSEntityItemUrl(currentJSActions[0], pageId);
+    const urlWithoutQueryParams = url.split("?")[0];
+    return identifyEntityFromPath(urlWithoutQueryParams);
   }
 };

--- a/app/client/src/selectors/queryPaneSelectors.ts
+++ b/app/client/src/selectors/queryPaneSelectors.ts
@@ -12,7 +12,9 @@ export const getFirstQuery = (state: AppState): FocusEntityInfo | undefined => {
   const queryItems = getQuerySegmentItems(state);
   const pageId = getCurrentPageId(state);
   if (queryItems.length) {
-    return identifyEntityFromPath(getQueryEntityItemUrl(queryItems[0], pageId));
+    const url = getQueryEntityItemUrl(queryItems[0], pageId);
+    const urlWithoutQueryParams = url.split("?")[0];
+    return identifyEntityFromPath(urlWithoutQueryParams);
   }
 };
 


### PR DESCRIPTION
fixes the case where 2 branch query params are getting added in the default selection when navigating to a segment for the first time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved entity identification in URLs by refining the logic to exclude query parameters, enhancing the accuracy of entity detection based on URL structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->