### PR TITLE
ci: [Cypress Test Results] Remove code wrappers from commit refs

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -137,7 +137,7 @@ jobs:
               > [!IMPORTANT]
               > 🟣 🟣 🟣 Your tests are running.
               > Tests running at: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
-              > Commit: `${{ github.event.pull_request.head.sha }}`
+              > Commit: ${{ github.event.pull_request.head.sha }}
               > Workflow: `${{ github.workflow }}`
               > Tags: `${{ steps.checkAll.outputs.tags }}`
 

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -178,10 +178,9 @@ jobs:
         with:
           content: |
             <!-- This is an auto-generated comment: Cypress test results  -->
-            > [!CAUTION]
-            > 🔴 🔴 🔴 Some tests have failed.
+            > [!CAUTION]> 🔴 🔴 🔴 Some tests have failed.
             > Workflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
-            > Commit: `${{ github.event.pull_request.head.sha }}`
+            > Commit: ${{ github.event.pull_request.head.sha }}
             > Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
             > The following are new failures, please fix them before merging the PR: <ol>
             ${{env.new_failed_spec_env}} </ol>
@@ -201,7 +200,7 @@ jobs:
             <!-- This is an auto-generated comment: Cypress test results  -->
             > [!WARNING]
             > Workflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
-            > Commit: `${{ github.event.pull_request.head.sha }}`
+            > Commit: ${{ github.event.pull_request.head.sha }}
             > Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}" target="_blank">Click here!</a>
             > It seems like **no tests ran** 😔. We are not able to recognize it, please check workflow <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" target="_blank">here.</a>
 
@@ -220,7 +219,7 @@ jobs:
             > [!TIP]
             > 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
             > Workflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
-            > Commit: `${{ github.event.pull_request.head.sha }}`
+            > Commit: ${{ github.event.pull_request.head.sha }}
             > Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}" target="_blank">Click here!</a>
 
             <!-- end of auto-generated comment: Cypress test results  -->

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -178,7 +178,8 @@ jobs:
         with:
           content: |
             <!-- This is an auto-generated comment: Cypress test results  -->
-            > [!CAUTION]> 🔴 🔴 🔴 Some tests have failed.
+            > [!CAUTION]
+            > 🔴 🔴 🔴 Some tests have failed.
             > Workflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
             > Commit: ${{ github.event.pull_request.head.sha }}
             > Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>


### PR DESCRIPTION
## Description

When Cypress Test Results are published, the content had `code` wrappers around them. Without these wrappers, github will automatically recognise that it is a commit hash and link to it. This will help devs to quickly see the commit which the current test results are associated with.



## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8628611061>
> Commit: b28f9da79f3167da13ffa5de84cbb0d1466a891c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8628611061&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

