### PR TITLE
chore: Remove stack trace in logs for action timeouts

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -751,12 +751,16 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
     protected Function<? super Throwable, ? extends Throwable> executionExceptionMapper(
             ActionDTO actionDTO, Integer timeoutDuration) {
         return error -> {
-            if (error instanceof TimeoutException e) {
+            if (error instanceof TimeoutException) {
                 return new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_QUERY_TIMEOUT_ERROR, actionDTO.getName(), timeoutDuration);
             } else if (error instanceof StaleConnectionException e) {
                 return new AppsmithPluginException(AppsmithPluginError.STALE_CONNECTION_ERROR, e.getMessage());
             } else {
+                log.debug(
+                        "{}: In the action execution error mode.",
+                        Thread.currentThread().getName(),
+                        error);
                 return error;
             }
         };
@@ -764,10 +768,6 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
 
     protected Function<? super Throwable, Mono<ActionExecutionResult>> executionExceptionHandler(ActionDTO actionDTO) {
         return error -> {
-            log.debug(
-                    "{}: In the action execution error mode.",
-                    Thread.currentThread().getName(),
-                    error);
             ActionExecutionResult result = new ActionExecutionResult();
             result.setErrorInfo(error);
             result.setIsExecutionSuccess(false);


### PR DESCRIPTION
Remove stack trace for action timeout logs, since they don't add any value. Example log here:

![shot-2024-04-08-13-37-10](https://github.com/appsmithorg/appsmith/assets/120119/cbe2b43c-bffe-4adb-a947-dc0b7934c740)
