### PR TITLE
fix: reverting the default port numbers for the datasources

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
@@ -25,8 +25,8 @@ describe(
         agHelper.RenameWithInPane(dataSourceName, false);
 
         dataSources.TestDatasource(false);
+        agHelper.ValidateToastMessage("Missing endpoint.");
         agHelper.ValidateToastMessage("Missing username for authentication.");
-        agHelper.ValidateToastMessage("Missing hostname.");
         agHelper.ClearTextField(dataSources._databaseName);
         dataSources.TestDatasource(false);
         agHelper.ValidateToastMessage("Missing database name.");
@@ -81,7 +81,7 @@ describe(
         agHelper.RenameWithInPane(dataSourceName, false);
 
         dataSources.TestDatasource(false);
-        agHelper.ValidateToastMessage("Host value cannot be empty");
+        agHelper.ValidateToastMessage("Missing endpoint and url");
         agHelper.ValidateToastMessage("Missing username for authentication.");
         agHelper.ValidateToastMessage("Missing password for authentication.");
         agHelper.ClearTextField(dataSources._databaseName);
@@ -135,9 +135,7 @@ describe(
         agHelper.RenameWithInPane(dataSourceName, false);
 
         dataSources.TestDatasource(false);
-        agHelper.ValidateToastMessage(
-          "Connection timed out. Please check if the datasource configuration fields have been filled correctly.",
-        );
+        agHelper.ValidateToastMessage("Missing endpoint(s)");
         dataSources.ValidateNSelectDropdown(
           "Use mongo connection string URI",
           "No",
@@ -168,9 +166,7 @@ describe(
           "Replica set",
         );
         dataSources.TestDatasource(false);
-        agHelper.ValidateToastMessage(
-          "REPLICA_SET connections should not be given a port. If you are trying to specify all the shards, please add more than one.",
-        );
+        agHelper.ValidateToastMessage("Missing endpoint(s)");
         agHelper.UpdateInputValue(
           dataSources._host(),
           dataManager.dsValues[dataManager.defaultEnviorment].mongo_host,

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
@@ -30,7 +30,7 @@ describe("Validate Oracle DS", { tags: ["@tag.Datasource"] }, () => {
     });
   });
 
-  it("1. Tc #2354, #2204 - Oracle placeholder, port default value & mandatory mark verification", () => {
+  it("1. Tc #2354, #2204 - Oracle placeholder & mandatory mark verification", () => {
     dataSources.NavigateToDSCreateNew();
     dataSources.CreatePlugIn("Oracle");
     agHelper.GetNAssertContains(locators._dsName, "Untitled datasource");
@@ -45,7 +45,6 @@ describe("Validate Oracle DS", { tags: ["@tag.Datasource"] }, () => {
       "placeholder",
       "myapp.abcde.oracle.net",
     );
-    agHelper.AssertAttribute(dataSources._port, "value", "1521");
     agHelper.AssertAttribute(
       dataSources._databaseName,
       "placeholder",

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Redis_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Redis_Basic_Spec.ts
@@ -14,7 +14,7 @@ describe("Validate Redis DS", { tags: ["@tag.Datasource"] }, () => {
     });
   });
 
-  it("1. Create HAST set (Multiple key value pair under single key name) in redis DB, Read, Delete", () => {
+  it("Create HAST set (Multiple key value pair under single key name) in redis DB, Read, Delete", () => {
     let hSetReceipe = `HSET recipe:1 name "Vegetable Stir Fry" ingredients "2 cups mixed vegetables (broccoli, carrots, bell peppers, mushrooms, snow peas), 2 cloves garlic, minced" instructions "1. Heat vegetable oil in a large skillet over medium-high heat. 2. Add mixed vegetables and garlic to the skillet and cook for 3-4 minutes. 3. In a small bowl, whisk together soy sauce and cornstarch. 4. Pour the soy sauce mixture over the vegetables and stir until the vegetables are coated. 5. Cook for an additional 1-2 minutes. 6. Serve hot." difficulty "easy"`;
     let hGetKeys = "HGET recipe:1 name";
     let hMGet = "HMGET recipe:1 difficulty name"; // getting multiple keys
@@ -90,19 +90,20 @@ describe("Validate Redis DS", { tags: ["@tag.Datasource"] }, () => {
     dataSources.EnterQuery(hGetKeys);
     dataSources.RunQueryNVerifyResponseViews(); //5 keys, 5 values
     dataSources.AssertQueryTableResponse(0, "null");
+  });
 
-    // Delete the query & datasource
+  after("Delete the query & datasource", () => {
     agHelper.ActionContextMenuWithInPane({
       action: "Delete",
       entityType: entityItems.Query,
     });
     dataSources.DeleteDatasourceFromWithinDS(dsName);
-  });
-
-  it("2. Verify the default port for the datasource", function () {
-    dataSources.NavigateToDSCreateNew();
-    dataSources.CreatePlugIn("Redis");
-
-    agHelper.AssertAttribute(dataSources._port, "value", "6379");
+    //commenting below since after query delete, we run into risk of not seeing the datasource in EntityExplorer
+    // EditorNavigation.SelectEntityByName(dsName, EntityType.Datasource);
+    // entityExplorer.ActionContextMenuByEntityName({
+    //   entityNameinLeftSidebar: dsName,
+    //   action: "Delete",
+    //   entityType: entityItems.Datasource,
+    // });
   });
 });

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/EmptyDataSource_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/EmptyDataSource_spec.js
@@ -23,7 +23,7 @@ describe(
       dataSources.RunQuery({ toValidateResponse: false });
       cy.wait(500);
       cy.get("[data-testid=t--query-error]").contains(
-        "[Missing username for authentication., Missing hostname.]",
+        "[Missing endpoint., Missing username for authentication.]",
       );
       agHelper.ActionContextMenuWithInPane({
         action: "Delete",

--- a/app/client/cypress/e2e/Sanity/Datasources/ArangoDataSourceStub_spec.js
+++ b/app/client/cypress/e2e/Sanity/Datasources/ArangoDataSourceStub_spec.js
@@ -47,12 +47,5 @@ describe(
         .then(($dbName) => expect($dbName).to.eq("_system"));
       dataSources.SaveDSFromDialog(false);
     });
-
-    it("5. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("ArangoDB");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "8529");
-    });
   },
 );

--- a/app/client/cypress/e2e/Sanity/Datasources/ElasticSearchDatasource_spec.js
+++ b/app/client/cypress/e2e/Sanity/Datasources/ElasticSearchDatasource_spec.js
@@ -1,6 +1,6 @@
 const datasource = require("../../../locators/DatasourcesEditor.json");
 
-import { agHelper, dataSources } from "../../../support/Objects/ObjectsCore";
+import { dataSources } from "../../../support/Objects/ObjectsCore";
 
 let elasticSearchName;
 
@@ -30,13 +30,6 @@ describe(
       // cy.testSaveDatasource();
 
       dataSources.SaveDSFromDialog(false);
-    });
-
-    it("2. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("Elasticsearch");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "9200");
     });
   },
 );

--- a/app/client/cypress/e2e/Sanity/Datasources/MongoDatasourceURI_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MongoDatasourceURI_spec.ts
@@ -43,12 +43,5 @@ describe(
         dataSources.DeleteDatasourceFromWithinDS(dsName);
       });
     });
-
-    it("4. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("MongoDB");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "27017");
-    });
   },
 );

