### PR TITLE
fix: Updated the label for the "Auto play" property in the Audio Widget to "Autoplay"

### DIFF
--- a/app/client/packages/dsl/src/migrate/helpers/widget-configs.json
+++ b/app/client/packages/dsl/src/migrate/helpers/widget-configs.json
@@ -11801,7 +11801,7 @@
         "children": [
           {
             "propertyName": "autoPlay",
-            "label": "Auto play",
+            "label": "Autoplay",
             "helpText": "Audio will be automatically played",
             "controlType": "SWITCH",
             "isJSConvertible": true,

--- a/app/client/src/widgets/AudioWidget/widget/index.tsx
+++ b/app/client/src/widgets/AudioWidget/widget/index.tsx
@@ -154,7 +154,7 @@ class AudioWidget extends BaseWidget<AudioWidgetProps, WidgetState> {
         children: [
           {
             propertyName: "autoPlay",
-            label: "Auto play",
+            label: "Autoplay",
             helpText: "Audio will be automatically played",
             controlType: "SWITCH",
             isJSConvertible: true,


### PR DESCRIPTION
## Description
Renamed `Auto play` to `Autoplay` in Audi Widget's autoplay text to make it consistent with `Autoplay` text in Video Widget.

Before: 
<img width="574" alt="image" src="https://github.com/appsmithorg/appsmith/assets/12482554/9c7da195-e8c4-4f0a-8ca9-a86615ed7d57">

After: 
<img width="569" alt="image" src="https://github.com/appsmithorg/appsmith/assets/12482554/f360e546-5ec3-4525-a3e8-91bd1dc06779">


Fixes #19488 


### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the label for the "Auto play" property in the Audio Widget to "Autoplay."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->