### PR TITLE
chore: Tiny NodeJS script as a linter for field name constants

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -484,14 +484,14 @@ public class Application extends BaseDomain implements Artifact {
 
     public static class Fields extends BaseDomain.Fields {
         public static final String gitApplicationMetadata_gitAuth =
-                gitApplicationMetadata + "." + GitArtifactMetadata.Fields.gitAuth;
+                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.gitAuth);
         public static final String gitApplicationMetadata_defaultApplicationId =
-                gitApplicationMetadata + "." + GitArtifactMetadata.Fields.defaultApplicationId;
+                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.defaultApplicationId);
         public static final String gitApplicationMetadata_branchName =
-                gitApplicationMetadata + "." + GitArtifactMetadata.Fields.branchName;
+                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.branchName);
         public static final String gitApplicationMetadata_isRepoPrivate =
-                gitApplicationMetadata + "." + GitArtifactMetadata.Fields.isRepoPrivate;
+                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.isRepoPrivate);
         public static final String gitApplicationMetadata_isProtectedBranch =
-                gitApplicationMetadata + "." + GitArtifactMetadata.Fields.isProtectedBranch;
+                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.isProtectedBranch);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import static com.appsmith.server.constants.ResourceModes.EDIT;
 import static com.appsmith.server.constants.ResourceModes.VIEW;
 import static com.appsmith.server.helpers.DateUtils.ISO_FORMATTER;
+import static com.appsmith.server.helpers.StringUtils.dotted;
 
 @Getter
 @Setter
@@ -484,14 +485,14 @@ public class Application extends BaseDomain implements Artifact {
 
     public static class Fields extends BaseDomain.Fields {
         public static final String gitApplicationMetadata_gitAuth =
-                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.gitAuth);
+                dotted(gitApplicationMetadata, GitArtifactMetadata.Fields.gitAuth);
         public static final String gitApplicationMetadata_defaultApplicationId =
-                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.defaultApplicationId);
+                dotted(gitApplicationMetadata, GitArtifactMetadata.Fields.defaultApplicationId);
         public static final String gitApplicationMetadata_branchName =
-                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.branchName);
+                dotted(gitApplicationMetadata, GitArtifactMetadata.Fields.branchName);
         public static final String gitApplicationMetadata_isRepoPrivate =
-                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.isRepoPrivate);
+                dotted(gitApplicationMetadata, GitArtifactMetadata.Fields.isRepoPrivate);
         public static final String gitApplicationMetadata_isProtectedBranch =
-                String.join(".", gitApplicationMetadata, GitArtifactMetadata.Fields.isProtectedBranch);
+                dotted(gitApplicationMetadata, GitArtifactMetadata.Fields.isProtectedBranch);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
@@ -52,21 +52,21 @@ public class ActionCollectionCE extends BranchAwareDomain {
 
     public static class Fields extends BranchAwareDomain.Fields {
         public static final String publishedCollection_name =
-                publishedCollection + "." + ActionCollectionDTO.Fields.name;
+                String.join(".", publishedCollection, ActionCollectionDTO.Fields.name);
         public static final String unpublishedCollection_name =
-                unpublishedCollection + "." + ActionCollectionDTO.Fields.name;
+                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.name);
 
         public static final String publishedCollection_pageId =
-                publishedCollection + "." + ActionCollectionDTO.Fields.pageId;
+                String.join(".", publishedCollection, ActionCollectionDTO.Fields.pageId);
         public static final String unpublishedCollection_pageId =
-                unpublishedCollection + "." + ActionCollectionDTO.Fields.pageId;
+                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.pageId);
 
         public static final String publishedCollection_contextType =
-                publishedCollection + "." + ActionCollectionDTO.Fields.contextType;
+                String.join(".", publishedCollection, ActionCollectionDTO.Fields.contextType);
         public static final String unpublishedCollection_contextType =
-                unpublishedCollection + "." + ActionCollectionDTO.Fields.contextType;
+                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.contextType);
 
         public static final String unpublishedCollection_deletedAt =
