### PR TITLE
fix: implicit voids in return types

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCE.java
@@ -64,7 +64,7 @@ public interface PermissionGroupServiceCE extends CrudService<PermissionGroup, S
 
     Mono<PermissionGroup> bulkUnAssignFromUserAndSendEvent(PermissionGroup permissionGroup, List<User> users);
 
-    Mono<Boolean> leaveExplicitlyAssignedSelfRole(String permissionGroupId);
+    Mono<Void> leaveExplicitlyAssignedSelfRole(String permissionGroupId);
 
     Mono<Set<String>> getSessionUserPermissionGroupIds();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCEImpl.java
@@ -117,7 +117,7 @@ public class UserWorkspaceServiceCEImpl implements UserWorkspaceServiceCE {
         Mono<UpdateResult> updateUserDataMono =
                 userMono.flatMap(user -> userDataService.removeRecentWorkspaceAndApps(user.getId(), workspaceId));
 
-        Mono<Boolean> removeUserFromOldPermissionGroupMono = oldDefaultPermissionGroupsMono.flatMap(
+        Mono<Void> removeUserFromOldPermissionGroupMono = oldDefaultPermissionGroupsMono.flatMap(
                 permissionGroup -> permissionGroupService.leaveExplicitlyAssignedSelfRole(permissionGroup.getId()));
 
         return removeUserFromOldPermissionGroupMono.then(updateUserDataMono).then(userMono);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PermissionGroupServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PermissionGroupServiceTest.java
@@ -66,7 +66,7 @@ public class PermissionGroupServiceTest {
                 .findFirst()
                 .get();
 
-        Mono<Boolean> leaveRoleMono = permissionGroupService
+        Mono<Void> leaveRoleMono = permissionGroupService
                 .leaveExplicitlyAssignedSelfRole(adminPermissionGroup.getId())
                 .cache();
 
@@ -107,7 +107,7 @@ public class PermissionGroupServiceTest {
         PermissionGroup createdPermissionGroup =
                 permissionGroupService.create(testPermissionGroup).block();
 
-        Mono<Boolean> leaveRoleMono = permissionGroupService
+        Mono<Void> leaveRoleMono = permissionGroupService
                 .leaveExplicitlyAssignedSelfRole(createdPermissionGroup.getId())
                 .cache();
 


### PR DESCRIPTION
The return type of these methods isn't `Mono<Void>`, but it might as well be, for all practical purposes. They claim to return `Mono<Boolean>`, but the returned publisher _never_ actually produces a value.

We even get a warning of the exact thing from IntelliJ.

![shot-2024-02-08-01-05-17](https://github.com/appsmithorg/appsmith/assets/120119/3a07e654-757c-4e47-87f1-7f53991a0702)
