### PR TITLE
fix: property navigation spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
@@ -50,7 +50,7 @@ describe(
       _.propPane.NavigateBackToPropertyPane();
       _.debuggerHelper.ClickDebuggerIcon();
       _.debuggerHelper.ClicklogEntityLink();
-      _.agHelper.GetNAssertContains(_.propPane._paneTitle, "Menu Item 1");
+      _.agHelper.GetNAssertContains(_.propPane._paneTitle, "Menu Item");
       _.propPane.AssertIfPropertyIsVisible("icon");
       _.debuggerHelper.CloseBottomBar();
       EditorNavigation.SelectEntityByName("ButtonGroup1", EntityType.Widget);


### PR DESCRIPTION
This PR fixes the property navigation spec that started failing in the recent PR #32736

## Automation

/ok-to-test tags="@tag.All"


<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8748159364>
> Commit: 6b662b3defea1046d0dedda5ccdcb3b2e30fef08
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8748159364&attempt=3&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/ExplorerTests/Hide_Page_spec.js
> <li>cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
> <li>cypress/e2e/Regression/ClientSide/Git/GitWithAutoLayout/conversion_of_git_connected_apps_spec.js
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_AutoLayout_Validation_BasicSpec.js
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionFlow_Corner_Cases_spec.ts
> <li>cypress/e2e/Regression/ClientSide/SettingsPane/PageSettings_spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->








