### PR TITLE
chore: fix text editor widget cypress spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
@@ -4,7 +4,7 @@ const widgetsPage = require("../../../../../locators/Widgets.json");
 
 describe(
   "RichTextEditor Widget Functionality in Form",
-  { tags: ["@tag.Widget", "@tag.Form"] },
+  { tags: ["@tag.Widget", "@tag.Form", "@tag.TextEditor"] },
   function () {
     before(() => {
       _.agHelper.AddDsl("formWithRTEDsl");
@@ -21,6 +21,8 @@ describe(
         formWidgetsPage.richTextEditorWidget,
         widgetsPage.widgetNameSpan,
       );
+
+      cy.wait(1000);
 
       //Validate Html
       cy.validateHTMLText(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
@@ -15,6 +15,13 @@ describe(
     });
 
     it("RichTextEditor required functionality", function () {
+      //Validate Html
+      cy.validateHTMLText(
+        formWidgetsPage.richTextEditorWidget,
+        "h1",
+        "Default",
+      );
+
       //changing the Text Name
       cy.widgetText(
         this.dataSet.RichTextEditorName,
@@ -22,14 +29,6 @@ describe(
         widgetsPage.widgetNameSpan,
       );
 
-      cy.wait(1000);
-
-      //Validate Html
-      cy.validateHTMLText(
-        formWidgetsPage.richTextEditorWidget,
-        "h1",
-        "Default",
-      );
       //   Make RTE Required
       cy.CheckWidgetProperties(formWidgetsPage.requiredJs);
 


### PR DESCRIPTION
## Automation

/ok-to-test tags="@tag.TextEditor"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8504305878>
> Commit: `277169acb8b7b5b9ef9903159fe7ac40bd04e64a`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8504305878&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Updated test descriptions and added a delay for improved reliability in the RichTextEditor widget within the Form Widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->