### PR TITLE
chore: Remove upsert in setting last release notes version

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCE.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface CustomUserDataRepositoryCE extends AppsmithRepository<UserData> {
 
-    Mono<Void> saveReleaseNotesViewedVersion(String userId, String version);
+    Mono<Integer> saveReleaseNotesViewedVersion(String userId, String version);
 
     Mono<Void> removeIdFromRecentlyUsedList(String userId, String workspaceId, List<String> applicationIds);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -14,8 +14,6 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 
 import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
-import static org.springframework.data.mongodb.core.query.Criteria.where;
-import static org.springframework.data.mongodb.core.query.Query.query;
 
 public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<UserData>
         implements CustomUserDataRepositoryCE {
@@ -28,14 +26,10 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
     }
 
     @Override
-    public Mono<Void> saveReleaseNotesViewedVersion(String userId, String version) {
-        return mongoOperations
-                .upsert(
-                        query(where(UserData.Fields.userId).is(userId)),
-                        Update.update(UserData.Fields.releaseNotesViewedVersion, version)
-                                .setOnInsert(UserData.Fields.userId, userId),
-                        UserData.class)
-                .then();
+    public Mono<Integer> saveReleaseNotesViewedVersion(String userId, String version) {
+        return queryBuilder()
+                .criteria(bridge().equal(UserData.Fields.userId, userId))
+                .updateFirst(Update.update(UserData.Fields.releaseNotesViewedVersion, version));
     }
 
     @Override


### PR DESCRIPTION
Instead of `upsert`, we `update` first, which is arguably the most used operation in this context, and if that fails, then we attempt an insert.

We're not expecting a performance hit, since most operations here would be an actual `update` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the method for saving viewed release notes versions to improve performance and reliability.
- **Bug Fixes**
	- Fixed an issue where viewing release notes under certain conditions wouldn't save correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->