### PR TITLE
test: Add AssertJ for plugins, for better assertions

### DIFF
--- a/app/server/appsmith-plugins/pom.xml
+++ b/app/server/appsmith-plugins/pom.xml
@@ -5,136 +5,79 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-
         <groupId>com.appsmith</groupId>
-
         <artifactId>integrated</artifactId>
-
         <version>1.0-SNAPSHOT</version>
-
     </parent>
 
     <artifactId>appsmith-plugins</artifactId>
-
     <version>1.0-SNAPSHOT</version>
-
     <packaging>pom</packaging>
 
     <modules>
-
         <module>oraclePlugin</module>
-
         <module>postgresPlugin</module>
-
         <module>restApiPlugin</module>
-
         <module>mongoPlugin</module>
-
         <module>mysqlPlugin</module>
-
         <module>elasticSearchPlugin</module>
-
         <module>dynamoPlugin</module>
-
         <module>redisPlugin</module>
-
         <module>mssqlPlugin</module>
-
         <module>firestorePlugin</module>
-
         <module>redshiftPlugin</module>
-
         <module>amazons3Plugin</module>
-
         <module>googleSheetsPlugin</module>
-
         <module>graphqlPlugin</module>
-
         <module>snowflakePlugin</module>
-
         <module>arangoDBPlugin</module>
-
         <module>jsPlugin</module>
-
         <module>saasPlugin</module>
-
         <module>smtpPlugin</module>
-
         <module>openAiPlugin</module>
-
         <module>anthropicPlugin</module>
-
         <module>googleAiPlugin</module>
         <module>appsmithAiPlugin</module>
-
         <module>awsLambdaPlugin</module>
-
         <module>databricksPlugin</module>
-
     </modules>
 
     <properties>
-
         <jjwt.version>0.11.5</jjwt.version>
-
     </properties>
 
     <dependencies>
 
         <dependency>
-
             <groupId>org.pf4j</groupId>
-
             <artifactId>pf4j-spring</artifactId>
-
             <version>0.8.0</version>
-
             <scope>provided</scope>
-
             <exclusions>
-
                 <exclusion>
-
                     <groupId>org.slf4j</groupId>
-
                     <artifactId>slf4j-reload4j</artifactId>
-
                 </exclusion>
-
             </exclusions>
-
         </dependency>
 
         <dependency>
-
             <groupId>org.pf4j</groupId>
-
             <artifactId>pf4j</artifactId>
-
             <version>${org.pf4j.version}</version>
-
         </dependency>
 
         <dependency>
-
             <groupId>com.appsmith</groupId>
-
             <artifactId>interfaces</artifactId>
-
             <version>1.0-SNAPSHOT</version>
-
             <scope>provided</scope>
-
         </dependency>
 
         <dependency>
-
             <groupId>org.projectlombok</groupId>
-
             <artifactId>lombok</artifactId>
-
             <scope>provided</scope>
-
         </dependency>
 
         <!-- Test Dependencies -->
@@ -142,133 +85,86 @@
         <!-- Actual Junit5 implementation. Will transitively include junit-jupiter-api -->
 
         <dependency>
-
             <groupId>org.junit.jupiter</groupId>
-
             <artifactId>junit-jupiter-engine</artifactId>
-
             <scope>test</scope>
-
         </dependency>
 
         <dependency>
-
             <groupId>org.junit.platform</groupId>
-
             <artifactId>junit-platform-suite-engine</artifactId>
-
             <scope>test</scope>
-
         </dependency>
 
         <!-- For junit5 parameterised test support -->
 
         <dependency>
-
             <groupId>org.junit.jupiter</groupId>
-
             <artifactId>junit-jupiter-params</artifactId>
-
             <scope>test</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Only required to run junit5 test from IDE -->
 
         <dependency>
-
             <groupId>org.junit.platform</groupId>
-
             <artifactId>junit-platform-launcher</artifactId>
-
             <scope>test</scope>
-
         </dependency>
 
         <dependency>
-
             <groupId>io.projectreactor</groupId>
-
             <artifactId>reactor-test</artifactId>
-
             <version>${reactor-test.version}</version>
-
             <scope>test</scope>
-
         </dependency>
 
         <dependency>
-
             <groupId>org.mockito</groupId>
-
             <artifactId>mockito-core</artifactId>
-
             <version>${mockito.version}</version>
-
             <scope>test</scope>
-
         </dependency>
 
         <dependency>
-
             <groupId>org.mockito</groupId>
-
             <artifactId>mockito-inline</artifactId>
-
             <version>${mockito.version}</version>
-
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver3 -->
-
         <dependency>
-
             <groupId>com.squareup.okhttp3</groupId>
-
             <artifactId>mockwebserver3</artifactId>
-
             <version>${mockwebserver.version}</version>
-
             <scope>test</scope>
-
         </dependency>
 
         <!-- We need this dependency only to ensure TestContainers work with JUnit5 -->
-
         <dependency>
-
             <groupId>io.quarkus</groupId>
-
             <artifactId>quarkus-junit4-mock</artifactId>
-
             <version>2.14.2.Final</version>
-
             <scope>test</scope>
-
         </dependency>
 
         <dependency>
-
             <groupId>org.testcontainers</groupId>
-
             <artifactId>junit-jupiter</artifactId>
-
             <version>${testcontainers.version}</version>
-
             <scope>test</scope>
-
             <exclusions>
-
                 <exclusion>
-
                     <groupId>junit</groupId>
-
                     <artifactId>junit</artifactId>
-
                 </exclusion>
-
             </exclusions>
-
         </dependency>
 
     </dependencies>

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -66,6 +66,7 @@ import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtil
 import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils.DUPLICATE_ATTRIBUTE_LOCATION.ACTION_CONFIG_ONLY;
 import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils.DUPLICATE_ATTRIBUTE_LOCATION.DATASOURCE_AND_ACTION_CONFIG;
 import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils.DUPLICATE_ATTRIBUTE_LOCATION.DATASOURCE_CONFIG_ONLY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -1912,9 +1913,8 @@ public class RestApiPluginTest {
         StepVerifier.create(resultMono)
                 .assertNext(result -> {
                     assertFalse(result.getIsExecutionSuccess());
-                    assertTrue(result.getPluginErrorDetails()
-                            .getDownstreamErrorMessage()
-                            .contains("Host not allowed."));
+                    assertThat(result.getPluginErrorDetails().getDownstreamErrorMessage())
+                            .endsWith("Host not allowed.");
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
PR adds assertj to the plugin modules as well so we can write better assertions there. We're changing just one test, but to illustrate as an example.

With the previous assertion used here, failure messages looked like this:

```
Expected <true>, but got <false>.
```

But with the better assertions introduced in this PR, we should see something like:

```
Expected `Random unexpected string` to end with `Host not allowed.`
```

Which should help us much better in troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved the reliability of a test method related to denying AWS instance metadata access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->