### PR TITLE
chore: execute action event updated with source

### DIFF
--- a/app/client/src/actions/pluginActionActions.ts
+++ b/app/client/src/actions/pluginActionActions.ts
@@ -3,7 +3,6 @@ import type {
   EvaluationReduxAction,
   AnyReduxAction,
   ReduxAction,
-  ReduxActionWithoutPayload,
 } from "@appsmith/constants/ReduxActionConstants";
 import type { JSUpdate } from "utils/JSPaneUtils";
 import {
@@ -11,6 +10,7 @@ import {
   ReduxActionTypes,
 } from "@appsmith/constants/ReduxActionConstants";
 import type { Action, ActionViewMode } from "entities/Action";
+import { ActionExecutionContext } from "entities/Action";
 import { batchAction } from "actions/batchActions";
 import type { ExecuteErrorPayload } from "constants/AppsmithActionConstants/ActionConstants";
 import type { ModalInfo } from "reducers/uiReducers/modalActionReducer";
@@ -107,6 +107,8 @@ export const runAction = (
   id: string,
   paginationField?: PaginationField,
   skipOpeningDebugger = false,
+  action = undefined,
+  actionExecutionContext = ActionExecutionContext.SELF,
 ) => {
   return {
     type: ReduxActionTypes.RUN_ACTION_REQUEST,
@@ -114,6 +116,8 @@ export const runAction = (
       id,
       paginationField,
       skipOpeningDebugger,
+      action,
+      actionExecutionContext,
     },
   };
 };
@@ -314,9 +318,16 @@ export const updateActionProperty = (
   });
 };
 
