### PR TITLE
chore: GitSynced and BranchAware are two different types

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -4,7 +4,6 @@ import com.appsmith.external.helpers.Identifiable;
 import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Git;
 import com.appsmith.external.views.Views;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -91,12 +90,6 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     @Transient
     @JsonView(Views.Public.class)
     public Set<String> userPermissions = new HashSet<>();
-
-    // This field will only be used for git related functionality to sync the action object across different instances.
-    // This field will be deprecated once we move to the new git sync implementation.
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    @JsonView({Views.Internal.class, Git.class})
-    String gitSyncId;
 
     public void sanitiseToExportDBObject() {
         this.setCreatedAt(null);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BranchAwareDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BranchAwareDomain.java
@@ -11,7 +11,7 @@ import static com.appsmith.external.helpers.StringUtils.dotted;
 @Setter
 @Getter
 @FieldNameConstants
-public abstract class BranchAwareDomain extends BaseDomain {
+public abstract class BranchAwareDomain extends GitSyncedDomain {
     // This field will be used to store the default/root resource IDs for branched resources generated for git
     // connected applications and will be used to connect resources across the branches
     @JsonView(Views.Internal.class)
@@ -23,7 +23,7 @@ public abstract class BranchAwareDomain extends BaseDomain {
         super.sanitiseToExportDBObject();
     }
 
-    public static class Fields extends BaseDomain.Fields {
+    public static class Fields extends GitSyncedDomain.Fields {
         public static final String defaultResources_applicationId =
                 dotted(defaultResources, DefaultResources.Fields.applicationId);
         public static final String defaultResources_branchName =

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Datasource.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Datasource.java
@@ -25,7 +25,7 @@ import java.util.Set;
 @NoArgsConstructor
 @Document
 @FieldNameConstants
-public class Datasource extends BranchAwareDomain {
+public class Datasource extends GitSyncedDomain {
 
     @Transient
     public static final String DEFAULT_NAME_PREFIX = "Untitled datasource";

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
@@ -26,7 +26,7 @@ import static com.appsmith.external.constants.PluginConstants.DEFAULT_REST_DATAS
 @NoArgsConstructor
 @Document
 @FieldNameConstants
-public class DatasourceStorage extends BaseDomain {
+public class DatasourceStorage extends GitSyncedDomain {
 
     @JsonView(Views.Public.class)
     String datasourceId;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/GitSyncedDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/GitSyncedDomain.java
@@ -1,0 +1,21 @@
+package com.appsmith.external.models;
+
+import com.appsmith.external.views.Git;
+import com.appsmith.external.views.Views;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldNameConstants;
+
+@Getter
+@Setter
+@FieldNameConstants
+public abstract class GitSyncedDomain extends BaseDomain {
+    // This field will only be used for git related functionality to sync the action object across different instances.
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonView({Views.Internal.class, Git.class})
+    String gitSyncId;
+
+    public static class Fields extends BaseDomain.Fields {}
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/imports/ApplicationImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/imports/ApplicationImportServiceCEImpl.java
@@ -310,10 +310,8 @@ public class ApplicationImportServiceCEImpl
         }
 
         if (applicationJson.getCustomJSLibList() != null) {
-            List<CustomJSLib> importedCustomJSLibList = applicationJson.getCustomJSLibList().stream()
-                    .peek(customJSLib -> customJSLib.setGitSyncId(
-                            null)) // setting this null so that this custom js lib can be imported again
-                    .collect(Collectors.toList());
+            List<CustomJSLib> importedCustomJSLibList =
+                    applicationJson.getCustomJSLibList().stream().collect(Collectors.toList());
             applicationJson.setCustomJSLibList(importedCustomJSLibList);
         }
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/CustomJSLibCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/CustomJSLibCE.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.domains.ce;
 
+import com.appsmith.external.models.BaseDomain;
 import com.appsmith.external.models.BranchAwareDomain;
 import com.appsmith.external.views.Git;
 import com.appsmith.external.views.Views;
@@ -22,7 +23,7 @@ import java.util.Set;
 @ToString
 @NoArgsConstructor
 @FieldNameConstants
-public class CustomJSLibCE extends BranchAwareDomain {
+public class CustomJSLibCE extends BaseDomain {
     /* Library name */
     @JsonView({Views.Public.class, Git.class})
     String name;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/artifactbased/ArtifactBasedImportableServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/artifactbased/ArtifactBasedImportableServiceCE.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.imports.importable.artifactbased;
 
 import com.appsmith.external.models.BaseDomain;
+import com.appsmith.external.models.GitSyncedDomain;
 import com.appsmith.server.domains.Artifact;
 import com.appsmith.server.domains.Context;
 import com.appsmith.server.dtos.ImportingMetaDTO;
@@ -35,11 +36,19 @@ public interface ArtifactBasedImportableServiceCE<T extends BaseDomain, U extend
             MappedImportableResourcesDTO mappedImportableResourcesDTO,
             Map<String, T> entityInCurrentArtifact,
             T entity) {
-        return entityInCurrentArtifact.get(entity.getGitSyncId());
+        if (entity instanceof GitSyncedDomain gitSyncedEntity) {
+            return entityInCurrentArtifact.get(gitSyncedEntity.getGitSyncId());
+        } else {
+            return entity;
+        }
     }
 
     default T getExistingEntityInOtherBranchForImportedEntity(
             MappedImportableResourcesDTO mappedImportableResourcesDTO, Map<String, T> entityInOtherArtifact, T entity) {
-        return entityInOtherArtifact.get(entity.getGitSyncId());
+        if (entity instanceof GitSyncedDomain gitSyncedEntity) {
+            return entityInOtherArtifact.get(gitSyncedEntity.getGitSyncId());
+        } else {
+            return entity;
+        }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -4,6 +4,7 @@ import com.appsmith.external.converters.ISOStringToInstantConverter;
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.external.models.BranchAwareDomain;
 import com.appsmith.external.models.Datasource;
+import com.appsmith.external.models.GitSyncedDomain;
 import com.appsmith.external.models.PluginType;
 import com.appsmith.external.models.Policy;
 import com.appsmith.server.acl.AclPermission;
@@ -115,7 +116,7 @@ public class DatabaseChangelog2 {
                 ActionCollection.class,
                 makeIndex(
                                 defaultResources + "." + FieldName.APPLICATION_ID,
-                                BaseDomain.Fields.gitSyncId,
+                                GitSyncedDomain.Fields.gitSyncId,
                                 FieldName.DELETED)
                         .named("defaultApplicationId_gitSyncId_deleted"));
 
@@ -124,7 +125,7 @@ public class DatabaseChangelog2 {
                 NewAction.class,
                 makeIndex(
                                 defaultResources + "." + FieldName.APPLICATION_ID,
-                                BaseDomain.Fields.gitSyncId,
+                                GitSyncedDomain.Fields.gitSyncId,
                                 FieldName.DELETED)
                         .named("defaultApplicationId_gitSyncId_deleted"));
 
@@ -133,7 +134,7 @@ public class DatabaseChangelog2 {
                 NewPage.class,
                 makeIndex(
                                 defaultResources + "." + FieldName.APPLICATION_ID,
-                                BaseDomain.Fields.gitSyncId,
+                                GitSyncedDomain.Fields.gitSyncId,
                                 FieldName.DELETED)
                         .named("defaultApplicationId_gitSyncId_deleted"));
     }


### PR DESCRIPTION
## Description
Not every git synced domain is branch aware, this separation allows us to escape from having to deal with branch aware logic for all domains.

Fixes #32930 

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8826985229>
> Commit: ea613150801b73f92b84c0af10e3c5e4545b8473
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8826985229&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new class structure to enhance Git-related synchronization across different instances and entities.
- **Refactor**
	- Updated various classes to extend from `GitSyncedDomain` to streamline Git synchronization capabilities.
	- Simplified code in the application import service for better maintainability.
- **Bug Fixes**
	- Adjusted inheritance and field references in multiple classes to fix issues related to Git synchronization and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->