### PR TITLE
chore: disable sending webworker logs in production

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -262,6 +262,8 @@ export function* evaluateTreeSaga(
   const widgetsMeta: ReturnType<typeof getWidgetsMeta> =
     yield select(getWidgetsMeta);
 
+  const isDebugLevel = log.getLevel() === log.levels.DEBUG;
+
   const evalTreeRequestData: EvalTreeRequestData = {
     unevalTree: unEvalAndConfigTree,
     widgetTypeConfigMap,
@@ -273,6 +275,7 @@ export function* evaluateTreeSaga(
     metaWidgets,
     appMode,
     widgetsMeta,
+    isDebugLevel,
   };
 
   const workerResponse: EvalTreeResponseData = yield call(

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -262,7 +262,7 @@ export function* evaluateTreeSaga(
   const widgetsMeta: ReturnType<typeof getWidgetsMeta> =
     yield select(getWidgetsMeta);
 
-  const isDebugLevel = log.getLevel() === log.levels.DEBUG;
+  const shouldRespondWithLogs = log.getLevel() === log.levels.DEBUG;
 
   const evalTreeRequestData: EvalTreeRequestData = {
     unevalTree: unEvalAndConfigTree,
@@ -275,7 +275,7 @@ export function* evaluateTreeSaga(
     metaWidgets,
     appMode,
     widgetsMeta,
-    isDebugLevel,
+    shouldRespondWithLogs,
   };
 
   const workerResponse: EvalTreeResponseData = yield call(

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -66,6 +66,7 @@ export function evalTree(request: EvalWorkerSyncRequest) {
     allActionValidationConfig,
     appMode,
     forceEvaluation,
+    isDebugLevel,
     metaWidgets,
     shouldReplay,
     theme,
@@ -292,7 +293,9 @@ export function evalTree(request: EvalWorkerSyncRequest) {
     evaluationOrder: evalOrder,
     jsUpdates,
     webworkerTelemetry,
-    logs,
+    // be weary of the payload size of logs it can be huge and contribute to transmission overhead
+    // we are only sending logs in local debug mode
+    logs: isDebugLevel ? logs : [],
     unEvalUpdates,
     isCreateFirstTree,
     configTree,

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -66,9 +66,9 @@ export function evalTree(request: EvalWorkerSyncRequest) {
     allActionValidationConfig,
     appMode,
     forceEvaluation,
-    isDebugLevel,
     metaWidgets,
     shouldReplay,
+    shouldRespondWithLogs,
     theme,
     unevalTree: __unevalTree__,
     widgets,
@@ -295,7 +295,7 @@ export function evalTree(request: EvalWorkerSyncRequest) {
     webworkerTelemetry,
     // be weary of the payload size of logs it can be huge and contribute to transmission overhead
     // we are only sending logs in local debug mode
-    logs: isDebugLevel ? logs : [],
+    logs: shouldRespondWithLogs ? logs : [],
     unEvalUpdates,
     isCreateFirstTree,
     configTree,

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -43,6 +43,7 @@ export interface EvalTreeRequestData {
   metaWidgets: MetaWidgetsReduxState;
   appMode?: APP_MODE;
   widgetsMeta: Record<string, any>;
+  isDebugLevel?: boolean;
 }
 
 export interface EvalTreeResponseData {

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -43,7 +43,7 @@ export interface EvalTreeRequestData {
   metaWidgets: MetaWidgetsReduxState;
   appMode?: APP_MODE;
   widgetsMeta: Record<string, any>;
-  isDebugLevel?: boolean;
+  shouldRespondWithLogs?: boolean;
 }
 
 export interface EvalTreeResponseData {


### PR DESCRIPTION
## Description
Its been observed the logs been sent to main thread even during production, sending the logs increases the transmission cost during production consequently slowing the main thread. In this PR we will be sending the logs when logs are at debug level.


Fixes #32907
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8804717249>
> Commit: 58999c947fc7aeb8b091c5f08581fa2ad35dc650
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8804717249&attempt=3" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->











## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities in evaluation processes to conditionally send logs based on the debug level, optimizing payload size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->