### PR TITLE
fix: Google Sheet Side by Side

### DIFF
--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/hooks.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/hooks.ts
@@ -23,6 +23,7 @@ import {
   BUILDER_PATH,
   BUILDER_PATH_DEPRECATED,
 } from "@appsmith/constants/routes/appRoutes";
+import { SAAS_EDITOR_API_ID_PATH } from "pages/Editor/SaaSEditor/constants";
 import ApiEditor from "pages/Editor/APIEditor";
 import type { UseRoutes } from "@appsmith/entities/IDE/constants";
 import { EditorViewMode } from "@appsmith/entities/IDE/constants";
@@ -114,13 +115,20 @@ export const useQuerySegmentRoutes = (path: string): UseRoutes => {
         path: [`${path}${ADD_PATH}`, `${path}/:queryId${ADD_PATH}`],
       },
       {
-        key: "QueryEditor",
+        key: "SAASEditor",
         component: QueryEditor,
         exact: true,
         path: [
-          path + "/api/:apiId", // SAAS path
-          path + "/:queryId",
+          BUILDER_PATH + SAAS_EDITOR_API_ID_PATH,
+          BUILDER_CUSTOM_PATH + SAAS_EDITOR_API_ID_PATH,
+          BUILDER_PATH_DEPRECATED + SAAS_EDITOR_API_ID_PATH,
         ],
+      },
+      {
+        key: "QueryEditor",
+        component: QueryEditor,
+        exact: true,
+        path: [path + "/:queryId"],
       },
     ];
   }

--- a/app/client/src/ce/pages/Editor/IDE/MainPane/useRoutes.ts
+++ b/app/client/src/ce/pages/Editor/IDE/MainPane/useRoutes.ts
@@ -92,7 +92,6 @@ function useRoutes(path: string): RouteReturnType[] {
           `${path}${CURL_IMPORT_PAGE_PATH}`,
           `${path}${CURL_IMPORT_PAGE_PATH}${ADD_PATH}`,
           `${path}${SAAS_EDITOR_PATH}`,
-          `${path}${SAAS_EDITOR_DATASOURCE_ID_PATH}`,
           `${path}${SAAS_EDITOR_API_ID_PATH}`,
           `${path}${SAAS_EDITOR_API_ID_ADD_PATH}`,
           `${path}${APP_LIBRARIES_EDITOR_PATH}`,
@@ -122,6 +121,12 @@ function useRoutes(path: string): RouteReturnType[] {
         component: DatasourceBlankState,
         exact: true,
         path: `${path}${DATA_SOURCES_EDITOR_LIST_PATH}`,
+      },
+      {
+        key: "SAASDatasourceEditor",
+        component: DatasourceForm,
+        exact: true,
+        path: `${path}${SAAS_EDITOR_DATASOURCE_ID_PATH}`,
       },
       {
         key: "GeneratePage",

--- a/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
@@ -57,6 +57,7 @@ export const resolveActionURL = ({
   if (pluginType === PluginType.SAAS) {
     return saasEditorApiIdURL({
       parentEntityId,
+      // It is safe to assume at this date, that only Google Sheets uses and will use PluginType.SAAS
       pluginPackageName: PluginPackageName.GOOGLE_SHEETS,
       apiId: id,
     });

--- a/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
@@ -6,7 +6,11 @@ import {
   EntityIcon,
   ENTITY_ICON_SIZE,
 } from "../ExplorerIcons";
-import { isGraphqlPlugin, PluginType } from "entities/Action";
+import {
+  isGraphqlPlugin,
+  PluginPackageName,
+  PluginType,
+} from "entities/Action";
 import { generateReactKey } from "utils/generators";
 
 import type { Plugin } from "api/PluginApi";
@@ -48,13 +52,12 @@ export interface ResolveActionURLProps {
 export const resolveActionURL = ({
   id,
   parentEntityId,
-  plugin,
   pluginType,
 }: ResolveActionURLProps) => {
-  if (!!plugin && pluginType === PluginType.SAAS) {
+  if (pluginType === PluginType.SAAS) {
     return saasEditorApiIdURL({
       parentEntityId,
-      pluginPackageName: plugin.packageName,
+      pluginPackageName: PluginPackageName.GOOGLE_SHEETS,
       apiId: id,
     });
   } else if (


### PR DESCRIPTION
## Description

Fixes GSheets (SaaS) routing for Side by Side

- Adds the missing Datasource Editor when in split screen
- Adds new SaaS Editor Route in Split Screen Query Segment
- Fixes the URL resolution by taking a safer bet


#### PR fixes following issue(s)
Fixes #31379



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced routing in the IDE to support a more streamlined editing experience for SAAS datasources.
	- Improved action resolution for Google Sheets, making it more straightforward to use within the app editor.

- **Refactor**
	- Updated key naming and path structures for better clarity and maintenance in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->