### PR TITLE
chore: Adding a beta check for adding description on options for creating JS objects

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/JS/Add.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/JS/Add.tsx
@@ -32,7 +32,7 @@ const AddJS = () => {
     return {
       startIcon: data.icon,
       title: data.entityExplorerTitle || data.title,
-      description: "",
+      description: !!data.isBeta ? "Beta" : "",
       descriptionType: "inline",
       onClick: onCreateItemClick.bind(null, data),
     } as ListItemProps;


### PR DESCRIPTION
## Description

Adding a beta check for adding description on options for creating JS objects

Fixes [#31949](https://github.com/appsmithorg/appsmith/issues/31949)  

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8356416960>
> Commit: `8117683b5b63fcb9f00612fd4083e2bd7f7a2b5a`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8356416960&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `AddJS` component to display "Beta" in the description for beta features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->