### PR TITLE
chore: Replace remaining Q* usage with Fields

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionDTO.java
@@ -6,10 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @ToString(callSuper = true)
 @QueryEmbeddable
-public class ActionDTO extends ActionCE_DTO {}
+@FieldNameConstants
+public class ActionDTO extends ActionCE_DTO {
+    public static class Fields extends ActionCE_DTO.Fields {}
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.FieldNameConstants;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.util.CollectionUtils;
@@ -24,6 +25,7 @@ import static com.appsmith.external.constants.PluginConstants.DEFAULT_REST_DATAS
 @AllArgsConstructor
 @NoArgsConstructor
 @Document
+@FieldNameConstants
 public class DatasourceStorage extends BaseDomain {
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import org.springframework.data.annotation.Transient;
 
 import java.time.Instant;
@@ -34,6 +35,7 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 @ToString
+@FieldNameConstants
 public class ActionCE_DTO implements Identifiable, Executable {
 
     @Transient
@@ -308,4 +310,6 @@ public class ActionCE_DTO implements Identifiable, Executable {
     public String calculateContextId() {
         return this.getPageId();
     }
+
+    public static class Fields {}
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
@@ -15,7 +15,6 @@ import com.appsmith.server.domains.GitArtifactMetadata;
 import com.appsmith.server.domains.GitAuth;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
-import com.appsmith.server.domains.QApplication;
 import com.appsmith.server.domains.Theme;
 import com.appsmith.server.domains.UserData;
 import com.appsmith.server.domains.Workspace;
@@ -266,12 +265,8 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         if (application.getApplicationVersion() != null) {
             int appVersion = application.getApplicationVersion();
             if (appVersion < ApplicationVersion.EARLIEST_VERSION || appVersion > ApplicationVersion.LATEST_VERSION) {
-                return Mono.error(new AppsmithException(
-                        AppsmithError.INVALID_PARAMETER,
-                        QApplication.application
-                                .applicationVersion
-                                .getMetadata()
-                                .getName()));
+                return Mono.error(
+                        new AppsmithException(AppsmithError.INVALID_PARAMETER, Application.Fields.applicationVersion));
             }
         }
         return repository.save(application).flatMap(this::setTransientFields);
@@ -342,11 +337,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
                 if (appVersion < ApplicationVersion.EARLIEST_VERSION
                         || appVersion > ApplicationVersion.LATEST_VERSION) {
                     return Mono.error(new AppsmithException(
-                            AppsmithError.INVALID_PARAMETER,
-                            QApplication.application
-                                    .applicationVersion
-                                    .getMetadata()
-                                    .getName()));
+                            AppsmithError.INVALID_PARAMETER, Application.Fields.applicationVersion));
                 }
             }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/jslibs/ApplicationJsLibServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/jslibs/ApplicationJsLibServiceCEImpl.java
@@ -2,7 +2,6 @@ package com.appsmith.server.applications.jslibs;
 
 import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.domains.Application;
-import com.appsmith.server.domains.QApplication;
 import com.appsmith.server.dtos.CustomJSLibContextDTO;
 import com.appsmith.server.jslibs.context.ContextBasedJsLibServiceCE;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.completeFieldName;
 
 @RequiredArgsConstructor
 @Service
@@ -30,8 +27,8 @@ public class ApplicationJsLibServiceCEImpl implements ContextBasedJsLibServiceCE
                         contextId,
                         List.of(
                                 isViewMode
-                                        ? completeFieldName(QApplication.application.publishedCustomJSLibs)
-                                        : completeFieldName(QApplication.application.unpublishedCustomJSLibs)),
+                                        ? Application.Fields.publishedCustomJSLibs
+                                        : Application.Fields.unpublishedCustomJSLibs),
                         branchName)
                 .map(application -> {
                     if (isViewMode) {
@@ -49,8 +46,7 @@ public class ApplicationJsLibServiceCEImpl implements ContextBasedJsLibServiceCE
     @Override
     public Mono<Integer> updateJsLibsInContext(
             String contextId, String branchName, Set<CustomJSLibContextDTO> updatedJSLibDTOSet) {
-        Map<String, Object> fieldNameValueMap =
-                Map.of(completeFieldName(QApplication.application.unpublishedCustomJSLibs), updatedJSLibDTOSet);
+        Map<String, Object> fieldNameValueMap = Map.of(Application.Fields.unpublishedCustomJSLibs, updatedJSLibDTOSet);
         return applicationService.update(contextId, fieldNameValueMap, branchName);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
@@ -38,5 +38,20 @@ public class NewPage extends BranchAwareDomain implements Context {
         super.sanitiseToExportDBObject();
     }
 
-    public static class Fields extends BranchAwareDomain.Fields {}
+    public static class Fields extends BranchAwareDomain.Fields {
+        public static String unpublishedPage_layouts = unpublishedPage + "." + PageDTO.Fields.layouts;
+        public static String unpublishedPage_name = unpublishedPage + "." + PageDTO.Fields.name;
+        public static String unpublishedPage_icon = unpublishedPage + "." + PageDTO.Fields.icon;
+        public static String unpublishedPage_isHidden = unpublishedPage + "." + PageDTO.Fields.isHidden;
+        public static String unpublishedPage_slug = unpublishedPage + "." + PageDTO.Fields.slug;
+        public static String unpublishedPage_customSlug = unpublishedPage + "." + PageDTO.Fields.customSlug;
+        public static String unpublishedPage_deletedAt = unpublishedPage + "." + PageDTO.Fields.deletedAt;
+
+        public static String publishedPage_layouts = publishedPage + "." + PageDTO.Fields.layouts;
+        public static String publishedPage_name = publishedPage + "." + PageDTO.Fields.name;
+        public static String publishedPage_icon = publishedPage + "." + PageDTO.Fields.icon;
+        public static String publishedPage_isHidden = publishedPage + "." + PageDTO.Fields.isHidden;
+        public static String publishedPage_slug = publishedPage + "." + PageDTO.Fields.slug;
+        public static String publishedPage_customSlug = publishedPage + "." + PageDTO.Fields.customSlug;
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -1,7 +1,9 @@
 package com.appsmith.server.domains.ce;
 
+import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.BranchAwareDomain;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.Documentation;
 import com.appsmith.external.models.PluginType;
 import com.appsmith.external.views.Views;
@@ -56,5 +58,29 @@ public class NewActionCE extends BranchAwareDomain {
         super.sanitiseToExportDBObject();
     }
 
-    public static class Fields extends BranchAwareDomain.Fields {}
+    public static class Fields extends BranchAwareDomain.Fields {
+        public static final String unpublishedAction_datasource_id =
+                String.join(".", unpublishedAction, ActionDTO.Fields.datasource, Datasource.Fields.id);
+        public static final String unpublishedAction_name = String.join(".", unpublishedAction, ActionDTO.Fields.name);
+        public static final String unpublishedAction_pageId =
+                String.join(".", unpublishedAction, ActionDTO.Fields.pageId);
+        public static final String unpublishedAction_deletedAt =
+                String.join(".", unpublishedAction, ActionDTO.Fields.deletedAt);
+        public static final String unpublishedAction_contextType =
+                String.join(".", unpublishedAction, ActionDTO.Fields.contextType);
+        public static final String unpublishedAction_userSetOnLoad =
+                String.join(".", unpublishedAction, ActionDTO.Fields.userSetOnLoad);
+        public static final String unpublishedAction_executeOnLoad =
+                String.join(".", unpublishedAction, ActionDTO.Fields.executeOnLoad);
+        public static final String unpublishedAction_fullyQualifiedName =
+                String.join(".", unpublishedAction, ActionDTO.Fields.fullyQualifiedName);
+        public static final String unpublishedAction_actionConfiguration_httpMethod = String.join(
+                ".", unpublishedAction, ActionDTO.Fields.actionConfiguration, ActionConfiguration.Fields.httpMethod);
+
+        public static final String publishedAction_name = String.join(".", unpublishedAction, ActionDTO.Fields.name);
+        public static final String publishedAction_pageId =
+                String.join(".", unpublishedAction, ActionDTO.Fields.pageId);
+        public static final String publishedAction_contextType =
+                String.join(".", unpublishedAction, ActionDTO.Fields.contextType);
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import org.springframework.data.annotation.Transient;
 
 import java.time.Instant;
@@ -21,6 +22,7 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 @ToString
+@FieldNameConstants
 public class PageDTO {
 
     @Transient

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/MigrationHelperMethods.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/MigrationHelperMethods.java
@@ -232,9 +232,8 @@ public class MigrationHelperMethods {
      * .newAction.id, type=NewAction.class
      */
     public static <T extends BaseDomain> List<T> fetchAllDomainObjectsUsingId(
-            String id, MongoTemplate mongoTemplate, Path path, Class<T> type) {
-        final List<T> domainObject =
-                mongoTemplate.find(query(where(fieldName(path)).is(id)), type);
+            String id, MongoTemplate mongoTemplate, String path, Class<T> type) {
+        final List<T> domainObject = mongoTemplate.find(query(where(path).is(id)), type);
         return domainObject;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration022AddConnectionMethodDefaultValueToAllMySQLDatasources.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration022AddConnectionMethodDefaultValueToAllMySQLDatasources.java
@@ -3,7 +3,6 @@ package com.appsmith.server.migrations.db.ce;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.external.models.Property;
-import com.appsmith.external.models.QDatasourceStorage;
 import com.appsmith.server.domains.Plugin;
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -51,7 +50,7 @@ public class Migration022AddConnectionMethodDefaultValueToAllMySQLDatasources {
          */
         mysqlDatasources.parallelStream().map(Datasource::getId).forEach(id -> {
             List<DatasourceStorage> datasourceStorageList = fetchAllDomainObjectsUsingId(
-                    id, mongoTemplate, QDatasourceStorage.datasourceStorage.datasourceId, DatasourceStorage.class);
+                    id, mongoTemplate, DatasourceStorage.Fields.datasourceId, DatasourceStorage.class);
             datasourceStorageList.stream()
                     .filter(datasourceStorage -> datasourceStorage.getDatasourceConfiguration() != null)
                     .forEach(datasourceStorage -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -6,7 +6,6 @@ import com.appsmith.external.models.DefaultResources;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.ActionCollection;
-import com.appsmith.server.domains.QActionCollection;
 import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
@@ -289,21 +288,20 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
 
         // Fetch published action collections
         if (Boolean.TRUE.equals(viewMode)) {
-            pageCriterion = where(completeFieldName(QActionCollection.actionCollection.publishedCollection.pageId))
-                    .is(pageId);
+            pageCriterion =
+                    where(ActionCollection.Fields.publishedCollection_pageId).is(pageId);
             criteria.add(pageCriterion);
         }
         // Fetch unpublished action collections
         else {
-            pageCriterion = where(completeFieldName(QActionCollection.actionCollection.unpublishedCollection.pageId))
-                    .is(pageId);
+            pageCriterion =
+                    where(ActionCollection.Fields.unpublishedCollection_pageId).is(pageId);
             criteria.add(pageCriterion);
 
             // In case an action collection has been deleted in edit mode, but still exists in deployed mode,
             // ActionCollection object
             // would exist. To handle this, only fetch non-deleted actions
-            Criteria deletedCriteria = where(
-                            completeFieldName(QActionCollection.actionCollection.unpublishedCollection.deletedAt))
+            Criteria deletedCriteria = where(ActionCollection.Fields.unpublishedCollection_deletedAt)
                     .is(null);
             criteria.add(deletedCriteria);
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -1,13 +1,11 @@
 package com.appsmith.server.repositories.ce;
 
-import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.BranchAwareDomain;
 import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.PluginType;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.NewAction;
-import com.appsmith.server.domains.QNewAction;
 import com.appsmith.server.dtos.PluginTypeAndCountDTO;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
@@ -79,17 +77,12 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     @Override
     public Mono<NewAction> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission aclPermission) {
-        Criteria nameCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.name))
-                .is(name);
-        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                .is(pageId);
+        Criteria nameCriteria = where(NewAction.Fields.unpublishedAction_name).is(name);
+        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction_pageId).is(pageId);
         // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object would
         // exist. To handle this, only fetch non-deleted actions
-        Criteria deletedCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                .is(null);
+        Criteria deletedCriteria =
+                where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
 
         return queryBuilder()
                 .criteria(nameCriteria, pageCriteria, deletedCriteria)
@@ -99,10 +92,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     @Override
     public Flux<NewAction> findByPageId(String pageId, AclPermission aclPermission) {
-        String unpublishedPage =
-                NewAction.Fields.unpublishedAction + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId);
-        String publishedPage =
-                NewAction.Fields.publishedAction + "." + fieldName(QNewAction.newAction.publishedAction.pageId);
+        String unpublishedPage = NewAction.Fields.unpublishedAction_pageId;
+        String publishedPage = NewAction.Fields.publishedAction_pageId;
 
         Criteria pageCriteria = new Criteria()
                 .orOperator(
@@ -113,10 +104,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     @Override
     public Flux<NewAction> findByPageId(String pageId, Optional<AclPermission> aclPermission) {
-        String unpublishedPage =
-                NewAction.Fields.unpublishedAction + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId);
-        String publishedPage =
-                NewAction.Fields.publishedAction + "." + fieldName(QNewAction.newAction.publishedAction.pageId);
+        String unpublishedPage = NewAction.Fields.unpublishedAction_pageId;
+        String publishedPage = NewAction.Fields.publishedAction_pageId;
 
         Criteria pageCriteria = new Criteria()
                 .orOperator(
@@ -142,23 +131,18 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
         // Fetch published actions
         if (Boolean.TRUE.equals(viewMode)) {
-            pageCriterion = where(NewAction.Fields.publishedAction + "."
-                            + fieldName(QNewAction.newAction.publishedAction.pageId))
-                    .is(pageId);
+            pageCriterion = where(NewAction.Fields.publishedAction_pageId).is(pageId);
             criteria.add(pageCriterion);
         }
         // Fetch unpublished actions
         else {
-            pageCriterion = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                    .is(pageId);
+            pageCriterion = where(NewAction.Fields.unpublishedAction_pageId).is(pageId);
             criteria.add(pageCriterion);
 
             // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object
             // would exist. To handle this, only fetch non-deleted actions
-            Criteria deletedCriteria = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                    .is(null);
+            Criteria deletedCriteria =
+                    where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
             criteria.add(deletedCriteria);
         }
         return queryBuilder().criteria(criteria).permission(aclPermission).all();
@@ -167,26 +151,14 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     @Override
     public Flux<NewAction> findUnpublishedActionsForRestApiOnLoad(
             Set<String> names, String pageId, String httpMethod, Boolean userSetOnLoad, AclPermission aclPermission) {
-        Criteria namesCriteria = where(NewAction.Fields.unpublishedAction
-                        + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.name))
-                .in(names);
+        Criteria namesCriteria = where(NewAction.Fields.unpublishedAction_name).in(names);
 
-        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction
-                        + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                .is(pageId);
+        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction_pageId).is(pageId);
 
-        Criteria userSetOnLoadCriteria = where(NewAction.Fields.unpublishedAction
-                        + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.userSetOnLoad))
-                .is(userSetOnLoad);
+        Criteria userSetOnLoadCriteria =
+                where(NewAction.Fields.unpublishedAction_userSetOnLoad).is(userSetOnLoad);
 
-        String httpMethodQueryKey = NewAction.Fields.unpublishedAction
-                + "."
-                + fieldName(QNewAction.newAction.unpublishedAction.actionConfiguration)
-                + "."
-                + ActionConfiguration.Fields.httpMethod;
+        String httpMethodQueryKey = NewAction.Fields.unpublishedAction_actionConfiguration_httpMethod;
 
         Criteria httpMethodCriteria = where(httpMethodQueryKey).is(httpMethod);
         List<Criteria> criterias = List.of(namesCriteria, pageCriteria, httpMethodCriteria, userSetOnLoadCriteria);
@@ -220,16 +192,14 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         if (Boolean.TRUE.equals(viewMode)) {
 
             if (name != null) {
-                Criteria nameCriteria = where(NewAction.Fields.publishedAction + "."
-                                + fieldName(QNewAction.newAction.publishedAction.name))
-                        .is(name);
+                Criteria nameCriteria =
+                        where(NewAction.Fields.publishedAction_name).is(name);
                 criteriaList.add(nameCriteria);
             }
 
             if (pageIds != null && !pageIds.isEmpty()) {
-                Criteria pageCriteria = where(NewAction.Fields.publishedAction + "."
-                                + fieldName(QNewAction.newAction.publishedAction.pageId))
-                        .in(pageIds);
+                Criteria pageCriteria =
+                        where(NewAction.Fields.publishedAction_pageId).in(pageIds);
                 criteriaList.add(pageCriteria);
             }
         }
@@ -237,24 +207,21 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         else {
 
             if (name != null) {
-                Criteria nameCriteria = where(NewAction.Fields.unpublishedAction + "."
-                                + fieldName(QNewAction.newAction.unpublishedAction.name))
-                        .is(name);
+                Criteria nameCriteria =
+                        where(NewAction.Fields.unpublishedAction_name).is(name);
                 criteriaList.add(nameCriteria);
             }
 
             if (pageIds != null && !pageIds.isEmpty()) {
-                Criteria pageCriteria = where(NewAction.Fields.unpublishedAction + "."
-                                + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                        .in(pageIds);
+                Criteria pageCriteria =
+                        where(NewAction.Fields.unpublishedAction_pageId).in(pageIds);
                 criteriaList.add(pageCriteria);
             }
 
             // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object
             // would exist. To handle this, only fetch non-deleted actions
-            Criteria deletedCriteria = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                    .is(null);
+            Criteria deletedCriteria =
+                    where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
             criteriaList.add(deletedCriteria);
         }
         return criteriaList;
@@ -265,26 +232,21 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
             Set<String> names, String pageId, AclPermission permission) {
         List<Criteria> criteriaList = new ArrayList<>();
         if (names != null) {
-            Criteria namesCriteria = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.name))
-                    .in(names);
+            Criteria namesCriteria =
+                    where(NewAction.Fields.unpublishedAction_name).in(names);
             criteriaList.add(namesCriteria);
         }
-        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                .is(pageId);
+        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction_pageId).is(pageId);
         criteriaList.add(pageCriteria);
 
-        Criteria executeOnLoadCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.executeOnLoad))
-                .is(Boolean.TRUE);
+        Criteria executeOnLoadCriteria =
+                where(NewAction.Fields.unpublishedAction_executeOnLoad).is(Boolean.TRUE);
         criteriaList.add(executeOnLoadCriteria);
 
         // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object would
         // exist. To handle this, only fetch non-deleted actions
-        Criteria deletedCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                .is(null);
+        Criteria deletedCriteria =
+                where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
         criteriaList.add(deletedCriteria);
 
         return queryBuilder().criteria(criteriaList).permission(permission).all();
@@ -296,24 +258,19 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         List<Criteria> criteriaList = new ArrayList<>();
 
         if (names != null) {
-            Criteria namesCriteria = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.name))
-                    .in(names);
-            Criteria fullyQualifiedNamesCriteria = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.fullyQualifiedName))
-                    .in(names);
+            Criteria namesCriteria =
+                    where(NewAction.Fields.unpublishedAction_name).in(names);
+            Criteria fullyQualifiedNamesCriteria =
+                    where(NewAction.Fields.unpublishedAction_fullyQualifiedName).in(names);
             criteriaList.add(new Criteria().orOperator(namesCriteria, fullyQualifiedNamesCriteria));
         }
-        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                .is(pageId);
+        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction_pageId).is(pageId);
         criteriaList.add(pageCriteria);
 
         // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object would
         // exist. To handle this, only fetch non-deleted actions
-        Criteria deletedCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                .is(null);
+        Criteria deletedCriteria =
+                where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
         criteriaList.add(deletedCriteria);
 
         return queryBuilder().criteria(criteriaList).permission(permission).all();
@@ -324,26 +281,21 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
             String pageId, AclPermission permission) {
         List<Criteria> criteriaList = new ArrayList<>();
 
-        Criteria executeOnLoadCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.executeOnLoad))
-                .is(Boolean.TRUE);
+        Criteria executeOnLoadCriteria =
+                where(NewAction.Fields.unpublishedAction_executeOnLoad).is(Boolean.TRUE);
         criteriaList.add(executeOnLoadCriteria);
 
