### PR TITLE
feat: Rollout Side by Side

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_Editor_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_Editor_spec.js
@@ -37,12 +37,7 @@ describe("Undo/Redo functionality", function () {
       //cy.get(datasourceEditor.sectionAuthentication).trigger("click").wait(1000);
 
       cy.get("body").type(`{${modifierKey}}z`);
-      cy.get(".t--application-name").click({ force: true }).wait(500);
-      cy.get(".ads-v2-menu__menu-item-children:contains(Edit)").click();
-      cy.get(".ads-v2-menu__menu-item-children:contains(Undo)").click({
-        force: true,
-      });
-      cy.get(datasourceEditor.password).should("be.empty").wait(1000);
+      cy.get("body").type(`{${modifierKey}}{shift}z`);
       cy.get(datasourceEditor.saveBtn).click({ force: true });
       dataSources.AssertDSInActiveList(postgresDatasourceName);
     });
@@ -105,12 +100,7 @@ describe("Undo/Redo functionality", function () {
     );
     cy.get("body").type(`{${modifierKey}}{shift}z`);
     cy.get(".CodeMirror-code span").contains("{{FirstAPI}}");
-    // undo/edo through app menu
-    cy.get(".t--application-name").click({ force: true });
-    cy.get(".ads-v2-menu__menu-item-children:contains(Edit)").click();
-    cy.get(".ads-v2-menu__menu-item-children:contains(Undo)").click({
-      multiple: true,
-    });
+    cy.get("body").type(`{${modifierKey}}z`);
     cy.get(".CodeMirror-code span")
       .last()
       .should("not.have.text", "{{FirstAPI}}");
@@ -132,12 +122,7 @@ describe("Undo/Redo functionality", function () {
     );
     // verifying testJSFunction is visible on page after redo
     cy.contains("testJSFunction").should("exist");
-    // performing undo from app menu
-    cy.get(".t--application-name").click({ force: true });
-    cy.get(".ads-v2-menu__menu-item-children:contains(Edit)").click();
-    cy.get(".ads-v2-menu__menu-item-children:contains(Undo)").click({
-      multiple: true,
-    });
+    cy.get("body").type(`{${modifierKey}}z`);
     // cy.get(".function-name").should("not.contain.text", "test");
   });
 

--- a/app/client/cypress/support/Objects/FeatureFlags.ts
+++ b/app/client/cypress/support/Objects/FeatureFlags.ts
@@ -14,9 +14,9 @@ export const featureFlagIntercept = (
     },
     data: {
       ...flags,
-      release_app_sidebar_enabled: true,
       release_show_new_sidebar_pages_pane_enabled: true,
       rollout_consolidated_page_load_fetch_enabled: true,
+      release_side_by_side_ide_enabled: true,
     },
     errorDisplay: "",
   };

--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -54,6 +54,7 @@ export const FEATURE_FLAG = {
     "release_drag_drop_building_blocks_enabled",
   rollout_js_enabled_one_click_binding_enabled:
     "rollout_js_enabled_one_click_binding_enabled",
+  rollout_side_by_side_enabled: "rollout_side_by_side_enabled",
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG;
@@ -96,6 +97,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_show_create_app_from_templates_enabled: false,
   rollout_remove_feature_walkthrough_enabled: false,
   rollout_js_enabled_one_click_binding_enabled: false,
+  rollout_side_by_side_enabled: false,
 };
 
 export const AB_TESTING_EVENT_KEYS = {

--- a/app/client/src/components/editorComponents/GlobalSearch/HelpBar.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/HelpBar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { connect } from "react-redux";
+import { connect, useSelector } from "react-redux";
 import { getTypographyByKey, Text, TextType } from "design-system-old";
 import { Icon } from "design-system";
 import { setGlobalSearchCategory } from "actions/globalSearchActions";
@@ -10,8 +10,7 @@ import { modText } from "utils/helpers";
 import { filterCategories, SEARCH_CATEGORY_ID } from "./utils";
 import { protectedModeSelector } from "selectors/gitSyncSelectors";
 import type { AppState } from "@appsmith/reducers";
-import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
-import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
+import { getIsSideBySideEnabled } from "selectors/ideSelectors";
 
 const StyledHelpBar = styled.button<{ isSideBySideFlagEnabled?: boolean }>`
   padding: 0 var(--ads-v2-spaces-3);
@@ -54,9 +53,7 @@ interface Props {
 }
 
 function HelpBar({ isProtectedMode, toggleShowModal }: Props) {
-  const isSideBySideFlagEnabled = useFeatureFlag(
-    FEATURE_FLAG.release_side_by_side_ide_enabled,
-  );
+  const isSideBySideFlagEnabled = useSelector(getIsSideBySideEnabled);
 
   return (
     <StyledHelpBar

--- a/app/client/src/pages/Editor/EditorName/NavigationMenuData.ts
+++ b/app/client/src/pages/Editor/EditorName/NavigationMenuData.ts
@@ -22,8 +22,7 @@ import { redoShortCut, undoShortCut } from "utils/helpers";
 import { toast } from "design-system";
 import type { ThemeProp } from "WidgetProvider/constants";
 import { DISCORD_URL, DOCS_BASE_URL } from "constants/ThirdPartyConstants";
-import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
-import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
+import { getIsSideBySideEnabled } from "selectors/ideSelectors";
 
 export interface NavigationMenuDataProps extends ThemeProp {
   editMode: typeof noop;
@@ -41,9 +40,7 @@ export const GetNavigationMenuData = ({
 
   const isApplicationIdPresent = !!(applicationId && applicationId.length > 0);
 
-  const isSideBySideFlagEnabled = useFeatureFlag(
-    FEATURE_FLAG.release_side_by_side_ide_enabled,
-  );
+  const isSideBySideFlagEnabled = useSelector(getIsSideBySideEnabled);
 
   const currentApplication = useSelector(getCurrentApplication);
   const hasExportPermission = isPermitted(

--- a/app/client/src/selectors/ideSelectors.tsx
+++ b/app/client/src/selectors/ideSelectors.tsx
@@ -6,7 +6,9 @@ import { EditorEntityTab } from "@appsmith/entities/IDE/constants";
 
 export const getIsSideBySideEnabled = createSelector(
   selectFeatureFlags,
-  (flags) => flags.release_side_by_side_ide_enabled,
+  (flags) =>
+    flags.release_side_by_side_ide_enabled ||
+    flags.rollout_side_by_side_enabled,
 );
 
 export const getIDEViewMode = (state: AppState) => state.ui.ide.view;


### PR DESCRIPTION
## Description

Rolls out the Side by Side feature on the App IDE



## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8247348570>
> Commit: `e9c3a284ff52d2012618c569324e25766f6f2411`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8247348570&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature flag to enable a side-by-side IDE layout, enhancing the user interface for code editing and preview.

- **Refactor**
	- Streamlined feature flag handling for the side-by-side IDE feature across various components.
	- Updated UI test scenarios to incorporate keyboard shortcuts for Undo/Redo actions.

- **Chores**
	- Removed an outdated feature flag related to the app sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->