### PR TITLE
ci: Show TED tag used in run name and summary

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -1,5 +1,8 @@
 name: Test, build and push Docker Image
 
+run-name: >
+  ${{ github.workflow }} with TED:${{ inputs.ted_tag }}
+
 on:
   # This workflow will run everyday at 7:00AM, 1:00PM IST on weekdays
   schedule:
@@ -34,6 +37,12 @@ jobs:
       tags: ${{ steps.setup.outputs.tags }}
       matrix: ${{ steps.setup.outputs.matrix }}
     steps:
+      - name: "Post inputs to run summary"
+        env:
+          INPUTS: "${{ toJSON(inputs) }}"
+        run: |
+          echo $'## Inputs\n```\n'"$INPUTS"$'\n```' > "$GITHUB_STEP_SUMMARY"
+
       - name: Set tags and matrix runner
         id: setup
         run: |


### PR DESCRIPTION
This is to make it apparent what TED tag was used to run a workflow, so that runs that happened with an unstable (non `latest`) tag of TED aren't taken seriously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated the build and test workflow for Docker images to include dynamic naming and posting inputs to run summary.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->