### PR TITLE
fix: Some widgets don't seem to beusing meta state resulting in it not holding state in between edit and preview modes

### DIFF
--- a/app/client/src/widgets/wds/WDSCheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCheckboxGroupWidget/widget/index.tsx
@@ -103,7 +103,7 @@ class WDSCheckboxGroupWidget extends BaseWidget<
   };
 
   getWidgetView() {
-    const { labelTooltip, options, selectedOptionValue, widgetId, ...rest } =
+    const { labelTooltip, options, selectedValues, widgetId, ...rest } =
       this.props;
 
     const validation = validateInput(this.props);
@@ -115,7 +115,7 @@ class WDSCheckboxGroupWidget extends BaseWidget<
         errorMessage={validation.errorMessage}
         onChange={this.onChange}
         validationState={validation.validationStatus}
-        value={selectedOptionValue}
+        value={selectedValues}
       >
         {options.map((option, index) => (
           <Checkbox key={`${widgetId}-option-${index}`} value={option.value}>

--- a/app/client/src/widgets/wds/WDSSwitchGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSSwitchGroupWidget/widget/index.tsx
@@ -107,7 +107,7 @@ class WDSSwitchGroupWidget extends BaseWidget<
       labelPosition,
       labelTooltip,
       options,
-      selectedOptionValue,
+      selectedValues,
       widgetId,
       ...rest
     } = this.props;
@@ -122,7 +122,7 @@ class WDSSwitchGroupWidget extends BaseWidget<
         onChange={this.onChange}
         optionsLabelPosition={labelPosition}
         validationState={validation.validationStatus}
-        value={selectedOptionValue}
+        value={selectedValues}
       >
         {options.map((option, index) => (
           <Switch key={`${widgetId}-option-${index}`} value={option.value}>


### PR DESCRIPTION
Fixes #31881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `selectedOptionValue` to `selectedValues` in Checkbox and Switch Group Widgets to more accurately describe its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->