### PR TITLE
fix: Debugger tab is not selected by default when open using shortkeys

### DIFF
--- a/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.test.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.test.tsx
@@ -124,6 +124,7 @@ describe("Canvas Hot Keys", () => {
               getMousePosition={() => {
                 return { x: 0, y: 0 };
               }}
+              toggleDebugger={() => {}}
             >
               <UpdatedEditor dsl={dsl} />
             </GlobalHotKeys>
@@ -262,6 +263,7 @@ describe("Cut/Copy/Paste hotkey", () => {
           getMousePosition={() => {
             return { x: 0, y: 0 };
           }}
+          toggleDebugger={() => {}}
         >
           <MockCanvas />
         </GlobalHotKeys>
@@ -353,6 +355,7 @@ describe("Cut/Copy/Paste hotkey", () => {
           getMousePosition={() => {
             return { x: 0, y: 0 };
           }}
+          toggleDebugger={() => {}}
         >
           <MockCanvas />
         </GlobalHotKeys>
@@ -410,6 +413,7 @@ describe("Undo/Redo hotkey", () => {
           getMousePosition={() => {
             return { x: 0, y: 0 };
           }}
+          toggleDebugger={() => {}}
         >
           <MockCanvas />
         </GlobalHotKeys>
@@ -440,6 +444,7 @@ describe("Undo/Redo hotkey", () => {
           getMousePosition={() => {
             return { x: 0, y: 0 };
           }}
+          toggleDebugger={() => {}}
         >
           <MockCanvas />
         </GlobalHotKeys>
@@ -470,6 +475,7 @@ describe("Undo/Redo hotkey", () => {
           getMousePosition={() => {
             return { x: 0, y: 0 };
           }}
+          toggleDebugger={() => {}}
         >
           <MockCanvas />
         </GlobalHotKeys>
@@ -503,6 +509,7 @@ describe("cmd + s hotkey", () => {
           getMousePosition={() => {
             return { x: 0, y: 0 };
           }}
+          toggleDebugger={() => {}}
         >
           <div />
         </GlobalHotKeys>

--- a/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys/GlobalHotKeys.tsx
@@ -19,7 +19,6 @@ import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { WIDGETS_SEARCH_ID } from "constants/Explorer";
 import { resetSnipingMode as resetSnipingModeAction } from "actions/propertyPaneActions";
-import { setCanvasDebuggerState } from "actions/debuggerActions";
 
 import { runActionViaShortcut } from "actions/pluginActionActions";
 import type { SearchCategory } from "components/editorComponents/GlobalSearch/utils";
@@ -43,19 +42,11 @@ import { matchBuilderPath } from "constants/routes";
 import { toggleInstaller } from "actions/JSLibraryActions";
 import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { toast } from "design-system";
-import {
-  getDebuggerContext,
-  showDebuggerFlag,
-} from "selectors/debuggerSelectors";
+import { showDebuggerFlag } from "selectors/debuggerSelectors";
 import { getIsFirstTimeUserOnboardingEnabled } from "selectors/onboardingSelectors";
 import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
 import { protectedModeSelector } from "selectors/gitSyncSelectors";
 import { setPreviewModeInitAction } from "actions/editorActions";
-import type {
-  CanvasDebuggerState,
-  DebuggerContext,
-} from "reducers/uiReducers/debuggerReducer";
-import { DEBUGGER_TAB_KEYS } from "components/editorComponents/Debugger/helpers";
 
 interface Props {
   copySelectedWidget: () => void;
@@ -73,8 +64,6 @@ interface Props {
   selectedWidget?: string;
   selectedWidgets: string[];
   isDebuggerOpen: boolean;
-  debuggerContext: DebuggerContext;
-  setCanvasDebuggerState: (debuggerState: Partial<CanvasDebuggerState>) => void;
   children: React.ReactNode;
   undo: () => void;
   redo: () => void;
@@ -86,6 +75,7 @@ interface Props {
   showCommitModal: () => void;
   getMousePosition: () => { x: number; y: number };
   hideInstaller: () => void;
+  toggleDebugger: () => void;
 }
 
 @HotkeysTarget
@@ -178,20 +168,7 @@ class GlobalHotKeys extends React.Component<Props> {
           global
           group="Canvas"
           label="Open Debugger"
-          onKeyDown={() => {
-            const dState: Partial<CanvasDebuggerState> = {
-              open: !this.props.isDebuggerOpen,
-            };
-            if (!this.props.debuggerContext.selectedDebuggerTab) {
-              dState["selectedTab"] = DEBUGGER_TAB_KEYS.ERROR_TAB;
-            }
-            this.props.setCanvasDebuggerState(dState);
-            if (this.props.isDebuggerOpen) {
-              AnalyticsUtil.logEvent("OPEN_DEBUGGER", {
-                source: "CANVAS",
-              });
-            }
-          }}
+          onKeyDown={this.props.toggleDebugger}
           preventDefault
         />
         <Hotkey
@@ -373,7 +350,6 @@ const mapStateToProps = (state: AppState) => ({
   selectedWidget: getLastSelectedWidget(state),
   selectedWidgets: getSelectedWidgets(state),
   isDebuggerOpen: showDebuggerFlag(state),
-  debuggerContext: getDebuggerContext(state),
   appMode: getAppMode(state),
   isPreviewMode: previewModeSelector(state),
   isProtectedMode: protectedModeSelector(state),
@@ -391,8 +367,6 @@ const mapDispatchToProps = (dispatch: any) => {
     setGlobalSearchCategory: (category: SearchCategory) =>
       dispatch(setGlobalSearchCategory(category)),
     resetSnipingMode: () => dispatch(resetSnipingModeAction()),
-    setCanvasDebuggerState: (debuggerState: Partial<CanvasDebuggerState>) =>
-      dispatch(setCanvasDebuggerState(debuggerState)),
     closeProppane: () => dispatch(closePropertyPane()),
     closeTableFilterProppane: () => dispatch(closeTableFilterPane()),
     selectAllWidgetsInit: () =>

--- a/app/client/src/pages/Editor/GlobalHotKeys/index.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys/index.tsx
@@ -1,13 +1,19 @@
 import GlobalHotKeys from "./GlobalHotKeys";
 import React from "react";
 import { useMouseLocation } from "./useMouseLocation";
+import useDebuggerTriggerClick from "components/editorComponents/Debugger/hooks/useDebuggerTriggerClick";
 
 //HOC to track user's mouse location, separated out so that it doesn't render the component on every mouse move
 function HotKeysHOC(props: any) {
   const getMousePosition = useMouseLocation();
+  const toggleDebugger = useDebuggerTriggerClick();
 
   return (
-    <GlobalHotKeys {...props} getMousePosition={getMousePosition}>
+    <GlobalHotKeys
+      {...props}
+      getMousePosition={getMousePosition}
+      toggleDebugger={toggleDebugger}
+    >
       {props.children}
     </GlobalHotKeys>
   );


### PR DESCRIPTION
## Description

When debugger is opened via short key, the default tab is not selected. This PR fixes this behaviour.

Fixes https://github.com/appsmithorg/appsmith/issues/31988

## Automation

/ok-to-test tags="@tag.IDE, @tag.Debugger"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8374340841>
> Commit: `8e65a3f678d6a682346c798b4f4bf61477d4a366`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8374340841&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the debugger functionality within the app, including the ability to toggle debugger states and set the selected debugger tab more intuitively.
- **Refactor**
	- Updated key functions and mappings related to debugger actions for improved performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->