### PR TITLE
fix: edit button on hover of suggested queries should appear on overall list item.

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/generateQuickCommands.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/generateQuickCommands.tsx
@@ -9,7 +9,7 @@ import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
 import { EntityIcon, JsFileIconV2 } from "pages/Editor/Explorer/ExplorerIcons";
 import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
 import type { FeatureFlags } from "@appsmith/entities/FeatureFlag";
-import { Icon } from "design-system";
+import { Button, Icon } from "design-system";
 import { APPSMITH_AI } from "@appsmith/components/editorComponents/GPT/trigger";
 import { DatasourceCreateEntryPoints } from "constants/Datasource";
 import AnalyticsUtil from "utils/AnalyticsUtil";
@@ -121,10 +121,10 @@ export function Command(props: {
   );
 
   return (
-    <div className="command-container relative group cursor-pointer w-full">
+    <div className="command-container relative cursor-pointer w-full">
       <div className="command flex w-full">
         <div className="self-center shrink-0">{props.icon}</div>
-        <div className="flex grow relative overflow-hidden">
+        <div className="flex grow">
           <div className="flex flex-col gap-1 grow w-full">
             <div className="whitespace-nowrap flex flex-row items-center gap-2 text-[color:var(--ads-v2\-colors-content-label-default-fg)] relative">
               <span className="flex items-center overflow-hidden overflow-ellipsis slash-command-hint-text">
@@ -137,12 +137,14 @@ export function Command(props: {
             ) : null}
           </div>
           {props.url ? (
-            <span
-              className="hidden group-hover:inline self-center h-full px-2 text-xs absolute right-0 command-suggestion-edit"
+            <Button
+              className="hidden group-hover:flex items-center self-center h-full px-2 text-xs !absolute command-suggestion-edit right-0 top-0"
+              kind="tertiary"
               onClick={switchToAction}
+              size="sm"
             >
               {createMessage(EDIT)}
-            </span>
+            </Button>
           ) : null}
         </div>
       </div>
@@ -203,7 +205,7 @@ export const generateQuickCommands = (
           ? `{{${name}.}}`
           : `{{${name}}}`,
       displayText: `${name}`,
-      className: "CodeMirror-commands",
+      className: "CodeMirror-commands group relative",
       data: suggestion,
       triggerCompletionsPostPick: suggestion.type !== ENTITY_TYPE.ACTION,
       render: (element: HTMLElement, _: unknown, data: CommandsCompletion) => {

--- a/app/client/src/globalStyles/CodemirrorHintStyles.ts
+++ b/app/client/src/globalStyles/CodemirrorHintStyles.ts
@@ -42,9 +42,6 @@ export const CodemirrorHintStyles = createGlobalStyle<{
           color: var(--ads-v2-color-fg);
         }
       }
-      .command-suggestion-edit {
-        background: var(--ads-v2-color-bg-subtle);
-      }
     }
 
     .CodeMirror-command-header {


### PR DESCRIPTION
## Description
This PR fixes two issues:
- The hover behavior now applies to the overall list item and not just the text.
- The edit button is now using the design-system button which handles the hover effect as well.

Fixes #32350
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.PropertyPane"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8702168462>
> Commit: 79cab6fb3cb3fb116e35ce2ddb53826175b59318
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8702168462&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the command editing interface in the Code Editor by replacing text elements with interactive buttons.

- **Style**
  - Updated and streamlined the styling of command suggestions within the Code Editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->