### PR TITLE
fix: Split pane JS setting overflow

### DIFF
--- a/app/client/src/pages/Editor/JSEditor/JSFunctionSettings.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSFunctionSettings.tsx
@@ -29,7 +29,10 @@ interface SettingsItemProps {
   action: JSAction;
   disabled?: boolean;
   onUpdateSettings?: (props: OnUpdateSettingsProps) => void;
-  renderAdditionalColumns?: (action: JSAction) => React.ReactNode;
+  renderAdditionalColumns?: (
+    action: JSAction,
+    headingCount: number,
+  ) => React.ReactNode;
 }
 
 export interface JSFunctionSettingsProps {
@@ -253,7 +256,7 @@ function SettingsItem({
           </SwitchWrapper>
         )}
       </SettingColumn>
-      {renderAdditionalColumns?.(action)}
+      {renderAdditionalColumns?.(action, headingCount)}
     </SettingRow>
   );
 }

--- a/app/client/src/pages/Editor/JSEditor/JSFunctionSettings.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSFunctionSettings.tsx
@@ -15,6 +15,7 @@ interface SettingsHeadingProps {
   hasInfo?: boolean;
   info?: string;
   grow: boolean;
+  headingCount: number;
 }
 
 export interface OnUpdateSettingsProps {
@@ -24,6 +25,7 @@ export interface OnUpdateSettingsProps {
 }
 
 interface SettingsItemProps {
+  headingCount: number;
   action: JSAction;
   disabled?: boolean;
   onUpdateSettings?: (props: OnUpdateSettingsProps) => void;
@@ -61,6 +63,7 @@ const StyledIcon = styled(Icon)`
 `;
 
 export const SettingColumn = styled.div<{
+  headingCount: number;
   grow?: boolean;
   isHeading?: boolean;
 }>`
@@ -68,13 +71,13 @@ export const SettingColumn = styled.div<{
   align-items: center;
   flex-grow: ${(props) => (props.grow ? 1 : 0)};
   padding: 5px 12px;
-  min-width: 250px;
+  width: ${({ headingCount }) => `calc(100% / ${headingCount})`};
 
   ${(props) =>
     props.isHeading &&
     `
   font-weight: ${props.theme.fontWeights[2]};
-  font-size: ${props.theme.fontSizes[2]}px
+  font-size: ${props.theme.fontSizes[2]}px;
   margin-right: 9px;
   `}
 
@@ -91,8 +94,7 @@ const JSFunctionSettingsWrapper = styled.div`
 const SettingsContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: max-content;
-  min-width: 700px;
+  width: 100%;
   height: 100%;
   & > h3 {
     margin: 20px 0;
@@ -116,9 +118,15 @@ const SettingsBodyWrapper = styled.div`
 const SwitchWrapper = styled.div`
   margin-left: 6ch;
 `;
-function SettingsHeading({ grow, hasInfo, info, text }: SettingsHeadingProps) {
+function SettingsHeading({
+  grow,
+  hasInfo,
+  headingCount,
+  info,
+  text,
+}: SettingsHeadingProps) {
   return (
-    <SettingColumn grow={grow} isHeading>
+    <SettingColumn grow={grow} headingCount={headingCount} isHeading>
       <span>{text}</span>
       {hasInfo && info && (
         <Tooltip content={createMessage(() => info)}>
@@ -132,6 +140,7 @@ function SettingsHeading({ grow, hasInfo, info, text }: SettingsHeadingProps) {
 function SettingsItem({
   action,
   disabled,
+  headingCount,
   onUpdateSettings,
   renderAdditionalColumns,
 }: SettingsItemProps) {
@@ -174,10 +183,13 @@ function SettingsItem({
       className="t--async-js-function-settings"
       id={`${action.name}-settings`}
     >
-      <SettingColumn grow>
+      <SettingColumn grow headingCount={headingCount}>
         <span>{action.name}</span>
       </SettingColumn>
-      <SettingColumn className={`${action.name}-on-page-load-setting`}>
+      <SettingColumn
+        className={`${action.name}-on-page-load-setting`}
+        headingCount={headingCount}
+      >
         {RADIO_OPTIONS.length > 2 ? (
           <RadioGroup
             defaultValue={executeOnPageLoad}
@@ -207,7 +219,10 @@ function SettingsItem({
           </SwitchWrapper>
         )}
       </SettingColumn>
-      <SettingColumn className={`${action.name}-confirm-before-execute`}>
+      <SettingColumn
+        className={`${action.name}-confirm-before-execute`}
+        headingCount={headingCount}
+      >
         {RADIO_OPTIONS.length > 2 ? (
           <RadioGroup
             defaultValue={confirmBeforeExecute}
@@ -250,6 +265,7 @@ function JSFunctionSettingsView({
   onUpdateSettings,
   renderAdditionalColumns,
 }: JSFunctionSettingsProps) {
+  const headings = [...SETTINGS_HEADINGS, ...additionalHeadings];
   return (
     <JSFunctionSettingsWrapper>
       <SettingsContainer>
@@ -257,17 +273,16 @@ function JSFunctionSettingsView({
         <SettingsRowWrapper>
           <SettingsHeaderWrapper>
             <SettingRow isHeading>
-              {[...SETTINGS_HEADINGS, ...additionalHeadings].map(
-                (setting, index) => (
-                  <SettingsHeading
-                    grow={index === 0}
-                    hasInfo={setting.hasInfo}
-                    info={setting.info}
-                    key={setting.key}
-                    text={setting.text}
-                  />
-                ),
-              )}
+              {headings.map((setting, index) => (
+                <SettingsHeading
+                  grow={index === 0}
+                  hasInfo={setting.hasInfo}
+                  headingCount={headings.length}
+                  info={setting.info}
+                  key={setting.key}
+                  text={setting.text}
+                />
+              ))}
             </SettingRow>
           </SettingsHeaderWrapper>
           <SettingsBodyWrapper>
@@ -276,6 +291,7 @@ function JSFunctionSettingsView({
                 <SettingsItem
                   action={action}
                   disabled={disabled}
+                  headingCount={headings.length}
                   key={action.id}
                   onUpdateSettings={onUpdateSettings}
                   renderAdditionalColumns={renderAdditionalColumns}
@@ -283,7 +299,9 @@ function JSFunctionSettingsView({
               ))
             ) : (
               <SettingRow noBorder>
-                <SettingColumn>{createMessage(NO_JS_FUNCTIONS)}</SettingColumn>
+                <SettingColumn headingCount={0}>
+                  {createMessage(NO_JS_FUNCTIONS)}
+                </SettingColumn>
               </SettingRow>
             )}
           </SettingsBodyWrapper>


### PR DESCRIPTION
## Description

JS setting was hidden in split pane because of the min width constraint it had.

Fixes https://github.com/appsmithorg/appsmith/issues/31716

## Automation

/ok-to-test tags="@tags.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8276826466>
> Commit: `14e012079ea5f08a63680d21ee2efeec25dc0e9e`
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8276826466&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MySQL2_Spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic adjustment of settings layout based on the number of headings to enhance user interface flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->