### PR TITLE
chore: remove redundant evalTreeWithChanges calls during plugin page load call

### DIFF
--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -1213,15 +1213,7 @@ function* executePageLoadAction(
           data: payload,
         }),
       );
-      yield put(
-        updateActionData([
-          {
-            entityName: action.name,
-            dataPath: "data",
-            data: payload.body,
-          },
-        ]),
-      );
+
       PerformanceTracker.stopAsyncTracking(
         PerformanceTransactionName.EXECUTE_ACTION,
         {
@@ -1276,15 +1268,7 @@ function* executePageLoadAction(
         undefined,
         pageAction.id,
       );
-      yield put(
-        updateActionData([
-          {
-            entityName: action.name,
-            dataPath: "data",
-            data: payload.body,
-          },
-        ]),
-      );
+
       yield take(ReduxActionTypes.SET_EVALUATED_TREE);
     }
   }


### PR DESCRIPTION
## Description
Removed redundant evalTreeWithChanges calls made during plugin on load execution. We have noticed a 30% reduction in both main thread and web worker scripting.

Fixes #32475  

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8578827174>
> Commit: `0446a81d087ad975f12cd8e3a83c10380b5eb52d`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8578827174&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Streamlined the execution logic for page load actions to improve performance and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->