### PR TITLE
chore: skip setup update tree in eval triggers

### DIFF
--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+#cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Numeric_Spec.ts
 
 
 # For running all specs - uncomment below:

--- a/app/client/src/workers/Evaluation/handlers/evalTrigger.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTrigger.ts
@@ -18,15 +18,15 @@ export default async function (request: EvalWorkerASyncRequest) {
 
   ExecutionMetaData.setExecutionMetaData({ triggerMeta, eventType });
 
-  const { evalOrder, unEvalUpdates } = dataTreeEvaluator.setupUpdateTree(
-    unEvalTree.unEvalTree,
-    unEvalTree.configTree,
-  );
+  // const { evalOrder, unEvalUpdates } = dataTreeEvaluator.setupUpdateTree(
+  //   unEvalTree.unEvalTree,
+  //   unEvalTree.configTree,
+  // );
 
   const { contextTree } = dataTreeEvaluator.evalAndValidateSubTree(
-    evalOrder,
+    [],
     unEvalTree.configTree,
-    unEvalUpdates,
+    [],
   );
 
   return dataTreeEvaluator.evaluateTriggers(


### PR DESCRIPTION
Fixes #31190

This PR does a POC to skip calculating diffs between uneval trees in EVALUATE_TRIGGER flows since architecturally it shouldn't be required. EVAL_TREE action preceding it in all scenarios should be calculating the diff for it already. Redoing the diff seems redundant and adds latency to EVALUATE_TRIGGER flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **Refactor**
	- Improved the efficiency of trigger evaluations in the application by refining the parameters and logic used in the evaluation process.
	- Commented out a section of code related to setting up update trees in `evalTrigger.ts`.
	- Switched the test spec from `Fork_Template_spec.js` to `Numeric_Spec.ts` in the `ServerSide/Postgres_DataTypes` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->