### PR TITLE
fix: Check page permission to show widget add panel

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/UI/index.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/UI/index.tsx
@@ -13,10 +13,27 @@ import {
 } from "constants/routes";
 import ListWidgets from "./List";
 import AddWidgets from "./Add";
+import { useSelector } from "react-redux";
+import { getPagePermissions } from "selectors/editorSelectors";
+import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
+import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
+import { getHasManagePagePermission } from "@appsmith/utils/BusinessFeatures/permissionPageHelpers";
 
 const UISegment = () => {
   const { path } = useRouteMatch();
   const [focusSearchInput, setFocusSearchInput] = React.useState(false);
+
+  const pagePermissions = useSelector(getPagePermissions);
+  const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
+
+  const canManagePages = getHasManagePagePermission(
+    isFeatureEnabled,
+    pagePermissions,
+  );
+
+  if (!canManagePages) {
+    return <ListWidgets setFocusSearchInput={setFocusSearchInput} />;
+  }
 
   return (
     <Flex


### PR DESCRIPTION
## Description

When the user does not have permission to edit a page, they should not be shown the widget pane with widgets

Fixes #32708

## Automation

/ok-to-test tags="@tag.IDE, @tag.AccessControl"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8814962106>
> Commit: 113a1477b4cfb3727ad392b83633ba878c90188f
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8814962106&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ x ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security by implementing permission checks before rendering widgets in the editor UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->