### PR TITLE
fix: JSON form splits keys to multiple lines when it should not #32230

### DIFF
--- a/app/client/src/widgets/CheckboxWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxWidget/component/index.tsx
@@ -24,7 +24,7 @@ const CheckboxContainer = styled.div<StyledCheckboxContainerProps>`
     display: flex;
     height: 100%;
     justify-content: start;
-    width: 100%;
+    width: auto;
 
     ${({ minHeight }) => `
     ${minHeight ? `min-height: ${minHeight}px;` : ""}`};

--- a/app/client/src/widgets/JSONFormWidget/component/FieldLabel.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/FieldLabel.tsx
@@ -82,6 +82,7 @@ const StyledRequiredMarker = styled.div`
 
 const StyledLabelText = styled.p<StyledLabelTextProps>`
   margin-bottom: 0;
+  white-space: nowrap;
   margin-right: ${({ isRequiredField }) =>
     isRequiredField ? LABEL_TEXT_MARGIN_RIGHT_WITH_REQUIRED : DEFAULT_GAP}px;
   color: ${({ color }) => color};


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

Fixes #32230

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JSONForm"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the JSON Form Widget to prevent text wrapping in field labels, ensuring labels are displayed in a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->