### PR TITLE
chore: Refine WDS dimension tokens

### DIFF
--- a/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
+++ b/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
@@ -18,7 +18,7 @@
     "userDensityRatio": 1.5
   },
   "innerSpacing": {
-    "V": 1.75,
+    "V": 1.5,
     "R": 2.5,
     "N": 2,
     "stepsUp": 8,

--- a/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
+++ b/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
@@ -18,8 +18,8 @@
     "userDensityRatio": 1.5
   },
   "innerSpacing": {
-    "V": 1.5,
-    "R": 2,
+    "V": 1.75,
+    "R": 2.5,
     "N": 2,
     "stepsUp": 8,
     "stepsDown": 0,
@@ -27,12 +27,12 @@
     "userDensityRatio": 2.5
   },
   "typography": {
-    "V": 6,
-    "R": 2,
+    "V": 6.25,
+    "R": 2.5,
     "N": 3,
     "stepsUp": 5,
     "stepsDown": 1,
-    "userSizingRatio": 1.6,
+    "userSizingRatio": 1.7,
     "userDensityRatio": 0
   }
 }

--- a/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
+++ b/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
@@ -9,13 +9,13 @@
     "userDensityRatio": 0.2
   },
   "outerSpacing": {
-    "V": 2,
+    "V": 2.25,
     "R": 2,
     "N": 2,
     "stepsUp": 8,
     "stepsDown": 0,
     "userSizingRatio": 0.8,
-    "userDensityRatio": 1.5
+    "userDensityRatio": 1.75
   },
   "innerSpacing": {
     "V": 1.5,

--- a/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
+++ b/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
@@ -5,7 +5,7 @@
     "N": 1,
     "stepsUp": 1,
     "stepsDown": 0,
-    "userSizingRatio": 1.4,
+    "userSizingRatio": 1.5,
     "userDensityRatio": 0.2
   },
   "outerSpacing": {

--- a/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
+++ b/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
@@ -27,12 +27,12 @@
     "userDensityRatio": 2.5
   },
   "typography": {
-    "V": 6.25,
-    "R": 2.5,
-    "N": 3,
-    "stepsUp": 5,
-    "stepsDown": 1,
-    "userSizingRatio": 1.7,
-    "userDensityRatio": 0
+    "V": 5.7125,
+    "R": 2.25,
+    "N": 4,
+    "stepsUp": 4,
+    "stepsDown": 2,
+    "userSizingRatio": 1.75,
+    "userDensityRatio": 0.1
   }
 }


### PR DESCRIPTION
Closes #30890 

![image](https://github.com/appsmithorg/appsmith/assets/80973/6300d8c4-e826-4892-b35a-5cf754509891)


This is not a full refinement, because we set height/block-size explicitly for some of our widgets with styles [such as these](https://github.com/appsmithorg/appsmith/blob/0d16dc0382b8fdd46dba8b5dc65c7cfc7c496c03/app/client/packages/design-system/widgets/src/components/Button/src/styles.module.css#L171). As such, changes to e.g. inner spacing only affect the horizontal/inline size and not the vertical/block one since the block padding doesn't affect an element that has block size set explicitly.
Ideally, we should switch to implicit sizing to fully embrace multi-dimensional sizing and density theming control over the widget dimensions (i.e. control it with padding that consumes the tokens of the inner spacing scale). If that is not feasible I'd like to know why and how we can closely tie together the sizing scale with inner spacing.