-        Criteria setByUserCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.userSetOnLoad))
-                .is(Boolean.TRUE);
+        Criteria setByUserCriteria =
+                where(NewAction.Fields.unpublishedAction_userSetOnLoad).is(Boolean.TRUE);
         criteriaList.add(setByUserCriteria);
 
-        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                .is(pageId);
+        Criteria pageCriteria = where(NewAction.Fields.unpublishedAction_pageId).is(pageId);
         criteriaList.add(pageCriteria);
 
         // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object would
         // exist. To handle this, only fetch non-deleted actions
-        Criteria deletedCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                .is(null);
+        Criteria deletedCriteria =
+                where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
         criteriaList.add(deletedCriteria);
 
         return queryBuilder().criteria(criteriaList).permission(permission).all();
@@ -384,9 +336,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         if (Boolean.FALSE.equals(viewMode)) {
             // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object
             // would exist. To handle this, only fetch non-deleted actions
-            Criteria deletedCriterion = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                    .is(null);
+            Criteria deletedCriterion =
+                    where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
             criteria.add(deletedCriterion);
         }
         return criteria;
@@ -444,18 +395,16 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     @Override
     public Flux<NewAction> findByPageIds(List<String> pageIds, AclPermission permission) {
 
-        Criteria pageIdCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                .in(pageIds);
+        Criteria pageIdCriteria =
+                where(NewAction.Fields.unpublishedAction_pageId).in(pageIds);
 
         return queryBuilder().criteria(pageIdCriteria).permission(permission).all();
     }
 
     @Override
     public Flux<NewAction> findByPageIds(List<String> pageIds, Optional<AclPermission> permission) {
-        Criteria pageIdCriteria = where(NewAction.Fields.unpublishedAction + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                .in(pageIds);
+        Criteria pageIdCriteria =
+                where(NewAction.Fields.unpublishedAction_pageId).in(pageIds);
 
         return queryBuilder()
                 .criteria(pageIdCriteria)
@@ -485,9 +434,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         if (Boolean.FALSE.equals(viewMode)) {
             // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object
             // would exist. To handle this, only fetch non-deleted actions
-            Criteria deletedCriterion = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                    .is(null);
+            Criteria deletedCriterion =
+                    where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
             criteria.add(deletedCriterion);
         }
         return criteria;
@@ -517,16 +465,14 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         if (Boolean.TRUE.equals(viewMode)) {
 
             if (name != null) {
-                Criteria nameCriteria = where(NewAction.Fields.publishedAction + "."
-                                + fieldName(QNewAction.newAction.publishedAction.name))
-                        .is(name);
+                Criteria nameCriteria =
+                        where(NewAction.Fields.publishedAction_name).is(name);
                 criteriaList.add(nameCriteria);
             }
 
             if (pageIds != null && !pageIds.isEmpty()) {
-                Criteria pageCriteria = where(NewAction.Fields.publishedAction + "."
-                                + fieldName(QNewAction.newAction.publishedAction.pageId))
-                        .in(pageIds);
+                Criteria pageCriteria =
+                        where(NewAction.Fields.publishedAction_pageId).in(pageIds);
                 criteriaList.add(pageCriteria);
             }
 
@@ -535,24 +481,21 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         else {
 
             if (name != null) {
-                Criteria nameCriteria = where(NewAction.Fields.unpublishedAction + "."
-                                + fieldName(QNewAction.newAction.unpublishedAction.name))
-                        .is(name);
+                Criteria nameCriteria =
+                        where(NewAction.Fields.unpublishedAction_name).is(name);
                 criteriaList.add(nameCriteria);
             }
 
             if (pageIds != null && !pageIds.isEmpty()) {
-                Criteria pageCriteria = where(NewAction.Fields.unpublishedAction + "."
-                                + fieldName(QNewAction.newAction.unpublishedAction.pageId))
-                        .in(pageIds);
+                Criteria pageCriteria =
+                        where(NewAction.Fields.unpublishedAction_pageId).in(pageIds);
                 criteriaList.add(pageCriteria);
             }
 
             // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object
             // would exist. To handle this, only fetch non-deleted actions
-            Criteria deletedCriteria = where(NewAction.Fields.unpublishedAction + "."
-                            + fieldName(QNewAction.newAction.unpublishedAction.deletedAt))
-                    .is(null);
+            Criteria deletedCriteria =
+                    where(NewAction.Fields.unpublishedAction_deletedAt).is(null);
             criteriaList.add(deletedCriteria);
         }
         return criteriaList;
@@ -608,9 +551,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     @Override
     public Mono<Integer> archiveDeletedUnpublishedActions(String applicationId, AclPermission permission) {
         Criteria applicationIdCriteria = this.getCriterionForFindByApplicationId(applicationId);
-        String unpublishedDeletedAtFieldName = String.format(
-                "%s.%s",
-                NewAction.Fields.unpublishedAction, fieldName(QNewAction.newAction.unpublishedAction.deletedAt));
+        String unpublishedDeletedAtFieldName = NewAction.Fields.unpublishedAction_deletedAt;
         Criteria deletedFromUnpublishedCriteria =
                 where(unpublishedDeletedAtFieldName).ne(null);
 
@@ -650,8 +591,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
             String contextId, CreatorContextType contextType, AclPermission permission, boolean includeJs) {
         List<Criteria> criteriaList = new ArrayList<>();
 
-        String contextIdPath = completeFieldName(QNewAction.newAction.unpublishedAction.pageId);
-        String contextTypePath = completeFieldName(QNewAction.newAction.unpublishedAction.contextType);
+        String contextIdPath = NewAction.Fields.unpublishedAction_pageId;
+        String contextTypePath = NewAction.Fields.unpublishedAction_contextType;
         Criteria contextTypeCriterion = new Criteria()
                 .orOperator(
                         where(contextTypePath).is(contextType),
@@ -674,8 +615,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     public Flux<NewAction> findAllPublishedActionsByContextIdAndContextType(
             String contextId, CreatorContextType contextType, AclPermission permission, boolean includeJs) {
         List<Criteria> criteriaList = new ArrayList<>();
-        String contextIdPath = completeFieldName(QNewAction.newAction.publishedAction.pageId);
-        String contextTypePath = completeFieldName(QNewAction.newAction.publishedAction.contextType);
+        String contextIdPath = NewAction.Fields.publishedAction_pageId;
+        String contextTypePath = NewAction.Fields.publishedAction_contextType;
         Criteria contextIdAndContextTypeCriteria =
                 where(contextIdPath).is(contextId).and(contextTypePath).is(contextType);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.BranchAwareDomain;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.NewPage;
-import com.appsmith.server.domains.QNewPage;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
@@ -67,9 +66,8 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         Criteria applicationIdCriteria = where(NewPage.Fields.applicationId).is(applicationId);
         // In case a page has been deleted in edit mode, but still exists in deployed mode, NewPage object would exist.
         // To handle this, only fetch non-deleted pages
-        Criteria activeEditModeCriteria = where(
-                        NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.deletedAt))
-                .is(null);
+        Criteria activeEditModeCriteria =
+                where(NewPage.Fields.unpublishedPage_deletedAt).is(null);
         return queryBuilder()
                 .criteria(applicationIdCriteria, activeEditModeCriteria)
                 .permission(aclPermission)
@@ -87,15 +85,14 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         criteria.add(idCriterion);
 
         if (Boolean.TRUE.equals(viewMode)) {
-            layoutsKey = NewPage.Fields.publishedPage + "." + fieldName(QNewPage.newPage.publishedPage.layouts);
+            layoutsKey = NewPage.Fields.publishedPage_layouts;
         } else {
-            layoutsKey = NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.layouts);
+            layoutsKey = NewPage.Fields.unpublishedPage_layouts;
 
             // In case a page has been deleted in edit mode, but still exists in deployed mode, NewPage object would
             // exist. To handle this, only fetch non-deleted pages
-            Criteria deletedCriterion = where(NewPage.Fields.unpublishedPage + "."
-                            + fieldName(QNewPage.newPage.unpublishedPage.deletedAt))
-                    .is(null);
+            Criteria deletedCriterion =
+                    where(NewPage.Fields.unpublishedPage_deletedAt).is(null);
             criteria.add(deletedCriterion);
         }
         layoutsIdKey = layoutsKey + "." + FieldName.ID;
@@ -117,9 +114,8 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         if (Boolean.FALSE.equals(viewMode)) {
             // In case a page has been deleted in edit mode, but still exists in deployed mode, NewPage object would
             // exist. To handle this, only fetch non-deleted pages
-            Criteria deletedCriterion = where(NewPage.Fields.unpublishedPage + "."
-                            + fieldName(QNewPage.newPage.unpublishedPage.deletedAt))
-                    .is(null);
+            Criteria deletedCriterion =
+                    where(NewPage.Fields.unpublishedPage_deletedAt).is(null);
             criteria.add(deletedCriterion);
         }
 
@@ -141,9 +137,8 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         if (Boolean.FALSE.equals(viewMode)) {
             // In case a page has been deleted in edit mode, but still exists in deployed mode, NewPage object would
             // exist. To handle this, only fetch non-deleted pages
-            Criteria deletedCriteria = where(NewPage.Fields.unpublishedPage + "."
-                            + fieldName(QNewPage.newPage.unpublishedPage.deletedAt))
-                    .is(null);
+            Criteria deletedCriteria =
+                    where(NewPage.Fields.unpublishedPage_deletedAt).is(null);
             criteria.add(deletedCriteria);
         }
 
@@ -152,20 +147,20 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
 
     @Override
     public Flux<NewPage> findAllPageDTOsByIds(List<String> ids, AclPermission aclPermission) {
-        ArrayList<String> includedFields = new ArrayList<>(List.of(
+        List<String> includedFields = List.of(
                 FieldName.APPLICATION_ID,
                 FieldName.DEFAULT_RESOURCES,
                 NewPage.Fields.policies,
-                (NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.name)),
-                (NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.icon)),
-                (NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.isHidden)),
-                (NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.slug)),
-                (NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.customSlug)),
-                (NewPage.Fields.publishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.name)),
-                (NewPage.Fields.publishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.icon)),
-                (NewPage.Fields.publishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.isHidden)),
-                (NewPage.Fields.publishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.slug)),
-                (NewPage.Fields.publishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.customSlug))));
+                NewPage.Fields.unpublishedPage_name,
+                NewPage.Fields.unpublishedPage_icon,
+                NewPage.Fields.unpublishedPage_isHidden,
+                NewPage.Fields.unpublishedPage_slug,
+                NewPage.Fields.unpublishedPage_customSlug,
+                NewPage.Fields.publishedPage_name,
+                NewPage.Fields.publishedPage_icon,
+                NewPage.Fields.publishedPage_isHidden,
+                NewPage.Fields.publishedPage_slug,
+                NewPage.Fields.publishedPage_customSlug);
 
         Criteria idsCriterion = where("id").in(ids);
 
