### PR TITLE
feat: WDS elevation borders

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -118,6 +118,10 @@ export class DarkModeTheme implements ColorModeTheme {
       bdOnPositive: this.bdOnPositive.to("sRGB").toString(),
       bdOnNegative: this.bdOnNegative.to("sRGB").toString(),
       bdOnWarning: this.bdOnWarning.to("sRGB").toString(),
+
+      bdElevation1: this.bdElevation1.to("sRGB").toString(),
+      bdElevation2: this.bdElevation2.to("sRGB").toString(),
+      bdElevation3: this.bdElevation3.to("sRGB").toString(),
     };
   };
 
@@ -1137,6 +1141,28 @@ export class DarkModeTheme implements ColorModeTheme {
 
     // Lightness of bgWarning is known, no additional checks like in bdOnAccent / bdOnNeutral
     color.oklch.l -= 0.25;
+
+    return color;
+  }
+
+  /*
+   * Elevation border colors
+   */
+
+  private get bdElevation1() {
+    const color = this.bdNeutral.clone();
+
+    return color;
+  }
+
+  private get bdElevation2() {
+    const color = this.bdNeutral.clone();
+
+    return color;
+  }
+
+  private get bdElevation3() {
+    const color = this.bdNeutral.clone();
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -14,6 +14,7 @@ export class DarkModeTheme implements ColorModeTheme {
   private readonly seedIsGreen: boolean;
   private readonly seedIsRed: boolean;
   private readonly seedIsVeryDark: boolean;
+  private readonly seedIsVeryLight: boolean;
   private readonly seedIsYellow: boolean;
 
   constructor(color: ColorTypes) {
@@ -26,6 +27,7 @@ export class DarkModeTheme implements ColorModeTheme {
       isGreen,
       isRed,
       isVeryDark,
+      isVeryLight,
       isYellow,
       lightness,
     } = new ColorsAccessor(color);
@@ -38,6 +40,7 @@ export class DarkModeTheme implements ColorModeTheme {
     this.seedIsGreen = isGreen;
     this.seedIsRed = isRed;
     this.seedIsVeryDark = isVeryDark;
+    this.seedIsVeryLight = isVeryLight;
     this.seedIsYellow = isYellow;
   }
 
@@ -1152,7 +1155,13 @@ export class DarkModeTheme implements ColorModeTheme {
   private get bdElevation1() {
     const color = this.bdNeutral.clone();
 
-    color.oklch.l -= 0.55;
+    if (this.seedIsVeryLight) {
+      color.oklch.l = 0.13;
+    }
+
+    if (!this.seedIsVeryLight) {
+      color.oklch.l -= 0.75;
+    }
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -1152,17 +1152,23 @@ export class DarkModeTheme implements ColorModeTheme {
   private get bdElevation1() {
     const color = this.bdNeutral.clone();
 
+    color.oklch.l -= 0.55;
+
     return color;
   }
 
   private get bdElevation2() {
-    const color = this.bdNeutral.clone();
+    const color = this.bdElevation1.clone();
+
+    color.oklch.l += 0.015;
 
     return color;
   }
 
   private get bdElevation3() {
-    const color = this.bdNeutral.clone();
+    const color = this.bdElevation2.clone();
+
+    color.oklch.l += 0.035;
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -1207,17 +1207,29 @@ export class LightModeTheme implements ColorModeTheme {
   private get bdElevation1() {
     const color = this.bdNeutral.clone();
 
+    if (this.seedIsVeryLight) {
+      color.oklch.l = 0.85;
+    }
+
+    if (!this.seedIsVeryLight) {
+      color.oklch.l = 0.9;
+    }
+
     return color;
   }
 
   private get bdElevation2() {
-    const color = this.bdNeutral.clone();
+    const color = this.bdElevation1.clone();
+
+    color.oklch.l += 0.03;
 
     return color;
   }
 
   private get bdElevation3() {
-    const color = this.bdNeutral.clone();
+    const color = this.bdElevation2.clone();
+
+    color.oklch.l += 0.015;
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -118,6 +118,10 @@ export class LightModeTheme implements ColorModeTheme {
       bdOnPositive: this.bdOnPositive.to("sRGB").toString(),
       bdOnNegative: this.bdOnNegative.to("sRGB").toString(),
       bdOnWarning: this.bdOnWarning.to("sRGB").toString(),
+
+      bdElevation1: this.bdElevation1.to("sRGB").toString(),
+      bdElevation2: this.bdElevation2.to("sRGB").toString(),
+      bdElevation3: this.bdElevation3.to("sRGB").toString(),
     };
   };
 
@@ -1192,6 +1196,28 @@ export class LightModeTheme implements ColorModeTheme {
 
     // Lightness of bgWarning is known, no additional checks like in bdOnAccent / bdOnNeutral
     color.oklch.l -= 0.33;
+
+    return color;
+  }
+
+  /*
+   * Elevation border colors
+   */
+
+  private get bdElevation1() {
+    const color = this.bdNeutral.clone();
+
+    return color;
+  }
+
+  private get bdElevation2() {
+    const color = this.bdNeutral.clone();
+
+    return color;
+  }
+
+  private get bdElevation3() {
+    const color = this.bdNeutral.clone();
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/types.ts
+++ b/app/client/packages/design-system/theming/src/color/src/types.ts
@@ -72,5 +72,9 @@ export interface ColorModeTheme {
     bdOnPositive: string;
     bdOnNegative: string;
     bdOnWarning: string;
+    // Elevation
+    bdElevation1: string;
+    bdElevation2: string;
+    bdElevation3: string;
   };
 }

--- a/app/client/packages/design-system/widgets/src/testing/Elevation.tsx
+++ b/app/client/packages/design-system/widgets/src/testing/Elevation.tsx
@@ -1,45 +1,159 @@
 import * as React from "react";
-import { Flex, Button } from "@design-system/widgets";
+import { Flex, Button, Text } from "@design-system/widgets";
 
 export const Elevation = () => {
   return (
-    <Flex
-      direction="column"
-      padding="spacing-6"
-      style={{
-        background: "var(--color-bg-elevation-1)",
-        // boxShadow: "var(--box-shadow-1)",
-        borderColor: "var(--color-bd-elevation-1)",
-        borderWidth: 1,
-        borderStyle: "solid",
-        borderRadius: "var(--border-radius-elevation-1)",
-      }}
-    >
-      <Flex
-        direction="column"
-        padding="spacing-6"
-        style={{
-          background: "var(--color-bg-elevation-2)",
-          // boxShadow: "var(--box-shadow-2)",
-          borderColor: "var(--color-bd-elevation-2)",
-          borderWidth: 1,
-          borderStyle: "solid",
-          borderRadius: "var(--border-radius-elevation-2)",
-        }}
-      >
-        <Flex
-          direction="column"
-          padding="spacing-6"
-          style={{
-            background: "var(--color-bg-elevation-3)",
-            // boxShadow: "var(--box-shadow-3)",
-            borderColor: "var(--color-bd-elevation-3)",
-            borderWidth: 1,
-            borderStyle: "solid",
-            borderRadius: "var(--border-radius-elevation-3)",
-          }}
-        >
-          <Button>Do the Thing</Button>
+    <Flex direction="column" gap="spacing-8">
+      <Flex direction="row" gap="spacing-6">
+        <Flex alignItems="center" direction="column" gap="spacing-4">
+          <Text variant="subtitle">Border</Text>
+          <Flex
+            direction="column"
+            padding="spacing-6"
+            style={{
+              background: "var(--color-bg-elevation-1)",
+              borderColor: "var(--color-bd-elevation-1)",
+              borderRadius: "var(--border-radius-elevation-1)",
+              borderStyle: "solid",
+              borderWidth: 1,
+            }}
+          >
+            <Flex
+              direction="column"
+              padding="spacing-6"
+              style={{
+                background: "var(--color-bg-elevation-2)",
+                borderColor: "var(--color-bd-elevation-2)",
+                borderRadius: "var(--border-radius-elevation-2)",
+                borderStyle: "solid",
+                borderWidth: 1,
+              }}
+            >
+              <Flex
+                direction="column"
+                padding="spacing-6"
+                style={{
+                  background: "var(--color-bg-elevation-3)",
+                  borderColor: "var(--color-bd-elevation-3)",
+                  borderRadius: "var(--border-radius-elevation-3)",
+                  borderStyle: "solid",
+                  borderWidth: 1,
+                }}
+              >
+                <Button>Do the Thing</Button>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Flex>
+        <Flex alignItems="center" direction="column" gap="spacing-4">
+          <Text variant="subtitle">Shadow</Text>
+          <Flex
+            direction="column"
+            padding="spacing-6"
+            style={{
+              background: "var(--color-bg-elevation-1)",
+              borderRadius: "var(--border-radius-elevation-1)",
+              boxShadow: "var(--box-shadow-1)",
+            }}
+          >
+            <Flex
+              direction="column"
+              padding="spacing-6"
+              style={{
+                background: "var(--color-bg-elevation-2)",
+                borderRadius: "var(--border-radius-elevation-2)",
+                boxShadow: "var(--box-shadow-2)",
+              }}
+            >
+              <Flex
+                direction="column"
+                padding="spacing-6"
+                style={{
+                  background: "var(--color-bg-elevation-3)",
+                  borderRadius: "var(--border-radius-elevation-3)",
+                  boxShadow: "var(--box-shadow-3)",
+                }}
+              >
+                <Button>Do the Thing</Button>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Flex direction="row" gap="spacing-6">
+        <Flex alignItems="center" direction="column" gap="spacing-4">
+          <Text variant="subtitle">Both</Text>
+          <Flex
+            direction="column"
+            padding="spacing-6"
+            style={{
+              background: "var(--color-bg-elevation-1)",
+              borderColor: "var(--color-bd-elevation-1)",
+              borderRadius: "var(--border-radius-elevation-1)",
+              borderStyle: "solid",
+              borderWidth: 1,
+              boxShadow: "var(--box-shadow-1)",
+            }}
+          >
+            <Flex
+              direction="column"
+              padding="spacing-6"
+              style={{
+                background: "var(--color-bg-elevation-2)",
+                borderColor: "var(--color-bd-elevation-2)",
+                borderRadius: "var(--border-radius-elevation-2)",
+                borderStyle: "solid",
+                borderWidth: 1,
+                boxShadow: "var(--box-shadow-2)",
+              }}
+            >
+              <Flex
+                direction="column"
+                padding="spacing-6"
+                style={{
+                  background: "var(--color-bg-elevation-3)",
+                  borderColor: "var(--color-bd-elevation-3)",
+                  borderRadius: "var(--border-radius-elevation-3)",
+                  borderStyle: "solid",
+                  borderWidth: 1,
+                  boxShadow: "var(--box-shadow-3)",
+                }}
+              >
+                <Button>Do the Thing</Button>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Flex>
+        <Flex alignItems="center" direction="column" gap="spacing-4">
+          <Text variant="subtitle">None</Text>
+          <Flex
+            direction="column"
+            padding="spacing-6"
+            style={{
+              background: "var(--color-bg-elevation-1)",
+              borderRadius: "var(--border-radius-elevation-1)",
+            }}
+          >
+            <Flex
+              direction="column"
+              padding="spacing-6"
+              style={{
+                background: "var(--color-bg-elevation-2)",
+                borderRadius: "var(--border-radius-elevation-2)",
+              }}
+            >
+              <Flex
+                direction="column"
+                padding="spacing-6"
+                style={{
+                  background: "var(--color-bg-elevation-3)",
+                  borderRadius: "var(--border-radius-elevation-3)",
+                }}
+              >
+                <Button>Do the Thing</Button>
+              </Flex>
+            </Flex>
+          </Flex>
         </Flex>
       </Flex>
     </Flex>

--- a/app/client/packages/design-system/widgets/src/testing/Elevation.tsx
+++ b/app/client/packages/design-system/widgets/src/testing/Elevation.tsx
@@ -8,8 +8,11 @@ export const Elevation = () => {
       padding="spacing-6"
       style={{
         background: "var(--color-bg-elevation-1)",
-        boxShadow: "var(--box-shadow-1)",
-        borderRadius: "var(--border-radius-elevation-3)",
+        // boxShadow: "var(--box-shadow-1)",
+        borderColor: "var(--color-bd-elevation-1)",
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderRadius: "var(--border-radius-elevation-1)",
       }}
     >
       <Flex
@@ -17,8 +20,11 @@ export const Elevation = () => {
         padding="spacing-6"
         style={{
           background: "var(--color-bg-elevation-2)",
-          boxShadow: "var(--box-shadow-2)",
-          borderRadius: "var(--border-radius-elevation-3)",
+          // boxShadow: "var(--box-shadow-2)",
+          borderColor: "var(--color-bd-elevation-2)",
+          borderWidth: 1,
+          borderStyle: "solid",
+          borderRadius: "var(--border-radius-elevation-2)",
         }}
       >
         <Flex
@@ -26,7 +32,10 @@ export const Elevation = () => {
           padding="spacing-6"
           style={{
             background: "var(--color-bg-elevation-3)",
-            boxShadow: "var(--box-shadow-3)",
+            // boxShadow: "var(--box-shadow-3)",
+            borderColor: "var(--color-bd-elevation-3)",
+            borderWidth: 1,
+            borderStyle: "solid",
             borderRadius: "var(--border-radius-elevation-3)",
           }}
         >


### PR DESCRIPTION
Fixes #31020 

We now have options to express elevation with backgrounds plus shadows, borders, or a combination of both.

https://github.com/appsmithorg/appsmith/assets/80973/6ab62bc7-b2e9-4de5-9c6a-d5447b591b14




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new methods in both dark and light mode themes to calculate elevation border color.
- **Refactor**
	- Restructured the `Elevation` testing story to offer a display of borders, shadows, and combined effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->