### PR TITLE
chore: code split to support other contexts

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/DatasourceControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/DatasourceControllerCE.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.controllers.ce;
 
 import com.appsmith.external.models.ActionExecutionResult;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceStorageDTO;
 import com.appsmith.external.models.DatasourceStructure;
@@ -154,18 +155,22 @@ public class DatasourceControllerCE {
     }
 
     @JsonView(Views.Public.class)
-    @GetMapping("/{datasourceId}/pages/{pageId}/code")
+    @GetMapping("/{datasourceId}/code")
     public Mono<Void> getTokenRequestUrl(
             @PathVariable String datasourceId,
-            @PathVariable String pageId,
+            @RequestParam(required = false, value = "PAGE") CreatorContextType contextType,
+            @RequestParam String contextId,
             @RequestParam String environmentId,
             @RequestParam(name = FieldName.BRANCH_NAME, required = false) String branchName,
             ServerWebExchange serverWebExchange) {
         log.debug(
-                "Going to retrieve token request URL for datasource with id: {} and page id: {}", datasourceId, pageId);
+                "Going to retrieve token request URL for datasource with id: {}, contextType: {} and context id: {}",
+                datasourceId,
+                contextType,
+                contextId);
         return authenticationService
                 .getAuthorizationCodeURLForGenericOAuth2(
-                        datasourceId, environmentId, pageId, branchName, serverWebExchange.getRequest())
+                        datasourceId, environmentId, contextType, contextId, branchName, serverWebExchange.getRequest())
                 .flatMap(url -> {
                     serverWebExchange.getResponse().setStatusCode(HttpStatus.FOUND);
                     serverWebExchange.getResponse().getHeaders().setLocation(URI.create(url));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCE.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.solutions.ce;
 
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.external.models.OAuth2ResponseDTO;
 import com.appsmith.server.dtos.AuthorizationCodeCallbackDTO;
@@ -16,12 +17,18 @@ public interface AuthenticationServiceCE {
      *
      * @param datasourceId  required to validate the details in the request and populate redirect url
      * @param environmentId
-     * @param pageId        Required to populate redirect url
+     * @param contextId        Required to populate redirect url
+     * @param contextType      Required to populate redirect url
      * @param httpRequest   Used to find the redirect domain
      * @return a url String to continue the authorization flow
      */
     Mono<String> getAuthorizationCodeURLForGenericOAuth2(
-            String datasourceId, String environmentId, String pageId, String branchName, ServerHttpRequest httpRequest);
+            String datasourceId,
+            String environmentId,
+            CreatorContextType contextType,
+            String contextId,
+            String branchName,
+            ServerHttpRequest httpRequest);
 
     /**
      * This is the method that handles callback for generic OAuth2. We will be retrieving and storing token information here

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
@@ -109,7 +109,7 @@ public class AuthenticationServiceTest {
     @WithUserDetails(value = "api_user")
     public void testGetAuthorizationCodeURL_missingDatasource() {
         Mono<String> authorizationCodeUrlMono = authenticationService.getAuthorizationCodeURLForGenericOAuth2(
-                "invalidId", FieldName.UNUSED_ENVIRONMENT_ID, "irrelevantPageId", null, null);
+                "invalidId", FieldName.UNUSED_ENVIRONMENT_ID, null, "irrelevantPageId", null, null);
 
         StepVerifier.create(authorizationCodeUrlMono)
                 .expectErrorMatches(throwable -> throwable instanceof AppsmithException
@@ -150,7 +150,7 @@ public class AuthenticationServiceTest {
         Mono<String> authorizationCodeUrlMono = datasourceMono
                 .map(BaseDomain::getId)
                 .flatMap(datasourceId -> authenticationService.getAuthorizationCodeURLForGenericOAuth2(
-                        datasourceId, defaultEnvironmentId, "irrelevantPageId", null, null));
+                        datasourceId, defaultEnvironmentId, null, "irrelevantPageId", null, null));
 
         StepVerifier.create(authorizationCodeUrlMono)
                 .expectErrorMatches(throwable -> throwable instanceof AppsmithException
@@ -228,7 +228,7 @@ public class AuthenticationServiceTest {
         final String datasourceId1 = datasourceMono.map(BaseDomain::getId).block();
 
         Mono<String> authorizationCodeUrlMono = authenticationService.getAuthorizationCodeURLForGenericOAuth2(
-                datasourceId1, defaultEnvironmentId, pageDto.getId(), null, httpRequest);
+                datasourceId1, defaultEnvironmentId, null, pageDto.getId(), null, httpRequest);
 
         StepVerifier.create(authorizationCodeUrlMono)
                 .assertNext(url -> {
@@ -322,7 +322,7 @@ public class AuthenticationServiceTest {
         final String datasourceId = datasourceMono.map(BaseDomain::getId).block();
 
         Mono<String> authorizationCodeUrlMono = authenticationService.getAuthorizationCodeURLForGenericOAuth2(
-                datasourceId, null, pageDTO.getId(), "testBranch", httpRequest);
+                datasourceId, null, null, pageDTO.getId(), "testBranch", httpRequest);
 
         StepVerifier.create(authorizationCodeUrlMono)
                 .assertNext(url -> {


### PR DESCRIPTION
## Description
> [!TIP]  
> _Datasource Controller's getTokenRequestUrl() is currently bounded to Pages._
> _This is a code split to support generation of token request url for other contexts like modules and workflows._

Fixes `https://github.com/appsmithorg/appsmith/issues/31554`

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->