@@ -180,9 +175,9 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         String nameKey;
 
         if (Boolean.TRUE.equals(viewMode)) {
-            nameKey = NewPage.Fields.publishedPage + "." + fieldName(QNewPage.newPage.publishedPage.name);
+            nameKey = NewPage.Fields.publishedPage_name;
         } else {
-            nameKey = NewPage.Fields.unpublishedPage + "." + fieldName(QNewPage.newPage.unpublishedPage.name);
+            nameKey = NewPage.Fields.unpublishedPage_name;
         }
         return where(nameKey).is(name);
     }
@@ -220,24 +215,15 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
     @Override
     public Flux<NewPage> findSlugsByApplicationIds(List<String> applicationIds, AclPermission aclPermission) {
         Criteria applicationIdCriteria = where(NewPage.Fields.applicationId).in(applicationIds);
-        String unpublishedSlugFieldPath = String.format(
-                "%s.%s", NewPage.Fields.unpublishedPage, fieldName(QNewPage.newPage.unpublishedPage.slug));
-        String unpublishedCustomSlugFieldPath = String.format(
-                "%s.%s", NewPage.Fields.unpublishedPage, fieldName(QNewPage.newPage.unpublishedPage.customSlug));
-        String publishedSlugFieldPath =
-                String.format("%s.%s", NewPage.Fields.publishedPage, fieldName(QNewPage.newPage.publishedPage.slug));
-        String publishedCustomSlugFieldPath = String.format(
-                "%s.%s", NewPage.Fields.publishedPage, fieldName(QNewPage.newPage.publishedPage.customSlug));
-        String applicationIdFieldPath = NewPage.Fields.applicationId;
 
         return queryBuilder()
                 .criteria(applicationIdCriteria)
                 .fields(
-                        unpublishedSlugFieldPath,
-                        unpublishedCustomSlugFieldPath,
-                        publishedSlugFieldPath,
-                        publishedCustomSlugFieldPath,
-                        applicationIdFieldPath)
+                        NewPage.Fields.unpublishedPage_slug,
+                        NewPage.Fields.unpublishedPage_customSlug,
+                        NewPage.Fields.publishedPage_slug,
+                        NewPage.Fields.publishedPage_customSlug,
+                        NewPage.Fields.applicationId)
                 .permission(aclPermission)
                 .all();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -20,7 +20,6 @@ import com.appsmith.server.domains.GitArtifactMetadata;
 import com.appsmith.server.domains.Layout;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
