### PR TITLE
chore: Support localhost in git repo URLs

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
@@ -2,8 +2,10 @@ package com.appsmith.server.configurations;
 
 import com.appsmith.server.filters.MDCFilter;
 import com.appsmith.server.helpers.LogHelper;
+import io.micrometer.tracing.Tracer;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
 import org.reactivestreams.Subscription;
 import org.slf4j.MDC;
 import org.springframework.context.annotation.Configuration;
@@ -15,9 +17,12 @@ import reactor.util.context.Context;
 import java.util.Map;
 
 @Configuration
+@RequiredArgsConstructor
 public class MDCConfig {
 
     private static final String MDC_CONTEXT_REACTOR_KEY = "MDCConfig";
+
+    private final Tracer tracer;
 
     @PostConstruct
     void contextOperatorHook() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
@@ -2,10 +2,8 @@ package com.appsmith.server.configurations;
 
 import com.appsmith.server.filters.MDCFilter;
 import com.appsmith.server.helpers.LogHelper;
-import io.micrometer.tracing.Tracer;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import lombok.RequiredArgsConstructor;
 import org.reactivestreams.Subscription;
 import org.slf4j.MDC;
 import org.springframework.context.annotation.Configuration;
@@ -17,12 +15,9 @@ import reactor.util.context.Context;
 import java.util.Map;
 
 @Configuration
-@RequiredArgsConstructor
 public class MDCConfig {
 
     private static final String MDC_CONTEXT_REACTOR_KEY = "MDCConfig";
-
-    private final Tracer tracer;
 
     @PostConstruct
     void contextOperatorHook() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -20,6 +20,9 @@ public class GitUtils {
     public static final Duration RETRY_DELAY = Duration.ofSeconds(1);
     public static final Integer MAX_RETRIES = 20;
 
+    public static final Pattern GIT_SSH_URL_PATTERN =
+            Pattern.compile("^(ssh://)?git@(?<host>.+?):/*(?<path>.+?)(\\.git)?$");
+
     /**
      * Sample repo urls :
      * git@example.com:user/repoName.git
@@ -33,9 +36,14 @@ public class GitUtils {
         if (StringUtils.isEmptyOrNull(sshUrl)) {
             throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "ssh url");
         }
-        return sshUrl.replaceFirst(".*git@", "https://")
-                .replaceFirst("(\\.[a-zA-Z0-9]*):", "$1/")
-                .replaceFirst("\\.git$", "");
+
+        final Matcher match = GIT_SSH_URL_PATTERN.matcher(sshUrl);
+
+        if (!match.matches()) {
+            throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "ssh url");
+        }
+
+        return "https://" + match.group("host") + "/" + match.group("path");
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -40,7 +40,9 @@ public class GitUtils {
         final Matcher match = GIT_SSH_URL_PATTERN.matcher(sshUrl);
 
         if (!match.matches()) {
-            throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "ssh url");
+            throw new AppsmithException(
+                    AppsmithError.INVALID_GIT_CONFIGURATION,
+                    "Remote URL is incorrect, please add a URL in standard format. Example: git@example.com:username/reponame.git");
         }
 
         return "https://" + match.group("host") + "/" + match.group("path");

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -42,7 +42,7 @@ public class GitUtils {
         if (!match.matches()) {
             throw new AppsmithException(
                     AppsmithError.INVALID_GIT_CONFIGURATION,
-                    "Remote URL is incorrect, please add a URL in standard format. Example: git@example.com:username/reponame.git");
+                    "Remote URL is incorrect. Please add a URL in standard format. Example: git@example.com:username/reponame.git");
         }
 
         return "https://" + match.group("host") + "/" + match.group("path");
@@ -67,8 +67,8 @@ public class GitUtils {
         }
         throw new AppsmithException(
                 AppsmithError.INVALID_GIT_CONFIGURATION,
-                "Remote URL is incorrect, "
-                        + "please add a URL in standard format. Example: git@example.com:username/reponame.git");
+                "Remote URL is incorrect. "
+                        + "Please add a URL in standard format. Example: git@example.com:username/reponame.git");
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
@@ -714,7 +714,12 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .switchIfEmpty(
                         Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_CONFIGURATION, GIT_PROFILE_ERROR)));
 
-        final String browserSupportedUrl = GitUtils.convertSshUrlToBrowserSupportedUrl(gitConnectDTO.getRemoteUrl());
+        final String browserSupportedUrl;
+        try {
+            browserSupportedUrl = GitUtils.convertSshUrlToBrowserSupportedUrl(gitConnectDTO.getRemoteUrl());
+        } catch (AppsmithException error) {
+            return Mono.error(error);
+        }
 
         Mono<Boolean> isPrivateRepoMono =
                 GitUtils.isRepoPrivate(browserSupportedUrl).cache();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -45,6 +45,10 @@ public class GitUtilsTest {
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@127.0.0.1:test/newRepo.git"))
                 .isEqualTo("https://127.0.0.1/test/newRepo");
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@localhost:test/newRepo.git"))
+                .isEqualTo("https://localhost/test/newRepo");
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@absolute.path.com:/test/newRepo.git"))
+                .isEqualTo("https://absolute.path.com/test/newRepo");
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/GitServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/GitServiceCETest.java
@@ -532,8 +532,8 @@ public class GitServiceCETest {
                 gitService.connectApplicationToGit(application1.getId(), gitConnectDTO, "baseUrl");
 
         StepVerifier.create(applicationMono)
-                .verifyErrorMessage(AppsmithError.INVALID_GIT_CONFIGURATION.getMessage("Remote URL is incorrect, "
-                        + "please add a URL in standard format. Example: git@example.com:username/reponame.git"));
+                .verifyErrorMessage(AppsmithError.INVALID_GIT_CONFIGURATION.getMessage("Remote URL is incorrect. "
+                        + "Please add a URL in standard format. Example: git@example.com:username/reponame.git"));
     }
 
     @Test


### PR DESCRIPTION
Fixes two things in the way we're parsing the Git repo URL:

1. Allow hosts that don't have a `.` in them. Like `localhost`.
2. Support absolute repo paths, that is, ones that start with a `/`.

Added test cases for both of these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved Git SSH URL handling to support a broader range of URL formats.
- **Bug Fixes**
	- Enhanced error handling during the Git connection process to provide clearer feedback on SSH URL issues.
- **Tests**
	- Added more comprehensive tests for Git SSH URL conversion to ensure robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->