### PR TITLE
fix: NPE in LoginRateLimitFilter

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -9,7 +9,7 @@ import com.appsmith.server.constants.Url;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.filters.CSRFFilter;
 import com.appsmith.server.filters.ConditionalFilter;
-import com.appsmith.server.filters.PreAuth;
+import com.appsmith.server.filters.LoginRateLimitFilter;
 import com.appsmith.server.helpers.RedirectHelper;
 import com.appsmith.server.ratelimiting.RateLimitService;
 import com.appsmith.server.services.AnalyticsService;
@@ -222,7 +222,7 @@ public class SecurityConfig {
                 .and()
                 // Add Pre Auth rate limit filter before authentication filter
                 .addFilterBefore(
-                        new ConditionalFilter(new PreAuth(rateLimitService), Url.LOGIN_URL),
+                        new ConditionalFilter(new LoginRateLimitFilter(rateLimitService), Url.LOGIN_URL),
                         SecurityWebFiltersOrder.FORM_LOGIN)
                 .httpBasic(httpBasicSpec -> httpBasicSpec.authenticationFailureHandler(failureHandler))
                 .formLogin(formLoginSpec -> formLoginSpec

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/LoginRateLimitFilter.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/LoginRateLimitFilter.java
@@ -18,12 +18,12 @@ import java.nio.charset.StandardCharsets;
 import static java.lang.Boolean.FALSE;
 
 @Slf4j
-public class PreAuth implements WebFilter {
+public class LoginRateLimitFilter implements WebFilter {
 
     private final ServerRedirectStrategy redirectStrategy = new DefaultServerRedirectStrategy();
     private final RateLimitService rateLimitService;
 
-    public PreAuth(RateLimitService rateLimitService) {
+    public LoginRateLimitFilter(RateLimitService rateLimitService) {
         this.rateLimitService = rateLimitService;
     }
 
@@ -52,7 +52,7 @@ public class PreAuth implements WebFilter {
 
     private Mono<String> getUsername(ServerWebExchange exchange) {
         return exchange.getFormData()
-                .map(formData -> formData.getFirst(FieldName.USERNAME.toString()))
+                .mapNotNull(formData -> formData.getFirst(FieldName.USERNAME.toString()))
                 .defaultIfEmpty("");
     }
 


### PR DESCRIPTION
We get an NPE when there's a request to the login API endpoint, with a missing `username` field. This PR fixes that.

![shot-2024-03-12-07-22-19](https://github.com/appsmithorg/appsmith/assets/120119/4256faea-5f93-4c47-aad4-c21c56ea9496)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new login rate limiting feature to enhance security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->