### PR TITLE
chore: Use queryBuilder for count op

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -22,7 +22,6 @@ import org.springframework.data.mongodb.core.aggregation.MatchOperation;
 import org.springframework.data.mongodb.core.aggregation.ProjectionOperation;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -351,12 +350,9 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 where(NewAction.Fields.publishedAction + ".datasource._id").is(new ObjectId(datasourceId));
 
         Criteria datasourceCriteria =
-                notDeleted().orOperator(unpublishedDatasourceCriteria, publishedDatasourceCriteria);
+                new Criteria().orOperator(unpublishedDatasourceCriteria, publishedDatasourceCriteria);
 
-        Query query = new Query();
-        query.addCriteria(datasourceCriteria);
-
-        return mongoOperations.count(query, NewAction.class);
+        return queryBuilder().criteria(datasourceCriteria).count();
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of counting documents by datasource ID in the server's database interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->