### PR TITLE
ci: Add `$PWD/` prefix for failed tests faile

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -182,17 +182,15 @@ jobs:
           fi
           if ! mvn test "${args[@]}"; then
             echo "Generating failed test list:"
+            failed_tests_file="$PWD/failed-server-tests.txt"
             gawk -F\" '/<testcase / {cur_test = $4 "#" $2} /<failure / {print cur_test}' $(find . -type f -name 'TEST-*.xml') \
-              | tee failed-server-tests.txt
-            echo "Report files found:"
-            find . -type f -name 'TEST-*.xml'
-            echo "Test case failure lines:"
-            grep -FoB1 '<failure ' $(find . -type f -name 'TEST-*.xml') || true
-            if [[ -s failed-server-tests.txt ]]; then
+              | tee "$failed_tests_file"
+            echo "Saved to $failed_tests_file"
+            if [[ -s $failed_tests_file ]]; then
               content="$(
                 echo "## Failed server tests"
                 echo
-                sed 's/^/- /' 'failed-server-tests.txt' | sort -u
+                sed 's/^/- /' "$failed_tests_file" | sort -u
               )"
               echo "$content" >> "$GITHUB_STEP_SUMMARY"
               # Add a comment to the PR with the list of failed tests.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Improved test failure handling in the server build process, including better messaging and file management for failed tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->