### PR TITLE
fix: Removing the unexpected error on updating the workspace name to blank

### DIFF
--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -49,7 +49,6 @@ import {
 import {
   AppIconCollection,
   Classes,
-  EditableText,
   MenuItem as ListItem,
   Text,
   TextType,
@@ -449,9 +448,6 @@ export const WorkspaceNameWrapper = styled.div<{ disabled?: boolean }>`
     margin-left: 8px;
     color: ${(props) => props.theme.colors.applications.iconColor};
   }
-`;
-export const WorkspaceRename = styled(EditableText)`
-  padding: 0 2px;
 `;
 
 export const NoSearchResultImg = styled.img`

--- a/app/client/src/ce/sagas/WorkspaceSagas.ts
+++ b/app/client/src/ce/sagas/WorkspaceSagas.ts
@@ -264,7 +264,7 @@ export function* saveWorkspaceSaga(action: ReduxAction<SaveWorkspaceRequest>) {
     yield put({
       type: ReduxActionErrorTypes.SAVE_WORKSPACE_ERROR,
       payload: {
-        error: (error as Error).message,
+        error,
       },
     });
   }


### PR DESCRIPTION
## Description

Removing the unexpected error on updating the workspace name to blank

Fixes [#12996](https://github.com/appsmithorg/appsmith/issues/12996)

## Automation

/ok-to-test tags="@tag.Settings @tag.Visual"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8716432739>
> Commit: 741bcf622ce0d7bd1aedaef8cebac43e71fc87bf
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8716432739&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified error handling in workspace operations.
	- Updated and streamlined the UI for renaming workspaces in the applications page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->