### PR TITLE
chore: No upsert when saving datasource structure

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCE.java
@@ -5,5 +5,5 @@ import reactor.core.publisher.Mono;
 
 public interface CustomDatasourceStorageStructureRepositoryCE {
 
-    Mono<Integer> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure);
+    Mono<Void> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCE.java
@@ -5,5 +5,5 @@ import reactor.core.publisher.Mono;
 
 public interface CustomDatasourceStorageStructureRepositoryCE {
 
-    Mono<Void> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure);
+    Mono<Integer> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
@@ -2,22 +2,30 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.external.models.DatasourceStorageStructure;
 import com.appsmith.external.models.DatasourceStructure;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
+import com.appsmith.server.repositories.DatasourceStorageStructureRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 
 @Component
 public class CustomDatasourceStorageStructureRepositoryCEImpl
         extends BaseAppsmithRepositoryImpl<DatasourceStorageStructure>
         implements CustomDatasourceStorageStructureRepositoryCE {
+
+    @SuppressWarnings("SpringJavaAutowiredFieldsWarningInspection") // Can't do lazy wiring in constructor params.
+    @Autowired
+    @Lazy
+    DatasourceStorageStructureRepository repository;
+
     public CustomDatasourceStorageStructureRepositoryCEImpl(
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
@@ -25,20 +33,22 @@ public class CustomDatasourceStorageStructureRepositoryCEImpl
         super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
     }
 
-    public static Criteria getDatasourceIdAndEnvironmentIdCriteria(String datasourceId, String environmentId) {
-        return new Criteria()
-                .andOperator(
-                        where(DatasourceStorageStructure.Fields.datasourceId).is(datasourceId),
-                        where(DatasourceStorageStructure.Fields.environmentId).is(environmentId));
-    }
-
     @Override
-    public Mono<Integer> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
-        return mongoOperations
-                .upsert(
-                        new Query().addCriteria(getDatasourceIdAndEnvironmentIdCriteria(datasourceId, environmentId)),
-                        Update.update(DatasourceStorageStructure.Fields.structure, structure),
-                        DatasourceStorageStructure.class)
-                .map(updateResult -> Math.toIntExact(updateResult.getModifiedCount()));
+    public Mono<Void> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
+        final Bridge criteria = bridge().equal(DatasourceStorageStructure.Fields.datasourceId, datasourceId)
+                .equal(DatasourceStorageStructure.Fields.environmentId, environmentId);
+
+        final Update update = Update.update(DatasourceStorageStructure.Fields.structure, structure);
+
+        return queryBuilder().criteria(criteria).updateFirst(update).flatMap(count -> {
+            if (count == 0) {
+                DatasourceStorageStructure dss = new DatasourceStorageStructure();
+                dss.setDatasourceId(datasourceId);
+                dss.setEnvironmentId(environmentId);
+                dss.setStructure(structure);
+                return repository.save(dss).then();
+            }
+            return Mono.empty();
+        });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
@@ -2,12 +2,8 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.external.models.DatasourceStorageStructure;
 import com.appsmith.external.models.DatasourceStructure;
-import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import com.appsmith.server.repositories.DatasourceStorageStructureRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Update;
@@ -21,11 +17,6 @@ public class CustomDatasourceStorageStructureRepositoryCEImpl
         extends BaseAppsmithRepositoryImpl<DatasourceStorageStructure>
         implements CustomDatasourceStorageStructureRepositoryCE {
 
-    @SuppressWarnings("SpringJavaAutowiredFieldsWarningInspection") // Can't do lazy wiring in constructor params.
-    @Autowired
-    @Lazy
-    DatasourceStorageStructureRepository repository;
-
     public CustomDatasourceStorageStructureRepositoryCEImpl(
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
@@ -34,21 +25,10 @@ public class CustomDatasourceStorageStructureRepositoryCEImpl
     }
 
     @Override
-    public Mono<Void> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
-        final Bridge criteria = bridge().equal(DatasourceStorageStructure.Fields.datasourceId, datasourceId)
-                .equal(DatasourceStorageStructure.Fields.environmentId, environmentId);
-
-        final Update update = Update.update(DatasourceStorageStructure.Fields.structure, structure);
-
-        return queryBuilder().criteria(criteria).updateFirst(update).flatMap(count -> {
-            if (count == 0) {
-                DatasourceStorageStructure dss = new DatasourceStorageStructure();
-                dss.setDatasourceId(datasourceId);
-                dss.setEnvironmentId(environmentId);
-                dss.setStructure(structure);
-                return repository.save(dss).then();
-            }
-            return Mono.empty();
-        });
+    public Mono<Integer> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
+        return queryBuilder()
+                .criteria(bridge().equal(DatasourceStorageStructure.Fields.datasourceId, datasourceId)
+                        .equal(DatasourceStorageStructure.Fields.environmentId, environmentId))
+                .updateFirst(Update.update(DatasourceStorageStructure.Fields.structure, structure));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStructureServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStructureServiceCE.java
@@ -10,5 +10,5 @@ public interface DatasourceStructureServiceCE {
 
     Mono<DatasourceStorageStructure> save(DatasourceStorageStructure datasourceStorageStructure);
 
-    Mono<Integer> saveStructure(String datasourceId, String environmentId, DatasourceStructure structure);
+    Mono<Void> saveStructure(String datasourceId, String environmentId, DatasourceStructure structure);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStructureServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStructureServiceCEImpl.java
@@ -25,7 +25,7 @@ public class DatasourceStructureServiceCEImpl implements DatasourceStructureServ
     }
 
     @Override
-    public Mono<Integer> saveStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
+    public Mono<Void> saveStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
         return repository.updateStructure(datasourceId, environmentId, structure);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStructureServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStructureServiceCEImpl.java
@@ -26,6 +26,17 @@ public class DatasourceStructureServiceCEImpl implements DatasourceStructureServ
 
     @Override
     public Mono<Void> saveStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
-        return repository.updateStructure(datasourceId, environmentId, structure);
+        return repository
+                .updateStructure(datasourceId, environmentId, structure)
+                .flatMap(count -> {
+                    if (count == 0) {
+                        DatasourceStorageStructure dss = new DatasourceStorageStructure();
+                        dss.setDatasourceId(datasourceId);
+                        dss.setEnvironmentId(environmentId);
+                        dss.setStructure(structure);
+                        return repository.save(dss).then();
+                    }
+                    return Mono.empty();
+                });
     }
 }


### PR DESCRIPTION
Instead of `upsert`, we `update` first, which is arguably the most used operation in this context, and if that fails, then we attempt an insert.

We're not expecting a performance hit, since most operations here would be an actual `update` only.


cherry picked from commit 75d2f2a8c455cd900aff83b5f1ac5b76ae72cce3, which was accidentally pushed to `release` branch.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the method for updating datasource structures for better reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->