### PR TITLE
test: Cypress | Skip bug test from MultiSelect5_spec.ts

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect5_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect5_spec.ts
@@ -308,7 +308,8 @@ describe(
       );
     });
 
-    it("8. Verify validation error in default selected values", () => {
+    //Skipping due to open bug #16870
+    it.skip("8. Bug # 16870 - Verify validation error in default selected values", () => {
       EditorNavigation.SelectEntityByName("NewMultiSelect", EntityType.Widget);
 
       propPane.MoveToTab("Content");
@@ -316,7 +317,6 @@ describe(
       propPane.UpdatePropertyFieldValue(
         "Default selected values",
         '["GREEN1", "RED1"]',
-        true,
       );
 
       agHelper.VerifyEvaluatedErrorMessage(
@@ -329,21 +329,17 @@ describe(
       propPane.UpdatePropertyFieldValue(
         "Source Data",
         '[{"name": "Green", "code":"GREEN1"}, { "name": "Red","code": "RED1" }]',
-        true,
       );
 
       agHelper.FocusElement(
         locators._propertyInputField("Default selected values"),
       );
-
-      agHelper.Sleep(1000);
       agHelper.AssertElementAbsence(locators._evaluatedErrorMessage);
 
       // Changes options to bring back validation error
       propPane.UpdatePropertyFieldValue(
         "Source Data",
         '[{"name": "Green", "code":"GREEN1"}, { "name": "Red","code": "RED" }]',
-        true,
       );
 
       agHelper.FocusElement(
@@ -373,8 +369,6 @@ describe(
         '{{["GREEN1"]}}',
         true,
       );
-
-      agHelper.Sleep(1000);
       agHelper.AssertElementAbsence(locators._evaluatedErrorMessage);
     });
   },

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,6 +1,8 @@
 # To run only limited tests - give the spec names in below format:
 #cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
+cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect5_spec.ts
+
 
 
 # For running all specs - uncomment below:

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+#cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
 
 
 # For running all specs - uncomment below:

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,8 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-#cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
-cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
-cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect5_spec.ts
-
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 
 # For running all specs - uncomment below:


### PR DESCRIPTION
## Description
- This PR does below:
- Flaky fixes /ServerSide/GenerateCRUD/MongoURI_Spec.ts (no fix needed, multiple runs passing, removed from skipped list)
- cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect5_spec.ts (skipped bug test & unskipping spec from CI runs)

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Testing

#### How Has This Been Tested?
- [X] Cypress CI runs


## Checklist:
#### QA activity:
- [X] Added `Test Plan Approved` label after Cypress tests were reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
	- Updated the test specification for limited tests in the ServerSide GenerateCRUD section to improve coverage and reliability.
	- Switched test spec from `Fork_Template_spec.js` to `MongoURI_Spec.ts` and `MultiSelect5_spec.ts` in the ClientSide Widgets Multiselect section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->