### PR TITLE
chore: Remove simple mongoOperations uses in repo classes

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
@@ -47,6 +47,11 @@ public class Bridge extends Criteria {
 
     @Override
     public Document getCriteriaObject() {
+        if (criteriaList.isEmpty()) {
+            throw new UnsupportedOperationException(
+                    "Empty bridge criteria leads to subtle bugs. Just don't call `.criteria()` in such cases.");
+        }
+
         return new Criteria().andOperator(criteriaList.toArray(new Criteria[0])).getCriteriaObject();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -16,7 +16,6 @@ import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.aggregation.Fields;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -189,18 +188,14 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
 
     @Override
     public Mono<String> getNameByPageId(String pageId, boolean isPublishedName) {
-        return mongoOperations
-                .query(NewPage.class)
-                .matching(Query.query(Criteria.where(NewPage.Fields.id).is(pageId)))
-                .one()
-                .map(p -> {
-                    PageDTO page = (isPublishedName ? p.getPublishedPage() : p.getUnpublishedPage());
-                    if (page != null) {
-                        return page.getName();
-                    }
-                    // If the page hasn't been published, just send the unpublished page name
-                    return p.getUnpublishedPage().getName();
-                });
+        return queryBuilder().byId(pageId).one().map(p -> {
+            PageDTO page = (isPublishedName ? p.getPublishedPage() : p.getUnpublishedPage());
+            if (page != null) {
+                return page.getName();
+            }
+            // If the page hasn't been published, just send the unpublished page name
+            return p.getUnpublishedPage().getName();
+        });
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
@@ -9,14 +9,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import reactor.core.publisher.Mono;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
-import static org.springframework.data.mongodb.core.query.Query.query;
 
 @Slf4j
 public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User> implements CustomUserRepositoryCE {
@@ -36,15 +35,9 @@ public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User>
 
     @Override
     public Mono<User> findByEmailAndTenantId(String email, String tenantId) {
-        Criteria emailCriteria = where(User.Fields.email).is(email);
-        Criteria tenantIdCriteria = where(User.Fields.tenantId).is(tenantId);
-
-        Criteria andCriteria = new Criteria();
-        andCriteria.andOperator(emailCriteria, tenantIdCriteria);
-
-        Query query = new Query();
-        query.addCriteria(andCriteria);
-        return mongoOperations.findOne(query, User.class);
+        return queryBuilder()
+                .criteria(bridge().equal(User.Fields.email, email).equal(User.Fields.tenantId, tenantId))
+                .one();
     }
 
     /**
@@ -55,12 +48,12 @@ public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User>
      */
     @Override
     public Mono<Boolean> isUsersEmpty() {
-        final Query q = query(new Criteria());
-        q.fields().include(User.Fields.email);
-        // Basically limit to system generated emails plus 1 more.
-        q.limit(getSystemGeneratedUserEmails().size() + 1);
-        return mongoOperations
-                .find(q, User.class)
+        return queryBuilder()
+                .criteria(bridge())
+                .fields(User.Fields.email)
+                // Basically limit to system generated emails plus 1 more.
+                .limit(getSystemGeneratedUserEmails().size() + 1)
+                .all()
                 .filter(user -> !getSystemGeneratedUserEmails().contains(user.getEmail()))
                 .count()
                 .map(count -> count == 0);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
@@ -41,7 +41,7 @@ public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User>
     }
 
     /**
-     * Fetch minmal information from *a* user document in the database, limit to two documents, filter anonymousUser
+     * Fetch minimal information from *a* user document in the database, limit to two documents, filter anonymousUser
      * If no documents left return true otherwise return false.
      *
      * @return Boolean, indicated where there exists at least one user in the system or not.
@@ -49,7 +49,6 @@ public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User>
     @Override
     public Mono<Boolean> isUsersEmpty() {
         return queryBuilder()
-                .criteria(bridge())
                 .fields(User.Fields.email)
                 // Basically limit to system generated emails plus 1 more.
                 .limit(getSystemGeneratedUserEmails().size() + 1)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
@@ -66,7 +66,7 @@ public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     @Override
     public Flux<Workspace> findAllWorkspaces() {
-        return mongoOperations.find(new Query(), Workspace.class);
+        return queryBuilder().all();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -3,6 +3,7 @@ package com.appsmith.server.repositories.ce.params;
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl;
 import lombok.Getter;
 import lombok.NonNull;
@@ -82,11 +83,19 @@ public class QueryAllParams<T extends BaseDomain> {
         return criteria(List.of(criteria));
     }
 
-    public QueryAllParams<T> criteria(List<Criteria> criterias) {
-        if (criterias == null) {
+    public QueryAllParams<T> criteria(List<Criteria> criteria) {
+        if (criteria == null) {
             return this;
         }
-        this.criteria.addAll(criterias);
+
+        for (Criteria c : criteria) {
+            if (c instanceof Bridge b && b.getCriteriaObject().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Empty bridge criteria leads to subtle bugs. Just don't call `.criteria()` in such cases.");
+            }
+            this.criteria.add(c);
+        }
+
         return this;
     }
 


### PR DESCRIPTION
Replace simple uses of `mongoOperations` in repo classes with equivalent operations using `queryBuilder` API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved query construction logic across various components for enhanced readability and maintainability.
	- Implemented checks to prevent issues related to empty criteria in queries.

- **Bug Fixes**
	- Added validations to avoid subtle bugs due to empty criteria in query construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->