### PR TITLE
chore: Don't break on missing info.json

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -162,11 +162,18 @@ spawnSync("/opt/caddy/caddy", ["fmt", "--overwrite", CaddyfilePath])
 spawnSync("/opt/caddy/caddy", ["reload", "--config", CaddyfilePath])
 
 function finalizeIndexHtml() {
-  const info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
+  let info = null;
+  try {
+    info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
+  } catch(e) {
+    // info will be empty, that's okay.
+    console.error("Error reading info.json", e)
+  }
+
   const extraEnv = {
-    APPSMITH_VERSION_ID: info.version ?? "",
-    APPSMITH_VERSION_SHA: info.commitSha ?? "",
-    APPSMITH_VERSION_RELEASE_DATE: info.imageBuiltAt ?? "",
+    APPSMITH_VERSION_ID: info?.version ?? "",
+    APPSMITH_VERSION_SHA: info?.commitSha ?? "",
+    APPSMITH_VERSION_RELEASE_DATE: info?.imageBuiltAt ?? "",
   }
 
   const content = fs.readFileSync("/opt/appsmith/editor/index.html", "utf8").replace(


### PR DESCRIPTION
The `caddy-reconfigure.mjs` script fails to gracefully continue when `info.json` is missing. This PR brings back that grace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced error handling in the `finalizeIndexHtml` function for more robust JSON parsing and property access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->