### PR TITLE
fix: Unable to publish forked app to community portal

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
@@ -516,6 +516,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
         application.setPages(new ArrayList<>());
         application.setPublishedPages(new ArrayList<>());
         application.setIsPublic(false);
+        application.setIsCommunityTemplate(false);
 
         Mono<User> userMono = sessionUserService.getCurrentUser();
 


### PR DESCRIPTION
## Description
The publish to community template flow does not allow users to publish the same app multiple times to the portal. This is controlled via a boolean flag in the Application object. But when the user forks this app, it should be allowed for the new application to be published. This PR fixes this issue by making sure the flag value is reset to null during the fork flow. 

Fixes https://github.com/appsmithorg/appsmith/issues/32221

## Automation

/ok-to-test tags="tag.Templates"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8684335987>
> Commit: 23acf129c6da337c8a198cdca63a1b0b3fbc9444
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8684335987&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

