### PR TITLE
chore: Remove BaseController on ThemeControllerCE

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ThemeControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ThemeControllerCE.java
@@ -6,11 +6,10 @@ import com.appsmith.server.constants.Url;
 import com.appsmith.server.domains.ApplicationMode;
 import com.appsmith.server.domains.Theme;
 import com.appsmith.server.dtos.ResponseDTO;
-import com.appsmith.server.exceptions.AppsmithError;
-import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.themes.base.ThemeService;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,22 +20,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 @Slf4j
 @RequestMapping(Url.THEME_URL)
-public class ThemeControllerCE extends BaseController<ThemeService, Theme, String> {
-    public ThemeControllerCE(ThemeService themeService) {
-        super(themeService);
-    }
+@RequiredArgsConstructor
+public class ThemeControllerCE {
 
-    @Override
-    public Mono<ResponseDTO<Theme>> create(Theme resource, String originHeader, ServerWebExchange exchange) {
-        throw new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION);
-    }
+    private final ThemeService service;
 
     @JsonView(Views.Public.class)
     @GetMapping("applications/{applicationId}")


### PR DESCRIPTION
Continuation of https://github.com/appsmithorg/appsmith/pull/32216, for `ThemeControllerCE`.

Server and Cypress Sanity passed on EE.
No conflicts or extra changes needed on EE for build to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the theme management architecture for enhanced performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->