### PR TITLE
chore: Move StringUtils to interfaces module

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/StringUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/StringUtils.java
@@ -1,4 +1,4 @@
-package com.appsmith.server.helpers;
+package com.appsmith.external.helpers;
 
 public class StringUtils {
     private StringUtils() {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -25,10 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.appsmith.external.helpers.StringUtils.dotted;
 import static com.appsmith.server.constants.ResourceModes.EDIT;
 import static com.appsmith.server.constants.ResourceModes.VIEW;
 import static com.appsmith.server.helpers.DateUtils.ISO_FORMATTER;
-import static com.appsmith.server.helpers.StringUtils.dotted;
 
 @Getter
 @Setter

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 
-import static com.appsmith.server.helpers.StringUtils.dotted;
+import static com.appsmith.external.helpers.StringUtils.dotted;
 
 /**
  * This class represents a collection of actions that may or may not belong to the same plugin.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 
-import static com.appsmith.server.helpers.StringUtils.dotted;
+import static com.appsmith.external.helpers.StringUtils.dotted;
 
 @Getter
 @Setter


### PR DESCRIPTION
This is a utility class with static methods, and we need them in domain classes in the `interfaces` module as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Moved `StringUtils` class to a new package for better code organization.
	- Updated import statements across various files to reflect the movement of `StringUtils`.
	- Added new import statements for `ResourceModes` in the `Application.java` file, enhancing resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->