### PR TITLE
fix: graphQL bindings issue resolved

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/ArrayType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/ArrayType.java
@@ -3,8 +3,8 @@ package com.appsmith.external.datatypes;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.minidev.json.JSONArray;
 import net.minidev.json.parser.JSONParser;
@@ -12,8 +12,7 @@ import reactor.core.Exceptions;
 
 public class ArrayType implements AppsmithType {
 
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     @Override
     public boolean test(String s) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/DateType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/DateType.java
@@ -3,8 +3,8 @@ package com.appsmith.external.datatypes;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.Exceptions;
 
@@ -16,8 +16,7 @@ import java.util.regex.Matcher;
 
 public class DateType implements AppsmithType {
 
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     @Override
     public boolean test(String s) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/JsonObjectType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/JsonObjectType.java
@@ -3,8 +3,8 @@ package com.appsmith.external.datatypes;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -22,8 +22,7 @@ import java.util.regex.Matcher;
 public class JsonObjectType implements AppsmithType {
 
     private static final TypeAdapter<JsonObject> strictGsonObjectAdapter = new Gson().getAdapter(JsonObject.class);
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     @Override
     public boolean test(String s) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/StringType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/StringType.java
@@ -3,8 +3,8 @@ package com.appsmith.external.datatypes;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.Exceptions;
 
@@ -12,8 +12,7 @@ import java.util.regex.Matcher;
 
 public class StringType implements AppsmithType {
 
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     @Override
     public boolean test(String s) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/TimeType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/TimeType.java
@@ -3,8 +3,8 @@ package com.appsmith.external.datatypes;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.Exceptions;
 
@@ -16,8 +16,7 @@ import java.util.regex.Matcher;
 
 public class TimeType implements AppsmithType {
 
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     @Override
     public boolean test(String s) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/TimestampType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/TimestampType.java
@@ -3,8 +3,8 @@ package com.appsmith.external.datatypes;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.Exceptions;
 
@@ -16,8 +16,7 @@ import java.util.regex.Matcher;
 
 public class TimestampType implements AppsmithType {
 
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     @Override
     public boolean test(String s) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
@@ -8,8 +8,8 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException
 import com.appsmith.external.models.Param;
 import com.appsmith.external.models.ParsedDataType;
 import com.appsmith.external.plugins.SmartSubstitutionInterface;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,8 +54,7 @@ public class DataTypeStringUtils {
 
     public static Pattern placeholderPattern = Pattern.compile(APPSMITH_SUBSTITUTION_PLACEHOLDER);
 
-    private static ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     private static final TypeAdapter<JsonObject> strictGsonObjectAdapter = new Gson().getAdapter(JsonObject.class);
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
@@ -10,8 +10,8 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.Param;
 import com.appsmith.external.models.Property;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -47,8 +47,7 @@ import static com.appsmith.external.constants.CommonFieldName.VALUE;
 @Slf4j
 public class PluginUtils {
 
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
     public static final TypeReference<String> STRING_TYPE = new TypeReference<>() {
         @Override
         public Type getType() {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -7,8 +7,8 @@ import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ApiContentType;
 import com.appsmith.external.models.Property;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -77,7 +77,7 @@ public class DataUtils {
     }
 
     public DataUtils() {
-        this.objectMapper = new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+        this.objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
         this.objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
@@ -1,14 +1,13 @@
 package com.appsmith.external.plugins;
 
-import com.fasterxml.jackson.core.StreamReadFeature;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 
 public abstract class BasePlugin extends Plugin {
 
-    protected static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    protected static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     public BasePlugin(PluginWrapper wrapper) {
         super(wrapper);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -8,7 +8,7 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
 import com.appsmith.external.models.UQIDataFilterParams;
-import com.fasterxml.jackson.core.StreamReadFeature;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -98,7 +98,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
     public FilterDataServiceCE() {
 
-        objectMapper = new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+        objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
         try {
             connection = DriverManager.getConnection(URL);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/SerializationUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/SerializationUtils.java
@@ -69,4 +69,8 @@ public class SerializationUtils {
             builder.registerTypeAdapter(HttpMethod.class, new HttpMethodConverter());
         };
     }
+
+    public static ObjectMapper getObjectMapperWithSourceInLocationEnabled() {
+        return new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    }
 }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/utils/WhereConditionUtils.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/utils/WhereConditionUtils.java
@@ -5,8 +5,8 @@ import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.helpers.DataTypeStringUtils;
+import com.appsmith.util.SerializationUtils;
 import com.external.plugins.exceptions.FirestoreErrorMessages;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.firestore.FieldPath;
 import com.google.cloud.firestore.Query;
@@ -20,8 +20,7 @@ import java.util.List;
 
 public class WhereConditionUtils {
 
-    protected static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    protected static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     public static Query applyWhereConditional(Query query, String strPath, String operatorString, String strValue)
             throws AppsmithPluginException {

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetDatasourceMetadataMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetDatasourceMetadataMethod.java
@@ -6,7 +6,6 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Property;
 import com.appsmith.util.WebClientUtils;
 import com.external.constants.FieldName;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -29,8 +28,7 @@ import static org.springframework.util.StringUtils.hasLength;
 @Slf4j
 public class GetDatasourceMetadataMethod {
 
-    protected static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    protected static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     public static Mono<DatasourceConfiguration> getDatasourceMetadata(DatasourceConfiguration datasourceConfiguration) {
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetDatasourceMetadataMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetDatasourceMetadataMethod.java
@@ -4,6 +4,7 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Property;
+import com.appsmith.util.SerializationUtils;
 import com.appsmith.util.WebClientUtils;
 import com.external.constants.FieldName;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLDataTypeUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLDataTypeUtils.java
@@ -2,6 +2,7 @@ package com.external.utils;
 
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.parser.InvalidSyntaxException;
@@ -19,7 +20,7 @@ import static com.appsmith.external.helpers.SmartSubstitutionHelper.APPSMITH_SUB
 public class GraphQLDataTypeUtils {
     public static final String GRAPHQL_BODY_ENDS_WITH_PARAM_REGEX = "[\\w\\W]+:$";
 
-    public static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     public static String smartlyReplaceGraphQLQueryBodyPlaceholderWithValue(
             String queryBody, String replacement, List<Map.Entry<String, String>> insertedParams) {

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLDataTypeUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLDataTypeUtils.java
@@ -3,7 +3,6 @@ package com.external.utils;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.parser.InvalidSyntaxException;
 import graphql.parser.Parser;
@@ -20,8 +19,7 @@ import static com.appsmith.external.helpers.SmartSubstitutionHelper.APPSMITH_SUB
 public class GraphQLDataTypeUtils {
     public static final String GRAPHQL_BODY_ENDS_WITH_PARAM_REGEX = "[\\w\\W]+:$";
 
-    public static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    public static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static String smartlyReplaceGraphQLQueryBodyPlaceholderWithValue(
             String queryBody, String replacement, List<Map.Entry<String, String>> insertedParams) {

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/MongoCommand.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/MongoCommand.java
@@ -4,9 +4,9 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceStructure;
+import com.appsmith.util.SerializationUtils;
 import com.external.plugins.exceptions.MongoPluginError;
 import com.external.plugins.exceptions.MongoPluginErrorMessages;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,8 +33,7 @@ import static com.external.plugins.constants.FieldName.COLLECTION;
 public abstract class MongoCommand {
     String collection;
     List<String> fieldNamesWithNoConfiguration;
-    protected static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    protected static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     public MongoCommand(ActionConfiguration actionConfiguration) {
 

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/datatypes/MySQLDateTimeType.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/datatypes/MySQLDateTimeType.java
@@ -4,8 +4,8 @@ import com.appsmith.external.constants.DataType;
 import com.appsmith.external.datatypes.AppsmithType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.Exceptions;
 
@@ -16,8 +16,7 @@ import java.time.format.DateTimeParseException;
 import java.util.regex.Matcher;
 
 public class MySQLDateTimeType implements AppsmithType {
-    private static final ObjectMapper objectMapper =
-            new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    private static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
     @Override
     public boolean test(String s) {

--- a/app/server/appsmith-plugins/saasPlugin/src/main/java/com/external/plugins/SaasPlugin.java
+++ b/app/server/appsmith-plugins/saasPlugin/src/main/java/com/external/plugins/SaasPlugin.java
@@ -12,13 +12,13 @@ import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.external.plugins.SmartSubstitutionInterface;
 import com.appsmith.external.services.SharedConfig;
+import com.appsmith.util.SerializationUtils;
 import com.appsmith.util.WebClientUtils;
 import com.external.helpers.RequestCaptureFilter;
 import com.external.plugins.exceptions.SaaSErrorMessages;
 import com.external.plugins.exceptions.SaaSPluginError;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,8 +61,7 @@ public class SaasPlugin extends BasePlugin {
         // Setting max content length. This would've been coming from `spring.codec.max-in-memory-size` property if the
         // `WebClient` instance was loaded as an auto-wired bean.
         private final ExchangeStrategies EXCHANGE_STRATEGIES;
-        private final ObjectMapper saasObjectMapper =
-                new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+        private final ObjectMapper saasObjectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
 
         public SaasPluginExecutor(SharedConfig sharedConfig) {
             this.sharedConfig = sharedConfig;


### PR DESCRIPTION
## Description
This PR resolved issue with graphQL, where if we create a graphQL with a binding and run such query, it returns with error response saying the query execution has timed out. A user had raised this issue [here](https://discord.com/channels/725602949748752515/1230134890704539709).

### Root cause:
The issue was not at all reproducible on local, but It was continuously erroring out on production, release and even DPs. From the logs, we can see that issue was with `GraphQLDataTypeUtils.java` class. This class was somehow not getting initialised. This was due to recent changes made in [PR](https://github.com/appsmithorg/appsmith/pull/32595), where the version for package was updated to v2.17.0, on local it was compiling properly but on release, production and other builds, it still seems to be referencing to the older version of it, we do not know the reason of it right now, we should further investigate this. But since this was a critical issue and we need to get user unblocked, we are going ahead with an alternate fix where we have moved the initialisation of objectMapper to serialisationUtils.java file.

![Screenshot 2024-04-18 at 11 22 55 AM](https://github.com/appsmithorg/appsmith/assets/30018882/9735aaed-07c2-402b-a798-d7a4c1b67a19)

### Steps to reproduce the issue:
1. Drag and drop a text widget on canvas, change text value to `US`
2. Create a new graphQL query with url as `https://countries.trevorblades.com/`
3. Add following in the query body and execute the API

```
{
  country(code: {{Text1.text}}) {
    name
	}
}
```


Fixes #32748
_or_  
Fixes [`Issue URL`](https://github.com/appsmithorg/appsmith/issues/32748)
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8735651316>
> Commit: a03f29f8078398a4c317e852667270c0810bddea
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8735651316&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated serialization configuration across various data types and plugins to enhance functionality and compatibility using a centralized utility method.
- **New Features**
	- Introduced a new method to standardize object mapper configurations, improving serialization processes across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->