### PR TITLE
Configurable init container images

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -81,6 +81,14 @@ The command uninstalls the release and removes all Kubernetes resources associat
 | `image.repository`	| Appsmith image repository		| `appsmith/appsmith-ce` 	 |
 | `image.tag`					| Appsmith image tag					| `latest` 										      |
 | `image.pullPolicy`	| Appsmith image pull policy	| `IfNotPresent` 							   |
+| `initContainer.redis.registry`		| Redis image registry			| `docker.io` 					  |
+| `initContainer.redis.repository`	| Redis image repository		| `bitnami/redis-cluster` 	 |
+| `initContainer.redis.tag`					| Redis image tag					| `7.0.13-debian-11-r10` 										      |
+| `initContainer.redis.pullPolicy`	| Redis image pull policy	| `IfNotPresent` 							   |
+| `initContainer.mongodb.registry`		| Mongodb image registry			| `docker.io` 					  |
+| `initContainer.mongodb.repository`	| Mongodb image repository		| `bitnami/mongodb` 	 |
+| `initContainer.mongodb.tag`					| Mongodb image tag					| `5.0.21-debian-11-r5` 										      |
+| `initContainer.mongodb.pullPolicy`	| Mongodb image pull policy	| `IfNotPresent` 							   |
 
 ### Appsmith deployment parameters
 | Name 											 	| Description 																				| Value 					|

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -49,18 +49,20 @@ spec:
       {{- if ((.Values.initContainer.redis).image) }}
         image: {{ .Values.initContainer.redis.image }}
       {{- else }}
-        image: "docker.io/bitnami/redis:7.0.13-debian-11-r10"
+        image: {{ .Values.initContainer.redis.registry }}/{{ .Values.initContainer.redis.repository }}:{{ .Values.initContainer.redis.tag }}
       {{- end }}
         command: ['sh', '-c', "until redis-cli -h {{.Release.Name}}-redis-master.{{.Release.Namespace}}.svc.cluster.local ping ; do echo waiting for redis; sleep 2; done"]
+        imagePullPolicy: {{ .Values.initContainer.redis.pullPolicy }}
       {{- end }}
       {{- if .Values.mongodb.enabled }}
       - name: mongo-init-container
       {{- if ((.Values.initContainer.mongodb).image) }}
         image: {{ .Values.initContainer.mongodb.image }}
       {{- else }}
-        image:  "docker.io/bitnami/mongodb:5.0.21-debian-11-r5"
+        image: {{ .Values.initContainer.mongodb.registry }}/{{ .Values.initContainer.mongodb.repository }}:{{ .Values.initContainer.mongodb.tag }}
       {{- end }}
         command: ['sh', '-c', "until mongo --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
+        imagePullPolicy: {{ .Values.initContainer.mongodb.pullPolicy }}
       {{- end }}
       containers:
         - name: {{ .Values.containerName }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -64,11 +64,17 @@ strategyType: RollingUpdate
 ##
 ## Init containers for redis & mongodb
 ##
-initContainer: {}
-  # redis:
-  #   image: docker.io/bitnami/redis-cluster:7.0.13-debian-11-r10
-  # mongodb:
-  #   image:  docker.io/bitnami/mongodb:5.0.21-debian-11-r5
+initContainer:
+  redis:
+    registry: docker.io
+    repository: bitnami/redis-cluster
+    tag: 7.0.13-debian-11-r10
+    pullPolicy: IfNotPresent
+  mongodb:
+    registry: docker.io
+    repository: bitnami/mongodb
+    tag: 5.0.21-debian-11-r5
+    pullPolicy: IfNotPresent
 ## Image
 ##
 image:


### PR DESCRIPTION
## Description
This PR enables configurable init container images. 
In line with other images in this chart, this PR makes sure you can configure registry, repository and tag all separately.
It also adds a imagePullPolicy. 
To ensure backwards compatibility I left the redis.image and mongodb.image properties in there. But imho these should be removed in a future major chart version.

Fixes #32844


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
