### PR TITLE
fix: MultiEnv switcher visible in view mode in cloud

### DIFF
--- a/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
+++ b/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
@@ -1,0 +1,306 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureMockStore from "redux-mock-store";
+// import type { AppState } from "@appsmith/reducers";
+import useShowEnvSwitcher from "./useShowEnvSwitcher";
+
+const spier = {
+  useShowEnvSwitcher: useShowEnvSwitcher,
+};
+
+const useShowEnvSwitcherSpy = jest.spyOn(spier, "useShowEnvSwitcher");
+
+const MockEl = ({ viewMode = false }: { viewMode?: boolean } = {}) => {
+  spier.useShowEnvSwitcher({ viewMode });
+  return <div />;
+};
+
+const renderMockElement = ({
+  store,
+  viewMode,
+}: {
+  store: any;
+  viewMode: boolean;
+}) => {
+  return render(
+    <Provider store={store}>
+      <MockEl viewMode={viewMode} />
+    </Provider>,
+  );
+};
+
+describe("BottomBar environment switcher", () => {
+  it("should render when admin in edit mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: ["manage:applications"],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: true,
+          },
+        },
+        editor: {
+          isPreviewMode: false,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: false });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(true);
+  });
+  it("should render when dev in edit mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: ["manage:applications"],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: false,
+          },
+        },
+        editor: {
+          isPreviewMode: false,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: false });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(true);
+  });
+  it("should render when viewer in edit mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: [],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: false,
+          },
+        },
+        editor: {
+          isPreviewMode: false,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: false });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
+  });
+
+  it("should render when admin in preview mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: ["manage:applications"],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: true,
+          },
+        },
+        editor: {
+          isPreviewMode: true,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: false });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
+  });
+  it("should render when dev in preview mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: ["manage:applications"],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: false,
+          },
+        },
+        editor: {
+          isPreviewMode: true,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: false });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
+  });
+  it("should render when viewer in preview mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: [],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: false,
+          },
+        },
+        editor: {
+          isPreviewMode: true,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: false });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
+  });
+
+  it("should render when admin in view mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: ["manage:applications"],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: true,
+          },
+        },
+        editor: {
+          isPreviewMode: false,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: true });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
+  });
+  it("should render when dev in view mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: ["manage:applications"],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: false,
+          },
+        },
+        editor: {
+          isPreviewMode: false,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: true });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
+  });
+  it("should render when viewer in view mode", () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      ui: {
+        selectedWorkspace: {
+          workspace: {},
+        },
+        applications: {
+          currentApplication: {
+            userPermissions: [],
+          },
+        },
+        users: {
+          featureFlag: {
+            data: {
+              release_datasource_environments_enabled: false,
+            },
+          },
+          currentUser: {
+            isSuperUser: false,
+          },
+        },
+        editor: {
+          isPreviewMode: false,
+        },
+      },
+    });
+    renderMockElement({ store, viewMode: true });
+    expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
+  });
+});

--- a/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
+++ b/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
-// import type { AppState } from "@appsmith/reducers";
 import useShowEnvSwitcher from "./useShowEnvSwitcher";
 
 const spier = {

--- a/app/client/src/ce/hooks/useShowEnvSwitcher.ts
+++ b/app/client/src/ce/hooks/useShowEnvSwitcher.ts
@@ -20,13 +20,18 @@ const useShowEnvSwitcher = ({ viewMode }: { viewMode: boolean }) => {
     const isLoaded = areEnvironmentsFetched(state, workspace?.id);
     const list = getEnvironmentsWithPermission(state);
     const isDefault = list?.[0]?.isDefault;
-    return isLoaded && (list.length === 0 || (list.length === 1 && isDefault));
+    if (!isFeatureEnabled) {
+      return true;
+    } else {
+      return (
+        isLoaded && (list.length === 0 || (list.length === 1 && isDefault))
+      );
+    }
   });
 
   const isRampAllowed = useSelector((state) =>
     showProductRamps(RAMP_NAME.MULTIPLE_ENV, true)(state),
   );
-
   if (!isFeatureEnabled && !isRampAllowed) {
     return false;
   }

--- a/app/client/src/ce/hooks/useShowEnvSwitcher.ts
+++ b/app/client/src/ce/hooks/useShowEnvSwitcher.ts
@@ -30,6 +30,7 @@ const useShowEnvSwitcher = ({ viewMode }: { viewMode: boolean }) => {
   if (!isFeatureEnabled && !isRampAllowed) {
     return false;
   }
+
   if (viewMode && isMultiEnvNotPresent) {
     return false;
   }


### PR DESCRIPTION
## Description
Issue with ME switcher showing up in cloud

Fixes #32315

## Automation

/ok-to-test tags="@tag.MultiEnv"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8520479330>
> Commit: `20ae88502963ec88f686ef237d4892886189f088`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8520479330&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated logic for displaying the environment switcher based on new feature flags and user roles.
- **Tests**
	- Added tests for the updated environment switcher visibility logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->