### PR TITLE
fix: ForkTemplateToGitConnectedApp.js - slack bot template has been removed

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Templates/ForkTemplateToGitConnectedApp.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Templates/ForkTemplateToGitConnectedApp.js
@@ -44,7 +44,7 @@ describe(
       cy.get(template.templateViewForkButton).first().click();
       cy.waitUntil(() => cy.xpath("//span[text()='Setting up the template']"), {
         errorMsg: "Setting Templates did not finish even after 75 seconds",
-        timeout: 950000,
+        timeout: 75000,
         interval: 5000,
       }).then(($ele) => {
         cy.wrap($ele).should("have.length", 0);

--- a/app/client/cypress/e2e/Regression/ClientSide/Templates/ForkTemplateToGitConnectedApp.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Templates/ForkTemplateToGitConnectedApp.js
@@ -40,7 +40,8 @@ describe(
       );
       cy.wait(1000);
       cy.get(template.templateDialogBox).should("be.visible");
-      cy.xpath("//h1[text()='Slack Bot']").scrollIntoView().wait(500).click();
+      // cy.xpath("//h1[text()='Slack Bot']").scrollIntoView().wait(500).click();
+      cy.get(template.templateCard).first().click();
       cy.get(template.templateViewForkButton).first().click();
       cy.waitUntil(() => cy.xpath("//span[text()='Setting up the template']"), {
         errorMsg: "Setting Templates did not finish even after 75 seconds",

--- a/app/client/cypress/e2e/Regression/ClientSide/Templates/ForkTemplateToGitConnectedApp.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Templates/ForkTemplateToGitConnectedApp.js
@@ -40,7 +40,6 @@ describe(
       );
       cy.wait(1000);
       cy.get(template.templateDialogBox).should("be.visible");
-      // cy.xpath("//h1[text()='Slack Bot']").scrollIntoView().wait(500).click();
       cy.get(template.templateCard).first().click();
       cy.get(template.templateViewForkButton).first().click();
       cy.waitUntil(() => cy.xpath("//span[text()='Setting up the template']"), {


### PR DESCRIPTION
## Description
Slack bot template has been removed from the list of templates so going to pick the first one whichever we can find.

Link --> 10th spec from https://www.notion.so/appsmith/Cypress-tests-analysis-4090efa5e3064a2e87f262d3c399a339

EE PR - https://github.com/appsmithorg/appsmith-ee/pull/3995

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of template selection in the app by updating the click action to target the entire template card.
	- Enhanced the user experience by adjusting the wait time for template setup completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->