### PR TITLE
feat: suggest queries query type added in action DTO

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/DatasourceQueryType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/DatasourceQueryType.java
@@ -1,0 +1,6 @@
+package com.appsmith.external.constants;
+
+public enum DatasourceQueryType {
+    FETCH,
+    UNKNOWN,
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
@@ -1,6 +1,7 @@
 package com.appsmith.external.models.ce;
 
 import com.appsmith.external.constants.ActionCreationSourceTypeEnum;
+import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.dtos.DslExecutableDTO;
 import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
 import com.appsmith.external.exceptions.ErrorDTO;
@@ -177,6 +178,10 @@ public class ActionCE_DTO implements Identifiable, Executable {
     @Transient
     @JsonView(Views.Public.class)
     ActionCreationSourceTypeEnum source;
+
+    @Transient
+    @JsonView(Views.Public.class)
+    DatasourceQueryType queryType;
 
     @Override
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -1,5 +1,6 @@
 package com.appsmith.external.plugins;
 
+import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
@@ -374,5 +375,14 @@ public interface PluginExecutor<C> extends ExtensionPoint, CrudTemplateService {
         // Currently this function is overridden only by postgresPlugin class, in future it will be done for all plugins
         // wherever applicable.
         return Mono.just("");
+    }
+
+    /*
+     * This method returns query type, query type is used for
+     * suggesting relevant actions to users when binding data
+     */
+    default Mono<DatasourceQueryType> getQueryType(ActionConfiguration actionConfig) {
+        // For all plugins where implementation is unclear right now, we will be returning its type as UNKNOWN
+        return Mono.just(DatasourceQueryType.UNKNOWN);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.newactions.base;
 
+import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.dtos.ExecutePluginDTO;
 import com.appsmith.external.dtos.RemoteDatasourceDTO;
 import com.appsmith.external.helpers.AppsmithBeanUtils;
@@ -675,6 +676,18 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 });
     }
 
+    private Mono<ActionDTO> setQueryTypeInUnpublishedAction(ActionDTO action) {
+        Mono<Plugin> pluginMono = pluginService.getById(action.getPluginId());
+        Mono<PluginExecutor> pluginExecutorMono = pluginExecutorHelper.getPluginExecutor(pluginMono);
+
+        return pluginExecutorMono.flatMap(pluginExecutor -> pluginExecutor
+                .getQueryType(action.getActionConfiguration())
+                .flatMap(queryType -> {
+                    action.setQueryType((DatasourceQueryType) queryType);
+                    return Mono.just(action);
+                }));
+    }
+
     @Override
     public Mono<ActionDTO> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission permission) {
         return repository
@@ -999,6 +1012,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 .collectList()
                 .flatMapMany(this::addMissingPluginDetailsIntoAllActions)
                 .flatMap(this::setTransientFieldsInUnpublishedAction)
+                .flatMap(this::setQueryTypeInUnpublishedAction)
                 // this generates four different tags, (ApplicationId, FieldId) *(True, False)
                 .tag(
                         "includeJsAction",


### PR DESCRIPTION
## Description
This PR adds query_type to actionDTO, when fetching queries, query type indicates whether it is a fetch query or any other query, this information can be further used to suggest queries to user when they bind data to widgets. This way we can suggest relevant queries to users first and their chances of success with Appsmith are higher.

Note: This PR only introduces the field in actionDTO and returns UNKNOWN, in subsequent PRs we will be adding plugin specific implementation to return relevant query_type. I have not added any unit tests as of now, we can add those once plugin specific implementations are done.

Fixes #`Issue Number`  
_or_  
Fixes [`Issue URL`](https://github.com/appsmithorg/appsmith/issues/32554)
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8643950238>
> Commit: 08e28bca9e4054ae78d4f4188cfecfc708a62608
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8643950238&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

