### PR TITLE
fix: Client development build performance

### DIFF
--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -17,6 +17,12 @@ module.exports = {
   babel: {
     plugins: ["babel-plugin-lodash"],
   },
+  typescript: {
+    enableTypeChecking: false,
+  },
+  eslint: {
+    enable: false,
+  },
   webpack: {
     configure: {
       resolve: {

--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -17,9 +17,6 @@ module.exports = {
   babel: {
     plugins: ["babel-plugin-lodash"],
   },
-  typescript: {
-    enableTypeChecking: false,
-  },
   eslint: {
     enable: false,
   },

--- a/app/client/craco.dev.config.js
+++ b/app/client/craco.dev.config.js
@@ -7,11 +7,18 @@ module.exports = merge(common, {
     client: {
       overlay: {
         warnings: false,
-        errors: false
-      }
-    }
+        errors: false,
+      },
+    },
   },
   optimization: {
     minimize: false,
+  },
+  cache: {
+    type: "filesystem",
+    memoryCacheUnaffected: true,
+  },
+  experiments: {
+    cacheUnaffected: true,
   },
 });

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "analyze": "yarn cra-bundle-analyzer",
-    "start": "BROWSER=none EXTEND_ESLINT=true REACT_APP_ENVIRONMENT=DEVELOPMENT REACT_APP_CLIENT_LOG_LEVEL=debug HOST=dev.appsmith.com craco --max_old_space_size=7168 start",
+    "start": "BROWSER=none REACT_APP_ENVIRONMENT=DEVELOPMENT REACT_APP_CLIENT_LOG_LEVEL=debug HOST=dev.appsmith.com craco --max_old_space_size=4096 start",
     "build": "./build.sh",
     "build-airgap": "node download-assets.js && ./build.sh",
     "build-local": "craco --max-old-space-size=4096 build --config craco.build.config.js",

--- a/app/client/tsconfig.json
+++ b/app/client/tsconfig.json
@@ -35,5 +35,5 @@
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src/**/*", "./packages"],
-  "exclude": ["./packages/rts"]
+  "exclude": ["./packages/rts", "**/node_modules", "**/.*/"]
 }


### PR DESCRIPTION
## Description
Dev mode performance:
- Disabled background tape checks for dev builds briefly.
- Configured caching for dev mode
- Added TS exclude paths

Timings: 
before:  build ~ 120 sec, recompile ~ 115 sec
after: build ~ 16 sec, recompile ~ 8 sec  