### PR TITLE
chore: Static and generified bridge API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
@@ -1,63 +1,55 @@
 package com.appsmith.server.helpers.ce.bridge;
 
+import com.appsmith.external.models.BaseDomain;
 import lombok.NonNull;
-import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.query.Criteria;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
-public class Bridge extends Criteria {
-    private final List<Criteria> criteriaList = new ArrayList<>();
-
+public final class Bridge {
     private Bridge() {}
 
-    public static Bridge bridge() {
-        return new Bridge();
+    public static <T extends BaseDomain> BridgeQuery<T> query() {
+        return new BridgeQuery<>();
     }
 
-    public Bridge equal(@NonNull String key, @NonNull String value) {
-        criteriaList.add(Criteria.where(key).is(value));
-        return this;
+    @Deprecated
+    public static <T extends BaseDomain> BridgeQuery<T> bridge() {
+        return new BridgeQuery<>();
     }
 
-    public Bridge equal(@NonNull String key, @NonNull ObjectId value) {
-        criteriaList.add(Criteria.where(key).is(value));
-        return this;
+    @SafeVarargs
+    public static <T extends BaseDomain> BridgeQuery<T> or(BridgeQuery<T>... items) {
+        final BridgeQuery<T> q = new BridgeQuery<>();
+        q.checks.add(new Criteria().orOperator(items));
+        return q;
     }
 
-    public Bridge in(@NonNull String key, @NonNull Collection<String> value) {
-        criteriaList.add(Criteria.where(key).in(value));
-        return this;
+    @SafeVarargs
+    public static <T extends BaseDomain> BridgeQuery<T> and(BridgeQuery<T>... items) {
+        final BridgeQuery<T> q = new BridgeQuery<>();
+        q.checks.add(new Criteria().andOperator(items));
+        return q;
     }
 
-    public Bridge exists(@NonNull String key) {
-        criteriaList.add(Criteria.where(key).exists(true));
-        return this;
+    public static <T extends BaseDomain> BridgeQuery<T> equal(@NonNull String key, @NonNull String value) {
+        return Bridge.<T>query().equal(key, value);
     }
 
-    public Bridge isTrue(@NonNull String key) {
-        criteriaList.add(Criteria.where(key).is(true));
-        return this;
+    public static <T extends BaseDomain> BridgeQuery<T> equal(@NonNull String key, @NonNull ObjectId value) {
+        return Bridge.<T>query().equal(key, value);
     }
 
-    /**
-     * Explicitly disable the `where()` API to prevent its usage. This is because querying with this API will work here,
-     * but won't work in the Postgres version.
-     */
-    public static Bridge where() {
-        throw new UnsupportedOperationException("Not implemented");
+    public static <T extends BaseDomain> BridgeQuery<T> in(@NonNull String key, @NonNull Collection<String> value) {
+        return Bridge.<T>query().in(key, value);
     }
 
-    @Override
-    public Document getCriteriaObject() {
-        if (criteriaList.isEmpty()) {
-            throw new UnsupportedOperationException(
-                    "Empty bridge criteria leads to subtle bugs. Just don't call `.criteria()` in such cases.");
-        }
+    public static <T extends BaseDomain> BridgeQuery<T> exists(@NonNull String key) {
+        return Bridge.<T>query().exists(key);
+    }
 
-        return new Criteria().andOperator(criteriaList.toArray(new Criteria[0])).getCriteriaObject();
+    public static <T extends BaseDomain> BridgeQuery<T> isTrue(@NonNull String key) {
+        return Bridge.<T>query().isTrue(key);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
@@ -1,0 +1,70 @@
+package com.appsmith.server.helpers.ce.bridge;
+
+import com.appsmith.external.models.BaseDomain;
+import lombok.NonNull;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class BridgeQuery<T extends BaseDomain> extends Criteria {
+    final List<Criteria> checks = new ArrayList<>();
+
+    BridgeQuery() {}
+
+    public BridgeQuery<T> equal(@NonNull String key, @NonNull String value) {
+        checks.add(Criteria.where(key).is(value));
+        return this;
+    }
+
+    public BridgeQuery<T> equal(@NonNull String key, @NonNull ObjectId value) {
+        checks.add(Criteria.where(key).is(value));
+        return this;
+    }
+
+    public BridgeQuery<T> in(@NonNull String key, @NonNull Collection<String> value) {
+        checks.add(Criteria.where(key).in(value));
+        return this;
+    }
+
+    public BridgeQuery<T> exists(@NonNull String key) {
+        checks.add(Criteria.where(key).exists(true));
+        return this;
+    }
+
+    public BridgeQuery<T> isTrue(@NonNull String key) {
+        checks.add(Criteria.where(key).is(true));
+        return this;
+    }
+
+    public BridgeQuery<T> or(BridgeQuery... items) {
+        checks.add(new Criteria().orOperator(items));
+        return this;
+    }
+
+    public BridgeQuery<T> and(BridgeQuery... items) {
+        checks.add(new Criteria().andOperator(items));
+        return this;
+    }
+
+    /**
+     * Explicitly disable the `where()` API to prevent its usage. This is because querying with this API will work here,
+     * but won't work in the Postgres version.
+     */
+    public static Bridge where() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public Document getCriteriaObject() {
+        if (checks.isEmpty()) {
+            throw new UnsupportedOperationException(
+                    "Empty bridge criteria leads to subtle bugs. Just don't call `.criteria()` in such cases.");
+        }
+
+        return new Criteria().andOperator(checks.toArray(new Criteria[0])).getCriteriaObject();
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
@@ -12,6 +12,7 @@ import com.appsmith.server.dtos.WorkspacePluginStatus;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
+import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.BaseService;
@@ -54,8 +55,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 
 @Slf4j
 public class PluginServiceCEImpl extends BaseService<PluginRepository, Plugin, String> implements PluginServiceCE {
@@ -131,7 +130,7 @@ public class PluginServiceCEImpl extends BaseService<PluginRepository, Plugin, S
                     List<String> pluginIds = org.getPlugins().stream()
                             .map(WorkspacePlugin::getPluginId)
                             .collect(Collectors.toList());
-                    final Bridge criteria = bridge().in(FieldName.ID, pluginIds);
+                    final BridgeQuery<Plugin> criteria = Bridge.in(FieldName.ID, pluginIds);
 
                     final String typeString = params.getFirst(FieldName.TYPE);
                     if (typeString != null) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.ApplicationPage;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.solutions.ApplicationPermission;
@@ -25,7 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @Slf4j
@@ -55,7 +55,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     public Mono<Application> findByIdAndWorkspaceId(String id, String workspaceId, AclPermission permission) {
         return queryBuilder()
                 .byId(id)
-                .criteria(bridge().equal(Application.Fields.workspaceId, workspaceId))
+                .criteria(Bridge.equal(Application.Fields.workspaceId, workspaceId))
                 .permission(permission)
                 .one();
     }
@@ -63,7 +63,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     @Override
     public Mono<Application> findByName(String name, AclPermission permission) {
         return queryBuilder()
-                .criteria(bridge().equal(Application.Fields.name, name))
+                .criteria(Bridge.equal(Application.Fields.name, name))
                 .permission(permission)
                 .one();
     }
@@ -71,7 +71,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     @Override
     public Flux<Application> findByWorkspaceId(String workspaceId, AclPermission permission) {
         return queryBuilder()
-                .criteria(bridge().equal(Application.Fields.workspaceId, workspaceId))
+                .criteria(Bridge.equal(Application.Fields.workspaceId, workspaceId))
                 .permission(permission)
                 .all();
     }
@@ -111,7 +111,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     @Override
     public Flux<Application> findByClonedFromApplicationId(String applicationId, AclPermission permission) {
         return queryBuilder()
-                .criteria(bridge().equal(Application.Fields.clonedFromApplicationId, applicationId))
+                .criteria(Bridge.equal(Application.Fields.clonedFromApplicationId, applicationId))
                 .permission(permission)
                 .all();
     }
@@ -140,12 +140,12 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
 
         final Mono<Integer> setAllAsNonDefaultMono = queryBuilder()
                 .byId(applicationId)
-                .criteria(bridge().isTrue("pages.isDefault"))
+                .criteria(Bridge.isTrue("pages.isDefault"))
                 .updateFirst(new Update().set("pages.$.isDefault", false));
 
         final Mono<Integer> setDefaultMono = queryBuilder()
                 .byId(applicationId)
-                .criteria(bridge().equal("pages._id", new ObjectId(pageId)))
+                .criteria(Bridge.equal("pages._id", new ObjectId(pageId)))
                 .updateFirst(new Update().set("pages.$.isDefault", true));
 
         return setAllAsNonDefaultMono.then(setDefaultMono).then();
@@ -166,7 +166,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
             AclPermission aclPermission) {
 
         return queryBuilder()
-                .criteria(bridge().equal(
+                .criteria(Bridge.equal(
                                 Application.Fields.gitApplicationMetadata_defaultApplicationId, defaultApplicationId)
                         .equal(Application.Fields.gitApplicationMetadata_branchName, branchName))
                 .fields(projectionFieldNames)
@@ -179,7 +179,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
             String defaultApplicationId, String branchName, Optional<AclPermission> aclPermission) {
 
         return queryBuilder()
-                .criteria(bridge().equal(
+                .criteria(Bridge.equal(
                                 Application.Fields.gitApplicationMetadata_defaultApplicationId, defaultApplicationId)
                         .equal(Application.Fields.gitApplicationMetadata_branchName, branchName))
                 .permission(aclPermission.orElse(null))
@@ -191,8 +191,8 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
             String defaultApplicationId, AclPermission permission) {
 
         return queryBuilder()
-                .criteria(bridge().equal(
-                                Application.Fields.gitApplicationMetadata_defaultApplicationId, defaultApplicationId))
+                .criteria(Bridge.equal(
+                        Application.Fields.gitApplicationMetadata_defaultApplicationId, defaultApplicationId))
                 .permission(permission)
                 .all();
     }
@@ -200,14 +200,14 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     @Override
     public Mono<Long> countByWorkspaceId(String workspaceId) {
         return queryBuilder()
-                .criteria(bridge().equal(Application.Fields.workspaceId, workspaceId))
+                .criteria(Bridge.equal(Application.Fields.workspaceId, workspaceId))
                 .count();
     }
 
     @Override
     public Mono<Long> getGitConnectedApplicationWithPrivateRepoCount(String workspaceId) {
         return queryBuilder()
-                .criteria(bridge().equal(Application.Fields.workspaceId, workspaceId)
+                .criteria(Bridge.equal(Application.Fields.workspaceId, workspaceId)
                         .isTrue(Application.Fields.gitApplicationMetadata_isRepoPrivate))
                 .count();
     }
@@ -216,7 +216,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     public Flux<Application> getGitConnectedApplicationByWorkspaceId(String workspaceId) {
         AclPermission aclPermission = applicationPermission.getEditPermission();
         return queryBuilder()
-                .criteria(bridge()
+                .criteria(Bridge
                         // isRepoPrivate and gitAuth will be stored only with default application which ensures we will
                         // have only single application per repo
                         .exists(Application.Fields.gitApplicationMetadata_isRepoPrivate)
@@ -230,8 +230,8 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     public Mono<Application> getApplicationByDefaultApplicationIdAndDefaultBranch(String defaultApplicationId) {
 
         return queryBuilder()
-                .criteria(bridge().equal(
-                                Application.Fields.gitApplicationMetadata_defaultApplicationId, defaultApplicationId))
+                .criteria(Bridge.equal(
+                        Application.Fields.gitApplicationMetadata_defaultApplicationId, defaultApplicationId))
                 .one();
     }
 
@@ -252,7 +252,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     @Override
     public Mono<Long> countByNameAndWorkspaceId(String applicationName, String workspaceId, AclPermission permission) {
         return queryBuilder()
-                .criteria(bridge().equal(Application.Fields.workspaceId, workspaceId)
+                .criteria(Bridge.equal(Application.Fields.workspaceId, workspaceId)
                         .equal(Application.Fields.name, applicationName))
                 .permission(permission)
                 .count();
@@ -298,7 +298,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
         Update unsetProtected = new Update().set(isProtectedFieldPath, false);
 
         return queryBuilder()
-                .criteria(bridge().equal(Application.Fields.gitApplicationMetadata_defaultApplicationId, applicationId))
+                .criteria(Bridge.equal(Application.Fields.gitApplicationMetadata_defaultApplicationId, applicationId))
                 .permission(permission)
                 .updateAll(unsetProtected);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
@@ -3,6 +3,7 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Config;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
@@ -10,7 +11,6 @@ import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
 import reactor.core.publisher.Mono;
 
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Config>
@@ -32,7 +32,7 @@ public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Con
     @Override
     public Mono<Config> findByNameAsUser(String name, User user, AclPermission permission) {
         return getAllPermissionGroupsForUser(user).flatMap(permissionGroups -> queryBuilder()
-                .criteria(bridge().equal(Config.Fields.name, name))
+                .criteria(Bridge.equal(Config.Fields.name, name))
                 .permission(permission)
                 .permissionGroups(permissionGroups)
                 .one());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.external.models.DatasourceStorageStructure;
 import com.appsmith.external.models.DatasourceStructure;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
@@ -9,8 +10,6 @@ import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 
 @Component
 public class CustomDatasourceStorageStructureRepositoryCEImpl
@@ -27,7 +26,7 @@ public class CustomDatasourceStorageStructureRepositoryCEImpl
     @Override
     public Mono<Integer> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure) {
         return queryBuilder()
-                .criteria(bridge().equal(DatasourceStorageStructure.Fields.datasourceId, datasourceId)
+                .criteria(Bridge.equal(DatasourceStorageStructure.Fields.datasourceId, datasourceId)
                         .equal(DatasourceStorageStructure.Fields.environmentId, environmentId))
                 .updateFirst(Update.update(DatasourceStorageStructure.Fields.structure, structure));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.UserData;
 import com.appsmith.server.dtos.RecentlyUsedEntityDTO;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.mongodb.BasicDBObject;
@@ -12,8 +13,6 @@ import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 
 public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<UserData>
         implements CustomUserDataRepositoryCE {
@@ -28,7 +27,7 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
     @Override
     public Mono<Integer> saveReleaseNotesViewedVersion(String userId, String version) {
         return queryBuilder()
-                .criteria(bridge().equal(UserData.Fields.userId, userId))
+                .criteria(Bridge.equal(UserData.Fields.userId, userId))
                 .updateFirst(Update.update(UserData.Fields.releaseNotesViewedVersion, version));
     }
 
@@ -42,7 +41,7 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
                 UserData.Fields.recentlyUsedEntityIds,
                 new BasicDBObject(RecentlyUsedEntityDTO.Fields.workspaceId, workspaceId));
         return queryBuilder()
-                .criteria(bridge().equal(UserData.Fields.userId, userId))
+                .criteria(Bridge.equal(UserData.Fields.userId, userId))
                 .updateFirst(update)
                 .then();
     }
@@ -50,7 +49,7 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
     @Override
     public Mono<String> fetchMostRecentlyUsedWorkspaceId(String userId) {
         return queryBuilder()
-                .criteria(bridge().equal(UserData.Fields.userId, userId))
+                .criteria(Bridge.equal(UserData.Fields.userId, userId))
                 .fields(UserData.Fields.recentlyUsedEntityIds)
                 .one()
                 .map(userData -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
@@ -3,6 +3,7 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +15,6 @@ import reactor.core.publisher.Mono;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @Slf4j
@@ -36,7 +36,7 @@ public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User>
     @Override
     public Mono<User> findByEmailAndTenantId(String email, String tenantId) {
         return queryBuilder()
-                .criteria(bridge().equal(User.Fields.email, email).equal(User.Fields.tenantId, tenantId))
+                .criteria(Bridge.equal(User.Fields.email, email).equal(User.Fields.tenantId, tenantId))
                 .one();
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -3,7 +3,7 @@ package com.appsmith.server.repositories.ce.params;
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
-import com.appsmith.server.helpers.ce.bridge.Bridge;
+import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl;
 import lombok.Getter;
 import lombok.NonNull;
@@ -94,7 +94,7 @@ public class QueryAllParams<T extends BaseDomain> {
         }
 
         for (Criteria c : criteria) {
-            if (c instanceof Bridge b && b.getCriteriaObject().isEmpty()) {
+            if (c instanceof BridgeQuery<?> b && b.getCriteriaObject().isEmpty()) {
                 throw new IllegalArgumentException(
                         "Empty bridge criteria leads to subtle bugs. Just don't call `.criteria()` in such cases.");
             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.services;
 
 import com.appsmith.external.models.BaseDomain;
-import com.appsmith.external.models.Policy;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.exceptions.AppsmithError;
@@ -25,12 +24,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toSet;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -137,12 +132,6 @@ public abstract class BaseService<
                     AppsmithError.INVALID_PARAMETER,
                     constraint.stream().findFirst().get().getPropertyPath()));
         });
-    }
-
-    private Map<String, Set<Policy>> getAllPoliciesAsMap(Set<Policy> policies) {
-        return policies.stream()
-                .collect(
-                        Collectors.groupingBy(Policy::getPermission, Collectors.mapping(Function.identity(), toSet())));
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -6,6 +6,7 @@ import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.AppsmithRepository;
 import com.appsmith.server.repositories.BaseRepository;
 import jakarta.validation.Validator;
@@ -29,7 +30,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 import static java.util.stream.Collectors.toSet;
 
 @Slf4j
@@ -62,7 +62,7 @@ public abstract class BaseService<
         //   too fragile to touch right now. Need to dig in slow and deep to fix this.
         return repository
                 .queryBuilder()
-                .criteria(bridge().equal(key, (String) id))
+                .criteria(Bridge.equal(key, (String) id))
                 .updateFirst(resource)
                 .flatMap(obj -> repository.findById(id))
                 .flatMap(savedResource ->

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -10,6 +10,7 @@ import com.appsmith.server.dtos.RecentlyUsedEntityDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.CollectionUtils;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.projections.IdOnly;
 import com.appsmith.server.projections.UserDataProfilePhotoProjection;
 import com.appsmith.server.repositories.ApplicationRepository;
@@ -37,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.appsmith.server.constants.ce.FieldNameCE.DEFAULT;
-import static com.appsmith.server.helpers.ce.bridge.Bridge.bridge;
 
 public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserData, String>
         implements UserDataServiceCE {
@@ -147,7 +147,7 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
 
         return repository
                 .queryBuilder()
-                .criteria(bridge().equal(UserData.Fields.userId, userId))
+                .criteria(Bridge.equal(UserData.Fields.userId, userId))
                 .updateFirst(resource)
                 .flatMap(count -> count == 0 ? Mono.empty() : repository.findByUserId(userId))
                 .flatMap(analyticsService::sendUpdateEvent);


### PR DESCRIPTION
Migration the Bridge APIs to static+non-static versions for a more fluent API, and to make it extendable to get `Bridge.or` and `Bridge.and`.

We're also making the API generified, which isn't strictly needed here, but is needed for the `CriteriaBuilder` API on Postgres.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced query building capabilities with the introduction of `BridgeQuery` for more structured and flexible MongoDB criteria construction.
	- Updated various service and repository implementations to utilize the new `Bridge` and `BridgeQuery` classes for improved query logic and criteria definition.
	- Deprecated the `bridge()` method in favor of more explicit and versatile methods like `query()`, `or()`, and `and()` for logical operations, enhancing the readability and maintainability of the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->