### PR TITLE
chore: Make GraphQL_spec repeatable

### DIFF
--- a/app/client/cypress/e2e/Sanity/Datasources/GraphQL_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/GraphQL_spec.ts
@@ -20,11 +20,11 @@ const GRAPHQL_QUERY = `query ($myid: Int!) {
   }
 }`;
 
-let POST_ID = 4;
+const POST_ID = 4;
 
-let GRAPHQL_VARIABLES = `{
-    "myid": ${POST_ID}
-  }`;
+const GRAPHQL_VARIABLES = `{
+  "myid": ${POST_ID}
+}`;
 
 const GRAPHQL_LIMIT_QUERY = `query($offsetz:Int, $firstz:Int){
           allPosts(offset:$offsetz, first:$firstz) {

--- a/app/client/cypress/e2e/Sanity/Datasources/GraphQL_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/GraphQL_spec.ts
@@ -13,8 +13,8 @@ let tokenToAuthorizeGraphQl = "";
 let authoemail = "";
 
 const GRAPHQL_QUERY = `query ($myid: Int!) {
-	postById(id: $myid) {
-	  id,
+  postById(id: $myid) {
+    id,
     title,
     content
   }
@@ -167,11 +167,15 @@ describe(
 
         dataSources.UpdateGraphqlQueryAndVariable({
           query: `mutation {
-          deletePostById(input: {id: ${POST_ID}}) {
-            clientMutationId
-            deletedPostId
-          }
-        }`,
+            createPost(input: {post: {title: "Brand new post for test 4", content: "Brand new content", published: false, authorId: 1}}) {
+              post {
+                title
+                content
+                published
+                authorId
+              }
+            }
+          }`,
         });
         apiPage.EnterHeader(
           "Authorization",
@@ -183,16 +187,22 @@ describe(
     });
 
     it("5. Authenticated GraphQL from Authenticated GraphQL", () => {
-      //Trying to delete without Autho code to see validation error
+      const mutationQuery = `mutation {
+        createPost(input: {post: {title: "Brand new post for test 5", content: "Brand new content", published: false, authorId: 1}}) {
+          post {
+            title
+            content
+            published
+            authorId
+          }
+        }
+      }`;
+
+      //Trying to delete without Auth code to see validation error
       dataSources.CreateDataSource("UnAuthenticatedGraphQL");
       apiPage.SelectPaneTab("Body");
       dataSources.UpdateGraphqlQueryAndVariable({
-        query: `mutation {
-        deletePostById(input: {id: 7}) {
-          clientMutationId
-          deletedPostId
-        }
-      }`,
+        query: mutationQuery,
       });
       apiPage.RunAPI(false);
       agHelper.Sleep(2000);
@@ -243,12 +253,7 @@ describe(
 
         dataSources.CreateQueryAfterDSSaved();
         dataSources.UpdateGraphqlQueryAndVariable({
-          query: `mutation {
-          deletePostById(input: {id: 7}) {
-            clientMutationId
-            deletedPostId
-          }
-        }`,
+          query: mutationQuery,
         });
         RunNValidateGraphQL();
       });
@@ -258,10 +263,6 @@ describe(
     });
 
     it("6. Validate Authenticated GraphQL with Empty body & then Save as Datasource + Bug #26873", () => {
-      POST_ID = 5;
-      GRAPHQL_VARIABLES = `{
-      "myid": ${POST_ID}
-    }`;
       dataSources.CreateDataSource("UnAuthenticatedGraphQL");
       // cy.get("@dsName").then(($dsName: any) => {
       //   cy.log("DS Name: " + $dsName);


### PR DESCRIPTION
When running `GraphQL_spec` locally, we have to restart TED on every re-run. Because the test 1 is checking for the presence of an item in the DB, where test 4 is deleting that same item. So we have to restart TED so the data is reset.

Instead, in this PR, we change the `delete` operation to `create` operation, so nothing is deleted, and we should be able to re-run it without having to restart TED.

Note to self: The test failure is because this line is re-running the GraphQL mutation, and is expecting the "delete" to fail. But since we're not running a delete operation anymore, the create operation succeeds, and we see no failure. Need to figure out a better way to do this part.

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8354992478>
> Commit: `a9b59ede79f6e9f8a65584c2c387dcad689386e3`
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8354992478&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Sanity/Datasources/GraphQL_spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated and refactored GraphQL queries for creating and deleting posts in test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->