### PR TITLE
fix: Request referer shouldn't influence redirect URL

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -219,18 +219,15 @@ public class UserSignupCEImpl implements UserSignupCE {
                 .flatMap(user -> signupAndLogin(user, exchange))
                 .then()
                 .onErrorResume(error -> {
-                    String referer = exchange.getRequest().getHeaders().getFirst("referer");
-                    if (referer == null) {
-                        referer = DEFAULT_ORIGIN_HEADER;
-                    }
-                    final URIBuilder redirectUriBuilder =
-                            new URIBuilder(URI.create(referer)).setParameter("error", error.getMessage());
                     URI redirectUri;
                     try {
-                        redirectUri = redirectUriBuilder.build();
+                        redirectUri = new URIBuilder()
+                                .setPath("/")
+                                .setParameter("error", error.getMessage())
+                                .build();
                     } catch (URISyntaxException e) {
                         log.error("Error building redirect URI with error for signup, {}.", e.getMessage(), error);
-                        redirectUri = URI.create(referer);
+                        redirectUri = URI.create("/");
                     }
                     return redirectStrategy.sendRedirect(exchange, redirectUri);
                 });


### PR DESCRIPTION
The form signup API responds in a failure state, with a redirection URL. That URL blindly uses the `Referer` header as passed-in. This shows up a security issue in a few places, although it's not very exploitable.

![shot-2024-02-15-11-13-01](https://github.com/appsmithorg/appsmith/assets/120119/9c4ea8b4-d028-4cbd-a348-f2483fad0f49)

Nonetheless, we don't need the host to show up in the redirection URL at all. The signup success API is already using a redirect URL without host, for example.

![shot-2024-02-15-11-11-41](https://github.com/appsmithorg/appsmith/assets/120119/5eb62c42-cf09-4c1f-8269-775f26af2dce)

With the changes in this PR, the failure response also uses a host-less redirect.

![shot-2024-02-15-11-14-04](https://github.com/appsmithorg/appsmith/assets/120119/d0640ea2-f934-4f57-ade4-189964d6d11a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the error handling logic during user signup to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->