### PR TITLE
chore: Correct top menu help options

### DIFF
--- a/app/client/src/pages/Editor/EditorName/NavigationMenuData.ts
+++ b/app/client/src/pages/Editor/EditorName/NavigationMenuData.ts
@@ -21,8 +21,12 @@ import { redoAction, undoAction } from "actions/pageActions";
 import { redoShortCut, undoShortCut } from "utils/helpers";
 import { toast } from "design-system";
 import type { ThemeProp } from "WidgetProvider/constants";
-import { DISCORD_URL, DOCS_BASE_URL } from "constants/ThirdPartyConstants";
+import { DOCS_BASE_URL } from "constants/ThirdPartyConstants";
 import { getIsSideBySideEnabled } from "selectors/ideSelectors";
+import { getAppsmithConfigs } from "@appsmith/configs";
+import { getCurrentUser } from "selectors/usersSelectors";
+
+const { cloudHosting, intercomAppID } = getAppsmithConfigs();
 
 export interface NavigationMenuDataProps extends ThemeProp {
   editMode: typeof noop;
@@ -41,6 +45,8 @@ export const GetNavigationMenuData = ({
   const isApplicationIdPresent = !!(applicationId && applicationId.length > 0);
 
   const isSideBySideFlagEnabled = useSelector(getIsSideBySideEnabled);
+
+  const user = useSelector(getCurrentUser);
 
   const currentApplication = useSelector(getCurrentApplication);
   const hasExportPermission = isPermitted(
@@ -162,33 +168,32 @@ export const GetNavigationMenuData = ({
       isVisible: true,
       children: [
         {
-          text: "Community forum",
-          onClick: () => openExternalLink("https://community.appsmith.com/"),
-          type: MenuTypes.MENU,
-          isVisible: true,
-          isOpensNewWindow: true,
-        },
-        {
-          text: "Discord channel",
-          onClick: () => openExternalLink(DISCORD_URL),
-          type: MenuTypes.MENU,
-          isVisible: true,
-          isOpensNewWindow: true,
-        },
-        {
-          text: "Github",
-          onClick: () =>
-            openExternalLink("https://github.com/appsmithorg/appsmith/"),
-          type: MenuTypes.MENU,
-          isVisible: true,
-          isOpensNewWindow: true,
-        },
-        {
           text: "Documentation",
           onClick: () => openExternalLink(DOCS_BASE_URL),
           type: MenuTypes.MENU,
           isVisible: true,
-          isOpensNewWindow: true,
+          startIcon: "book-line",
+        },
+        {
+          text: "Report a bug",
+          onClick: () =>
+            openExternalLink(
+              "https://github.com/appsmithorg/appsmith/issues/new/choose",
+            ),
+          type: MenuTypes.MENU,
+          isVisible: true,
+          startIcon: "bug-line",
+        },
+        {
+          startIcon: "chat-help",
+          text: "Chat with us",
+          onClick: () => {
+            if (cloudHosting || user?.isIntercomConsentGiven) {
+              window.Intercom("show");
+            }
+          },
+          type: MenuTypes.MENU,
+          isVisible: intercomAppID && window.Intercom,
         },
       ],
     },

--- a/app/client/src/pages/Editor/EditorName/NavigationMenuItem.tsx
+++ b/app/client/src/pages/Editor/EditorName/NavigationMenuItem.tsx
@@ -26,6 +26,7 @@ export interface MenuItemData {
   confirmText?: string;
   isOpensNewWindow?: boolean | undefined;
   style?: React.CSSProperties;
+  startIcon?: string;
 }
 
 type NavigationMenuItemProps = CommonComponentProps & {
@@ -94,18 +95,21 @@ export function NavigationMenuItem({
         <MenuSub data-testid={`t--editor-menu-${kebabCase(text)}`}>
           <MenuSubTrigger>{menuItemData.text}</MenuSubTrigger>
           <MenuSubContent width="214px">
-            {menuItemData?.children?.map((subitem, idx) => (
-              <MenuItem
-                endIcon={subitem?.isOpensNewWindow ? "share-box-line" : ""}
-                key={idx}
-                onClick={(e) => handleClick(e, subitem)}
-              >
-                <div className="flex justify-between">
-                  {subitem.text}
-                  {subitem?.labelElement}
-                </div>
-              </MenuItem>
-            ))}
+            {menuItemData?.children
+              ?.filter((child) => child.isVisible)
+              .map((subitem, idx) => (
+                <MenuItem
+                  endIcon={subitem?.isOpensNewWindow ? "share-box-line" : ""}
+                  key={idx}
+                  onClick={(e) => handleClick(e, subitem)}
+                  startIcon={subitem?.startIcon}
+                >
+                  <div className="flex justify-between">
+                    {subitem.text}
+                    {subitem?.labelElement}
+                  </div>
+                </MenuItem>
+              ))}
           </MenuSubContent>
         </MenuSub>
       );


### PR DESCRIPTION
## Description
Fixes the top menu help options. Removes the old links and shows the same options as we show on the help menu on the bottom bar


Fixes #31983

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8373566846>
> Commit: `32047270804cf14dcef7ef423c58d3afa800580e`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8373566846&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the navigation menu to include options for reporting bugs and chatting with support, improving user assistance and feedback mechanisms.
	- Updated navigation menu items to display icons, enhancing visual identification and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->