### PR TITLE
chore: Use Bridge API for user, config, theme repos

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CollectionUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CollectionUtils.java
@@ -1,6 +1,8 @@
 package com.appsmith.server.helpers;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -91,5 +93,20 @@ public class CollectionUtils {
         } else {
             map.put(key, 1);
         }
+    }
+
+    /**
+     * Use this like `List.of`, but can take any `null` values and will not include them in the resulting list.
+     * @return An unmodifiable list of the non-null items.
+     */
+    @SafeVarargs
+    public static <T> List<T> ofNonNulls(T... items) {
+        List<T> list = new ArrayList<>();
+        for (T item : items) {
+            if (item != null) {
+                list.add(item);
+            }
+        }
+        return Collections.unmodifiableList(list);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
@@ -37,6 +37,10 @@ public final class Bridge {
         return Bridge.<T>query().equal(key, value);
     }
 
+    public static <T extends BaseDomain> BridgeQuery<T> equalIgnoreCase(@NonNull String key, @NonNull String value) {
+        return Bridge.<T>query().equalIgnoreCase(key, value);
+    }
+
     public static <T extends BaseDomain> BridgeQuery<T> equal(@NonNull String key, @NonNull ObjectId value) {
         return Bridge.<T>query().equal(key, value);
     }
@@ -51,5 +55,9 @@ public final class Bridge {
 
     public static <T extends BaseDomain> BridgeQuery<T> isTrue(@NonNull String key) {
         return Bridge.<T>query().isTrue(key);
+    }
+
+    public static <T extends BaseDomain> BridgeQuery<T> isFalse(@NonNull String key) {
+        return Bridge.<T>query().isFalse(key);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
@@ -9,6 +9,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public final class BridgeQuery<T extends BaseDomain> extends Criteria {
     final List<Criteria> checks = new ArrayList<>();
@@ -17,6 +18,11 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
 
     public BridgeQuery<T> equal(@NonNull String key, @NonNull String value) {
         checks.add(Criteria.where(key).is(value));
+        return this;
+    }
+
+    public BridgeQuery<T> equalIgnoreCase(@NonNull String key, @NonNull String value) {
+        checks.add(Criteria.where(key).regex("^" + Pattern.quote(value) + "$", "i"));
         return this;
     }
 
@@ -40,6 +46,11 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
         return this;
     }
 
+    public BridgeQuery<T> isFalse(@NonNull String key) {
+        checks.add(Criteria.where(key).is(false));
+        return this;
+    }
+
     public BridgeQuery<T> or(BridgeQuery... items) {
         checks.add(new Criteria().orOperator(items));
         return this;
@@ -55,6 +66,14 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
      * but won't work in the Postgres version.
      */
     public static Bridge where() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Explicitly disable the `and()` API to prevent its usage. This is because querying with this API will work here,
+     * but won't work in the Postgres version.
+     */
+    public static Bridge and() {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
@@ -4,14 +4,12 @@ import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Config;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
+import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.query.Criteria;
 import reactor.core.publisher.Mono;
-
-import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Config>
         implements CustomConfigRepositoryCE {
@@ -25,7 +23,7 @@ public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Con
 
     @Override
     public Mono<Config> findByName(String name, AclPermission permission) {
-        Criteria nameCriteria = where(Config.Fields.name).is(name);
+        BridgeQuery<Config> nameCriteria = Bridge.equal(Config.Fields.name, name);
         return queryBuilder().criteria(nameCriteria).permission(permission).one();
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -2,23 +2,20 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Theme;
-import com.appsmith.server.domains.User;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
+import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Update;
-import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
-import java.util.regex.Pattern;
-
-import static org.springframework.data.mongodb.core.query.Criteria.where;
+import java.util.List;
 
 @Component
 @Slf4j
@@ -32,62 +29,47 @@ public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Them
 
     @Override
     public Flux<Theme> getApplicationThemes(String applicationId, AclPermission aclPermission) {
-        Criteria appThemeCriteria = Criteria.where(Theme.Fields.applicationId).is(applicationId);
-        Criteria systemThemeCriteria =
-                Criteria.where(Theme.Fields.isSystemTheme).is(Boolean.TRUE);
-        Criteria criteria = new Criteria().orOperator(appThemeCriteria, systemThemeCriteria);
-        return queryBuilder().criteria(criteria).permission(aclPermission).all();
+        BridgeQuery<Theme> appThemeCriteria = Bridge.equal(Theme.Fields.applicationId, applicationId);
+        BridgeQuery<Theme> systemThemeCriteria = Bridge.isTrue(Theme.Fields.isSystemTheme);
+        return queryBuilder()
+                .criteria(Bridge.or(appThemeCriteria, systemThemeCriteria))
+                .permission(aclPermission)
+                .all();
     }
 
     @Override
     public Flux<Theme> getSystemThemes() {
-        Criteria systemThemeCriteria =
-                Criteria.where(Theme.Fields.isSystemTheme).is(Boolean.TRUE);
         return queryBuilder()
-                .criteria(systemThemeCriteria)
+                .criteria(Bridge.isTrue(Theme.Fields.isSystemTheme))
                 .permission(AclPermission.READ_THEMES)
                 .all();
     }
 
     @Override
     public Mono<Theme> getSystemThemeByName(String themeName) {
-        String findNameRegex = String.format("^%s$", Pattern.quote(themeName));
-        Criteria criteria = where(Theme.Fields.name)
-                .regex(findNameRegex, "i")
-                .and(Theme.Fields.isSystemTheme)
-                .is(true);
         return queryBuilder()
-                .criteria(criteria)
+                .criteria(Bridge.equalIgnoreCase(Theme.Fields.name, themeName).isTrue(Theme.Fields.isSystemTheme))
                 .permission(AclPermission.READ_THEMES)
                 .one();
     }
 
-    private Mono<Boolean> archiveThemeByCriteria(Criteria criteria) {
-        return ReactiveSecurityContextHolder.getContext()
-                .map(ctx -> ctx.getAuthentication())
-                .map(auth -> auth.getPrincipal())
-                .flatMap(principal -> getAllPermissionGroupsForUser((User) principal))
-                .flatMap(permissionGroups -> {
-                    Criteria permissionCriteria = userAcl(permissionGroups, AclPermission.MANAGE_THEMES);
-
-                    Update update = new Update();
-                    update.set(Theme.Fields.deletedAt, Instant.now());
-                    return queryBuilder().criteria(criteria, permissionCriteria).updateAll(update);
-                })
+    private Mono<Boolean> archiveThemeByCriteria(BridgeQuery<Theme> criteria) {
+        return queryBuilder()
+                .criteria(criteria)
+                .permission(AclPermission.MANAGE_THEMES)
+                .updateAll(new Update().set(Theme.Fields.deletedAt, Instant.now()))
                 .map(count -> count > 0);
     }
 
     @Override
     public Mono<Boolean> archiveByApplicationId(String applicationId) {
-        return archiveThemeByCriteria(where(Theme.Fields.applicationId).is(applicationId));
+        return archiveThemeByCriteria(Bridge.equal(Theme.Fields.applicationId, applicationId));
     }
 
     @Override
     public Mono<Boolean> archiveDraftThemesById(String editModeThemeId, String publishedModeThemeId) {
-        Criteria criteria = where(Theme.Fields.id)
-                .in(editModeThemeId, publishedModeThemeId)
-                .and(Theme.Fields.isSystemTheme)
-                .is(false);
+        BridgeQuery<Theme> criteria = Bridge.<Theme>in(Theme.Fields.id, List.of(editModeThemeId, publishedModeThemeId))
+                .isFalse(Theme.Fields.isSystemTheme);
         return archiveThemeByCriteria(criteria);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Theme;
+import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
@@ -15,7 +16,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
-import java.util.List;
 
 @Component
 @Slf4j
@@ -68,7 +68,8 @@ public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Them
 
     @Override
     public Mono<Boolean> archiveDraftThemesById(String editModeThemeId, String publishedModeThemeId) {
-        BridgeQuery<Theme> criteria = Bridge.<Theme>in(Theme.Fields.id, List.of(editModeThemeId, publishedModeThemeId))
+        BridgeQuery<Theme> criteria = Bridge.<Theme>in(
+                        Theme.Fields.id, CollectionUtils.ofNonNulls(editModeThemeId, publishedModeThemeId))
                 .isFalse(Theme.Fields.isSystemTheme);
         return archiveThemeByCriteria(criteria);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
@@ -4,18 +4,16 @@ import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
+import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.query.Criteria;
 import reactor.core.publisher.Mono;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @Slf4j
 public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User> implements CustomUserRepositoryCE {
@@ -29,7 +27,7 @@ public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User>
 
     @Override
     public Mono<User> findByEmail(String email, AclPermission aclPermission) {
-        Criteria emailCriteria = where(User.Fields.email).is(email);
+        BridgeQuery<User> emailCriteria = Bridge.equal(User.Fields.email, email);
         return queryBuilder().criteria(emailCriteria).permission(aclPermission).one();
     }
 


### PR DESCRIPTION
Managed to remove the `Criteria` and `where` imported from MongoDB APIs. The `Bridge` API calls should work the same on Postgres as well as here. We'll be moving more repository methods over to this API soon.

Notice that the `Update` import is still there. Bridge API for `Update` objects is also almost ready, and is coming up soon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced utility methods for creating unmodifiable lists excluding `null` values, and for case-insensitive equality checks and checking for false values.
- **Refactor**
	- Enhanced query construction in various repositories by utilizing a new helper class, improving code readability and maintainability.
- **Chores**
	- Disabled the use of a specific method due to compatibility issues with the database version, ensuring smoother operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->