### PR TITLE
chore: Replace more `new ObjectId` with UUIDs

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -37,7 +37,15 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNewFieldValuesIntoOldObject;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -27,7 +27,6 @@ import com.appsmith.server.solutions.ApplicationPermission;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
-import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.util.CollectionUtils;
@@ -38,14 +37,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNewFieldValuesIntoOldObject;
@@ -132,7 +124,7 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
 
     protected void setGitSyncIdInActionCollection(ActionCollection collection) {
         if (collection.getGitSyncId() == null) {
-            collection.setGitSyncId(collection.getApplicationId() + "_" + new ObjectId());
+            collection.setGitSyncId(collection.getApplicationId() + "_" + UUID.randomUUID());
         }
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/clonepage/ActionCollectionClonePageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/clonepage/ActionCollectionClonePageServiceCEImpl.java
@@ -8,7 +8,6 @@ import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.ClonePageMetaDTO;
 import com.appsmith.server.newactions.base.NewActionService;
 import lombok.RequiredArgsConstructor;
-import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
@@ -16,6 +15,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
 
@@ -106,7 +106,7 @@ public class ActionCollectionClonePageServiceCEImpl implements ClonePageServiceC
                     toBeClonedActionCollection.getDefaultResources().setPageId(null);
                     // Assign new gitSyncId for cloned actionCollection
                     toBeClonedActionCollection.setGitSyncId(
-                            toBeClonedActionCollection.getApplicationId() + "_" + new ObjectId());
+                            toBeClonedActionCollection.getApplicationId() + "_" + UUID.randomUUID());
                     return actionCollectionService
                             .create(toBeClonedActionCollection)
                             .flatMap(clonedActionCollection -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/importable/applications/ActionCollectionApplicationImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/importable/applications/ActionCollectionApplicationImportableServiceCEImpl.java
@@ -19,14 +19,10 @@ import com.appsmith.server.imports.importable.artifactbased.ArtifactBasedImporta
 import com.appsmith.server.repositories.ActionCollectionRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 @RequiredArgsConstructor
 @Service
@@ -147,7 +143,7 @@ public class ActionCollectionApplicationImportableServiceCEImpl
 
         // generate gitSyncId if it's not present
         if (actionCollection.getGitSyncId() == null) {
-            actionCollection.setGitSyncId(actionCollection.getApplicationId() + "_" + new ObjectId());
+            actionCollection.setGitSyncId(actionCollection.getApplicationId() + "_" + UUID.randomUUID());
         }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
@@ -37,7 +37,6 @@ import com.appsmith.server.solutions.EnvironmentPermission;
 import com.appsmith.server.solutions.WorkspacePermission;
 import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
-import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
@@ -50,14 +49,7 @@ import reactor.util.function.Tuples;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
 import static com.appsmith.server.helpers.CollectionUtils.isNullOrEmpty;
@@ -153,7 +145,7 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.PLUGIN_ID));
         }
         if (!hasText(datasource.getGitSyncId())) {
-            datasource.setGitSyncId(datasource.getWorkspaceId() + "_" + new ObjectId());
+            datasource.setGitSyncId(datasource.getWorkspaceId() + "_" + UUID.randomUUID());
         }
 
         if (isNullOrEmpty(datasource.getDatasourceStorages())) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -58,7 +58,6 @@ import io.micrometer.observation.ObservationRegistry;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
-import org.bson.types.ObjectId;
 import org.springframework.data.domain.Sort;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedCaseInsensitiveMap;
