### PR TITLE
chore: added test for asserting save button

### DIFF
--- a/app/client/cypress/e2e/Sanity/Datasources/GraphQL_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/GraphQL_spec.ts
@@ -6,6 +6,7 @@ import {
   locators,
   dataManager,
   propPane,
+  assertHelper,
 } from "../../../support/Objects/ObjectsCore";
 
 let datasourceName = "GraphQL_DS";
@@ -323,6 +324,10 @@ describe(
         "Client Credentials",
         "Authorization Code",
       ]);
+
+      // For Client Credentials Grant Type, the button should be Save
+      // Default first selection from dropdown is Client Credentials
+      assertHelper.AssertContains("Save", "exist", dataSources._saveDs);
 
       propPane.AssertPropertiesDropDownValues("Add Access Token To", [
         "Request Header",


### PR DESCRIPTION
## Description
> This PR adds asserts the Save button which was added in place of Save and Authorize in https://github.com/appsmithorg/appsmith/pull/32047
Fixes #32071 

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8451764949>
> Commit: `d86c6561c9cce0bab2f7dc405bdb609019556ba6`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8451764949&attempt=3" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Tests**
	- Enhanced testing for GraphQL data sources by adding an assertion to verify the presence of a "Save" button for Client Credentials Grant Type scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->