### PR TITLE
chore: No `X-Request-Id` handling

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/MDCFilter.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/MDCFilter.java
@@ -87,12 +87,8 @@ public class MDCFilter implements WebFilter {
                     final HttpHeaders httpHeaders = response.getHeaders();
                     // Add all the request MDC keys to the response object
                     ctx.<Map<String, String>>get(LogHelper.CONTEXT_MAP).forEach((key, value) -> {
-                        if (!key.equalsIgnoreCase(USER_EMAIL)) {
-                            if (!key.contains(REQUEST_ID_LOG)) {
-                                httpHeaders.add(MDC_HEADER_PREFIX + key, value);
-                            } else {
-                                httpHeaders.add(REQUEST_ID_HEADER, value);
-                            }
+                        if (!key.equalsIgnoreCase(USER_EMAIL) && !key.contains(REQUEST_ID_LOG)) {
+                            httpHeaders.add(MDC_HEADER_PREFIX + key, value);
                         }
                     });
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/MDCFilter.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/MDCFilter.java
@@ -3,6 +3,7 @@ package com.appsmith.server.filters;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.LogHelper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -105,13 +106,11 @@ public class MDCFilter implements WebFilter {
     }
 
     private String getOrCreateRequestId(final ServerHttpRequest request) {
-        if (!request.getHeaders().containsKey(REQUEST_ID_HEADER)) {
-            request.mutate()
-                    .header(REQUEST_ID_HEADER, UUID.randomUUID().toString())
-                    .build();
+        final String header = request.getHeaders().getFirst(REQUEST_ID_HEADER);
+        if (!StringUtils.isEmpty(header)) {
+            return header;
         }
 
-        String header = request.getHeaders().get(REQUEST_ID_HEADER).get(0);
-        return header;
+        return UUID.randomUUID().toString();
     }
 }


### PR DESCRIPTION
1. Don't copy request's `X-Request-Id` value in the response.
2. If missing in request, don't add a generated values either, but do retain in internal request context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved efficiency in handling request IDs and streamlined conditional logic in server response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->