### PR TITLE
fix: save flow enabled for client credentials grant type

### DIFF
--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -27,7 +27,7 @@ import {
   createMessage,
 } from "@appsmith/constants/messages";
 import { Button, toast } from "design-system";
-import type { AuthorizationCode } from "entities/Datasource/RestAPIForm";
+import type { ClientCredentials } from "entities/Datasource/RestAPIForm";
 import {
   GrantType,
   type ApiDatasourceForm,
@@ -165,10 +165,10 @@ function DatasourceAuth({
         formData?.datasourceStorages[currentEnvironment]
           ?.datasourceConfiguration?.authentication?.authenticationType;
 
-  const authorizationCodeGrantType: GrantType | undefined = (
+  const clientCredentialsGrantType: GrantType | undefined = (
     formData &&
     (formData as ApiDatasourceForm)?.authentication &&
-    ((formData as ApiDatasourceForm)?.authentication as AuthorizationCode)
+    ((formData as ApiDatasourceForm)?.authentication as ClientCredentials)
   )?.grantType;
 
   const { id: datasourceId } = datasource;
@@ -204,7 +204,7 @@ function DatasourceAuth({
   useEffect(() => {
     if (
       authType === AuthType.OAUTH2 &&
-      authorizationCodeGrantType === GrantType.AuthorizationCode
+      clientCredentialsGrantType !== GrantType.ClientCredentials // Client Credentials grant type does not require authorization
     ) {
       // When the authorization server redirects a user to the datasource form page, the url contains the "response_status" query parameter .
       // Get the access token if response_status is successful else show a toast error
@@ -411,14 +411,14 @@ function DatasourceAuth({
           key={buttonType}
           onClick={
             authType === AuthType.OAUTH2 &&
-            authorizationCodeGrantType === GrantType.AuthorizationCode
+            clientCredentialsGrantType !== GrantType.ClientCredentials // Client Credentials grant type does not require oauth authorization
               ? handleOauthDatasourceSave
               : handleDefaultAuthDatasourceSave
           }
           size="md"
         >
           {authType === AuthType.OAUTH2 &&
-          authorizationCodeGrantType === GrantType.AuthorizationCode
+          clientCredentialsGrantType !== GrantType.ClientCredentials
             ? isAuthorized
               ? createMessage(SAVE_AND_RE_AUTHORIZE_BUTTON_TEXT)
               : createMessage(SAVE_AND_AUTHORIZE_BUTTON_TEXT)

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -443,7 +443,6 @@ function DatasourceAuth({
   return (
     <>
       {authType === AuthType.OAUTH2 &&
-        authorizationCodeGrantType === GrantType.AuthorizationCode &&
         !isAuthorized &&
         shouldDisplayAuthMessage && (
           <StyledAuthMessage>Datasource not authorized</StyledAuthMessage>

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -165,7 +165,7 @@ function DatasourceAuth({
         formData?.datasourceStorages[currentEnvironment]
           ?.datasourceConfiguration?.authentication?.authenticationType;
 
-  const clientCredentialsGrantType: GrantType | undefined = (
+  const authGrantType: GrantType | undefined = (
     formData &&
     (formData as ApiDatasourceForm)?.authentication &&
     ((formData as ApiDatasourceForm)?.authentication as ClientCredentials)
@@ -204,7 +204,7 @@ function DatasourceAuth({
   useEffect(() => {
     if (
       authType === AuthType.OAUTH2 &&
-      clientCredentialsGrantType !== GrantType.ClientCredentials // Client Credentials grant type does not require authorization
+      authGrantType !== GrantType.ClientCredentials // Client Credentials grant type does not require authorization
     ) {
       // When the authorization server redirects a user to the datasource form page, the url contains the "response_status" query parameter .
       // Get the access token if response_status is successful else show a toast error
@@ -411,14 +411,14 @@ function DatasourceAuth({
           key={buttonType}
           onClick={
             authType === AuthType.OAUTH2 &&
-            clientCredentialsGrantType !== GrantType.ClientCredentials // Client Credentials grant type does not require oauth authorization
+            authGrantType !== GrantType.ClientCredentials // Client Credentials grant type does not require oauth authorization
               ? handleOauthDatasourceSave
               : handleDefaultAuthDatasourceSave
           }
           size="md"
         >
           {authType === AuthType.OAUTH2 &&
-          clientCredentialsGrantType !== GrantType.ClientCredentials
+          authGrantType !== GrantType.ClientCredentials
             ? isAuthorized
               ? createMessage(SAVE_AND_RE_AUTHORIZE_BUTTON_TEXT)
               : createMessage(SAVE_AND_AUTHORIZE_BUTTON_TEXT)

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -27,7 +27,11 @@ import {
   createMessage,
 } from "@appsmith/constants/messages";
 import { Button, toast } from "design-system";
-import type { ApiDatasourceForm } from "entities/Datasource/RestAPIForm";
+import type { AuthorizationCode } from "entities/Datasource/RestAPIForm";
+import {
+  GrantType,
+  type ApiDatasourceForm,
+} from "entities/Datasource/RestAPIForm";
 import { TEMP_DATASOURCE_ID } from "constants/Datasource";
 import { INTEGRATION_TABS, SHOW_FILE_PICKER_KEY } from "constants/routes";
 import { integrationEditorURL } from "@appsmith/RouteBuilder";
@@ -161,6 +165,12 @@ function DatasourceAuth({
         formData?.datasourceStorages[currentEnvironment]
           ?.datasourceConfiguration?.authentication?.authenticationType;
 
+  const authorizationCodeGrantType: GrantType | undefined = (
+    formData &&
+    (formData as ApiDatasourceForm)?.authentication &&
+    ((formData as ApiDatasourceForm)?.authentication as AuthorizationCode)
+  )?.grantType;
+
   const { id: datasourceId } = datasource;
   const applicationId = useSelector(getCurrentApplicationId);
 
@@ -192,7 +202,10 @@ function DatasourceAuth({
   );
 
   useEffect(() => {
-    if (authType === AuthType.OAUTH2) {
+    if (
+      authType === AuthType.OAUTH2 &&
+      authorizationCodeGrantType === GrantType.AuthorizationCode
+    ) {
       // When the authorization server redirects a user to the datasource form page, the url contains the "response_status" query parameter .
       // Get the access token if response_status is successful else show a toast error
 
@@ -397,13 +410,15 @@ function DatasourceAuth({
           isLoading={isSaving}
           key={buttonType}
           onClick={
-            authType === AuthType.OAUTH2
+            authType === AuthType.OAUTH2 &&
+            authorizationCodeGrantType === GrantType.AuthorizationCode
               ? handleOauthDatasourceSave
               : handleDefaultAuthDatasourceSave
           }
           size="md"
         >
-          {authType === AuthType.OAUTH2
+          {authType === AuthType.OAUTH2 &&
+          authorizationCodeGrantType === GrantType.AuthorizationCode
             ? isAuthorized
               ? createMessage(SAVE_AND_RE_AUTHORIZE_BUTTON_TEXT)
               : createMessage(SAVE_AND_AUTHORIZE_BUTTON_TEXT)
@@ -428,6 +443,7 @@ function DatasourceAuth({
   return (
     <>
       {authType === AuthType.OAUTH2 &&
+        authorizationCodeGrantType === GrantType.AuthorizationCode &&
         !isAuthorized &&
         shouldDisplayAuthMessage && (
           <StyledAuthMessage>Datasource not authorized</StyledAuthMessage>


### PR DESCRIPTION
## Description
> On selecting `Client Credentials` grant type, the button shows up as `Save and Authorize` which triggered the flow for redirection as in the case required for `Authorization Code` grant type.
> This PR changes the button trigger to `Save` which only saves the datasource configuration in the database for client credentials grant type since it does not require the redirection authorization flow.

Fixes #31207 

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8423946100>
> Commit: `d19714118dda656f40ef5158a398d61ab39cef22`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8423946100&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->













<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced OAuth2 authorization support, allowing for different grant types.
    - Improved user interface for OAuth2 authorization, including specific messages under certain conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->