### PR TITLE
chore: Inject AuthenticationPrincipal in controller method

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UserControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UserControllerCE.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.multipart.Part;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -161,10 +162,8 @@ public class UserControllerCE extends BaseController<UserService, User, String> 
 
     @JsonView(Views.Public.class)
     @GetMapping("/me")
-    public Mono<ResponseDTO<UserProfileDTO>> getUserProfile() {
-        return sessionUserService
-                .getCurrentUser()
-                .flatMap(service::buildUserProfileDTO)
+    public Mono<ResponseDTO<UserProfileDTO>> getUserProfile(@AuthenticationPrincipal User user) {
+        return service.buildUserProfileDTO(user)
                 .map(profile -> new ResponseDTO<>(HttpStatus.OK.value(), profile, null));
     }
 


### PR DESCRIPTION
Instead of using `sessionUserService.getCurrentUser()`, or the `ReactiveSecurityContextHolder.getContext` directly (which we are doing in several places), this injection will let us get the principal directly at controller-level.

Yes, it produces the anonymous user, when there's no session.

Why? Less code. More relying on letting Spring do the right thing for us. :stuck_out_tongue:

Why aren't we making this change across the board everywhere? Sure, eventually. Small PR like this helps me get consensus, be less daunting to review, and most important of all, easy to revert if we notice something going wrong. In a week or two, if we want to do this, we can start rolling it out to more places in code.

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved user profile retrieval process for enhanced efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8446283232>
> Commit: `8eef3717b3eb9d3fbf5b28c4c1a8eb491f088483`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8446283232&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->

