### PR TITLE
chore: add the commands to start the RTS server

### DIFF
--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -57,6 +57,13 @@ On your development machine, please ensure that:
     - The backend server can be run in two ways
         1.  Use Appsmith's staging server hosted at `https://release.app.appsmith.com` for development purposes. <b>(Recommended)</b>
         1.  Run the backend server locally. To setup the backend server locally, refer [here](#running-backend-locally).
+    - To start the RTS server for communication between a server and clients, use these commands below,
+      ```bash
+          cd app/client/packages/rts
+          cp .env.example .env
+          yarn install
+          yarn start
+          ```
     -  Run the script `start-https.sh` to start the nginx container that will proxy the frontend requests to the backend server.
         - Pass the server name as an argument to this command to use that server as backend.
 


### PR DESCRIPTION
This PR adds the commands to start the RTS server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added instructions for starting the RTS server to facilitate server-client communication.
	- Provided a script `start-https.sh` for proxying frontend requests to the backend server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->