### PR TITLE
fix: Closing modal in Split view, exits code mode

### DIFF
--- a/app/client/src/layoutSystems/common/modalOverlay/ModalOverlayLayer.tsx
+++ b/app/client/src/layoutSystems/common/modalOverlay/ModalOverlayLayer.tsx
@@ -7,8 +7,6 @@ import { Layers } from "constants/Layers";
 import { theme } from "constants/DefaultTheme";
 import { useDispatch, useSelector } from "react-redux";
 import { getAppViewHeaderHeight } from "selectors/appViewSelectors";
-import { selectWidgetInitAction } from "actions/widgetSelectionActions";
-import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { useMaxModalWidth } from "widgets/ModalWidget/component/useModalWidth";
 import { useAppViewerSidebarProperties } from "utils/hooks/useAppViewerSidebarProperties";
@@ -123,7 +121,6 @@ export function ModalOverlayLayer(props: BaseWidgetProps) {
         modalName: props.widgetName,
       },
     });
-    dispatch(selectWidgetInitAction(SelectionRequestType.Empty));
     e.stopPropagation();
     e.preventDefault();
   };

--- a/app/client/src/sagas/ModalSagas.ts
+++ b/app/client/src/sagas/ModalSagas.ts
@@ -53,6 +53,8 @@ import { getModalWidgetType } from "selectors/widgetSelectors";
 import { getLayoutSystemType } from "selectors/layoutSystemSelectors";
 import { LayoutSystemTypes } from "layoutSystems/types";
 import { AnvilReduxActionTypes } from "layoutSystems/anvil/integrations/actions/actionTypes";
+import { getWidgetSelectionBlock } from "selectors/ui";
+
 const WidgetTypes = WidgetFactory.widgetTypes;
 
 export function* createModalSaga(action: ReduxAction<{ modalName: string }>) {
@@ -242,8 +244,13 @@ export function* closeModalSaga(
       );
     }
     if (modalName) {
-      yield put(selectWidgetInitAction(SelectionRequestType.Empty));
-      yield put(focusWidget(MAIN_CONTAINER_WIDGET_ID));
+      const isWidgetSelectionBlocked: boolean = yield select(
+        getWidgetSelectionBlock,
+      );
+      if (!isWidgetSelectionBlocked) {
+        yield put(selectWidgetInitAction(SelectionRequestType.Empty));
+        yield put(focusWidget(MAIN_CONTAINER_WIDGET_ID));
+      }
     }
   } catch (error) {
     log.error(error);


### PR DESCRIPTION
## Description

Avoids widget selection on modal close when widget selection is blocked.


Fixes #32118

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8453269683>
> Commit: `a1c3fdbc4e21cdbb2627d4b1fe71bb427bfef291`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8453269683&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Enhanced the modal overlay functionality to improve user interaction.
	- Optimized modal handling to ensure smoother user experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->