### PR TITLE
feat: query type configured for s3 plugin

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -15,6 +15,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.util.IOUtils;
+import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.dtos.MultipartFormDataDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
@@ -1096,6 +1097,33 @@ public class AmazonS3Plugin extends BasePlugin {
                     (String) ((Map<?, ?>) formData.get(KEY_BUCKET)).get(KEY_DATA), userSelectedBucketName);
 
             return Mono.empty();
+        }
+
+        @Override
+        public Mono<DatasourceQueryType> getQueryType(ActionConfiguration actionConfig) {
+            Map<String, Object> formData = actionConfig.getFormData();
+            DatasourceQueryType queryType = DatasourceQueryType.UNKNOWN;
+            String command = getDataValueSafelyFromFormData(formData, COMMAND, STRING_TYPE);
+
+            if (!StringUtils.isNullOrEmpty(command)) {
+                AmazonS3Action s3Action = AmazonS3Action.valueOf(command);
+                // Switch case added so that this functionality can be extended for
+                // other query types too in future based on command
+                switch (s3Action) {
+                    case LIST:
+                        queryType = DatasourceQueryType.FETCH;
+                        break;
+                    case UPLOAD_FILE_FROM_BODY:
+                    case UPLOAD_MULTIPLE_FILES_FROM_BODY:
+                    case READ_FILE:
+                    case DELETE_FILE:
+                    case DELETE_MULTIPLE_FILES:
+                    case LIST_BUCKETS:
+                    default:
+                        break;
+                }
+            }
+            return Mono.just(queryType);
         }
     }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.util.Base64;
+import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.datatypes.ClientDataType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
@@ -1534,5 +1535,148 @@ public class AmazonS3PluginTest {
                         List.of(actionConfiguration), mappedColumnsAndTableName, userSelectedBucketName)
                 .block();
         assertEquals(userSelectedBucketName, mappedColumnsAndTableName.get("templateBucket"));
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnFetchIfCommandIsList() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+        setDataValueSafelyInFormData(configMap, COMMAND, "LIST");
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.FETCH, result);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnUnknownIfCommandNotDefined() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.UNKNOWN, result);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnUnknownIfCommandIsUploadFiles() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+        setDataValueSafelyInFormData(configMap, COMMAND, "UPLOAD_FILE_FROM_BODY");
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.UNKNOWN, result);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnUnknownIfCommandIsUploadMultipleFiles() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+        setDataValueSafelyInFormData(configMap, COMMAND, "UPLOAD_MULTIPLE_FILES_FROM_BODY");
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.UNKNOWN, result);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnUnknownIfCommandIsReadFile() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+        setDataValueSafelyInFormData(configMap, COMMAND, "READ_FILE");
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.UNKNOWN, result);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnUnknownIfCommandIsDeleteFile() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+        setDataValueSafelyInFormData(configMap, COMMAND, "DELETE_FILE");
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.UNKNOWN, result);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnUnknownIfCommandIsDeleteMultipleFiles() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+        setDataValueSafelyInFormData(configMap, COMMAND, "DELETE_MULTIPLE_FILES");
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.UNKNOWN, result);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void verify_getQueryType_shouldReturnUnknownIfCommandIsListBuckets() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+
+        Map<String, Object> configMap = new HashMap<>();
+        setDataValueSafelyInFormData(configMap, COMMAND, "LIST_BUCKETS");
+
+        actionConfiguration.setFormData(configMap);
+        Mono<DatasourceQueryType> datasourceQueryTypeMono = pluginExecutor.getQueryType(actionConfiguration);
+
+        StepVerifier.create(datasourceQueryTypeMono)
+                .assertNext(result -> {
+                    assertEquals(DatasourceQueryType.UNKNOWN, result);
+                })
+                .verifyComplete();
     }
 }


### PR DESCRIPTION
## Description
This PR configures value of `query_type` for S3 plugin queries, where if command in query is `List files in buckets`, it will be classified as FETCH query where as for others it will be UNKNOWN.

This PR also adds relevant JUnit test cases.

Fixes #32558 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8660626592>
> Commit: db4934c356c341b328e0bf43f3906638ad00b119
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8660626592&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Amazon S3 plugin to automatically determine the query type based on user commands, improving the accuracy and efficiency of data handling.
- **Tests**
	- Added new test cases to ensure the reliability of the new query type determination feature in the Amazon S3 plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->