### PR TITLE
fix: gsheet query UI doesnt load on change of command fixed

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/root.json
@@ -53,6 +53,7 @@
           "controlType": "DROP_DOWN",
           "initialValue": "ROWS",
           "isRequired": true,
+          "setFirstOptionAsDefault": true,
           "options": [
             {
               "disabled": "{{ ['INSERT_ONE', 'UPDATE_ONE', 'DELETE_ONE', 'FETCH_MANY', 'UPDATE_MANY', 'INSERT_MANY'].includes(actionConfiguration.formData.command.data) === false }}",


### PR DESCRIPTION
## Description
This PR fixes a UI issue where Google Sheets query form does not show correct inputs until unselecting and reselecting the entity [row, sheet, spreadsheet]
![318921276-6fb2ef69-9bc2-457b-87ea-601c1aa8646b](https://github.com/appsmithorg/appsmith/assets/30018882/d7218963-6e14-4913-8e8e-737882c13e5f)


Fixes #32349 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->