### PR TITLE
fix: move useFeatureFlagOverride to routes instead of app router

### DIFF
--- a/app/client/src/ce/AppRouter.tsx
+++ b/app/client/src/ce/AppRouter.tsx
@@ -73,6 +73,7 @@ export function Routes() {
   const user = useSelector(getCurrentUserSelector);
   const tenantPermissions = useSelector(getTenantPermissions);
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
+  useFeatureFlagOverride();
 
   return (
     <Switch>
@@ -150,7 +151,6 @@ export default function AppRouter() {
   const safeCrashCode: ERROR_CODES | undefined = useSelector(getSafeCrashCode);
   const isConsolidatedPageLoading = useSelector(getIsConsolidatedPageLoading);
   const dispatch = useDispatch();
-  useFeatureFlagOverride();
 
   useEffect(() => {
     dispatch(initCurrentPage());


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX14GHmfZYDq4deKu54qT3FqPW13473c%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=FaUTV9u)
## Description
Moving useFeatureFlagOverride from app router to ce routes to make sure it is available for all environments.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.MobileResponsive"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8690542934>
> Commit: 19cabc927d62cd0216fd37c5d2c1738937544a15
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8690542934&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the timing of feature flag checks by adjusting where they are invoked in the application routing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->