### PR TITLE
feat: collapse all prop sections except data for table, json widgets

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -53,6 +53,8 @@ export const FEATURE_FLAG = {
   rollout_side_by_side_enabled: "rollout_side_by_side_enabled",
   ab_learnability_ease_of_initial_use_enabled:
     "ab_learnability_ease_of_initial_use_enabled",
+  ab_learnability_discoverability_collapse_all_except_data_enabled:
+    "ab_learnability_discoverability_collapse_all_except_data_enabled",
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG;
@@ -94,6 +96,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   rollout_js_enabled_one_click_binding_enabled: false,
   rollout_side_by_side_enabled: false,
   ab_learnability_ease_of_initial_use_enabled: false,
+  ab_learnability_discoverability_collapse_all_except_data_enabled: false,
 };
 
 export const AB_TESTING_EVENT_KEYS = {

--- a/app/client/src/constants/PropertyControlConstants.tsx
+++ b/app/client/src/constants/PropertyControlConstants.tsx
@@ -30,6 +30,7 @@ export interface PropertyPaneSectionConfig {
   generateDynamicProperties?: (
     widget: WidgetProps,
   ) => PropertyPaneControlConfig[];
+  expandedByDefault?: boolean;
 }
 
 export interface PanelConfig {

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.test.ts
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.test.ts
@@ -63,4 +63,24 @@ describe("Property Controls Generator", () => {
     const result = shouldSectionBeExpanded(config[1], false);
     expect(result).toEqual(true);
   });
+
+  it("Should return true when feature flag is enabled and expandedByDefault property is missing", () => {
+    const configWithoutExpandedByDefault: PropertyPaneSectionConfig = {
+      sectionName: "Styling",
+      children: [
+        {
+          label: "Background Color",
+          propertyName: "backgroundColor",
+          controlType: "CONTROL_TYPE",
+          isBindProperty: false,
+          isTriggerProperty: false,
+        },
+      ],
+    };
+    const result = shouldSectionBeExpanded(
+      configWithoutExpandedByDefault,
+      true,
+    );
+    expect(result).toEqual(true);
+  });
 });

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.test.ts
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.test.ts
@@ -1,0 +1,66 @@
+import type { PropertyPaneSectionConfig } from "constants/PropertyControlConstants";
+import { shouldSectionBeExpanded } from "./PropertyControlsGenerator";
+
+describe("Property Controls Generator", () => {
+  const commonProperties = {
+    controlType: "CONTROL_TYPE",
+    isBindProperty: false,
+    isTriggerProperty: false,
+  };
+  const config: PropertyPaneSectionConfig[] = [
+    {
+      sectionName: "Data",
+      children: [
+        {
+          label: "Disable Invalid Forms",
+          propertyName: "disabledWhenInvalid",
+          ...commonProperties,
+        },
+        {
+          label: "Scroll contents",
+          propertyName: "scrollContents",
+          ...commonProperties,
+        },
+      ],
+      expandedByDefault: true,
+    },
+    {
+      sectionName: "General",
+      children: [
+        {
+          label: "Button color",
+          propertyName: "buttonColor",
+          ...commonProperties,
+        },
+        {
+          label: "Button variant",
+          propertyName: "buttonVariant",
+          ...commonProperties,
+        },
+      ],
+      expandedByDefault: false,
+    },
+  ];
+
+  // When feature flag is enabled, it should check for expandedByDefault property of section config
+  it("Should return true when section has expandedByDefault property set to true", () => {
+    const result = shouldSectionBeExpanded(config[0], true);
+    expect(result).toEqual(true);
+  });
+
+  it("Should return false when section has expandedByDefault property set to false", () => {
+    const result = shouldSectionBeExpanded(config[1], true);
+    expect(result).toEqual(false);
+  });
+
+  // Following tests check for a case where feature flag is disabled, it should always expand the sections
+  it("Should return true as the flag is set to false, even though expandedByDefault is true", () => {
+    const result = shouldSectionBeExpanded(config[0], false);
+    expect(result).toEqual(true);
+  });
+
+  it("Should return true as the flag is set to false, even though expandedByDefault is false", () => {
+    const result = shouldSectionBeExpanded(config[1], false);
+    expect(result).toEqual(true);
+  });
+});

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.tsx
@@ -35,14 +35,12 @@ export const shouldSectionBeExpanded = (
   sectionConfig: PropertyPaneSectionConfig,
   isFlagEnabled: boolean,
 ) => {
-  if (isFlagEnabled && "expandedByDefault" in sectionConfig) {
+  if (isFlagEnabled && "expandedByDefault" in sectionConfig)
     return !!sectionConfig.expandedByDefault;
-  } else {
-    if (!!sectionConfig.isDefaultOpen) {
-      return sectionConfig.isDefaultOpen;
-    }
-    return true;
-  }
+
+  if ("isDefaultOpen" in sectionConfig) return sectionConfig.isDefaultOpen;
+
+  return true;
 };
 
 const generatePropertyControl = (

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.tsx
@@ -18,8 +18,7 @@ import type { EnhancementFns } from "selectors/widgetEnhancementSelectors";
 import { getWidgetEnhancementSelector } from "selectors/widgetEnhancementSelectors";
 import equal from "fast-deep-equal/es6";
 import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
-import { selectFeatureFlagCheck } from "@appsmith/selectors/featureFlagsSelectors";
-import type { AppState } from "@appsmith/reducers";
+import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 
 export interface PropertyControlsGeneratorProps {
   id: string;
@@ -36,11 +35,14 @@ export const shouldSectionBeExpanded = (
   sectionConfig: PropertyPaneSectionConfig,
   isFlagEnabled: boolean,
 ) => {
-  return isFlagEnabled && "expandedByDefault" in sectionConfig
-    ? !!sectionConfig.expandedByDefault
-    : !!sectionConfig.isDefaultOpen
-    ? sectionConfig.isDefaultOpen
-    : true;
+  if (isFlagEnabled && "expandedByDefault" in sectionConfig) {
+    return !!sectionConfig.expandedByDefault;
+  } else {
+    if (!!sectionConfig.isDefaultOpen) {
+      return sectionConfig.isDefaultOpen;
+    }
+    return true;
+  }
 };
 
 const generatePropertyControl = (
@@ -101,12 +103,8 @@ const generatePropertyControl = (
 function PropertyControlsGenerator(props: PropertyControlsGeneratorProps) {
   const widgetProps: any = useSelector(getWidgetPropsForPropertyPane);
 
-  const isCollapseAllExceptDataEnabled: boolean = useSelector(
-    (state: AppState) =>
-      selectFeatureFlagCheck(
-        state,
-        FEATURE_FLAG.ab_learnability_discoverability_collapse_all_except_data_enabled,
-      ),
+  const isCollapseAllExceptDataEnabled: boolean = useFeatureFlag(
+    FEATURE_FLAG.ab_learnability_discoverability_collapse_all_except_data_enabled,
   );
 
   const enhancementSelector = getWidgetEnhancementSelector(

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControlsGenerator.tsx
@@ -17,6 +17,9 @@ import { evaluateHiddenProperty } from "./helpers";
 import type { EnhancementFns } from "selectors/widgetEnhancementSelectors";
 import { getWidgetEnhancementSelector } from "selectors/widgetEnhancementSelectors";
 import equal from "fast-deep-equal/es6";
+import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
+import { selectFeatureFlagCheck } from "@appsmith/selectors/featureFlagsSelectors";
+import type { AppState } from "@appsmith/reducers";
 
 export interface PropertyControlsGeneratorProps {
   id: string;
@@ -29,11 +32,23 @@ export interface PropertyControlsGeneratorProps {
   searchQuery?: string;
 }
 
+export const shouldSectionBeExpanded = (
+  sectionConfig: PropertyPaneSectionConfig,
+  isFlagEnabled: boolean,
+) => {
+  return isFlagEnabled && "expandedByDefault" in sectionConfig
+    ? !!sectionConfig.expandedByDefault
+    : !!sectionConfig.isDefaultOpen
+    ? sectionConfig.isDefaultOpen
+    : true;
+};
+
 const generatePropertyControl = (
   propertyPaneConfig: readonly PropertyPaneConfig[],
   props: PropertyControlsGeneratorProps,
   isSearchResult: boolean,
   enhancements: EnhancementFns,
+  isCollapseAllExceptDataEnabled: boolean,
 ) => {
   if (!propertyPaneConfig) return null;
   return propertyPaneConfig.map((config: PropertyPaneConfig) => {
@@ -46,7 +61,10 @@ const generatePropertyControl = (
           collapsible={sectionConfig.collapsible ?? true}
           hidden={sectionConfig.hidden}
           id={config.id || sectionConfig.sectionName}
-          isDefaultOpen={sectionConfig.isDefaultOpen}
+          isDefaultOpen={shouldSectionBeExpanded(
+            sectionConfig,
+            isCollapseAllExceptDataEnabled,
+          )}
           key={config.id + props.id}
           name={sectionConfig.sectionName}
           panelPropertyPath={props.panelPropertyPath}
@@ -59,6 +77,7 @@ const generatePropertyControl = (
               props,
               isSearchResult,
               enhancements,
+              isCollapseAllExceptDataEnabled,
             )}
         </PropertySection>
       );
@@ -81,6 +100,14 @@ const generatePropertyControl = (
 
 function PropertyControlsGenerator(props: PropertyControlsGeneratorProps) {
   const widgetProps: any = useSelector(getWidgetPropsForPropertyPane);
+
+  const isCollapseAllExceptDataEnabled: boolean = useSelector(
+    (state: AppState) =>
+      selectFeatureFlagCheck(
+        state,
+        FEATURE_FLAG.ab_learnability_discoverability_collapse_all_except_data_enabled,
+      ),
+  );
 
   const enhancementSelector = getWidgetEnhancementSelector(
     widgetProps?.widgetId,
@@ -112,6 +139,7 @@ function PropertyControlsGenerator(props: PropertyControlsGeneratorProps) {
         props,
         isSearchResult,
         enhancements,
+        isCollapseAllExceptDataEnabled,
       )}
     </>
   );

--- a/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
@@ -97,7 +97,7 @@ export const CollapseContext: Context<boolean> = createContext<boolean>(false);
 export const PropertySection = memo((props: PropertySectionProps) => {
   const dispatch = useDispatch();
   const currentWidgetId = useSelector(getCurrentWidgetId);
-  const { isDefaultOpen = true } = props;
+  const { isDefaultOpen } = props;
   const isContextOpen = useSelector((state: AppState) =>
     getPropertySectionState(state, {
       key: `${currentWidgetId}.${props.id}`,

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
@@ -294,6 +294,7 @@ export const contentConfig = [
         dependencies: ["schema", "childStylesheet"],
       },
     ],
+    expandedByDefault: true,
   },
   {
     sectionName: "General",
@@ -398,6 +399,7 @@ export const contentConfig = [
         validation: { type: ValidationTypes.TEXT },
       },
     ],
+    expandedByDefault: false,
   },
   {
     sectionName: "Events",
@@ -412,6 +414,7 @@ export const contentConfig = [
         isTriggerProperty: true,
       },
     ],
+    expandedByDefault: false,
   },
 ];
 

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -142,6 +142,12 @@ export default [
         validation: { type: ValidationTypes.TEXT },
       },
     ],
+    // Added this prop to indicate that data section needs to be expanded by default
+    // Rest all sections needs to be collapsed
+    // We already have a isDefaultOpen prop configured to keep a section expanded or not
+    // but introducing new prop so that we can control is based on flag
+    // Once we decide to keep this feature, we can go back to using isDefaultOpen and removeexpandedByDefault
+    expandedByDefault: true,
   },
   {
     sectionName: "Pagination",
@@ -210,6 +216,7 @@ export default [
         dependencies: ["serverSidePaginationEnabled"],
       },
     ],
+    expandedByDefault: false,
   },
   {
     sectionName: "Search & filters",
@@ -290,6 +297,7 @@ export default [
         validation: { type: ValidationTypes.BOOLEAN },
       },
     ],
+    expandedByDefault: false,
   },
   {
     sectionName: "Row selection",
@@ -357,6 +365,7 @@ export default [
         isTriggerProperty: true,
       },
     ],
+    expandedByDefault: false,
   },
   {
     sectionName: "Sorting",
@@ -388,6 +397,7 @@ export default [
         dependencies: ["isSortable"],
       },
     ],
+    expandedByDefault: false,
   },
   {
     sectionName: "Adding a row",
@@ -464,6 +474,7 @@ export default [
         },
       },
     ],
+    expandedByDefault: false,
   },
   {
     sectionName: "General",
@@ -528,5 +539,6 @@ export default [
         dependencies: ["isVisibleDownload"],
       },
     ],
+    expandedByDefault: false,
   },
 ] as PropertyPaneConfig[];


### PR DESCRIPTION
## Description
As part of learnability initiative, we want to make the property pane simpler and properties easy to discover for a new users, so in this feature, we want to collapse all sections except data in the property pane for table and json widgets. This PR achieves that.

Figma: https://www.figma.com/file/85kYou9qfqrxMXFuJLDKeU/Learnability?type=design&node-id=351-70390&mode=design&t=SPPs2O8y8I1vAAgx-0

Notion: https://www.notion.so/appsmith/Collapse-all-sections-except-the-data-section-for-new-users-in-the-property-pane-c6995a5588094576b0dc408460949042

**Limitations**:
- This is done only for table and json widgets initially, we can gradually roll this out for other widgets too.

Fixes #30980 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8432589876>
> Commit: `9d1851c4b29e52ddf428ca22bf3ed131d22f97ad`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8432589876&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->












<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a feature flag to enhance learnability and discoverability by collapsing all sections except data by default.
	- Added the ability for section components in the property pane to be expanded or collapsed by default, based on new configuration settings.
- **Refactor**
	- Updated property pane generation logic to respect new expansion settings.
- **Tests**
	- Added tests to ensure property pane sections expand or collapse as expected according to the new feature flag.
- **Documentation**
	- Updated component and widget property configurations to include instructions on setting default expansion states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->