### PR TITLE
fix: appsmith.URL.queryParams update on same page navigation

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/NavigateTo1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/NavigateTo1_spec.ts
@@ -1,3 +1,4 @@
+import { WIDGETSKIT } from "../../../../locators/WidgetLocators";
 import {
   agHelper,
   dataSources,
@@ -10,16 +11,17 @@ import {
 import EditorNavigation, {
   EntityType,
 } from "../../../../support/Pages/EditorNavigation";
-import PageList from "../../../../support/Pages/PageList";
 
 describe("Navigate To feature", { tags: ["@tag.JS"] }, () => {
   it("1. Navigates to page name clicked from the page name tab of navigate to", () => {
-    PageList.AddNewPage(); // page 2
     EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
+    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 500, 600);
+    EditorNavigation.SelectEntityByName("Text1", EntityType.Widget);
+    propPane.TypeTextIntoField("Text", "{{appsmith.URL.queryParams.test}}");
     entityExplorer.DragDropWidgetNVerify(draggableWidgets.BUTTON, 300, 300);
     EditorNavigation.SelectEntityByName("Button1", EntityType.Widget);
     propPane.SelectPlatformFunction("onClick", "Navigate to");
-    dataSources.ValidateNSelectDropdown("Choose page", "Select page", "Page2");
+    dataSources.ValidateNSelectDropdown("Choose page", "Select page", "Page1");
     propPane.UpdatePropertyFieldValue(
       "Query params",
       `{{
@@ -30,21 +32,23 @@ describe("Navigate To feature", { tags: ["@tag.JS"] }, () => {
     );
     agHelper.GetNClick(propPane._actionSelectorPopupClose);
     agHelper.ClickButton("Submit");
+
+    agHelper.GetNAssertElementText(
+      WIDGETSKIT.textWidgetContainer,
+      "123",
+      "have.text",
+      0,
+    );
+
     cy.url().should("include", "a=b").and("include", "test=123");
-    EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
     deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.BUTTON));
     agHelper.WaitUntilEleAppear(
       locators._widgetInDeployed(draggableWidgets.BUTTON),
     );
     agHelper.ClickButton("Submit");
-    agHelper.GetNAssertContains(
-      locators._emptyPageTxt,
-      "This page seems to be blank",
-    );
     cy.url().then(($url) => {
       cy.log("deploy url is" + $url);
       expect($url).to.contain("test=123");
     });
-    //cy.location().its('href').should('include', 'test=123')//both are same
   });
 });

--- a/app/client/src/ce/actions/evaluationActionsList.ts
+++ b/app/client/src/ce/actions/evaluationActionsList.ts
@@ -105,6 +105,8 @@ export const EVALUATE_REDUX_ACTIONS = [
   ReduxActionTypes.BUFFERED_ACTION,
   // Generic
   ReduxActionTypes.TRIGGER_EVAL,
+  //
+  ReduxActionTypes.SET_URL_DATA,
 ];
 // Topics used for datasource and query form evaluations
 export const FORM_EVALUATION_REDUX_ACTIONS = [

--- a/app/client/src/ce/actions/evaluationActionsList.ts
+++ b/app/client/src/ce/actions/evaluationActionsList.ts
@@ -97,7 +97,6 @@ export const EVALUATE_REDUX_ACTIONS = [
   ReduxActionTypes.UPDATE_SELECTED_APP_THEME_SUCCESS,
   ReduxActionTypes.CHANGE_SELECTED_APP_THEME_SUCCESS,
   ReduxActionTypes.SET_PREVIEW_APP_THEME,
-
   // Custom Library
   ReduxActionTypes.INSTALL_LIBRARY_SUCCESS,
   ReduxActionTypes.UNINSTALL_LIBRARY_SUCCESS,
@@ -105,8 +104,6 @@ export const EVALUATE_REDUX_ACTIONS = [
   ReduxActionTypes.BUFFERED_ACTION,
   // Generic
   ReduxActionTypes.TRIGGER_EVAL,
-  //
-  ReduxActionTypes.SET_URL_DATA,
 ];
 // Topics used for datasource and query form evaluations
 export const FORM_EVALUATION_REDUX_ACTIONS = [

--- a/app/client/src/sagas/ActionExecution/NavigateActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/NavigateActionSaga.ts
@@ -1,7 +1,10 @@
-import { call, select } from "redux-saga/effects";
+import { call, put, select } from "redux-saga/effects";
 import { getCurrentPageId, getPageList } from "selectors/editorSelectors";
 import _ from "lodash";
-import type { Page } from "@appsmith/constants/ReduxActionConstants";
+import {
+  ReduxActionTypes,
+  type Page,
+} from "@appsmith/constants/ReduxActionConstants";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { getAppMode } from "@appsmith/selectors/applicationSelectors";
 import { APP_MODE } from "entities/App";
@@ -58,6 +61,9 @@ export default function* navigateActionSaga(action: TNavigateToDescription) {
       history.push(path);
       if (currentPageId === page.pageId) {
         yield call(setDataUrl);
+        yield put({
+          type: ReduxActionTypes.TRIGGER_EVAL,
+        });
       }
     } else if (target === NavigationTargetType.NEW_WINDOW) {
       window.open(path, "_blank");
@@ -88,6 +94,7 @@ export default function* navigateActionSaga(action: TNavigateToDescription) {
     } else if (target === NavigationTargetType.NEW_WINDOW) {
       window.open(url, "_blank");
     }
+
     AppsmithConsole.info({
       text: `navigateTo('${url}') was triggered`,
       state: {


### PR DESCRIPTION
## Description

- Making sure to trigger evaluation after navigateTo on same page to make sure we update the `appsmith.URL.queryParams`
- Update the cypress test to check queryParams update on same page

Fixes https://github.com/appsmithorg/appsmith/issues/26831


## Steps to test 
1. Add a button widget
2. Add a `navigateTo` action on click event of button 
3. NavigateTo should have params as below and should navigate to same page
```js
{{
{
key: "aff", 
key2: "dsfs" 
}
}}
```
4. Add a text widget with binding `{{appsmith.URL.queryParams}}` 
5. Make sure that the text widget updates once the button is clicked
## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8598783804>
> Commit: `634477b53582ae5392eb26dde1a1fcd434f55883`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8598783804&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->













<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for setting URL data through Redux actions for enhanced state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->