### PR TITLE
feat: add layout on load actions to import block API response

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
@@ -15,6 +15,7 @@ import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.ArtifactImportDTO;
 import com.appsmith.server.dtos.BuildingBlockDTO;
+import com.appsmith.server.dtos.BuildingBlockResponseDTO;
 import com.appsmith.server.dtos.GitAuthDTO;
 import com.appsmith.server.dtos.PartialExportFileDTO;
 import com.appsmith.server.dtos.ReleaseItemsDTO;
@@ -409,7 +410,7 @@ public class ApplicationControllerCE extends BaseController<ApplicationService, 
 
     @JsonView(Views.Public.class)
     @PostMapping("/import/partial/block")
-    public Mono<ResponseDTO<String>> importBlock(
+    public Mono<ResponseDTO<BuildingBlockResponseDTO>> importBlock(
             @RequestBody BuildingBlockDTO buildingBlockDTO,
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
         return partialImportService

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/BuildingBlockResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/BuildingBlockResponseDTO.java
@@ -1,0 +1,13 @@
+package com.appsmith.server.dtos;
+
+import com.appsmith.external.dtos.DslExecutableDTO;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BuildingBlockResponseDTO {
+    String widgetDsl;
+
+    List<DslExecutableDTO> onPageLoadActions;
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCE.java
@@ -2,6 +2,7 @@ package com.appsmith.server.imports.internal.partial;
 
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.dtos.BuildingBlockDTO;
+import com.appsmith.server.dtos.BuildingBlockResponseDTO;
 import org.springframework.http.codec.multipart.Part;
 import reactor.core.publisher.Mono;
 
@@ -10,5 +11,5 @@ public interface PartialImportServiceCE {
     Mono<Application> importResourceInPage(
             String workspaceId, String applicationId, String pageId, String branchName, Part file);
 
-    Mono<String> importBuildingBlock(BuildingBlockDTO buildingBlockDTO, String branchName);
+    Mono<BuildingBlockResponseDTO> importBuildingBlock(BuildingBlockDTO buildingBlockDTO, String branchName);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
@@ -18,6 +18,7 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.BuildingBlockDTO;
 import com.appsmith.server.dtos.BuildingBlockImportDTO;
+import com.appsmith.server.dtos.BuildingBlockResponseDTO;
 import com.appsmith.server.dtos.ImportingMetaDTO;
 import com.appsmith.server.dtos.MappedImportableResourcesDTO;
 import com.appsmith.server.exceptions.AppsmithError;
@@ -51,6 +52,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -397,17 +399,62 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
     }
 
     @Override
-    public Mono<String> importBuildingBlock(BuildingBlockDTO buildingBlockDTO, String branchName) {
+    public Mono<BuildingBlockResponseDTO> importBuildingBlock(BuildingBlockDTO buildingBlockDTO, String branchName) {
         Mono<ApplicationJson> applicationJsonMono =
                 applicationTemplateService.getApplicationJsonFromTemplate(buildingBlockDTO.getTemplateId());
 
-        return applicationJsonMono
-                .flatMap(applicationJson -> this.importResourceInPage(
-                        buildingBlockDTO.getWorkspaceId(),
-                        buildingBlockDTO.getApplicationId(),
-                        buildingBlockDTO.getPageId(),
-                        branchName,
-                        applicationJson))
-                .map(BuildingBlockImportDTO::getWidgetDsl);
+        return applicationJsonMono.flatMap(applicationJson -> {
+            return this.importResourceInPage(
+                            buildingBlockDTO.getWorkspaceId(),
+                            buildingBlockDTO.getApplicationId(),
+                            buildingBlockDTO.getPageId(),
+                            branchName,
+                            applicationJson)
+                    .flatMap(buildingBlockImportDTO -> {
+                        // Fetch layout and get new onPageLoadActions
+                        // This data is not present in a client, since these are created
+                        // after importing the block
+                        Set<String> newOnPageLoadActionNames = new HashSet<>();
+                        applicationJson
+                                .getPageList()
+                                .get(0)
+                                .getPublishedPage()
+                                .getLayouts()
+                                .get(0)
+                                .getLayoutOnLoadActions()
+                                .forEach(dslExecutableDTOS -> {
+                                    dslExecutableDTOS.forEach(dslExecutableDTO -> {
+                                        if (dslExecutableDTO.getName() != null) {
+                                            newOnPageLoadActionNames.add(dslExecutableDTO.getName());
+                                        }
+                                    });
+                                });
+
+                        BuildingBlockResponseDTO buildingBlockResponseDTO = new BuildingBlockResponseDTO();
+                        buildingBlockResponseDTO.setWidgetDsl(buildingBlockImportDTO.getWidgetDsl());
+                        return newPageService
+                                .findBranchedPageId(
+                                        branchName, buildingBlockDTO.getPageId(), AclPermission.MANAGE_PAGES)
+                                .flatMap(branchedPageId -> newPageService
+                                        .findById(branchedPageId, Optional.empty())
+                                        .map(newPage -> {
+                                            newPage.getUnpublishedPage()
+                                                    .getLayouts()
+                                                    .get(0)
+                                                    .getLayoutOnLoadActions()
+                                                    .forEach(dslExecutableDTOS -> {
+                                                        // Filter the onPageLoadActions based on the json file
+                                                        buildingBlockResponseDTO
+                                                                .getOnPageLoadActions()
+                                                                .addAll(dslExecutableDTOS.stream()
+                                                                        .filter(dslExecutableDTO ->
+                                                                                newOnPageLoadActionNames.contains(
+                                                                                        dslExecutableDTO.getName()))
+                                                                        .toList());
+                                                    });
+                                            return buildingBlockResponseDTO;
+                                        }));
+                    });
+        });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
@@ -438,6 +438,13 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
                                 .flatMap(branchedPageId -> newPageService
                                         .findById(branchedPageId, Optional.empty())
                                         .map(newPage -> {
+                                            if (newPage.getUnpublishedPage()
+                                                            .getLayouts()
+                                                            .get(0)
+                                                            .getLayoutOnLoadActions()
+                                                    == null) {
+                                                return buildingBlockResponseDTO;
+                                            }
                                             newPage.getUnpublishedPage()
                                                     .getLayouts()
                                                     .get(0)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
@@ -18,6 +18,7 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.BuildingBlockDTO;
+import com.appsmith.server.dtos.BuildingBlockResponseDTO;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
@@ -495,16 +496,16 @@ public class PartialImportServiceTest {
         buildingBlockDTO1.setWorkspaceId(workspaceId);
         buildingBlockDTO1.setTemplateId("templatedId1");
 
-        Mono<String> result = partialImportService
+        Mono<BuildingBlockResponseDTO> result = partialImportService
                 .importBuildingBlock(buildingBlockDTO, null)
                 .flatMap(s -> partialImportService.importBuildingBlock(buildingBlockDTO1, null));
 
         StepVerifier.create(result)
-                .assertNext(dsl -> {
-                    assertThat(dsl).isNotNull();
+                .assertNext(BuildingBlockResponseDTO1 -> {
+                    assertThat(BuildingBlockResponseDTO1.getWidgetDsl()).isNotNull();
                     // Compare the json string of widget DSL,
                     // the binding names will be updated, and hence the json will be different
-                    assertThat(dsl)
+                    assertThat(BuildingBlockResponseDTO1.getWidgetDsl())
                             .isNotEqualTo(applicationJson
                                     .getPageList()
                                     .get(0)


### PR DESCRIPTION
## Description
* After importing the block into a page, the browser does not have the updated values on the on page load actions. 
* The newly created actions, actionCollections which needs to run after adding the block to canvas are missing. 
* This is because unlike normal flow, here the server fetch the Block data from DSL and then has to import it and send the widget DSL from the block to client so that the widgets are visible on the canvas. Hence adding this to response to make the experience same as other widgets

Fixes #31992 

## Automation

/ok-to-test tags="tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8379501235>
> Commit: `a6599b14c4027179f79a31b3d6a8e1dad1cc96f0`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8379501235&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new data structure to enhance building block imports, including widget layouts and onPageLoad actions.
- **Refactor**
	- Updated the import functionality to utilize the new data structure for building blocks, improving the handling of layout data and onPageLoad actions.
- **Tests**
	- Modified unit tests to align with the new data structure for building block imports, ensuring compatibility and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->