### PR TITLE
chore: Remove non-static `or` API in Bridge

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
@@ -88,13 +88,16 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
         return this;
     }
 
-    public BridgeQuery<T> or(BridgeQuery... items) {
-        checks.add(new Criteria().orOperator(items));
-        return this;
+    /**
+     * Please use {@code Bridge.or} instead. This API looks and reads very confusing and unintuitive, so is explicitly
+     * disabled.
+     */
+    public BridgeQuery<T> or(BridgeQuery<T> ignoredUnused) {
+        throw new UnsupportedOperationException("Not supported");
     }
 
-    public BridgeQuery<T> and(BridgeQuery... items) {
-        checks.add(new Criteria().andOperator(items));
+    public BridgeQuery<T> and(BridgeQuery<T> item) {
+        checks.add(new Criteria().andOperator(item));
         return this;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -167,9 +167,9 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         BridgeQuery<NewAction> q = Bridge.equal(NewAction.Fields.unpublishedAction_pageId, pageId);
 
         if (names != null) {
-            q.or(
+            q.and(Bridge.or(
                     Bridge.in(NewAction.Fields.unpublishedAction_name, names),
-                    Bridge.in(NewAction.Fields.unpublishedAction_fullyQualifiedName, names));
+                    Bridge.in(NewAction.Fields.unpublishedAction_fullyQualifiedName, names)));
         }
 
         // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object would


### PR DESCRIPTION
Removing the `BridgeQuery.or` API since

1. it reads confusing. Are the passed-in items applied with an `or`, or the current queries applied with the parameters with an `or`. Unlike `and` method, this difference with `or` can change the meaning of the query drastically.
2. it doesn't translate very well into Postgres world. Multiple hoops to manage the same API, just not worth it.

The static `Bridge.or` looks, reads, and works much better. That's the suggested alternative for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated logical operations in query handling: deprecated the use of `or` in favor of more robust handling with `and`.
- **Bug Fixes**
	- Improved filtering logic for unpublished actions by name and page ID, ensuring more accurate search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->