### PR TITLE
chore: Simpler sequence implementation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/SequenceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/SequenceServiceCE.java
@@ -5,9 +5,5 @@ import reactor.core.publisher.Mono;
 
 public interface SequenceServiceCE {
 
-    Mono<Long> getNext(String name);
-
-    Mono<Long> getNext(Class<? extends BaseDomain> domainClass, String suffix);
-
     Mono<String> getNextAsSuffix(Class<? extends BaseDomain> domainClass, String suffix);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/SequenceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/SequenceServiceCEImpl.java
@@ -2,7 +2,7 @@ package com.appsmith.server.services.ce;
 
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.domains.Sequence;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Mono;
@@ -11,17 +11,12 @@ import static org.springframework.data.mongodb.core.FindAndModifyOptions.options
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
 
+@RequiredArgsConstructor
 public class SequenceServiceCEImpl implements SequenceServiceCE {
 
     private final ReactiveMongoTemplate mongoTemplate;
 
-    @Autowired
-    public SequenceServiceCEImpl(ReactiveMongoTemplate mongoTemplate) {
-        this.mongoTemplate = mongoTemplate;
-    }
-
-    @Override
-    public Mono<Long> getNext(String name) {
+    private Mono<Long> getNext(String name) {
         return mongoTemplate
                 .findAndModify(
                         query(where("name").is(name)),
@@ -32,13 +27,9 @@ public class SequenceServiceCEImpl implements SequenceServiceCE {
     }
 
     @Override
-    public Mono<Long> getNext(Class<? extends BaseDomain> domainClass, String suffix) {
-        return getNext(mongoTemplate.getCollectionName(domainClass) + suffix);
-    }
-
-    @Override
     public Mono<String> getNextAsSuffix(Class<? extends BaseDomain> domainClass, String suffix) {
-        return getNext(mongoTemplate.getCollectionName(domainClass) + suffix)
-                .map(number -> number > 1 ? " " + number : "");
+        final String className = domainClass.getName();
+        final String name = className.substring(0, 1).toLowerCase() + className.substring(1) + suffix;
+        return getNext(name).map(number -> number > 1 ? " " + number : "");
     }
 }


### PR DESCRIPTION
Don't use MongoDB API to decide the key name to use for the sequence name. This API is currently used only for datasources, so this implementation will be compatible with both MongoDB and Postgres.

The actual sequence number generation, in the `getNext` method, will basically need to be rewritten in the Postgres branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated sequence retrieval process with a focus on suffix generation.
	- Improved the internal construction logic for sequence names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->