### PR TITLE
chore: Fluent API for strict permission query

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -30,6 +30,12 @@ public class QueryAllParams<T extends BaseDomain> {
     private int limit = NO_RECORD_LIMIT;
     private int skip = NO_SKIP;
 
+    /**
+     * When this flag is true, permission checks will include the affects of anonymous user permissions. This is the
+     * default and very-usually, what we want. When it's false, we are only checking for the permissions of the user.
+     */
+    private boolean includeAnonymousUserPermissions = true;
+
     public QueryAllParams(BaseAppsmithRepositoryCEImpl<T> repo) {
         this.repo = repo;
     }
@@ -104,6 +110,11 @@ public class QueryAllParams<T extends BaseDomain> {
 
     public QueryAllParams<T> skip(int skip) {
         this.skip = skip;
+        return this;
+    }
+
+    public QueryAllParams<T> includeAnonymousUserPermissions(boolean value) {
+        includeAnonymousUserPermissions = value;
         return this;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -29,7 +29,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -252,8 +251,13 @@ public abstract class BaseService<
                 .toList();
         Criteria criteria = new Criteria().orOperator(criteriaList);
 
-        Flux<T> result = repository.queryAllWithStrictPermissionGroups(
-                List.of(criteria), Optional.empty(), Optional.ofNullable(permission), sort, -1, 0);
+        Flux<T> result = repository
+                .queryBuilder()
+                .criteria(criteria)
+                .permission(permission)
+                .sort(sort)
+                .includeAnonymousUserPermissions(false)
+                .all();
         if (pageable != null) {
             return result.skip(pageable.getOffset()).take(pageable.getPageSize());
         }


### PR DESCRIPTION
Extending the fluent repository API to `queryAllWithStrictPermissionGroups`.