--- a/app/client/cypress/e2e/Sanity/Datasources/MsSQL_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MsSQL_Basic_Spec.ts
@@ -343,13 +343,6 @@ describe(
       table.WaitUntilTableLoad();
     });
 
-    it("7. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("Microsoft SQL Server");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "1433");
-    });
-
     after("Verify Deletion of the datasource", () => {
       cy.intercept("DELETE", "/api/v1/datasources/*").as("deleteDatasource"); //Since intercept from before is not working
       dataSources.DeleteDatasourceFromWithinDS(dsName, 409); //since CRUD pages are still active

--- a/app/client/cypress/e2e/Sanity/Datasources/MySQL_spec.js
+++ b/app/client/cypress/e2e/Sanity/Datasources/MySQL_spec.js
@@ -45,12 +45,5 @@ describe(
       cy.deleteQueryUsingContext();
       cy.deleteDatasource(datasourceName);
     });
-
-    it("4. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("MySQL");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "3306");
-    });
   },
 );

--- a/app/client/cypress/e2e/Sanity/Datasources/PostgresDatasource_spec.js
+++ b/app/client/cypress/e2e/Sanity/Datasources/PostgresDatasource_spec.js
@@ -42,12 +42,5 @@ describe(
       cy.deleteQueryUsingContext();
       cy.deleteDatasource(datasourceName);
     });
