### PR TITLE
chore: Have a failsafe for split screen if we turn off the feature flag

### DIFF
--- a/app/client/src/selectors/ideSelectors.tsx
+++ b/app/client/src/selectors/ideSelectors.tsx
@@ -2,7 +2,10 @@ import { createSelector } from "reselect";
 import { selectFeatureFlags } from "@appsmith/selectors/featureFlagsSelectors";
 import type { AppState } from "@appsmith/reducers";
 import { getPageActions } from "@appsmith/selectors/entitiesSelector";
-import { EditorEntityTab } from "@appsmith/entities/IDE/constants";
+import {
+  EditorEntityTab,
+  EditorViewMode,
+} from "@appsmith/entities/IDE/constants";
 
 export const getIsSideBySideEnabled = createSelector(
   selectFeatureFlags,
@@ -11,7 +14,16 @@ export const getIsSideBySideEnabled = createSelector(
     flags.rollout_side_by_side_enabled,
 );
 
-export const getIDEViewMode = (state: AppState) => state.ui.ide.view;
+export const getIDEViewMode = createSelector(
+  getIsSideBySideEnabled,
+  (state) => state.ui.ide.view,
+  (featureFlag, ideViewMode) => {
+    if (featureFlag) {
+      return ideViewMode;
+    }
+    return EditorViewMode.FullScreen;
+  },
+);
 
 export const getPagesActiveStatus = (state: AppState) =>
   state.ui.ide.pagesActive;


### PR DESCRIPTION
## Description
Adds a failsafe for Split screen feature when flag is turned off



## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8294997501>
> Commit: `434c36e595e46c378b58fa14bd1c9d04a3bfd119`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8294997501&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `Editor View Mode` option to enhance user interface customization based on feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->