### PR TITLE
fix: Moving datasource context creation synchronized call to boundedElastic threadpool

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -91,70 +91,79 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
             PluginExecutor<Object> pluginExecutor,
             Object monitor,
             DatasourceContextIdentifier datasourceContextIdentifier) {
-        synchronized (monitor) {
-            /* Destroy any connection that is stale or in error state to free up resource */
-            final boolean isStale = getIsStale(datasourceStorage, datasourceContextIdentifier);
-            final boolean isInErrorState = getIsInErrorState(datasourceContextIdentifier);
 
-            if (isStale || isInErrorState) {
-                final Object connection =
-                        datasourceContextMap.get(datasourceContextIdentifier).getConnection();
-                if (connection != null) {
-                    try {
-                        // Basically remove entry from both cache maps
-                        pluginExecutor.datasourceDestroy(connection);
-                    } catch (Exception e) {
-                        log.info(
-                                Thread.currentThread().getName() + ": Error destroying stale datasource connection", e);
+        return Mono.fromCallable(() -> {
+                    synchronized (monitor) {
+                        /* Destroy any connection that is stale or in error state to free up resource */
+                        final boolean isStale = getIsStale(datasourceStorage, datasourceContextIdentifier);
+                        final boolean isInErrorState = getIsInErrorState(datasourceContextIdentifier);
+
+                        if (isStale || isInErrorState) {
+                            final Object connection = datasourceContextMap
+                                    .get(datasourceContextIdentifier)
+                                    .getConnection();
+                            if (connection != null) {
+                                try {
+                                    // Basically remove entry from both cache maps
+                                    pluginExecutor.datasourceDestroy(connection);
+                                } catch (Exception e) {
+                                    log.info(
+                                            Thread.currentThread().getName()
+                                                    + ": Error destroying stale datasource connection",
+                                            e);
+                                }
+                            }
+                            datasourceContextMonoMap.remove(datasourceContextIdentifier);
+                            datasourceContextMap.remove(datasourceContextIdentifier);
+                        }
+
+                        /*
+                         * If a publisher with cached value already exists then return it. Please note that even if this publisher is
+                         * evaluated multiple times the actual datasource creation will only happen once and get cached and the same
+                         * value would directly be returned to further evaluations / subscriptions.
+                         */
+                        if (datasourceContextIdentifier.getDatasourceId() != null
+                                && datasourceContextMonoMap.get(datasourceContextIdentifier) != null) {
+                            log.debug(Thread.currentThread().getName()
+                                    + ": Cached resource context mono exists. Returning the same.");
+                            return datasourceContextMonoMap.get(datasourceContextIdentifier);
+                        }
+
+                        /* Create a fresh datasource context */
+                        DatasourceContext<Object> datasourceContext = new DatasourceContext<>();
+                        if (datasourceContextIdentifier.isKeyValid() && shouldCacheContextForThisPlugin(plugin)) {
+                            /* For this datasource, either the context doesn't exist, or the context is stale. Replace (or add) with
+                            the new connection in the context map. */
+                            datasourceContextMap.put(datasourceContextIdentifier, datasourceContext);
+                        }
+
+                        Mono<Object> connectionMonoCache = pluginExecutor
+                                .datasourceCreate(datasourceStorage.getDatasourceConfiguration())
+                                .cache();
+
+                        Mono<DatasourceContext<Object>> datasourceContextMonoCache = connectionMonoCache
+                                .flatMap(connection ->
+                                        updateDatasourceAndSetAuthentication(connection, datasourceStorage))
+                                .map(connection -> {
+                                    /* When a connection object exists and makes sense for the plugin, we put it in the
+                                    context. Example, DB plugins. */
+                                    datasourceContext.setConnection(connection);
+                                    return datasourceContext;
+                                })
+                                .defaultIfEmpty(
+                                        /* When a connection object doesn't make sense for the plugin, we get an empty mono
+                                        and we just return the context object as is. */
+                                        datasourceContext)
+                                .cache(); /* Cache the value so that further evaluations don't result in new connections */
+
+                        if (datasourceContextIdentifier.isKeyValid() && shouldCacheContextForThisPlugin(plugin)) {
+                            datasourceContextMonoMap.put(datasourceContextIdentifier, datasourceContextMonoCache);
+                        }
+                        log.debug(Thread.currentThread().getName() + ": Cached new datasource context");
+                        return datasourceContextMonoCache;
                     }
-                }
-                datasourceContextMonoMap.remove(datasourceContextIdentifier);
-                datasourceContextMap.remove(datasourceContextIdentifier);
-            }
-
-            /*
-             * If a publisher with cached value already exists then return it. Please note that even if this publisher is
-             * evaluated multiple times the actual datasource creation will only happen once and get cached and the same
-             * value would directly be returned to further evaluations / subscriptions.
-             */
-            if (datasourceContextIdentifier.getDatasourceId() != null
-                    && datasourceContextMonoMap.get(datasourceContextIdentifier) != null) {
-                log.debug(Thread.currentThread().getName()
-                        + ": Cached resource context mono exists. Returning the same.");
-                return datasourceContextMonoMap.get(datasourceContextIdentifier);
-            }
-
-            /* Create a fresh datasource context */
-            DatasourceContext<Object> datasourceContext = new DatasourceContext<>();
-            if (datasourceContextIdentifier.isKeyValid() && shouldCacheContextForThisPlugin(plugin)) {
-                /* For this datasource, either the context doesn't exist, or the context is stale. Replace (or add) with
-                the new connection in the context map. */
-                datasourceContextMap.put(datasourceContextIdentifier, datasourceContext);
-            }
-
-            Mono<Object> connectionMonoCache = pluginExecutor
-                    .datasourceCreate(datasourceStorage.getDatasourceConfiguration())
-                    .cache();
-
-            Mono<DatasourceContext<Object>> datasourceContextMonoCache = connectionMonoCache
-                    .flatMap(connection -> updateDatasourceAndSetAuthentication(connection, datasourceStorage))
-                    .map(connection -> {
-                        /* When a connection object exists and makes sense for the plugin, we put it in the
-                        context. Example, DB plugins. */
-                        datasourceContext.setConnection(connection);
-                        return datasourceContext;
-                    })
-                    .defaultIfEmpty(
-                            /* When a connection object doesn't make sense for the plugin, we get an empty mono
-                            and we just return the context object as is. */
-                            datasourceContext)
-                    .cache(); /* Cache the value so that further evaluations don't result in new connections */
-
-            if (datasourceContextIdentifier.isKeyValid() && shouldCacheContextForThisPlugin(plugin)) {
-                datasourceContextMonoMap.put(datasourceContextIdentifier, datasourceContextMonoCache);
-            }
-            return datasourceContextMonoCache;
-        }
+                })
+                .flatMap(obj -> obj);
     }
 
     /**
@@ -207,6 +216,9 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                     if (datasourceContextIdentifier.isKeyValid()) {
                         if (datasourceContextSynchronizationMonitorMap.get(datasourceContextIdentifier) == null) {
                             synchronized (this) {
+                                log.debug(
+                                        Thread.currentThread().getName() + ": Creating monitor for datasource id {}",
+                                        datasourceContextIdentifier.getDatasourceId());
                                 datasourceContextSynchronizationMonitorMap.computeIfAbsent(
                                         datasourceContextIdentifier, k -> new Object());
                             }


### PR DESCRIPTION
## Description

Synchronized blocks shouldn't ever run on the main event loop threads. Moving all the synchronized blocks during datasource context creation to elastic thread pool to ensure event loop threads are always available to servicing new requests.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8539901946>
> Commit: `6d23c5604ebd848dc7c934fb852ae9cb326fb131`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8539901946&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency and thread safety in managing datasource connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->