-
-    it("4. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("PostgreSQL");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "5432");
-    });
   },
 );

--- a/app/client/cypress/e2e/Sanity/Datasources/RedshiftDataSourceStub_spec.js
+++ b/app/client/cypress/e2e/Sanity/Datasources/RedshiftDataSourceStub_spec.js
@@ -1,6 +1,5 @@
 const datasource = require("../../../locators/DatasourcesEditor.json");
 let datasourceName;
-import { agHelper, dataSources } from "../../../support/Objects/ObjectsCore";
 import { ObjectsRegistry } from "../../../support/Objects/Registry";
 
 describe(
@@ -49,13 +48,6 @@ describe(
       );
       cy.deleteQueryUsingContext();
       cy.deleteDatasource(datasourceName);
-    });
-
-    it("4. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("Redshift");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "5439");
     });
   },
 );

--- a/app/client/cypress/e2e/Sanity/Datasources/SMTPDatasource_spec.js
+++ b/app/client/cypress/e2e/Sanity/Datasources/SMTPDatasource_spec.js
@@ -126,12 +126,5 @@ describe(
         expect(thisTestEmail.attachments.length).equal(1);
       });
     });
-
-    it("4. Verify the default port for the datasource", function () {
-      dataSources.NavigateToDSCreateNew();
-      dataSources.CreatePlugIn("SMTP");
-
-      agHelper.AssertAttribute(dataSources._port, "value", "25");
-    });
   },
 );

