### PR TITLE
fix: Background color change for the tab bar

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorTabs/Container.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/Container.tsx
@@ -6,7 +6,7 @@ const Container = (props: { children: ReactNode }) => {
   return (
     <Flex
       alignItems="center"
-      backgroundColor="#F8FAFC"
+      backgroundColor="#FFFFFF"
       borderBottom="1px solid var(--ads-v2-color-border)"
       gap="spaces-2"
       maxHeight="32px"


### PR DESCRIPTION
Changed the background color of the tab bar to #FFF to minimise  background colors in the tab bar area.
