### PR TITLE
ci: Make TED image tag configurable

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]"
+      ted_tag:
+        description: TestEventDriver image tag
+        required: false
+        type: string
+        default: latest
 
 jobs:
   ci-test:
@@ -142,7 +147,7 @@ jobs:
           mkdir -p ~/git-server/repos
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
-          -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
+          -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:${{inputs.ted_tag}}
           docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \
             --privileged --pid=host --ipc=host --add-host=host.docker.internal:host-gateway\
             -e APPSMITH_CLOUD_SERVICES_MONGODB_URI=mongodb://host.docker.internal:27017 \

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: ""
+      ted_tag:
+        description: TestEventDriver image tag
+        required: false
+        type: string
+        default: latest
 
   # trigger for pushes to master
   push:
@@ -94,6 +99,7 @@ jobs:
       pr: 0
       tags: ${{needs.setup.outputs.tags}}
       matrix: ${{needs.setup.outputs.matrix}}
+      ted_tag: ${{inputs.ted_tag}}
 
   server-unit-tests:
     name: server-unit-tests
@@ -208,25 +214,25 @@ jobs:
         run:  |
           echo "$GITHUB_CONTEXT"
           echo ${{ github.repository }}
-          
+
       # This step triggers an external workflow for automated analysis of Cypress test runs.
       - name: Invoke Automated analysis workflow
         run: |
          curl --location --request POST ${{secrets.CYPRESS_WORKFLOW_API}}    \
          --header 'x-appsmith-key: ${{ secrets.CYPRESS_WORKFLOW_KEY }}'      \
          --header 'Content-Type: application/json' \
-         --data-raw '{ "workflow_id" : ${{ github.run_id }} , 
-                       "commit_id" : "${{ github.sha }}" , 
-                       "repo" : "${{  github.event.repository.full_name }}" , 
-                       "task" : "${{  github.job }}" ,   
-                       "workflow_type" : "${{ github.event_name }}",  
-                       "workflow_name" : "${{ github.workflow }}", 
-                       "job_id" : "",     
-                       "job_data": { 
-                           "ci_test_result_sample_data" : "sample_data" 
-                        }  
+         --data-raw '{ "workflow_id" : ${{ github.run_id }} ,
+                       "commit_id" : "${{ github.sha }}" ,
+                       "repo" : "${{  github.event.repository.full_name }}" ,
+                       "task" : "${{  github.job }}" ,
+                       "workflow_type" : "${{ github.event_name }}",
+                       "workflow_name" : "${{ github.workflow }}",
+                       "job_id" : "",
+                       "job_data": {
+                           "ci_test_result_sample_data" : "sample_data"
+                        }
           }'
-          
+
       # Force save the CI failed spec list into a cache
       - name: Store the combined run result for CI
         if: needs.ci-test.result != 'success'

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -214,25 +214,25 @@ jobs:
         run:  |
           echo "$GITHUB_CONTEXT"
           echo ${{ github.repository }}
-
+          
       # This step triggers an external workflow for automated analysis of Cypress test runs.
       - name: Invoke Automated analysis workflow
         run: |
          curl --location --request POST ${{secrets.CYPRESS_WORKFLOW_API}}    \
          --header 'x-appsmith-key: ${{ secrets.CYPRESS_WORKFLOW_KEY }}'      \
          --header 'Content-Type: application/json' \
-         --data-raw '{ "workflow_id" : ${{ github.run_id }} ,
-                       "commit_id" : "${{ github.sha }}" ,
-                       "repo" : "${{  github.event.repository.full_name }}" ,
-                       "task" : "${{  github.job }}" ,
-                       "workflow_type" : "${{ github.event_name }}",
-                       "workflow_name" : "${{ github.workflow }}",
-                       "job_id" : "",
-                       "job_data": {
-                           "ci_test_result_sample_data" : "sample_data"
-                        }
+         --data-raw '{ "workflow_id" : ${{ github.run_id }} , 
+                       "commit_id" : "${{ github.sha }}" , 
+                       "repo" : "${{  github.event.repository.full_name }}" , 
+                       "task" : "${{  github.job }}" ,   
+                       "workflow_type" : "${{ github.event_name }}",  
+                       "workflow_name" : "${{ github.workflow }}", 
+                       "job_id" : "",     
+                       "job_data": { 
+                           "ci_test_result_sample_data" : "sample_data" 
+                        }  
           }'
-
+          
       # Force save the CI failed spec list into a cache
       - name: Store the combined run result for CI
         if: needs.ci-test.result != 'success'


### PR DESCRIPTION
With this, we should be able to set the image tag (`latest` or `nightly` for example), to be used for the TED run for Cypress tests.

Unless we already have a different method to run Cypress with nightly TED, this should give us that flexibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflows to accept a new input parameter for dynamic Docker image tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->