### PR TITLE
fix: Add null checks for focus setters

### DIFF
--- a/app/client/src/ce/navigation/FocusSetters.ts
+++ b/app/client/src/ce/navigation/FocusSetters.ts
@@ -14,7 +14,7 @@ import type { FocusEntityInfo } from "navigation/FocusEntity";
 import { FocusEntity } from "navigation/FocusEntity";
 import { getQueryEntityItemUrl } from "../pages/Editor/IDE/EditorPane/Query/utils";
 
-export function setSelectedDatasource(id: string | undefined) {
+export function setSelectedDatasource(id: string) {
   if (id) {
     history.replace(
       datasourcesEditorIdURL({
@@ -27,7 +27,7 @@ export function setSelectedDatasource(id: string | undefined) {
   }
 }
 
-export function setSelectedQuery(entityInfo: FocusEntityInfo) {
+export function setSelectedQuery(entityInfo?: FocusEntityInfo) {
   if (entityInfo && entityInfo.params.pageId) {
     if ([FocusEntity.API, FocusEntity.QUERY].includes(entityInfo.entity)) {
       const { apiId, pluginPackageName, queryId } = entityInfo.params;
@@ -53,8 +53,8 @@ export function setSelectedQuery(entityInfo: FocusEntityInfo) {
   }
 }
 
-export function setSelectedJSObject(focusInfo: FocusEntityInfo) {
-  if (focusInfo.entity === FocusEntity.JS_OBJECT) {
+export function setSelectedJSObject(focusInfo?: FocusEntityInfo) {
+  if (focusInfo && focusInfo.entity === FocusEntity.JS_OBJECT) {
     history.replace(
       jsCollectionIdURL({
         collectionId: focusInfo.id,

--- a/app/client/src/ce/navigation/FocusSetters.ts
+++ b/app/client/src/ce/navigation/FocusSetters.ts
@@ -14,7 +14,7 @@ import type { FocusEntityInfo } from "navigation/FocusEntity";
 import { FocusEntity } from "navigation/FocusEntity";
 import { getQueryEntityItemUrl } from "../pages/Editor/IDE/EditorPane/Query/utils";
 
-export function setSelectedDatasource(id: string) {
+export function setSelectedDatasource(id?: string) {
   if (id) {
     history.replace(
       datasourcesEditorIdURL({


### PR DESCRIPTION
## Description

Adds the missing null checks in Focus Setters. 

Since `undefined` is a valid state for an element to have, null checks need to happen at the focus setter levels to ensure it is getting the correct format of the state to set. This was missed in a few setters which caused a user error. 


Fixes #32457

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8569084375>
> Commit: `d69f9e53dbbd4e949da768a5a594066c50d0d2f7`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8569084375&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved parameter handling and logic in navigation focus setters for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->