### PR TITLE
chore: Fix double-brace-initialization

### DIFF
--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -83,18 +82,8 @@ public class FileUtilsImplTest {
         Path pageDirectoryPath = localTestDirectoryPath.resolve(PAGE_DIRECTORY);
 
         // Create random page directories in the file system
-        Set<String> directorySet = new HashSet<String>() {
-            {
-                add("Uneisean");
-                add("Keladia");
-                add("Lothemas");
-                add("Edaemwen");
-                add("Qilabwyn");
-                add("Dreralle");
-                add("Wendadia");
-                add("Lareibeth");
-            }
-        };
+        Set<String> directorySet =
+                Set.of("Uneisean", "Keladia", "Lothemas", "Edaemwen", "Qilabwyn", "Dreralle", "Wendadia", "Lareibeth");
 
         directorySet.forEach(directory -> {
             try {
@@ -127,18 +116,15 @@ public class FileUtilsImplTest {
         Path actionDirectoryPath = localTestDirectoryPath.resolve(ACTION_DIRECTORY);
 
         // Create random action files in the file system
-        Set<String> actionsSet = new HashSet<String>() {
-            {
-                add("uneisean.json");
-                add("keladia.json");
-                add("lothemas.json");
-                add("edaemwen.json");
-                add("qilabwyn.json");
-                add("dreralle.json");
-                add("wendadia.json");
-                add("lareibeth.json");
-            }
-        };
+        Set<String> actionsSet = Set.of(
+                "uneisean.json",
+                "keladia.json",
+                "lothemas.json",
+                "edaemwen.json",
+                "qilabwyn.json",
+                "dreralle.json",
+                "wendadia.json",
+                "lareibeth.json");
 
         try {
             Files.createDirectories(actionDirectoryPath);

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/TemplateUtils.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/TemplateUtils.java
@@ -131,11 +131,7 @@ public class TemplateUtils {
         setDataValueSafelyInFormData(configMap, BUCKET, bucketName);
         setDataValueSafelyInFormData(configMap, LIST_SIGNED_URL, NO);
         setDataValueSafelyInFormData(configMap, LIST_UNSIGNED_URL, YES);
-        setDataValueSafelyInFormData(configMap, LIST_WHERE, new HashMap<String, Object>() {
-            {
-                put("condition", "AND");
-            }
-        });
+        setDataValueSafelyInFormData(configMap, LIST_WHERE, Map.of("condition", "AND"));
 
         return new Template(LIST_FILES_TEMPLATE_NAME, configMap, true);
     }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
@@ -1027,11 +1027,7 @@ public class AmazonS3PluginTest {
                             PluginUtils.getDataValueSafelyFromFormData(
                                     listFilesConfig, LIST_UNSIGNED_URL, STRING_TYPE));
                     assertEquals(
-                            new HashMap<String, Object>() {
-                                {
-                                    put("condition", "AND");
-                                }
-                            },
+                            Map.of("condition", "AND"),
                             PluginUtils.getDataValueSafelyFromFormData(
                                     listFilesConfig, LIST_WHERE, new TypeReference<HashMap<String, Object>>() {}));
 

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -465,11 +465,9 @@ public class FirestorePlugin extends BasePlugin {
                              */
                             if (targetKeyValuePair.get(key) == null) {
                                 String nextKey = singlePathList.get(i + 1);
-                                targetKeyValuePair.put(key, new HashMap<>() {
-                                    {
-                                        put(nextKey, null);
-                                    }
-                                });
+                                final Map<String, ?> pair = new HashMap<>();
+                                pair.put(nextKey, null);
+                                targetKeyValuePair.put(key, pair);
                             }
 
                             /*

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -935,25 +935,19 @@ public class FirestorePluginTest {
          * - get all documents where category == test.
          * - this returns 2 documents.
          */
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "EQ");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "EQ",
+                "value", "{{Input2.text}}"));
 
         /*
          * - get all documents where name == two.
          * - Of the two documents returned by above condition, this will narrow it down to one.
          */
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input3.text}}");
-                put("condition", "EQ");
-                put("value", "{{Input4.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input3.text}}",
+                "condition", "EQ",
+                "value", "{{Input4.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1019,13 +1013,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "EQ");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "EQ",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1065,13 +1056,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "EQ");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "EQ",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1111,13 +1099,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "EQ");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "EQ",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1157,13 +1142,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "EQ");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "EQ",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1202,13 +1184,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "ARRAY_CONTAINS");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "ARRAY_CONTAINS",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1247,13 +1226,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "ARRAY_CONTAINS");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "ARRAY_CONTAINS",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1292,13 +1268,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "ARRAY_CONTAINS_ANY");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "ARRAY_CONTAINS_ANY",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1337,13 +1310,10 @@ public class FirestorePluginTest {
         setDataValueSafelyInFormData(configMap, COMMAND, "GET_COLLECTION");
 
         List<Object> children = new ArrayList<>();
-        children.add(new HashMap<String, Object>() {
-            {
-                put("key", "{{Input1.text}}");
-                put("condition", "IN");
-                put("value", "{{Input2.text}}");
-            }
-        });
+        children.add(Map.of(
+                "key", "{{Input1.text}}",
+                "condition", "IN",
+                "value", "{{Input2.text}}"));
 
         Map<String, Object> whereMap = new HashMap<>();
         whereMap.put(CHILDREN, children);
@@ -1604,13 +1574,11 @@ public class FirestorePluginTest {
          * - get all documents where category == test.
          * - this returns 2 documents.
          */
-        ((List) whereProperty.getValue()).add(new HashMap<String, Object>() {
-            {
-                put("path", "{{Input2.text}}");
-                put("operator", "EQ");
-                put("value", "{{Input3.text}}");
-            }
-        });
+        ((List) whereProperty.getValue())
+                .add(Map.of(
+                        "path", "{{Input2.text}}",
+                        "operator", "EQ",
+                        "value", "{{Input3.text}}"));
 
         pluginSpecifiedTemplates.add(whereProperty);
         actionConfiguration.setPluginSpecifiedTemplates(pluginSpecifiedTemplates);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -534,12 +534,9 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                     Set<String> datasourceKeys = datasourceBindings.stream()
                             .map(token -> token.getValue())
                             .collect(Collectors.toSet());
-                    Set<String> keys = new HashSet<>() {
-                        {
-                            addAll(actionKeys);
-                            addAll(datasourceKeys);
-                        }
-                    };
+                    Set<String> keys = new HashSet<>();
+                    keys.addAll(actionKeys);
+                    keys.addAll(datasourceKeys);
 
                     action.setJsonPathKeys(keys);
                     return newAction;


### PR DESCRIPTION
This PR fixes all uses of double brace initialization, with ordinary normal code.

It is usually advised to avoid Double brace initialization, especially for building collections as it can cause very hard-to-troubleshoot bugs with systems that use reflection a lot, like Spring, Hibernate, Jackson, etc.

Almost every Java linter out there recommends to avoid this.

This can be configured in IntelliJ to show up as an error with the following configuration. Please **please** do this.
![shot-2024-03-11-04-14-16](https://github.com/appsmithorg/appsmith/assets/120119/cc3d8c67-5dfc-4884-a36a-8f9e1aeea19f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced code readability and efficiency by simplifying collection initializations across various components and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->