### PR TITLE
chore: Refactor API for hiding logs

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/BaseException.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/BaseException.java
@@ -11,7 +11,7 @@ public abstract class BaseException extends RuntimeException {
 
     private Map<String, String> contextMap;
 
-    private boolean hideStackTraceInLogs = false;
+    protected boolean hideStackTraceInLogs = false;
 
     public BaseException(String message) {
         super(message);
@@ -38,14 +38,4 @@ public abstract class BaseException extends RuntimeException {
     public abstract String getDownstreamErrorCode();
 
     public abstract String getErrorType();
-
-    @SuppressWarnings("unchecked")
-    public <T extends BaseException> T hideStackTraceInLogs() {
-        hideStackTraceInLogs = true;
-        return (T) this;
-    }
-
-    public boolean shouldHideStackTraceInLogs() {
-        return hideStackTraceInLogs;
-    }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginException.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginException.java
@@ -60,4 +60,9 @@ public class AppsmithPluginException extends BaseException {
                 ? AppsmithPluginErrorCode.GENERIC_PLUGIN_ERROR.getCode()
                 : this.error.getAppErrorCode();
     }
+
+    public AppsmithPluginException hideStackTraceInLogs() {
+        hideStackTraceInLogs = true;
+        return this;
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithException.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithException.java
@@ -63,4 +63,9 @@ public class AppsmithException extends BaseException {
     public String getReferenceDoc() {
         return this.error.getReferenceDoc();
     }
+
+    public AppsmithException hideStackTraceInLogs() {
+        hideStackTraceInLogs = true;
+        return this;
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
@@ -67,7 +67,7 @@ public class GlobalExceptionHandler {
     }
 
     private void doLog(Throwable error) {
-        if (error instanceof BaseException baseException && baseException.shouldHideStackTraceInLogs()) {
+        if (error instanceof BaseException baseException && baseException.isHideStackTraceInLogs()) {
             log.error(baseException.getClass().getSimpleName() + ": " + baseException.getMessage());
         } else {
             log.error("", error);


### PR DESCRIPTION
Sorry for quickly changing the signature(s) of this.

1. The generic method in the super class just wasn't working well. The generic return type needs to be set explicitly in some places, and is inferred in some, and is just too volatile. So we replicate the method definition in both the subclasses for better API usage code.
2. The field already has a getter with Lombok, I didn't need to write a new one. 🤦


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved control over stack trace visibility in logs for enhanced error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->