### PR TITLE
chore: Reduce test logging noise

### DIFF
--- a/app/server/appsmith-interfaces/src/test/resources/logback-test.xml
+++ b/app/server/appsmith-interfaces/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+  <logger name="org.testcontainers" level="INFO"/>
+  <!-- The following logger can be used for containers logs since 1.18.0 -->
+  <logger name="tc" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
Removes log lines about downloading the Docker images by Testcontainers.

Taken from [recommended configuration by Testcontainers](https://java.testcontainers.org/supported_docker_environment/logging_config/).
