### PR TITLE
chore: Autowire MongoDB beans with annotation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
@@ -3,17 +3,11 @@ package com.appsmith.server.repositories;
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 
 @Slf4j
 public abstract class BaseAppsmithRepositoryImpl<T extends BaseDomain> extends BaseAppsmithRepositoryCEImpl<T> {
 
-    public BaseAppsmithRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public BaseAppsmithRepositoryImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
@@ -5,9 +5,4 @@ import com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public abstract class BaseAppsmithRepositoryImpl<T extends BaseDomain> extends BaseAppsmithRepositoryCEImpl<T> {
-
-    public BaseAppsmithRepositoryImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+public abstract class BaseAppsmithRepositoryImpl<T extends BaseDomain> extends BaseAppsmithRepositoryCEImpl<T> {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomActionCollectionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomActionCollectionRepositoryImpl.java
@@ -13,6 +13,6 @@ public class CustomActionCollectionRepositoryImpl extends CustomActionCollection
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomActionCollectionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomActionCollectionRepositoryImpl.java
@@ -1,18 +1,8 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomActionCollectionRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CustomActionCollectionRepositoryImpl extends CustomActionCollectionRepositoryCEImpl
-        implements CustomActionCollectionRepository {
-
-    public CustomActionCollectionRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomActionCollectionRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationRepositoryImpl.java
@@ -2,11 +2,8 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomApplicationRepositoryCEImpl;
 import com.appsmith.server.solutions.ApplicationPermission;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,10 +13,7 @@ public class CustomApplicationRepositoryImpl extends CustomApplicationRepository
 
     @Autowired
     public CustomApplicationRepositoryImpl(
-            @NonNull ReactiveMongoOperations mongoOperations,
-            @NonNull MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            ApplicationPermission applicationPermission) {
+            CacheableRepositoryHelper cacheableRepositoryHelper, ApplicationPermission applicationPermission) {
         super(cacheableRepositoryHelper, applicationPermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationRepositoryImpl.java
@@ -20,6 +20,6 @@ public class CustomApplicationRepositoryImpl extends CustomApplicationRepository
             @NonNull MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper,
             ApplicationPermission applicationPermission) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper, applicationPermission);
+        super(cacheableRepositoryHelper, applicationPermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationSnapshotRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationSnapshotRepositoryImpl.java
@@ -12,6 +12,6 @@ public class CustomApplicationSnapshotRepositoryImpl extends CustomApplicationSn
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationSnapshotRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationSnapshotRepositoryImpl.java
@@ -1,17 +1,8 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomApplicationSnapshotRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CustomApplicationSnapshotRepositoryImpl extends CustomApplicationSnapshotRepositoryCEImpl
-        implements CustomApplicationSnapshotRepository {
-    public CustomApplicationSnapshotRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomApplicationSnapshotRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCollectionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCollectionRepositoryImpl.java
@@ -1,20 +1,8 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomCollectionRepositoryCEImpl;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CustomCollectionRepositoryImpl extends CustomCollectionRepositoryCEImpl
-        implements CustomCollectionRepository {
-
-    @Autowired
-    public CustomCollectionRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomCollectionRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCollectionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCollectionRepositoryImpl.java
@@ -15,6 +15,6 @@ public class CustomCollectionRepositoryImpl extends CustomCollectionRepositoryCE
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomConfigRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomConfigRepositoryImpl.java
@@ -12,6 +12,6 @@ public class CustomConfigRepositoryImpl extends CustomConfigRepositoryCEImpl imp
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomConfigRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomConfigRepositoryImpl.java
@@ -1,17 +1,7 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomConfigRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CustomConfigRepositoryImpl extends CustomConfigRepositoryCEImpl implements CustomConfigRepository {
-
-    public CustomConfigRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+public class CustomConfigRepositoryImpl extends CustomConfigRepositoryCEImpl implements CustomConfigRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceRepositoryImpl.java
@@ -1,18 +1,8 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomDatasourceRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CustomDatasourceRepositoryImpl extends CustomDatasourceRepositoryCEImpl
-        implements CustomDatasourceRepository {
-
-    public CustomDatasourceRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomDatasourceRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceRepositoryImpl.java
@@ -13,6 +13,6 @@ public class CustomDatasourceRepositoryImpl extends CustomDatasourceRepositoryCE
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageRepositoryImpl.java
@@ -15,6 +15,6 @@ public class CustomDatasourceStorageRepositoryImpl extends CustomDatasourceStora
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageRepositoryImpl.java
@@ -2,19 +2,9 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomDatasourceStorageRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 public class CustomDatasourceStorageRepositoryImpl extends CustomDatasourceStorageRepositoryCEImpl
-        implements CustomDatasourceStorageRepository {
-
-    public CustomDatasourceStorageRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomDatasourceStorageRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageStructureRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageStructureRepositoryImpl.java
@@ -1,15 +1,6 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomDatasourceStorageStructureRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 
 public class CustomDatasourceStorageStructureRepositoryImpl extends CustomDatasourceStorageStructureRepositoryCEImpl
-        implements CustomDatasourceStorageStructureRepository {
-    public CustomDatasourceStorageStructureRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomDatasourceStorageStructureRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageStructureRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomDatasourceStorageStructureRepositoryImpl.java
@@ -10,6 +10,6 @@ public class CustomDatasourceStorageStructureRepositoryImpl extends CustomDataso
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomJSLibRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomJSLibRepositoryImpl.java
@@ -2,14 +2,5 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomJSLibRepositoryCE;
 import com.appsmith.server.repositories.ce.CustomJSLibRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 
-public class CustomJSLibRepositoryImpl extends CustomJSLibRepositoryCEImpl implements CustomJSLibRepositoryCE {
-    public CustomJSLibRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+public class CustomJSLibRepositoryImpl extends CustomJSLibRepositoryCEImpl implements CustomJSLibRepositoryCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomJSLibRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomJSLibRepositoryImpl.java
@@ -10,6 +10,6 @@ public class CustomJSLibRepositoryImpl extends CustomJSLibRepositoryCEImpl imple
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Component;
 public class CustomNewActionRepositoryImpl extends CustomNewActionRepositoryCEImpl
         implements CustomNewActionRepository {
 
-    public CustomNewActionRepositoryImpl(
-            ReactiveMongoOperations mongoOperations, CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, cacheableRepositoryHelper);
+    public CustomNewActionRepositoryImpl(ReactiveMongoOperations mongoOperations) {
+        super(mongoOperations);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.appsmith.server.repositories;
 import com.appsmith.server.repositories.ce.CustomNewActionRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,9 +11,7 @@ public class CustomNewActionRepositoryImpl extends CustomNewActionRepositoryCEIm
         implements CustomNewActionRepository {
 
     public CustomNewActionRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+            ReactiveMongoOperations mongoOperations, CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(mongoOperations, cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
@@ -3,19 +3,13 @@ package com.appsmith.server.repositories;
 import com.appsmith.server.repositories.ce.CustomNewPageRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class CustomNewPageRepositoryImpl extends CustomNewPageRepositoryCEImpl implements CustomNewPageRepository {
 
-    public CustomNewPageRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            MongoTemplate mongoTemplate) {
-        super(cacheableRepositoryHelper, mongoTemplate);
+    public CustomNewPageRepositoryImpl(MongoTemplate mongoTemplate) {
+        super(mongoTemplate);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
@@ -16,6 +16,6 @@ public class CustomNewPageRepositoryImpl extends CustomNewPageRepositoryCEImpl i
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper,
             MongoTemplate mongoTemplate) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper, mongoTemplate);
+        super(cacheableRepositoryHelper, mongoTemplate);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPermissionGroupRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPermissionGroupRepositoryImpl.java
@@ -13,6 +13,6 @@ public class CustomPermissionGroupRepositoryImpl extends CustomPermissionGroupRe
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPermissionGroupRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPermissionGroupRepositoryImpl.java
@@ -1,18 +1,13 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomPermissionGroupRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CustomPermissionGroupRepositoryImpl extends CustomPermissionGroupRepositoryCEImpl
         implements CustomPermissionGroupRepository {
 
-    public CustomPermissionGroupRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
+    public CustomPermissionGroupRepositoryImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
         super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPluginRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPluginRepositoryImpl.java
@@ -1,7 +1,5 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomPluginRepositoryCEImpl;
-import org.springframework.stereotype.Component;
 
-@Component
 public class CustomPluginRepositoryImpl extends CustomPluginRepositoryCEImpl implements CustomPluginRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPluginRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPluginRepositoryImpl.java
@@ -1,17 +1,7 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomPluginRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CustomPluginRepositoryImpl extends CustomPluginRepositoryCEImpl implements CustomPluginRepository {
-
-    public CustomPluginRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+public class CustomPluginRepositoryImpl extends CustomPluginRepositoryCEImpl implements CustomPluginRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPluginRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomPluginRepositoryImpl.java
@@ -12,6 +12,6 @@ public class CustomPluginRepositoryImpl extends CustomPluginRepositoryCEImpl imp
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomTenantRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomTenantRepositoryImpl.java
@@ -1,16 +1,5 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomTenantRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 
-public class CustomTenantRepositoryImpl extends CustomTenantRepositoryCEImpl implements CustomTenantRepository {
-
-    public CustomTenantRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-
-        super(cacheableRepositoryHelper);
-    }
-}
+public class CustomTenantRepositoryImpl extends CustomTenantRepositoryCEImpl implements CustomTenantRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomTenantRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomTenantRepositoryImpl.java
@@ -11,6 +11,6 @@ public class CustomTenantRepositoryImpl extends CustomTenantRepositoryCEImpl imp
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
 
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomThemeRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomThemeRepositoryImpl.java
@@ -2,17 +2,8 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomThemeRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class CustomThemeRepositoryImpl extends CustomThemeRepositoryCEImpl implements CustomThemeRepository {
-    public CustomThemeRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+public class CustomThemeRepositoryImpl extends CustomThemeRepositoryCEImpl implements CustomThemeRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomThemeRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomThemeRepositoryImpl.java
@@ -13,6 +13,6 @@ public class CustomThemeRepositoryImpl extends CustomThemeRepositoryCEImpl imple
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepositoryImpl.java
@@ -15,6 +15,6 @@ public class CustomUsagePulseRepositoryImpl extends CustomUsagePulseRepositoryCE
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepositoryImpl.java
@@ -2,19 +2,9 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomUsagePulseRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class CustomUsagePulseRepositoryImpl extends CustomUsagePulseRepositoryCEImpl
-        implements CustomUsagePulseRepository {
-
-    public CustomUsagePulseRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomUsagePulseRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepositoryImpl.java
@@ -1,17 +1,7 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomUserDataRepositoryCEImpl;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CustomUserDataRepositoryImpl extends CustomUserDataRepositoryCEImpl implements CustomUserDataRepository {
-
-    public CustomUserDataRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+public class CustomUserDataRepositoryImpl extends CustomUserDataRepositoryCEImpl implements CustomUserDataRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepositoryImpl.java
@@ -12,6 +12,6 @@ public class CustomUserDataRepositoryImpl extends CustomUserDataRepositoryCEImpl
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepositoryImpl.java
@@ -14,6 +14,6 @@ public class CustomUserRepositoryImpl extends CustomUserRepositoryCEImpl impleme
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepositoryImpl.java
@@ -2,18 +2,8 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomUserRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class CustomUserRepositoryImpl extends CustomUserRepositoryCEImpl implements CustomUserRepository {
-
-    public CustomUserRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+public class CustomUserRepositoryImpl extends CustomUserRepositoryCEImpl implements CustomUserRepository {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomWorkspaceRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomWorkspaceRepositoryImpl.java
@@ -17,6 +17,6 @@ public class CustomWorkspaceRepositoryImpl extends CustomWorkspaceRepositoryCEIm
             MongoConverter mongoConverter,
             SessionUserService sessionUserService,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(sessionUserService, cacheableRepositoryHelper);
+        super(sessionUserService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomWorkspaceRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomWorkspaceRepositoryImpl.java
@@ -17,6 +17,6 @@ public class CustomWorkspaceRepositoryImpl extends CustomWorkspaceRepositoryCEIm
             MongoConverter mongoConverter,
             SessionUserService sessionUserService,
             CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, sessionUserService, cacheableRepositoryHelper);
+        super(sessionUserService, cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomWorkspaceRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomWorkspaceRepositoryImpl.java
@@ -3,8 +3,6 @@ package com.appsmith.server.repositories;
 import com.appsmith.server.repositories.ce.CustomWorkspaceRepositoryCEImpl;
 import com.appsmith.server.services.SessionUserService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,11 +10,7 @@ import org.springframework.stereotype.Component;
 public class CustomWorkspaceRepositoryImpl extends CustomWorkspaceRepositoryCEImpl
         implements CustomWorkspaceRepository {
 
-    public CustomWorkspaceRepositoryImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            SessionUserService sessionUserService,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
+    public CustomWorkspaceRepositoryImpl(SessionUserService sessionUserService) {
         super(sessionUserService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -72,17 +72,17 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
     protected final Class<T> genericDomain;
 
     @Autowired
-    MongoConverter mongoConverter;
+    private MongoConverter mongoConverter;
 
-    protected final CacheableRepositoryHelper cacheableRepositoryHelper;
+    @Autowired
+    private CacheableRepositoryHelper cacheableRepositoryHelper;
 
     public static final int NO_RECORD_LIMIT = -1;
 
     public static final int NO_SKIP = 0;
 
     @SuppressWarnings("unchecked")
-    public BaseAppsmithRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        this.cacheableRepositoryHelper = cacheableRepositoryHelper;
+    public BaseAppsmithRepositoryCEImpl() {
         this.genericDomain =
                 (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), BaseAppsmithRepositoryCEImpl.class);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -66,11 +66,13 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  */
 public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
-    protected final ReactiveMongoOperations mongoOperations;
+    @Autowired
+    private ReactiveMongoOperations mongoOperations;
 
     protected final Class<T> genericDomain;
 
-    protected final MongoConverter mongoConverter;
+    @Autowired
+    MongoConverter mongoConverter;
 
     protected final CacheableRepositoryHelper cacheableRepositoryHelper;
 
@@ -78,14 +80,8 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
     public static final int NO_SKIP = 0;
 
-    @Autowired
     @SuppressWarnings("unchecked")
-    public BaseAppsmithRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        this.mongoOperations = mongoOperations;
-        this.mongoConverter = mongoConverter;
+    public BaseAppsmithRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
         this.cacheableRepositoryHelper = cacheableRepositoryHelper;
         this.genericDomain =
                 (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), BaseAppsmithRepositoryCEImpl.class);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -27,7 +27,7 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         implements CustomActionCollectionRepositoryCE {
 
     public CustomActionCollectionRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
+        super();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -10,7 +10,6 @@ import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -25,10 +24,6 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<ActionCollection>
         implements CustomActionCollectionRepositoryCE {
-
-    public CustomActionCollectionRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super();
-    }
 
     @Override
     @Deprecated

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -13,8 +13,6 @@ import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -28,11 +26,8 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<ActionCollection>
         implements CustomActionCollectionRepositoryCE {
 
-    public CustomActionCollectionRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomActionCollectionRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -9,12 +9,9 @@ import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.solutions.ApplicationPermission;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -34,11 +31,8 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
 
     @Autowired
     public CustomApplicationRepositoryCEImpl(
-            @NonNull ReactiveMongoOperations mongoOperations,
-            @NonNull MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            ApplicationPermission applicationPermission) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+            CacheableRepositoryHelper cacheableRepositoryHelper, ApplicationPermission applicationPermission) {
+        super(cacheableRepositoryHelper);
         this.cacheableRepositoryHelper = cacheableRepositoryHelper;
         this.applicationPermission = applicationPermission;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -9,9 +9,9 @@ import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.solutions.ApplicationPermission;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -23,19 +23,12 @@ import java.util.Optional;
 import java.util.Set;
 
 @Slf4j
+@RequiredArgsConstructor
 public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Application>
         implements CustomApplicationRepositoryCE {
 
     private final CacheableRepositoryHelper cacheableRepositoryHelper;
     private final ApplicationPermission applicationPermission;
-
-    @Autowired
-    public CustomApplicationRepositoryCEImpl(
-            CacheableRepositoryHelper cacheableRepositoryHelper, ApplicationPermission applicationPermission) {
-        super();
-        this.cacheableRepositoryHelper = cacheableRepositoryHelper;
-        this.applicationPermission = applicationPermission;
-    }
 
     @Override
     public Mono<Application> findByIdAndWorkspaceId(String id, String workspaceId, AclPermission permission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCEImpl.java
@@ -32,7 +32,7 @@ public class CustomApplicationRepositoryCEImpl extends BaseAppsmithRepositoryImp
     @Autowired
     public CustomApplicationRepositoryCEImpl(
             CacheableRepositoryHelper cacheableRepositoryHelper, ApplicationPermission applicationPermission) {
-        super(cacheableRepositoryHelper);
+        super();
         this.cacheableRepositoryHelper = cacheableRepositoryHelper;
         this.applicationPermission = applicationPermission;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationSnapshotRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationSnapshotRepositoryCEImpl.java
@@ -5,8 +5,6 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -14,11 +12,8 @@ import java.util.List;
 public class CustomApplicationSnapshotRepositoryCEImpl extends BaseAppsmithRepositoryImpl<ApplicationSnapshot>
         implements CustomApplicationSnapshotRepositoryCE {
 
-    public CustomApplicationSnapshotRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomApplicationSnapshotRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationSnapshotRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationSnapshotRepositoryCEImpl.java
@@ -4,17 +4,12 @@ import com.appsmith.server.domains.ApplicationSnapshot;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 public class CustomApplicationSnapshotRepositoryCEImpl extends BaseAppsmithRepositoryImpl<ApplicationSnapshot>
         implements CustomApplicationSnapshotRepositoryCE {
-
-    public CustomApplicationSnapshotRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Mono<ApplicationSnapshot> findWithoutData(String applicationId) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomCollectionRepositoryCEImpl.java
@@ -2,14 +2,6 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.Collection;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class CustomCollectionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Collection>
-        implements CustomCollectionRepositoryCE {
-
-    @Autowired
-    public CustomCollectionRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomCollectionRepositoryCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomCollectionRepositoryCEImpl.java
@@ -4,17 +4,12 @@ import com.appsmith.server.domains.Collection;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 
 public class CustomCollectionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Collection>
         implements CustomCollectionRepositoryCE {
 
     @Autowired
-    public CustomCollectionRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomCollectionRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
@@ -7,18 +7,13 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import reactor.core.publisher.Mono;
 
 public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Config>
         implements CustomConfigRepositoryCE {
 
-    public CustomConfigRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomConfigRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
@@ -6,15 +6,10 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import reactor.core.publisher.Mono;
 
 public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Config>
         implements CustomConfigRepositoryCE {
-
-    public CustomConfigRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Mono<Config> findByName(String name, AclPermission permission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
@@ -6,8 +6,6 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -17,11 +15,8 @@ import java.util.Set;
 public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Datasource>
         implements CustomDatasourceRepositoryCE {
 
-    public CustomDatasourceRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomDatasourceRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.Datasource;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.data.domain.Sort;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -14,10 +13,6 @@ import java.util.Set;
 
 public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Datasource>
         implements CustomDatasourceRepositoryCE {
-
-    public CustomDatasourceRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Flux<Datasource> findAllByWorkspaceId(String workspaceId, AclPermission permission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageRepositoryCEImpl.java
@@ -3,17 +3,11 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 
 public class CustomDatasourceStorageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<DatasourceStorage>
         implements CustomDatasourceStorageRepositoryCE {
 
-    public CustomDatasourceStorageRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomDatasourceStorageRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageRepositoryCEImpl.java
@@ -2,12 +2,6 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 
 public class CustomDatasourceStorageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<DatasourceStorage>
-        implements CustomDatasourceStorageRepositoryCE {
-
-    public CustomDatasourceStorageRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomDatasourceStorageRepositoryCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
@@ -5,8 +5,6 @@ import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -16,11 +14,8 @@ public class CustomDatasourceStorageStructureRepositoryCEImpl
         extends BaseAppsmithRepositoryImpl<DatasourceStorageStructure>
         implements CustomDatasourceStorageStructureRepositoryCE {
 
-    public CustomDatasourceStorageStructureRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomDatasourceStorageStructureRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceStorageStructureRepositoryCEImpl.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.DatasourceStorageStructure;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -13,10 +12,6 @@ import reactor.core.publisher.Mono;
 public class CustomDatasourceStorageStructureRepositoryCEImpl
         extends BaseAppsmithRepositoryImpl<DatasourceStorageStructure>
         implements CustomDatasourceStorageStructureRepositoryCE {
-
-    public CustomDatasourceStorageStructureRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Mono<Integer> updateStructure(String datasourceId, String environmentId, DatasourceStructure structure) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
@@ -5,7 +5,6 @@ import com.appsmith.server.dtos.CustomJSLibContextDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -14,10 +13,6 @@ import java.util.stream.Collectors;
 
 public class CustomJSLibRepositoryCEImpl extends BaseAppsmithRepositoryImpl<CustomJSLib>
         implements CustomJSLibRepositoryCE {
-
-    public CustomJSLibRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Mono<CustomJSLib> findUniqueCustomJsLib(CustomJSLib customJSLib) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomJSLibRepositoryCEImpl.java
@@ -6,8 +6,6 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -17,11 +15,8 @@ import java.util.stream.Collectors;
 public class CustomJSLibRepositoryCEImpl extends BaseAppsmithRepositoryImpl<CustomJSLib>
         implements CustomJSLibRepositoryCE {
 
-    public CustomJSLibRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomJSLibRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -10,6 +10,7 @@ import com.appsmith.server.dtos.PluginTypeAndCountDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Sort;
@@ -37,15 +38,11 @@ import static org.springframework.data.mongodb.core.aggregation.Aggregation.proj
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @Slf4j
+@RequiredArgsConstructor
 public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<NewAction>
         implements CustomNewActionRepositoryCE {
 
     private final ReactiveMongoOperations mongoOperations;
-
-    public CustomNewActionRepositoryCEImpl(ReactiveMongoOperations mongoOperations) {
-        super();
-        this.mongoOperations = mongoOperations;
-    }
 
     @Override
     public Flux<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -10,7 +10,6 @@ import com.appsmith.server.dtos.PluginTypeAndCountDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Sort;
@@ -43,9 +42,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     private final ReactiveMongoOperations mongoOperations;
 
-    public CustomNewActionRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations, CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
+    public CustomNewActionRepositoryCEImpl(ReactiveMongoOperations mongoOperations) {
+        super();
         this.mongoOperations = mongoOperations;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -21,7 +21,6 @@ import org.springframework.data.mongodb.core.aggregation.Fields;
 import org.springframework.data.mongodb.core.aggregation.GroupOperation;
 import org.springframework.data.mongodb.core.aggregation.MatchOperation;
 import org.springframework.data.mongodb.core.aggregation.ProjectionOperation;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Flux;
@@ -42,11 +41,12 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<NewAction>
         implements CustomNewActionRepositoryCE {
 
+    private final ReactiveMongoOperations mongoOperations;
+
     public CustomNewActionRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+            ReactiveMongoOperations mongoOperations, CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
+        this.mongoOperations = mongoOperations;
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -9,7 +9,6 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -33,9 +32,8 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
 
     private final MongoTemplate mongoTemplate;
 
-    public CustomNewPageRepositoryCEImpl(
-            CacheableRepositoryHelper cacheableRepositoryHelper, MongoTemplate mongoTemplate) {
-        super(cacheableRepositoryHelper);
+    public CustomNewPageRepositoryCEImpl(MongoTemplate mongoTemplate) {
+        super();
         this.mongoTemplate = mongoTemplate;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -9,6 +9,7 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -27,15 +28,11 @@ import java.util.Set;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @Slf4j
+@RequiredArgsConstructor
 public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<NewPage>
         implements CustomNewPageRepositoryCE {
 
     private final MongoTemplate mongoTemplate;
-
-    public CustomNewPageRepositoryCEImpl(MongoTemplate mongoTemplate) {
-        super();
-        this.mongoTemplate = mongoTemplate;
-    }
 
     @Override
     public Flux<NewPage> findByApplicationId(String applicationId, AclPermission aclPermission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -12,11 +12,9 @@ import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.aggregation.Fields;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -36,11 +34,8 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
     private final MongoTemplate mongoTemplate;
 
     public CustomNewPageRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            MongoTemplate mongoTemplate) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+            CacheableRepositoryHelper cacheableRepositoryHelper, MongoTemplate mongoTemplate) {
+        super(cacheableRepositoryHelper);
         this.mongoTemplate = mongoTemplate;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
@@ -11,8 +11,6 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -24,11 +22,8 @@ import java.util.Set;
 public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositoryImpl<PermissionGroup>
         implements CustomPermissionGroupRepositoryCE {
 
-    public CustomPermissionGroupRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomPermissionGroupRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
@@ -22,8 +22,11 @@ import java.util.Set;
 public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositoryImpl<PermissionGroup>
         implements CustomPermissionGroupRepositoryCE {
 
+    private final CacheableRepositoryHelper cacheableRepositoryHelper;
+
     public CustomPermissionGroupRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
+        super();
+        this.cacheableRepositoryHelper = cacheableRepositoryHelper;
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
@@ -11,6 +11,7 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -19,15 +20,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+@RequiredArgsConstructor
 public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositoryImpl<PermissionGroup>
         implements CustomPermissionGroupRepositoryCE {
 
     private final CacheableRepositoryHelper cacheableRepositoryHelper;
-
-    public CustomPermissionGroupRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super();
-        this.cacheableRepositoryHelper = cacheableRepositoryHelper;
-    }
 
     @Override
     public Flux<PermissionGroup> findAllByAssignedToUserIdAndDefaultWorkspaceId(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
@@ -4,8 +4,6 @@ import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -14,11 +12,8 @@ import java.util.Set;
 public class CustomPluginRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Plugin>
         implements CustomPluginRepositoryCE {
 
-    public CustomPluginRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomPluginRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPluginRepositoryCEImpl.java
@@ -3,7 +3,6 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -11,10 +10,6 @@ import java.util.Set;
 
 public class CustomPluginRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Plugin>
         implements CustomPluginRepositoryCE {
-
-    public CustomPluginRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Flux<Plugin> findDefaultPluginIcons() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomTenantRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomTenantRepositoryCEImpl.java
@@ -4,17 +4,12 @@ import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 
 @Slf4j
 public class CustomTenantRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Tenant>
         implements CustomTenantRepositoryCE {
 
-    public CustomTenantRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomTenantRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomTenantRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomTenantRepositoryCEImpl.java
@@ -2,14 +2,8 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CustomTenantRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Tenant>
-        implements CustomTenantRepositoryCE {
-
-    public CustomTenantRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomTenantRepositoryCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -6,7 +6,6 @@ import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
@@ -18,10 +17,6 @@ import java.time.Instant;
 @Component
 @Slf4j
 public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Theme> implements CustomThemeRepositoryCE {
-    public CustomThemeRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-
     @Override
     public Flux<Theme> getApplicationThemes(String applicationId, AclPermission aclPermission) {
         BridgeQuery<Theme> appThemeCriteria = Bridge.equal(Theme.Fields.applicationId, applicationId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -8,8 +8,6 @@ import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -20,11 +18,8 @@ import java.time.Instant;
 @Component
 @Slf4j
 public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Theme> implements CustomThemeRepositoryCE {
-    public CustomThemeRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomThemeRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCEImpl.java
@@ -4,8 +4,6 @@ import com.appsmith.server.domains.UsagePulse;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,10 +11,7 @@ import org.springframework.stereotype.Component;
 public class CustomUsagePulseRepositoryCEImpl extends BaseAppsmithRepositoryImpl<UsagePulse>
         implements CustomUsagePulseRepositoryCE {
 
-    public CustomUsagePulseRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomUsagePulseRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCEImpl.java
@@ -2,16 +2,10 @@ package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.UsagePulse;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class CustomUsagePulseRepositoryCEImpl extends BaseAppsmithRepositoryImpl<UsagePulse>
-        implements CustomUsagePulseRepositoryCE {
-
-    public CustomUsagePulseRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
-}
+        implements CustomUsagePulseRepositoryCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -6,8 +6,6 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.mongodb.BasicDBObject;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Mono;
@@ -17,11 +15,8 @@ import java.util.List;
 public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<UserData>
         implements CustomUserDataRepositoryCE {
 
-    public CustomUserDataRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomUserDataRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -4,7 +4,6 @@ import com.appsmith.server.domains.UserData;
 import com.appsmith.server.dtos.RecentlyUsedEntityDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.mongodb.BasicDBObject;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.util.CollectionUtils;
@@ -14,10 +13,6 @@ import java.util.List;
 
 public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<UserData>
         implements CustomUserDataRepositoryCE {
-
-    public CustomUserDataRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Mono<Integer> saveReleaseNotesViewedVersion(String userId, String version) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
@@ -6,7 +6,6 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -15,10 +14,6 @@ import java.util.Set;
 
 @Slf4j
 public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User> implements CustomUserRepositoryCE {
-
-    public CustomUserRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
-    }
 
     @Override
     public Mono<User> findByEmail(String email, AclPermission aclPermission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserRepositoryCEImpl.java
@@ -8,8 +8,6 @@ import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import reactor.core.publisher.Mono;
 
 import java.util.HashSet;
@@ -18,11 +16,8 @@ import java.util.Set;
 @Slf4j
 public class CustomUserRepositoryCEImpl extends BaseAppsmithRepositoryImpl<User> implements CustomUserRepositoryCE {
 
-    public CustomUserRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+    public CustomUserRepositoryCEImpl(CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
@@ -8,8 +8,6 @@ import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.services.SessionUserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -22,11 +20,8 @@ public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     private final SessionUserService sessionUserService;
 
     public CustomWorkspaceRepositoryCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            MongoConverter mongoConverter,
-            SessionUserService sessionUserService,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
+            SessionUserService sessionUserService, CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(cacheableRepositoryHelper);
         this.sessionUserService = sessionUserService;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
@@ -4,7 +4,6 @@ import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
-import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.services.SessionUserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
@@ -19,9 +18,8 @@ public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     private final SessionUserService sessionUserService;
 
-    public CustomWorkspaceRepositoryCEImpl(
-            SessionUserService sessionUserService, CacheableRepositoryHelper cacheableRepositoryHelper) {
-        super(cacheableRepositoryHelper);
+    public CustomWorkspaceRepositoryCEImpl(SessionUserService sessionUserService) {
+        super();
         this.sessionUserService = sessionUserService;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomWorkspaceRepositoryCEImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.services.SessionUserService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import reactor.core.publisher.Flux;
@@ -13,15 +14,11 @@ import reactor.core.publisher.Mono;
 import java.util.Set;
 
 @Slf4j
+@RequiredArgsConstructor
 public class CustomWorkspaceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Workspace>
         implements CustomWorkspaceRepositoryCE {
 
     private final SessionUserService sessionUserService;
-
-    public CustomWorkspaceRepositoryCEImpl(SessionUserService sessionUserService) {
-        super();
-        this.sessionUserService = sessionUserService;
-    }
 
     @Override
     public Mono<Workspace> findByName(String name, AclPermission aclPermission) {


### PR DESCRIPTION
The heart change of this PR is in [`BaseAppsmithRepositoryCEImpl`](https://github.com/appsmithorg/appsmith/pull/32294/files#diff-5b9270d513f9654dd47da330dca88f1426fdbedf35dde0d5823ac29795b1bebb).

By using `@Autowire` annotation to inject the `mongoOperations` and `mongoConverter` beans, we remove MongoDB imports and injections in all the `Impl` classes. This is a whole lot of diff that shows up on Postgres, that holds no semantic value.

EE Server and Sanity tests pass.
Do not merge when PR author isn't available. There's quite a few conflicts from this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the constructor implementation across various repository classes to enhance maintainability and readability. This includes removing specific dependencies from constructors and adopting a more streamlined approach for dependency injection, improving the overall code structure without altering the functionality visible to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->