### PR TITLE
chore: Remove common `GET /` route

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCE.java
@@ -8,6 +8,7 @@ import com.appsmith.server.dtos.GitAuthDTO;
 import com.appsmith.server.services.CrudService;
 import com.mongodb.client.result.UpdateResult;
 import org.springframework.http.codec.multipart.Part;
+import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -16,6 +17,8 @@ import java.util.Map;
 import java.util.Optional;
 
 public interface ApplicationServiceCE extends CrudService<Application, String> {
+
+    Flux<Application> get(MultiValueMap<String, String> params);
 
     Mono<Application> findByIdAndBranchName(String id, List<String> projectionFieldNames, String branchName);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
@@ -134,6 +134,10 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         this.workspacePermission = workspacePermission;
     }
 
+    /**
+     * @deprecated Not used anymore. It's currently only used in tests.
+     */
+    @Deprecated(forRemoval = true)
     @Override
     public Flux<Application> get(MultiValueMap<String, String> params) {
         if (!StringUtils.isEmpty(params.getFirst(FieldName.DEFAULT_RESOURCES + "." + FieldName.BRANCH_NAME))) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
@@ -39,7 +39,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.Part;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -365,17 +364,6 @@ public class ApplicationControllerCE extends BaseController<ApplicationService, 
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
         return service.deleteAppNavigationLogo(branchName, defaultApplicationId)
                 .map(ignored -> new ResponseDTO<>(HttpStatus.OK.value(), null, null));
-    }
-
-    // !! This API endpoint should not be exposed !!
-    @Override
-    @JsonView(Views.Public.class)
-    @GetMapping("")
-    public Mono<ResponseDTO<List<Application>>> getAll(
-            @RequestParam MultiValueMap<String, String> params,
-            @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
-        return Mono.just(new ResponseDTO<>(
-                HttpStatus.BAD_REQUEST.value(), null, AppsmithError.UNSUPPORTED_OPERATION.getMessage()));
     }
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/BaseController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/BaseController.java
@@ -10,9 +10,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,12 +17,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -44,30 +38,6 @@ public abstract class BaseController<S extends CrudService<T, ID>, T extends Bas
                 "Going to create resource from base controller {}",
                 resource.getClass().getName());
         return service.create(resource).map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
-    }
-
-    /**
-     * TODO : Remove this function completely if this is not being used.
-     * If not, atleast remove it for :
-     * 1. Page
-     * 2. Datasources
-     *
-     * @param params
-     * @return
-     */
-    @JsonView(Views.Public.class)
-    @GetMapping("")
-    public Mono<ResponseDTO<List<T>>> getAll(
-            @RequestParam MultiValueMap<String, String> params,
-            @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
-        log.debug("Going to get all resources from base controller {}", params);
-        MultiValueMap<String, String> modifiableParams = new LinkedMultiValueMap<>(params);
-        if (!StringUtils.isEmpty(branchName)) {
-            modifiableParams.add(FieldName.DEFAULT_RESOURCES + "." + FieldName.BRANCH_NAME, branchName);
-        }
-        return service.get(modifiableParams)
-                .collectList()
-                .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
     }
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ThemeControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ThemeControllerCE.java
@@ -39,6 +39,14 @@ public class ThemeControllerCE extends BaseController<ThemeService, Theme, Strin
     }
 
     @JsonView(Views.Public.class)
+    @GetMapping
+    public Mono<ResponseDTO<List<Theme>>> getAll() {
+        return service.getSystemThemes()
+                .collectList()
+                .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
+    }
+
+    @JsonView(Views.Public.class)
     @GetMapping("applications/{applicationId}")
     public Mono<ResponseDTO<List<Theme>>> getApplicationThemes(
             @PathVariable String applicationId,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/WorkspaceControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/WorkspaceControllerCE.java
@@ -36,6 +36,14 @@ public class WorkspaceControllerCE extends BaseController<WorkspaceService, Work
         this.userWorkspaceService = userWorkspaceService;
     }
 
