### PR TITLE
chore: add node variable for ts type checking 

### DIFF
--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -20,6 +20,11 @@ module.exports = {
   eslint: {
     enable: false,
   },
+  typescript: {
+    enableTypeChecking:
+      process.env.ENABLE_TYPE_CHECKING === "true" ||
+      process.env.ENABLE_TYPE_CHECKING === undefined,
+  },
   webpack: {
     configure: {
       resolve: {

--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -21,9 +21,7 @@ module.exports = {
     enable: false,
   },
   typescript: {
-    enableTypeChecking:
-      process.env.ENABLE_TYPE_CHECKING === "true" ||
-      process.env.ENABLE_TYPE_CHECKING === undefined,
+    enableTypeChecking: process.env.ENABLE_TYPE_CHECKING !== "false",
   },
   webpack: {
     configure: {

--- a/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
@@ -55,7 +55,7 @@ export const AnvilFlexComponent = forwardRef(
 
     const widgetConfigProps = useMemo(() => {
       const widgetConfig:
-        | (Partial<WidgetProps> & WidgetConfigProps & { type: null })
+        | (Partial<WidgetProps> & WidgetConfigProps & { type: string })
         | undefined = WidgetFactory.getConfig(widgetType);
       const isFillWidget =
         widgetConfig?.responsiveBehavior === ResponsiveBehavior.Fill;

--- a/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
@@ -55,7 +55,7 @@ export const AnvilFlexComponent = forwardRef(
 
     const widgetConfigProps = useMemo(() => {
       const widgetConfig:
-        | (Partial<WidgetProps> & WidgetConfigProps & { type: string })
+        | (Partial<WidgetProps> & WidgetConfigProps & { type: null })
         | undefined = WidgetFactory.getConfig(widgetType);
       const isFillWidget =
         widgetConfig?.responsiveBehavior === ResponsiveBehavior.Fill;


### PR DESCRIPTION
## Description
Add node variable for TS type checking. 

Before run `yarn start` write `export ENABLE_TYPE_CHECKING=false` to disabled checks and  `export ENABLE_TYPE_CHECKING=true` to enabled. Checks work by default if the variable is not set at all.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8378067976>
> Commit: `e451199e48112ebe9230590ee822eb38f419f86c`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8378067976&attempt=1" target="_blank">Click here!</a>
> It seems like **no tests ran** 😔. We are not able to recognize it, please check workflow <a href="https://github.com/appsmithorg/appsmith/actions/runs/8378067976" target="_blank">here.</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced TypeScript with dynamic type checking based on environment variables.
- **Refactor**
	- Improved flexibility by modifying the type property in widget configuration for layout components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->