### PR TITLE
fix: Support symlinks in `ca-certs` folder

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -319,7 +319,7 @@ setup-custom-ca-certificates() (
     -deststorepass changeit
 
   # Add the custom CA certificates to the store.
-  find "$stacks_ca_certs_path" -maxdepth 1 -type f -name '*.crt' \
+  find -L "$stacks_ca_certs_path" -maxdepth 1 -type f -name '*.crt' \
     -print \
     -exec keytool -import -alias '{}' -noprompt -keystore "$store" -file '{}' -storepass changeit ';'
 


### PR DESCRIPTION
Fixes: [30928](https://github.com/appsmithorg/appsmith/issues/30928)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved certificate search operation by enabling symbolic link resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->