### PR TITLE
fix: Signup error redirect to wrong path

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -219,10 +219,21 @@ public class UserSignupCEImpl implements UserSignupCE {
                 .flatMap(user -> signupAndLogin(user, exchange))
                 .then()
                 .onErrorResume(error -> {
+                    String path = "/user/signup";
+
+                    String referer = exchange.getRequest().getHeaders().getFirst("referer");
+                    if (referer != null) {
+                        try {
+                            path = URI.create(referer).getPath();
+                        } catch(IllegalArgumentException ex) {
+                            // This is okay, we just use the default value for `path`.
+                        }
+                    }
+
                     URI redirectUri;
                     try {
                         redirectUri = new URIBuilder()
-                                .setPath(exchange.getRequest().getPath().value())
+                                .setPath(path)
                                 .setParameter("error", error.getMessage())
                                 .build();
                     } catch (URISyntaxException e) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -225,7 +225,7 @@ public class UserSignupCEImpl implements UserSignupCE {
                     if (referer != null) {
                         try {
                             path = URI.create(referer).getPath();
-                        } catch(IllegalArgumentException ex) {
+                        } catch (IllegalArgumentException ex) {
                             // This is okay, we just use the default value for `path`.
                         }
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -222,7 +222,7 @@ public class UserSignupCEImpl implements UserSignupCE {
                     URI redirectUri;
                     try {
                         redirectUri = new URIBuilder()
-                                .setPath("/")
+                                .setPath(exchange.getRequest().getPath().value())
                                 .setParameter("error", error.getMessage())
                                 .build();
                     } catch (URISyntaxException e) {


### PR DESCRIPTION
On signup failure, we need to redirect the client to same signup page they were on, for the error message to show up. So instead of redirecting to the homepage, we get the path from the incoming request and use that.