### PR TITLE
chore: Update the `getNextEntityName` selector to re-use it in copy/move module instances feature on EE

### DIFF
--- a/app/client/src/ce/selectors/entitiesSelector.ts
+++ b/app/client/src/ce/selectors/entitiesSelector.ts
@@ -94,6 +94,7 @@ export interface NewEntityNameOptions {
   prefix: string;
   parentEntityId: string;
   parentEntityKey: CreateNewActionKeyInterface;
+  isCopy?: boolean;
 }
 
 export type DatasourceGroupByPluginCategory = Record<
@@ -1462,7 +1463,7 @@ export const getNewEntityName = createSelector(
   getJSCollections,
   (_state: AppState, options: NewEntityNameOptions) => options,
   (actions, jsCollections, options) => {
-    const { parentEntityId, parentEntityKey, prefix } = options;
+    const { isCopy = false, parentEntityId, parentEntityKey, prefix } = options;
 
     const actionNames = actions
       .filter((a) => a.config[parentEntityKey] === parentEntityId)
@@ -1471,7 +1472,12 @@ export const getNewEntityName = createSelector(
       .filter((a) => a.config[parentEntityKey] === parentEntityId)
       .map((a) => a.config.name);
 
-    return getNextEntityName(prefix, actionNames.concat(jsActionNames));
+    const entityNames = actionNames.concat(jsActionNames);
+
+    return getNextEntityName(
+      isCopy && entityNames.indexOf(prefix) > -1 ? `${prefix}Copy` : prefix,
+      entityNames,
+    );
   },
 );
 

--- a/app/client/src/ce/selectors/entitiesSelector.ts
+++ b/app/client/src/ce/selectors/entitiesSelector.ts
@@ -94,7 +94,8 @@ export interface NewEntityNameOptions {
   prefix: string;
   parentEntityId: string;
   parentEntityKey: CreateNewActionKeyInterface;
-  isCopy?: boolean;
+  suffix?: string;
+  startWithoutIndex?: boolean;
 }
 
 export type DatasourceGroupByPluginCategory = Record<
@@ -1463,7 +1464,13 @@ export const getNewEntityName = createSelector(
   getJSCollections,
   (_state: AppState, options: NewEntityNameOptions) => options,
   (actions, jsCollections, options) => {
-    const { isCopy = false, parentEntityId, parentEntityKey, prefix } = options;
+    const {
+      parentEntityId,
+      parentEntityKey,
+      prefix,
+      startWithoutIndex = false,
+      suffix = "",
+    } = options;
 
     const actionNames = actions
       .filter((a) => a.config[parentEntityKey] === parentEntityId)
@@ -1474,8 +1481,10 @@ export const getNewEntityName = createSelector(
 
     const entityNames = actionNames.concat(jsActionNames);
 
+    const prefixExists = entityNames.indexOf(`${prefix}`) > -1;
+
     return getNextEntityName(
-      isCopy && entityNames.indexOf(prefix) > -1 ? `${prefix}Copy` : prefix,
+      prefixExists ? `${prefix}${suffix}` : prefix,
       entityNames,
     );
   },

--- a/app/client/src/ce/selectors/entitiesSelector.ts
+++ b/app/client/src/ce/selectors/entitiesSelector.ts
@@ -1486,6 +1486,7 @@ export const getNewEntityName = createSelector(
     return getNextEntityName(
       prefixExists ? `${prefix}${suffix}` : prefix,
       entityNames,
+      startWithoutIndex,
     );
   },
 );


### PR DESCRIPTION
## Description

Update the `getNextEntityName` selector to re-use it in copy/move module instances feature on EE.

Fixes [#31969](https://github.com/appsmithorg/appsmith/issues/31969)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8466748833>
> Commit: `703764c3d460530372121e58445990e1d40bc7f8`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8466748833&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Enhanced the entity naming functionality to support more flexible naming conventions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->