### PR TITLE
fix: remove counter of cmd + click navigation usage

### DIFF
--- a/app/client/src/sagas/WidgetSelectionSagas.ts
+++ b/app/client/src/sagas/WidgetSelectionSagas.ts
@@ -61,10 +61,6 @@ import type { FeatureFlags } from "@appsmith/entities/FeatureFlag";
 import { getWidgetSelectorByWidgetId } from "selectors/layoutSystemSelectors";
 import { getAppViewerPageIdFromPath } from "@appsmith/pages/Editor/Explorer/helpers";
 import AnalyticsUtil from "../utils/AnalyticsUtil";
-import {
-  retrieveCodeWidgetNavigationUsed,
-  storeCodeWidgetNavigationUsed,
-} from "../utils/storage";
 
 // The following is computed to be used in the entity explorer
 // Every time a widget is selected, we need to expand widget entities
@@ -220,9 +216,6 @@ function* appendSelectedWidgetToUrlSaga(
   const isWidgetSelectionBlocked: boolean = yield select(
     getWidgetSelectionBlock,
   );
-  const timesUsedCodeModeWidgetSelection: number = yield call(
-    retrieveCodeWidgetNavigationUsed,
-  );
   const appMode: APP_MODE = yield select(getAppMode);
   const viewMode = appMode === APP_MODE.PUBLISHED;
   if (isSnipingMode || viewMode) return;
@@ -243,12 +236,6 @@ function* appendSelectedWidgetToUrlSaga(
       });
   if (invokedBy === NavigationMethod.CanvasClick && isWidgetSelectionBlocked) {
     AnalyticsUtil.logEvent("CODE_MODE_WIDGET_SELECTION");
-    if (timesUsedCodeModeWidgetSelection < 2) {
-      yield call(
-        storeCodeWidgetNavigationUsed,
-        timesUsedCodeModeWidgetSelection + 1,
-      );
-    }
   }
   if (currentURL !== newUrl) {
     history.push(newUrl, { invokedBy });


### PR DESCRIPTION
## Description

Fixes the blocker issue for canvas resize by removing the counter of cmd + click as that goes to local storage and that is somehow causing this issue


Fixes #31820

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8293559664>
> Commit: `00eee43d89c9df1071a3a1daca449629e48386ca`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8293559664&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the widget selection process by streamlining the tracking and storage method within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->