### PR TITLE
chore: remove BaseDomain on WorkspacePlugin

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/WorkspacePlugin.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/WorkspacePlugin.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.domains;
 
-import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.dtos.WorkspacePluginStatus;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -15,7 +14,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class WorkspacePlugin extends BaseDomain {
+public class WorkspacePlugin {
 
     String pluginId;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
@@ -134,7 +134,6 @@ public class PluginServiceCEImpl extends BaseService<PluginRepository, Plugin, S
                     }
 
                     List<String> pluginIds = org.getPlugins().stream()
-                            .filter(plugin -> !plugin.isDeleted())
                             .map(WorkspacePlugin::getPluginId)
                             .collect(Collectors.toList());
                     Query query = new Query();


### PR DESCRIPTION
The `WorkspacePlugin` is not a top-level entity. Yet, it extends `BaseDomain`. It gets all the fields from `BaseDomain`, but since it doesn't have a collection of its own, nothing is ever used.

This is fine today, with the `@Document` annotation, but with Postgres, with `@Entity` annotation, querydsl is getting confused and is creating a `QWorkspacePlugin` class, which is producing a compile error in `QWorkspace.plugins` field.

This PR removes this unneeded inheritance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the structure of the Workspace Plugin to enhance performance.
- **Bug Fixes**
	- Ensured all plugins, including previously inaccessible ones, are now correctly retrievable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->