### PR TITLE
chore: Add Bridge Update APIs

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
@@ -10,6 +10,10 @@ import java.util.Collection;
 public final class Bridge {
     private Bridge() {}
 
+    public static BridgeUpdate update() {
+        return new BridgeUpdate();
+    }
+
     public static <T extends BaseDomain> BridgeQuery<T> query() {
         return new BridgeQuery<>();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeUpdate.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeUpdate.java
@@ -1,0 +1,56 @@
+package com.appsmith.server.helpers.ce.bridge;
+
+import lombok.NonNull;
+import org.apache.commons.lang.NotImplementedException;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
+
+import java.util.Collections;
+import java.util.List;
+
+public class BridgeUpdate implements UpdateDefinition {
+    private final Update update = new Update();
+
+    public BridgeUpdate set(@NonNull String key, Object value) {
+        update.set(key, value);
+        return this;
+    }
+
+    public BridgeUpdate push(@NonNull String key, @NonNull Object value) {
+        update.push(key, value);
+        return this;
+    }
+
+    /**
+     * Set the value of the field `key`, to the current value of the field `valueKey`.
+     */
+    public BridgeUpdate setToValueFromField(String key, String valueKey) {
+        throw new NotImplementedException("Not implemented here yet, but is ready on Postgres");
+    }
+
+    @Override
+    public Boolean isIsolated() {
+        return false;
+    }
+
+    @Override
+    public Document getUpdateObject() {
+        return update.getUpdateObject();
+    }
+
+    @Override
+    public boolean modifies(@NonNull String key) {
+        return false;
+    }
+
+    @Override
+    public void inc(@NonNull String key) {
+        update.inc(key);
+    }
+
+    @Override
+    public List<ArrayFilter> getArrayFilters() {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
Just as we've developed querying APIs with `Bridge` to get rid of MongoDB specific APIs, this PR introduces an update API to move away from MongoDB specific `Update` APIs.

/ok-to-test tags="@tag.Sanity"
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8506783476>
> Commit: `644c923c6462e6cd6887c2ac44895dd3d4eda58c`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8506783476&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced database update operations with a more flexible update mechanism.
- **Refactor**
	- Improved internal database query handling for application management features such as page additions, theme updates, and branch protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->