### PR TITLE
test: Fix button label to create new JS Object

### DIFF
--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -76,7 +76,7 @@ export class JSEditor {
   private _outputConsole = ".CodeEditorTarget";
   private _jsObjName = ".t--js-action-name-edit-field span";
   public _jsObjTxt = ".t--js-action-name-edit-field input";
-  public _newJSobj = "span:contains('New JS Object')";
+  public _newJSobj = "span:contains('New JS object')";
   private _bindingsClose = ".t--entity-property-close";
   public _propertyList = ".binding";
   private _responseTabAction = (funName: string) =>


### PR DESCRIPTION
Reverting label change from https://github.com/appsmithorg/appsmith/pull/32226.

/ok-to-test tags="@tag.Sanity"
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8488111456>
> Commit: `fc88aaf394ac6d436ab4a29742e9185ccc37beef`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8488111456&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the selector in the JavaScript Editor to correctly target the 'New JS object' option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->