### PR TITLE
chore: Don't use .subList like it's a List

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -300,7 +300,7 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
         }
         // keeping the last maxSize ids, there may be a lot of ids which are not used anymore
         if (srcIdList.size() > maxSize) {
-            srcIdList = srcIdList.subList(0, maxSize);
+            srcIdList.subList(maxSize, srcIdList.size()).clear();
         }
         return srcIdList;
     }
@@ -331,7 +331,7 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
 
         // keeping the last maxSize ids, there may be a lot of ids which are not used anymore
         if (srcIdList.size() > maxSize) {
-            srcIdList = srcIdList.subList(0, maxSize);
+            srcIdList.subList(maxSize, srcIdList.size()).clear();
         }
         return srcIdList;
     }


### PR DESCRIPTION
Instead or getting the sub-list and returning that, which would be an instance of `ArrayList$SubList`, we instead remove the extra items in the original `ArrayList` and return that itself.

This is because the `SubList` objects are just _views_ on the underlying `ArrayList` object, and cannot be serialized by Hibernate directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for managing recent lists and workspace orders for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->