### PR TITLE
chore: Add tests for IDE url utils

### DIFF
--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/JS/utils.test.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/JS/utils.test.ts
@@ -1,0 +1,69 @@
+import { getJSEntityItemUrl, getJSUrl } from "./utils";
+import { URLBuilder } from "@appsmith/entities/URLRedirect/URLAssembly";
+import { PluginType } from "entities/Action";
+import type { FocusEntityInfo } from "navigation/FocusEntity";
+import { FocusEntity } from "navigation/FocusEntity";
+import { EditorState } from "@appsmith/entities/IDE/constants";
+
+describe("getJSEntityItemUrl", () => {
+  URLBuilder._instance.setCurrentPageId("testPage");
+  it("returns a JS url", () => {
+    const url = getJSEntityItemUrl(
+      {
+        title: "TestTitle",
+        key: "abc",
+        type: PluginType.JS,
+      },
+      "testPage",
+    );
+
+    expect(url).toEqual("/app/application/page-testPage/edit/jsObjects/abc");
+  });
+});
+
+describe("getJSUrl", () => {
+  URLBuilder._instance.setCurrentPageId("testPage");
+  it("returns a JS collection url", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.JS_OBJECT,
+      id: "abc",
+      appState: EditorState.EDITOR,
+      params: {},
+    };
+    const url = getJSUrl(focusEntity, false);
+    expect(url).toEqual("/app/application/page-testPage/edit/jsObjects/abc");
+
+    const addUrl = getJSUrl(focusEntity);
+    expect(addUrl).toEqual(
+      "/app/application/page-testPage/edit/jsObjects/abc/add",
+    );
+  });
+
+  it("if focus is on add, it will return the list url", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.JS_OBJECT_ADD,
+      id: "abc",
+      appState: EditorState.EDITOR,
+      params: {},
+    };
+    const url = getJSUrl(focusEntity, false);
+    expect(url).toEqual("/app/application/page-testPage/edit/jsObjects");
+  });
+
+  it("returns the js url even if the focus is not on JS", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.QUERY,
+      id: "abc",
+      appState: EditorState.EDITOR,
+      params: {
+        queryId: "abc",
+        pageId: "testPage",
+      },
+    };
+    const url = getJSUrl(focusEntity, false);
+    expect(url).toEqual("/app/application/page-testPage/edit/jsObjects");
+
+    const addUrl = getJSUrl(focusEntity);
+    expect(addUrl).toEqual("/app/application/page-testPage/edit/jsObjects/add");
+  });
+});

--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/utils.test.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/utils.test.ts
@@ -1,0 +1,122 @@
+import { getQueryEntityItemUrl, getQueryUrl } from "./utils";
+import type { FocusEntityInfo } from "navigation/FocusEntity";
+import { FocusEntity } from "navigation/FocusEntity";
+import { EditorState } from "@appsmith/entities/IDE/constants";
+import { PluginPackageName, PluginType } from "entities/Action";
+import { URLBuilder } from "@appsmith/entities/URLRedirect/URLAssembly";
+
+describe("getQueryEntityItemUrl", () => {
+  it("throws error if plugin type is not a query", () => {
+    const item = {
+      title: "testTitle",
+      type: PluginType.JS,
+      key: "abc",
+    };
+
+    expect(() => getQueryEntityItemUrl(item, "testPage")).toThrow();
+  });
+
+  it("returns url for a query type plugin", () => {
+    const item = {
+      title: "testTitle",
+      type: PluginType.INTERNAL,
+      key: "abc",
+    };
+
+    expect(getQueryEntityItemUrl(item, "testPage")).toEqual(
+      "/app/application/page-testPage/edit/queries/abc",
+    );
+  });
+});
+
+describe("getQueryUrl", () => {
+  URLBuilder._instance.setCurrentPageId("testPage");
+  it("gets the correct SAAS plugin url", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.QUERY,
+      id: "abc",
+      appState: EditorState.EDITOR,
+      params: {
+        pluginPackageName: PluginPackageName.GOOGLE_SHEETS,
+        apiId: "abc",
+      },
+    };
+
+    const url = getQueryUrl(focusEntity, false);
+    expect(url).toEqual(
+      "/app/application/page-testPage/edit/saas/google-sheets-plugin/api/abc",
+    );
+
+    const addUrl = getQueryUrl(focusEntity);
+    expect(addUrl).toEqual(
+      "/app/application/page-testPage/edit/saas/google-sheets-plugin/api/abc/add",
+    );
+  });
+
+  it("gets the correct API plugin url", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.QUERY,
+      id: "abc",
+      appState: EditorState.EDITOR,
+      params: {
+        apiId: "abc",
+      },
+    };
+
+    const url = getQueryUrl(focusEntity, false);
+    expect(url).toEqual("/app/application/page-testPage/edit/api/abc");
+
+    const addUrl = getQueryUrl(focusEntity);
+    expect(addUrl).toEqual("/app/application/page-testPage/edit/api/abc/add");
+  });
+
+  it("gets the correct Query Plugin url", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.QUERY,
+      id: "abc",
+      appState: EditorState.EDITOR,
+      params: {
+        queryId: "abc",
+      },
+    };
+
+    const url = getQueryUrl(focusEntity, false);
+    expect(url).toEqual("/app/application/page-testPage/edit/queries/abc");
+
+    const addUrl = getQueryUrl(focusEntity);
+    expect(addUrl).toEqual(
+      "/app/application/page-testPage/edit/queries/abc/add",
+    );
+  });
+
+  it("Returns the query list url if is query add state", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.QUERY,
+      id: "add",
+      appState: EditorState.EDITOR,
+      params: {
+        queryId: "add",
+      },
+    };
+
+    const url = getQueryUrl(focusEntity);
+    expect(url).toEqual("/app/application/page-testPage/edit/queries");
+  });
+
+  it("returns query url even if the focus is on another entity type", () => {
+    const focusEntity: FocusEntityInfo = {
+      entity: FocusEntity.JS_OBJECT,
+      id: "abc",
+      appState: EditorState.EDITOR,
+      params: {
+        collectionId: "abc",
+      },
+    };
+
+    const url = getQueryUrl(focusEntity, false);
+    expect(url).toEqual("/app/application/page-testPage/edit/queries");
+
+    const addUrl = getQueryUrl(focusEntity);
+    expect(addUrl).toEqual("/app/application/page-testPage/edit/queries/add");
+  });
+});


### PR DESCRIPTION
## Description
Adds url tests for IDE utils


Fixes #31870

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->