### PR TITLE
chore: Remove `@Document` on non-entity classes

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
@@ -12,7 +12,6 @@ import lombok.experimental.FieldNameConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.data.annotation.Transient;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.http.HttpMethod;
 import reactor.netty.http.HttpProtocol;
 
@@ -28,7 +27,6 @@ import static com.appsmith.external.constants.ActionConstants.DEFAULT_ACTION_EXE
 @ToString
 @Slf4j
 @NoArgsConstructor
-@Document
 @FieldNameConstants
 public class ActionConfiguration implements AppsmithDomain, ExecutableConfiguration {
     private static final int MIN_TIMEOUT_VALUE = 0; // in Milliseconds

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Connection.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Connection.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @Setter
@@ -14,7 +13,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
-@Document
 public class Connection implements AppsmithDomain {
 
     public enum Mode {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
 
@@ -19,7 +18,6 @@ import java.util.List;
 @EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
-@Document
 @FieldNameConstants
 public class DatasourceConfiguration implements AppsmithDomain {
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Endpoint.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Endpoint.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @Setter
@@ -14,7 +13,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
-@Document
 public class Endpoint {
 
     String host;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PEMCertificate.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PEMCertificate.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @Setter
@@ -16,7 +15,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
-@Document
 public class PEMCertificate implements AppsmithDomain {
 
     UploadedFile file;


### PR DESCRIPTION
These few classes have the `@Document` annotation, but aren't mapped to collections in the database, and don't have corresponding `*Repository` interfaces either. They're not database entities, and shouldn't have this annotation.


Sanity passed on both CE and EE.

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8633559103>
> Commit: 52db7bdf8fba1cdd4cbd9141169854a32b32ca42
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8633559103&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

