### PR TITLE
fix: Zones and Sections elevation token update

### DIFF
--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -555,6 +555,8 @@ export function* fetchFeatureFlags(action?: {
 
     const isValidResponse: boolean = yield validateResponse(response);
     if (isValidResponse) {
+      response.data.ab_wds_enabled = true;
+      response.data.release_anvil_enabled = true;
       yield put(
         fetchFeatureFlagsSuccess({
           ...DEFAULT_FEATURE_FLAG_VALUE,

--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -555,8 +555,6 @@ export function* fetchFeatureFlags(action?: {
 
     const isValidResponse: boolean = yield validateResponse(response);
     if (isValidResponse) {
-      response.data.ab_wds_enabled = true;
-      response.data.release_anvil_enabled = true;
       yield put(
         fetchFeatureFlagsSuccess({
           ...DEFAULT_FEATURE_FLAG_VALUE,

--- a/app/client/src/widgets/anvil/Container.tsx
+++ b/app/client/src/widgets/anvil/Container.tsx
@@ -27,7 +27,7 @@ const StyledContainerComponent = styled.div<
       background-color: var(--color-bg-elevation-${props.elevation});
       border-radius: var(--border-radius-elevation-${props.elevation})};
       border-color: var(--color-bd-elevation-${props.elevation});
-      border-width: 1px;
+      border-width: var(--border-width-1);
       border-style: solid;
 
       /* Add padding to the container to maintain the visual spacing rhythm */

--- a/app/client/src/widgets/anvil/Container.tsx
+++ b/app/client/src/widgets/anvil/Container.tsx
@@ -19,16 +19,24 @@ const StyledContainerComponent = styled.div<
   outline: none;
   border: none;
   position: relative;
-  background-color: ${(props) =>
-    props.elevatedBackground
-      ? `var(--color-bg-elevation-${props.elevation})`
-      : "inherit"};
-  border-radius: ${(props) =>
-    `var(--border-radius-elevation-${props.elevation})`};
-  padding-block: var(--outer-spacing-0);
-  padding-inline: var(--outer-spacing-0);
+  border-radius: var(--border-radius-1);
+  /* If the elevatedBackground is true, then apply the elevation styles */
+  ${(props) => {
+    if (props.elevatedBackground) {
+      return `
+      background-color: var(--color-bg-elevation-${props.elevation});
+      border-radius: var(--border-radius-elevation-${props.elevation})};
+      border-color: var(--color-bd-elevation-${props.elevation});
+      border-width: 1px;
+      border-style: solid;
 
-  border-width: var(--border-width-1);
+      /* Add padding to the container to maintain the visual spacing rhythm */
+      /* This is based on the hypothesis of asymmetric padding */
+      padding-block: var(--inner-spacing-1);
+      padding-inline: var(--inner-spacing-1);
+      `;
+    }
+  }}
 `;
 
 export function ContainerComponent(props: ContainerComponentProps) {

--- a/app/client/src/widgets/anvil/SectionWidget/widget/config/propertyPaneStyle.ts
+++ b/app/client/src/widgets/anvil/SectionWidget/widget/config/propertyPaneStyle.ts
@@ -2,14 +2,15 @@ import { ValidationTypes } from "constants/WidgetValidation";
 
 export const propertyPaneStyle = [
   {
-    sectionName: "Background",
+    sectionName: "General",
     children: [
       {
         propertyName: "elevatedBackground",
-        label: "Background",
+        label: "Visual Separation",
         controlType: "SWITCH",
         fullWidth: true,
-        helpText: "Sets the semantic elevated background of the section",
+        helpText:
+          "Sets the semantic elevated background and/or borders of the section. This separates the section visually. This could be useful for separating the contents of this section visually from the rest of the sections in the page",
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: false,

--- a/app/client/src/widgets/anvil/ZoneWidget/widget/config/propertyPaneStyle.ts
+++ b/app/client/src/widgets/anvil/ZoneWidget/widget/config/propertyPaneStyle.ts
@@ -2,14 +2,15 @@ import { ValidationTypes } from "constants/WidgetValidation";
 
 export const propertyPaneStyle = [
   {
-    sectionName: "Background",
+    sectionName: "General",
     children: [
       {
         propertyName: "elevatedBackground",
-        label: "Background",
+        label: "Visual separation",
         controlType: "SWITCH",
         fullWidth: true,
-        helpText: "Sets the semantic elevated background of the zone",
+        helpText:
+          "Sets the semantic elevated background and/or borders of the zone. This separates the zone visually. This could be useful for separating the contents of this zone visually from the rest of the zones in the section",
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: false,


### PR DESCRIPTION
## Description
This PR makes the following changes:
- Adds elevation token for `border-color` zones and sections, based on their elevations
- Updates the `Background` property pane description for zones and sections to make them relevant to what they mean semantically for the user
- Adds a padding to the containers within zones and sections, when they have their backgrounds visible.
- The above padding is not applied when backgrounds are not visible, as described in the hypothesis for asymmetric padding.

### Before:
![Screenshot 2024-03-11 at 2 55 47 PM](https://github.com/appsmithorg/appsmith/assets/103687/b656914f-39d7-4486-b63f-4f58e9de199d)

### After:
![Screenshot 2024-03-11 at 2 54 02 PM](https://github.com/appsmithorg/appsmith/assets/103687/dcc7bc45-68b8-44e3-9e51-caa1c49da63d)

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated `ContainerComponent` to support conditional styling for enhanced visual separation based on `elevatedBackground` property.
- **Refactor**
	- Renamed configuration sections from "Background" to "General" and updated labels and help texts to better describe the purpose of the `elevatedBackground` property in both Section and Zone widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->