### PR TITLE
fix: commands title changed to command for each datasource query editor forms

### DIFF
--- a/app/client/cypress/e2e/Regression/Apps/MongoDBShoppingCart_spec.ts
+++ b/app/client/cypress/e2e/Regression/Apps/MongoDBShoppingCart_spec.ts
@@ -32,7 +32,7 @@ describe("Shopping cart App", { tags: ["@tag.Datasource"] }, function () {
     // EditProducts query to update the cart
     dataSources.CreateQueryFromOverlay(datasourceName, "", "EditProducts");
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Find document(s)",
       "Update document(s)",
     );
@@ -62,7 +62,7 @@ describe("Shopping cart App", { tags: ["@tag.Datasource"] }, function () {
     // AddProducts query to add to cart
     dataSources.CreateQueryFromOverlay(datasourceName, "", "AddProduct");
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Find document(s)",
       "Insert document(s)",
     );
@@ -89,7 +89,7 @@ describe("Shopping cart App", { tags: ["@tag.Datasource"] }, function () {
     // Delete product
     dataSources.CreateQueryFromOverlay(datasourceName, "", "DeleteProduct");
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Find document(s)",
       "Delete document(s)",
     );

--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
@@ -268,7 +268,7 @@ describe("Autocomplete tests", { tags: ["@tag.JS"] }, () => {
     dataSources.CreateQueryAfterDSSaved();
 
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Find document(s)",
       "Insert document(s)",
     );

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug25982_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug25982_Spec.ts
@@ -9,7 +9,7 @@ describe("Fix UQI query switching", { tags: ["@tag.Datasource"] }, function () {
     dataSources.CreateDataSource("Mongo", false, false);
     dataSources.CreateQueryAfterDSSaved("", "MongoQuery");
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Find document(s)",
       "Insert document(s)",
     );
@@ -17,14 +17,14 @@ describe("Fix UQI query switching", { tags: ["@tag.Datasource"] }, function () {
     dataSources.CreateDataSource("S3", false, false);
     dataSources.CreateQueryAfterDSSaved("", "S3Query");
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "List files in bucket",
       "Create a new file",
     );
     EditorNavigation.SelectEntityByName("MongoQuery", EntityType.Query);
-    dataSources.ValidateNSelectDropdown("Commands", "Insert document(s)");
+    dataSources.ValidateNSelectDropdown("Command", "Insert document(s)");
 
     EditorNavigation.SelectEntityByName("S3Query", EntityType.Query);
-    dataSources.ValidateNSelectDropdown("Commands", "Create a new file");
+    dataSources.ValidateNSelectDropdown("Command", "Create a new file");
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bugs26410_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bugs26410_spec.ts
@@ -12,19 +12,19 @@ describe(
       dataSources.CreateDataSource("Mongo", false, false);
       dataSources.CreateQueryAfterDSSaved("", "MongoQuery");
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "Find document(s)",
         "Insert document(s)",
       );
       dataSources.NavigateToDSCreateNew();
       dataSources.CreateDataSource("Twilio", false, false);
       dataSources.CreateQueryAfterDSSaved("", "TwilioQuery");
-      dataSources.ValidateNSelectDropdown("Commands", "", "Schedule message");
+      dataSources.ValidateNSelectDropdown("Command", "", "Schedule message");
       EditorNavigation.SelectEntityByName("MongoQuery", EntityType.Query);
-      dataSources.ValidateNSelectDropdown("Commands", "Insert document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Insert document(s)");
 
       EditorNavigation.SelectEntityByName("TwilioQuery", EntityType.Query);
-      dataSources.ValidateNSelectDropdown("Commands", "Schedule message");
+      dataSources.ValidateNSelectDropdown("Command", "Schedule message");
     });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Fork/ForkAppWithMultipleDS_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Fork/ForkAppWithMultipleDS_Spec.ts
@@ -31,7 +31,7 @@ describe(
         // Create S3 DS
         dataSources.CreateDataSource("S3");
         dataSources.CreateQueryAfterDSSaved();
-        dataSources.ValidateNSelectDropdown("Commands", "List files in bucket");
+        dataSources.ValidateNSelectDropdown("Command", "List files in bucket");
         agHelper.EnterValue("assets-test.appsmith.com", {
           propFieldName: "",
           directInput: false,

--- a/app/client/cypress/e2e/Regression/ClientSide/FormNativeToRawTests/MongoConversion_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/FormNativeToRawTests/MongoConversion_spec.ts
@@ -33,22 +33,14 @@ describe("Mongo Form to Native conversion works", () => {
       formControls.mongoFindProjection,
     );
 
-    _.dataSources.ValidateNSelectDropdown(
-      "Commands",
-      "Find document(s)",
-      "Raw",
-    );
+    _.dataSources.ValidateNSelectDropdown("Command", "Find document(s)", "Raw");
 
     _.agHelper.VerifyCodeInputValue(formControls.rawBody, expectedOutput);
 
     // then we test to check if the conversion is only done once.
     // and then we ensure that upon switching between another command and Raw, the Template menu does not show up.
 
-    _.dataSources.ValidateNSelectDropdown(
-      "Commands",
-      "Raw",
-      "Find document(s)",
-    );
+    _.dataSources.ValidateNSelectDropdown("Command", "Raw", "Find document(s)");
 
     cy.wait(500);
 
@@ -58,11 +50,7 @@ describe("Mongo Form to Native conversion works", () => {
       inputFieldName: "Collection",
     });
 
-    _.dataSources.ValidateNSelectDropdown(
-      "Commands",
-      "Find document(s)",
-      "Raw",
-    );
+    _.dataSources.ValidateNSelectDropdown("Command", "Find document(s)", "Raw");
 
     // make sure template menu no longer reappears
     _.agHelper.AssertElementAbsence(_.dataSources._templateMenu);

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Firestore_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Firestore_Basic_Spec.ts
@@ -76,7 +76,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
       //Create
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "List Documents",
         "Create document",
       );
@@ -100,7 +100,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
       //Find the document id of the newly inserted record + Verify List all records
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "Create document",
         "List Documents",
       );
@@ -151,7 +151,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
         //Update document
         dataSources.ValidateNSelectDropdown(
-          "Commands",
+          "Command",
           "List Documents",
           "Update document",
         );
@@ -177,7 +177,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
         //Validate the update happened fine
         dataSources.ValidateNSelectDropdown(
-          "Commands",
+          "Command",
           "Update document",
           "List Documents",
         );
@@ -206,7 +206,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
         //Get Document
         dataSources.ValidateNSelectDropdown(
-          "Commands",
+          "Command",
           "List Documents",
           "Get Document",
         );
@@ -228,7 +228,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
   it("3. Validate Widget binding & Deploy app", () => {
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Get Document",
       "List Documents",
     );
@@ -249,7 +249,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
   it("4. Validate Upsert [Update & Insert]/Delete documents", () => {
     //Validating Upsert
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "List Documents",
       "Upsert Document",
     );
@@ -273,7 +273,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
     dataSources.RunQuery(); //Upsert the document
 
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Upsert Document",
       "List Documents",
     );
@@ -309,7 +309,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
     //Validating Delete
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "List Documents",
       "Delete document",
     );
@@ -323,7 +323,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
 
     //Validate Deletion
     dataSources.ValidateNSelectDropdown(
-      "Commands",
+      "Command",
       "Delete document",
       "List Documents",
     );

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo1_spec.ts
@@ -290,7 +290,7 @@ describe(
       assertHelper.AssertNetworkStatus("@trigger");
 
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "Find document(s)",
         "Insert document(s)",
       );
@@ -329,7 +329,7 @@ describe(
         "AuthorNAwards",
         "Find",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Find document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Find document(s)");
       dataSources.RunQueryNVerifyResponseViews(1, false);
       agHelper.ActionContextMenuWithInPane({
         action: "Delete",
@@ -343,7 +343,7 @@ describe(
         "AuthorNAwards",
         "Find by id",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Find document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Find document(s)");
       agHelper.EnterValue(`{"_id": ObjectId("51df07b094c6acd67e492f41")}`, {
         propFieldName: "",
         directInput: false,
@@ -415,7 +415,7 @@ describe(
         "AuthorNAwards",
         "Insert",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Insert document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Insert document(s)");
       agHelper.EnterValue(insertauthorNAwards, {
         propFieldName: "",
         directInput: false,
@@ -441,7 +441,7 @@ describe(
         "AuthorNAwards",
         "Update",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Update document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Update document(s)");
       agHelper.EnterValue(`{"_id": 3}`, {
         propFieldName: "",
         directInput: false,
@@ -474,7 +474,7 @@ describe(
         "AuthorNAwards",
         "Update",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Update document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Update document(s)");
       agHelper.EnterValue(
         `{
       "name.first": "John",
@@ -517,7 +517,7 @@ describe(
         "AuthorNAwards",
         "Update",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Update document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Update document(s)");
       agHelper.EnterValue(`{"_id": 4}`, {
         propFieldName: "",
         directInput: false,
@@ -555,7 +555,7 @@ describe(
         "AuthorNAwards",
         "Delete",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Delete document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Delete document(s)");
       agHelper.EnterValue(`{ "_id": ObjectId("51df07b094c6acd67e492f43") }`, {
         propFieldName: "",
         directInput: false,
@@ -582,7 +582,7 @@ describe(
         "AuthorNAwards",
         "Delete",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Delete document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Delete document(s)");
       agHelper.EnterValue(`{ "_id": ObjectId("51df07b094c6acd67e492f41") }`, {
         propFieldName: "",
         directInput: false,
@@ -611,7 +611,7 @@ describe(
         "AuthorNAwards",
         "Delete",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Delete document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Delete document(s)");
       agHelper.EnterValue(`{ "awards.award": "Rosing Prize" }`, {
         propFieldName: "",
         directInput: false,
@@ -644,7 +644,7 @@ describe(
         "AuthorNAwards",
         "Count",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Count");
+      dataSources.ValidateNSelectDropdown("Command", "Count");
       dataSources.RunQuery();
       cy.get("@postExecute").then((resObj: any) => {
         expect(Number(JSON.stringify(resObj.response.body.data.body.n))).to.eq(
@@ -665,7 +665,7 @@ describe(
         "AuthorNAwards",
         "Distinct",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Distinct");
+      dataSources.ValidateNSelectDropdown("Command", "Distinct");
       agHelper.EnterValue(
         `{ "awards.award": "National Medal of Technology" }`,
         {
@@ -698,7 +698,7 @@ describe(
         "AuthorNAwards",
         "Aggregate",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Aggregate");
+      dataSources.ValidateNSelectDropdown("Command", "Aggregate");
       dataSources.RunQueryNVerifyResponseViews(7, false);
       agHelper.ActionContextMenuWithInPane({
         action: "Delete",
@@ -739,11 +739,7 @@ describe(
       const dropCollection = `{ "drop": "AuthorNAwards" }`;
       dataSources.CreateQueryForDS(dsName);
 
-      dataSources.ValidateNSelectDropdown(
-        "Commands",
-        "Find document(s)",
-        "Raw",
-      );
+      dataSources.ValidateNSelectDropdown("Command", "Find document(s)", "Raw");
       agHelper.RenameWithInPane("DropAuthorNAwards"); //Due to template appearing after renaming
       agHelper.GetNClick(dataSources._templateMenu);
       dataSources.EnterQuery(dropCollection);
@@ -762,11 +758,7 @@ describe(
     it("18. Verify application does not break when user runs the query with wrong collection name", function () {
       const dropCollection = `{ "drop": "AuthorNAwards" }`;
       dataSources.CreateQueryForDS(dsName);
-      dataSources.ValidateNSelectDropdown(
-        "Commands",
-        "Find document(s)",
-        "Raw",
-      );
+      dataSources.ValidateNSelectDropdown("Command", "Find document(s)", "Raw");
       agHelper.GetNClick(dataSources._templateMenu);
       agHelper.RenameWithInPane("DropAuthorNAwards");
       dataSources.EnterQuery(dropCollection);
@@ -829,7 +821,7 @@ describe(
       assertHelper.AssertNetworkStatus("@trigger");
 
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "Find document(s)",
         "Insert document(s)",
       );
@@ -867,7 +859,7 @@ describe(
         "BirthNDeath",
         "Find",
       );
-      dataSources.ValidateNSelectDropdown("Commands", "Find document(s)");
+      dataSources.ValidateNSelectDropdown("Command", "Find document(s)");
       dataSources.RunQueryNVerifyResponseViews(4, false);
       agHelper.ActionContextMenuWithInPane({
         action: "Delete",
@@ -877,11 +869,7 @@ describe(
       const dropCollection = `{ "drop": "BirthNDeath" }`;
 
       dataSources.CreateQueryForDS(dsName);
-      dataSources.ValidateNSelectDropdown(
-        "Commands",
-        "Find document(s)",
-        "Raw",
-      );
+      dataSources.ValidateNSelectDropdown("Command", "Find document(s)", "Raw");
       agHelper.GetNClick(dataSources._templateMenu);
       agHelper.RenameWithInPane("DropBirthNDeath");
       dataSources.EnterQuery(dropCollection);

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo_Spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo_Spec.js
@@ -488,7 +488,7 @@ describe(
       });
 
       // //Update document - All matching documents
-      // cy.validateNSelectDropdown("Commands", "Find document(s)", "Update document(s)");
+      // cy.validateNSelectDropdown("Command", "Find document(s)", "Update document(s)");
       // cy.typeValueNValidate("{_id: {$gte:2}}", "Query");
       // cy.typeValueNValidate("{$set:{ 'Frõ': 'InActive'}}", "Update");
       // cy.validateNSelectDropdown("Limit", "Single document", "All matching documents");
@@ -498,7 +498,7 @@ describe(
       // });
 
       // //Verify Updation Successful:
-      // cy.validateNSelectDropdown("Commands", "Update document(s)", "Find document(s)");
+      // cy.validateNSelectDropdown("Command", "Update document(s)", "Find document(s)");
       // cy.runQuery()
       // cy.wait("@postExecute").then(({ response }) => {
       //   expect(response.body.data.body[0].Frõ).to.eq('InActive');

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
@@ -58,7 +58,7 @@ describe(
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.INPUT_V2);
       propPane.UpdatePropertyFieldValue("Default value", "AutoTest");
       dataSources.CreateQueryForDS(datasourceName);
-      dataSources.ValidateNSelectDropdown("Commands", "List files in bucket");
+      dataSources.ValidateNSelectDropdown("Command", "List files in bucket");
       dataSources.RunQuery({ toValidateResponse: false });
       cy.wait("@postExecute").should(({ response }) => {
         expect(response.body.data.isExecutionSuccess).to.eq(false);
@@ -98,7 +98,7 @@ describe(
       dataSources.CreateQueryForDS(datasourceName);
       cy.setQueryTimeout(30000);
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "List files in bucket",
         "Create a new file",
       );
@@ -183,7 +183,7 @@ describe(
 
     it("3. Validate List Files in bucket command for new file, Verify possible error msgs, run & delete the query", () => {
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "Create a new file",
         "List files in bucket",
       );
@@ -256,7 +256,7 @@ describe(
 
       //cy.setQueryTimeout(30000);
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "List files in bucket",
         "Read file",
       );
@@ -344,7 +344,7 @@ describe(
       dataSources.CreateQueryForDS(datasourceName);
       cy.setQueryTimeout(30000);
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "List files in bucket",
         "Delete file",
       );
@@ -390,7 +390,7 @@ describe(
 
       //Validating List Files in bucket command after new file is deleted
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "Delete file",
         "List files in bucket",
       );
@@ -408,7 +408,7 @@ describe(
       //Creating new file in bucket
       dataSources.CreateQueryForDS(datasourceName);
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "List files in bucket",
         "Create a new file",
       );

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_2_spec.ts
@@ -425,7 +425,7 @@ describe(
       dataSources.CreateQueryForDS(datasourceName);
 
       agHelper.GetObjectName().then(($queryName) => {
-        dataSources.ValidateNSelectDropdown("Commands", "List files in bucket");
+        dataSources.ValidateNSelectDropdown("Command", "List files in bucket");
         agHelper.UpdateCodeInput(formControls.s3BucketName, bucketName);
 
         dataSources.RunQuery();
@@ -451,7 +451,7 @@ describe(
       dataSources.CreateQueryForDS(datasourceName);
       agHelper.GetObjectName().then(($queryName) => {
         EditorNavigation.SelectEntityByName($queryName, EntityType.Query);
-        dataSources.ValidateNSelectDropdown("Commands", "List files in bucket");
+        dataSources.ValidateNSelectDropdown("Command", "List files in bucket");
         agHelper.UpdateCodeInput(formControls.s3BucketName, bucketName);
         dataSources.RunQuery();
         agHelper.Sleep(); //for CI runs

--- a/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
@@ -36,7 +36,7 @@ describe(
 
       //List all records
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "Please select an option",
         "List records",
       );
@@ -292,7 +292,7 @@ describe(
 
       //Create
       dataSources.ValidateNSelectDropdown(
-        "Commands",
+        "Command",
         "List records",
         "Create records",
       );
@@ -313,7 +313,7 @@ describe(
         //Retrieve a record
         insertedRecordId = jsonSpecies.records[0].id;
         dataSources.ValidateNSelectDropdown(
-          "Commands",
+          "Command",
           "Create records",
           "Retrieve a record",
         );
@@ -340,7 +340,7 @@ describe(
 
         //Update Records
         dataSources.ValidateNSelectDropdown(
-          "Commands",
+          "Command",
           "Retrieve a record",
           "Update records",
         );
@@ -377,7 +377,7 @@ describe(
         //Delete A record
         //insertedRecordId = jsonSpecies.id;
         dataSources.ValidateNSelectDropdown(
-          "Commands",
+          "Command",
           "Update records",
           "Delete a record",
         );

--- a/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
@@ -73,7 +73,7 @@ describe(
         dataSources.CreateQueryAfterDSSaved();
 
         assertHelper.AssertNetworkStatus("@trigger");
-        dataSources.ValidateNSelectDropdown("Commands", "Find document(s)");
+        dataSources.ValidateNSelectDropdown("Command", "Find document(s)");
         agHelper.Sleep(2000); //for movies collection to load & populate in dropdown
         dataSources.ValidateNSelectDropdown("Collection", "movies");
         dataSources.RunQueryNVerifyResponseViews(1, false);
@@ -85,7 +85,7 @@ describe(
           );
 
         entityExplorer.CreateNewDsQuery(mockDBName);
-        dataSources.ValidateNSelectDropdown("Commands", "Find document(s)");
+        dataSources.ValidateNSelectDropdown("Command", "Find document(s)");
         dataSources.ValidateNSelectDropdown("Collection", "movies");
         dataSources.RunQueryNVerifyResponseViews(1, false);
         AppSidebar.navigate(AppSidebarButton.Data);

--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -3361,7 +3361,7 @@ export const defaultAppState = {
           actionUiConfig: {
             editor: [
               {
-                label: "Commands",
+                label: "Command",
                 description: "Select the method to run",
                 configProperty: "actionConfiguration.formData.command",
                 controlType: "DROP_DOWN",
@@ -6803,7 +6803,7 @@ export const defaultAppState = {
           actionUiConfig: {
             editor: [
               {
-                label: "Commands",
+                label: "Command",
                 description: "Select the method to run",
                 configProperty: "actionConfiguration.formData.command",
                 controlType: "DROP_DOWN",
@@ -7217,7 +7217,7 @@ export const defaultAppState = {
           actionUiConfig: {
             editor: [
               {
-                label: "Commands",
+                label: "Command",
                 description: "Select the method to run",
                 configProperty: "actionConfiguration.formData.command",
                 controlType: "DROP_DOWN",
@@ -9186,7 +9186,7 @@ export const defaultAppState = {
             identifier: "SELECTOR",
             children: [
               {
-                label: "Commands",
+                label: "Command",
                 description:
                   "Choose method you would like to use to query the database",
                 configProperty: "actionConfiguration.formData.command.data",

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
@@ -879,7 +879,7 @@
                 "value": "RAW"
               }
             ],
-            "label": "Commands",
+            "label": "Command",
             "description": "Choose method you would like to use to query the database",
             "configProperty": "actionConfiguration.formData.command",
             "controlType": "DROP_DOWN",
@@ -2208,7 +2208,7 @@
                 "value": "DELETE_FILE"
               }
             ],
-            "label": "Commands",
+            "label": "Command",
             "description": "Choose method you would like to use",
             "configProperty": "actionConfiguration.formData.command",
             "controlType": "DROP_DOWN",

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
@@ -878,7 +878,7 @@
                 "value": "RAW"
               }
             ],
-            "label": "Commands",
+            "label": "Command",
             "description": "Choose method you would like to use to query the database",
             "configProperty": "actionConfiguration.formData.command",
             "controlType": "DROP_DOWN",
@@ -2207,7 +2207,7 @@
                 "value": "DELETE_FILE"
               }
             ],
-            "label": "Commands",
+            "label": "Command",
             "description": "Choose method you would like to use",
             "configProperty": "actionConfiguration.formData.command",
             "controlType": "DROP_DOWN",

--- a/app/client/test/factories/MockPluginsState.ts
+++ b/app/client/test/factories/MockPluginsState.ts
@@ -537,7 +537,7 @@ export default {
       actionUiConfig: {
         editor: [
           {
-            label: "Commands",
+            label: "Command",
             description: "Select the method to run",
             configProperty: "actionConfiguration.formData.command",
             controlType: "DROP_DOWN",
@@ -3912,7 +3912,7 @@ export default {
       actionUiConfig: {
         editor: [
           {
-            label: "Commands",
+            label: "Command",
             description: "Select the method to run",
             configProperty: "actionConfiguration.formData.command",
             controlType: "DROP_DOWN",
@@ -4326,7 +4326,7 @@ export default {
       actionUiConfig: {
         editor: [
           {
-            label: "Commands",
+            label: "Command",
             description: "Select the method to run",
             configProperty: "actionConfiguration.formData.command",
             controlType: "DROP_DOWN",

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose the method you would like to use",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose the method you would like to use",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose the method you would like to use",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose method you would like to use",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose the method you would like to use",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose method you would like to use to query the database",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose the method you would like to use",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-plugins/smtpPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/smtpPlugin/src/main/resources/editor/root.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose method you would like to use to send an email",
           "configProperty": "actionConfiguration.formData.command",
           "controlType": "DROP_DOWN",

--- a/app/server/appsmith-server/src/test/resources/test_assets/PluginServiceTest/mock-editor.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/PluginServiceTest/mock-editor.json
@@ -5,7 +5,7 @@
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Commands",
+          "label": "Command",
           "description": "Choose the method you would like to use",
           "configProperty": "actionConfiguration.formData.command.data",
           "controlType": "DROP_DOWN",


### PR DESCRIPTION
## Description
Changed the title of one of the query form field from `Commands` to `Command` for s3, anthropic, lambda, firestore, google sheets, mongo, openai, smtp plugins.

Fixes #25055 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8615528041>
> Commit: `83aa3c0abd1820296d2796220aa215394c154912`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8615528041&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->

