### PR TITLE
chore: Add tests for useGetPageFocusUrl hook

### DIFF
--- a/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
+++ b/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
@@ -81,6 +81,16 @@ const isPageChange = (prevPath: string, currentPath: string) => {
   );
 };
 
+export const createEditorFocusInfo = (pageId: string, branch?: string) => ({
+  key: `EDITOR_STATE.${pageId}#${branch}`,
+  entityInfo: {
+    id: `EDITOR.${pageId}`,
+    appState: EditorState.EDITOR,
+    entity: FocusEntity.EDITOR,
+    params: {},
+  },
+});
+
 export const AppIDEFocusStrategy: FocusStrategy = {
   focusElements: AppIDEFocusElements,
   getEntitiesForSet: function* (
@@ -102,15 +112,11 @@ export const AppIDEFocusStrategy: FocusStrategy = {
       (prevEntityInfo.params.pageId !== currentEntityInfo.params.pageId ||
         prevEntityInfo.appState !== currentEntityInfo.appState)
     ) {
-      entities.push({
-        key: `EDITOR_STATE.${currentEntityInfo.params.pageId}#${branch}`,
-        entityInfo: {
-          id: `EDITOR.${currentEntityInfo.params.pageId}`,
-          appState: EditorState.EDITOR,
-          entity: FocusEntity.EDITOR,
-          params: {},
-        },
-      });
+      if (currentEntityInfo.params.pageId) {
+        entities.push(
+          createEditorFocusInfo(currentEntityInfo.params.pageId, branch),
+        );
+      }
     }
 
     entities.push({

--- a/app/client/src/pages/Editor/IDE/hooks.test.tsx
+++ b/app/client/src/pages/Editor/IDE/hooks.test.tsx
@@ -1,0 +1,103 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { hookWrapper } from "test/testUtils";
+import { getIDETestState } from "test/factories/AppIDEFactoryUtils";
+import { PageFactory } from "test/factories/PageFactory";
+import { useGetPageFocusUrl } from "./hooks";
+import { EditorEntityTab } from "@appsmith/entities/IDE/constants";
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { createEditorFocusInfo } from "../../../ce/navigation/FocusStrategy/AppIDEFocusStrategy";
+
+describe("useGetPageFocusUrl", () => {
+  const pages = PageFactory.buildList(4);
+  pages[0].isDefault = true;
+  const page1FocusHistory = createEditorFocusInfo(pages[0].pageId);
+  const page2FocusHistory = createEditorFocusInfo(pages[1].pageId);
+  const page3FocusHistory = createEditorFocusInfo(pages[2].pageId);
+
+  const focusHistory = {
+    [page1FocusHistory.key]: {
+      entityInfo: page1FocusHistory.entityInfo,
+      state: { SelectedSegment: EditorEntityTab.JS },
+    },
+    [page2FocusHistory.key]: {
+      entityInfo: page2FocusHistory.entityInfo,
+      state: { SelectedSegment: EditorEntityTab.UI },
+    },
+    [page3FocusHistory.key]: {
+      entityInfo: page3FocusHistory.entityInfo,
+      state: { SelectedSegment: EditorEntityTab.QUERIES },
+    },
+  };
+
+  const state = getIDETestState({
+    pages,
+    focusHistory,
+  });
+  const wrapper = hookWrapper({ initialState: state });
+  it("works for JS focus history", () => {
+    const { result } = renderHook(() => useGetPageFocusUrl(pages[0].pageId), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual(
+      "/app/application/page-page_id_1/edit/jsObjects",
+    );
+  });
+
+  it("works for UI focus history", () => {
+    const { result } = renderHook(() => useGetPageFocusUrl(pages[1].pageId), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual(
+      "/app/application/page-page_id_2/edit/widgets",
+    );
+  });
+
+  it("works for Query focus history", () => {
+    const { result } = renderHook(() => useGetPageFocusUrl(pages[2].pageId), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual(
+      "/app/application/page-page_id_3/edit/queries",
+    );
+  });
+
+  it("returns builder url when no focus history exists", () => {
+    const { result } = renderHook(() => useGetPageFocusUrl(pages[3].pageId), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual("/app/application/page-page_id_4/edit");
+  });
+
+  it("returns correct state when branches exist", () => {
+    const branch = "featureBranch";
+    const page1FocusHistoryWithBranch = createEditorFocusInfo(
+      pages[0].pageId,
+      branch,
+    );
+    const state = getIDETestState({
+      pages,
+      focusHistory: {
+        ...focusHistory,
+        [page1FocusHistoryWithBranch.key]: {
+          entityInfo: page1FocusHistoryWithBranch.entityInfo,
+          state: { SelectedSegment: EditorEntityTab.UI },
+        },
+      },
+      branch,
+    });
+
+    const wrapperWithBranch = hookWrapper({ initialState: state });
+
+    const { result } = renderHook(() => useGetPageFocusUrl(pages[0].pageId), {
+      wrapper: wrapperWithBranch,
+    });
+
+    expect(result.current).toEqual(
+      "/app/application/page-page_id_1/edit/widgets",
+    );
+  });
+});

--- a/app/client/src/pages/Editor/IDE/hooks.ts
+++ b/app/client/src/pages/Editor/IDE/hooks.ts
@@ -186,9 +186,7 @@ export const useGetPageFocusUrl = (pageId: string): string => {
       return;
     }
 
-    const segment =
-      Object.values(editorState)[0].state?.SelectedSegment ||
-      EditorEntityTab.UI;
+    const segment = Object.values(editorState)[0].state?.SelectedSegment;
 
     switch (segment) {
       case EditorEntityTab.UI:
@@ -200,6 +198,8 @@ export const useGetPageFocusUrl = (pageId: string): string => {
       case EditorEntityTab.QUERIES:
         setFocusPageUrl(queryListURL({ pageId: pageId }));
         break;
+      default:
+        setFocusPageUrl(widgetListURL({ pageId: pageId }));
     }
   }, [focusInfo, branch]);
 

--- a/app/client/test/factories/AppIDEFactoryUtils.ts
+++ b/app/client/test/factories/AppIDEFactoryUtils.ts
@@ -7,6 +7,7 @@ import type { Action } from "entities/Action";
 import type { IDETabs } from "reducers/uiReducers/ideReducer";
 import { IDETabsDefaultValue } from "reducers/uiReducers/ideReducer";
 import type { JSCollection } from "entities/JSCollection";
+import type { FocusHistory } from "reducers/uiReducers/focusHistoryReducer";
 
 interface IDEStateArgs {
   ideView?: EditorViewMode;
@@ -15,11 +16,13 @@ interface IDEStateArgs {
   js?: JSCollection[];
   tabs?: IDETabs;
   branch?: string;
+  focusHistory?: FocusHistory;
 }
 
 export const getIDETestState = ({
   actions = [],
   branch,
+  focusHistory = {},
   ideView = EditorViewMode.FullScreen,
   js = [],
   pages = [],
@@ -55,6 +58,11 @@ export const getIDETestState = ({
         ...initialState.ui.ide,
         view: ideView,
         tabs,
+      },
+      focusHistory: {
+        history: {
+          ...focusHistory,
+        },
       },
       editor: {
         ...initialState.ui.editor,


### PR DESCRIPTION
## Description

- Create a new hookWrapper util to enable hook testing with redux state
- Create a util function to create EditorState Focus Info
- Small refactor of `useGetPageFocusUrl` hook
- Adds tests for `useGetPageFocusUrl` hook

Fixes #31871 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8451092610>
> Commit: `a4660177de70be17d94928eef4fbe29a37f1a1d5`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8451092610&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a function to streamline the creation of editor focus information, enhancing navigation within the IDE.
- **Refactor**
	- Refactored logic for setting focus page URLs in the IDE, improving the accuracy and reliability of navigation.
- **Tests**
	- Added tests for the `useGetPageFocusUrl` hook, ensuring URL generation behaves as expected.
- **Chores**
	- Updated utility functions for IDE tests, facilitating better test setup and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->