### PR TITLE
chore: ce split for permission scoping for CD

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
@@ -45,6 +45,11 @@ public interface ActionCollectionServiceCE extends CrudService<ActionCollection,
 
     Mono<ActionCollectionDTO> deleteUnpublishedActionCollection(String id);
 
+    Mono<ActionCollectionDTO> deleteUnpublishedActionCollectionWithOptionalPermission(
+            String id,
+            Optional<AclPermission> deleteCollectionPermission,
+            Optional<AclPermission> deleteActionPermission);
+
     Mono<ActionCollectionDTO> deleteWithoutPermissionUnpublishedActionCollection(String id);
 
     Mono<ActionCollectionDTO> deleteUnpublishedActionCollection(String id, String branchName);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -82,6 +82,9 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
 
     Mono<ActionDTO> deleteUnpublishedAction(String id);
 
+    Mono<ActionDTO> deleteUnpublishedActionWithOptionalPermission(
+            String id, Optional<AclPermission> newActionDeletePermission);
+
     Flux<ActionDTO> getUnpublishedActions(MultiValueMap<String, String> params, Boolean includeJsActions);
 
     Flux<ActionDTO> getUnpublishedActions(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -842,8 +842,14 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
 
     @Override
     public Mono<ActionDTO> deleteUnpublishedAction(String id) {
+        return deleteUnpublishedActionWithOptionalPermission(id, Optional.of(actionPermission.getDeletePermission()));
+    }
+
+    @Override
+    public Mono<ActionDTO> deleteUnpublishedActionWithOptionalPermission(
+            String id, Optional<AclPermission> newActionDeletePermission) {
         Mono<NewAction> actionMono = repository
-                .findById(id, actionPermission.getDeletePermission())
+                .findById(id, newActionDeletePermission)
                 .switchIfEmpty(
                         Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.ACTION, id)));
         return actionMono

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
@@ -98,7 +99,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                         log.info("Deleting {} actions which are no more used", invalidActionIds.size());
                         return Flux.fromIterable(invalidActionIds)
                                 .flatMap(actionId -> newActionService
-                                        .deleteUnpublishedAction(actionId)
+                                        .deleteUnpublishedActionWithOptionalPermission(actionId, Optional.empty())
                                         // return an empty action so that the filter can remove it from the list
                                         .onErrorResume(throwable -> {
                                             log.debug("Failed to delete action with id {} during import", actionId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
@@ -358,7 +358,14 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
                         // Delete the pages which were removed during git merge operation
                         // This does not apply to the traditional import via file approach
                         return Flux.fromIterable(invalidPageIds)
-                                .flatMap(applicationPageService::deleteWithoutPermissionUnpublishedPage)
+                                .flatMap(pageId -> {
+                                    return applicationPageService.deleteUnpublishedPageWithOptionalPermission(
+                                            pageId,
+                                            Optional.empty(),
+                                            Optional.empty(),
+                                            Optional.empty(),
+                                            Optional.empty());
+                                })
                                 .flatMap(page -> newPageService
                                         .archiveWithoutPermissionById(page.getId())
                                         .onErrorResume(e -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCE.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services.ce;
 
+import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.domains.User;
@@ -7,6 +8,8 @@ import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.ClonePageMetaDTO;
 import com.appsmith.server.dtos.PageDTO;
 import reactor.core.publisher.Mono;
+
+import java.util.Optional;
 
 public interface ApplicationPageServiceCE {
 
@@ -47,9 +50,14 @@ public interface ApplicationPageServiceCE {
 
     Mono<PageDTO> deleteUnpublishedPageByBranchAndDefaultPageId(String defaultPageId, String branchName);
 
-    Mono<PageDTO> deleteUnpublishedPage(String id);
+    Mono<PageDTO> deleteUnpublishedPageWithOptionalPermission(
+            String id,
+            Optional<AclPermission> deletePagePermission,
+            Optional<AclPermission> readApplicationPermission,
+            Optional<AclPermission> deleteCollectionPermission,
+            Optional<AclPermission> deleteActionPermission);
 
-    Mono<PageDTO> deleteWithoutPermissionUnpublishedPage(String id);
+    Mono<PageDTO> deleteUnpublishedPage(String id);
 
     Mono<Application> publish(String applicationId, boolean isPublishedManually);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -640,6 +640,10 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                             return page;
                         }));
 
+        final Flux<ActionCollection> sourceActionCollectionsFlux = getCloneableActionCollections(pageId);
+
+        Flux<NewAction> sourceActionFlux = getCloneableActions(pageId);
+
         return sourcePageMono
                 .flatMap(page -> {
                     clonePageMetaDTO.setBranchedSourcePageId(page.getId());
@@ -736,6 +740,26 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                             })
                             .thenReturn(savedPage);
                 }));
+    }
+
+    protected Flux<ActionCollection> getCloneableActionCollections(String pageId) {
+        final Flux<ActionCollection> sourceActionCollectionsFlux = actionCollectionService.findByPageId(pageId);
+        return sourceActionCollectionsFlux;
+    }
+
+    protected Flux<NewAction> getCloneableActions(String pageId) {
+        Flux<NewAction> sourceActionFlux = newActionService
+                .findByPageId(pageId, actionPermission.getEditPermission())
+                // Set collection reference in actions to null to reset to the new application's collections later
+                .map(newAction -> {
+                    if (newAction.getUnpublishedAction() != null) {
+                        newAction.getUnpublishedAction().setCollectionId(null);
+                    }
+                    return newAction;
+                })
+                // In case there are no actions in the page being cloned, return empty
+                .switchIfEmpty(Flux.empty());
+        return sourceActionFlux;
     }
 
     private Mono<PageDTO> clonePageGivenApplicationId(String pageId, String applicationId) {
@@ -901,17 +925,34 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
      * In this scenario, if we were to delete all actions associated with the page, we would end up deleting an action
      * which is currently in published state and is being used.
      *
-     * @param id The pageId which needs to be archived.
+     * @param id                   The pageId which needs to be archived.
+     * @param deletePagePermission
      * @return
      */
     @Override
-    public Mono<PageDTO> deleteWithoutPermissionUnpublishedPage(String id) {
-        return deleteUnpublishedPageEx(id, Optional.empty());
+    public Mono<PageDTO> deleteUnpublishedPageWithOptionalPermission(
+            String id,
+            Optional<AclPermission> deletePagePermission,
+            Optional<AclPermission> readApplicationPermission,
+            Optional<AclPermission> deleteCollectionPermission,
+            Optional<AclPermission> deleteActionPermission) {
+        return deleteUnpublishedPageEx(
+                id, Optional.empty(), readApplicationPermission, deleteCollectionPermission, deleteActionPermission);
     }
 
     @Override
     public Mono<PageDTO> deleteUnpublishedPage(String id) {
-        return deleteUnpublishedPageEx(id, Optional.of(pagePermission.getDeletePermission()));
+
+        Optional<AclPermission> deletePagePermission = Optional.of(pagePermission.getDeletePermission());
+        Optional<AclPermission> readApplicationPermission = Optional.of(applicationPermission.getReadPermission());
+        Optional<AclPermission> deleteCollectionPermission = Optional.of(actionPermission.getDeletePermission());
+        Optional<AclPermission> deleteActionPermission = Optional.of(actionPermission.getDeletePermission());
+        return deleteUnpublishedPageEx(
+                id,
+                deletePagePermission,
+                readApplicationPermission,
+                deleteCollectionPermission,
+                deleteActionPermission);
     }
 
     /**
@@ -923,23 +964,36 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
      * In this scenario, if we were to delete all actions associated with the page, we would end up deleting an action
      * which is currently in published state and is being used.
      *
-     * @param id The pageId which needs to be archived.
+     * @param id                         The pageId which needs to be archived.
+     * @param readApplicationPermission
+     * @param deleteCollectionPermission
+     * @param deleteActionPermission
      * @return
      */
-    private Mono<PageDTO> deleteUnpublishedPageEx(String id, Optional<AclPermission> permission) {
+    private Mono<PageDTO> deleteUnpublishedPageEx(
+            String id,
+            Optional<AclPermission> deletePagePermission,
+            Optional<AclPermission> readApplicationPermission,
+            Optional<AclPermission> deleteCollectionPermission,
+            Optional<AclPermission> deleteActionPermission) {
 
         return newPageService
-                .findById(id, permission)
+                .findById(id, deletePagePermission)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.PAGE, id)))
                 .flatMap(page -> {
                     log.debug(
                             "Going to archive pageId: {} for applicationId: {}", page.getId(), page.getApplicationId());
+                    // Application is accessed without any application permission over here.
+                    // previously it was getting accessed only with read permission.
                     Mono<Application> applicationMono = applicationService
-                            .getById(page.getApplicationId())
+                            .findById(page.getApplicationId(), readApplicationPermission)
+                            .switchIfEmpty(Mono.error(
+                                    new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, id)))
                             .flatMap(application -> {
                                 application.getPages().removeIf(p -> p.getId().equals(page.getId()));
                                 return applicationService.save(application);
                             });
+
                     Mono<NewPage> newPageMono;
                     if (page.getPublishedPage() != null) {
                         PageDTO unpublishedPage = page.getUnpublishedPage();
@@ -966,12 +1020,13 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                      *  condition for delete action
                      */
                     Mono<List<ActionDTO>> archivedActionsMono = newActionService
-                            .findByPageId(page.getId(), actionPermission.getDeletePermission())
+                            .findByPageId(page.getId(), deleteActionPermission)
                             .filter(newAction -> !StringUtils.hasLength(
                                     newAction.getUnpublishedAction().getCollectionId()))
                             .flatMap(action -> {
                                 log.debug("Going to archive actionId: {} for applicationId: {}", action.getId(), id);
-                                return newActionService.deleteUnpublishedAction(action.getId());
+                                return newActionService.deleteUnpublishedActionWithOptionalPermission(
+                                        action.getId(), deleteActionPermission);
                             })
                             .collectList();
 
@@ -985,8 +1040,8 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                                         "Going to archive actionCollectionId: {} for applicationId: {}",
                                         actionCollection.getId(),
                                         id);
-                                return actionCollectionService.deleteUnpublishedActionCollection(
-                                        actionCollection.getId());
+                                return actionCollectionService.deleteUnpublishedActionCollectionWithOptionalPermission(
+                                        actionCollection.getId(), deleteCollectionPermission, deleteActionPermission);
                             })
                             .collectList();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -937,7 +937,11 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
             Optional<AclPermission> deleteCollectionPermission,
             Optional<AclPermission> deleteActionPermission) {
         return deleteUnpublishedPageEx(
-                id, Optional.empty(), readApplicationPermission, deleteCollectionPermission, deleteActionPermission);
+                id,
+                deletePagePermission,
+                readApplicationPermission,
+                deleteCollectionPermission,
+                deleteActionPermission);
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -683,7 +683,7 @@ public class ActionCollectionServiceImplTest {
         Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<Optional<AclPermission>>any()))
                 .thenReturn(Mono.just(actionCollection));
 
