### PR TITLE
fix: added min width to the table cell element to avoid shrinking

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -33,7 +33,7 @@ const NoDataMessage = styled.span`
 `;
 
 // TODO: replace with ads table
-export const TableWrapper = styled.div`
+export const TableWrapper = styled.div<{ minColumnWidth?: number }>`
   width: 100%;
   height: auto;
   background: var(--ads-v2-color-bg);
@@ -94,6 +94,10 @@ export const TableWrapper = styled.div`
       position: relative;
       font-size: ${TABLE_SIZES.ROW_FONT_SIZE}px;
       line-height: ${TABLE_SIZES.ROW_FONT_SIZE}px;
+      ${(props) =>
+        `${
+          props.minColumnWidth ? `min-width: ${props.minColumnWidth}px;` : ""
+        }`}
       :last-child {
         border-right: 0;
       }
@@ -322,6 +326,7 @@ function Table(props: TableProps) {
       <TableWrapper
         className="t--table-response"
         data-guided-tour-id="query-table-response"
+        minColumnWidth={defaultColumn.width}
       >
         <div className="tableWrap">
           <div {...getTableProps()} className="table">


### PR DESCRIPTION
## Description
Earlier the table cell was shrinking to width less than `170px` although the column cell width is set to width 170px of the react-table. Hence the min-width restricts the element to shrink the width from the 170px.

Fixes #32246
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8551604525>
> Commit: `053d6d35c18d5828815539b07a92c7511744b030`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8551604525&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `TableWrapper` component to support dynamic minimum column width settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->