### PR TITLE
fix: Revert "feat: suggest queries query type added in action DTO"

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/DatasourceQueryType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/DatasourceQueryType.java
@@ -1,6 +1,0 @@
-package com.appsmith.external.constants;
-
-public enum DatasourceQueryType {
-    FETCH,
-    UNKNOWN,
-}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
@@ -1,7 +1,6 @@
 package com.appsmith.external.models.ce;
 
 import com.appsmith.external.constants.ActionCreationSourceTypeEnum;
-import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.dtos.DslExecutableDTO;
 import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
 import com.appsmith.external.exceptions.ErrorDTO;
@@ -174,10 +173,6 @@ public class ActionCE_DTO implements Identifiable, Executable {
     @Transient
     @JsonView({Views.Public.class, FromRequest.class})
     ActionCreationSourceTypeEnum source;
-
-    @Transient
-    @JsonView(Views.Public.class)
-    DatasourceQueryType queryType;
 
     @Override
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -1,6 +1,5 @@
 package com.appsmith.external.plugins;
 
-import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
@@ -375,14 +374,5 @@ public interface PluginExecutor<C> extends ExtensionPoint, CrudTemplateService {
         // Currently this function is overridden only by postgresPlugin class, in future it will be done for all plugins
         // wherever applicable.
         return Mono.just("");
-    }
-
-    /*
-     * This method returns query type, query type is used for
-     * suggesting relevant actions to users when binding data
-     */
-    default Mono<DatasourceQueryType> getQueryType(ActionConfiguration actionConfig) {
-        // For all plugins where implementation is unclear right now, we will be returning its type as UNKNOWN
-        return Mono.just(DatasourceQueryType.UNKNOWN);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.newactions.base;
 
-import com.appsmith.external.constants.DatasourceQueryType;
 import com.appsmith.external.dtos.ExecutePluginDTO;
 import com.appsmith.external.dtos.RemoteDatasourceDTO;
 import com.appsmith.external.helpers.AppsmithBeanUtils;
@@ -682,18 +681,6 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 });
     }
 
-    private Mono<ActionDTO> setQueryTypeInUnpublishedAction(ActionDTO action) {
-        Mono<Plugin> pluginMono = pluginService.getById(action.getPluginId());
-        Mono<PluginExecutor> pluginExecutorMono = pluginExecutorHelper.getPluginExecutor(pluginMono);
-
-        return pluginExecutorMono.flatMap(pluginExecutor -> pluginExecutor
-                .getQueryType(action.getActionConfiguration())
-                .flatMap(queryType -> {
-                    action.setQueryType((DatasourceQueryType) queryType);
-                    return Mono.just(action);
-                }));
-    }
-
     @Override
     public Mono<ActionDTO> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission permission) {
         return repository
@@ -1018,7 +1005,6 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 .collectList()
                 .flatMapMany(this::addMissingPluginDetailsIntoAllActions)
                 .flatMap(this::setTransientFieldsInUnpublishedAction)
-                .flatMap(this::setQueryTypeInUnpublishedAction)
                 // this generates four different tags, (ApplicationId, FieldId) *(True, False)
                 .tag(
                         "includeJsAction",


### PR DESCRIPTION
Reverts appsmithorg/appsmith#32593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8705514361>
> Commit: 5788f9731859cffc7ec1e7ab8dd61effa17d6a66
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8705514361&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Summary by CodeRabbit

- **Refactor**
	- Removed unused `DatasourceQueryType` field and associated methods to streamline backend services, enhancing overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->