### PR TITLE
chore: Support configurable body max size in Caddyfile

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -73,7 +73,7 @@ parts.push(`
   }
 
   request_body {
-    max_size 150MB
+    max_size ${process.env.APPSMITH_CODEC_SIZE || 150}MB
   }
 
   handle {


### PR DESCRIPTION
Fixes #31454.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the request body size limit configuration to dynamically adjust based on an environment variable, with a default limit of 150MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->