### PR TITLE
chore: Remove config tree from eval worker response

### DIFF
--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,5 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
-cypress/e2e/Regression/ClientSide/BugTests/Bug29566_Spec.ts
-cypress/e2e/Regression/ClientSide/Widgets/ContainerTest2_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,7 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/BugTests/Bug29566_Spec.ts
+cypress/e2e/Regression/ClientSide/Widgets/ContainerTest2_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/src/sagas/EvalWorkerActionSagas.ts
+++ b/app/client/src/sagas/EvalWorkerActionSagas.ts
@@ -1,4 +1,4 @@
-import { all, call, put, spawn, take } from "redux-saga/effects";
+import { all, call, put, select, spawn, take } from "redux-saga/effects";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { MAIN_THREAD_ACTION } from "@appsmith/workers/Evaluation/evalWorkerActions";
 import log from "loglevel";
@@ -23,6 +23,7 @@ import type { UnEvalTree } from "entities/DataTree/dataTreeTypes";
 import { sortJSExecutionDataByCollectionId } from "workers/Evaluation/JSObject/utils";
 import type { LintTreeSagaRequestData } from "plugins/Linting/types";
 import { evalErrorHandler } from "./EvalErrorHandler";
+import { getUnevaluatedDataTree } from "selectors/dataTreeSelectors";
 export interface UpdateDataTreeMessageData {
   workerResponse: EvalTreeResponseData;
   unevalTree: UnEvalTree;
@@ -140,10 +141,13 @@ export function* handleEvalWorkerMessage(message: TMessage<any>) {
     }
     case MAIN_THREAD_ACTION.UPDATE_DATATREE: {
       const { unevalTree, workerResponse } = data as UpdateDataTreeMessageData;
+      const unEvalAndConfigTree: ReturnType<typeof getUnevaluatedDataTree> =
+        yield select(getUnevaluatedDataTree);
       yield call(updateDataTreeHandler, {
         evalTreeResponse: workerResponse as EvalTreeResponseData,
         unevalTree,
         requiresLogging: false,
+        configTree: unEvalAndConfigTree.configTree,
       });
       break;
     }

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -126,13 +126,14 @@ export function* updateDataTreeHandler(
     evalTreeResponse: EvalTreeResponseData;
     unevalTree: UnEvalTree;
     requiresLogging: boolean;
+    configTree: any;
   },
   postEvalActions?: Array<AnyReduxAction>,
 ) {
-  const { evalTreeResponse, requiresLogging, unevalTree } = data;
+  const { configTree, evalTreeResponse, requiresLogging, unevalTree } = data;
   const postEvalActionsToDispatch: Array<AnyReduxAction> =
     postEvalActions || [];
-  const { configTree } = yield select(getUnevaluatedDataTree);
+
   const {
     dependencies,
     errors,
@@ -285,7 +286,12 @@ export function* evaluateTreeSaga(
 
   yield call(
     updateDataTreeHandler,
-    { evalTreeResponse: workerResponse, unevalTree, requiresLogging },
+    {
+      evalTreeResponse: workerResponse,
+      unevalTree,
+      configTree: unEvalAndConfigTree.configTree,
+      requiresLogging,
+    },
     postEvalActions,
   );
 }

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -132,9 +132,8 @@ export function* updateDataTreeHandler(
   const { evalTreeResponse, requiresLogging, unevalTree } = data;
   const postEvalActionsToDispatch: Array<AnyReduxAction> =
     postEvalActions || [];
-
+  const { configTree } = yield select(getUnevaluatedDataTree);
   const {
-    configTree,
     dependencies,
     errors,
     evalMetaUpdates = [],

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -84,7 +84,11 @@ import {
   getAllJSActionsData,
 } from "@appsmith/selectors/entitiesSelector";
 import type { WidgetEntityConfig } from "@appsmith/entities/DataTree/types";
-import type { DataTree, UnEvalTree } from "entities/DataTree/dataTreeTypes";
+import type {
+  ConfigTree,
+  DataTree,
+  UnEvalTree,
+} from "entities/DataTree/dataTreeTypes";
 import { initiateLinting, lintWorker } from "./LintingSagas";
 import type {
   EvalTreeRequestData,
@@ -126,7 +130,7 @@ export function* updateDataTreeHandler(
     evalTreeResponse: EvalTreeResponseData;
     unevalTree: UnEvalTree;
     requiresLogging: boolean;
-    configTree: any;
+    configTree: ConfigTree;
   },
   postEvalActions?: Array<AnyReduxAction>,
 ) {

--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
@@ -1,8 +1,4 @@
-import type {
-  ConfigTree,
-  DataTree,
-  UnEvalTree,
-} from "entities/DataTree/dataTreeTypes";
+import type { DataTree, UnEvalTree } from "entities/DataTree/dataTreeTypes";
 import { dataTreeEvaluator } from "./handlers/evalTree";
 import type { DataTreeDiff } from "@appsmith/workers/Evaluation/evaluationUtils";
 import type { EvalMetaUpdates } from "@appsmith/workers/common/DataTreeEvaluator/types";
@@ -35,7 +31,6 @@ export function evalTreeWithChanges(
   let staleMetaIds: string[] = [];
   const removedPaths: Array<{ entityId: string; fullpath: string }> = [];
   let unevalTree: UnEvalTree = {};
-  let configTree: ConfigTree = {};
 
   if (dataTreeEvaluator) {
     const setupUpdateTreeResponse =
@@ -62,7 +57,6 @@ export function evalTreeWithChanges(
 
     staleMetaIds = updateResponse.staleMetaIds;
     unevalTree = dataTreeEvaluator.getOldUnevalTree();
-    configTree = dataTreeEvaluator.oldConfigTree;
   }
   const allUnevalUpdates = unEvalUpdates.map(
     (update) => update.payload.propertyPath,
@@ -94,7 +88,6 @@ export function evalTreeWithChanges(
     logs,
     unEvalUpdates,
     isCreateFirstTree,
-    configTree,
     staleMetaIds,
     removedPaths,
     isNewWidgetAdded: false,

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -298,7 +298,6 @@ export function evalTree(request: EvalWorkerSyncRequest) {
     logs: shouldRespondWithLogs ? logs : [],
     unEvalUpdates,
     isCreateFirstTree,
-    configTree,
     staleMetaIds,
     removedPaths,
     isNewWidgetAdded,

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -1,7 +1,4 @@
-import type {
-  ConfigTree,
-  unEvalAndConfigTree,
-} from "entities/DataTree/dataTreeTypes";
+import type { unEvalAndConfigTree } from "entities/DataTree/dataTreeTypes";
 import type { ActionValidationConfigMap } from "constants/PropertyControlConstants";
 import type { AppTheme } from "entities/AppTheming";
 
@@ -55,7 +52,6 @@ export interface EvalTreeResponseData {
   logs: unknown[];
   unEvalUpdates: DataTreeDiff[];
   isCreateFirstTree: boolean;
-  configTree: ConfigTree;
   staleMetaIds: string[];
   removedPaths: Array<{ entityId: string; fullpath: string }>;
   isNewWidgetAdded: boolean;


### PR DESCRIPTION
## Description
Sending configTree from the webworker is a redundant operation, we can directly the same from the main thread state. By removing this property we reduce the transmission cost between the main thread to webworker, we are seeing as much as 10% reduction in main thread scripting from these changes.
Fixes #32969  

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8832685819>
> Commit: 58ad75ebf73714e7a6603a95f074826fcd11ec67
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8832685819&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

















## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Optimized the evaluation process by streamlining how configuration data is retrieved and handled across different components.
	- Updated data retrieval methods in sagas and workers to improve efficiency and maintain consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->