### PR TITLE
chore: Added trace and span info to context

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
@@ -3,13 +3,11 @@ package com.appsmith.server.configurations;
 import com.appsmith.server.filters.MDCFilter;
 import com.appsmith.server.helpers.LogHelper;
 import io.micrometer.observation.Observation;
-import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.TracingObservationHandler;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.reactivestreams.Subscription;
 import org.slf4j.MDC;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Hooks;
@@ -26,9 +24,6 @@ public class MDCConfig {
     private static final String OBSERVATION = "micrometer.observation";
     private static final String TRACE_ID = "traceId";
     private static final String SPAN_ID = "spanId";
-
-    @Autowired
-    Tracer tracer;
 
     @PostConstruct
     void contextOperatorHook() {


### PR DESCRIPTION
## Description
Contains changes to make sure that any ongoing observation shows up in the logs as well as is retained in context in case we need to trigger a span manually.

<img width="1312" alt="Screenshot 2024-04-04 at 9 50 49 AM" src="https://github.com/appsmithorg/appsmith/assets/5298848/5fd292ae-1274-47e7-8608-7b6856ac274f">


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced performance monitoring with micrometer tracing and observation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->