### PR TITLE
fix: Auth datasource new api button not working fixed

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
@@ -36,6 +36,22 @@ interface NewActionButtonProps {
   style?: any;
   isNewQuerySecondaryButton?: boolean;
 }
+
+export const isApiPluginInvalidUrl = (
+  currentEnvironment: string,
+  pluginType?: string,
+  datasource?: Datasource,
+) => {
+  return (
+    pluginType === PluginType.API &&
+    (!datasource ||
+      !datasource.datasourceStorages[currentEnvironment]
+        ?.datasourceConfiguration ||
+      !datasource.datasourceStorages[currentEnvironment]
+        ?.datasourceConfiguration?.url)
+  );
+};
+
 function NewActionButton(props: NewActionButtonProps) {
   const {
     datasource,
@@ -59,14 +75,7 @@ function NewActionButton(props: NewActionButtonProps) {
 
   const createQueryAction = useCallback(
     (pageId: string) => {
-      if (
-        pluginType === PluginType.API &&
-        (!datasource ||
-          !datasource.datasourceStorages[currentEnvironment]
-            .datasourceConfiguration ||
-          !datasource.datasourceStorages[currentEnvironment]
-            .datasourceConfiguration.url)
-      ) {
+      if (isApiPluginInvalidUrl(currentEnvironment, pluginType, datasource)) {
         toast.show(ERROR_ADD_API_INVALID_URL(), {
           kind: "error",
         });

--- a/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
@@ -37,18 +37,18 @@ interface NewActionButtonProps {
   isNewQuerySecondaryButton?: boolean;
 }
 
-export const isApiPluginInvalidUrl = (
+export const apiPluginHasUrl = (
   currentEnvironment: string,
   pluginType?: string,
   datasource?: Datasource,
 ) => {
+  if (pluginType !== PluginType.API) {
+    return false;
+  }
   return (
-    pluginType === PluginType.API &&
-    (!datasource ||
-      !datasource.datasourceStorages[currentEnvironment]
-        ?.datasourceConfiguration ||
-      !datasource.datasourceStorages[currentEnvironment]
-        ?.datasourceConfiguration?.url)
+    !datasource ||
+    !datasource?.datasourceStorages[currentEnvironment]?.datasourceConfiguration
+      ?.url
   );
 };
 
@@ -75,7 +75,7 @@ function NewActionButton(props: NewActionButtonProps) {
 
   const createQueryAction = useCallback(
     (pageId: string) => {
-      if (isApiPluginInvalidUrl(currentEnvironment, pluginType, datasource)) {
+      if (apiPluginHasUrl(currentEnvironment, pluginType, datasource)) {
         toast.show(ERROR_ADD_API_INVALID_URL(), {
           kind: "error",
         });

--- a/app/client/src/pages/Editor/__tests__/NewActionButton.test.tsx
+++ b/app/client/src/pages/Editor/__tests__/NewActionButton.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { PluginType } from "entities/Action";
 import type { Datasource } from "entities/Datasource";
-import { isApiPluginInvalidUrl } from "../DataSourceEditor/NewActionButton";
+import { apiPluginHasUrl } from "../DataSourceEditor/NewActionButton";
 
 const datasourceWithUrl: Datasource = {
   id: "test",
@@ -40,7 +40,7 @@ const datasourceWithoutUrl: Datasource = {
 describe("New Action Button Component", () => {
   // Positive case where everything is correct in datasource / Plugin type is different, basically no error
   it("1. Plugin type is API and datasource defined with url, should return false", () => {
-    const result: boolean = isApiPluginInvalidUrl(
+    const result: boolean = apiPluginHasUrl(
       "env1",
       PluginType.API,
       datasourceWithUrl,
@@ -49,7 +49,7 @@ describe("New Action Button Component", () => {
   });
 
   it("2. If plugin type is different, should return false", () => {
-    const result: boolean = isApiPluginInvalidUrl(
+    const result: boolean = apiPluginHasUrl(
       "env1",
       PluginType.SAAS,
       datasourceWithUrl,
@@ -59,16 +59,12 @@ describe("New Action Button Component", () => {
 
   // Negative cases, error is there due to various reasons
   it("3. Plugin type is API but datasource not defined, should return true", () => {
-    const result: boolean = isApiPluginInvalidUrl(
-      "env1",
-      PluginType.API,
-      undefined,
-    );
+    const result: boolean = apiPluginHasUrl("env1", PluginType.API, undefined);
     expect(result).toBe(true);
   });
 
   it("4. If current environment is different from datasource env, should return true", () => {
-    const result: boolean = isApiPluginInvalidUrl(
+    const result: boolean = apiPluginHasUrl(
       "env2",
       PluginType.API,
       datasourceWithUrl,
@@ -77,7 +73,7 @@ describe("New Action Button Component", () => {
   });
 
   it("5. Plugin type is API and datasource defined without url, should return false", () => {
-    const result: boolean = isApiPluginInvalidUrl(
+    const result: boolean = apiPluginHasUrl(
       "env1",
       PluginType.API,
       datasourceWithoutUrl,

--- a/app/client/src/pages/Editor/__tests__/NewActionButton.test.tsx
+++ b/app/client/src/pages/Editor/__tests__/NewActionButton.test.tsx
@@ -1,0 +1,87 @@
+import "@testing-library/jest-dom";
+import { PluginType } from "entities/Action";
+import type { Datasource } from "entities/Datasource";
+import { isApiPluginInvalidUrl } from "../DataSourceEditor/NewActionButton";
+
+const datasourceWithUrl: Datasource = {
+  id: "test",
+  datasourceStorages: {
+    env1: {
+      datasourceId: "test",
+      environmentId: "env1",
+      datasourceConfiguration: {
+        url: "https://example.com",
+      },
+      isValid: false,
+    },
+  },
+  pluginId: "plugin",
+  workspaceId: "workspace",
+  name: "datasource1",
+};
+
+const datasourceWithoutUrl: Datasource = {
+  id: "test",
+  datasourceStorages: {
+    env1: {
+      datasourceId: "test",
+      environmentId: "env1",
+      datasourceConfiguration: {
+        url: "",
+      },
+      isValid: false,
+    },
+  },
+  pluginId: "plugin",
+  workspaceId: "workspace",
+  name: "datasource1",
+};
+
+describe("New Action Button Component", () => {
+  // Positive case where everything is correct in datasource / Plugin type is different, basically no error
+  it("1. Plugin type is API and datasource defined with url, should return false", () => {
+    const result: boolean = isApiPluginInvalidUrl(
+      "env1",
+      PluginType.API,
+      datasourceWithUrl,
+    );
+    expect(result).toBe(false);
+  });
+
+  it("2. If plugin type is different, should return false", () => {
+    const result: boolean = isApiPluginInvalidUrl(
+      "env1",
+      PluginType.SAAS,
+      datasourceWithUrl,
+    );
+    expect(result).toBe(false);
+  });
+
+  // Negative cases, error is there due to various reasons
+  it("3. Plugin type is API but datasource not defined, should return true", () => {
+    const result: boolean = isApiPluginInvalidUrl(
+      "env1",
+      PluginType.API,
+      undefined,
+    );
+    expect(result).toBe(true);
+  });
+
+  it("4. If current environment is different from datasource env, should return true", () => {
+    const result: boolean = isApiPluginInvalidUrl(
+      "env2",
+      PluginType.API,
+      datasourceWithUrl,
+    );
+    expect(result).toBe(true);
+  });
+
+  it("5. Plugin type is API and datasource defined without url, should return false", () => {
+    const result: boolean = isApiPluginInvalidUrl(
+      "env1",
+      PluginType.API,
+      datasourceWithoutUrl,
+    );
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description
This PR fixes the issue:
New API button does not work from REST API datasource from review page. This issue is only observed in enterprise version as it has connections to multiple environments:

https://github.com/appsmithorg/appsmith/assets/30018882/1f1f3a75-fa4c-4f0a-a463-541299ad8f15



Fixes #32064 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8449817023>
> Commit: `70549d166af84a9484439ce966a5e26a1e71f909`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8449817023&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error detection by introducing a validation mechanism for API plugin URLs during query action creation in the Editor, based on environment, plugin type, and datasource configuration.
- **Tests**
	- Added tests to validate the new API plugin URL validation functionality in the Editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->