### PR TITLE
fix: Snapshot response DTO missing fields

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
@@ -27,7 +27,7 @@ import com.appsmith.server.exports.internal.partial.PartialExportService;
 import com.appsmith.server.fork.internal.ApplicationForkingService;
 import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.imports.internal.partial.PartialImportService;
-import com.appsmith.server.projections.DefaultTimestampOnly;
+import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import com.appsmith.server.services.ApplicationPageService;
 import com.appsmith.server.services.ApplicationSnapshotService;
 import com.appsmith.server.solutions.ApplicationFetcher;
@@ -232,7 +232,7 @@ public class ApplicationControllerCE {
 
     @JsonView(Views.Public.class)
     @GetMapping("/snapshot/{id}")
-    public Mono<ResponseDTO<DefaultTimestampOnly>> getSnapshotWithoutApplicationJson(
+    public Mono<ResponseDTO<ApplicationSnapshotResponseDTO>> getSnapshotWithoutApplicationJson(
             @PathVariable String id, @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
         log.debug("Going to get snapshot with application id: {}, branch: {}", id, branchName);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/ApplicationSnapshotResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/ApplicationSnapshotResponseDTO.java
@@ -1,0 +1,33 @@
+package com.appsmith.server.projections;
+
+import com.appsmith.server.helpers.DateUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+public record ApplicationSnapshotResponseDTO(
+        @JsonIgnore String id, int chunkOrder, @JsonIgnore Instant updatedAt, @JsonIgnore Instant createdAt) {
+
+    public ApplicationSnapshotResponseDTO() {
+        this(null, 0, null, null);
+    }
+
+    @JsonInclude
+    public boolean isNew() {
+        return id == null;
+    }
+
+    @JsonInclude
+    public String getUpdatedTime() {
+        return updatedAt == null ? null : DateUtils.ISO_FORMATTER.format(updatedAt);
+    }
+
+    // Likely not used by the client. Verify and remove if not needed.
+    @JsonInclude
+    public List<?> getUserPermissions() {
+        return Collections.emptyList();
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/DefaultTimestampOnly.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/DefaultTimestampOnly.java
@@ -1,5 +1,0 @@
-package com.appsmith.server.projections;
-
-import java.time.Instant;
-
-public record DefaultTimestampOnly(Instant updatedAt, Instant createdAt) {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/ApplicationSnapshotRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/ApplicationSnapshotRepositoryCE.java
@@ -1,7 +1,7 @@
 package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.ApplicationSnapshot;
-import com.appsmith.server.projections.DefaultTimestampOnly;
+import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import com.appsmith.server.repositories.BaseRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -12,5 +12,5 @@ public interface ApplicationSnapshotRepositoryCE
 
     Mono<Void> deleteAllByApplicationId(String applicationId);
 
-    Mono<DefaultTimestampOnly> findByApplicationIdAndChunkOrder(String applicationId, Integer chunkOrder);
+    Mono<ApplicationSnapshotResponseDTO> findByApplicationIdAndChunkOrder(String applicationId, Integer chunkOrder);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCE.java
@@ -1,7 +1,7 @@
 package com.appsmith.server.services.ce;
 
 import com.appsmith.server.domains.Application;
-import com.appsmith.server.projections.DefaultTimestampOnly;
+import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import reactor.core.publisher.Mono;
 
 public interface ApplicationSnapshotServiceCE {
@@ -15,7 +15,7 @@ public interface ApplicationSnapshotServiceCE {
      */
     Mono<Boolean> createApplicationSnapshot(String applicationId, String branchName);
 
-    Mono<DefaultTimestampOnly> getWithoutDataByApplicationId(String applicationId, String branchName);
+    Mono<ApplicationSnapshotResponseDTO> getWithoutDataByApplicationId(String applicationId, String branchName);
 
     Mono<Application> restoreSnapshot(String applicationId, String branchName);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
@@ -12,7 +12,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.exports.internal.ExportService;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.imports.internal.ImportService;
-import com.appsmith.server.projections.DefaultTimestampOnly;
+import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import com.appsmith.server.repositories.ApplicationSnapshotRepository;
 import com.appsmith.server.solutions.ApplicationPermission;
 import com.google.gson.Gson;
@@ -68,13 +68,13 @@ public class ApplicationSnapshotServiceCEImpl implements ApplicationSnapshotServ
     }
 
     @Override
-    public Mono<DefaultTimestampOnly> getWithoutDataByApplicationId(String applicationId, String branchName) {
+    public Mono<ApplicationSnapshotResponseDTO> getWithoutDataByApplicationId(String applicationId, String branchName) {
         // get application first to check the permission and get child aka branched application ID
         return applicationService
                 .findBranchedApplicationId(branchName, applicationId, applicationPermission.getEditPermission())
                 .flatMap(branchedApplicationId ->
                         applicationSnapshotRepository.findByApplicationIdAndChunkOrder(branchedApplicationId, 1))
-                .defaultIfEmpty(new DefaultTimestampOnly(null, null));
+                .defaultIfEmpty(new ApplicationSnapshotResponseDTO());
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/ApplicationSnapshotRepositoryTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/ApplicationSnapshotRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.domains.ApplicationSnapshot;
-import com.appsmith.server.projections.DefaultTimestampOnly;
+import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,7 +35,7 @@ public class ApplicationSnapshotRepositoryTest {
         snapshot2.setApplicationId(testAppId2);
         snapshot2.setChunkOrder(1);
 
-        Mono<DefaultTimestampOnly> snapshotMono = applicationSnapshotRepository
+        Mono<ApplicationSnapshotResponseDTO> snapshotMono = applicationSnapshotRepository
                 .saveAll(List.of(snapshot1, snapshot2))
                 .then(applicationSnapshotRepository.findByApplicationIdAndChunkOrder(testAppId2, 1));
 
@@ -61,7 +61,7 @@ public class ApplicationSnapshotRepositoryTest {
         snapshot2.setApplicationId(testAppId1);
         snapshot2.setChunkOrder(2);
 
-        Mono<DefaultTimestampOnly> snapshotMono = applicationSnapshotRepository
+        Mono<ApplicationSnapshotResponseDTO> snapshotMono = applicationSnapshotRepository
                 .saveAll(List.of(snapshot1, snapshot2))
                 .then(applicationSnapshotRepository.findByApplicationIdAndChunkOrder(testAppId1, 1));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
@@ -10,7 +10,7 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.newpages.base.NewPageService;
-import com.appsmith.server.projections.DefaultTimestampOnly;
+import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import com.appsmith.server.repositories.ApplicationSnapshotRepository;
 import com.appsmith.server.solutions.ApplicationPermission;
 import org.junit.jupiter.api.AfterEach;
@@ -92,7 +92,7 @@ public class ApplicationSnapshotServiceTest {
         Application testApplication = new Application();
         testApplication.setName("Test app for snapshot");
         testApplication.setWorkspaceId(workspace.getId());
-        Mono<DefaultTimestampOnly> snapshotMono = applicationPageService
+        Mono<ApplicationSnapshotResponseDTO> snapshotMono = applicationPageService
                 .createApplication(testApplication)
                 .flatMap(application -> {
                     assert application.getId() != null;
@@ -117,7 +117,7 @@ public class ApplicationSnapshotServiceTest {
         Application testApplication = new Application();
         testApplication.setName("Test app for snapshot");
         testApplication.setWorkspaceId(workspace.getId());
-        Mono<DefaultTimestampOnly> snapshotMono = applicationPageService
+        Mono<ApplicationSnapshotResponseDTO> snapshotMono = applicationPageService
                 .createApplication(testApplication)
                 .flatMap(application -> {
                     assert application.getId() != null;
@@ -153,7 +153,7 @@ public class ApplicationSnapshotServiceTest {
         gitArtifactMetadata.setDefaultApplicationId(testDefaultAppId);
         gitArtifactMetadata.setBranchName(testBranchName);
         testApplication.setGitApplicationMetadata(gitArtifactMetadata);
-        Mono<Tuple2<DefaultTimestampOnly, Application>> tuple2Mono = applicationPageService
+        Mono<Tuple2<ApplicationSnapshotResponseDTO, Application>> tuple2Mono = applicationPageService
                 .createApplication(testApplication)
                 .flatMap(application -> applicationSnapshotService
                         .createApplicationSnapshot(testDefaultAppId, testBranchName)
@@ -163,7 +163,7 @@ public class ApplicationSnapshotServiceTest {
 
         StepVerifier.create(tuple2Mono)
                 .assertNext(objects -> {
-                    DefaultTimestampOnly applicationSnapshot = objects.getT1();
+                    ApplicationSnapshotResponseDTO applicationSnapshot = objects.getT1();
                     assertThat(applicationSnapshot.updatedAt()).isNotNull();
                     assertThat(applicationSnapshot.createdAt()).isNotNull();
                 })
@@ -304,7 +304,7 @@ public class ApplicationSnapshotServiceTest {
         Application testApplication = new Application();
         testApplication.setName("Test app for snapshot");
         testApplication.setWorkspaceId(workspace.getId());
-        Mono<DefaultTimestampOnly> applicationSnapshotMono = applicationPageService
+        Mono<ApplicationSnapshotResponseDTO> applicationSnapshotMono = applicationPageService
                 .createApplication(testApplication)
                 .flatMap(application1 -> {
                     return applicationSnapshotService.getWithoutDataByApplicationId(application1.getId(), null);


### PR DESCRIPTION
The response from `GET /api/v1/applications/snapshot/{id}` currently has `isNew`, `chunkOrder` and `userPermissions` (which is always set to an empty list). This PR brings that behavior back. We'll raise a separate PR to clean up the ones not being used on the client, `userPermissions` being especially likely, but not now.


/ok-to-test tags="@tag.Sanity, @tag.Git, @tag.IDE, @tag.MobileResponsive, @tag.Settings"<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8749078413>
> Commit: b7546820a2a10eeaecb75a1e1df58f390be60468
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8749078413&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/ExplorerTests/Hide_Page_spec.js
> <li>cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
> <li>cypress/e2e/Regression/ClientSide/SettingsPane/PageSettings_spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->


