### PR TITLE
chore: Remove deprecated API uses in SecurityConfig

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -115,12 +115,10 @@ public class SecurityConfig {
      * hence using RouterFunctions to implement this feature.
      * <p>
      * Future folks: Please check out links:
-     * - https://www.baeldung.com/spring-webflux-static-content
-     * - https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html#webflux-config-static-resources
+     * - <a href="https://www.baeldung.com/spring-webflux-static-content">...</a>
+     * - <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html#webflux-config-static-resources">...</a>
      * - Class ResourceHandlerRegistry
      * for details. If you figure out a cleaner approach, please modify this function
-     *
-     * @return
      */
     @Bean
     public RouterFunction<ServerResponse> publicRouter() {
@@ -136,8 +134,7 @@ public class SecurityConfig {
     @Bean
     public SecurityWebFilterChain internalWebFilterChain(ServerHttpSecurity http) {
         return http.securityMatcher(new PathPatternParserServerWebExchangeMatcher("/actuator/**"))
-                .httpBasic()
-                .authenticationManager(authentication -> {
+                .httpBasic(httpBasicSpec -> httpBasicSpec.authenticationManager(authentication -> {
                     if (INTERNAL_PASSWORD.equals(authentication.getCredentials().toString())) {
                         return Mono.just(UsernamePasswordAuthenticationToken.authenticated(
                                 authentication.getPrincipal(),
@@ -147,79 +144,72 @@ public class SecurityConfig {
                         return Mono.just(UsernamePasswordAuthenticationToken.unauthenticated(
                                 authentication.getPrincipal(), authentication.getCredentials()));
                     }
-                })
-                .and()
-                .authorizeExchange()
-                .anyExchange()
-                .hasAnyAuthority(INTERNAL)
-                .and()
+                }))
+                .authorizeExchange(authorizeExchangeSpec ->
+                        authorizeExchangeSpec.anyExchange().hasAnyAuthority(INTERNAL))
                 .build();
     }
 
     @Bean
+    @SuppressWarnings("Convert2MethodRef") // Helps readability.
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
         ServerAuthenticationEntryPointFailureHandler failureHandler =
                 new ServerAuthenticationEntryPointFailureHandler(authenticationEntryPoint);
 
         return http
                 // The native CSRF solution doesn't work with WebFlux, yet, but only for WebMVC. So we make our own.
-                .csrf()
-                .disable()
+                .csrf(csrfSpec -> csrfSpec.disable())
                 .addFilterAt(new CSRFFilter(), SecurityWebFiltersOrder.CSRF)
                 // Default security headers configuration from
                 // https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/headers.html
-                .headers()
-                // Disabled here because add it in NGINX instead.
-                .contentTypeOptions()
-                .disable()
-                // Disabled because we use CSP's `frame-ancestors` instead.
-                .frameOptions()
-                .disable()
-                .and()
-                .anonymous()
-                .principal(createAnonymousUser())
-                .and()
+                .headers(headerSpec -> headerSpec
+                        // Disabled here because add it in Caddy instead.
+                        .contentTypeOptions(options -> options.disable())
+                        // Disabled because we use CSP's `frame-ancestors` instead.
+                        .frameOptions(options -> options.disable()))
+                .anonymous(anonymousSpec -> anonymousSpec.principal(createAnonymousUser()))
                 // This returns 401 unauthorized for all requests that are not authenticated but authentication is
                 // required
                 // The client will redirect to the login page if we return 401 as Http status response
-                .exceptionHandling()
-                .authenticationEntryPoint(authenticationEntryPoint)
-                .accessDeniedHandler(accessDeniedHandler)
-                .and()
-                .authorizeExchange()
-                .matchers(
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, Url.LOGIN_URL),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, Url.HEALTH_CHECK),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL + "/super"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL + "/forgotPassword"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/verifyPasswordResetToken"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/resetPassword"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/invite/verify"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/invite/confirm"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/me"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/features"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ASSET_URL + "/*"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_URL + "/**"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_COLLECTION_URL + "/view"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, PAGE_URL + "/**"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, APPLICATION_URL + "/**"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, THEME_URL + "/**"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, ACTION_URL + "/execute"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, TENANT_URL + "/current"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USAGE_PULSE_URL),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, CUSTOM_JS_LIB_URL + "/*/view"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL + "/resendEmailVerification"),
-                        ServerWebExchangeMatchers.pathMatchers(
-                                HttpMethod.POST, USER_URL + "/verifyEmailVerificationToken"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, PRODUCT_ALERT + "/alert"),
-                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, CONSOLIDATED_API_URL + "/view"))
-                .permitAll()
-                .pathMatchers("/public/**", "/oauth2/**")
-                .permitAll()
-                .anyExchange()
-                .authenticated()
-                .and()
+                .exceptionHandling(exceptionHandlingSpec -> exceptionHandlingSpec
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeExchange(authorizeExchangeSpec -> authorizeExchangeSpec
+                        // The following endpoints are allowed to be accessed without authentication
+                        .matchers(
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, Url.LOGIN_URL),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, Url.HEALTH_CHECK),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL + "/super"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL + "/forgotPassword"),
+                                ServerWebExchangeMatchers.pathMatchers(
+                                        HttpMethod.GET, USER_URL + "/verifyPasswordResetToken"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/resetPassword"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/invite/verify"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/invite/confirm"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/me"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/features"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ASSET_URL + "/*"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_URL + "/**"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_COLLECTION_URL + "/view"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, PAGE_URL + "/**"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, APPLICATION_URL + "/**"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, THEME_URL + "/**"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, ACTION_URL + "/execute"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, TENANT_URL + "/current"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USAGE_PULSE_URL),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, CUSTOM_JS_LIB_URL + "/*/view"),
+                                ServerWebExchangeMatchers.pathMatchers(
+                                        HttpMethod.POST, USER_URL + "/resendEmailVerification"),
+                                ServerWebExchangeMatchers.pathMatchers(
+                                        HttpMethod.POST, USER_URL + "/verifyEmailVerificationToken"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, PRODUCT_ALERT + "/alert"),
+                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, CONSOLIDATED_API_URL + "/view"))
+                        .permitAll()
+                        .pathMatchers("/public/**", "/oauth2/**")
+                        .permitAll()
+                        .anyExchange()
+                        .authenticated())
                 // Add Pre Auth rate limit filter before authentication filter
                 .addFilterBefore(
                         new ConditionalFilter(new PreAuth(rateLimitService), Url.LOGIN_URL),
@@ -245,17 +235,14 @@ public class SecurityConfig {
                         .authenticationSuccessHandler(authenticationSuccessHandler)
                         .authenticationFailureHandler(authenticationFailureHandler)
                         .authorizedClientRepository(new ClientUserRepository(userService, commonConfig)))
-                .logout()
-                .logoutUrl(Url.LOGOUT_URL)
-                .logoutSuccessHandler(new LogoutSuccessHandler(objectMapper, analyticsService))
-                .and()
+                .logout(logoutSpec -> logoutSpec
+                        .logoutUrl(Url.LOGOUT_URL)
+                        .logoutSuccessHandler(new LogoutSuccessHandler(objectMapper, analyticsService)))
                 .build();
     }
 
     /**
      * This bean configures the parameters that need to be set when a Cookie is created for a logged in user
-     *
-     * @return
      */
     @Bean
     public WebSessionIdResolver webSessionIdResolver() {


### PR DESCRIPTION
These APIs are getting deprecated and are setting up for removal soon. This PR changes such API uses to ones that aren't deprecated. This is needed towards upgrading Spring to get rid of a few CVEs on Appsmith image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved security configurations and endpoint permissions management.
	- Enhanced code readability and maintenance in security settings through the use of lambda expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->