### PR TITLE
fix: updated help text and client tests

### DIFF
--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -7004,8 +7004,7 @@ export const defaultAppState = {
                     isRequired: true,
                     label: "Message SID",
                     placeholderText: "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                    subtitle:
-                      "Specify the SID of the messaging Service used with the message.",
+                    subtitle: "Specify the SID of the message.",
                     tooltipText:
                       "The Twilio-provided string that uniquely identifies the message resource to fetch.",
                   },
@@ -7097,8 +7096,7 @@ export const defaultAppState = {
                     isRequired: true,
                     tooltipText:
                       "The Twilio-provided string that uniquely identifies the message resource to fetch.",
-                    subtitle:
-                      "Specify the SID of the messaging Service used with the message.",
+                    subtitle: "Specify the SID of the message.",
                     label: "Message SID",
                     placeholderText: "SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
                     configProperty: "actionConfiguration.formData.MESSAGE_SID",
@@ -7133,8 +7131,7 @@ export const defaultAppState = {
                     isRequired: true,
                     label: "Message SID",
                     placeholderText: "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                    subtitle:
-                      "Specify the SID of the messaging Service used with the message.",
+                    subtitle: "Specify the SID of the message.",
                     tooltipText:
                       "The Twilio-provided string that uniquely identifies the message resource to delete.",
                   },

--- a/app/client/test/factories/MockPluginsState.ts
+++ b/app/client/test/factories/MockPluginsState.ts
@@ -4112,8 +4112,7 @@ export default {
                 isRequired: true,
                 label: "Message SID",
                 placeholderText: "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                subtitle:
-                  "Specify the SID of the messaging Service used with the message.",
+                subtitle: "Specify the SID of the message.",
                 tooltipText:
                   "The Twilio-provided string that uniquely identifies the message resource to fetch.",
               },
@@ -4205,8 +4204,7 @@ export default {
                 isRequired: true,
                 tooltipText:
                   "The Twilio-provided string that uniquely identifies the message resource to fetch.",
-                subtitle:
-                  "Specify the SID of the messaging Service used with the message.",
+                subtitle: "Specify the SID of the message.",
                 label: "Message SID",
                 placeholderText: "SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
                 configProperty: "actionConfiguration.formData.MESSAGE_SID",
@@ -4241,8 +4239,7 @@ export default {
                 isRequired: true,
                 label: "Message SID",
                 placeholderText: "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                subtitle:
-                  "Specify the SID of the messaging Service used with the message.",
+                subtitle: "Specify the SID of the message.",
                 tooltipText:
                   "The Twilio-provided string that uniquely identifies the message resource to delete.",
               },


### PR DESCRIPTION
## Description
> This PR updates the help text for twilio message SID for client side tests.
> This fix also needs a cloud services database updation as the data on the UI is received from cs.

Fixes #25056 

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8613830151>
> Commit: `6f8450c97e501dbfecfd328079bf21b911234c13`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8613830151&attempt=2" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->


