### PR TITLE
CI: Migrate ci-test to 4core machine

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ci-test:
-    runs-on: ubuntu-latest
+    runs-on: appsmith-self-hosted-deployment-runner-4cpu-8gb-ram
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||
       github.event_name == 'push' ||


### PR DESCRIPTION
Migrate ci-test to 4core machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated the CI test job to run on a more powerful, self-hosted deployment runner.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->