### PR TITLE
chore: Get control over what stack traces show up in logs

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/BaseException.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/BaseException.java
@@ -41,7 +41,7 @@ public abstract class BaseException extends RuntimeException {
 
     @SuppressWarnings("unchecked")
     public <T extends BaseException> T hideStackTraceInLogs() {
-        hideStackTraceInLogs = false;
+        hideStackTraceInLogs = true;
         return (T) this;
     }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/BaseException.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/BaseException.java
@@ -11,6 +11,8 @@ public abstract class BaseException extends RuntimeException {
 
     private Map<String, String> contextMap;
 
+    private boolean hideStackTraceInLogs = false;
+
     public BaseException(String message) {
         super(message);
         contextMap = MDC.getCopyOfContextMap();
@@ -36,4 +38,14 @@ public abstract class BaseException extends RuntimeException {
     public abstract String getDownstreamErrorCode();
 
     public abstract String getErrorType();
+
+    @SuppressWarnings("unchecked")
+    public <T extends BaseException> T hideStackTraceInLogs() {
+        hideStackTraceInLogs = false;
+        return (T) this;
+    }
+
+    public boolean shouldHideStackTraceInLogs() {
+        return hideStackTraceInLogs;
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
@@ -67,7 +67,11 @@ public class GlobalExceptionHandler {
     }
 
     private void doLog(Throwable error) {
-        log.error("", error);
+        if (error instanceof BaseException baseException && baseException.shouldHideStackTraceInLogs()) {
+            log.error(baseException.getClass().getSimpleName() + ": " + baseException.getMessage());
+        } else {
+            log.error("", error);
+        }
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter(stringWriter);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
@@ -116,12 +116,11 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
                                             datasourceStorage.getIsMock()));
                 })
                 .timeout(Duration.ofSeconds(GET_STRUCTURE_TIMEOUT_SECONDS))
-                .onErrorMap(
-                        TimeoutException.class,
-                        error -> new AppsmithPluginException(
+                .onErrorMap(TimeoutException.class, error -> new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR,
                                 "Appsmith server timed out when fetching structure. Please reach out to appsmith "
-                                        + "customer support to resolve this."))
+                                        + "customer support to resolve this.")
+                        .hideStackTraceInLogs())
                 .onErrorMap(
                         StaleConnectionException.class,
                         error -> new AppsmithPluginException(


### PR DESCRIPTION
This should give us control over what exceptions print a stack trace and what exceptions don't need to. Should help us get more control over our logs and reduce noice.

![shot-2024-04-02-12-33-05](https://github.com/appsmithorg/appsmith/assets/120119/26214102-373a-452f-baa9-7c6492604e83)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error logging capabilities to selectively hide stack traces in logs for improved log readability and security.
- **Bug Fixes**
	- Improved error handling for datasource timeouts, minimizing unnecessary stack trace logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->