### PR TITLE
chore: Revert Upgrade Mockito and surefire plugin (#31073)

### DIFF
--- a/app/server/appsmith-plugins/pom.xml
+++ b/app/server/appsmith-plugins/pom.xml
@@ -209,6 +209,16 @@
 
         </dependency>
 
+        <dependency>
+
+            <groupId>org.mockito</groupId>
+
+            <artifactId>mockito-inline</artifactId>
+
+            <version>${mockito.version}</version>
+
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver3 -->
 
         <dependency>

--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -370,6 +370,11 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
         </dependency>

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -324,7 +324,7 @@ public class EnvManagerTest {
         file.deleteOnExit();
 
         Mockito.when(commonConfig.getEnvFilePath()).thenReturn(file.getAbsolutePath());
-        Mockito.when(fileUtils.createZip(any(FileUtils.ZipSourceFile[].class))).thenReturn(new byte[1024]);
+        Mockito.when(fileUtils.createZip(any())).thenReturn(new byte[1024]);
 
         ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
         ServerHttpResponse response = Mockito.mock(ServerHttpResponse.class);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -165,7 +165,9 @@ class ActionExecutionSolutionCEImplTest {
                 configService,
                 tenantService);
 
-        Mockito.when(observationRegistry.isNoop()).thenReturn(true);
+        ObservationRegistry.ObservationConfig mockObservationConfig =
+                Mockito.mock(ObservationRegistry.ObservationConfig.class);
+        Mockito.when(observationRegistry.observationConfig()).thenReturn(mockObservationConfig);
     }
 
     @BeforeEach

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -32,7 +32,7 @@
         <logback.version>1.4.14</logback.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <mockito.version>5.10.0</mockito.version>
+        <mockito.version>4.4.0</mockito.version>
         <mockwebserver.version>5.0.0-alpha.2</mockwebserver.version>
         <okhttp3.version>4.10.0</okhttp3.version>
         <org.pf4j.version>3.10.0</org.pf4j.version>
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <printSummary>true</printSummary>
                     <!-- Allow JUnit to access the test classes -->
@@ -85,6 +85,19 @@
                         --add-opens java.base/java.time=ALL-UNNAMED
                         --add-opens java.base/java.util=ALL-UNNAMED</argLine>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.6.2</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>org.junit.platform</groupId>
+                                <artifactId>junit-platform-commons</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reverts commit 56479164787fed420f641f98ade5e759ada2a9c2.

This seems to have broken our ability to re-run failed tests on server workflow. We'll bring the changes back after we figure out how to not lose that capability.

