### PR TITLE
fix: Making userTag a hidden field to not expose it as a user configurable option with Appsmith being the default value

### DIFF
--- a/app/server/appsmith-plugins/databricksPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/databricksPlugin/src/main/resources/form.json
@@ -92,11 +92,7 @@
           "isRequired": false,
           "initialValue": "Appsmith",
           "placeholderText": "Appsmith",
-          "hidden": {
-            "path": "datasourceConfiguration.properties[0].value",
-            "comparison": "NOT_EQUALS",
-            "value": "FORM_PROPERTIES_CONFIGURATION"
-          }
+          "hidden": true
         },
         {
           "label": "JDBC URL",


### PR DESCRIPTION
This is to abide by the Databricks standard practice which expects the user agent tag to be set automatically and shouldnt be configurable by end user (in this case developers creating datasources on top of Databricks). The user agent tag would be set to Appsmith.