### PR TITLE
fix: Make the active tab standout from the background

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
@@ -42,6 +42,7 @@ export const StyledTab = styled(Flex)`
   }
 
   &.active {
+    background: var(--ads-v2-colors-control-field-default-bg);
     border-top: 2px solid var(--ads-v2-color-bg-brand);
     border-left: 1px solid var(--ads-v2-color-border);
     border-right: 1px solid var(--ads-v2-color-border);


### PR DESCRIPTION
Regression from the previous state where the background of the active tab has been missed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the background color of the active tab in the editor for improved visibility and aesthetics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->