+    @JsonView(Views.Public.class)
+    @GetMapping
+    public Mono<ResponseDTO<List<Workspace>>> getAll() {
+        return service.getForCurrentUser()
+                .collectList()
+                .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
+    }
+
     /**
      * This function would be used to fetch default permission groups of workspace, for which user has access to invite users.
      *

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCE.java
@@ -6,6 +6,7 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.InstallPluginRedisDTO;
 import com.appsmith.server.dtos.PluginWorkspaceDTO;
 import com.appsmith.server.services.CrudService;
+import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -14,6 +15,8 @@ import java.util.Map;
 import java.util.Set;
 
 public interface PluginServiceCE extends CrudService<Plugin, String> {
+
+    Flux<Plugin> get(MultiValueMap<String, String> params);
 
     Flux<Plugin> getDefaultPlugins();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -123,14 +123,6 @@ public abstract class BaseService<
     }
 
     @Override
-    public Flux<T> get(MultiValueMap<String, String> params) {
-        // In the base service we aren't handling the query parameters. In order to filter records using the query
-        // params,
-        // each service must implement it for their usecase. Need to come up with a better strategy for doing this.
-        return repository.findAll();
-    }
-
-    @Override
     public Mono<T> getById(ID id) {
         if (id == null) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ID));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CrudService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CrudService.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -12,8 +11,6 @@ import java.util.List;
 import java.util.Map;
 
 public interface CrudService<T extends BaseDomain, ID> {
-
-    Flux<T> get(MultiValueMap<String, String> params);
 
     Mono<T> create(T resource);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -56,7 +56,6 @@ import org.springframework.security.web.server.DefaultServerRedirectStrategy;
 import org.springframework.security.web.server.ServerRedirectStrategy;
 import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
@@ -618,12 +617,6 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
 
         AppsmithBeanUtils.copyNewFieldValuesIntoOldObject(userUpdate, existingUser);
         return repository.save(existingUser).map(userChangedHandler::publish);
-    }
-
-    @Override
-    public Flux<User> get(MultiValueMap<String, String> params) {
-        // Get All Users should not be supported. Return an error
-        return Flux.error(new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION));
     }
 
     private boolean validateName(String name) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
@@ -17,6 +17,8 @@ public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
 
     Mono<Workspace> create(Workspace workspace);
 
+    Flux<Workspace> getForCurrentUser();
+
     Mono<Workspace> createDefault(Workspace workspace, User user);
 
     Mono<Workspace> create(Workspace workspace, User user, Boolean isDefault);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -44,7 +44,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.http.codec.multipart.Part;
 import org.springframework.stereotype.Service;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -127,7 +126,7 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
     }
 
     @Override
-    public Flux<Workspace> get(MultiValueMap<String, String> params) {
+    public Flux<Workspace> getForCurrentUser() {
         return sessionUserService.getCurrentUser().flatMapMany(user -> {
             Set<String> workspaceIds = user.getWorkspaceIds();
             if (workspaceIds == null || workspaceIds.isEmpty()) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/base/ThemeServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/base/ThemeServiceCEImpl.java
@@ -19,7 +19,6 @@ import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -71,12 +70,6 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
     public Mono<Theme> getById(String s) {
         // we don't allow to get a theme by id from DB
         throw new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION);
-    }
-
-    @Override
-    public Flux<Theme> get(MultiValueMap<String, String> params) {
-        // we return all system themes
-        return repository.getSystemThemes();
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -44,9 +44,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.CollectionUtils;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
@@ -363,17 +360,6 @@ public class UserServiceTest {
         Workspace deletedWorkspace = workspaceMono
                 .flatMap(workspace1 -> workspaceService.archiveById(workspace1.getId()))
                 .block();
-    }
-
-    @Test
-    @WithUserDetails(value = "api_user")
-    public void getAllUsersTest() {
-        Flux<User> userFlux = userService.get(CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>()));
-
-        StepVerifier.create(userFlux)
-                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
-                        && throwable.getMessage().equals(AppsmithError.UNSUPPORTED_OPERATION.getMessage()))
-                .verify();
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/resources/application-test.properties
+++ b/app/server/appsmith-server/src/test/resources/application-test.properties
@@ -1,5 +1,3 @@
 # embedded mongo DB version which is used during junit tests
-#de.flapdoodle.mongodb.embedded.version=5.0.5
-spring.autoconfigure.exclude=de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration
-spring.data.mongodb.uri = mongodb+srv://one:cranes@test1.xsfdf.mongodb.net/t
+de.flapdoodle.mongodb.embedded.version=5.0.5
 logging.level.root=error

--- a/app/server/appsmith-server/src/test/resources/application-test.properties
+++ b/app/server/appsmith-server/src/test/resources/application-test.properties
@@ -1,3 +1,5 @@
 # embedded mongo DB version which is used during junit tests
-de.flapdoodle.mongodb.embedded.version=5.0.5
+#de.flapdoodle.mongodb.embedded.version=5.0.5
+spring.autoconfigure.exclude=de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration
+spring.data.mongodb.uri = mongodb+srv://one:cranes@test1.xsfdf.mongodb.net/t
 logging.level.root=error


### PR DESCRIPTION
The `BaseController` is used by only five controller classes. Regarding the `GET /` route in the base controller,

- two override and block it (`Application` and `User`).
- two override with a custom implementation and logic, completely ignoring the `params` object (`Theme` and `Workspace`).
- one appears to be using it (`Plugin`).

This makes it confusing and hard-to-maintain. This common route is overridden more times than it's reused.

This PR removes this common route so it doesn't have to be blocked when not needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to retrieve all system themes and workspaces for the current user, enhancing user experience by providing more accessible information.
- **API Changes**
	- Removed certain API endpoints that were previously marked as not to be exposed, streamlining the API surface and focusing on essential functionalities.
- **Refactor**
	- Deprecated and removed unused methods across various services, focusing on improving code maintainability and clarity.
	- Shifted responsibility for handling query parameters to individual services, allowing for more flexible and specific data retrieval.
- **Tests**
	- Simplified the test suite by removing redundant user retrieval testing logic, focusing on more relevant user actions like signing up after being invited to a workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->