--- a/app/client/cypress/support/dataSourceCommands.js
+++ b/app/client/cypress/support/dataSourceCommands.js
@@ -93,9 +93,7 @@ Cypress.Commands.add(
       : datasourceFormData["postgres-databaseName"];
 
     cy.get(datasourceEditor.host).type(hostAddress);
-    cy.get(datasourceEditor.port)
-      .clear()
-      .type(datasourceFormData["postgres-port"]);
+    cy.get(datasourceEditor.port).type(datasourceFormData["postgres-port"]);
     cy.get(datasourceEditor.databaseName).clear().type(databaseName);
     cy.get(datasourceEditor.username).type(
       datasourceFormData["postgres-username"],
@@ -115,9 +113,7 @@ Cypress.Commands.add(
     const headerValue = "Bearer token";
 
     cy.get(datasourceEditor.host).type(hostAddress);
-    cy.get(datasourceEditor.port)
-      .clear()
-      .type(datasourceFormData["postgres-port"]);
+    cy.get(datasourceEditor.port).type(datasourceFormData["postgres-port"]);
     cy.get(datasourceEditor.sectionAuthentication).click();
     cy.get(datasourceEditor.username).type(
       datasourceFormData["postgres-username"],
@@ -140,9 +136,7 @@ Cypress.Commands.add(
       : datasourceFormData["mysql-databaseName"];
 
     cy.get(datasourceEditor.host).type(hostAddress);
-    cy.get(datasourceEditor.port)
-      .clear()
-      .type(datasourceFormData["mysql-port"]);
+    cy.get(datasourceEditor.port).type(datasourceFormData["mysql-port"]);
     cy.get(datasourceEditor.databaseName).clear().type(databaseName);
     cy.get(datasourceEditor.username).type(
       datasourceFormData["mysql-username"],
@@ -164,9 +158,7 @@ Cypress.Commands.add(
       : datasourceFormData["mssql-databaseName"];
 
     cy.get(datasourceEditor.host).type(hostAddress);
-    cy.get(datasourceEditor.port)
-      .clear()
-      .type(datasourceFormData["mssql-port"]);
+    cy.get(datasourceEditor.port).type(datasourceFormData["mssql-port"]);
     cy.get(datasourceEditor.databaseName).clear().type(databaseName);
     cy.get(datasourceEditor.username).type(
       datasourceFormData["mssql-username"],
@@ -188,9 +180,7 @@ Cypress.Commands.add(
       : datasourceFormData["arango-databaseName"];
 
     cy.get(datasourceEditor.host).type(hostAddress);
-    cy.get(datasourceEditor.port)
-      .clear()
-      .type(datasourceFormData["arango-port"]);
+    cy.get(datasourceEditor.port).type(datasourceFormData["arango-port"]);
     cy.get(datasourceEditor.databaseName).clear().type(databaseName);
 
     cy.get(datasourceEditor.username).type(
@@ -213,9 +203,7 @@ Cypress.Commands.add(
       : datasourceFormData["redshift-databaseName"];
 
     cy.get(datasourceEditor.host).type(hostAddress);
-    cy.get(datasourceEditor.port)
-      .clear()
-      .type(datasourceFormData["redshift-port"]);
+    cy.get(datasourceEditor.port).type(datasourceFormData["redshift-port"]);
     cy.get(datasourceEditor.databaseName).clear().type(databaseName);
     cy.get(datasourceEditor.username).type(
       datasourceFormData["redshift-username"],
@@ -262,7 +250,7 @@ Cypress.Commands.add(
       ? datasourceFormData["smtp-host"] + "  "
       : datasourceFormData["smtp-host"];
     cy.get(datasourceEditor.host).type(hostAddress);
-    cy.get(datasourceEditor.port).clear().type(datasourceFormData["smtp-port"]);
+    cy.get(datasourceEditor.port).type(datasourceFormData["smtp-port"]);
     cy.get(datasourceEditor.sectionAuthentication).click();
     cy.get(datasourceEditor.username).type(datasourceFormData["smtp-username"]);
     cy.get(datasourceEditor.password).type(datasourceFormData["smtp-password"]);

--- a/app/client/test/factories/MockPluginsState.ts
+++ b/app/client/test/factories/MockPluginsState.ts
@@ -5954,7 +5954,6 @@ export default {
                 label: "Port",
                 configProperty: "datasourceConfiguration.endpoints[*].port",
                 dataType: "NUMBER",
-                initialValue: ["5432"],
                 controlType: "KEYVALUE_ARRAY",
                 placeholderText: "5432",
               },

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/form.json
@@ -19,7 +19,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["8529"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "8529"
             }

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/form.json
@@ -18,7 +18,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["9200"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "9200"
             }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/form.json
@@ -107,7 +107,6 @@
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
               "controlType": "KEYVALUE_ARRAY",
-              "initialValue": ["27017"],
               "hidden": {
                 "path": "datasourceConfiguration.properties[0].value",
                 "comparison": "EQUALS",

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
@@ -36,7 +36,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["1433"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "1433"
             }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/form.json
@@ -62,7 +62,6 @@
                   "label": "MySQL port",
                   "configProperty": "datasourceConfiguration.endpoints[*].port",
                   "dataType": "NUMBER",
-                  "initialValue": ["3306"],
                   "controlType": "KEYVALUE_ARRAY",
                   "placeholderText": "3306"
                 }

--- a/app/server/appsmith-plugins/oraclePlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/oraclePlugin/src/main/resources/form.json
@@ -20,7 +20,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["1521"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "1521"
             }

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/form.json
@@ -29,7 +29,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["5432"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "5432"
             }

--- a/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
@@ -19,7 +19,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["6379"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "6379"
             }

--- a/app/server/appsmith-plugins/redshiftPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/redshiftPlugin/src/main/resources/form.json
@@ -36,7 +36,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["5439"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "5439"
             }

--- a/app/server/appsmith-plugins/smtpPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/smtpPlugin/src/main/resources/form.json
@@ -19,7 +19,6 @@
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "initialValue": ["25"],
               "controlType": "KEYVALUE_ARRAY",
               "placeholderText": "25"
             }


### PR DESCRIPTION
This PR is created to revert the changes from the PR #32592 due to flakiness in the test specs.

Reverts appsmithorg/appsmith#32592


## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8717847856>
> Commit: e6b4c320d893490c37bf4b4a2efa02fc4c4a2c4b
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8717847856&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->


