### PR TITLE
chore: Fix for CVE-2024-1597

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/pom.xml
+++ b/app/server/appsmith-plugins/postgresPlugin/pom.xml
@@ -20,6 +20,8 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <!-- Overriding version to get fix for CVE-2024-1597. Remove once spring-boot is at least at 3.1.9 or 3.2.3 -->
+            <version>42.6.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This should get rid of the vulnerable Postgres driver version.