### PR TITLE
fix: Handle widget selection on modal closure when url changes.

### DIFF
--- a/app/client/src/sagas/WidgetSelectionSagas.ts
+++ b/app/client/src/sagas/WidgetSelectionSagas.ts
@@ -55,6 +55,7 @@ import { getModalWidgetType } from "selectors/widgetSelectors";
 import { selectFeatureFlags } from "@appsmith/selectors/featureFlagsSelectors";
 import type { FeatureFlags } from "@appsmith/entities/FeatureFlag";
 import { getWidgetSelectorByWidgetId } from "selectors/layoutSystemSelectors";
+import { getAppViewerPageIdFromPath } from "@appsmith/pages/Editor/Explorer/helpers";
 
 // The following is computed to be used in the entity explorer
 // Every time a widget is selected, we need to expand widget entities
@@ -67,8 +68,10 @@ function* selectWidgetSaga(action: ReduxAction<WidgetSelectionRequestPayload>) {
       payload = [],
       selectionRequestType,
     } = action.payload;
-
-    if (payload.some(isInvalidSelectionRequest)) {
+    const isOnEditorURL = !!getAppViewerPageIdFromPath(
+      window.location.pathname,
+    );
+    if (payload.some(isInvalidSelectionRequest) || !isOnEditorURL) {
       // Throw error
       return;
     }

--- a/app/client/src/sagas/WidgetSelectionSagas.ts
+++ b/app/client/src/sagas/WidgetSelectionSagas.ts
@@ -68,6 +68,13 @@ function* selectWidgetSaga(action: ReduxAction<WidgetSelectionRequestPayload>) {
       payload = [],
       selectionRequestType,
     } = action.payload;
+    /**
+     * Apart from the normal selection request by a user on canvas, there are other ways which can trigger selection
+     * e.g. when a modal closes in the editor -> we select the main container.
+     * One way modal closes is because user navigates to home page using the appsmith icon. In this case, we don't want the selection process to trigger.
+     * This also safeguards against the case where the selection process is triggered by a non-canvas click where user moves out of editor.
+     * */
+
     const isOnEditorURL = !!getAppViewerPageIdFromPath(
       window.location.pathname,
     );


### PR DESCRIPTION
## Description

<ins>Root cause</ins>
In the case of `Vehicle maintenence app` the problem was when you had modal open and clicked on appsmith logo - it triggered evaluations, which in turn closed the modal -> and modal saga called select widget saga (to select the main container)

This PR adds a check in the widget selection saga to ensure that we dont run the selection logic if we are not on the editor url.

Fixes #31614
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget,@tag.Modal,@tag.MainContainer,@tag.Container"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8249215900>
> Commit: `f9aee9ac5e03c556782df6b8306ddc75261e2d10`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8249215900&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Improved the selection process of widgets by checking if the user is on the editor page, enhancing the app usability and performance.
	- Added a condition to the selectWidgetSaga function to ensure actions are performed only when the current URL is on the editor page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->