-                unpublishedCollection + "." + ActionCollectionDTO.Fields.deletedAt;
+                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.deletedAt);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
@@ -10,6 +10,8 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 
+import static com.appsmith.server.helpers.StringUtils.dotted;
+
 /**
  * This class represents a collection of actions that may or may not belong to the same plugin.
  * The logic for grouping is agnostic of the handling of this collection
@@ -52,21 +54,21 @@ public class ActionCollectionCE extends BranchAwareDomain {
 
     public static class Fields extends BranchAwareDomain.Fields {
         public static final String publishedCollection_name =
-                String.join(".", publishedCollection, ActionCollectionDTO.Fields.name);
+                dotted(publishedCollection, ActionCollectionDTO.Fields.name);
         public static final String unpublishedCollection_name =
-                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.name);
+                dotted(unpublishedCollection, ActionCollectionDTO.Fields.name);
 
         public static final String publishedCollection_pageId =
-                String.join(".", publishedCollection, ActionCollectionDTO.Fields.pageId);
+                dotted(publishedCollection, ActionCollectionDTO.Fields.pageId);
         public static final String unpublishedCollection_pageId =
-                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.pageId);
+                dotted(unpublishedCollection, ActionCollectionDTO.Fields.pageId);
 
         public static final String publishedCollection_contextType =
-                String.join(".", publishedCollection, ActionCollectionDTO.Fields.contextType);
+                dotted(publishedCollection, ActionCollectionDTO.Fields.contextType);
         public static final String unpublishedCollection_contextType =
-                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.contextType);
+                dotted(unpublishedCollection, ActionCollectionDTO.Fields.contextType);
 
         public static final String unpublishedCollection_deletedAt =
-                String.join(".", unpublishedCollection, ActionCollectionDTO.Fields.deletedAt);
+                dotted(unpublishedCollection, ActionCollectionDTO.Fields.deletedAt);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -13,6 +13,8 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 
+import static com.appsmith.server.helpers.StringUtils.dotted;
+
 @Getter
 @Setter
 @ToString
@@ -60,26 +62,23 @@ public class NewActionCE extends BranchAwareDomain {
 
     public static class Fields extends BranchAwareDomain.Fields {
         public static final String unpublishedAction_datasource_id =
-                String.join(".", unpublishedAction, ActionDTO.Fields.datasource, Datasource.Fields.id);
-        public static final String unpublishedAction_name = String.join(".", unpublishedAction, ActionDTO.Fields.name);
-        public static final String unpublishedAction_pageId =
-                String.join(".", unpublishedAction, ActionDTO.Fields.pageId);
-        public static final String unpublishedAction_deletedAt =
-                String.join(".", unpublishedAction, ActionDTO.Fields.deletedAt);
+                dotted(unpublishedAction, ActionDTO.Fields.datasource, Datasource.Fields.id);
+        public static final String unpublishedAction_name = dotted(unpublishedAction, ActionDTO.Fields.name);
+        public static final String unpublishedAction_pageId = dotted(unpublishedAction, ActionDTO.Fields.pageId);
+        public static final String unpublishedAction_deletedAt = dotted(unpublishedAction, ActionDTO.Fields.deletedAt);
         public static final String unpublishedAction_contextType =
-                String.join(".", unpublishedAction, ActionDTO.Fields.contextType);
+                dotted(unpublishedAction, ActionDTO.Fields.contextType);
         public static final String unpublishedAction_userSetOnLoad =
-                String.join(".", unpublishedAction, ActionDTO.Fields.userSetOnLoad);
+                dotted(unpublishedAction, ActionDTO.Fields.userSetOnLoad);
         public static final String unpublishedAction_executeOnLoad =
-                String.join(".", unpublishedAction, ActionDTO.Fields.executeOnLoad);
+                dotted(unpublishedAction, ActionDTO.Fields.executeOnLoad);
         public static final String unpublishedAction_fullyQualifiedName =
-                String.join(".", unpublishedAction, ActionDTO.Fields.fullyQualifiedName);
-        public static final String unpublishedAction_actionConfiguration_httpMethod = String.join(
-                ".", unpublishedAction, ActionDTO.Fields.actionConfiguration, ActionConfiguration.Fields.httpMethod);
+                dotted(unpublishedAction, ActionDTO.Fields.fullyQualifiedName);
+        public static final String unpublishedAction_actionConfiguration_httpMethod =
+                dotted(unpublishedAction, ActionDTO.Fields.actionConfiguration, ActionConfiguration.Fields.httpMethod);
 
-        public static final String publishedAction_name = String.join(".", publishedAction, ActionDTO.Fields.name);
-        public static final String publishedAction_pageId = String.join(".", publishedAction, ActionDTO.Fields.pageId);
-        public static final String publishedAction_contextType =
-                String.join(".", publishedAction, ActionDTO.Fields.contextType);
+        public static final String publishedAction_name = dotted(publishedAction, ActionDTO.Fields.name);
+        public static final String publishedAction_pageId = dotted(publishedAction, ActionDTO.Fields.pageId);
+        public static final String publishedAction_contextType = dotted(publishedAction, ActionDTO.Fields.contextType);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -77,7 +77,7 @@ public class NewActionCE extends BranchAwareDomain {
         public static final String unpublishedAction_actionConfiguration_httpMethod = String.join(
                 ".", unpublishedAction, ActionDTO.Fields.actionConfiguration, ActionConfiguration.Fields.httpMethod);
 
-        public static final String publishedAction_name = String.join(".", unpublishedAction, ActionDTO.Fields.name);
+        public static final String publishedAction_name = String.join(".", publishedAction, ActionDTO.Fields.name);
         public static final String publishedAction_pageId = String.join(".", publishedAction, ActionDTO.Fields.pageId);
         public static final String publishedAction_contextType =
                 String.join(".", publishedAction, ActionDTO.Fields.contextType);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -77,7 +77,7 @@ public class NewActionCE extends BranchAwareDomain {
         public static final String unpublishedAction_actionConfiguration_httpMethod = String.join(
                 ".", unpublishedAction, ActionDTO.Fields.actionConfiguration, ActionConfiguration.Fields.httpMethod);
 
-        public static final String publishedAction_name = String.join(".", publishedAction, ActionDTO.Fields.name);
+        public static final String publishedAction_name = String.join(".", unpublishedAction, ActionDTO.Fields.name);
         public static final String publishedAction_pageId = String.join(".", publishedAction, ActionDTO.Fields.pageId);
         public static final String publishedAction_contextType =
                 String.join(".", publishedAction, ActionDTO.Fields.contextType);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/StringUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/StringUtils.java
@@ -1,0 +1,9 @@
+package com.appsmith.server.helpers;
+
+public class StringUtils {
+    private StringUtils() {}
+
+    public static String dotted(String... parts) {
+        return String.join(".", parts);
+    }
+}

--- a/app/server/scripts/check-field-constants.mjs
+++ b/app/server/scripts/check-field-constants.mjs
@@ -1,0 +1,62 @@
+import {promises as fs} from "fs";
+import path from "path";
+
+async function findInnerClassDefinitions(directory) {
+  try {
+    const files = await fs.readdir(directory);
+
+    for (const file of files) {
+      const filePath = path.join(directory, file);
+      const stats = await fs.stat(filePath);
+
+      if (stats.isDirectory()) {
+        await findInnerClassDefinitions(filePath);
+      } else if (path.extname(filePath) === '.java') {
+        await processJavaFile(filePath);
+      }
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+async function processJavaFile(filePath) {
+  try {
+    const contents = await fs.readFile(filePath, 'utf8');
+
+    const innerClassRegex = /^ {4}([\w ]+?)\s+class\s+Fields\s+(extends (\w+)\.Fields)?\s*{(.+?\n {4})?}$/gsm;
+
+    for (const innerClassMatch of contents.matchAll(innerClassRegex)) {
+      const classQualifiers = innerClassMatch[1]; // we don't care much about this
+      const expectedParentClass = innerClassMatch[3];
+      console.log(filePath, classQualifiers, expectedParentClass);
+
+      for (const match of innerClassMatch[0].matchAll(/\bpublic\s+static\s+final\s+String\s+(\w+)\s+=\s+(.+?);/gs)) {
+        const key = match[1]
+        const valMatcherParts = [`^String\\.join\\(\\s*"."`];
+        for (const field of key.split("_")) {
+          valMatcherParts.push(`\\s*,\\s+(\\w+\\.\\w+\\.)?${field}`);
+        }
+        valMatcherParts.push(`\\s*\\)$`);
+        const valMatcher = new RegExp(valMatcherParts.join(''));
+        if (!valMatcher.test(match[2])) {
+          console.log("key is", key);
+          console.log("val is", match[2]);
+          console.log("pattern", valMatcher);
+          console.error(`Field ${key} in ${filePath} is not looking right.`);
+        }
+      }
+    }
+
+    // if (finds.length > 1) {
+    //   console.error(`Found multiple inner class definitions in file: ${filePath}`);
+    //   return;
+    // }
+
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+const directoryPath = '.';
+findInnerClassDefinitions(directoryPath);

--- a/app/server/scripts/check-field-constants.mjs
+++ b/app/server/scripts/check-field-constants.mjs
@@ -33,9 +33,12 @@ async function processJavaFile(filePath) {
 
       for (const match of innerClassMatch[0].matchAll(/\bpublic\s+static\s+final\s+String\s+(\w+)\s+=\s+(.+?);/gs)) {
         const key = match[1]
-        const valMatcherParts = [`^String\\.join\\(\\s*"."`];
-        for (const field of key.split("_")) {
-          valMatcherParts.push(`\\s*,\\s+(\\w+\\.\\w+\\.)?${field}`);
+        const valMatcherParts = [`^dotted\\(`];
+        for (const [i, field] of key.split("_").entries()) {
+          if (i > 0) {
+            valMatcherParts.push(`\\s*,\\s+`);
+          }
+          valMatcherParts.push(`(\\w+\\.\\w+\\.)?${field}`);
         }
         valMatcherParts.push(`\\s*\\)$`);
         const valMatcher = new RegExp(valMatcherParts.join(''));


### PR DESCRIPTION
The point is to prevent unfortunate field name problems like this: https://github.com/appsmithorg/appsmith/pull/31760/files.

This NodeJS script does a very rudimentary analysis on all Java files, with a few regular expressions, and finds anomalies. As such, since it's not very smart, it's quite strict. I intend to make it a little more strict in the coming days, but it's a start.

It's not hooked into any processes/CI yet, but that will also come in next. Since it's not very smart, it actually runs quite fast (.8s on EE).

The script also doesn't exit with a non-zero exit code when it finds a problem. Also will be solved as part of integrating it into CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved string concatenation practices across various domain models for better readability and maintainability.
- **New Features**
	- Introduced a utility method for standardized string concatenation using a dot separator.
- **Chores**
	- Added a script to validate field constants, ensuring consistency and adherence to naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->