### PR TITLE
fix: Feature flags not intercepted correctly

### DIFF
--- a/app/client/cypress/support/Objects/FeatureFlags.ts
+++ b/app/client/cypress/support/Objects/FeatureFlags.ts
@@ -11,7 +11,7 @@ export const featureFlagIntercept = (
   flags: Record<string, boolean> = {},
   reload = true,
 ) => {
-  getConsolidatedDataApi({ ...flags, ...defaultFlags }, reload);
+  getConsolidatedDataApi({ ...flags, ...defaultFlags }, false);
   const response = {
     responseMeta: {
       status: 200,

--- a/app/client/cypress/support/Objects/FeatureFlags.ts
+++ b/app/client/cypress/support/Objects/FeatureFlags.ts
@@ -11,7 +11,7 @@ export const featureFlagIntercept = (
   flags: Record<string, boolean> = {},
   reload = true,
 ) => {
-  getConsolidatedDataApi(flags, reload, defaultFlags);
+  getConsolidatedDataApi({ ...flags, ...defaultFlags }, reload);
   const response = {
     responseMeta: {
       status: 200,
@@ -30,7 +30,6 @@ export const featureFlagIntercept = (
 export const getConsolidatedDataApi = (
   flags: Record<string, boolean> = {},
   reload = true,
-  defaultFlags = {},
 ) => {
   cy.intercept("GET", "/api/v1/consolidated-api/*?*", (req) => {
     req.reply((res: any) => {
@@ -43,7 +42,6 @@ export const getConsolidatedDataApi = (
         const updatedResponse = produce(originalResponse, (draft: any) => {
           draft.data.featureFlags.data = {
             ...flags,
-            ...defaultFlags,
           };
         });
         return res.send(updatedResponse);

--- a/app/client/cypress/support/Objects/FeatureFlags.ts
+++ b/app/client/cypress/support/Objects/FeatureFlags.ts
@@ -6,22 +6,7 @@ export const featureFlagIntercept = (
   flags: Record<string, boolean> = {},
   reload = true,
 ) => {
-  getConsolidatedDataApi(flags, false);
-  const response = {
-    responseMeta: {
-      status: 200,
-      success: true,
-    },
-    data: {
-      ...flags,
-      release_show_new_sidebar_pages_pane_enabled: true,
-      release_side_by_side_ide_enabled: true,
-    },
-    errorDisplay: "",
-  };
-  cy.intercept("GET", "/api/v1/users/features", response);
-
-  if (reload) ObjectsRegistry.AggregateHelper.CypressReload();
+  getConsolidatedDataApi(flags, reload);
 };
 
 export const getConsolidatedDataApi = (
@@ -38,10 +23,11 @@ export const getConsolidatedDataApi = (
         const originalResponse = res?.body;
         const updatedResponse = produce(originalResponse, (draft: any) => {
           draft.data.featureFlags.data = { ...flags };
-          draft.data.featureFlags.data["release_app_sidebar_enabled"] = true;
           draft.data.featureFlags.data[
             "release_show_new_sidebar_pages_pane_enabled"
           ] = true;
+          draft.data.featureFlags.data["release_side_by_side_ide_enabled"] =
+            true;
         });
         return res.send(updatedResponse);
       }


### PR DESCRIPTION
## Description

Fix for correctly intercepting Feature Flags in the testing env

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8533833714>
> Commit: `e7a1bebf9feda3c92015907b73f9cdcd8bc806a7`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8533833714&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Optimized feature flag management for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->