### PR TITLE
fix: broken jest test cases for MutiEnv

### DIFF
--- a/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
+++ b/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
@@ -57,8 +57,8 @@ describe("BottomBar environment switcher", () => {
         editor: {
           isPreviewMode: false,
         },
-        environments,
       },
+      environments,
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(true);

--- a/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
+++ b/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
@@ -55,6 +55,7 @@ describe("BottomBar environment switcher", () => {
         editor: {
           isPreviewMode: false,
         },
+        environments: {},
       },
     });
     renderMockElement({ store, viewMode: false });
@@ -86,6 +87,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(true);
@@ -116,6 +118,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -147,6 +150,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: true,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -177,6 +181,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: true,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -207,6 +212,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: true,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -238,6 +244,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: true });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -268,6 +275,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: true });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -298,6 +306,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
+      environments: {},
     });
     renderMockElement({ store, viewMode: true });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);

--- a/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
+++ b/app/client/src/ce/hooks/useShowEnvSwitcher.test.tsx
@@ -29,6 +29,8 @@ const renderMockElement = ({
   );
 };
 
+const environments = { data: [] };
+
 describe("BottomBar environment switcher", () => {
   it("should render when admin in edit mode", () => {
     const mockStore = configureMockStore();
@@ -55,7 +57,7 @@ describe("BottomBar environment switcher", () => {
         editor: {
           isPreviewMode: false,
         },
-        environments: {},
+        environments,
       },
     });
     renderMockElement({ store, viewMode: false });
@@ -87,7 +89,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(true);
@@ -118,7 +120,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -150,7 +152,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: true,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -181,7 +183,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: true,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -212,7 +214,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: true,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: false });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -244,7 +246,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: true });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -275,7 +277,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: true });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);
@@ -306,7 +308,7 @@ describe("BottomBar environment switcher", () => {
           isPreviewMode: false,
         },
       },
-      environments: {},
+      environments,
     });
     renderMockElement({ store, viewMode: true });
     expect(useShowEnvSwitcherSpy).lastReturnedWith(false);


### PR DESCRIPTION
Fixes broken EE test-cases

Fixes #32315

## Automation
/ok-to-test tags="@tag.MultiEnv"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8521228071>
> Commit: `d6f8c9b28a382698f6f6371755ae15091cb0ab2b`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8521228071&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test cases for the "BottomBar environment switcher" to include a new `environments` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->