### PR TITLE
fix: fixing page change messaging in commit modal

### DIFF
--- a/app/client/src/pages/Editor/gitSync/components/GitChangesList/NewChangesList/PageChanges.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/GitChangesList/NewChangesList/PageChanges.tsx
@@ -63,24 +63,21 @@ function SinglePageChange({ page, status }: SinglePageChangeProps) {
 
   const titleText = useMemo(() => {
     let text = `${page} `;
-    if (
-      changeFlags.isPageModified ||
-      changeFlags.isJsObjectModified ||
-      changeFlags.isQueryModified
-    ) {
+    if (changeFlags.isPageAdded) {
+      text += "added";
+    } else if (changeFlags.isPageRemoved) {
+      text += "removed";
+    } else if (changeFlags.isPageModified) {
       text += "modified";
     } else if (
-      changeFlags.isPageAdded ||
+      changeFlags.isJsObjectModified ||
+      changeFlags.isQueryModified ||
       changeFlags.isJsObjectAdded ||
-      changeFlags.isQueryAdded
-    ) {
-      text += "added";
-    } else if (
-      changeFlags.isPageRemoved ||
+      changeFlags.isQueryAdded ||
       changeFlags.isJsObjectRemoved ||
       changeFlags.isQueryRemoved
     ) {
-      text += "removed";
+      text += "modified";
     }
     return text;
   }, [page, changeFlags]);


### PR DESCRIPTION
## Description
Query changes to an existing page shows up as `x page added`. This commit fixes it to `x page modified`

Fixes #32729

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8718165211>
> Commit: b3ee3904056eb2d3d3af426eb774f12b13003606
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8718165211&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for determining page titles in the Git Changes List, ensuring accurate representation for additions, removals, and modifications of pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->