### PR TITLE
fix: Make sure order of vertices does not make opl calculations flaky

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
@@ -702,14 +702,11 @@ public class OnLoadExecutablesUtilCEImpl implements OnLoadExecutablesUtilCE {
 
                     Set<String> vertices = Set.of(source, target);
 
-                    boolean isValidVertex = true;
+                    boolean isValidEdge = true;
 
                     // Assert that the vertices which are entire property paths have a possible parent which is either
                     // an executable or a widget or a static variable provided by appsmith at page/application level.
                     for (String vertex : vertices) {
-                        if (!isValidVertex) {
-                            break;
-                        }
                         Optional<String> validEntity = getPossibleParents(vertex).stream()
                                 .filter(parent -> {
                                     if (!executableNames.contains(parent)
@@ -722,14 +719,13 @@ public class OnLoadExecutablesUtilCEImpl implements OnLoadExecutablesUtilCE {
                                 .findFirst();
                         // If any of the generated entity names from the path are valid appsmith entity name,
                         // the vertex is considered valid
-                        if (validEntity.isPresent()) {
-                            isValidVertex = TRUE;
-                        } else {
-                            isValidVertex = FALSE;
+                        if (!validEntity.isPresent()) {
+                            isValidEdge = FALSE;
+                            break;
                         }
                     }
 
-                    return isValidVertex;
+                    return isValidEdge;
                 })
                 .collect(Collectors.toSet());
 


### PR DESCRIPTION
## Description
 
Fixes the check for valid edges in the graph by making sure to fail fast as soon as an invalid vertex is identified.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic and clarity in the execution flow of certain internal operations, enhancing efficiency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->