### PR TITLE
chore: Add telemetry for monitoring evaluations processing

### DIFF
--- a/app/client/src/UITelemetry/generateTraces.ts
+++ b/app/client/src/UITelemetry/generateTraces.ts
@@ -17,7 +17,7 @@ export const generateContext = (span: Span) => {
 };
 export function startNestedSpan(
   spanName: string,
-  parentSpan: Span,
+  parentSpan?: Span,
   spanAttributes?: Attributes,
   startTime?: TimeInput,
 ) {

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -97,7 +97,12 @@ export function evalTree(request: EvalWorkerSyncRequest) {
         "setupFirstTree",
         { description: "during initialisation" },
         webworkerTelemetry,
-        () => dataTreeEvaluator?.setupFirstTree(unevalTree, configTree),
+        () =>
+          dataTreeEvaluator?.setupFirstTree(
+            unevalTree,
+            configTree,
+            webworkerTelemetry,
+          ),
       );
 
       evalOrder = setupFirstTreeResponse.evalOrder;
@@ -171,7 +176,12 @@ export function evalTree(request: EvalWorkerSyncRequest) {
         "setupUpdateTree",
         undefined,
         webworkerTelemetry,
-        () => dataTreeEvaluator?.setupUpdateTree(unevalTree, configTree),
+        () =>
+          dataTreeEvaluator?.setupUpdateTree(
+            unevalTree,
+            configTree,
+            webworkerTelemetry,
+          ),
       );
 
       evalOrder = setupUpdateTreeResponse.evalOrder;

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -248,7 +248,9 @@ export default class DataTreeEvaluator {
       "SetupFirstTree.parseJSActions",
       undefined,
       webworkerTelemetry,
-      () => parseJSActions(this, localUnEvalTree),
+      () => {
+        return parseJSActions(this, localUnEvalTree);
+      },
     );
     const parseJSActionsEndTime = performance.now();
 
@@ -278,7 +280,9 @@ export default class DataTreeEvaluator {
       "createDependencyMap",
       undefined,
       webworkerTelemetry,
-      () => createDependencyMap(this, localUnEvalTree, configTree),
+      () => {
+        return createDependencyMap(this, localUnEvalTree, configTree);
+      },
     );
     const createDependencyMapEndTime = performance.now();
 
@@ -655,8 +659,8 @@ export default class DataTreeEvaluator {
       "setupTree",
       undefined,
       webworkerTelemetry,
-      () =>
-        this.setupTree(localUnEvalTree, updatedValuePaths, {
+      () => {
+        return this.setupTree(localUnEvalTree, updatedValuePaths, {
           totalUpdateTreeSetupStartTime,
           dependenciesOfRemovedPaths,
           removedPaths,
@@ -665,7 +669,8 @@ export default class DataTreeEvaluator {
           updateDependencyMapTime,
           configTree,
           isNewWidgetAdded,
-        }),
+        });
+      },
     );
 
     return {

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -655,7 +655,7 @@ export default class DataTreeEvaluator {
       "setupTree",
       undefined,
       webworkerTelemetry,
-      () => {
+      () =>
         this.setupTree(localUnEvalTree, updatedValuePaths, {
           totalUpdateTreeSetupStartTime,
           dependenciesOfRemovedPaths,
@@ -665,8 +665,7 @@ export default class DataTreeEvaluator {
           updateDependencyMapTime,
           configTree,
           isNewWidgetAdded,
-        });
-      },
+        }),
     );
 
     return {

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -127,6 +127,10 @@ import { DependencyMapUtils } from "entities/DependencyMap/DependencyMapUtils";
 import { isWidgetActionOrJsObject } from "@appsmith/entities/DataTree/utils";
 import DataStore from "workers/Evaluation/dataStore";
 import { updateTreeWithData } from "workers/Evaluation/dataStore/utils";
+import {
+  profileFn,
+  type WebworkerSpanData,
+} from "UITelemetry/generateWebWorkerTraces";
 
 type SortedDependencies = Array<string>;
 export interface EvalProps {
@@ -221,6 +225,7 @@ export default class DataTreeEvaluator {
   setupFirstTree(
     unEvalTree: any,
     configTree: ConfigTree,
+    webworkerTelemetry: Record<string, WebworkerSpanData> = {},
   ): {
     jsUpdates: Record<string, JSUpdate>;
     evalOrder: string[];
@@ -239,7 +244,12 @@ export default class DataTreeEvaluator {
     //save functions in resolveFunctions (as functions) to be executed as functions are not allowed in evalTree
     //and functions are saved in dataTree as strings
     const parseJSActionsStartTime = performance.now();
-    const parsedCollections = parseJSActions(this, localUnEvalTree);
+    const parsedCollections = profileFn(
+      "SetupFirstTree.parseJSActions",
+      undefined,
+      webworkerTelemetry,
+      () => parseJSActions(this, localUnEvalTree),
+    );
     const parseJSActionsEndTime = performance.now();
 
     jsUpdates = parsedCollections.jsUpdates;
@@ -263,10 +273,12 @@ export default class DataTreeEvaluator {
     const allKeysGenerationEndTime = performance.now();
 
     const createDependencyMapStartTime = performance.now();
-    const { dependencies, inverseDependencies } = createDependencyMap(
-      this,
-      localUnEvalTree,
-      configTree,
+
+    const { dependencies, inverseDependencies } = profileFn(
+      "createDependencyMap",
+      undefined,
+      webworkerTelemetry,
+      () => createDependencyMap(this, localUnEvalTree, configTree),
     );
     const createDependencyMapEndTime = performance.now();
 
@@ -465,6 +477,7 @@ export default class DataTreeEvaluator {
   setupUpdateTree(
     unEvalTree: any,
     configTree: ConfigTree,
+    webworkerTelemetry: Record<string, WebworkerSpanData> = {},
   ): {
     unEvalUpdates: DataTreeDiff[];
     evalOrder: string[];
@@ -488,7 +501,16 @@ export default class DataTreeEvaluator {
     const jsDifferences: Diff<
       Record<string, JSActionEntity>,
       Record<string, JSActionEntity>
-    >[] = diff(oldUnEvalTreeJSCollections, localUnEvalTreeJSCollection) || [];
+    >[] = profileFn(
+      "SetupUpdateTree.Diff1",
+      undefined,
+      webworkerTelemetry,
+      () => {
+        return (
+          diff(oldUnEvalTreeJSCollections, localUnEvalTreeJSCollection) || []
+        );
+      },
+    );
     const jsTranslatedDiffs = flatten(
       jsDifferences.map((diff) =>
         translateDiffEventToDataTreeDiffEvent(diff, localUnEvalTree),
@@ -496,11 +518,18 @@ export default class DataTreeEvaluator {
     );
 
     //save parsed functions in resolveJSFunctions, update current state of js collection
-    const parsedCollections = parseJSActions(
-      this,
-      localUnEvalTree,
-      this.oldUnEvalTree,
-      jsTranslatedDiffs,
+    const parsedCollections = profileFn(
+      "SetupUpdateTree.parseJSActions",
+      undefined,
+      webworkerTelemetry,
+      () => {
+        return parseJSActions(
+          this,
+          localUnEvalTree,
+          this.oldUnEvalTree,
+          jsTranslatedDiffs,
+        );
+      },
     );
 
     jsUpdates = parsedCollections.jsUpdates;
@@ -584,11 +613,13 @@ export default class DataTreeEvaluator {
       dependenciesOfRemovedPaths,
       inverseDependencies,
       removedPaths,
-    } = updateDependencyMap({
-      configTree,
-      dataTreeEvalRef: this,
-      translatedDiffs,
-      unEvalDataTree: localUnEvalTree,
+    } = profileFn("updateDependencyMap", undefined, webworkerTelemetry, () => {
+      return updateDependencyMap({
+        configTree,
+        dataTreeEvalRef: this,
+        translatedDiffs,
+        unEvalDataTree: localUnEvalTree,
+      });
     });
     const updateDependencyEndTime = performance.now();
 
@@ -620,17 +651,26 @@ export default class DataTreeEvaluator {
       translatedDiffs,
     });
 
+    const setupUpdateTreeOutput = profileFn(
+      "setupTree",
+      undefined,
+      webworkerTelemetry,
+      () => {
+        this.setupTree(localUnEvalTree, updatedValuePaths, {
+          totalUpdateTreeSetupStartTime,
+          dependenciesOfRemovedPaths,
+          removedPaths,
+          translatedDiffs,
+          findDifferenceTime,
+          updateDependencyMapTime,
+          configTree,
+          isNewWidgetAdded,
+        });
+      },
+    );
+
     return {
-      ...this.setupTree(localUnEvalTree, updatedValuePaths, {
-        totalUpdateTreeSetupStartTime,
-        dependenciesOfRemovedPaths,
-        removedPaths,
-        translatedDiffs,
-        findDifferenceTime,
-        updateDependencyMapTime,
-        configTree,
-        isNewWidgetAdded,
-      }),
+      ...setupUpdateTreeOutput,
       jsUpdates,
     };
   }


### PR DESCRIPTION
This PR adds more monitoring to evaluations.

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8503175561>
> Commit: `7bc70d14f103f671e0c60f5bcc5756be7c9bf8c7`
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8503175561&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_With_RichTextEditor_spec.js </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->













<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced tracing capabilities for performance analysis, providing detailed telemetry for different sections in the app.
	- Improved tracing functionality in tree evaluation processes with additional telemetry parameters and profiling.

- **Refactor**
	- Updated the `startNestedSpan` function to accept an optional `parentSpan` for more flexible tracing setups.
	- Integrated telemetry enhancements in data tree generation and evaluation processes for better performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->