-export const executePageLoadActions = (): ReduxActionWithoutPayload => ({
-  type: ReduxActionTypes.EXECUTE_PAGE_LOAD_ACTIONS,
-});
+export const executePageLoadActions = (
+  actionExecutionContext?: ActionExecutionContext,
+) => {
+  return {
+    type: ReduxActionTypes.EXECUTE_PAGE_LOAD_ACTIONS,
+    payload: {
+      actionExecutionContext,
+    },
+  };
+};
 
 export const executeJSUpdates = (
   payload: Record<string, JSUpdate>,

--- a/app/client/src/ce/sagas/PageSagas.tsx
+++ b/app/client/src/ce/sagas/PageSagas.tsx
@@ -145,6 +145,7 @@ import type { DSLWidget } from "WidgetProvider/constants";
 import type { FeatureFlags } from "@appsmith/entities/FeatureFlag";
 import { getIsServerDSLMigrationsEnabled } from "selectors/pageSelectors";
 import { getCurrentWorkspaceId } from "@appsmith/selectors/selectedWorkspaceSelectors";
+import { ActionExecutionContext } from "entities/Action";
 
 export const checkIfMigrationIsNeeded = (
   fetchPageResponse?: FetchPageResponse,
@@ -977,7 +978,11 @@ export function* clonePageSaga(
       }
 
       yield put(selectWidgetInitAction(SelectionRequestType.Empty));
-      yield put(fetchAllPageEntityCompletion([executePageLoadActions()]));
+      yield put(
+        fetchAllPageEntityCompletion([
+          executePageLoadActions(ActionExecutionContext.CLONE_PAGE),
+        ]),
+      );
 
       // TODO: Update URL params here.
 
@@ -1374,7 +1379,11 @@ export function* generateTemplatePageSaga(
       if (!afterActionsFetch) {
         throw new Error("Failed generating template");
       }
-      yield put(fetchAllPageEntityCompletion([executePageLoadActions()]));
+      yield put(
+        fetchAllPageEntityCompletion([
+          executePageLoadActions(ActionExecutionContext.GENERATE_CRUD_PAGE),
+        ]),
+      );
 
       history.replace(
         builderURL({

--- a/app/client/src/ce/utils/actionExecutionUtils.ts
+++ b/app/client/src/ce/utils/actionExecutionUtils.ts
@@ -1,4 +1,5 @@
 import type { Action } from "entities/Action";
+import { ActionExecutionContext } from "entities/Action";
 import type { JSAction, JSCollection } from "entities/JSCollection";
 import type { ApplicationPayload } from "@appsmith/constants/ReduxActionConstants";
 import store from "store";
@@ -65,6 +66,7 @@ export function getActionExecutionAnalytics(
     isMock: !!datasource?.isMock,
     actionId: action?.id,
     inputParams: Object.keys(params).length,
+    source: ActionExecutionContext.EVALUATION_ACTION_TRIGGER, // Used in analytic events to understand who triggered action execution
   };
 
   if (!!currentApp) {

--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -75,6 +75,18 @@ export enum ActionCreationSourceTypeEnum {
   COPY_ACTION = "COPY_ACTION",
 }
 
+// Used for analytic events
+export enum ActionExecutionContext {
+  SELF = "SELF",
+  ONE_CLICK_BINDING = "ONE_CLICK_BINDING",
+  GENERATE_CRUD_PAGE = "GENERATE_CRUD_PAGE",
+  CLONE_PAGE = "CLONE_PAGE",
+  FORK_TEMPLATE_PAGE = "FORK_TEMPLATE_PAGE",
+  PAGE_LOAD = "PAGE_LOAD",
+  EVALUATION_ACTION_TRIGGER = "EVALUATION_ACTION_TRIGGER",
+  REFRESH_ACTIONS_ON_ENV_CHANGE = "REFRESH_ACTIONS_ON_ENV_CHANGE",
+}
+
 export interface KeyValuePair {
   key?: string;
   value?: unknown;

--- a/app/client/src/sagas/OneClickBindingSaga.ts
+++ b/app/client/src/sagas/OneClickBindingSaga.ts
@@ -6,6 +6,7 @@ import {
 import type { Plugin } from "api/PluginApi";
 import {
   ActionCreationSourceTypeEnum,
+  ActionExecutionContext,
   PluginType,
   type Action,
   type QueryActionConfig,
@@ -223,7 +224,15 @@ function* BindWidgetToDatasource(
 
       //TODO(Balaji): Need to make changes to plugin saga to execute the actions in parallel
       for (const actionToRun of actionsToRun) {
-        yield put(runAction(actionToRun.id, undefined, true));
+        yield put(
+          runAction(
+            actionToRun.id,
+            undefined,
+            true,
+            undefined,
+            ActionExecutionContext.ONE_CLICK_BINDING,
+          ),
+        );
 
         const runResponse: ReduxAction<unknown> = yield take([
           ReduxActionTypes.RUN_ACTION_SUCCESS,


### PR DESCRIPTION
## Description
Updated execute action event to contain source property as per [learnability instrumentation requirements](https://www.notion.so/appsmith/Problems-with-tracking-learnability-accurately-3c3d5d76c779437f916d1bafff6e5969?d=efc319525fac4c9d8c570877e805701f#b3cb4f9525f646d4b5479eaa95a64299)

Following sources have been added in `EXECUTE_ACTION` frontend event:

Action | Source | Modified Event details
-- | -- | --
Clicking on RUN button (API / Query / Saas Query) | SELF | `EXECUTE_ACTION { source: "SELF" }`
Drag a table widget → Click connect data → Select datasource → select table → click on connect data | ONE_CLICK_BINDING | `EXECUTE_ACTION { source: "ONE_CLICK_BINDING" }`
Generate CRUD triggered from new page menu or datasource preview | GENERATE_CRUD_PAGE | `EXECUTE_ACTION { source: "GENERATE_CRUD_PAGE" }`
Clone a page | CLONE_PAGE | `EXECUTE_ACTION { source: "CLONE_PAGE" }`
Switch environment -> leads to actions refresh and execute | REFRESH_ACTIONS_ON_ENV_CHANGE | `EXECUTE_ACTION { source: "REFRESH_ACTIONS_ON_ENV_CHANGE" }`
Actions executed as part of JSObject functions | EVALUATION_ACTION_TRIGGER | `EXECUTE_ACTION { source: "EVALUATION_ACTION_TRIGGER" }`


Fixes # 31174
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="Datasource, Bindings, Widgets"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->