### PR TITLE
Fix: Deselect all widgets on canvas click

### DIFF
--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -555,6 +555,8 @@ export function* fetchFeatureFlags(action?: {
 
     const isValidResponse: boolean = yield validateResponse(response);
     if (isValidResponse) {
+      response.data.ab_wds_enabled = true;
+      response.data.release_anvil_enabled = true;
       yield put(
         fetchFeatureFlagsSuccess({
           ...DEFAULT_FEATURE_FLAG_VALUE,

--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -555,8 +555,6 @@ export function* fetchFeatureFlags(action?: {
 
     const isValidResponse: boolean = yield validateResponse(response);
     if (isValidResponse) {
-      response.data.ab_wds_enabled = true;
-      response.data.release_anvil_enabled = true;
       yield put(
         fetchFeatureFlagsSuccess({
           ...DEFAULT_FEATURE_FLAG_VALUE,

--- a/app/client/src/layoutSystems/anvil/canvas/AnvilMainCanvas.tsx
+++ b/app/client/src/layoutSystems/anvil/canvas/AnvilMainCanvas.tsx
@@ -19,8 +19,20 @@ export const AnvilMainCanvas = (props: BaseWidgetProps) => {
   const clickToClearSelections = useClickToClearSelections(props.widgetId);
 
   const handleOnClickCapture = useCallback(
+    // We need to make sure to call this only if we're clicking on the main canvas
+    // To do this, we'll inspect the event.target to make sure it has the className
+    // we would expect only the main canvas to have.
+    // Note: This className also exists in the view mode, but this file is rendered only in edit mode.
     (event) => {
-      if (event.eventPhase === 2) clickToClearSelections(event);
+      // Get the main canvas identifier (layoutId)
+      const mainCanvasIdentifier = props.layout[0]?.layoutId;
+      const isTargetMainCanvas = event.target.classList.contains(
+        `layout-${mainCanvasIdentifier}`,
+      );
+
+      // If we can confirm that the event target is the main canvas, we can clear selections.
+      if (isTargetMainCanvas) clickToClearSelections(event);
+      else event.stopPropagation(); // Stops bubbling of this event.
     },
     [clickToClearSelections],
   );

--- a/app/client/src/layoutSystems/anvil/canvas/useClickToClearSelections.ts
+++ b/app/client/src/layoutSystems/anvil/canvas/useClickToClearSelections.ts
@@ -4,8 +4,6 @@ import { useSelector } from "react-redux";
 import { useShowPropertyPane } from "utils/hooks/dragResizeHooks";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
 import { getAnvilSpaceDistributionStatus } from "../integrations/selectors";
-import { AnvilCanvasClassName } from "widgets/anvil/constants";
-
 /**
  * Custom hook to handle click events for clearing widget selections.
  * @param {string} widgetId - ID of the widget associated with the click event.
@@ -29,24 +27,14 @@ export const useClickToClearSelections = (widgetId: string) => {
 
   // Click event handler function
   return (e: MouseEvent<HTMLElement>) => {
-    // This feature is only relevant in the Anvil canvas
-    const isTargetMainCanvas = (e.target as HTMLElement)?.classList.contains(
-      AnvilCanvasClassName,
-    );
-
     // Checking if there is no ongoing dragging, canvas resizing, or space distribution
     if (!(isDragging || isCanvasResizing || isDistributingSpace)) {
       // Check if the target is the MainCanvas
-      if (isTargetMainCanvas) {
-        // Deselect all widgets, focus on the clicked widget, show the property pane, and prevent the default click behavior
-        goToWidgetAdd();
-        focusWidget && focusWidget(widgetId);
-        showPropertyPane && showPropertyPane();
-        e.preventDefault();
-      } else {
-        // Prevent onClick from bubbling out of the canvas to the WidgetEditor for any other widget except the MainCanvas
-        e.stopPropagation();
-      }
+      // Deselect all widgets, focus on the clicked widget, show the property pane, and prevent the default click behavior
+      goToWidgetAdd();
+      focusWidget && focusWidget(widgetId);
+      showPropertyPane && showPropertyPane();
+      e.preventDefault();
     }
   };
 };


### PR DESCRIPTION
## Description
Clicking on the canvas in Anvil layouts did not deselect all widgets.
This PR fixes it. Now all widgets

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->