-        Mockito.when(newActionService.deleteUnpublishedAction(Mockito.any()))
+        Mockito.when(newActionService.deleteUnpublishedActionWithOptionalPermission(Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.just(
                         actionCollection.getUnpublishedCollection().getActions().get(0)));
 


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8275604593>
> Commit: `a87c10acf65e2d874d8e4b61c62d1c61e0cfca51`
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8275604593&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
> <li>cypress/e2e/Regression/Apps/EchoApiCMS_spec.js
> <li>cypress/e2e/Regression/Apps/PgAdmin_spec.js
> <li>cypress/e2e/Regression/ClientSide/BugTests/ApiBugs_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/BugTests/SelectWidget_Bug9334_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/JSEnabledByDefaultExperiment_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/ConnectToWidget_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/mongoDb_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/mongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/mongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/mongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/PartialImportExport/PartialExport_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/DataIdentifier_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_PageNo_PageSize_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicServerSideData_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Migration_Spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect4_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Select/Select3_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Button_Icon_validation_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Button_Icon_validation_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/server_side_filtering_spec_1.ts
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_Mustache_spec.js
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/Mongo_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MySQL1_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MySQL2_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/Postgres1_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/Postgres2_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/S3_Spec.js
> <li>cypress/e2e/Regression/ServerSide/MySQL_Datatypes/False_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
> <li>cypress/e2e/Regression/ServerSide/Params/ExecutionParams_spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/Mongo1_spec.ts
> <li>cypress/e2e/Regression/ServerSide/QueryPane/Mongo_Spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/Postgres_Spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
> <li>cypress/e2e/Sanity/Datasources/Arango_Basic_Spec.ts
> <li>cypress/e2e/Sanity/Datasources/SMTPDatasource_spec.js </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced a more flexible permission handling mechanism for deleting unpublished actions, action collections, and pages, allowing for optional permissions.
- **Enhancements**
	- Improved deletion logic in various services to support optional permissions, enhancing security and flexibility.
- **Refactor**
	- Updated methods across several services to accept additional permission parameters for deletion operations, aligning with the new flexible permission approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->