### PR TITLE
fix: Email Verification `not you` link opened in same tab

### DIFF
--- a/app/client/src/pages/UserAuth/VerificationPending.tsx
+++ b/app/client/src/pages/UserAuth/VerificationPending.tsx
@@ -40,7 +40,7 @@ const VerificationPending = (props: RouteComponentProps<{ email: string }>) => {
         <Text kind={"body-m"}>
           {createMessage(VERIFICATION_PENDING_BODY)} <Email>{email}</Email>
         </Text>
-        <Link kind="primary" to={AUTH_LOGIN_URL}>
+        <Link kind="primary" target="_self" to={AUTH_LOGIN_URL}>
           {createMessage(VERIFICATION_PENDING_NOT_YOU)}
         </Link>
       </Body>


### PR DESCRIPTION
## Description
> This PR opens the `not you` link in the Email Verification screen in the same window. Earlier, the link was getting opened in a new window.

Fixes #28613   
## Automation

/ok-to-test tags="@tag.Authentication"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8535346664>
> Commit: `9274e4755151a27368dfd2b66bb15cc999f8077b`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8535346664&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->

