### PR TITLE
chore: Add mysql plugin tinyInt1isBit configuration

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
@@ -251,7 +251,7 @@ public class MySqlDatasourceUtils {
         ob = addSslOptionsToBuilder(datasourceConfiguration, ob);
 
         boolean tinyInt1isBit = true;
-        if (datasourceConfiguration.getProperties().size() > 2
+        if (datasourceConfiguration.getProperties() != null && datasourceConfiguration.getProperties().size() > 2
                 && datasourceConfiguration.getProperties().get(2) != null) {
             Object value = datasourceConfiguration.getProperties().get(2).getValue();
             if (value instanceof Boolean) {

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
@@ -249,9 +249,20 @@ public class MySqlDatasourceUtils {
             throws AppsmithPluginException {
         ConnectionFactoryOptions.Builder ob = getBuilder(datasourceConfiguration, connectionContext);
         ob = addSslOptionsToBuilder(datasourceConfiguration, ob);
+
+        boolean tinyInt1isBit = true;
+        if (datasourceConfiguration.getProperties().size() > 2
+                && datasourceConfiguration.getProperties().get(2) != null) {
+            Object value = datasourceConfiguration.getProperties().get(2).getValue();
+            if (value instanceof Boolean) {
+                tinyInt1isBit = (boolean) value;
+            }
+        }
+
         MariadbConnectionFactory connectionFactory =
                 MariadbConnectionFactory.from(MariadbConnectionConfiguration.fromOptions(ob.build())
                         .allowPublicKeyRetrieval(true)
+                        .tinyInt1isBit(tinyInt1isBit)
                         .build());
 
         /**

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/form.json
@@ -227,6 +227,13 @@
           "placeholderText": "UTC or any valid timezone"
         }
       ]
+    },
+    {
+      "label": "TinyInt1isBit",
+      "configProperty": "datasourceConfiguration.properties[2].value",
+      "controlType": "SWITCH",
+      "subtitle": "Will convert tinyint1 to bit",
+      "initialValue": true
     }
   ]
 }


### PR DESCRIPTION
## Description
> When designing the program, it was expected that a certain column might only contain a few very small numbers, so the column was designed as tinyint(1). 
> When this field is set to tinyint(1), for example.
create table test_tinyint_types (c_tinyint TINYINT, c_tinyInt1isBit TINYINT(1));
> At this time, the query through mysql-plugin will be treated as a Boolean value by default, but its values ​​are not only 0 and 1, but also 2, 3, etc.
> Therefore, when connecting to mysql-plugin, you can support specifying the tinyInt1isBit configuration item to solve this problem.

> When the tinyInt1isBit switch is turned on, the result of the query is a Boolean value 
![image](https://github.com/appsmithorg/appsmith/assets/56068188/8a477ed8-895f-4c2c-8da8-6db369f3509b)
![image](https://github.com/appsmithorg/appsmith/assets/56068188/3d2443a2-cb6c-4fa5-a853-40aaa0d33956)

> When the tinyInt1isBit switch is turned off, the result of the query is a number.
![image](https://github.com/appsmithorg/appsmith/assets/56068188/b2da13c3-1228-4201-8db1-bce5ffd83b6f)
![image](https://github.com/appsmithorg/appsmith/assets/56068188/b62a2137-45c2-4697-93d3-ce1d8438a782)



## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new configuration option in MySQL Plugin to allow conversion of `tinyint1` to `bit`, enhancing data type handling.

- **Tests**
	- Updated tests to cover new scenarios for `tinyint1` data type conversions in MySQL Plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->