### PR TITLE
chore: WDS inner spacing scale adjustments

### DIFF
--- a/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
+++ b/app/client/packages/design-system/theming/src/token/src/tokensConfigs.json
@@ -18,12 +18,12 @@
     "userDensityRatio": 1.75
   },
   "innerSpacing": {
-    "V": 1.5,
-    "R": 2.5,
+    "V": 1.4,
+    "R": 2.25,
     "N": 2,
     "stepsUp": 8,
     "stepsDown": 0,
-    "userSizingRatio": 0.25,
+    "userSizingRatio": 0.5,
     "userDensityRatio": 2.5
   },
   "typography": {


### PR DESCRIPTION
Closes #31256 

Some comparisons for key theme settings combinations:

| | Before | After |
|--------|--------|--------|
| tight - small | <img width="1348" alt="tight-small" src="https://github.com/appsmithorg/appsmith/assets/80973/48eb2f72-a9e4-4609-a6d0-3bfe9d8c191e"> | <img width="1348" alt="tight-small" src="https://github.com/appsmithorg/appsmith/assets/80973/ac229e79-74fb-4fc7-bf58-95f8965cbcbe"> |
| tight - big | <img width="1348" alt="tight-big" src="https://github.com/appsmithorg/appsmith/assets/80973/5c7ebfdf-e67b-47c0-99ce-0d0283b840ba"> | <img width="1348" alt="tight-big" src="https://github.com/appsmithorg/appsmith/assets/80973/acba7177-04cc-445e-96b1-484c5ce6395e"> |
| regular - small | <img width="1348" alt="regular-small" src="https://github.com/appsmithorg/appsmith/assets/80973/0a735227-4b68-41b9-8c50-1c1b7918468d"> | <img width="1348" alt="regular-small" src="https://github.com/appsmithorg/appsmith/assets/80973/ceb3c513-c245-45d2-8948-dc37115c0720"> |
| regular - big | <img width="1348" alt="regular-big" src="https://github.com/appsmithorg/appsmith/assets/80973/1c9013f9-3ed7-4d76-96d7-83d43e55a3a3"> | <img width="1348" alt="regular-big" src="https://github.com/appsmithorg/appsmith/assets/80973/2425c31a-9ffc-49b4-be60-51bdb6331851"> |
| loose - small | <img width="1348" alt="loose-small" src="https://github.com/appsmithorg/appsmith/assets/80973/22ac12fa-abc3-40bc-b77d-10310c2e417a"> | <img width="1348" alt="loose-small" src="https://github.com/appsmithorg/appsmith/assets/80973/3a0fd27b-7a02-41a0-8f57-102094f8eec0"> | 