### PR TITLE
fix: bug- Audio recorder does not reset UI when a recording is taking place #14693

### DIFF
--- a/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
+++ b/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
@@ -260,6 +260,7 @@ class AudioRecorderWidget extends BaseWidget<
       URL.revokeObjectURL(this.props.blobURL);
     }
 
+    this.props.updateWidgetMetaProperty("blobURL", null);
     this.props.updateWidgetMetaProperty("dataURL", undefined);
     this.props.updateWidgetMetaProperty("rawBinary", undefined);
 


### PR DESCRIPTION
## Automation

/ok-to-test tags="@tag.Widget"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the Audio Recorder Widget by resetting the recording data properly after each use.

<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8737095212>
> Commit: 9c6e4d693b11f7a8bf12b0c47e4db650f9be1e40
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8737095212&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_2_spec.js </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->

