### PR TITLE
fix: Datasource null check in QueryDebugger

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/QueryDebuggerTabs.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryDebuggerTabs.tsx
@@ -98,18 +98,21 @@ function QueryDebuggerTabs({
   );
 
   const datasourceStructure = useSelector((state) =>
-    getDatasourceStructureById(state, currentActionConfig?.datasource.id || ""),
+    getDatasourceStructureById(
+      state,
+      currentActionConfig?.datasource?.id ?? "",
+    ),
   );
 
   useEffect(() => {
     if (
-      currentActionConfig?.datasource.id &&
+      currentActionConfig?.datasource?.id &&
       datasourceStructure === undefined &&
       pluginDatasourceForm !== DatasourceComponentTypes.RestAPIDatasourceForm
     ) {
       dispatch(
         fetchDatasourceStructure(
-          currentActionConfig?.datasource.id,
+          currentActionConfig.datasource.id,
           true,
           DatasourceStructureContext.QUERY_EDITOR,
         ),
@@ -180,7 +183,7 @@ function QueryDebuggerTabs({
     });
   }
 
-  if (showSchema && currentActionConfig) {
+  if (showSchema && currentActionConfig && currentActionConfig.datasource) {
     responseTabs.unshift({
       key: "schema",
       title: "Schema",


### PR DESCRIPTION
Adds null check for datasources as sometimes they may not be available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability in accessing datasource properties within the Query Debugger, ensuring safer operations and correcting the datasource structure fetching process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->