### PR TITLE
chore: add more four types and definitions of BlueprintOperationType

### DIFF
--- a/contributions/AppsmithWidgetDevelopmentGuide.md
+++ b/contributions/AppsmithWidgetDevelopmentGuide.md
@@ -390,6 +390,10 @@ Type of `BlueprintOperation`:
 - The operations to modify properties `BlueprintOperationTypes.MODIFY_PROPS`
 - The operations to add action trigger handlers `BlueprintOperationTypes.ADD_ACTION`
 - The operations to be performed, if a child widget is added to this widget. `BlueprintOperationTypes.CHILD_OPERATIONS`
+- The operations to be triggered before a widget is finalized in a new position after being dragged and dropped. `BlueprintOperationTypes.BEFORE_DROP`
+- The operations to be triggered before a widget or a group of widgets is pasted into a destination widget. `BlueprintOperationTypes.BEFORE_PASTE`
+- The operations to be triggered before a child widget is added to a parent widget. `BlueprintOperationTypes.BEFORE_ADD`
+- The operations to update and create parameters before adding the new widget. `BlueprintOperationTypes.UPDATE_CREATE_PARAMS_BEFORE_ADD`
 
 ### Widget Enhancements
 


### PR DESCRIPTION
This PR is about adding more types and definitions of BlueprintOperationType
There are 4 types of BlueprintOperationType that I added
1. BEFORE_DROP
2. BEFORE_PASTE
3. BEFORE_ADD
4. UPDATE_CREATE_PARAMS_BEFORE_ADD
I'm an Appsmith contributor who wants to develop a new widget. I have noticed that this document is not updated for six months, that's why I'm trying to patch this document. Correct me If I am wrong and please tell me the right thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Appsmith Widget Development Guide to include new operations for widget interactions such as triggering actions before dropping, pasting, adding child widgets, and updating parameters before adding new widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->