### PR TITLE
fix: Tab editor expt: Juxtaposing the more menu with the tabs

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
@@ -31,8 +31,12 @@ export const StyledTab = styled(Flex)`
   justify-content: center;
   max-width: calc((${DEFAULT_SPLIT_SCREEN_WIDTH} - 116px) / 5);
 
+  div[data-testid="editor-tabs"]{
+    flex-grow: 0;
+  }
+
   // After element - the seperator in between tabs
-  &:not(&.active):not(:has(+ .active)):not(:last-child):after {
+  &:not(&.active):not(:has(+ .active)):after {
     content: "";
     position: absolute;
     right: 0;


### PR DESCRIPTION
Experimenting with moving the more menu that displays the rest of the tab items next to the last tab item.