### PR TITLE
chore: Remove more MongoDB API uses in tests

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/domains/DatasourceContextIdentifierTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/domains/DatasourceContextIdentifierTest.java
@@ -1,7 +1,8 @@
 package com.appsmith.server.domains;
 
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,8 +12,8 @@ public class DatasourceContextIdentifierTest {
 
     @Test
     public void verifyDsMapKeyEquality() {
-        String dsId = new ObjectId().toHexString();
-        String defaultEnvironmentId = new ObjectId().toHexString();
+        String dsId = UUID.randomUUID().toString();
+        String defaultEnvironmentId = UUID.randomUUID().toString();
         DatasourceContextIdentifier keyObj = new DatasourceContextIdentifier(dsId, defaultEnvironmentId);
         DatasourceContextIdentifier keyObj1 = new DatasourceContextIdentifier(dsId, defaultEnvironmentId);
         assertEquals(keyObj, keyObj1);
@@ -20,8 +21,8 @@ public class DatasourceContextIdentifierTest {
 
     @Test
     public void verifyDsMapKeyNotEqual() {
-        String dsId = new ObjectId().toHexString();
-        String dsId1 = new ObjectId().toHexString();
+        String dsId = UUID.randomUUID().toString();
+        String dsId1 = UUID.randomUUID().toString();
 
         // with different datasourceId and null environment id
         DatasourceContextIdentifier keyObj = new DatasourceContextIdentifier(dsId, null);
@@ -33,14 +34,14 @@ public class DatasourceContextIdentifierTest {
         assertNotEquals(keyObj, keyObj2);
 
         // with same datasource but different environment id
-        String differentEnvironmentId = new ObjectId().toHexString();
+        String differentEnvironmentId = UUID.randomUUID().toString();
         DatasourceContextIdentifier keyObj3 = new DatasourceContextIdentifier(dsId, differentEnvironmentId);
         assertNotEquals(keyObj, keyObj3);
     }
 
     @Test
     public void verifyDsMapKeyNotEqualWhenBothDatasourceIdNull() {
-        String defaultEnvironmentId = new ObjectId().toHexString();
+        String defaultEnvironmentId = UUID.randomUUID().toString();
         DatasourceContextIdentifier keyObj = new DatasourceContextIdentifier(null, defaultEnvironmentId);
         DatasourceContextIdentifier keyObj1 = new DatasourceContextIdentifier(null, defaultEnvironmentId);
         assertNotEquals(keyObj, keyObj1);
@@ -48,8 +49,8 @@ public class DatasourceContextIdentifierTest {
 
     @Test
     public void verifyDatasourceContextIdentifierHashCode() {
-        String sampleDatasourceId = new ObjectId().toHexString();
-        String defaultEnvironmentId = new ObjectId().toHexString();
+        String sampleDatasourceId = UUID.randomUUID().toString();
+        String defaultEnvironmentId = UUID.randomUUID().toString();
         DatasourceContextIdentifier datasourceContextIdentifier =
                 new DatasourceContextIdentifier(sampleDatasourceId, defaultEnvironmentId);
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImplTest.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.DefaultResources;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.repositories.ActionCollectionRepository;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +61,7 @@ public class CustomActionCollectionRepositoryCEImplTest {
 
     @Test
     public void bulkInsert_WhenDuplicateId_ExceptionThrown() {
-        String duplicateId = new ObjectId().toString();
+        String duplicateId = UUID.randomUUID().toString();
         List<ActionCollection> actionCollections = new ArrayList<>();
 
         for (int i = 0; i < 2; i++) {
@@ -81,7 +80,7 @@ public class CustomActionCollectionRepositoryCEImplTest {
         String applicationId = UUID.randomUUID().toString();
 
         for (int i = 0; i < 5; i++) {
-            String generatedId = new ObjectId().toString();
+            String generatedId = UUID.randomUUID().toString();
             ActionCollection actionCollection = new ActionCollection();
             actionCollection.setId(generatedId);
             actionCollection.setApplicationId(applicationId);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -38,7 +38,6 @@ import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.EnvironmentPermission;
 import lombok.extern.slf4j.Slf4j;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +55,7 @@ import reactor.test.StepVerifier;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -581,7 +581,7 @@ public class DatasourceContextServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void verifyInitialiseDatasourceContextReturningRightIdentifier() {
-        String sampleDatasourceId = new ObjectId().toHexString();
+        String sampleDatasourceId = UUID.randomUUID().toString();
         DatasourceStorage datasourceStorage = new DatasourceStorage();
         datasourceStorage.setDatasourceId(sampleDatasourceId);
         datasourceStorage.setEnvironmentId(defaultEnvironmentId);
@@ -732,7 +732,7 @@ public class DatasourceContextServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void verifyDatasourceContext_withRateLimitExceeded_returnsTooManyRequests() {
-        String sampleDatasourceId = new ObjectId().toHexString();
+        String sampleDatasourceId = UUID.randomUUID().toString();
         Plugin redshiftPlugin = pluginService
                 .findByPackageName(PluginConstants.PackageName.REDSHIFT_PLUGIN)
                 .block();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -76,7 +76,6 @@ import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.READ_PAGES;
 import static com.appsmith.server.constants.FieldName.DEFAULT_PAGE_LAYOUT;
-import static com.mongodb.assertions.Assertions.assertNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1279,7 +1278,7 @@ public class LayoutActionServiceTest {
         // by default there should be no error in the layout, hence no error should be sent to ActionDTO/ errorReports
         // will be null
         assertNotNull(createdAction);
-        assertNull(createdAction.getErrorReports());
+        assertThat(createdAction.getErrorReports()).isNull();
 
         // since the dependency has been introduced calling updateLayout will return a LayoutDTO with a populated
         // layoutOnLoadActionErrors


### PR DESCRIPTION
Removes a lot of API uses from MongoDB libraries, that don't strictly have to depend on MongoDB dependencies.
