### PR TITLE
chore: extend the update recently used workspaces to workflows and packages

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/WorkspaceResourceContext.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/WorkspaceResourceContext.java
@@ -1,0 +1,20 @@
+package com.appsmith.external.enums;
+
+public enum WorkspaceResourceContext {
+    APPLICATIONS,
+    WORKFLOWS,
+    PACKAGES,
+    ;
+
+    public static boolean isApplicationContext(WorkspaceResourceContext context) {
+        return context == null || context == APPLICATIONS;
+    }
+
+    public static boolean isWorkflowContext(WorkspaceResourceContext context) {
+        return context == WORKFLOWS;
+    }
+
+    public static boolean isPackageContext(WorkspaceResourceContext context) {
+        return context == PACKAGES;
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/WorkspaceResourceContext.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/WorkspaceResourceContext.java
@@ -1,20 +1,23 @@
 package com.appsmith.external.enums;
 
+import java.util.Objects;
+
 public enum WorkspaceResourceContext {
     APPLICATIONS,
     WORKFLOWS,
     PACKAGES,
     ;
 
+    // Default to APPLICATIONS
     public static boolean isApplicationContext(WorkspaceResourceContext context) {
-        return context == null || context == APPLICATIONS;
+        return Objects.isNull(context) || APPLICATIONS.equals(context);
     }
 
     public static boolean isWorkflowContext(WorkspaceResourceContext context) {
-        return context == WORKFLOWS;
+        return WORKFLOWS.equals(context);
     }
 
     public static boolean isPackageContext(WorkspaceResourceContext context) {
-        return context == PACKAGES;
+        return PACKAGES.equals(context);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
@@ -255,7 +255,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
                     if (markApplicationAsRecentlyAccessed) {
                         // add this application and workspace id to the recently used list in UserData
                         return userDataService
-                                .updateLastUserResourceAndWorkspaceList(
+                                .updateLastUsedResourceAndWorkspaceList(
                                         application.getId(),
                                         application.getWorkspaceId(),
                                         WorkspaceResourceContext.APPLICATIONS)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.newpages.base;
 
+import com.appsmith.external.enums.WorkspaceResourceContext;
 import com.appsmith.external.models.DefaultResources;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.applications.base.ApplicationService;
@@ -254,7 +255,10 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
                     if (markApplicationAsRecentlyAccessed) {
                         // add this application and workspace id to the recently used list in UserData
                         return userDataService
-                                .updateLastUsedAppAndWorkspaceList(application)
+                                .updateLastUserResourceAndWorkspaceList(
+                                        application.getId(),
+                                        application.getWorkspaceId(),
+                                        WorkspaceResourceContext.APPLICATIONS)
                                 .thenReturn(application);
                     } else {
                         return Mono.just(application);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
@@ -43,7 +43,7 @@ public interface UserDataServiceCE {
 
     Mono<Void> makeProfilePhotoResponse(ServerWebExchange exchange);
 
-    Mono<UserData> updateLastUserResourceAndWorkspaceList(
+    Mono<UserData> updateLastUsedResourceAndWorkspaceList(
             String resourceId, String workspaceId, WorkspaceResourceContext context);
 
     Mono<Map<String, Boolean>> getFeatureFlagsForCurrentUser();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
@@ -1,6 +1,6 @@
 package com.appsmith.server.services.ce;
 
-import com.appsmith.server.domains.Application;
+import com.appsmith.external.enums.WorkspaceResourceContext;
 import com.appsmith.server.domains.GitProfile;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserData;
@@ -43,7 +43,8 @@ public interface UserDataServiceCE {
 
     Mono<Void> makeProfilePhotoResponse(ServerWebExchange exchange);
 
-    Mono<UserData> updateLastUsedAppAndWorkspaceList(Application application);
+    Mono<UserData> updateLastUserResourceAndWorkspaceList(
+            String resourceId, String workspaceId, WorkspaceResourceContext context);
 
     Mono<Map<String, Boolean>> getFeatureFlagsForCurrentUser();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -246,7 +246,7 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
     }
 
     @Override
-    public Mono<UserData> updateLastUserResourceAndWorkspaceList(
+    public Mono<UserData> updateLastUsedResourceAndWorkspaceList(
             String resourceId, String workspaceId, WorkspaceResourceContext context) {
         return sessionUserService
                 .getCurrentUser()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -1,7 +1,7 @@
 package com.appsmith.server.services.ce;
 
+import com.appsmith.external.enums.WorkspaceResourceContext;
 import com.appsmith.server.constants.FieldName;
-import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.Asset;
 import com.appsmith.server.domains.GitProfile;
 import com.appsmith.server.domains.User;
@@ -60,7 +60,7 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
 
     private static final int MAX_RECENT_WORKSPACES_LIMIT = 10;
 
-    private static final int MAX_RECENT_APPLICATIONS_LIMIT = 20;
+    private static final int MAX_RECENT_WORKSPACE_RESOURCE_LIMIT = 20;
 
     @Autowired
     public UserDataServiceCEImpl(
@@ -245,48 +245,40 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
                 .flatMap(assetId -> assetService.makeImageResponse(exchange, assetId));
     }
 
-    /**
-     * This function is used to update the recently used application and workspace for the user
-     *
-     * @param application
-     * @return Updated {@link UserData}
-     */
     @Override
-    public Mono<UserData> updateLastUsedAppAndWorkspaceList(Application application) {
+    public Mono<UserData> updateLastUserResourceAndWorkspaceList(
+            String resourceId, String workspaceId, WorkspaceResourceContext context) {
         return sessionUserService
                 .getCurrentUser()
                 .zipWhen(this::getForUser)
                 .flatMap(tuple -> {
                     final User user = tuple.getT1();
                     final UserData userData = tuple.getT2();
-                    // TODO remove the updated to deprecated fields once client starts consuming the updated API
-                    // set recently used workspace ids
-                    userData.setRecentlyUsedWorkspaceIds(addIdToRecentList(
-                            userData.getRecentlyUsedWorkspaceIds(),
-                            application.getWorkspaceId(),
-                            MAX_RECENT_WORKSPACES_LIMIT));
-                    // set recently used application ids
-                    userData.setRecentlyUsedAppIds(addIdToRecentList(
-                            userData.getRecentlyUsedAppIds(), application.getId(), MAX_RECENT_APPLICATIONS_LIMIT));
-
                     // Update recently used workspace and corresponding application ids
                     List<RecentlyUsedEntityDTO> recentlyUsedEntities = reorderWorkspacesInRecentlyUsedOrderForUser(
-                            userData.getRecentlyUsedEntityIds(),
-                            application.getWorkspaceId(),
-                            MAX_RECENT_WORKSPACES_LIMIT);
+                            userData.getRecentlyUsedEntityIds(), workspaceId, MAX_RECENT_WORKSPACES_LIMIT);
 
                     if (!CollectionUtils.isNullOrEmpty(recentlyUsedEntities)) {
                         RecentlyUsedEntityDTO latest = recentlyUsedEntities.get(0);
                         // Add the current applicationId to the list
-                        latest.setApplicationIds(addIdToRecentList(
-                                latest.getApplicationIds(), application.getId(), MAX_RECENT_APPLICATIONS_LIMIT));
+                        setResourceIds(
+                                latest,
+                                context,
+                                addIdToRecentList(
+                                        latest.getApplicationIds(), resourceId, MAX_RECENT_WORKSPACE_RESOURCE_LIMIT));
                     }
                     userData.setRecentlyUsedEntityIds(recentlyUsedEntities);
                     return Mono.zip(
-                            analyticsService.identifyUser(user, userData, application.getWorkspaceId()),
-                            repository.save(userData));
+                            analyticsService.identifyUser(user, userData, workspaceId), repository.save(userData));
                 })
                 .map(Tuple2::getT2);
+    }
+
+    protected void setResourceIds(
+            RecentlyUsedEntityDTO recentlyUsedEntityDTO,
+            WorkspaceResourceContext workspaceResourceContext,
+            List<String> resourceIds) {
+        recentlyUsedEntityDTO.setApplicationIds(resourceIds);
     }
 
     protected List<String> addIdToRecentList(List<String> srcIdList, String newId, int maxSize) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -260,12 +260,14 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
 
                     if (!CollectionUtils.isNullOrEmpty(recentlyUsedEntities)) {
                         RecentlyUsedEntityDTO latest = recentlyUsedEntities.get(0);
+                        // Get the correct resource id based on the context
+                        List<String> existingResourceIds = getResourceIds(latest, context);
                         // Add the current applicationId to the list
                         setResourceIds(
                                 latest,
                                 context,
                                 addIdToRecentList(
-                                        latest.getApplicationIds(), resourceId, MAX_RECENT_WORKSPACE_RESOURCE_LIMIT));
+                                        existingResourceIds, resourceId, MAX_RECENT_WORKSPACE_RESOURCE_LIMIT));
                     }
                     userData.setRecentlyUsedEntityIds(recentlyUsedEntities);
                     return Mono.zip(
@@ -279,6 +281,11 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
             WorkspaceResourceContext workspaceResourceContext,
             List<String> resourceIds) {
         recentlyUsedEntityDTO.setApplicationIds(resourceIds);
+    }
+
+    protected List<String> getResourceIds(
+            RecentlyUsedEntityDTO recentlyUsedEntityDTO, WorkspaceResourceContext context) {
+        return recentlyUsedEntityDTO.getApplicationIds();
     }
 
     protected List<String> addIdToRecentList(List<String> srcIdList, String newId, int maxSize) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -238,7 +237,6 @@ public class UserDataServiceTest {
                 .getForCurrentUser()
                 .flatMap(userData -> {
                     // set recently used org ids to null
-                    userData.setRecentlyUsedWorkspaceIds(null);
                     userData.setRecentlyUsedEntityIds(null);
                     return userDataRepository.save(userData);
                 })
@@ -247,11 +245,6 @@ public class UserDataServiceTest {
 
         StepVerifier.create(saveMono)
                 .assertNext(userData -> {
-                    assertEquals(1, userData.getRecentlyUsedWorkspaceIds().size());
-                    assertEquals(
-                            sampleWorkspaceId,
-                            userData.getRecentlyUsedWorkspaceIds().get(0));
-
                     assertThat(userData.getRecentlyUsedEntityIds()).hasSize(1);
                     assertThat(userData.getRecentlyUsedEntityIds().get(0).getWorkspaceId())
                             .isEqualTo(sampleWorkspaceId);
@@ -289,11 +282,6 @@ public class UserDataServiceTest {
 
         StepVerifier.create(resultMono)
                 .assertNext(userData -> {
-                    assertEquals(3, userData.getRecentlyUsedWorkspaceIds().size());
-                    assertEquals(
-                            "sample-org-id",
-                            userData.getRecentlyUsedWorkspaceIds().get(0));
-
                     assertThat(userData.getRecentlyUsedEntityIds()).hasSize(3);
                     assertThat(userData.getRecentlyUsedEntityIds().get(0).getWorkspaceId())
                             .isEqualTo("sample-org-id");
@@ -347,14 +335,6 @@ public class UserDataServiceTest {
 
         StepVerifier.create(resultMono)
                 .assertNext(userData -> {
-                    assertThat(userData.getRecentlyUsedWorkspaceIds()).hasSize(MAX_RECENT_WORKSPACES_LIMIT);
-                    assertThat(userData.getRecentlyUsedWorkspaceIds().get(0)).isEqualTo(sampleWorkspaceId);
-                    assertThat(userData.getRecentlyUsedWorkspaceIds().get(9)).isEqualTo("org-9");
-
-                    assertThat(userData.getRecentlyUsedAppIds()).hasSize(MAX_RECENT_APPLICATIONS_LIMIT);
-                    assertThat(userData.getRecentlyUsedAppIds().get(0)).isEqualTo(sampleAppId);
-                    assertThat(userData.getRecentlyUsedAppIds().get(19)).isEqualTo("app-19");
-
                     assertThat(userData.getRecentlyUsedEntityIds()).hasSize(MAX_RECENT_WORKSPACES_LIMIT);
                     assertThat(userData.getRecentlyUsedEntityIds().get(0).getWorkspaceId())
                             .isEqualTo(sampleWorkspaceId);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
@@ -242,7 +242,8 @@ public class UserDataServiceTest {
                     userData.setRecentlyUsedEntityIds(null);
                     return userDataRepository.save(userData);
                 })
-                .then(userDataService.updateLastUsedAppAndWorkspaceList(application));
+                .then(userDataService.updateLastUsedResourceAndWorkspaceList(
+                        application.getId(), sampleWorkspaceId, null));
 
         StepVerifier.create(saveMono)
                 .assertNext(userData -> {
@@ -282,7 +283,8 @@ public class UserDataServiceTest {
                     Application application = new Application();
                     application.setWorkspaceId(sampleWorkspaceId);
                     application.setId("sample-app-id");
-                    return userDataService.updateLastUsedAppAndWorkspaceList(application);
+                    return userDataService.updateLastUsedResourceAndWorkspaceList(
+                            application.getId(), sampleWorkspaceId, null);
                 });
 
         StepVerifier.create(resultMono)
@@ -338,7 +340,8 @@ public class UserDataServiceTest {
                     Application application = new Application();
                     application.setId(sampleAppId);
                     application.setWorkspaceId(sampleWorkspaceId);
-                    return userDataService.updateLastUsedAppAndWorkspaceList(application);
+                    return userDataService.updateLastUsedResourceAndWorkspaceList(
+                            application.getId(), sampleWorkspaceId, null);
                 })
                 .cache();
 
@@ -380,7 +383,7 @@ public class UserDataServiceTest {
             Application application = new Application();
             application.setId(sampleAppId);
             application.setWorkspaceId("org-1");
-            return userDataService.updateLastUsedAppAndWorkspaceList(application);
+            return userDataService.updateLastUsedResourceAndWorkspaceList(application.getId(), "org-1", null);
         });
 
         StepVerifier.create(updateRecentlyUsedEntitiesMono)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserWorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserWorkspaceServiceTest.java
@@ -8,6 +8,7 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.dtos.MemberInfoDTO;
+import com.appsmith.server.dtos.RecentlyUsedEntityDTO;
 import com.appsmith.server.dtos.UpdatePermissionGroupDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
@@ -164,8 +165,12 @@ public class UserWorkspaceServiceTest {
 
         StepVerifier.create(userDataService.getForCurrentUser())
                 .assertNext(userData -> {
-                    assertThat(userData.getRecentlyUsedWorkspaceIds()).doesNotContain(testWorkspace.getId());
-                    assertThat(userData.getRecentlyUsedAppIds()).doesNotContain(savedApplication.getId());
+                    List<RecentlyUsedEntityDTO> recentlyUsedEntityIds = userData.getRecentlyUsedEntityIds();
+                    assertThat(recentlyUsedEntityIds).isNotNull();
+                    Set<String> workspaceIds = recentlyUsedEntityIds.stream()
+                            .map(RecentlyUsedEntityDTO::getWorkspaceId)
+                            .collect(Collectors.toSet());
+                    assertThat(workspaceIds).doesNotContain(testWorkspace.getId());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
> [!TIP]  
> Code split the recently used workspaces code to other workspace children

Fixes [[Task]: Workflows to get sorted based on recently used objects per user in a workspace](https://github.com/appsmithorg/appsmith/issues/30841)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8323719016>
> Commit: `af46466b7d88662d656fcaf8034ccda9dd72f657`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8323719016&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced tracking for user interactions across applications, workflows, and packages to improve the user experience.
- **Refactor**
	- Updated user data service to support the new tracking feature, ensuring a more personalized and efficient user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->