### PR TITLE
chore: Remove CA bundle env variable for certbot

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -327,9 +327,6 @@ setup-custom-ca-certificates() (
     echo "-Djavax.net.ssl.trustStore=$store"
     echo "-Djavax.net.ssl.trustStorePassword=changeit"
   } > "$opts_file"
-
-  # Get certbot to use the combined trusted CA certs file.
-  export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 )
 
 configure_supervisord() {


### PR DESCRIPTION
We don't use certbot anymore, so this isn't needed anymore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the configuration of `REQUESTS_CA_BUNDLE` environment variable to enhance certificate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->