### PR TITLE
chore: Remove `mongoTemplate` from custom action repo impl

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
@@ -17,6 +17,6 @@ public class CustomNewActionRepositoryImpl extends CustomNewActionRepositoryCEIm
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper,
             MongoTemplate mongoTemplate) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper, mongoTemplate);
+        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -12,7 +12,6 @@ import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
@@ -26,7 +25,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -44,15 +42,11 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<NewAction>
         implements CustomNewActionRepositoryCE {
 
-    private final MongoTemplate mongoTemplate;
-
     public CustomNewActionRepositoryCEImpl(
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            MongoTemplate mongoTemplate) {
+            CacheableRepositoryHelper cacheableRepositoryHelper) {
         super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
-        this.mongoTemplate = mongoTemplate;
     }
 
     @Override
@@ -515,37 +509,34 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     @Override
     public Mono<Void> publishActions(String applicationId, AclPermission permission) {
         Criteria applicationIdCriteria = this.getCriterionForFindByApplicationId(applicationId);
+        return copyUnpublishedActionToPublishedAction(applicationIdCriteria, permission);
+    }
 
+    protected Mono<Void> copyUnpublishedActionToPublishedAction(Criteria criteria, AclPermission permission) {
         Mono<Set<String>> permissionGroupsMono =
                 getCurrentUserPermissionGroupsIfRequired(Optional.ofNullable(permission));
 
         return permissionGroupsMono
-                .flatMap(permissionGroups -> {
-                    return Mono.fromCallable(() -> {
-                                AggregationOperation matchAggregationWithPermission = null;
-                                if (permission == null) {
-                                    matchAggregationWithPermission =
-                                            Aggregation.match(new Criteria().andOperator(notDeleted()));
-                                } else {
-                                    matchAggregationWithPermission = Aggregation.match(new Criteria()
-                                            .andOperator(notDeleted(), userAcl(permissionGroups, permission)));
-                                }
-                                AggregationOperation matchAggregation = Aggregation.match(applicationIdCriteria);
-                                AggregationOperation wholeProjection = Aggregation.project(NewAction.class);
-                                AggregationOperation addFieldsOperation = Aggregation.addFields()
-                                        .addField(NewAction.Fields.publishedAction)
-                                        .withValueOf(Fields.field(NewAction.Fields.unpublishedAction))
-                                        .build();
-                                Aggregation combinedAggregation = Aggregation.newAggregation(
-                                        matchAggregation,
-                                        matchAggregationWithPermission,
-                                        wholeProjection,
-                                        addFieldsOperation);
-                                return mongoTemplate.aggregate(combinedAggregation, NewAction.class, NewAction.class);
-                            })
-                            .subscribeOn(Schedulers.boundedElastic());
+                .flatMapMany(permissionGroups -> {
+                    AggregationOperation matchAggregationWithPermission;
+                    if (permission == null) {
+                        matchAggregationWithPermission = Aggregation.match(new Criteria().andOperator(notDeleted()));
+                    } else {
+                        matchAggregationWithPermission = Aggregation.match(
+                                new Criteria().andOperator(notDeleted(), userAcl(permissionGroups, permission)));
+                    }
+                    AggregationOperation matchAggregation = Aggregation.match(criteria);
+                    AggregationOperation wholeProjection = Aggregation.project(NewAction.class);
+                    AggregationOperation addFieldsOperation = Aggregation.addFields()
+                            .addField(NewAction.Fields.publishedAction)
+                            .withValueOf(Fields.field(NewAction.Fields.unpublishedAction))
+                            .build();
+                    Aggregation combinedAggregation = Aggregation.newAggregation(
+                            matchAggregation, matchAggregationWithPermission, wholeProjection, addFieldsOperation);
+                    return mongoOperations.aggregate(combinedAggregation, NewAction.class, NewAction.class);
                 })
-                .flatMap(updatedResults -> bulkUpdate(updatedResults.getMappedResults()));
+                .collectList()
+                .flatMap(this::bulkUpdate);
     }
 
     @Override


### PR DESCRIPTION
1. We remove the `mongoTemplate` and replace it with `mongoOperations`, which we get from the base impl class anyway. One less thing to port.

2. We also move the actual _publish_ logic to a separate protected method so it can be reused in the EE repo impl class, which has this logic duplicated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated constructors in specific repository classes for streamlined dependency management.
	- Enhanced the publish actions process with improved aggregation operations and a new method for action state management.
	- Transitioned from `mongoTemplate` to `mongoOperations` for certain database operations, optimizing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->