### PR TITLE
fix: Updating the primary action on clicking app card in mobile view

### DIFF
--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -46,6 +46,7 @@ import {
 import ForkApplicationModal from "./ForkApplicationModal";
 import { getExportAppAPIRoute } from "@appsmith/constants/ApiConstants";
 import { builderURL, viewerURL } from "@appsmith/RouteBuilder";
+import history from "utils/history";
 import urlBuilder from "@appsmith/entities/URLRedirect/URLAssembly";
 import { toast } from "design-system";
 import { getCurrentUser } from "actions/authActions";
@@ -438,6 +439,17 @@ export function ApplicationCard(props: ApplicationCardProps) {
     dispatch(getCurrentUser());
   }, []);
 
+  const launchMobileApp = useCallback(() => {
+    setURLParams();
+    history.push(
+      viewerURL({
+        pageId: props.application.defaultPageId,
+        params,
+      }),
+    );
+    dispatch(getCurrentUser());
+  }, [props.application.defaultPageId]);
+
   return (
     <Card
       backgroundColor={selectedColor}
@@ -450,7 +462,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
       isFetching={isFetchingApplications}
       isMobile={props.isMobile}
       moreActionItems={moreActionItems}
-      primaryAction={props.isMobile ? launchApp : noop}
+      primaryAction={props.isMobile ? launchMobileApp : noop}
       setShowOverlay={setShowOverlay}
       showGitBadge={Boolean(showGitBadge)}
       showOverlay={showOverlay}


### PR DESCRIPTION
## Description

Updating the primary action for app card click on mobile.

Fixes [#32084](https://github.com/appsmithorg/appsmith/issues/32084)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8448397082>
> Commit: `2424f0f6a1f891f0ff74162ebdb718e6a433a411`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8448397082&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced the application card to support launching the mobile app directly with specific URL parameters for a more tailored user experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->