### PR TITLE
fix: bug- Audio recorder does not reset UI when a recording is taking place #14693

### DIFF
--- a/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
+++ b/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
@@ -259,7 +259,7 @@ class AudioRecorderWidget extends BaseWidget<
     if (this.props.blobURL) {
       URL.revokeObjectURL(this.props.blobURL);
     }
-
+    this.props.updateWidgetMetaProperty("blobURL", null);
     this.props.updateWidgetMetaProperty("dataURL", undefined);
     this.props.updateWidgetMetaProperty("rawBinary", undefined);
 


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

Fixes #14693
_or_  
Fixes https://github.com/appsmithorg/appsmith/issues/14693
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

media : https://www.loom.com/share/fb1c08173024427d96e483e782d41ee3?sid=49f2fdd8-ca3f-449f-ad09-aec8b294642a

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the Audio Recorder Widget to reset the blob URL property to `null` after use, enhancing the control flow and logic for handling audio recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->