### PR TITLE
chore: Change wait for viewPage in EditAppFromSearch to getConsolidatedData

### DIFF
--- a/app/client/cypress/support/Pages/HomePage.ts
+++ b/app/client/cypress/support/Pages/HomePage.ts
@@ -513,7 +513,7 @@ export class HomePage {
   public EditAppFromSearch(appName: string, element?: string) {
     this.agHelper.WaitUntilEleAppear(`[data-testid="${appName}"]`);
     this.agHelper.GetNClick(`[data-testid="${appName}"]`);
-    this.assertHelper.AssertNetworkStatus("viewPage");
+    this.assertHelper.AssertNetworkStatus("getConsolidatedData");
     this.AssertViewPageLoad(element);
     this.deployHelper.NavigateBacktoEditor();
   }


### PR DESCRIPTION
## Description
Wait for end of consolidated api instead of view page api in EditAppFromSearch in `app/client/cypress/support/Pages/HomePage.ts`

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8788063697>
> Commit: f9c0fc0292c242f0bf1510085754de69fc910280
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8788063697&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
