### PR TITLE
chore: Get optimization for adding plugin details to actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -763,7 +763,8 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
 
                     return Mono.just(action);
                 })
-                .flatMap(this::sanitizeAction);
+                .collectList()
+                .flatMapMany(this::addMissingPluginDetailsIntoAllActions);
     }
 
     @Override


### PR DESCRIPTION
The optimization done in adding missing plugin details to a list of actions, was set for only one signature of this function. This PR takes it to the other signature as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the process for enriching actions with missing plugin details for enhanced performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->