### PR TITLE
fix: Filter Appsmith exceptions from feature flagged aspect to provide context based exception

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
@@ -81,6 +81,9 @@ public class FeatureFlaggedMethodInvokerAspect {
             Method superMethod = targetSuperClass.getMethod(method.getName(), method.getParameterTypes());
             return superMethod.invoke(service, joinPoint.getArgs());
         } catch (Throwable e) {
+            if (e instanceof AppsmithException) {
+                throw (AppsmithException) e;
+            }
             String errorMessage = "Exception while invoking super class method";
             AppsmithException exception = getInvalidAnnotationUsageException(method, errorMessage);
             log.error(exception.getMessage(), e);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -957,7 +957,7 @@ public enum AppsmithError {
     INVALID_METHOD_LEVEL_ANNOTATION_USAGE(
             403,
             AppsmithErrorCode.INVALID_METHOD_LEVEL_ANNOTATION_USAGE.getCode(),
-            "Invalid usage for {0} annotation from class {1} on method {2}. Error: {3}. Please contact Appsmith support for more details!",
+            "Invalid usage for {0} annotation from class {1} on method {2}. {3}. Please contact Appsmith support for more details!",
             AppsmithErrorAction.LOG_EXTERNALLY,
             "Invalid usage for custom annotation",
             ErrorType.CONFIGURATION_ERROR,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -957,7 +957,7 @@ public enum AppsmithError {
     INVALID_METHOD_LEVEL_ANNOTATION_USAGE(
             403,
             AppsmithErrorCode.INVALID_METHOD_LEVEL_ANNOTATION_USAGE.getCode(),
-            "Invalid usage for {0} annotation from class {1} on method {2}. {3}. Please contact Appsmith support for more details!",
+            "Invalid usage for {0} annotation from class {1} on method {2}. Error: {3}. Please contact Appsmith support for more details!",
             AppsmithErrorAction.LOG_EXTERNALLY,
             "Invalid usage for custom annotation",
             ErrorType.CONFIGURATION_ERROR,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspectTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspectTest.java
@@ -2,6 +2,7 @@ package com.appsmith.server.aspect;
 
 import com.appsmith.server.aspect.component.TestComponent;
 import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.featureflags.CachedFeatures;
 import com.appsmith.server.featureflags.FeatureFlagEnum;
 import com.appsmith.server.services.FeatureFlagService;
@@ -20,6 +21,7 @@ import reactor.test.StepVerifier;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 
 @SpringBootTest
@@ -127,11 +129,10 @@ class FeatureFlaggedMethodInvokerAspectTest {
         CachedFeatures cachedFeatures = new CachedFeatures();
         cachedFeatures.setFeatures(Map.of(FeatureFlagEnum.TENANT_TEST_FEATURE.name(), Boolean.TRUE));
         Mockito.when(featureFlagService.getCachedTenantFeatureFlags()).thenReturn(cachedFeatures);
-        try {
-            testComponent.ceEeThrowAppsmithException("arg_");
-        } catch (Exception e) {
-            assertEquals(AppsmithError.GENERIC_BAD_REQUEST.getMessage("This is a test exception"), e.getMessage());
-        }
+        assertThrows(
+                AppsmithException.class,
+                () -> testComponent.ceEeThrowAppsmithException("arg_"),
+                AppsmithError.GENERIC_BAD_REQUEST.getMessage("This is a test exception"));
     }
 
     @Test
@@ -139,16 +140,13 @@ class FeatureFlaggedMethodInvokerAspectTest {
         CachedFeatures cachedFeatures = new CachedFeatures();
         cachedFeatures.setFeatures(Map.of(FeatureFlagEnum.TENANT_TEST_FEATURE.name(), Boolean.TRUE));
         Mockito.when(featureFlagService.getCachedTenantFeatureFlags()).thenReturn(cachedFeatures);
-        try {
-            testComponent.ceEeThrowNonAppsmithException("arg_");
-        } catch (Exception e) {
-            assertEquals(
-                    AppsmithError.INVALID_METHOD_LEVEL_ANNOTATION_USAGE.getMessage(
-                            "FeatureFlagged",
-                            "TestComponentImpl",
-                            "ceEeThrowNonAppsmithException",
-                            "Exception while invoking super class method"),
-                    e.getMessage());
-        }
+        assertThrows(
+                AppsmithException.class,
+                () -> testComponent.ceEeThrowNonAppsmithException("arg_"),
+                AppsmithError.INVALID_METHOD_LEVEL_ANNOTATION_USAGE.getMessage(
+                        "FeatureFlagged",
+                        "TestComponentImpl",
+                        "ceEeThrowNonAppsmithException",
+                        "Exception while invoking super class method"));
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponentImpl.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponentImpl.java
@@ -2,6 +2,8 @@ package com.appsmith.server.aspect.component;
 
 import com.appsmith.server.annotations.FeatureFlagged;
 import com.appsmith.server.aspect.component.ce_compatible.TestComponentCECompatibleImpl;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.featureflags.FeatureFlagEnum;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -40,5 +42,17 @@ public class TestComponentImpl extends TestComponentCECompatibleImpl implements 
     @FeatureFlagged(featureFlagName = FeatureFlagEnum.TENANT_TEST_FEATURE)
     public String ceEeSyncMethod(String arg) {
         return arg + "ee_impl_method";
+    }
+
+    @Override
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.TENANT_TEST_FEATURE)
+    public void ceEeThrowAppsmithException(String arg) {
+        throw new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "This is a test exception");
+    }
+
+    @Override
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.TENANT_TEST_FEATURE)
+    public void ceEeThrowNonAppsmithException(String arg) {
+        throw new RuntimeException("This is a test exception");
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCE.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCE.java
@@ -14,4 +14,8 @@ public interface TestComponentCE {
     Flux<String> ceEeDiffMethodReturnsFlux();
 
     String ceEeSyncMethod(String arg);
+
+    void ceEeThrowAppsmithException(String arg);
+
+    void ceEeThrowNonAppsmithException(String arg);
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCEImpl.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCEImpl.java
@@ -30,4 +30,10 @@ public class TestComponentCEImpl implements TestComponentCE {
     public String ceEeSyncMethod(String arg) {
         return arg + "ce_impl_method";
     }
+
+    @Override
+    public void ceEeThrowAppsmithException(String arg) {}
+
+    @Override
+    public void ceEeThrowNonAppsmithException(String arg) {}
 }


### PR DESCRIPTION
## Description
PR to provide more contextual exception when Appsmith exception is thrown within method marked with `@FeatureFlagged`.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8339550893>
> Commit: `e5a0be3166e7ede54240c8981683f61e09f506f8`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8339550893&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved handling of specific exceptions during method invocations to directly rethrow known exceptions for clearer error reporting.
- **Bug Fixes**
	- Enhanced an error message in the system to provide more detailed information about encountered issues.
- **Tests**
	- Added new tests to verify the correct handling and messaging of exceptions under different conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->