### PR TITLE
chore: discord CTA changed to intercom

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
@@ -3,10 +3,9 @@ import styled from "styled-components";
 import NoSearchDataImage from "assets/images/no_search_data.png";
 import { NO_SEARCH_DATA_TEXT } from "@appsmith/constants/messages";
 import { getTypographyByKey } from "design-system-old";
-import AnalyticsUtil from "utils/AnalyticsUtil";
 import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 import { importSvg } from "design-system-old";
-import { DISCORD_URL } from "constants/ThirdPartyConstants";
+import { Button } from "design-system";
 
 const DiscordIcon = importSvg(
   async () => import("assets/icons/help/discord.svg"),
@@ -26,19 +25,6 @@ const Container = styled.div`
   .no-data-title {
     margin-top: ${(props) => props.theme.spaces[3]}px;
   }
-
-  .discord {
-    margin: ${(props) => props.theme.spaces[3]}px 0;
-    display: flex;
-    gap: 0.25rem;
-  }
-
-  .discord-link {
-    cursor: pointer;
-    display: flex;
-    color: ${(props) => props.theme.colors.globalSearch.searchItemText};
-    font-weight: 700;
-  }
 `;
 
 const StyledDiscordIcon = styled(DiscordIcon)`
@@ -55,20 +41,12 @@ function ResultsNotFound() {
       <img alt="No data" src={NoSearchDataImage} />
       <div className="no-data-title">{NO_SEARCH_DATA_TEXT()}</div>
       {!isAirgappedInstance && (
-        <span className="discord">
-          🤖 Join our{"  "}
-          <span
-            className="discord-link"
-            onClick={() => {
-              window.open(DISCORD_URL, "_blank");
-              AnalyticsUtil.logEvent("DISCORD_LINK_CLICK");
-            }}
-          >
-            <StyledDiscordIcon color="red" height={22} width={24} />
-            Discord Server
-          </span>{" "}
-          for more help.
-        </span>
+        <Button
+            kind="secondary"
+            onClick={() => window.Intercom && window.Intercom('show')}
+            startIcon="chat-help">
+              Chat with us on Intercom
+        </Button>
       )}
     </Container>
   );

--- a/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
@@ -7,9 +7,6 @@ import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 import { importSvg } from "design-system-old";
 import { Button } from "design-system";
 
-const DiscordIcon = importSvg(
-  async () => import("assets/icons/help/discord.svg"),
-);
 
 const Container = styled.div`
   display: flex;
@@ -27,12 +24,6 @@ const Container = styled.div`
   }
 `;
 
-const StyledDiscordIcon = styled(DiscordIcon)`
-  path {
-    fill: #5c6bc0;
-  }
-  vertical-align: -7px;
-`;
 
 function ResultsNotFound() {
   const isAirgappedInstance = isAirgapped();

--- a/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import styled from "styled-components";
 import NoSearchDataImage from "assets/images/no_search_data.png";
 import { NO_SEARCH_DATA_TEXT } from "@appsmith/constants/messages";
+import { getAppsmithConfigs } from "@appsmith/configs";
 import { getTypographyByKey } from "design-system-old";
 import { isAirgapped } from "@appsmith/utils/airgapHelpers";
-import { importSvg } from "design-system-old";
 import { Button } from "design-system";
 
-
+const { intercomAppID } = getAppsmithConfigs();
 const Container = styled.div`
   display: flex;
   width: 100%;
@@ -31,7 +31,7 @@ function ResultsNotFound() {
     <Container>
       <img alt="No data" src={NoSearchDataImage} />
       <div className="no-data-title">{NO_SEARCH_DATA_TEXT()}</div>
-      {!isAirgappedInstance && (
+      {(!isAirgappedInstance && intercomAppID) && (
         <Button
             kind="secondary"
             onClick={() => window.Intercom && window.Intercom('show')}

--- a/app/client/src/pages/common/ErrorPages/ClientError.tsx
+++ b/app/client/src/pages/common/ErrorPages/ClientError.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useDispatch } from "react-redux";
 import { Button } from "design-system";
-import { flushErrors } from "actions/errorActions";
 
 import Page from "./Page";
 import {
@@ -21,13 +20,10 @@ function ClientError() {
           className="button-position"
           endIcon="right-arrow"
           kind="primary"
-          onClick={() => {
-            dispatch(flushErrors());
-            window.open(DISCORD_URL, "_blank");
-          }}
+          onClick={() => window.Intercom && window.Intercom('show')}
           size="md"
         >
-          Contact us on discord
+          Chat with us on Intercom
         </Button>
       }
       description={createMessage(PAGE_CLIENT_ERROR_DESCRIPTION)}

--- a/app/client/src/pages/common/ErrorPages/ClientError.tsx
+++ b/app/client/src/pages/common/ErrorPages/ClientError.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { useDispatch } from "react-redux";
 import { Button } from "design-system";
-
+import { getAppsmithConfigs } from "@appsmith/configs";
 import Page from "./Page";
 import {
   createMessage,
   PAGE_CLIENT_ERROR_DESCRIPTION,
   PAGE_CLIENT_ERROR_TITLE,
 } from "@appsmith/constants/messages";
-import { DISCORD_URL } from "constants/ThirdPartyConstants";
+
+const { intercomAppID } = getAppsmithConfigs();
 
 function ClientError() {
   const dispatch = useDispatch();
@@ -16,15 +17,17 @@ function ClientError() {
   return (
     <Page
       cta={
-        <Button
-          className="button-position"
-          endIcon="right-arrow"
-          kind="primary"
-          onClick={() => window.Intercom && window.Intercom('show')}
-          size="md"
-        >
-          Chat with us on Intercom
-        </Button>
+        intercomAppID && (
+          <Button
+            className="button-position"
+            endIcon="right-arrow"
+            kind="primary"
+            onClick={() => window.Intercom && window.Intercom('show')}
+            size="md"
+          >
+            Chat with us on Intercom
+          </Button>
+        )
       }
       description={createMessage(PAGE_CLIENT_ERROR_DESCRIPTION)}
       title={createMessage(PAGE_CLIENT_ERROR_TITLE)}

--- a/app/client/src/pages/common/ErrorPages/GenericError.tsx
+++ b/app/client/src/pages/common/ErrorPages/GenericError.tsx
@@ -7,9 +7,7 @@ import {
   PAGE_CLIENT_ERROR_DESCRIPTION,
   PAGE_CLIENT_ERROR_TITLE,
 } from "@appsmith/constants/messages";
-import { flushErrors } from "actions/errorActions";
 import { useDispatch } from "react-redux";
-import { DISCORD_URL } from "constants/ThirdPartyConstants";
 
 function GenericError(props: { errorCode?: string }) {
   const dispatch = useDispatch();
@@ -20,13 +18,10 @@ function GenericError(props: { errorCode?: string }) {
           className="button-position"
           endIcon="right-arrow"
           kind="primary"
-          onClick={() => {
-            dispatch(flushErrors());
-            window.open(DISCORD_URL, "_blank");
-          }}
+          onClick={() => window.Intercom && window.Intercom('show')}
           size="md"
         >
-          Contact us on discord
+          Chat with us on Intercom
         </Button>
       }
       description={createMessage(PAGE_CLIENT_ERROR_DESCRIPTION)}

--- a/app/client/src/pages/common/ErrorPages/GenericError.tsx
+++ b/app/client/src/pages/common/ErrorPages/GenericError.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "design-system";
-
+import { getAppsmithConfigs } from "@appsmith/configs";
 import Page from "./Page";
 import {
   createMessage,
@@ -9,11 +9,14 @@ import {
 } from "@appsmith/constants/messages";
 import { useDispatch } from "react-redux";
 
+const { intercomAppID } = getAppsmithConfigs();
+
 function GenericError(props: { errorCode?: string }) {
   const dispatch = useDispatch();
   return (
     <Page
       cta={
+        intercomAppID && (
         <Button
           className="button-position"
           endIcon="right-arrow"
@@ -23,7 +26,7 @@ function GenericError(props: { errorCode?: string }) {
         >
           Chat with us on Intercom
         </Button>
-      }
+      )}
       description={createMessage(PAGE_CLIENT_ERROR_DESCRIPTION)}
       errorCode={props.errorCode}
       title={createMessage(PAGE_CLIENT_ERROR_TITLE)}


### PR DESCRIPTION
## Description
discord CTA changed to intercom in omnibar empty results and generic error pages

#### PR fixes following issue(s)
Fixes #30016

#### Media

#### Type of change
- New feature (non-breaking change which adds functionality)

## Testing
- [ ] Manual
>
>
#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Replaced Discord contact links with buttons to trigger an Intercom chat window across various error and not-found pages for enhanced user support.
- **Bug Fixes**
	- Updated the interaction logic for user support, shifting from external Discord links to integrated Intercom chat functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->