### PR TITLE
chore: migrate plugin repository class to use Bridge API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
@@ -1,17 +1,15 @@
 package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.Plugin;
+import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
-import org.springframework.data.mongodb.core.query.Criteria;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
 import java.util.Set;
-
-import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 public class CustomPluginRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Plugin>
         implements CustomPluginRepositoryCE {
@@ -25,14 +23,18 @@ public class CustomPluginRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Plu
 
     @Override
     public Flux<Plugin> findDefaultPluginIcons() {
-        Criteria criteria = Criteria.where(Plugin.Fields.defaultInstall).is(Boolean.TRUE);
         List<String> projections = List.of(Plugin.Fields.name, Plugin.Fields.packageName, Plugin.Fields.iconLocation);
-        return queryBuilder().criteria(criteria).fields(projections).all();
+        return queryBuilder()
+                .criteria(Bridge.isTrue(Plugin.Fields.defaultInstall))
+                .fields(projections)
+                .all();
     }
 
     @Override
     public Flux<Plugin> findAllByIdsWithoutPermission(Set<String> ids, List<String> includeFields) {
-        Criteria idCriteria = where(Plugin.Fields.id).in(ids);
-        return queryBuilder().criteria(idCriteria).fields(includeFields).all();
+        return queryBuilder()
+                .criteria(Bridge.in(Plugin.Fields.id, ids))
+                .fields(includeFields)
+                .all();
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/imports/internal/ImportServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/imports/internal/ImportServiceTests.java
@@ -3690,7 +3690,7 @@ public class ImportServiceTests {
     @Test
     @WithUserDetails(value = "api_user")
     public void importApplication_invalidPluginReferenceForDatasource_throwException() {
-        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.any(), Mockito.anyList()))
+        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.anySet(), Mockito.anyList()))
                 .thenReturn(Flux.fromIterable(List.of(installedPlugin, installedJsPlugin)));
 
         Workspace newWorkspace = new Workspace();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialExportServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialExportServiceTest.java
@@ -240,7 +240,7 @@ public class PartialExportServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     void testGetPartialExport_nonGitConnectedApp_success() {
-        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.any(), Mockito.anyList()))
+        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.anySet(), Mockito.anyList()))
                 .thenReturn(Flux.fromIterable(List.of(installedPlugin, installedJsPlugin)));
 
         // Create an application with all resources
@@ -284,7 +284,7 @@ public class PartialExportServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void testGetPartialExport_gitConnectedApp_branchResourceExported() {
-        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.any(), Mockito.anyList()))
+        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.anySet(), Mockito.anyList()))
                 .thenReturn(Flux.fromIterable(List.of(installedPlugin, installedJsPlugin)));
 
         Application application = createGitConnectedApp("testGetPartialExport_gitConnectedApp_branchResourceExported");
@@ -348,7 +348,7 @@ public class PartialExportServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void testGetPartialExport_gitConnectedApp_featureBranchResourceExported() {
-        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.any(), Mockito.anyList()))
+        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.anySet(), Mockito.anyList()))
                 .thenReturn(Flux.fromIterable(List.of(installedPlugin, installedJsPlugin)));
 
         Application application =


### PR DESCRIPTION
## Description
Move the Plugin Repository class to the new Bridge API. 

## Automation

/ok-to-test tags="@tag.Datasource, tag.NewAction"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8280016055>
> Commit: `6c3f001a4c23d53f173aecc797b9f5ee9f233d78`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8280016055&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Improved criteria construction in plugin repository for enhanced query performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->