### PR TITLE
chore: Add tags for consolidated api spans

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ConsolidatedAPIController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ConsolidatedAPIController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Mono;
 
+import java.util.Objects;
+
 import static com.appsmith.external.constants.spans.ConsolidatedApiSpanNames.CONSOLIDATED_API_ROOT_EDIT;
 import static com.appsmith.external.constants.spans.ConsolidatedApiSpanNames.CONSOLIDATED_API_ROOT_VIEW;
 
@@ -58,6 +60,9 @@ public class ConsolidatedAPIController {
                 .getConsolidatedInfoForPageLoad(defaultPageId, applicationId, branchName, ApplicationMode.EDIT)
                 .map(consolidatedAPIResponseDTO ->
                         new ResponseDTO<>(HttpStatus.OK.value(), consolidatedAPIResponseDTO, null))
+                .tag("pageId", Objects.toString(defaultPageId))
+                .tag("applicationId", Objects.toString(applicationId))
+                .tag("branchName", Objects.toString(branchName))
                 .name(CONSOLIDATED_API_ROOT_EDIT)
                 .tap(Micrometer.observation(observationRegistry));
     }
@@ -80,6 +85,9 @@ public class ConsolidatedAPIController {
                 .getConsolidatedInfoForPageLoad(defaultPageId, applicationId, branchName, ApplicationMode.PUBLISHED)
                 .map(consolidatedAPIResponseDTO ->
                         new ResponseDTO<>(HttpStatus.OK.value(), consolidatedAPIResponseDTO, null))
+                .tag("pageId", Objects.toString(defaultPageId))
+                .tag("applicationId", Objects.toString(applicationId))
+                .tag("branchName", Objects.toString(branchName))
                 .name(CONSOLIDATED_API_ROOT_VIEW)
                 .tap(Micrometer.observation(observationRegistry));
     }


### PR DESCRIPTION
This PR adds tags for consolidated api spans so that slow spans can debugged using pageID, applicationID and branchName

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8732019146>
> Commit: 3fc5d68fe08d6f68cce2ecd68ee55502b935a15b
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8732019146&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced data tagging in API controller methods for improved data management and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->