### PR TITLE
ci: Remove unused code from Cypress setup

### DIFF
--- a/app/client/cypress/setup-test-ci.sh
+++ b/app/client/cypress/setup-test-ci.sh
@@ -3,21 +3,8 @@
 # This script is responsible for setting up the local Nginx server for running E2E Cypress tests
 # on our CI/CD system. Currently the script is geared towards Github Actions
 
-# Serve the react bundle on a specific port. Nginx will proxy to this port
-echo "Starting the setup the test framework"
+echo "Starting the setup for test framework"
 sudo echo "127.0.0.1	localhost" | sudo tee -a /etc/hosts
-serve -s build -p 3000 &
-
-# Substitute all the env variables in nginx
-vars_to_substitute=$(printf '\$%s,' $(env | grep -o "^APPSMITH_[A-Z0-9_]\+" | xargs))
-cat ./docker/templates/nginx-app.conf.template | sed -e "s|__APPSMITH_CLIENT_PROXY_PASS__|http://localhost:3000|g" | sed -e "s|__APPSMITH_SERVER_PROXY_PASS__|http://localhost:8080|g" | envsubst ${vars_to_substitute} | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' > ./docker/nginx.conf
-cat ./docker/templates/nginx-root.conf.template | envsubst ${vars_to_substitute} | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' > ./docker/nginx-root.conf
-
-# Create the SSL files for Nginx. Required for service workers to work properly.
-touch ./docker/localhost ./docker/localhost.pem
-echo "$APPSMITH_SSL_CERTIFICATE" > ./docker/localhost.pem
-echo "$APPSMITH_SSL_KEY" > ./docker/localhost.pem
-
 
 sleep 10
 


### PR DESCRIPTION
The `serve` command isn't available anymore and has been throwing an error for some time now. The other NGINX configuration related commands also aren't impactful.

/ok-to-test tags="@tag.Sanity"<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]  
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8627538008>
> Commit: `f460fd31da02c2e390d59cf70410f950db343fa1`
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8627538008&attempt=1" target="_blank">Click here!</a>
> All cypress tests have passed 🎉🎉🎉

<!-- end of auto-generated comment: Cypress test results  -->

