### PR TITLE
chore: Don't expect .save() to return given object

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasourcestorages/base/DatasourceStorageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasourcestorages/base/DatasourceStorageServiceCEImpl.java
@@ -217,15 +217,8 @@ public class DatasourceStorageServiceCEImpl implements DatasourceStorageServiceC
                 .map(this::sanitizeDatasourceStorage)
                 .flatMap(datasourceStorage1 -> validateDatasourceStorage(datasourceStorage1))
                 .flatMap(this::executePreSaveActions)
-                .flatMap(unsavedDatasourceStorage -> {
-                    return repository.save(unsavedDatasourceStorage).map(datasourceStorage1 -> {
-                        // datasourceStorage.pluginName is a transient field. It was set by validateDatasource method
-                        // object from db will have pluginName=null so set it manually from the unsaved
-                        // datasourceStorage obj
-                        datasourceStorage1.setPluginName(unsavedDatasourceStorage.getPluginName());
-                        return datasourceStorage1;
-                    });
-                });
+                .flatMap(unsavedDatasourceStorage ->
+                        repository.save(unsavedDatasourceStorage).thenReturn(unsavedDatasourceStorage));
     }
 
     @Override


### PR DESCRIPTION
The `.save()` method currently returns the given object as is. But with Hibernate, it returns the corresponding object from the persistence store, if any, which _may_ be different. This is causing some very hard to debug and subtle bugs.

This fix here, to just ignore the result of `.save()` is not a permanent fix, it's just a workaround that works well in both worlds, MongoDB and Hibernate. Once we move though, we may need to revisit.


![shot-2024-02-12-07-14-37](https://github.com/appsmithorg/appsmith/assets/120119/095d32fc-5009-4203-b906-df3d34a40818)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic for saving datasource storage to enhance code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->