### PR TITLE
add new relic agent to the container

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -18,7 +18,7 @@ RUN set -o xtrace \
   && apt-get update \
   && apt-get upgrade --yes \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-    supervisor curl nfs-common gnupg wget netcat openssh-client \
+    supervisor curl nfs-common gnupg wget netcat openssh-client unzip \
     gettext \
     ca-certificates \
   # Install MongoDB v5, Redis, PostgreSQL v13
@@ -49,6 +49,9 @@ RUN set -o xtrace \
 
 # Install Caddy
 COPY --from=caddybuilder /usr/bin/caddy /opt/caddy/caddy
+
+# Add newrelic related files
+RUN curl -o /opt/appsmith/newrelic-java.zip https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.9.1/newrelic-java-8.9.1.zip ; unzip /opt/appsmith/newrelic-java.zip -d /opt/appsmith/ ; rm -rf /opt/appsmith/newrelic-java.zip
 
 # Clean up
 RUN rm -rf \

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -51,7 +51,9 @@ RUN set -o xtrace \
 COPY --from=caddybuilder /usr/bin/caddy /opt/caddy/caddy
 
 # Add newrelic related files
-RUN curl -o /opt/appsmith/newrelic-java.zip https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.9.1/newrelic-java-8.9.1.zip ; unzip /opt/appsmith/newrelic-java.zip -d /opt/appsmith/ ; rm -rf /opt/appsmith/newrelic-java.zip
+RUN mkdir /opt/newrelic \
+  && curl -o /opt/newrelic/newrelic.jar https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.9.1/newrelic-agent-8.9.1.jar
+
 
 # Clean up
 RUN rm -rf \

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -18,7 +18,7 @@ RUN set -o xtrace \
   && apt-get update \
   && apt-get upgrade --yes \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-    supervisor curl nfs-common gnupg wget netcat openssh-client unzip \
+    supervisor curl nfs-common gnupg wget netcat openssh-client \
     gettext \
     ca-certificates \
   # Install MongoDB v5, Redis, PostgreSQL v13

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -472,6 +472,20 @@ function capture_infra_details(){
   bash /opt/appsmith/generate-infra-details.sh || true
 }
 
+function setup_new_relic_agent(){
+   if [[ ${APPSMITH_ENABLE_NEW_RELIC_LOGGING-} = 1 ]]; then
+     export APPSMITH_JAVA_ARGS+=" -javaagent:/opt/newrelic/newrelic.jar"
+     # By default APPSMITH_ENABLE_NEW_RELIC_LOGGING=0
+     cat > /opt/appsmith/newrelic/newrelic.yml << EOF
+common:
+  license_key: $APPSMITH_APP_NEW_RELIC_LICENSE_KEY
+  app_name: $APPSMITH_NEW_RELIC_APP_NAME
+  enable_auto_transaction_naming: false
+  log_file_name: "$APPSMITH_LOG_DIR/newrelic_agent.log"
+EOF
+   fi
+}
+
 # Main Section
 print_appsmith_info
 init_loading_pages


### PR DESCRIPTION
Fixes: #29892 

docker_env is the environments we setup to have new_relic
```
(base) ➜  appsmith git:(feat/add/newrelicagent) ✗ cat ./docker_env
APPSMITH_ENABLE_NEW_RELIC_LOGGING=1
APPSMITH_NEW_RELIC_APP_NAME="appsmith"
APPSMITH_APP_NEW_RELIC_LICENSE_KEY="temp"
```


```
(base) ➜  appsmith git:(feat/add/newrelicagent) ✗ docker run -it -d --name appsmith_custom -v ./deploy/docker/fs/opt/appsmith/entrypoint.sh:/opt/appsmith/entrypoint.sh --env-file=./docker_env -p 8003:80 -p 9003:9001 -v "$PWD/stacks_new:/appsmith-stacks" appsmith/appsmith-ce:nightly
de97599ccbb38c3a540b1d746c3ac933d196e4bac768433cfe5f010cfcf1215f
(base) ➜  appsmith git:(feat/add/newrelicagent) ✗ docker ps -a
CONTAINER ID   IMAGE                          COMMAND                  CREATED         STATUS                            PORTS                                                   NAMES
de97599ccbb3   appsmith/appsmith-ce:nightly   "/opt/appsmith/entry…"   3 seconds ago   Up 2 seconds (health: starting)   443/tcp, 0.0.0.0:8003->80/tcp, 0.0.0.0:9003->9001/tcp   appsmith_custom
```

Results:
```
(base) ➜  appsmith git:(feat/add/newrelicagent) ✗ docker exec -it -u root de97599ccbb3 bash
root@de97599ccbb3:/opt/appsmith# ps -eAf | grep java
root      1947     1 99 11:15 pts/0    00:01:05 java -javaagent:/opt/appsmith/newrelic/newrelic.jar --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED -Dserver.port=8080 -XX:+ShowCodeDetailsInExceptionMessages -Djava.security.egd=file:/dev/./urandom -Dlog4j2.formatMsgNoLookups=true -jar server.jar
root      2301  2257  0 11:16 pts/1    00:00:00 grep --color=auto java
root@de97599ccbb3:/opt/appsmith# cat newrelic/newrelic.yml
common:
  license_key: "temp"
  app_name: "appsmith"
```


If 
`APPSMITH_ENABLE_NEW_RELIC_LOGGING` is not set

```
root@bd22ad16f9e5:/opt/appsmith# head -n 20 newrelic/newrelic.yml
# This file configures the New Relic agent. New Relic monitors
# Java applications with deep visibility and low overhead. For more details and additional
# configuration options visit https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file.
#
# <%= generated_for_user %>
#
# This section is for settings common to all environments.
# Do not add anything above this next line.
common: &default_settings

  # ============================== LICENSE KEY ===============================
  # You must specify the license key associated with your New Relic
  # account. For example, if your license key is 12345 use this:
  # license_key: '12345'
  # The key binds your agent's data to your account in the New Relic UI.
  license_key: '<%= license_key %>'

  # Agent enabled
  # Use this setting to disable the agent instead of removing it from the startup command.
  # Default is true.
root@bd22ad16f9e5:/opt/appsmith# ps -eAf | grep java
root      1946     1 76 11:19 pts/0    00:00:56 java --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED -Dserver.port=8080 -XX:+ShowCodeDetailsInExceptionMessages -Djava.security.egd=file:/dev/./urandom -Dlog4j2.formatMsgNoLookups=true -jar server.jar
root      2366  2106  0 11:21 pts/1    00:00:00 grep --color=auto java
```

