### PR TITLE
fix: template name usage in analytics

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
@@ -281,6 +281,8 @@ public class ApplicationTemplateServiceCEImpl implements ApplicationTemplateServ
             List<String> pagesToImport) {
         Mono<ApplicationImportDTO> importedApplicationMono = getApplicationJsonFromTemplate(templateId)
                 .flatMap(applicationJson -> {
+                    String templateName =
+                            applicationJson.getExportedApplication().getName();
                     if (branchName != null) {
                         return applicationService
                                 .findByBranchNameAndDefaultApplicationId(
@@ -292,15 +294,13 @@ public class ApplicationTemplateServiceCEImpl implements ApplicationTemplateServ
                                         applicationJson,
                                         pagesToImport))
                                 .map(importableArtifact -> (Application) importableArtifact)
-                                .zipWith(Mono.just(
-                                        applicationJson.getExportedApplication().getName()));
+                                .zipWith(Mono.just(templateName));
                     }
                     return importService
                             .mergeArtifactExchangeJsonWithImportableArtifact(
                                     organizationId, applicationId, null, applicationJson, pagesToImport)
                             .map(importableArtifact -> (Application) importableArtifact)
-                            .zipWith(Mono.just(
-                                    applicationJson.getExportedApplication().getName()));
+                            .zipWith(Mono.just(templateName));
                 })
                 .flatMap(tuple -> {
                     Application application = tuple.getT1();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
@@ -281,8 +281,9 @@ public class ApplicationTemplateServiceCEImpl implements ApplicationTemplateServ
             List<String> pagesToImport) {
         Mono<ApplicationImportDTO> importedApplicationMono = getApplicationJsonFromTemplate(templateId)
                 .flatMap(applicationJson -> {
-                    String templateName =
-                            applicationJson.getExportedApplication().getName();
+                    String templateName = applicationJson.getExportedApplication() != null
+                            ? applicationJson.getExportedApplication().getName()
+                            : "";
                     if (branchName != null) {
                         return applicationService
                                 .findByBranchNameAndDefaultApplicationId(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
@@ -281,9 +281,11 @@ public class ApplicationTemplateServiceCEImpl implements ApplicationTemplateServ
             List<String> pagesToImport) {
         Mono<ApplicationImportDTO> importedApplicationMono = getApplicationJsonFromTemplate(templateId)
                 .flatMap(applicationJson -> {
-                    String templateName = applicationJson.getExportedApplication() != null
-                            ? applicationJson.getExportedApplication().getName()
-                            : "";
+                    String templateName = "";
+                    if (applicationJson.getExportedApplication() != null
+                            && applicationJson.getExportedApplication().getName() != null) {
+                        templateName = applicationJson.getExportedApplication().getName();
+                    }
                     if (branchName != null) {
                         return applicationService
                                 .findByBranchNameAndDefaultApplicationId(


### PR DESCRIPTION
## Description
Fix NPE caused by the template name used for analytics PR. 

Fixes #32437 

## Automation

/ok-to-test tags="tag.Templates"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8567991310>
> Commit: `8e04b161dcacb89fb4c08ec8a32cbd4c2e7c4129`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8567991310&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved how the application name is handled when merging templates with applications for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->