### PR TITLE
test: Fix user used for test

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
@@ -501,7 +501,7 @@ public class ApplicationForkingServiceTests {
     }
 
     @Test
-    @WithUserDetails(value = "admin@solutiontest.com")
+    @WithUserDetails(value = "api_user")
     public void forkingEnabledPublicApp_noPermission_ForkApplicationSuccess() {
         Workspace targetWorkspace = new Workspace();
         targetWorkspace.setName("Target Workspace");


### PR DESCRIPTION
The test has a `@WithUserDetails(value = "admin@solutiontest.com")` annotation, which means that's the logged-in user for the test's scope. But the setup method calls `inviteUserToWorkspaceWithViewAccess`, which tries to invite `usertest@usertest.com` and `admin@solutiontest.com` to a just-created workspace. But since the workspace was just created by `admin@solutiontest.com`, that user is already an admin on the workpace. So we get this error:

```
com.appsmith.server.exceptions.AppsmithException: The user admin@solutiontest.com has already been added to the workspace with role Administrator - Source Workspace. To change the role, please navigate to `Manage users` page.
```

The test method's doesn't even get called. This error is from the `setup` phase.

This PR fixes it by using `api_user` for the session instead of `admin@solutiontest.com`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated user details in `ApplicationForkingServiceTests` to enhance testing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->