### PR TITLE
chore: Health check only backend, caddy and RTS

### DIFF
--- a/deploy/docker/fs/opt/appsmith/healthcheck.sh
+++ b/deploy/docker/fs/opt/appsmith/healthcheck.sh
@@ -32,7 +32,7 @@ while read -r line
         fi
       fi
     fi
-  done <<< $(supervisorctl status all)
+  done <<< $(supervisorctl status editor rts backend)
 if [ $healthy == true ]; then
   exit 0
 else


### PR DESCRIPTION
This is to avoid low-impact failures from getting the whole container to restart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified health check to focus on critical services (`editor`, `rts`, `backend`) for more efficient monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->