### PR TITLE
fix: safari user select

### DIFF
--- a/app/client/src/layoutSystems/anvil/viewer/canvas/styles.module.css
+++ b/app/client/src/layoutSystems/anvil/viewer/canvas/styles.module.css
@@ -3,5 +3,4 @@
   width: 100%;
   height: 100%;
   pointer-events: all;
-  user-select: none;
 }

--- a/app/client/src/pages/Editor/WidgetsEditor/components/WidgetEditorContentWrapper.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/components/WidgetEditorContentWrapper.tsx
@@ -1,6 +1,9 @@
 import React, { type ReactNode, useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { getIsAutoLayout } from "selectors/editorSelectors";
+import {
+  combinedPreviewModeSelector,
+  getIsAutoLayout,
+} from "selectors/editorSelectors";
 import { setCanvasSelectionFromEditor } from "actions/canvasSelectionActions";
 import { useAllowEditorDragToSelect } from "utils/hooks/useAllowEditorDragToSelect";
 import { useAutoHeightUIState } from "utils/hooks/autoHeightUIHooks";
@@ -10,6 +13,7 @@ export const WidgetEditorContentWrapper = (props: { children: ReactNode }) => {
   const allowDragToSelect = useAllowEditorDragToSelect();
   const { isAutoHeightWithLimitsChanging } = useAutoHeightUIState();
   const dispatch = useDispatch();
+  const isCombinedPreviewMode = useSelector(combinedPreviewModeSelector);
 
   const handleWrapperClick = useCallback(
     (e) => {
@@ -62,7 +66,7 @@ export const WidgetEditorContentWrapper = (props: { children: ReactNode }) => {
     <div
       className="relative flex flex-row h-full w-full overflow-hidden"
       data-testid="t--widgets-editor"
-      draggable
+      draggable={!isCombinedPreviewMode}
       id="widgets-editor"
       onClick={handleWrapperClick}
       onDragStart={onDragStart}

--- a/app/client/src/pages/Editor/commons/EditorWrapperContainer.tsx
+++ b/app/client/src/pages/Editor/commons/EditorWrapperContainer.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+import classNames from "classnames";
+import { useSelector } from "react-redux";
+import { combinedPreviewModeSelector } from "../../../selectors/editorSelectors";
 
 interface EditorWrapperContainerProps {
   children: React.ReactNode;
@@ -15,8 +18,17 @@ const Wrapper = styled.div`
 `;
 
 function EditorWrapperContainer({ children }: EditorWrapperContainerProps) {
+  const isCombinedPreviewMode = useSelector(combinedPreviewModeSelector);
+
   return (
-    <Wrapper className="relative w-full overflow-x-hidden">{children}</Wrapper>
+    <Wrapper
+      className={classNames({
+        [`relative w-full overflow-x-hidden`]: true,
+        "select-none": !isCombinedPreviewMode,
+      })}
+    >
+      {children}
+    </Wrapper>
   );
 }
 


### PR DESCRIPTION
## Description
Disable user selection for main area 
![Снимок экрана 2024-04-08 в 11 19 00](https://github.com/appsmithorg/appsmith/assets/11555074/314556aa-3712-41da-87e9-83e18dd1cdae)


## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8596821731>
> Commit: `bbfb2f4c48a398f22aef2ee0b47465b06e51bb92`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8596821731&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->




