### PR TITLE
fix: Limit email length as per RFC 5321

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ValidationUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ValidationUtils.java
@@ -22,6 +22,16 @@ public final class ValidationUtils {
             SPECIAL_CHARACTERS, LOGIN_PASSWORD_MIN_LENGTH, LOGIN_PASSWORD_MAX_LENGTH);
 
     public static boolean validateEmail(String emailStr) {
+        // Limits defined by RFC 5321 at https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.
+        if (!StringUtils.hasLength(emailStr)) {
+            return false;
+        }
+
+        final String[] parts = emailStr.split("@");
+        if (parts.length != 2 || parts[0].length() > 64 || parts[1].length() > 255) {
+            return false;
+        }
+
         return EmailValidator.getInstance().isValid(emailStr);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/notifications/EmailSender.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/notifications/EmailSender.java
@@ -84,7 +84,7 @@ public class EmailSender {
         }
 
         // Check if the email address is valid. It's possible for certain OAuth2 providers to not return the email ID
-        if (to == null || !validateEmail(to)) {
+        if (!validateEmail(to)) {
             log.error("The email ID: {} is not valid. Not sending an email", to);
             return;
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceCEImpl.java
@@ -9,6 +9,7 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.ValidationUtils;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.CaptchaService;
@@ -116,6 +117,9 @@ public class UserAndAccessManagementServiceCEImpl implements UserAndAccessManage
 
         Set<String> usernames = new HashSet<>();
         for (String username : originalUsernames) {
+            if (!ValidationUtils.validateEmail(username)) {
+                return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.USERNAMES));
+            }
             usernames.add(username.toLowerCase());
         }
 


### PR DESCRIPTION
Adds a length check on validating email addresses, as per [RFC 5321](https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1), quoting here:

> [4.5.3.1.1](https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.1).  Local-part
> 
>    The maximum total length of a user name or other local-part is 64
>    octets.
> 
> [4.5.3.1.2](https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.2).  Domain
> 
>    The maximum total length of a domain name or number is 255 octets.

/ok-to-test tags="@tag.Sanity"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email validation based on RFC 5321 standards, ensuring email addresses meet specific length and format requirements before processing.

- **Improvements**
	- Simplified email validation logic by removing redundant null checks.

- **Tests**
	- Added tests for inviting users with invalid email addresses, focusing on excessively long local or domain parts.

<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8464010263>
> Commit: `8af5c9e5e2a5a9862afd8b3293a0eea3106fd8b9`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8464010263&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->

