### PR TITLE
fix: Entity Explorer Test

### DIFF
--- a/app/client/src/pages/Editor/Explorer/EntityExplorer.test.tsx
+++ b/app/client/src/pages/Editor/Explorer/EntityExplorer.test.tsx
@@ -81,6 +81,13 @@ describe("Entity Explorer tests", () => {
         <WidgetsEditorEntityExplorer />
       </MockPageDSL>,
     );
+    const widgetsTree: any = component.queryByText("Widgets", {
+      selector: "div.t--entity-name",
+    });
+    act(() => {
+      fireEvent.click(widgetsTree);
+      jest.runAllTimers();
+    });
     const tabsWidget = component.queryByText(children[0].widgetName);
     expect(tabsWidget).toBeTruthy();
   });
@@ -106,13 +113,6 @@ describe("Entity Explorer tests", () => {
           <WidgetsEditorEntityExplorer />
         </MockPageDSL>,
       );
-      const widgetsTree: any = component.queryByText("Widgets", {
-        selector: "div.t--entity-name",
-      });
-      act(() => {
-        fireEvent.click(widgetsTree);
-        jest.runAllTimers();
-      });
       const tabsWidget: any = component.queryByText(children[0].widgetName);
       act(() => {
         fireEvent.click(tabsWidget);


### PR DESCRIPTION
Fixes the entity explorer test that is failing due to a bad merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved the flow and validation of the `Widgets` tree node click event in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->