### PR TITLE
chore: Fix warnings on `@EqualsAndHashCode`

### DIFF
--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/UserImageContent.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/UserImageContent.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UserImageContent extends UserContent {
     ImageUrl imageUrl;

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/UserTextContent.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/UserTextContent.java
@@ -1,8 +1,10 @@
 package com.external.plugins.models;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class UserTextContent extends UserContent {
     String text;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitDeployKeys.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitDeployKeys.java
@@ -2,8 +2,10 @@ package com.appsmith.server.domains;
 
 import com.appsmith.external.models.BaseDomain;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class GitDeployKeys extends BaseDomain {
     String email;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/License.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/License.java
@@ -2,6 +2,8 @@ package com.appsmith.server.domains;
 
 import com.appsmith.server.domains.ce.LicenseCE;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class License extends LicenseCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UpdatePermissionGroupDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UpdatePermissionGroupDTO.java
@@ -2,8 +2,10 @@ package com.appsmith.server.dtos;
 
 import com.appsmith.server.dtos.ce.UpdatePermissionGroupCE_DTO;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 public class UpdatePermissionGroupDTO extends UpdatePermissionGroupCE_DTO {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
@@ -2,6 +2,8 @@ package com.appsmith.server.dtos;
 
 import com.appsmith.server.dtos.ce.UserProfileCE_DTO;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class UserProfileDTO extends UserProfileCE_DTO {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserUpdateDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserUpdateDTO.java
@@ -2,9 +2,11 @@ package com.appsmith.server.dtos;
 
 import com.appsmith.server.dtos.ce.UserUpdateCE_DTO;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * Includes **only** those fields that can be updated for a user, via an API call.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class UserUpdateDTO extends UserUpdateCE_DTO {}


### PR DESCRIPTION
Fixes build warnings like these:

```
Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.
```

Why is this important?

1. Warnings are always a worse thing than errors, because they only fail at runtime. And this is quite a significant warning, so should be fixed.
2. This _incorrect_ `equals` method screws up Hibernate's dirty checking when working with Postgres.



/ok-to-test tags="@tag.Sanity"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8679350830>
> Commit: 4f697fc3f9431fcfd35fc0f9814fce763382d06c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8679350830&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced data consistency across various models by ensuring that equality and hash code calculations now consider superclass fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->