### PR TITLE
chore: Added NOOP behaviour for observation helper

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ObservationHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ObservationHelperImpl.java
@@ -5,19 +5,24 @@ import com.appsmith.server.configurations.CommonConfig;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 import static com.appsmith.external.constants.MDCConstants.SPAN_ID;
 import static com.appsmith.external.constants.MDCConstants.TRACE_ID;
 
-@RequiredArgsConstructor
 @Component
 public class ObservationHelperImpl implements ObservationHelper {
 
     private final Tracer tracer;
     private final CommonConfig commonConfig;
+
+    public ObservationHelperImpl(Optional<Tracer> tracer, CommonConfig commonConfig) {
+        this.commonConfig = commonConfig;
+        this.tracer = tracer.orElse(Tracer.NOOP);
+    }
 
     @Override
     public Span createSpan(String name) {


### PR DESCRIPTION
## Description
Make sure that observation helper bean can be created even when tracing is turned off.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->