### PR TITLE
chore: Remove `blockNavigation` in Page create API body

### DIFF
--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -44,7 +44,6 @@ export interface CreatePageActionPayload {
   applicationId: string;
   name: string;
   layouts: Partial<PageLayout>[];
-  blockNavigation?: boolean;
 }
 
 export interface updateLayoutOptions {
@@ -176,7 +175,6 @@ export const createPage = (
   pageName: string,
   layouts: Partial<PageLayout>[],
   orgId: string,
-  blockNavigation?: boolean,
   instanceId?: string,
 ) => {
   AnalyticsUtil.logEvent("CREATE_PAGE", {
@@ -190,7 +188,6 @@ export const createPage = (
       applicationId,
       name: pageName,
       layouts,
-      blockNavigation,
     },
   };
 };
@@ -199,7 +196,6 @@ export const createNewPageFromEntities = (
   applicationId: string,
   pageName: string,
   orgId: string,
-  blockNavigation?: boolean,
   instanceId?: string,
 ) => {
   AnalyticsUtil.logEvent("CREATE_PAGE", {
@@ -212,7 +208,6 @@ export const createNewPageFromEntities = (
     payload: {
       applicationId,
       name: pageName,
-      blockNavigation,
     },
   };
 };

--- a/app/client/src/api/PageApi.tsx
+++ b/app/client/src/api/PageApi.tsx
@@ -253,7 +253,10 @@ class PageApi extends Api {
   static async updatePage(
     request: UpdatePageRequest,
   ): Promise<AxiosPromise<ApiResponse<UpdatePageResponse>>> {
-    return Api.put(PageApi.updatePageUrl(request.id), request);
+    return Api.put(PageApi.updatePageUrl(request.id), {
+      ...request,
+      id: undefined,
+    });
   }
 
   static async generateTemplatePage(

--- a/app/client/src/pages/Editor/Explorer/Pages/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/index.tsx
@@ -77,13 +77,7 @@ function Pages() {
     );
 
     dispatch(
-      createNewPageFromEntities(
-        applicationId,
-        name,
-        workspaceId,
-        false,
-        instanceId,
-      ),
+      createNewPageFromEntities(applicationId, name, workspaceId, instanceId),
     );
   }, [dispatch, pages, applicationId]);
 

--- a/app/client/src/pages/Editor/IDE/EditorPane/PagesSection.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/PagesSection.tsx
@@ -69,13 +69,7 @@ const PagesSection = ({ onItemSelected }: { onItemSelected: () => void }) => {
       pages.map((page: Page) => page.pageName),
     );
     dispatch(
-      createNewPageFromEntities(
-        applicationId,
-        name,
-        workspaceId,
-        false,
-        instanceId,
-      ),
+      createNewPageFromEntities(applicationId, name, workspaceId, instanceId),
     );
   }, [dispatch, pages, applicationId]);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/PageControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/PageControllerCE.java
@@ -7,6 +7,7 @@ import com.appsmith.server.domains.ApplicationMode;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.CRUDPageResourceDTO;
 import com.appsmith.server.dtos.CRUDPageResponseDTO;
+import com.appsmith.server.dtos.PageCreationDTO;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.PageUpdateDTO;
 import com.appsmith.server.dtos.ResponseDTO;
@@ -16,8 +17,8 @@ import com.appsmith.server.solutions.CreateDBTablePageSolution;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.validation.Valid;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import reactor.core.publisher.Mono;
 
 @RequestMapping(Url.PAGE_URL)
+@RequiredArgsConstructor
 @Slf4j
 public class PageControllerCE {
 
@@ -39,25 +41,15 @@ public class PageControllerCE {
     private final NewPageService newPageService;
     private final CreateDBTablePageSolution createDBTablePageSolution;
 
-    @Autowired
-    public PageControllerCE(
-            ApplicationPageService applicationPageService,
-            NewPageService newPageService,
-            CreateDBTablePageSolution createDBTablePageSolution) {
-        this.applicationPageService = applicationPageService;
-        this.newPageService = newPageService;
-        this.createDBTablePageSolution = createDBTablePageSolution;
-    }
-
     @JsonView(Views.Public.class)
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<ResponseDTO<PageDTO>> createPage(
-            @Valid @RequestBody PageDTO resource,
+            @Valid @RequestBody PageCreationDTO page,
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
-        log.debug("Going to create resource {}", resource.getClass().getName());
+        log.debug("Going to create page {}", page.getClass().getName());
         return applicationPageService
-                .createPageWithBranchName(resource, branchName)
+                .createPageWithBranchName(page.toPageDTO(), branchName)
                 .map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageCreationDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageCreationDTO.java
@@ -1,0 +1,22 @@
+package com.appsmith.server.dtos;
+
+import com.appsmith.server.domains.Layout;
+import com.appsmith.server.meta.validations.FileName;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record PageCreationDTO(
+        @FileName(message = "Page names must be valid file names") @Size(max = 30) String name,
+        @NotEmpty @Size(min = 24, max = 50) String applicationId,
+        @NotEmpty List<Layout> layouts) {
+
+    public PageDTO toPageDTO() {
+        final PageDTO page = new PageDTO();
+        page.setName(name);
+        page.setApplicationId(applicationId);
+        page.setLayouts(layouts);
+        return page;
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/PageControllerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/PageControllerTest.java
@@ -46,7 +46,7 @@ public class PageControllerTest {
     @Test
     @WithMockUser
     void noBody() {
-        client.post().uri("/api/v1/pages/abcdef").exchange().expectStatus().isBadRequest();
+        client.post().uri("/api/v1/pages").exchange().expectStatus().isBadRequest();
         client.put().uri("/api/v1/pages/abcdef").exchange().expectStatus().isBadRequest();
     }
 
@@ -154,7 +154,7 @@ public class PageControllerTest {
     @WithMockUser
     void invalidName(String name) {
         client.post()
-                .uri("/api/v1/pages/abcdef")
+                .uri("/api/v1/pages")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(BodyInserters.fromValue(Map.of("name", name)))
                 .exchange()
@@ -202,7 +202,7 @@ public class PageControllerTest {
     @WithMockUser
     void invalidCustomSlug(String slug) {
         client.post()
-                .uri("/api/v1/pages/abcdef")
+                .uri("/api/v1/pages")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(BodyInserters.fromValue(Map.of("customSlug", slug)))
                 .exchange()
@@ -231,16 +231,6 @@ public class PageControllerTest {
     @Test
     @WithMockUser
     void emptyCustomSlugShouldBeOkay() {
-        doReturn(Mono.just(new PageDTO())).when(applicationPageService).createPageWithBranchName(any(), anyString());
-
-        client.post()
-                .uri("/api/v1/pages/abcdef")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(BodyInserters.fromValue(Map.of("customSlug", "")))
-                .exchange();
-
-        verify(applicationPageService, times(1)).createPageWithBranchName(any(), anyString());
-
         doReturn(Mono.just(new PageDTO()))
                 .when(newPageService)
                 .updatePageByDefaultPageIdAndBranch(anyString(), any(), anyString());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/PageControllerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/PageControllerTest.java
@@ -3,6 +3,7 @@ package com.appsmith.server.controllers;
 import com.appsmith.server.configurations.SecurityTestConfig;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.newpages.base.NewPageService;
+import com.appsmith.server.services.ApplicationPageService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -37,11 +38,15 @@ public class PageControllerTest {
     private WebTestClient client;
 
     @MockBean
+    private ApplicationPageService applicationPageService;
+
+    @MockBean
     private NewPageService newPageService;
 
     @Test
     @WithMockUser
     void noBody() {
+        client.post().uri("/api/v1/pages/abcdef").exchange().expectStatus().isBadRequest();
         client.put().uri("/api/v1/pages/abcdef").exchange().expectStatus().isBadRequest();
     }
 
@@ -148,6 +153,19 @@ public class PageControllerTest {
             })
     @WithMockUser
     void invalidName(String name) {
+        client.post()
+                .uri("/api/v1/pages/abcdef")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(Map.of("name", name)))
+                .exchange()
+                .expectStatus()
+                .isBadRequest()
+                .expectBody()
+                .jsonPath("$.errorDisplay")
+                .value(s -> assertThat((String) s).contains("Validation Failure"));
+
+        verifyNoInteractions(applicationPageService);
+
         client.put()
                 .uri("/api/v1/pages/abcdef")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -183,6 +201,19 @@ public class PageControllerTest {
             })
     @WithMockUser
     void invalidCustomSlug(String slug) {
+        client.post()
+                .uri("/api/v1/pages/abcdef")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(Map.of("customSlug", slug)))
+                .exchange()
+                .expectStatus()
+                .isBadRequest()
+                .expectBody()
+                .jsonPath("$.errorDisplay")
+                .value(s -> assertThat((String) s).contains("Validation Failure"));
+
+        verifyNoInteractions(applicationPageService);
+
         client.put()
                 .uri("/api/v1/pages/abcdef")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -200,6 +231,16 @@ public class PageControllerTest {
     @Test
     @WithMockUser
     void emptyCustomSlugShouldBeOkay() {
+        doReturn(Mono.just(new PageDTO())).when(applicationPageService).createPageWithBranchName(any(), anyString());
+
+        client.post()
+                .uri("/api/v1/pages/abcdef")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(Map.of("customSlug", "")))
+                .exchange();
+
+        verify(applicationPageService, times(1)).createPageWithBranchName(any(), anyString());
+
         doReturn(Mono.just(new PageDTO()))
                 .when(newPageService)
                 .updatePageByDefaultPageIdAndBranch(anyString(), any(), anyString());


### PR DESCRIPTION
1. The `blockNavigation` parameter in request body isn't being used, so removing it.
2. We're sending the page `id` in both the URL path as well as the request body. This is confusing, and may lead to a security regression in the future. Removing it from the body.

All tag Cypress tests pass on EE, with no extra changes over the diff here.
Ref: https://github.com/appsmithorg/appsmith-ee/pull/3698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced page creation process with streamlined parameters and validation constraints.

- **Refactor**
	- Simplified navigation and page creation logic in the application.
	- Updated method parameters and logging to improve clarity and maintainability.

- **Bug Fixes**
	- Fixed the issue where unnecessary data was included in page update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->