### PR TITLE
fix: Statbox widget min-height inconsistency (#28677)

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Statbox_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Statbox_spec.ts
@@ -1,0 +1,49 @@
+import {
+	agHelper,
+	assertHelper,
+	draggableWidgets,
+	locators,
+	entityExplorer,
+	propPane,
+} from "../../../../support/Objects/ObjectsCore";
+import EditorNavigation, {
+	EntityType,
+} from "../../../../support/Pages/EditorNavigation";
+
+describe(
+	"Dynamic Height Adjustment for Statbox Widget",
+	{ tags: ["@tag.AutoHeight"] },
+	function () {
+		before(() => {
+			entityExplorer.DragDropWidgetNVerify(draggableWidgets.STATBOX);
+		});
+		it("Validate decreasing height of Statbox widget by removing its widgets", function () {
+			propPane.AssertPropertiesDropDownCurrentValue("Height", "Auto Height");
+
+			// Function to delete widget and verify height change
+			function deleteWidgetAndVerifyHeightChange(widgetName: string) {
+				agHelper.GetWidgetCSSHeight(locators._widgetInDeployed(draggableWidgets.STATBOX))
+					.then($currentStatboxHeight => {
+						EditorNavigation.SelectEntityByName(widgetName, EntityType.Widget, {}, ["Statbox1"]);
+						agHelper.PressDelete();
+						agHelper.WaitUntilAllToastsDisappear();
+						assertHelper.AssertNetworkStatus("updateLayout");
+						agHelper.Sleep(2000);
+
+						agHelper.GetWidgetCSSHeight(locators._widgetInDeployed(draggableWidgets.STATBOX))
+							.then($updatedStatboxHeight => {
+								// Verify that the height of the Statbox widget has decreased
+								expect($currentStatboxHeight).to.not.equal($updatedStatboxHeight);
+							});
+					});
+			}
+
+			// Delete bottom text widget from statbox and verify height change
+			deleteWidgetAndVerifyHeightChange("Text3");
+
+			// Delete icon button widget from statbox and verify height change
+			deleteWidgetAndVerifyHeightChange("IconButton1");
+
+		});
+	}
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Statbox_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Statbox_spec.ts
@@ -1,49 +1,61 @@
 import {
-	agHelper,
-	assertHelper,
-	draggableWidgets,
-	locators,
-	entityExplorer,
-	propPane,
+  agHelper,
+  assertHelper,
+  draggableWidgets,
+  locators,
+  entityExplorer,
+  propPane,
 } from "../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
-	EntityType,
+  EntityType,
 } from "../../../../support/Pages/EditorNavigation";
 
 describe(
-	"Dynamic Height Adjustment for Statbox Widget",
-	{ tags: ["@tag.AutoHeight"] },
-	function () {
-		before(() => {
-			entityExplorer.DragDropWidgetNVerify(draggableWidgets.STATBOX);
-		});
-		it("Validate decreasing height of Statbox widget by removing its widgets", function () {
-			propPane.AssertPropertiesDropDownCurrentValue("Height", "Auto Height");
+  "Dynamic Height Adjustment for Statbox Widget",
+  { tags: ["@tag.AutoHeight"] },
+  function () {
+    before(() => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.STATBOX);
+    });
+    it("Validate decreasing height of Statbox widget by removing its widgets", function () {
+      propPane.AssertPropertiesDropDownCurrentValue("Height", "Auto Height");
 
-			// Function to delete widget and verify height change
-			function deleteWidgetAndVerifyHeightChange(widgetName: string) {
-				agHelper.GetWidgetCSSHeight(locators._widgetInDeployed(draggableWidgets.STATBOX))
-					.then($currentStatboxHeight => {
-						EditorNavigation.SelectEntityByName(widgetName, EntityType.Widget, {}, ["Statbox1"]);
-						agHelper.PressDelete();
-						agHelper.WaitUntilAllToastsDisappear();
-						assertHelper.AssertNetworkStatus("updateLayout");
-						agHelper.Sleep(2000);
+      // Function to delete widget and verify height change
+      function deleteWidgetAndVerifyHeightChange(widgetName: string) {
+        agHelper
+          .GetWidgetCSSHeight(
+            locators._widgetInDeployed(draggableWidgets.STATBOX),
+          )
+          .then(($currentStatboxHeight) => {
+            EditorNavigation.SelectEntityByName(
+              widgetName,
+              EntityType.Widget,
+              {},
+              ["Statbox1"],
+            );
+            agHelper.PressDelete();
+            agHelper.WaitUntilAllToastsDisappear();
+            assertHelper.AssertNetworkStatus("updateLayout");
+            agHelper.Sleep(2000);
 
-						agHelper.GetWidgetCSSHeight(locators._widgetInDeployed(draggableWidgets.STATBOX))
-							.then($updatedStatboxHeight => {
-								// Verify that the height of the Statbox widget has decreased
-								expect($currentStatboxHeight).to.not.equal($updatedStatboxHeight);
-							});
-					});
-			}
+            agHelper
+              .GetWidgetCSSHeight(
+                locators._widgetInDeployed(draggableWidgets.STATBOX),
+              )
+              .then(($updatedStatboxHeight) => {
+                // Verify that the height of the Statbox widget has decreased
+                expect($currentStatboxHeight).to.not.equal(
+                  $updatedStatboxHeight,
+                );
+              });
+          });
+      }
 
-			// Delete bottom text widget from statbox and verify height change
-			deleteWidgetAndVerifyHeightChange("Text3");
+      // Delete bottom text widget from statbox and verify height change
+      deleteWidgetAndVerifyHeightChange("Text3");
 
-			// Delete icon button widget from statbox and verify height change
-			deleteWidgetAndVerifyHeightChange("IconButton1");
-
-		});
-	}
+      // Delete icon button widget from statbox and verify height change
+      deleteWidgetAndVerifyHeightChange("IconButton1");
+    });
+  },
 );

--- a/app/client/src/widgets/StatboxWidget/widget/index.tsx
+++ b/app/client/src/widgets/StatboxWidget/widget/index.tsx
@@ -82,7 +82,6 @@ class StatboxWidget extends ContainerWidget {
       backgroundColor: "white",
       borderWidth: "1",
       borderColor: Colors.GREY_5,
-      minDynamicHeight: 14,
       children: [],
       positioning: Positioning.Fixed,
       responsiveBehavior: ResponsiveBehavior.Fill,


### PR DESCRIPTION
## Description
- Removed the Statbox widget's minimum dynamic height of 14 to fix height inconsistencies when toggling between Fixed Height and Auto Height modes.
- Although this minimum height had been implemented to mitigate a flicker upon dragging and dropping the widget, the removal of this minimum height did not affect the flicker.
- Created a Cypress test to validate the Statbox widget's Auto Height functionality.

Fixes #28677 

## Automation

/ok-to-test tags="@tag.Widget, @tag.AutoHeight"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced flexibility in dashboard design by introducing dynamic height adjustment for Statbox widgets.
- **Refactor**
	- Increased customization options by removing the minimum dynamic height restriction from Statbox widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->