### PR TITLE
chore: Prepared statement description changes

### DIFF
--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -9769,7 +9769,7 @@ export const defaultAppState = {
               },
               {
                 label: "Use Prepared Statement",
-                info: "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+                info: "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
                 configProperty:
                   "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 controlType: "SWITCH",
@@ -10085,7 +10085,7 @@ export const defaultAppState = {
               {
                 label: "Use Prepared Statement",
                 subtitle:
-                  "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+                  "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
                 configProperty:
                   "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 controlType: "SWITCH",

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
@@ -1289,7 +1289,7 @@
               },
               {
                 "label": "Use Prepared Statement",
-                "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+                "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
                 "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 "controlType": "SWITCH",
                 "initialValue": true
@@ -2590,7 +2590,7 @@
               },
               {
                 "label": "Use Prepared Statement",
-                "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+                "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
                 "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 "controlType": "SWITCH",
                 "initialValue": true

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
@@ -1288,7 +1288,7 @@
               },
               {
                 "label": "Use Prepared Statement",
-                "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+                "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
                 "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 "controlType": "SWITCH",
                 "initialValue": true
@@ -2589,7 +2589,7 @@
               },
               {
                 "label": "Use Prepared Statement",
-                "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+                "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
                 "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 "controlType": "SWITCH",
                 "initialValue": true

--- a/app/client/test/factories/MockPluginsState.ts
+++ b/app/client/test/factories/MockPluginsState.ts
@@ -6926,7 +6926,7 @@ export default {
           },
           {
             label: "Use Prepared Statement",
-            info: "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+            info: "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
             configProperty:
               "actionConfiguration.pluginSpecifiedTemplates[0].value",
             controlType: "SWITCH",
@@ -7126,7 +7126,7 @@ export default {
           {
             label: "Use Prepared Statement",
             subtitle:
-              "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+              "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
             configProperty:
               "actionConfiguration.pluginSpecifiedTemplates[0].value",
             controlType: "SWITCH",

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/editor.json
@@ -30,7 +30,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
           "initialValue": true

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
@@ -18,7 +18,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "subtitle": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "subtitle": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
           "initialValue": true

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/editor.json
@@ -30,7 +30,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
           "initialValue": true

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
@@ -18,7 +18,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "subtitle": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "subtitle": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
           "initialValue": true

--- a/app/server/appsmith-plugins/oraclePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/oraclePlugin/src/main/resources/editor.json
@@ -30,7 +30,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.formData.preparedStatement.data",
           "controlType": "SWITCH",
           "initialValue": true

--- a/app/server/appsmith-plugins/oraclePlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/oraclePlugin/src/main/resources/setting.json
@@ -18,7 +18,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "subtitle": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "subtitle": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.formData.preparedStatement.data",
           "controlType": "SWITCH",
           "initialValue": true

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/editor.json
@@ -30,7 +30,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "info": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "info": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
           "initialValue": true

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
@@ -18,7 +18,7 @@
         },
         {
           "label": "Use Prepared Statement",
-          "subtitle": "Turning on Prepared Statement makes your queries resilient against bad things like SQL injections. However, it cannot be used if your dynamic binding contains any SQL keywords like 'SELECT', 'WHERE', 'AND', etc.",
+          "subtitle": "Prepared statements prevent SQL injections on your queries but do not support dynamic bindings outside values in your SQL",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
           "initialValue": true


### PR DESCRIPTION
## Description



Fixes https://github.com/appsmithorg/appsmith/issues/32045

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8432564141>
> Commit: `120b0d79d5c4139a92bba228bdcb476cf1f7710c`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8432564141&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated information text related to using Prepared Statements in queries, emphasizing the prevention of SQL injections and highlighting limitations on dynamic bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->