### PR TITLE
fix: Added assert for network status in IDE add pane interactions spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/IDE_Add_Pane_Interactions_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/IDE_Add_Pane_Interactions_spec.ts
@@ -5,6 +5,7 @@ import EditorNavigation, {
 } from "../../../../support/Pages/EditorNavigation";
 import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 import FileTabs from "../../../../support/Pages/IDE/FileTabs";
+import { assertHelper } from "../../../../support/Objects/ObjectsCore";
 
 const agHelper = ObjectsRegistry.AggregateHelper;
 const commonLocators = ObjectsRegistry.CommonLocators;
@@ -62,6 +63,7 @@ describe("IDE add pane interactions", { tags: ["@tag.IDE"] }, () => {
       cy.selectByTestId("more-action-trigger").click();
       cy.get(".t--apiFormDeleteBtn").click();
       cy.get(".t--apiFormDeleteBtn").click();
+      assertHelper.AssertNetworkStatus("@deleteJSCollection");
     });
     PageLeftPane.assertInAddView();
   });
@@ -100,6 +102,7 @@ describe("IDE add pane interactions", { tags: ["@tag.IDE"] }, () => {
       cy.selectByTestId("more-action-trigger").click();
       cy.get(".t--apiFormDeleteBtn").click();
       cy.get(".t--apiFormDeleteBtn").click();
+      assertHelper.AssertNetworkStatus("@deleteAction");
     });
     PageLeftPane.assertInAddView();
   });


### PR DESCRIPTION
## Description

Added API assert check for IDE Add pane interactions spec.

Fixes #32394

## Automation

/ok-to-test tags="@tag.IDE, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8543927682>
> Commit: `53c5cfca1b691298e4938bd5437da3e41fa72f75`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8543927682&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced the "IDE add pane interactions" test suite with additional assertions to verify network status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->