### PR TITLE
chore: Split changes for idempotent exports with module instances

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exportable/NewActionExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exportable/NewActionExportableServiceCEImpl.java
@@ -132,19 +132,26 @@ public class NewActionExportableServiceCEImpl implements ExportableServiceCE<New
             newAction.setPluginId(mappedExportableResourcesDTO.getPluginMap().get(newAction.getPluginId()));
             newAction.setWorkspaceId(null);
             newAction.setPolicies(null);
-            // Only add the datasource for this action to dbNamesUsed if it is not a module action
-            dbNamesUsedInActions.add(sanitizeDatasourceInActionDTO(
+
+            String publishedDbName = sanitizeDatasourceInActionDTO(
                     newAction.getPublishedAction(),
                     mappedExportableResourcesDTO.getDatasourceIdToNameMap(),
                     mappedExportableResourcesDTO.getPluginMap(),
                     null,
-                    true));
-            dbNamesUsedInActions.add(sanitizeDatasourceInActionDTO(
+                    true);
+
+            String unpublishedDbName = sanitizeDatasourceInActionDTO(
                     newAction.getUnpublishedAction(),
                     mappedExportableResourcesDTO.getDatasourceIdToNameMap(),
                     mappedExportableResourcesDTO.getPluginMap(),
                     null,
-                    true));
+                    true);
+
+            // Only add the datasource for this action to dbNamesUsed if it is not a module action
+            if (hasExportableDatasource(newAction)) {
+                dbNamesUsedInActions.add(publishedDbName);
+                dbNamesUsedInActions.add(unpublishedDbName);
+            }
 
             // Set unique id for action
             if (newAction.getUnpublishedAction() != null) {
@@ -155,5 +162,9 @@ public class NewActionExportableServiceCEImpl implements ExportableServiceCE<New
             }
         });
         return dbNamesUsedInActions;
+    }
+
+    protected boolean hasExportableDatasource(NewAction newAction) {
+        return true;
     }
 }


### PR DESCRIPTION
Companion to https://github.com/appsmithorg/appsmith-ee/pull/3658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated logic for handling datasource names in actions to differentiate between published and unpublished actions more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->