@@ -71,14 +70,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -467,7 +459,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
 
     protected void setGitSyncIdInNewAction(NewAction newAction) {
         if (newAction.getGitSyncId() == null) {
-            newAction.setGitSyncId(newAction.getApplicationId() + "_" + new ObjectId());
+            newAction.setGitSyncId(newAction.getApplicationId() + "_" + UUID.randomUUID());
         }
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -70,7 +70,15 @@ import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
@@ -22,7 +22,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
@@ -19,14 +19,10 @@ import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.repositories.NewActionRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 @RequiredArgsConstructor
 @Service
@@ -144,7 +140,7 @@ public class NewActionApplicationImportableServiceCEImpl
 
         // generate gitSyncId if it's not present
         if (newAction.getGitSyncId() == null) {
-            newAction.setGitSyncId(newAction.getApplicationId() + "_" + new ObjectId());
+            newAction.setGitSyncId(newAction.getApplicationId() + "_" + UUID.randomUUID());
         }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
@@ -29,8 +29,6 @@ public interface NewPageServiceCE extends CrudService<NewPage, String> {
 
     Flux<NewPage> findNewPagesByApplicationId(String applicationId, AclPermission permission);
 
-    Flux<NewPage> findNewPagesByApplicationId(String applicationId, Optional<AclPermission> permission);
-
     Mono<PageDTO> saveUnpublishedPage(PageDTO page);
 
     Mono<PageDTO> createDefault(PageDTO object);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
@@ -36,7 +36,16 @@ import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNewFieldValuesIntoOldObject;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
@@ -18,7 +18,6 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.helpers.TextUtils;
-import com.appsmith.server.repositories.ApplicationSnapshotRepository;
 import com.appsmith.server.repositories.NewPageRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.BaseService;
@@ -37,15 +36,7 @@ import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNewFieldValuesIntoOldObject;
@@ -59,7 +50,6 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     private final ResponseUtils responseUtils;
     private final ApplicationPermission applicationPermission;
     private final PagePermission pagePermission;
-    private final ApplicationSnapshotRepository applicationSnapshotRepository;
 
     @Autowired
     public NewPageServiceCEImpl(
@@ -70,15 +60,13 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
             UserDataService userDataService,
             ResponseUtils responseUtils,
             ApplicationPermission applicationPermission,
-            PagePermission pagePermission,
-            ApplicationSnapshotRepository applicationSnapshotRepository) {
+            PagePermission pagePermission) {
         super(validator, repository, analyticsService);
         this.applicationService = applicationService;
         this.userDataService = userDataService;
         this.responseUtils = responseUtils;
         this.applicationPermission = applicationPermission;
         this.pagePermission = pagePermission;
-        this.applicationSnapshotRepository = applicationSnapshotRepository;
     }
 
     @Override
@@ -150,7 +138,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
                     newPage.setUnpublishedPage(page);
                     // gitSyncId will be used to sync resource across instances
                     if (newPage.getGitSyncId() == null) {
-                        newPage.setGitSyncId(page.getApplicationId() + "_" + new ObjectId());
+                        newPage.setGitSyncId(page.getApplicationId() + "_" + UUID.randomUUID());
                     }
                     return repository.save(newPage);
                 })
@@ -166,7 +154,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
         newPage.setPolicies(object.getPolicies());
         if (newPage.getGitSyncId() == null) {
             // Make sure gitSyncId will be unique
-            newPage.setGitSyncId(newPage.getApplicationId() + "_" + new ObjectId());
+            newPage.setGitSyncId(newPage.getApplicationId() + "_" + UUID.randomUUID());
         }
         DefaultResources defaultResources = object.getDefaultResources();
         newPage.setDefaultResources(defaultResources);
@@ -475,11 +463,6 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     }
 
     @Override
