### PR TITLE
fix: property pane collapse expand icon issue fixed

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
@@ -196,9 +196,8 @@ function setPropertyPaneSectionState(propertySectionState) {
   )) {
     cy.get("body").then(($body) => {
       if (
-        $body.find(
-          `${propertySectionClass(sectionName)} .t--chevron-icon.rotate-180`,
-        ).length >
+        $body.find(`${propertySectionClass(sectionName)} .t--chevron-icon`)
+          .length >
           0 !==
         shouldSectionOpen
       ) {
@@ -214,9 +213,8 @@ function verifyPropertyPaneSectionState(propertySectionState) {
   )) {
     cy.get("body").then(($body) => {
       const isSectionOpen =
-        $body.find(
-          `${propertySectionClass(sectionName)} .t--chevron-icon.rotate-180`,
-        ).length > 0;
+        $body.find(`${propertySectionClass(sectionName)} .t--chevron-icon`)
+          .length > 0;
       expect(isSectionOpen).to.equal(shouldSectionOpen);
     });
   }

--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_2_spec.js
@@ -180,9 +180,8 @@ function setPropertyPaneSectionState(propertySectionState) {
   )) {
     cy.get("body").then(($body) => {
       if (
-        $body.find(
-          `${propertySectionClass(sectionName)} .t--chevron-icon.rotate-180`,
-        ).length >
+        $body.find(`${propertySectionClass(sectionName)} .t--chevron-icon`)
+          .length >
           0 !==
         shouldSectionOpen
       ) {
@@ -198,9 +197,8 @@ function verifyPropertyPaneSectionState(propertySectionState) {
   )) {
     cy.get("body").then(($body) => {
       const isSectionOpen =
-        $body.find(
-          `${propertySectionClass(sectionName)} .t--chevron-icon.rotate-180`,
-        ).length > 0;
+        $body.find(`${propertySectionClass(sectionName)} .t--chevron-icon`)
+          .length > 0;
       expect(isSectionOpen).to.equal(shouldSectionOpen);
     });
   }

--- a/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
@@ -194,8 +194,8 @@ export const PropertySection = memo((props: PropertySectionProps) => {
         )}
         {props.collapsible && (
           <Icon
-            className={`ml-auto t--chevron-icon ${isOpen ? "rotate-180" : ""}`}
-            name="arrow-up-s-line"
+            className={`ml-auto t--chevron-icon`}
+            name={isOpen ? "expand-less" : "expand-more"}
             size="md"
           />
         )}


### PR DESCRIPTION
## Description
The PR fixes:

Issue with icon being reversed in property pane.
In property pane, for each section if it is expanded currently, it should have collapse icon beside it, if section is in collapsed state, it should have expand icon beside it. Earlier it was reverse, this PR corrects it

<img width="286" alt="Screenshot 2024-03-27 at 2 02 57 PM" src="https://github.com/appsmithorg/appsmith/assets/30018882/6af152fd-895e-4529-b8da-70c8ffe0559c">
<img width="289" alt="Screenshot 2024-03-27 at 2 00 48 PM" src="https://github.com/appsmithorg/appsmith/assets/30018882/45ba123f-3102-4205-8d44-6ba25f330ca6">


Note: This PR fixes only of the UI issues mentioned in #32069 

Fixes #32069
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8448851715>
> Commit: `37457a290f6258fbeda84376d62327d5fbe1d78b`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8448851715&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic for displaying the chevron icon in the property pane sections, enhancing user interface consistency.
	- Updated icons for open and closed states in the property sections for clearer visual cues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->