### PR TITLE
fix: default icon in statbox widget

### DIFF
--- a/app/client/src/widgets/wds/WDSStatBoxWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSStatBoxWidget/config/defaultsConfig.ts
@@ -11,6 +11,6 @@ export const defaultsConfig = {
   value: "1500",
   label: "Active Users",
   sublabel: "Since 21 Jan 2022",
-  icon: "user",
+  iconName: "user",
   responsiveBehavior: ResponsiveBehavior.Fill,
 } as unknown as WidgetDefaultProps;


### PR DESCRIPTION
Fixes #31292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the `icon` property to `iconName` in the Stat Box Widget configuration for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->