-    public Flux<NewPage> findNewPagesByApplicationId(String applicationId, Optional<AclPermission> permission) {
-        return repository.findByApplicationId(applicationId, permission);
-    }
-
-    @Override
     public Mono<List<NewPage>> archivePagesByApplicationId(String applicationId, AclPermission permission) {
         return findNewPagesByApplicationId(applicationId, permission)
                 .flatMap(repository::archive)
@@ -540,7 +523,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     public Mono<NewPage> save(NewPage page) {
         // gitSyncId will be used to sync resource across instances
         if (page.getGitSyncId() == null) {
-            page.setGitSyncId(page.getApplicationId() + "_" + new ObjectId());
+            page.setGitSyncId(page.getApplicationId() + "_" + UUID.randomUUID());
         }
         return repository.save(page);
     }
@@ -578,7 +561,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     public Flux<NewPage> saveAll(List<NewPage> pages) {
         pages.stream()
                 .filter(newPage -> newPage.getGitSyncId() == null)
-                .forEach(newPage -> newPage.setGitSyncId(newPage.getId() + "_" + new ObjectId()));
+                .forEach(newPage -> newPage.setGitSyncId(newPage.getId() + "_" + UUID.randomUUID()));
         return repository.saveAll(pages);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceImpl.java
@@ -2,7 +2,6 @@ package com.appsmith.server.newpages.base;
 
 import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.helpers.ResponseUtils;
-import com.appsmith.server.repositories.ApplicationSnapshotRepository;
 import com.appsmith.server.repositories.NewPageRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.UserDataService;
@@ -24,8 +23,7 @@ public class NewPageServiceImpl extends NewPageServiceCEImpl implements NewPageS
             UserDataService userDataService,
             ResponseUtils responseUtils,
             ApplicationPermission applicationPermission,
-            PagePermission pagePermission,
-            ApplicationSnapshotRepository applicationSnapshotRepository) {
+            PagePermission pagePermission) {
 
         super(
                 validator,
@@ -35,7 +33,6 @@ public class NewPageServiceImpl extends NewPageServiceCEImpl implements NewPageS
                 userDataService,
                 responseUtils,
                 applicationPermission,
-                pagePermission,
-                applicationSnapshotRepository);
+                pagePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/exportable/NewPageExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/exportable/NewPageExportableServiceCEImpl.java
@@ -22,7 +22,6 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.appsmith.server.constants.ResourceModes.EDIT;
@@ -55,8 +54,8 @@ public class NewPageExportableServiceCEImpl implements ExportableServiceCE<NewPa
             ArtifactExchangeJson artifactExchangeJson) {
 
         ApplicationJson applicationJson = (ApplicationJson) artifactExchangeJson;
-        Optional<AclPermission> optionalPermission = Optional.ofNullable(pagePermission.getExportPermission(
-                exportingMetaDTO.getIsGitSync(), exportingMetaDTO.getExportWithConfiguration()));
+        AclPermission optionalPermission = pagePermission.getExportPermission(
+                exportingMetaDTO.getIsGitSync(), exportingMetaDTO.getExportWithConfiguration());
 
         List<String> unpublishedPages = exportingMetaDTO.getUnpublishedContextIds();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
@@ -84,7 +84,7 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
         // For git-sync this will not be empty
         Mono<List<NewPage>> existingPagesMono = importableArtifactMono
                 .flatMap(application -> newPageService
-                        .findNewPagesByApplicationId(application.getId(), Optional.empty())
+                        .findNewPagesByApplicationId(application.getId(), null)
                         .collectList())
                 .cache();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
@@ -12,10 +12,7 @@ import java.util.Optional;
 
 public interface CustomNewPageRepositoryCE extends AppsmithRepository<NewPage> {
 
-    @Deprecated
     Flux<NewPage> findByApplicationId(String applicationId, AclPermission aclPermission);
-
-    Flux<NewPage> findByApplicationId(String applicationId, Optional<AclPermission> permission);
 
     Flux<NewPage> findByApplicationIdAndNonDeletedEditMode(String applicationId, AclPermission aclPermission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -43,14 +43,6 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
     }
 
     @Override
-    public Flux<NewPage> findByApplicationId(String applicationId, Optional<AclPermission> permission) {
-        return queryBuilder()
-                .criteria(Bridge.equal(NewPage.Fields.applicationId, applicationId))
-                .permission(permission.orElse(null))
-                .all();
-    }
-
-    @Override
     public Flux<NewPage> findByApplicationIdAndNonDeletedEditMode(String applicationId, AclPermission aclPermission) {
         BridgeQuery<NewPage> q = Bridge.<NewPage>equal(NewPage.Fields.applicationId, applicationId)
                 // In case a page has been deleted in edit mode, but still exists in deployed mode, NewPage object would


### PR DESCRIPTION
This refactor is in an effort to reduce the diff between `release` and `pg` branches.

/ok-to-test tags="@tag.Sanity"
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8747276123>
> Commit: 1d34803416f34b17959c5b3b11c7c9eefc3e07ed
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8747276123&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated identifier generation from `ObjectId` to `UUID` across various services for consistency and improved performance.
	- Simplified method signatures and removed unnecessary overloads to enhance code maintainability and readability.
- **Bug Fixes**
	- Adjusted method parameters from `Optional` types to direct assignments to fix logical errors in entity fetching processes.
- **Chores**
	- Removed deprecated code segments and unused dependencies to clean up the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->