### PR TITLE
fix: Restricting the re-submission of welcome form on multiple submit button clicks

### DIFF
--- a/app/client/src/pages/setup/SetupForm.tsx
+++ b/app/client/src/pages/setup/SetupForm.tsx
@@ -97,6 +97,7 @@ function SetupForm(props: SetupFormProps) {
   const [isSubmitted, setIsSubmitted] = useState(false);
 
   const onSubmit = () => {
+    if (isSubmitted) return;
     const form: HTMLFormElement = formRef.current as HTMLFormElement;
     const verifyPassword: HTMLInputElement = document.querySelector(
       `[name="verifyPassword"]`,
@@ -147,6 +148,8 @@ function SetupForm(props: SetupFormProps) {
     if (signupForNewsletter)
       signupForNewsletter.value = signupForNewsletter.checked.toString();
     form.submit();
+    //if form is already submitted once do not submit it again
+    setIsSubmitted(true);
     return true;
   };
 
@@ -171,9 +174,7 @@ function SetupForm(props: SetupFormProps) {
           toggleFormPage();
         } else {
           // If we are on the second page we submit the form if not submitted already
-          if (!isSubmitted) onSubmit();
-          //if form is already submitted once do not submit it again
-          setIsSubmitted(true);
+          onSubmit();
         }
       } else {
         // The fields to be marked as touched so that we can display the errors


### PR DESCRIPTION
## Description

Restricting the re-submission of welcome form on multiple submit button clicks to fix the instance admin not getting correct access issue.

Fixes [#31202](https://github.com/appsmithorg/appsmith/issues/31202)

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8504873135>
> Commit: `15ffef64c4b9b770ecf1ee95a3a20cfd4f193a3c`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8504873135&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the setup form to prevent multiple submissions by refining the submission logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->