### PR TITLE
fix: separator styles missing from action group menu

### DIFF
--- a/app/client/packages/design-system/headless/src/components/Menu/src/MenuItem.tsx
+++ b/app/client/packages/design-system/headless/src/components/Menu/src/MenuItem.tsx
@@ -17,6 +17,7 @@ export const MenuItem = <T extends object>(props: MenuItemProps<T>) => {
       data-focused={isFocused ? "" : undefined}
       data-hovered={isFocused ? "" : undefined}
       data-selected={isSelected ? "" : undefined}
+      data-separator={Boolean(item.props.isSeparator) ? "" : undefined}
       ref={ref}
     >
       <div data-text>{item.rendered}</div>

--- a/app/client/packages/design-system/widgets/src/components/ActionGroup/src/ActionGroup.tsx
+++ b/app/client/packages/design-system/widgets/src/components/ActionGroup/src/ActionGroup.tsx
@@ -73,14 +73,29 @@ const _ActionGroup = <T extends object>(
           );
         })}
         {menuChildren?.length > 0 && (
-          <Menu onAction={onAction}>
+          <Menu
+            disabledKeys={[
+              ...state.disabledKeys,
+              ...menuChildren
+                // filtering out separators so that they can't be clicked or navigated
+                .filter((item) => item.props.isSeparator)
+                .map((item) => item.key),
+            ]}
+            onAction={onAction}
+          >
             <IconButton color={color} icon="dots" variant={variant} />
             <MenuList>
-              {menuChildren.map((item) => (
-                <Item isSeparator={item.props.isSeparator} key={item.key}>
-                  {item.rendered}
-                </Item>
-              ))}
+              {menuChildren.map((item) => {
+                return (
+                  <Item
+                    icon={item.props.icon}
+                    isSeparator={item.props.isSeparator}
+                    key={item.key}
+                  >
+                    {item.rendered}
+                  </Item>
+                );
+              })}
             </MenuList>
           </Menu>
         )}

--- a/app/client/packages/design-system/widgets/src/components/ActionGroup/stories/ActionGroup.stories.mdx
+++ b/app/client/packages/design-system/widgets/src/components/ActionGroup/stories/ActionGroup.stories.mdx
@@ -113,9 +113,11 @@ The `ActionGroup` can be `collapse`. By default it is not collapsed. When collpa
 <Story name="OverflowMode">
   <div style={{ maxWidth: 150 }}>
     <ActionGroup overflowMode="collapse" variant="outlined">
-      <Item key="option-1">Option 1</Item>
-      <Item isSeparator />
+      <Item key="option-1" icon="file">
+        Option 1
+      </Item>
       <Item key="option-2">Option 2</Item>
+      <Item isSeparator />
       <Item key="option-3" icon="file">
         {"Option 3"}
       </Item>

--- a/app/client/packages/design-system/widgets/src/components/Menu/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Menu/src/styles.module.css
@@ -75,3 +75,13 @@
     0 0 0 2px var(--color-bg),
     0 0 0 4px var(--color-bd-focus);
 }
+
+.menuList li[data-separator] {
+  border-top: 1px solid var(--color-bd);
+  padding: 0;
+}
+
+/* making sure the first and last child are not displayed when they have the data-separator attribute */
+.menuList li:is(:first-child, :last-child):is([data-separator]) {
+  display: none;
+}


### PR DESCRIPTION
This PR adds styles for separator in the action group menu