### PR TITLE
fix: wider code edit boxes

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/addToCollection.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/addToCollection.json
@@ -23,7 +23,7 @@
     {
       "label": "Timestamp Path",
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
-      "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+      "controlType": "QUERY_DYNAMIC_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/createDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/createDocument.json
@@ -23,7 +23,7 @@
     {
       "label": "Timestamp Path",
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
-      "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+      "controlType": "QUERY_DYNAMIC_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/getCollection.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/getCollection.json
@@ -65,7 +65,7 @@
     {
       "label": "Order By",
       "configProperty": "actionConfiguration.formData.orderBy.data",
-      "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+      "controlType": "QUERY_DYNAMIC_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "isRequired": false,
       "initialValue": "",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/setDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/setDocument.json
@@ -23,7 +23,7 @@
     {
       "label": "Timestamp Path",
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
-      "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+      "controlType": "QUERY_DYNAMIC_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/updateDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/updateDocument.json
@@ -23,7 +23,7 @@
     {
       "label": "Delete Key Path",
       "configProperty": "actionConfiguration.formData.deleteKeyPath.data",
-      "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+      "controlType": "QUERY_DYNAMIC_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "isRequired": true,
       "initialValue": "",
@@ -32,7 +32,7 @@
     {
       "label": "Timestamp Path",
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
-      "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+      "controlType": "QUERY_DYNAMIC_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/count.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/count.json
@@ -39,7 +39,7 @@
         {
           "label": "Query",
           "configProperty": "actionConfiguration.formData.count.query.data",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_TEXT",
           "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{rating : {$gte : 9}}"

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/delete.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/delete.json
@@ -39,7 +39,7 @@
         {
           "label": "Query",
           "configProperty": "actionConfiguration.formData.delete.query.data",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_TEXT",
           "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{rating : {$gte : 9}}"

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/distinct.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/distinct.json
@@ -39,7 +39,7 @@
         {
           "label": "Query",
           "configProperty": "actionConfiguration.formData.distinct.query.data",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_TEXT",
           "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{rating : {$gte : 9}}"

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/update.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/update.json
@@ -39,7 +39,7 @@
         {
           "label": "Query",
           "configProperty": "actionConfiguration.formData.updateMany.query.data",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_TEXT",
           "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{rating : {$gte : 9}}"
@@ -47,7 +47,7 @@
         {
           "label": "Update",
           "configProperty": "actionConfiguration.formData.updateMany.update.data",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_TEXT",
           "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{ $inc: { score: 1 } }"


### PR DESCRIPTION
- **fix: increase width of mongodb code edit fields by switching to QUERY_DYNAMIC_TEXT**
  Follow-up to
  18ef195f13cd2648cb82157e08792d256ff4f2f1 &
  1ecffb8272e45a83443797caf379c733f884eea2
  
  Fixes #15396
  

- **fix: reapply wider widths to firestore edit fields (#15365)**
  The fixes applied in
  1ecffb8272e45a83443797caf379c733f884eea2 (PR #15396)
  were accidentally overwritten by
  2f2cb42e0282551ad0a762bcfc61639cf6c613c5
  
  This restores those widget type changes.
  
  With this, all examples listed here should be resolved:
  https://appsmith.notion.site/The-problem-with-Form-Input-Widths-ba295cd8205b4809b7e8e97d75f3cc07
  