### PR TITLE
fix: label for data type in s3 create file action

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
@@ -153,7 +153,7 @@ describe(
           response.body.data.pluginErrorDetails.appsmithErrorMessage,
         ).to.contains("File content is not base64 encoded.");
       });
-      dataSources.ValidateNSelectDropdown("File data type", "Base64", "Text");
+      dataSources.ValidateNSelectDropdown("File data type", "Base64", "Text / Binary");
 
       dataSources.RunQuery({ toValidateResponse: false });
       cy.wait("@postExecute").then(({ response }) => {
@@ -417,7 +417,7 @@ describe(
         fileName = "S3Crud_" + uid;
 
         cy.typeValueNValidate(fileName, formControls.s3FilePath);
-        dataSources.ValidateNSelectDropdown("File data type", "Base64", "Text");
+        dataSources.ValidateNSelectDropdown("File data type", "Base64", "Text / Binary");
         cy.typeValueNValidate(
           '{"data": "Hi, this is Automation script adding file for S3 CRUD New Page validation!"}',
           formControls.rawBody,

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
@@ -153,7 +153,11 @@ describe(
           response.body.data.pluginErrorDetails.appsmithErrorMessage,
         ).to.contains("File content is not base64 encoded.");
       });
-      dataSources.ValidateNSelectDropdown("File data type", "Base64", "Text / Binary");
+      dataSources.ValidateNSelectDropdown(
+        "File data type",
+        "Base64",
+        "Text / Binary",
+      );
 
       dataSources.RunQuery({ toValidateResponse: false });
       cy.wait("@postExecute").then(({ response }) => {
@@ -417,7 +421,11 @@ describe(
         fileName = "S3Crud_" + uid;
 
         cy.typeValueNValidate(fileName, formControls.s3FilePath);
-        dataSources.ValidateNSelectDropdown("File data type", "Base64", "Text / Binary");
+        dataSources.ValidateNSelectDropdown(
+          "File data type",
+          "Base64",
+          "Text / Binary",
+        );
         cy.typeValueNValidate(
           '{"data": "Hi, this is Automation script adding file for S3 CRUD New Page validation!"}',
           formControls.rawBody,

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/create.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/create.json
@@ -41,7 +41,7 @@
               "value": "YES"
             },
             {
-              "label": "Text",
+              "label": "Text / Binary",
               "value": "NO"
             }
           ]


### PR DESCRIPTION
## Description
Updated the label for file data type for s3 `create a new file` command to `Text / Binary` from `Text`. 
<img width="340" alt="Screenshot 2024-04-08 at 1 22 42 PM" src="https://github.com/appsmithorg/appsmith/assets/7565635/8c7f166d-9ace-458a-ad84-22fc2a9aa177">

Fixes #24804 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8598594220>
> Commit: `56103c283527960d19035ed9ad1c256c36a03d69`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8598594220&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->





