### PR TITLE
chore: Refactoring code to show plugin based icons for module instances on EE

### DIFF
--- a/app/client/src/ce/constants/ModuleConstants.ts
+++ b/app/client/src/ce/constants/ModuleConstants.ts
@@ -1,3 +1,5 @@
+import type { PluginType } from "entities/Action";
+
 type ID = string;
 
 export enum MODULE_TYPE {
@@ -15,9 +17,17 @@ export interface ModuleInputSection {
   children?: ModuleInput[];
 }
 
-export interface Module {
+export interface Module extends ModuleMetadata {
   id: ID;
   name: string;
   packageId: ID;
   inputsForm: ModuleInputSection[];
+  type: MODULE_TYPE;
+}
+
+export interface ModuleMetadata {
+  moduleId: string;
+  datasourceId?: string;
+  pluginId: string;
+  pluginType: PluginType;
 }

--- a/app/client/src/ce/constants/ModuleInstanceConstants.ts
+++ b/app/client/src/ce/constants/ModuleInstanceConstants.ts
@@ -15,6 +15,7 @@ export interface ModuleInstance {
   inputs: {
     [key: string]: string;
   };
+  sourceModuleId: ModuleId;
 }
 
 export interface ModuleInstanceData {

--- a/app/client/src/ce/pages/Applications/ResourceListLoader.tsx
+++ b/app/client/src/ce/pages/Applications/ResourceListLoader.tsx
@@ -14,7 +14,7 @@ interface ResourcesLoaderProps {
 
 const DEFAULT_BACKGROUND_COLOR = "#9747FF1A";
 const DEFAULT_ICON = "book";
-const DEAFULT_RESOURCES = [{ name: "Default Resource" }];
+const DEAFULT_RESOURCES = [{ id: "default", name: "Default Resource" }];
 
 function ResourceListLoader({ isMobile, resources }: ResourcesLoaderProps) {
   const resourcesToUse = resources?.length ? resources : DEAFULT_RESOURCES;

--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -369,7 +369,6 @@ export function WorkspaceMenuItem({
         isFetchingWorkspaces ? 100 : 22
       } /* this is to avoid showing tooltip for loaders */
       icon="group-2-line"
-      key={workspace?.id}
       onSelect={handleWorkspaceClick}
       selected={selected}
       text={workspace?.name}
@@ -386,8 +385,8 @@ export const submitCreateWorkspaceForm = async (data: any, dispatch: any) => {
 export interface LeftPaneProps {
   isBannerVisible?: boolean;
   isFetchingWorkspaces: boolean;
-  workspaces: any;
-  activeWorkspaceId: string | undefined;
+  workspaces: Workspace[];
+  activeWorkspaceId?: string;
 }
 
 export function LeftPane(props: LeftPaneProps) {
@@ -395,7 +394,7 @@ export function LeftPane(props: LeftPaneProps) {
     activeWorkspaceId,
     isBannerVisible = false,
     isFetchingWorkspaces,
-    workspaces,
+    workspaces = [],
   } = props;
   const isMobile = useIsMobileDevice();
 
@@ -408,18 +407,14 @@ export function LeftPane(props: LeftPaneProps) {
         isFetchingWorkspaces={isFetchingWorkspaces}
       >
         <WorkpsacesNavigator data-testid="t--left-panel">
-          {workspaces &&
-            workspaces.map(
-              (workspace: any) =>
-                workspace && (
-                  <WorkspaceMenuItem
-                    isFetchingWorkspaces={isFetchingWorkspaces}
-                    key={workspace?.id}
-                    selected={workspace?.id === activeWorkspaceId}
-                    workspace={workspace}
-                  />
-                ),
-            )}
+          {workspaces.map((workspace) => (
+            <WorkspaceMenuItem
+              isFetchingWorkspaces={isFetchingWorkspaces}
+              key={workspace.id}
+              selected={workspace.id === activeWorkspaceId}
+              workspace={workspace}
+            />
+          ))}
         </WorkpsacesNavigator>
       </LeftPaneSection>
     </LeftPaneWrapper>
@@ -895,7 +890,9 @@ export const ApplictionsMainPage = (props: any) => {
   if (!isFetchingWorkspaces) {
     workspaces = fetchedWorkspaces;
   } else {
-    workspaces = loadingUserWorkspaces as any;
+    workspaces = loadingUserWorkspaces.map(
+      (loadingWorkspaces) => loadingWorkspaces.workspace,
+    ) as any;
   }
 
   const [activeWorkspaceId, setActiveWorkspaceId] = useState<

--- a/app/client/src/ce/selectors/modulesSelector.ts
+++ b/app/client/src/ce/selectors/modulesSelector.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { AppState } from "@appsmith/reducers";
+import type { Module } from "@appsmith/constants/ModuleConstants";
+
+export const getAllModules = (
+  state: AppState,
+): Record<string, Module> | any => {};

--- a/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
+++ b/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
@@ -28,6 +28,8 @@ import type { AppState } from "@appsmith/reducers";
 import type { Module } from "@appsmith/constants/ModuleConstants";
 import { getAllModules } from "@appsmith/selectors/modulesSelector";
 import { resolveIcon } from "pages/Editor/utils";
+import { Icon } from "design-system";
+import { EntityIcon } from "pages/Editor/Explorer/ExplorerIcons";
 
 enum SortingWeights {
   alphabetical = 1,
@@ -103,11 +105,19 @@ export const getQueryIcon = (
   if (query.config.hasOwnProperty("type")) {
     const q = query as ModuleInstanceData;
     const module = modules[q.config.sourceModuleId];
-    return resolveIcon({
+    const icon = resolveIcon({
       iconLocation: pluginImages[module.pluginId] || "",
       pluginType: module.pluginType,
       moduleType: module.type,
     });
+
+    return (
+      icon || (
+        <EntityIcon>
+          <Icon name="module" />
+        </EntityIcon>
+      )
+    );
   } else {
     const action = query as ActionData;
     return (

--- a/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
+++ b/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
@@ -18,8 +18,6 @@ import type {
   ActionData,
   ActionDataState,
 } from "@appsmith/reducers/entityReducers/actionsReducer";
-import { EntityIcon } from "pages/Editor/Explorer/ExplorerIcons";
-import { Icon } from "design-system";
 import type {
   ModuleInstanceData,
   ModuleInstanceDataState,
@@ -27,6 +25,9 @@ import type {
 import { selectFeatureFlagCheck } from "@appsmith/selectors/featureFlagsSelectors";
 import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
 import type { AppState } from "@appsmith/reducers";
+import type { Module } from "@appsmith/constants/ModuleConstants";
+import { getAllModules } from "@appsmith/selectors/modulesSelector";
+import { resolveIcon } from "pages/Editor/utils";
 
 enum SortingWeights {
   alphabetical = 1,
@@ -97,13 +98,16 @@ interface ConnectToOptionsProps {
 export const getQueryIcon = (
   query: ActionData | ModuleInstanceData,
   pluginImages: Record<string, string>,
+  modules: Record<string, Module>,
 ) => {
   if (query.config.hasOwnProperty("type")) {
-    return (
-      <EntityIcon>
-        <Icon name="module" />
-      </EntityIcon>
-    );
+    const q = query as ModuleInstanceData;
+    const module = modules[q.config.sourceModuleId];
+    return resolveIcon({
+      iconLocation: pluginImages[module.pluginId] || "",
+      pluginType: module.pluginType,
+      moduleType: module.type,
+    });
   } else {
     const action = query as ActionData;
     return (
@@ -172,6 +176,7 @@ function useConnectToOptions(props: ConnectToOptionsProps) {
   const { pluginImages, widget } = props;
 
   const queryModuleInstances = useSelector(getQueryModuleInstances);
+  const modules = useSelector(getAllModules);
   let filteredQueries: ActionData[] | ModuleInstanceData[] = queries;
 
   /* Exclude Gsheets from query options till this gets resolved https://github.com/appsmithorg/appsmith/issues/27102*/
@@ -193,7 +198,7 @@ function useConnectToOptions(props: ConnectToOptionsProps) {
       id: query.config.id,
       label: query.config.name,
       value: getBindingValue(widget, query),
-      icon: getQueryIcon(query, pluginImages),
+      icon: getQueryIcon(query, pluginImages, modules),
       onSelect: function (value?: string, valueOption?: DropdownOptionType) {
         addBinding(
           valueOption?.value,

--- a/app/client/src/components/propertyControls/ActionSelectorControl.tsx
+++ b/app/client/src/components/propertyControls/ActionSelectorControl.tsx
@@ -32,6 +32,7 @@ import type {
 } from "@appsmith/constants/ModuleInstanceConstants";
 import { MODULE_TYPE } from "@appsmith/constants/ModuleConstants";
 import type { JSAction } from "entities/JSCollection";
+import { getAllModules } from "@appsmith/selectors/modulesSelector";
 
 class ActionSelectorControl extends BaseControl<ControlProps> {
   componentRef = React.createRef<HTMLDivElement>();
@@ -108,6 +109,7 @@ class ActionSelectorControl extends BaseControl<ControlProps> {
     const moduleInstances = getModuleInstances(state);
     const queryModuleInstances = [] as ModuleInstanceDataState;
     const jsModuleInstances = getJSModuleInstancesData(state);
+    const modules = getAllModules(state);
 
     if (!!moduleInstances) {
       for (const moduleInstance of Object.values(moduleInstances)) {
@@ -166,6 +168,7 @@ class ActionSelectorControl extends BaseControl<ControlProps> {
       },
       queryModuleInstances,
       jsModuleInstances,
+      modules,
     );
 
     try {

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -34,7 +34,7 @@ export const NameWrapper = styled.div<{ enableFontStyling?: boolean }>`
 }`
       : null}
 
-  & .t--action-name-edit-field, & .t--js-action-name-edit-field {
+  & .t--action-name-edit-field, & .t--js-action-name-edit-field, & .t--module-instance-name-edit-field {
     width: 100%;
 
     & > span {

--- a/app/client/src/ee/selectors/modulesSelector.ts
+++ b/app/client/src/ee/selectors/modulesSelector.ts
@@ -1,0 +1,1 @@
+export * from "ce/selectors/modulesSelector";

--- a/app/client/src/pages/Editor/APIEditor/index.tsx
+++ b/app/client/src/pages/Editor/APIEditor/index.tsx
@@ -28,7 +28,7 @@ import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { ApiEditorContextProvider } from "./ApiEditorContext";
 import type { PaginationField } from "api/ActionAPI";
-import { get } from "lodash";
+import { get, keyBy } from "lodash";
 import PerformanceTracker, {
   PerformanceTransactionName,
 } from "utils/PerformanceTracker";
@@ -38,6 +38,8 @@ import { MODULE_TYPE } from "@appsmith/constants/ModuleConstants";
 import Disabler from "pages/common/Disabler";
 import ConvertEntityNotification from "@appsmith/pages/common/ConvertEntityNotification";
 import { useIsEditorPaneSegmentsEnabled } from "../IDE/hooks";
+import { Icon } from "design-system";
+import { resolveIcon } from "../utils";
 
 type ApiEditorWrapperProps = RouteComponentProps<APIEditorRouteParams>;
 
@@ -65,6 +67,12 @@ function ApiEditorWrapper(props: ApiEditorWrapperProps) {
   const isConverting = useSelector((state) =>
     getIsActionConverting(state, action?.id || ""),
   );
+  const pluginGroups = useMemo(() => keyBy(plugins, "id"), [plugins]);
+  const icon = resolveIcon({
+    iconLocation: pluginGroups[pluginId]?.iconLocation || "",
+    pluginType: action?.pluginType || "",
+    moduleType: action?.actionConfiguration?.body?.moduleType,
+  }) || <Icon name="module" />;
 
   const isChangePermitted = getHasManageActionPermission(
     isFeatureEnabled,
@@ -150,7 +158,7 @@ function ApiEditorWrapper(props: ApiEditorWrapperProps) {
   const notification = useMemo(() => {
     if (!isConverting) return null;
 
-    return <ConvertEntityNotification name={action?.name || ""} />;
+    return <ConvertEntityNotification icon={icon} name={action?.name || ""} />;
   }, [action?.name, isConverting]);
 
   return (

--- a/app/client/src/pages/Editor/Explorer/ExplorerIcons.tsx
+++ b/app/client/src/pages/Editor/Explorer/ExplorerIcons.tsx
@@ -337,21 +337,3 @@ export function AppsmithAIIcon() {
 export function ActionUrlIcon(url: string) {
   return <img src={url} />;
 }
-
-export function ModuleIcon(
-  height = 18,
-  width = 18,
-  noBackground = false,
-  noBorder = false,
-) {
-  return (
-    <EntityIcon
-      height={height + "px"}
-      noBackground={noBackground}
-      noBorder={noBorder}
-      width={width + "px"}
-    >
-      <Icon name="module" size="md" />
-    </EntityIcon>
-  );
-}

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -19,6 +19,7 @@ import { DatasourceCreateEntryPoints } from "constants/Datasource";
 import {
   getAction,
   getIsActionConverting,
+  getPluginImages,
   getPluginSettingConfigs,
 } from "@appsmith/selectors/entitiesSelector";
 import { integrationEditorURL } from "@appsmith/RouteBuilder";
@@ -38,6 +39,8 @@ import { MODULE_TYPE } from "@appsmith/constants/ModuleConstants";
 import ConvertEntityNotification from "@appsmith/pages/common/ConvertEntityNotification";
 import { PluginType } from "entities/Action";
 import { useIsEditorPaneSegmentsEnabled } from "../IDE/hooks";
+import { Icon } from "design-system";
+import { resolveIcon } from "../utils";
 
 type QueryEditorProps = RouteComponentProps<QueryEditorRouteParams>;
 
@@ -58,6 +61,12 @@ function QueryEditor(props: QueryEditorProps) {
   const isConverting = useSelector((state) =>
     getIsActionConverting(state, actionId || ""),
   );
+  const pluginImages = useSelector(getPluginImages);
+  const icon = resolveIcon({
+    iconLocation: pluginImages[pluginId] || "",
+    pluginType: action?.pluginType || "",
+    moduleType: action?.actionConfiguration?.body?.moduleType,
+  }) || <Icon name="module" />;
 
   const isDeletePermitted = getHasDeleteActionPermission(
     isFeatureEnabled,
@@ -156,7 +165,13 @@ function QueryEditor(props: QueryEditorProps) {
   const notification = useMemo(() => {
     if (!isConverting) return null;
 
-    return <ConvertEntityNotification name={action?.name || ""} withPadding />;
+    return (
+      <ConvertEntityNotification
+        icon={icon}
+        name={action?.name || ""}
+        withPadding
+      />
+    );
   }, [action?.name, isConverting]);
 
   return (

--- a/app/client/src/pages/Editor/utils.tsx
+++ b/app/client/src/pages/Editor/utils.tsx
@@ -1,7 +1,8 @@
-import { debounce, random } from "lodash";
-import { useEffect, useMemo, useState } from "react";
+import React from "react";
 import ReactDOM from "react-dom";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router";
+import { debounce, random } from "lodash";
 import type {
   WidgetCardsGroupedByTags,
   WidgetTags,
@@ -19,6 +20,15 @@ import { useSelector } from "react-redux";
 import { getCurrentPageId } from "selectors/editorSelectors";
 import type { WidgetCardProps } from "widgets/BaseWidget";
 import type { ActionResponse } from "api/ActionAPI";
+import { MODULE_TYPE } from "@appsmith/constants/ModuleConstants";
+import {
+  ENTITY_ICON_SIZE,
+  EntityIcon,
+  JsFileIconV2,
+  dbQueryIcon,
+} from "pages/Editor/Explorer/ExplorerIcons";
+import { PluginType } from "entities/Action";
+import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
 
 export const draggableElement = (
   id: string,
@@ -336,3 +346,38 @@ export const actionResponseDisplayDataFormats = (
     responseDisplayFormat,
   };
 };
+
+function resolveQueryModuleIcon(
+  iconLocation: string,
+  pluginType: string,
+  isLargeIcon: boolean,
+) {
+  if (iconLocation)
+    return (
+      <EntityIcon
+        height={`${isLargeIcon ? ENTITY_ICON_SIZE * 2 : ENTITY_ICON_SIZE}px`}
+        width={`${isLargeIcon ? ENTITY_ICON_SIZE * 2 : ENTITY_ICON_SIZE}px`}
+      >
+        <img alt="entityIcon" src={getAssetUrl(iconLocation)} />
+      </EntityIcon>
+    );
+  else if (pluginType === PluginType.DB) return dbQueryIcon;
+}
+
+export function resolveIcon({
+  iconLocation,
+  isLargeIcon = false,
+  moduleType,
+  pluginType,
+}: {
+  iconLocation: string;
+  pluginType: string;
+  moduleType: string;
+  isLargeIcon?: boolean;
+}) {
+  if (moduleType === MODULE_TYPE.JS) {
+    return isLargeIcon ? JsFileIconV2(34, 34) : JsFileIconV2(16, 16);
+  } else {
+    return resolveQueryModuleIcon(iconLocation, pluginType, isLargeIcon);
+  }
+}


### PR DESCRIPTION
## Description

Refactoring code to show plugin based icons for module instances on EE

Fixes [#30163](https://github.com/appsmithorg/appsmith/issues/30163)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8256707865>
> Commit: `897cc28f1c8d15efb7789788aba89687b85a4916`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8256707865&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface for module metadata, including properties like module and plugin identifiers.
	- Added a new type property to the Module interface to distinguish module types.
	- Enhanced resource list loading with unique identifiers for each resource.
	- Implemented functionality to dynamically resolve and display icons based on module or plugin properties.
- **Enhancements**
	- Updated the applications page to support workspaces more effectively, including active workspace identification.
	- Improved module selection and display across the application, allowing for a more integrated module management experience.
- **Refactor**
	- Removed unused functions and components related to module icon resolution.
	- Streamlined the logic for fetching and displaying module-related information, including in action selectors and query editors.
- **Bug Fixes**
	- Fixed an issue with resource object identification by introducing unique `id` fields.
- **Style**
	- Added new class selector for module instance name editing, enhancing the styling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->