### PR TITLE
fix: number slider + category slider color spec fails

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
@@ -10,7 +10,7 @@ import {
   propPane,
 } from "../../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
-EntityType,
+  EntityType,
   PageLeftPane,
   PagePaneSegment,
 } from "../../../../../support/Pages/EditorNavigation";
@@ -288,7 +288,8 @@ describe(
           agHelper
             .GetWidgetCSSFrAttribute(
               `${propPane._propertyControlSelectedColorButton("fillcolor")}`,
-              "background-color")
+              "background-color",
+            )
             .then((newColor) => {
               expect(sliderColor).to.eq(newColor);
             });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
@@ -10,7 +10,7 @@ import {
   propPane,
 } from "../../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
-  EntityType,
+EntityType,
   PageLeftPane,
   PagePaneSegment,
 } from "../../../../../support/Pages/EditorNavigation";
@@ -286,7 +286,9 @@ describe(
         .GetWidgetCSSFrAttribute(locators._sliderThumb, "background-color")
         .then((sliderColor) => {
           agHelper
-            .GetWidgetCSSFrAttribute(`${propPane._propertyControlSelectedColorButton("fillcolor")}`, "background-color")
+            .GetWidgetCSSFrAttribute(
+              `${propPane._propertyControlSelectedColorButton("fillcolor")}`,
+              "background-color")
             .then((newColor) => {
               expect(sliderColor).to.eq(newColor);
             });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
@@ -251,7 +251,7 @@ describe(
       deployMode.NavigateBacktoEditor();
     });
 
-    it("9. Verify size change and color change", () => {
+    it.only("9. Verify size change and color change", () => {
       EditorNavigation.SelectEntityByName("CategorySlider1", EntityType.Widget);
       propPane.MoveToTab("Style");
       // Verify Size
@@ -286,7 +286,7 @@ describe(
         .GetWidgetCSSFrAttribute(locators._sliderThumb, "background-color")
         .then((sliderColor) => {
           agHelper
-            .GetWidgetCSSFrAttribute(propPane._fillColor, "background-color")
+            .GetWidgetCSSFrAttribute(`${propPane._propertyControlSelectedColorButton("fillcolor")}`, "background-color")
             .then((newColor) => {
               expect(sliderColor).to.eq(newColor);
             });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategorySlider_spec.ts
@@ -251,7 +251,7 @@ describe(
       deployMode.NavigateBacktoEditor();
     });
 
-    it.only("9. Verify size change and color change", () => {
+    it("9. Verify size change and color change", () => {
       EditorNavigation.SelectEntityByName("CategorySlider1", EntityType.Widget);
       propPane.MoveToTab("Style");
       // Verify Size

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/NumberSlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/NumberSlider_spec.ts
@@ -377,7 +377,10 @@ describe("Number Slider spec", { tags: ["@tag.Widget", "@tag.Slider"] }, () => {
       .GetWidgetCSSFrAttribute(locators._sliderThumb, "background-color")
       .then((sliderColor) => {
         agHelper
-          .GetWidgetCSSFrAttribute(`${propPane._propertyControlSelectedColorButton("fillcolor")}`, "background-color")
+          .GetWidgetCSSFrAttribute(
+            `${propPane._propertyControlSelectedColorButton("fillcolor")}`,
+            "background-color"
+          )
           .then((newColor) => {
             expect(sliderColor).to.eq(newColor);
           });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/NumberSlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/NumberSlider_spec.ts
@@ -379,7 +379,7 @@ describe("Number Slider spec", { tags: ["@tag.Widget", "@tag.Slider"] }, () => {
         agHelper
           .GetWidgetCSSFrAttribute(
             `${propPane._propertyControlSelectedColorButton("fillcolor")}`,
-            "background-color"
+            "background-color",
           )
           .then((newColor) => {
             expect(sliderColor).to.eq(newColor);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/NumberSlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/NumberSlider_spec.ts
@@ -377,7 +377,7 @@ describe("Number Slider spec", { tags: ["@tag.Widget", "@tag.Slider"] }, () => {
       .GetWidgetCSSFrAttribute(locators._sliderThumb, "background-color")
       .then((sliderColor) => {
         agHelper
-          .GetWidgetCSSFrAttribute(propPane._fillColor, "background-color")
+          .GetWidgetCSSFrAttribute(`${propPane._propertyControlSelectedColorButton("fillcolor")}`, "background-color")
           .then((newColor) => {
             expect(sliderColor).to.eq(newColor);
           });

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -139,6 +139,8 @@ export class PropertyPane {
   _dropdownOptionSpan = ".t--dropdown-option span";
   public _propertyControlColorPicker = (property: string) =>
     `.t--property-control-${property} .bp3-input-group input`;
+  public _propertyControlSelectedColorButton = (property: string) =>
+    `.t--property-control-${property} ${this._fillColor}`;
   _propertyText = ".bp3-ui-text span";
   _paneTitle = ".t--property-pane-title";
   _segmentedControl = (value: string) =>


### PR DESCRIPTION
Fixes a spec for slider and cateogry widget where it fails when changing and asserting the background color

/ok-to-test tags="@tag.Slider"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8873791272>
> Commit: b7111f115b691aeb6e6ccc2eceb30c476b91e3a3
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8873791272&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Modified a specific test case to run exclusively, improving focus on critical functionality during testing.
- **New Features**
	- Enhanced color selection capabilities in the property control for a more intuitive user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->