### PR TITLE
chore: Move action redesign into its on flag

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -53,6 +53,7 @@ export const FEATURE_FLAG = {
   rollout_consolidated_page_load_fetch_enabled:
     "rollout_consolidated_page_load_fetch_enabled",
   ab_start_with_data_default_enabled: "ab_start_with_data_default_enabled",
+  release_actions_redesign_enabled: "release_actions_redesign_enabled",
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG;
@@ -96,6 +97,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   ab_flip_primary_secondary_ctas_dsform_enabled: false,
   rollout_consolidated_page_load_fetch_enabled: false,
   ab_start_with_data_default_enabled: false,
+  release_actions_redesign_enabled: false,
 };
 
 export const AB_TESTING_EVENT_KEYS = {

--- a/app/client/src/components/formControls/DynamicTextFieldControl.tsx
+++ b/app/client/src/components/formControls/DynamicTextFieldControl.tsx
@@ -52,7 +52,7 @@ class DynamicTextControl extends BaseControl<
       actionName,
       configProperty,
       evaluationSubstitutionType,
-      isSideBySideEnabled,
+      isActionRedesignEnabled,
       placeholderText,
       pluginName,
       responseType,
@@ -66,7 +66,7 @@ class DynamicTextControl extends BaseControl<
     return (
       <Wrapper
         className={`t--${configProperty}`}
-        fullWidth={isSideBySideEnabled}
+        fullWidth={isActionRedesignEnabled}
       >
         <DynamicTextField
           dataTreePath={dataTreePath}
@@ -77,7 +77,9 @@ class DynamicTextControl extends BaseControl<
           mode={mode}
           name={this.props.configProperty}
           placeholder={placeholderText}
-          showLineNumbers={isSideBySideEnabled || this.props.showLineNumbers}
+          showLineNumbers={
+            isActionRedesignEnabled || this.props.showLineNumbers
+          }
           size={EditorSize.EXTENDED}
           tabBehaviour={TabBehaviour.INDENT}
         />
@@ -94,7 +96,7 @@ export interface DynamicTextFieldProps extends ControlProps {
   evaluationSubstitutionType: EvaluationSubstitutionType;
   mutedHinting?: boolean;
   pluginName: string;
-  isSideBySideEnabled: boolean;
+  isActionRedesignEnabled: boolean;
 }
 
 const mapStateToProps = (state: AppState, props: DynamicTextFieldProps) => {
@@ -105,14 +107,14 @@ const mapStateToProps = (state: AppState, props: DynamicTextFieldProps) => {
   const pluginId = valueSelector(state, "datasource.pluginId");
   const responseTypes = getPluginResponseTypes(state);
   const pluginName = getPluginNameFromId(state, pluginId);
-  const { release_side_by_side_ide_enabled } = selectFeatureFlags(state);
+  const { release_actions_redesign_enabled } = selectFeatureFlags(state);
 
   return {
     actionName,
     pluginId,
     responseType: responseTypes[pluginId],
     pluginName,
-    isSideBySideEnabled: release_side_by_side_ide_enabled,
+    isActionRedesignEnabled: release_actions_redesign_enabled,
   };
 };
 

--- a/app/client/src/pages/Editor/IDE/EditorPane/components/ActionToolbar.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/components/ActionToolbar.tsx
@@ -20,10 +20,10 @@ interface Props {
 }
 
 const ActionToolbar = (props: Props) => {
-  const isSideBySideEnabled = useFeatureFlag(
-    FEATURE_FLAG.release_side_by_side_ide_enabled,
+  const isActionRedesignEnabled = useFeatureFlag(
+    FEATURE_FLAG.release_actions_redesign_enabled,
   );
-  if (!isSideBySideEnabled) return null;
+  if (!isActionRedesignEnabled) return null;
   return (
     <Flex
       alignItems="center"

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -253,8 +253,8 @@ export function EditorJSONtoForm(props: Props) {
     useShowSchema(currentActionConfig?.pluginId || "") &&
     pluginRequireDatasource;
 
-  const isSideBySideEnabled = useFeatureFlag(
-    FEATURE_FLAG.release_side_by_side_ide_enabled,
+  const isActionRedesignEnabled = useFeatureFlag(
+    FEATURE_FLAG.release_actions_redesign_enabled,
   );
 
   const showRightPane =
@@ -331,7 +331,7 @@ export function EditorJSONtoForm(props: Props) {
     return null;
   }
 
-  if (isSideBySideEnabled && plugin) {
+  if (isActionRedesignEnabled && plugin) {
     const responseTabs = [];
     if (currentActionConfig) {
       responseTabs.push({


### PR DESCRIPTION
## Description

Create a new Feature flag called `release_action_redesign_enabled` and use that for Query Redesign paths instead of Side by Side Feature flag as now it is out of its scope

Post this, query redesign changes will not show up for any side by side feature activation scenarios

resolves #30911



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature flag `release_actions_redesign_enabled` to toggle the redesigned actions feature.
- **Refactor**
	- Updated components and logic to utilize the new `release_actions_redesign_enabled` flag, ensuring a consistent toggle mechanism across the application. This includes changes in the dynamic text field behavior and action toolbar rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->