### PR TITLE
fix: Omnibar_spec - removed external dependency and asserted appropriate elements

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
@@ -5,11 +5,14 @@ import EditorNavigation, {
 const omnibar = require("../../../../locators/Omnibar.json");
 import {
   agHelper,
-  entityExplorer,
   assertHelper,
-  deployMode,
-  draggableWidgets,
 } from "../../../../support/Objects/ObjectsCore";
+
+import {
+  createMessage,
+  NAV_DESCRIPTION,
+  ACTION_OPERATION_DESCRIPTION,
+} from "../../../../../src/ce/constants/messages";
 
 describe("Omnibar functionality test cases", () => {
   const apiName = "Omnibar1";
@@ -19,17 +22,7 @@ describe("Omnibar functionality test cases", () => {
     agHelper.AddDsl("omnibarDsl");
   });
 
-  it("1. Bug #15104  Docs tab opens after clicking on learn more link from property pane", function () {
-    cy.dragAndDropToCanvas(draggableWidgets.AUDIO, { x: 300, y: 500 });
-    agHelper.Sleep(2000);
-    deployMode.StubWindowNAssert(
-      '//span[text()="Learn more"]',
-      "connect-to-a-database",
-      "getConsolidatedData",
-    );
-  });
-
-  it("2.Verify omnibar is present across all pages and validate its fields", function () {
+  it("1.Verify omnibar is present across all pages and validate its fields", function () {
     cy.get(omnibar.globalSearch)
       .trigger("mouseover")
       .should("have.css", "background-color", "rgb(255, 255, 255)");
@@ -41,17 +34,17 @@ describe("Omnibar functionality test cases", () => {
       .next()
       .should(
         "have.text",
-        "Navigate to any page, widget or file across this project.",
+        createMessage(NAV_DESCRIPTION),
       );
     cy.get(omnibar.categoryTitle)
       .eq(1)
       .should("have.text", "Create new")
       .next()
-      .should("have.text", "Create a new query, API or JS Object");
+      .should("have.text", createMessage(ACTION_OPERATION_DESCRIPTION));
     cy.get("body").type("{esc}");
   });
 
-  it("3. Verify Create new section and its data, also create a new api, new js object and new cURL import from omnibar ", function () {
+  it("2. Verify Create new section and its data, also create a new api, new js object and new cURL import from omnibar ", function () {
     cy.intercept("POST", "/api/v1/actions").as("createNewApi");
     cy.intercept("POST", "/api/v1/collections/actions").as(
       "createNewJSCollection",
@@ -90,7 +83,7 @@ describe("Omnibar functionality test cases", () => {
   });
 
   it(
-    "4. On an invalid search, discord link should be displayed and on clicking that link, should open discord in new tab",
+    "3. On an invalid search, discord link should be displayed and on clicking that link, should open discord in new tab",
     { tags: ["@tag.excludeForAirgap"] },
     function () {
       // typing a random string in search bar
@@ -101,30 +94,11 @@ describe("Omnibar functionality test cases", () => {
       cy.get(omnibar.globalSearchInput).should("have.value", "vnjkv");
       // discord link should be visible
       cy.get(omnibar.discordLink).should("be.visible");
-      // cy.window().then((win) => {
-      //   cy.stub(win, "open", (url) => {
-      //     win.location.href = "https://discord.com/invite/rBTTVJp";
-      //   }).as("discordLink");
-      // });
-      // cy.url().then(($urlBeforeDiscord) => {
-      //   // clicking on discord link should open discord
-      //   agHelper.GetNClick(omnibar.discordLink, 0, false, 4000);
-      //   cy.get("@discordLink").should("be.called");
-      //   cy.wait(2000);
-      //   //cy.go(-1);
-      //   cy.visit($urlBeforeDiscord);
-      //   cy.wait(4000); //for page to load
-      // });
-
-      deployMode.StubWindowNAssert(
-        omnibar.discordLink,
-        "https://discord.com/invite/rBTTVJp",
-        "getConsolidatedData",
-      );
+      cy.get(".no-data-title").should("be.visible");
     },
   );
 
-  it("5. Verify Navigate section shows recently opened widgets and datasources", function () {
+  it("4. Verify Navigate section shows recently opened widgets and datasources", function () {
     EditorNavigation.SelectEntityByName("Button1", EntityType.Widget);
     cy.get(omnibar.globalSearch).click({ force: true });
     cy.get(omnibar.categoryTitle).contains("Navigate").click();
@@ -147,12 +121,6 @@ describe("Omnibar functionality test cases", () => {
       .next()
       .should("have.text", "Page1");
 
-    cy.xpath(omnibar.recentlyopenItem)
-      .eq(3)
-      .should("have.text", "Audio1")
-      .next()
-      .should("have.text", "Page1");
-
-    cy.xpath(omnibar.recentlyopenItem).eq(4).should("have.text", "Page1");
+    cy.xpath(omnibar.recentlyopenItem).eq(3).should("have.text", "Page1");
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
@@ -32,10 +32,7 @@ describe("Omnibar functionality test cases", () => {
       .eq(0)
       .should("have.text", "Navigate")
       .next()
-      .should(
-        "have.text",
-        createMessage(NAV_DESCRIPTION),
-      );
+      .should("have.text", createMessage(NAV_DESCRIPTION));
     cy.get(omnibar.categoryTitle)
       .eq(1)
       .should("have.text", "Create new")

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description

1. Removed the third party dependency test case - assertion for appsmith docs 
2. Modified assertions to reduce flakiness - assert "no result" on Omnibar search instead of discord link being open 

Link 1st spec in https://www.notion.so/appsmith/Cypress-tests-analysis-4090efa5e3064a2e87f262d3c399a339?pvs=4#7dca72e1cf7a49bd8d9883ad9caa7746

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
    - Enhanced clarity and consistency in test descriptions for the Omnibar feature.
    - Updated text validation in tests to enhance accuracy and maintainability.
    - Added imports for message constants.

- **Chores**
    - Updated test configuration to reflect the renaming of a test spec.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->