### PR TITLE
fix: Refactoring fetching of icon for module instances

### DIFF
--- a/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
+++ b/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
@@ -27,9 +27,7 @@ import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
 import type { AppState } from "@appsmith/reducers";
 import type { Module } from "@appsmith/constants/ModuleConstants";
 import { getAllModules } from "@appsmith/selectors/modulesSelector";
-import { resolveIcon } from "pages/Editor/utils";
-import { Icon } from "design-system";
-import { EntityIcon } from "pages/Editor/Explorer/ExplorerIcons";
+import { getModuleIcon } from "pages/Editor/utils";
 
 enum SortingWeights {
   alphabetical = 1,
@@ -105,19 +103,8 @@ export const getQueryIcon = (
   if (query.config.hasOwnProperty("type")) {
     const q = query as ModuleInstanceData;
     const module = modules[q.config.sourceModuleId];
-    const icon = resolveIcon({
-      iconLocation: pluginImages[module.pluginId] || "",
-      pluginType: module.pluginType,
-      moduleType: module.type,
-    });
 
-    return (
-      icon || (
-        <EntityIcon>
-          <Icon name="module" />
-        </EntityIcon>
-      )
-    );
+    return getModuleIcon(module, pluginImages);
   } else {
     const action = query as ActionData;
     return (

--- a/app/client/src/components/propertyControls/ActionSelectorControl.tsx
+++ b/app/client/src/components/propertyControls/ActionSelectorControl.tsx
@@ -22,7 +22,6 @@ import {
   getPlugins,
 } from "@appsmith/selectors/entitiesSelector";
 import store from "store";
-import keyBy from "lodash/keyBy";
 import { getCurrentPageId } from "selectors/editorSelectors";
 import { getApiQueriesAndJSActionOptionsWithChildren } from "components/editorComponents/ActionCreator/helpers";
 import { selectEvaluationVersion } from "@appsmith/selectors/applicationSelectors";
@@ -152,12 +151,11 @@ class ActionSelectorControl extends BaseControl<ControlProps> {
 
     const pageId = getCurrentPageId(state);
     const plugins = getPlugins(state);
-    const pluginGroups: any = keyBy(plugins, "id");
 
     // this function gets all the Queries/API's/JS Objects and attaches it to actionList
     const fieldOptions = getApiQueriesAndJSActionOptionsWithChildren(
       pageId,
-      pluginGroups,
+      plugins,
       actions,
       jsCollections,
       () => {

--- a/app/client/src/pages/Editor/APIEditor/index.tsx
+++ b/app/client/src/pages/Editor/APIEditor/index.tsx
@@ -40,6 +40,7 @@ import ConvertEntityNotification from "@appsmith/pages/common/ConvertEntityNotif
 import { useIsEditorPaneSegmentsEnabled } from "../IDE/hooks";
 import { Icon } from "design-system";
 import { resolveIcon } from "../utils";
+import { ENTITY_ICON_SIZE, EntityIcon } from "../Explorer/ExplorerIcons";
 
 type ApiEditorWrapperProps = RouteComponentProps<APIEditorRouteParams>;
 
@@ -72,7 +73,14 @@ function ApiEditorWrapper(props: ApiEditorWrapperProps) {
     iconLocation: pluginGroups[pluginId]?.iconLocation || "",
     pluginType: action?.pluginType || "",
     moduleType: action?.actionConfiguration?.body?.moduleType,
-  }) || <Icon name="module" />;
+  }) || (
+    <EntityIcon
+      height={`${ENTITY_ICON_SIZE}px`}
+      width={`${ENTITY_ICON_SIZE}px`}
+    >
+      <Icon name="module" />
+    </EntityIcon>
+  );
 
   const isChangePermitted = getHasManageActionPermission(
     isFeatureEnabled,

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -41,6 +41,7 @@ import { PluginType } from "entities/Action";
 import { useIsEditorPaneSegmentsEnabled } from "../IDE/hooks";
 import { Icon } from "design-system";
 import { resolveIcon } from "../utils";
+import { ENTITY_ICON_SIZE, EntityIcon } from "../Explorer/ExplorerIcons";
 
 type QueryEditorProps = RouteComponentProps<QueryEditorRouteParams>;
 
@@ -66,7 +67,14 @@ function QueryEditor(props: QueryEditorProps) {
     iconLocation: pluginImages[pluginId] || "",
     pluginType: action?.pluginType || "",
     moduleType: action?.actionConfiguration?.body?.moduleType,
-  }) || <Icon name="module" />;
+  }) || (
+    <EntityIcon
+      height={`${ENTITY_ICON_SIZE}px`}
+      width={`${ENTITY_ICON_SIZE}px`}
+    >
+      <Icon name="module" />
+    </EntityIcon>
+  );
 
   const isDeletePermitted = getHasDeleteActionPermission(
     isFeatureEnabled,

--- a/app/client/src/pages/Editor/utils.tsx
+++ b/app/client/src/pages/Editor/utils.tsx
@@ -20,6 +20,7 @@ import { useSelector } from "react-redux";
 import { getCurrentPageId } from "selectors/editorSelectors";
 import type { WidgetCardProps } from "widgets/BaseWidget";
 import type { ActionResponse } from "api/ActionAPI";
+import type { Module } from "@appsmith/constants/ModuleConstants";
 import { MODULE_TYPE } from "@appsmith/constants/ModuleConstants";
 import {
   ENTITY_ICON_SIZE,
@@ -29,6 +30,9 @@ import {
 } from "pages/Editor/Explorer/ExplorerIcons";
 import { PluginType } from "entities/Action";
 import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
+import type { Plugin } from "api/PluginApi";
+import ImageAlt from "assets/images/placeholder-image.svg";
+import { Icon } from "design-system";
 
 export const draggableElement = (
   id: string,
@@ -380,4 +384,33 @@ export function resolveIcon({
   } else {
     return resolveQueryModuleIcon(iconLocation, pluginType, isLargeIcon);
   }
+}
+
+export function getModuleIcon(
+  module: Module | undefined,
+  pluginImages: Record<string, string>,
+  isLargeIcon = false,
+) {
+  return module ? (
+    resolveIcon({
+      iconLocation: pluginImages[module.pluginId] || "",
+      pluginType: module.pluginType,
+      moduleType: module.type,
+    })
+  ) : (
+    <EntityIcon
+      height={`${isLargeIcon ? ENTITY_ICON_SIZE * 2 : ENTITY_ICON_SIZE}px`}
+      width={`${isLargeIcon ? ENTITY_ICON_SIZE * 2 : ENTITY_ICON_SIZE}px`}
+    >
+      <Icon name="module" />
+    </EntityIcon>
+  );
+}
+
+export function getPluginImagesFromPlugins(plugins: Plugin[]) {
+  const pluginImages: Record<string, string> = {};
+  plugins.forEach((plugin) => {
+    pluginImages[plugin.id] = plugin?.iconLocation ?? ImageAlt;
+  });
+  return pluginImages;
 }


### PR DESCRIPTION
## Description

Refactoring fetching of icon for module instances to fix the icon for suspended module instances on EE

Fixes [#31762](https://github.com/appsmithorg/appsmith/issues/31762)  

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->