### PR TITLE
add more types and definitions of BlueprintOperationType

### DIFF
--- a/contributions/AppsmithWidgetDevelopmentGuide.md
+++ b/contributions/AppsmithWidgetDevelopmentGuide.md
@@ -385,11 +385,15 @@ Type of `BlueprintOperation`:
 
 `{ type: BlueprintOperationType, fn: BlueprintOperationFunction }`
 
-`BlueprintOperationType`: These operations can be of three types:
+`BlueprintOperationType`: These operations can be of seven types:
 
 - The operations to modify properties `BlueprintOperationTypes.MODIFY_PROPS`
 - The operations to add action trigger handlers `BlueprintOperationTypes.ADD_ACTION`
 - The operations to be performed, if a child widget is added to this widget. `BlueprintOperationTypes.CHILD_OPERATIONS`
+- The operations to trigger before a widget is finalized in a new position after being dragged and dropped. `BlueprintOperationTypes.BEFORE_DROP`
+- The operations to trigger triggered before a widget or a group of widgets is pasted into a destination widget. `BlueprintOperationTypes.BEFORE_PASE`
+- The operations to trigger before a child widget is added to a parent widget. `BlueprintOperationTypes.BEFORE_ADD`
+- The operations to update and create parameters before adding the new widget. `BlueprintOperationTypes.UPDATE_CREATE_PARAMS_BEFORE_ADD`
 
 ### Widget Enhancements
 

--- a/contributions/AppsmithWidgetDevelopmentGuide.md
+++ b/contributions/AppsmithWidgetDevelopmentGuide.md
@@ -391,7 +391,7 @@ Type of `BlueprintOperation`:
 - The operations to add action trigger handlers `BlueprintOperationTypes.ADD_ACTION`
 - The operations to be performed, if a child widget is added to this widget. `BlueprintOperationTypes.CHILD_OPERATIONS`
 - The operations to trigger before a widget is finalized in a new position after being dragged and dropped. `BlueprintOperationTypes.BEFORE_DROP`
-- The operations to trigger triggered before a widget or a group of widgets is pasted into a destination widget. `BlueprintOperationTypes.BEFORE_PASE`
+- The operations to be triggered before a widget or a group of widgets is pasted into a destination widget. `BlueprintOperationTypes.BEFORE_PASE`
 - The operations to trigger before a child widget is added to a parent widget. `BlueprintOperationTypes.BEFORE_ADD`
 - The operations to update and create parameters before adding the new widget. `BlueprintOperationTypes.UPDATE_CREATE_PARAMS_BEFORE_ADD`
 


### PR DESCRIPTION
This PR is about adding more types and definitions of BlueprintOperationType
There are  4 types of BlueprintOperationType that I added
1. BEFORE_DROP
2. BEFORE_PASTE
3. BEFORE_ADD
4. UPDATE_CREATE_PARAMS_BEFORE_ADD
I'm an Appsmith contributor who wants to develop a new widget. I have noticed that this document is not updated for six months,  that's why  I'm trying to patch this document. Correct me If I am wrong and please tell me the right thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Expanded the `BlueprintOperationType` enum from three to seven types, introducing new operations for widget positioning, pasting, and parameter updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->