### PR TITLE
fix: Progress Bar widget animation inconsistency (#11915)

### DIFF
--- a/app/client/src/widgets/ProgressWidget/component/index.tsx
+++ b/app/client/src/widgets/ProgressWidget/component/index.tsx
@@ -149,8 +149,7 @@ const DeterminateLinearProgress = styled.div<{
 
   &:after {
     background: ${({ fillColor }) => fillColor};
-    ${({ value }) => value !== undefined && value >= 0 && `width: ${value}%;`}
-    ${({ value }) => value !== undefined && value < 0 && `width: 0;`}
+    ${({ value }) => value !== undefined && `width: ${Math.max(0, value)}%;`}
     transition: width 0.4s ease;
     position: absolute;
     content: "";

--- a/app/client/src/widgets/ProgressWidget/component/index.tsx
+++ b/app/client/src/widgets/ProgressWidget/component/index.tsx
@@ -149,7 +149,8 @@ const DeterminateLinearProgress = styled.div<{
 
   &:after {
     background: ${({ fillColor }) => fillColor};
-    ${({ value }) => value && `width: ${value}%`};
+    ${({ value }) => value !== undefined && value >= 0 && `width: ${value}%;`}
+    ${({ value }) => value !== undefined && value < 0 && `width: 0;`}
     transition: width 0.4s ease;
     position: absolute;
     content: "";


### PR DESCRIPTION
## Description
- Fixed the issue where the animation of the progress bar wouldn't work if the value was going from zero or going to zero.
- Made the animation consistent even when the introduced value is less than zero.

Fixes #11915

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the `ProgressWidget` to correctly handle negative progress values by ensuring the progress bar width is never negative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->