### PR TITLE
fix: removing uppercase from ssh key

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnectionV2/AddDeployKey.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnectionV2/AddDeployKey.tsx
@@ -72,7 +72,6 @@ export const KeyText = styled.span`
   overflow: hidden;
   flex: 1;
   font-size: 10px;
-  text-transform: uppercase;
   color: var(--ads-v2-color-fg);
   direction: rtl;
   margin-right: 8px;


### PR DESCRIPTION
## Description
SSH keys are case sensitive, should not add `text-transform: uppercase` to it


Fixes #32362

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
