### PR TITLE
test: Better assertion failure message for duplicate error test

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/AppsmithErrorTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/AppsmithErrorTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/AppsmithErrorTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/AppsmithErrorTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DuplicateKeyException;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/AppsmithErrorTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/AppsmithErrorTest.java
@@ -13,11 +13,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class AppsmithErrorTest {
     @Test
     public void verifyUniquenessOfAppsmithErrorCode() {
-        assert (Arrays.stream(AppsmithError.values())
-                        .map(AppsmithError::getAppErrorCode)
-                        .distinct()
-                        .count()
-                == AppsmithError.values().length);
+        final List<String> duplicateErrorCodes = Arrays.stream(AppsmithError.values())
+                .collect(Collectors.groupingBy(AppsmithError::getAppErrorCode, Collectors.counting()))
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() > 1)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        assertThat(duplicateErrorCodes).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Currently, when this fails we see this:

```
org.opentest4j.AssertionFailedError: 
expected: 156L
 but was: 155L
Expected :156L
Actual   :155L
```

(It's comparing the count vs distinct-count).

This PR makes the failure show up like this:

```
java.lang.AssertionError: 
Expecting empty but was: ["AE-APP-4001"]
```

Making the failure message much more useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Updated the method for verifying the uniqueness of error codes in the system to enhance reliability by using a new approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->