### PR TITLE
fix: Debugger shows up with no tab selected

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/DebuggerTabs.tsx
+++ b/app/client/src/components/editorComponents/Debugger/DebuggerTabs.tsx
@@ -99,10 +99,11 @@ function DebuggerTabs() {
     },
   ];
 
-  // Do not render if response tab and header tab is selected in the bottom bar.
+  // Do not render if response, header or schema tab is selected in the bottom bar.
   const shouldRender = !(
     selectedTab === DEBUGGER_TAB_KEYS.RESPONSE_TAB ||
-    selectedTab === DEBUGGER_TAB_KEYS.HEADER_TAB
+    selectedTab === DEBUGGER_TAB_KEYS.HEADER_TAB ||
+    selectedTab === DEBUGGER_TAB_KEYS.SCHEMA_TAB
   );
 
   return shouldRender ? (

--- a/app/client/src/pages/Editor/DataSourceEditor/Debugger.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/Debugger.tsx
@@ -147,10 +147,11 @@ export default function Debugger() {
   //TODO: move this to a common place
   const onClose = () => dispatch(showDebugger(false));
 
-  // Do not render if response tab and header tab is selected in the bottom bar.
+  // Do not render if response, header or schema tab is selected in the bottom bar.
   const shouldRender = !(
     selectedResponseTab === DEBUGGER_TAB_KEYS.RESPONSE_TAB ||
-    selectedResponseTab === DEBUGGER_TAB_KEYS.HEADER_TAB
+    selectedResponseTab === DEBUGGER_TAB_KEYS.HEADER_TAB ||
+    selectedResponseTab === DEBUGGER_TAB_KEYS.SCHEMA_TAB
   );
 
   return shouldRender ? (


### PR DESCRIPTION
fixes: #31124 

Updates the debugger showing logic for Schema tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the debugger to not render certain tabs (response, header, or schema) when selected in the bottom bar, enhancing the interface's usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->