### PR TITLE
fix: Removed box-shadow for the active tab that is causing a visual artefact.

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
@@ -47,7 +47,6 @@ export const StyledTab = styled(Flex)`
     border-top: 2px solid var(--ads-v2-color-bg-brand);
     border-left: 1px solid var(--ads-v2-color-border);
     border-right: 1px solid var(--ads-v2-color-border);
-    box-shadow: 0px -2px 4px rgba(0, 0, 0, 0.08);
   }
 `;
 


### PR DESCRIPTION
Removed box-shadow for the active tab that is causing a visual artefact.
<img width="328" alt="image" src="https://github.com/appsmithorg/appsmith/assets/101088862/6e7ed92a-fb74-4994-969d-d92188f0ffc6">
