### PR TITLE
fix: Updating the height of inputs form on the right pane of modules editor

### DIFF
--- a/app/client/src/components/editorComponents/ActionRightPane/index.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/index.tsx
@@ -106,7 +106,7 @@ function ActionSidebar({
         {actionRightPaneBackLink}
         <CollapsibleGroupContainer>
           {additionalSections && (
-            <CollapsibleGroup maxHeight={"50%"}>
+            <CollapsibleGroup height={"100%"}>
               {additionalSections}
             </CollapsibleGroup>
           )}


### PR DESCRIPTION
## Description

Updating the height of inputs form on the right pane of modules editor.

Fixes [#31955](https://github.com/appsmithorg/appsmith/issues/31955) 

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->