### PR TITLE
chore: git remote autocommit

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/AutoCommitEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/AutoCommitEvent.java
@@ -1,6 +1,8 @@
 package com.appsmith.server.events;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
@@ -9,6 +11,8 @@ import lombok.ToString;
  */
 @Data
 @ToString
+@NoArgsConstructor
+@AllArgsConstructor
 public class AutoCommitEvent {
     private String applicationId;
     private String branchName;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/GitAutoCommitHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/GitAutoCommitHelperImpl.java
@@ -12,18 +12,18 @@ import com.appsmith.server.featureflags.FeatureFlagEnum;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
 import com.appsmith.server.helpers.GitUtils;
 import com.appsmith.server.helpers.RedisUtils;
+import com.appsmith.server.services.CommonGitService;
 import com.appsmith.server.services.FeatureFlagService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.AutoCommitEventHandler;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-@RequiredArgsConstructor
 @Service
 public class GitAutoCommitHelperImpl implements GitAutoCommitHelper {
     private final GitPrivateRepoHelper gitPrivateRepoHelper;
@@ -33,6 +33,26 @@ public class GitAutoCommitHelperImpl implements GitAutoCommitHelper {
     private final ApplicationService applicationService;
     private final ApplicationPermission applicationPermission;
     private final RedisUtils redisUtils;
+    private final CommonGitService commonGitService;
+
+    public GitAutoCommitHelperImpl(
+            GitPrivateRepoHelper gitPrivateRepoHelper,
+            AutoCommitEventHandler autoCommitEventHandler,
+            UserDataService userDataService,
+            FeatureFlagService featureFlagService,
+            ApplicationService applicationService,
+            ApplicationPermission applicationPermission,
+            RedisUtils redisUtils,
+            @Lazy CommonGitService commonGitService) {
+        this.gitPrivateRepoHelper = gitPrivateRepoHelper;
+        this.autoCommitEventHandler = autoCommitEventHandler;
+        this.userDataService = userDataService;
+        this.featureFlagService = featureFlagService;
+        this.applicationService = applicationService;
+        this.applicationPermission = applicationPermission;
+        this.redisUtils = redisUtils;
+        this.commonGitService = commonGitService;
+    }
 
     @Override
     public Mono<AutoCommitProgressDTO> getAutoCommitProgress(String applicationId) {
@@ -50,9 +70,23 @@ public class GitAutoCommitHelperImpl implements GitAutoCommitHelper {
 
     @Override
     public Mono<Boolean> autoCommitApplication(String defaultApplicationId, String branchName) {
+
+        // if either param is absent, then application is not connected to git.
+        if (!StringUtils.hasText(branchName) || !StringUtils.hasText(defaultApplicationId)) {
+            return Mono.just(Boolean.FALSE);
+        }
+
         Mono<Application> applicationMono = applicationService
                 .findById(defaultApplicationId, applicationPermission.getEditPermission())
                 .cache();
+
+        final String finalBranchName = branchName.replaceFirst("origin/", "");
+
+        Mono<Application> branchedApplicationMono = applicationService
+                .findByBranchNameAndDefaultApplicationId(
+                        finalBranchName, defaultApplicationId, applicationPermission.getEditPermission())
+                .cache();
+
         Mono<Boolean> featureEnabledMono =
                 featureFlagService.check(FeatureFlagEnum.release_git_autocommit_feature_enabled);
         Mono<Boolean> autoCommitDisabledForThisBranchMono = applicationMono.flatMap(application -> {
@@ -67,63 +101,74 @@ public class GitAutoCommitHelperImpl implements GitAutoCommitHelper {
                 .map(a -> Boolean.TRUE)
                 .switchIfEmpty(Mono.just(Boolean.FALSE));
 
-        if (StringUtils.hasLength(defaultApplicationId) && StringUtils.hasLength(branchName)) {
-            // both of them are present, so it's a git connected application
-            return isAutoCommitRunningMono
-                    .flatMap(isRunning -> {
-                        if (isRunning) {
-                            return Mono.error(new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION));
-                        }
-                        return Mono.zip(featureEnabledMono, autoCommitDisabledForThisBranchMono)
-                                .flatMap(tuple -> {
-                                    Boolean isFeatureEnabled = tuple.getT1();
-                                    Boolean isAutoCommitDisabledForBranch = tuple.getT2();
-                                    if (isFeatureEnabled && !isAutoCommitDisabledForBranch) {
-                                        return applicationMono;
-                                    } else {
-                                        log.debug(
-                                                "auto commit is not applicable for application: {} branch: {} isFeatureEnabled: {}, isAutoCommitDisabledForBranch: {}",
-                                                defaultApplicationId,
-                                                branchName,
-                                                isFeatureEnabled,
-                                                isAutoCommitDisabledForBranch);
-                                        return Mono.empty();
-                                    }
-                                })
-                                .zipWith(userDataService.getGitProfileForCurrentUser(defaultApplicationId))
-                                .map(objects -> {
-                                    Application application = objects.getT1();
-                                    GitProfile gitProfile = objects.getT2();
-                                    GitArtifactMetadata gitArtifactMetadata = application.getGitApplicationMetadata();
+        return isAutoCommitRunningMono
+                .flatMap(isRunning -> {
+                    if (isRunning) {
+                        return Mono.error(new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION));
+                    }
+                    return Mono.zip(featureEnabledMono, autoCommitDisabledForThisBranchMono)
+                            .flatMap(tuple -> {
+                                Boolean isFeatureEnabled = tuple.getT1();
+                                Boolean isAutoCommitDisabledForBranch = tuple.getT2();
+                                if (isFeatureEnabled && !isAutoCommitDisabledForBranch) {
+                                    return Mono.zip(applicationMono, branchedApplicationMono);
+                                }
 
-                                    AutoCommitEvent autoCommitEvent = new AutoCommitEvent();
-                                    autoCommitEvent.setApplicationId(defaultApplicationId);
-                                    autoCommitEvent.setBranchName(branchName);
-                                    autoCommitEvent.setRepoName(gitArtifactMetadata.getRepoName());
-                                    autoCommitEvent.setWorkspaceId(application.getWorkspaceId());
-                                    autoCommitEvent.setAuthorName(gitProfile.getAuthorName());
-                                    autoCommitEvent.setAuthorEmail(gitProfile.getAuthorEmail());
-                                    autoCommitEvent.setRepoUrl(gitArtifactMetadata.getRemoteUrl());
-                                    autoCommitEvent.setPrivateKey(
-                                            gitArtifactMetadata.getGitAuth().getPrivateKey());
-                                    autoCommitEvent.setPublicKey(
-                                            gitArtifactMetadata.getGitAuth().getPublicKey());
-                                    // it's a synchronous call, no need to return anything
-                                    autoCommitEventHandler.publish(autoCommitEvent);
-                                    return Boolean.TRUE;
-                                });
-                    })
-                    .defaultIfEmpty(Boolean.FALSE)
-                    // we cannot throw exception from this flow because doing so will fail the main operation
-                    .onErrorResume(throwable -> {
-                        log.error(
-                                "Error during auto-commit for application: {}, branch: {}",
-                                defaultApplicationId,
-                                branchName,
-                                throwable);
-                        return Mono.just(Boolean.FALSE);
-                    });
-        }
-        return Mono.just(Boolean.FALSE);
+                                log.debug(
+                                        "auto commit is not applicable for application: {} branch: {} isFeatureEnabled: {}, isAutoCommitDisabledForBranch: {}",
+                                        defaultApplicationId,
+                                        branchName,
+                                        isFeatureEnabled,
+                                        isAutoCommitDisabledForBranch);
+                                return Mono.empty();
+                            })
+                            .flatMap(tuple2 -> {
+                                Application defaultApplication = tuple2.getT1();
+                                Application branchedApplication = tuple2.getT2();
+                                return commonGitService
+                                        .fetchRemoteChanges(defaultApplication, branchedApplication, branchName, true)
+                                        .flatMap(branchTrackingStatus -> {
+                                            if (branchTrackingStatus.getBehindCount() > 0) {
+                                                log.debug(
+                                                        "the remote is ahead of the local, aborting autocommit for application {} and branch {}",
+                                                        defaultApplicationId,
+                                                        branchName);
+                                                return Mono.empty();
+                                            }
+
+                                            return Mono.just(defaultApplication);
+                                        });
+                            })
+                            .zipWith(userDataService.getGitProfileForCurrentUser(defaultApplicationId))
+                            .map(objects -> {
+                                Application application = objects.getT1();
+                                GitProfile gitProfile = objects.getT2();
+                                GitArtifactMetadata gitArtifactMetadata = application.getGitApplicationMetadata();
+
+                                AutoCommitEvent autoCommitEvent = new AutoCommitEvent(
+                                        defaultApplicationId,
+                                        branchName,
+                                        application.getWorkspaceId(),
+                                        gitArtifactMetadata.getRepoName(),
+                                        gitProfile.getAuthorName(),
+                                        gitProfile.getAuthorEmail(),
+                                        gitArtifactMetadata.getRemoteUrl(),
+                                        gitArtifactMetadata.getGitAuth().getPrivateKey(),
+                                        gitArtifactMetadata.getGitAuth().getPublicKey());
+                                // it's a synchronous call, no need to return anything
+                                autoCommitEventHandler.publish(autoCommitEvent);
+                                return Boolean.TRUE;
+                            });
+                })
+                .defaultIfEmpty(Boolean.FALSE)
+                // we cannot throw exception from this flow because doing so will fail the main operation
+                .onErrorResume(throwable -> {
+                    log.error(
+                            "Error during auto-commit for application: {}, branch: {}",
+                            defaultApplicationId,
+                            branchName,
+                            throwable);
+                    return Mono.just(Boolean.FALSE);
+                });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommonGitServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommonGitServiceCE.java
@@ -20,6 +20,9 @@ public interface CommonGitServiceCE {
     Mono<GitStatusDTO> getStatus(String defaultArtifactId, boolean compareRemote, String branchName);
 
     Mono<BranchTrackingStatus> fetchRemoteChanges(
+            Artifact defaultArtifact, Artifact branchedArtifact, String branchName, boolean isFileLock);
+
+    Mono<BranchTrackingStatus> fetchRemoteChanges(
             String defaultApplicationId, String branchName, boolean isFileLock, ArtifactType artifactType);
 
     Mono<? extends Artifact> connectArtifactToGit(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommonGitServiceCEImpl.java
@@ -299,6 +299,101 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                 });
     }
 
+    @Override
+    public Mono<BranchTrackingStatus> fetchRemoteChanges(
+            Artifact defaultArtifact, Artifact branchedArtifact, String branchName, boolean isFileLock) {
+
+        if (StringUtils.isEmptyOrNull(branchName)) {
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.BRANCH_NAME));
+        }
+
+        if (branchedArtifact == null || defaultArtifact == null || defaultArtifact.getGitArtifactMetadata() == null) {
+            return Mono.error(new AppsmithException(AppsmithError.GIT_GENERIC_ERROR));
+        }
+
+        final String finalBranchName = branchName.replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT);
+        GitArtifactMetadata defaultGitData = defaultArtifact.getGitArtifactMetadata();
+        String defaultArtifactId = defaultGitData.getDefaultArtifactId();
+
+        GitArtifactHelper<?> artifactGitHelper = getArtifactGitService(defaultArtifact.getArtifactType());
+
+        Mono<User> currUserMono = sessionUserService.getCurrentUser().cache(); // will be used to send analytics event
+
+        Mono<Boolean> addFileLockMono = Mono.just(Boolean.TRUE);
+        if (Boolean.TRUE.equals(isFileLock)) {
+            addFileLockMono = addFileLock(defaultArtifactId);
+        }
+        /*
+           1. Copy resources from DB to local repo
+           2. Fetch the current status from local repo
+        */
+
+        // current user mono has been zipped just to run in parallel.
+        Mono<BranchTrackingStatus> fetchRemoteStatusMono = addFileLockMono
+                .flatMap(isFileLocked -> {
+                    GitArtifactMetadata gitData = branchedArtifact.getGitArtifactMetadata();
+                    gitData.setGitAuth(defaultGitData.getGitAuth());
+
+                    Path repoSuffix = artifactGitHelper.getRepoSuffixPath(
+                            branchedArtifact.getWorkspaceId(),
+                            gitData.getDefaultApplicationId(),
+                            gitData.getRepoName());
+
+                    Path repoPath = gitExecutor.createRepoPath(repoSuffix);
+                    Mono<Boolean> checkoutBranchMono = gitExecutor.checkoutToBranch(repoSuffix, finalBranchName);
+                    Mono<String> fetchRemoteMono = gitExecutor.fetchRemote(
+                            repoPath,
+                            gitData.getGitAuth().getPublicKey(),
+                            gitData.getGitAuth().getPrivateKey(),
+                            true,
+                            finalBranchName,
+                            false);
+
+                    Mono<BranchTrackingStatus> branchedStatusMono =
+                            gitExecutor.getBranchTrackingStatus(repoPath, finalBranchName);
+
+                    return checkoutBranchMono
+                            .then(Mono.defer(() -> fetchRemoteMono))
+                            .then(Mono.defer(() -> branchedStatusMono))
+                            .flatMap(branchTrackingStatus -> {
+                                if (isFileLock) {
+                                    return releaseFileLock(defaultArtifactId).thenReturn(branchTrackingStatus);
+                                }
+                                return Mono.just(branchTrackingStatus);
+                            })
+                            .onErrorResume(throwable -> {
+                                /*
+                                 in case of any error, the global exception handler will release the lock
+                                 hence we don't need to do that manually
+                                */
+                                log.error(
+                                        "Error to fetch from remote for application: {}, branch: {}",
+                                        defaultArtifactId,
+                                        branchName,
+                                        throwable);
+                                return Mono.error(new AppsmithException(
+                                        AppsmithError.GIT_ACTION_FAILED, "fetch", throwable.getMessage()));
+                            });
+                })
+                .elapsed()
+                .zipWith(currUserMono)
+                .flatMap(objects -> {
+                    Long elapsedTime = objects.getT1().getT1();
+                    BranchTrackingStatus branchTrackingStatus = objects.getT1().getT2();
+                    User currentUser = objects.getT2();
+                    return sendUnitExecutionTimeAnalyticsEvent(
+                                    AnalyticsEvents.GIT_FETCH.getEventName(),
+                                    elapsedTime,
+                                    currentUser,
+                                    branchedArtifact)
+                            .thenReturn(branchTrackingStatus);
+                });
+
+        return Mono.create(sink -> {
+            fetchRemoteStatusMono.subscribe(sink::success, sink::error, null, sink.currentContext());
+        });
+    }
+
     /**
      * This method is responsible to compare the current branch with the remote branch.
      * Comparing means finding two numbers - how many commits ahead and behind the local branch is.


### PR DESCRIPTION
## Description
 - This Pr adds a remote comparison check in `autocommit` flow.
 - When the remote is ahead of the local repository, the application should not be commited to remote, local should pull the changes first  and then the respective commit & push should happen. Likewise in autocommit the remote check has been placed. 
 - The check is meant to silently abort the autocommit if the remote is found to be ahead of the local.

Fixes https://github.com/appsmithorg/appsmith/issues/32110

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8451614719>
> Commit: `4f696b752a8f3f847f2e6f8ff5acf9ef0e67a276`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8451614719&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced auto-commit functionality for Git integration, including better handling based on branch and application states, and improved remote changes fetching.
- **Refactor**
	- Refactored Git-related services to support new auto-commit logic and remote changes fetching.
- **Tests**
	- Added new tests for the updated auto-commit functionality, ensuring it behaves as expected under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->