### PR TITLE
chore: Remove unused anonymous user cache

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CacheableRepositoryHelperCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CacheableRepositoryHelperCE.java
@@ -15,10 +15,6 @@ public interface CacheableRepositoryHelperCE {
 
     Mono<Void> evictPermissionGroupsUser(String email, String tenantId);
 
-    Mono<User> getAnonymousUser(String tenantId);
-
-    Mono<User> getAnonymousUser();
-
     Mono<String> getDefaultTenantId();
 
     Mono<String> getInstanceAdminPermissionGroupId();


### PR DESCRIPTION
1. This is unused.

2. Such perma-caching is better owned by the repository, whose data is being cached. For example, `UserRepository*` in case of `getAnonymousUser`. Having all cached resources in one place doesn't scale. Besides, doing it this way means we have do hit the DB directly with `mongoOperations`, because injecting any repository beans will cause cyclic injections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of user permissions and tenant information in the system's backend.
	- Enhanced system performance by refining the logic related to anonymous users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->