-import com.appsmith.server.domains.QNewAction;
 import com.appsmith.server.domains.Theme;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
@@ -88,7 +87,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
-import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.fieldName;
 import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 
 @Slf4j
@@ -1448,11 +1446,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
         Flux<BaseDomain> datasourceFlux = applicationMono
                 .flatMapMany(application -> newActionRepository.findAllByApplicationIdsWithoutPermission(
                         List.of(application.getId()),
-                        List.of(
-                                "id",
-                                NewAction.Fields.unpublishedAction + "."
-                                        + fieldName(QNewAction.newAction.unpublishedAction.datasource) + "."
-                                        + fieldName(QNewAction.newAction.unpublishedAction.datasource.id))))
+                        List.of(BaseDomain.Fields.id, NewAction.Fields.unpublishedAction_datasource_id)))
                 .collectList()
                 .map(actions -> {
                     return actions.stream()


### PR DESCRIPTION
Continuation of https://github.com/appsmithorg/appsmith/pull/31269.

We're not removing QueryDSL itself in this PR. That will happen after we remove uses on the EE repo as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error message handling for application version validation.
	- Enhanced field access in application and page services for better readability and maintenance.
	- Streamlined criteria for fetching action collections and pages based on view mode.
- **Chores**
	- Updated various classes with `@FieldNameConstants` annotation for consistent field naming.
	- Adjusted method parameters and updated migration scripts for MySQL datasources to enhance database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->