### PR TITLE
chore: Introduce defaultId as internal concept

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BranchAwareDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BranchAwareDomain.java
@@ -17,6 +17,14 @@ public abstract class BranchAwareDomain extends GitSyncedDomain {
     @JsonView(Views.Internal.class)
     DefaultResources defaultResources;
 
+    @JsonView(Views.Internal.class)
+    String defaultId;
+
+    @JsonView(Views.Internal.class)
+    public String getDefaultId() {
+        return this.getId();
+    }
+
     @Override
     public void sanitiseToExportDBObject() {
         this.setDefaultResources(null);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldNameConstants;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.util.StringUtils;
 
 @Getter
 @Setter
@@ -25,6 +26,16 @@ public class NewPage extends BranchAwareDomain implements Context {
 
     @JsonView(Views.Public.class)
     PageDTO publishedPage;
+
+    @Override
+    public String getDefaultId() {
+        if (this.getDefaultResources() != null
+                && StringUtils.hasLength(this.getDefaultResources().getPageId())) {
+            return this.getDefaultResources().getPageId();
+        } else {
+            return super.getDefaultId();
+        }
+    }
 
     @Override
     public void sanitiseToExportDBObject() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ActionCollectionCE.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
+import org.springframework.util.StringUtils;
 
 import static com.appsmith.external.helpers.StringUtils.dotted;
 
@@ -39,6 +40,16 @@ public class ActionCollectionCE extends BranchAwareDomain {
 
     @JsonView(Views.Public.class)
     CreatorContextType contextType;
+
+    @Override
+    public String getDefaultId() {
+        if (this.getDefaultResources() != null
+                && StringUtils.hasLength(this.getDefaultResources().getCollectionId())) {
+            return this.getDefaultResources().getCollectionId();
+        } else {
+            return super.getDefaultId();
+        }
+    }
 
     @Override
     public void sanitiseToExportDBObject() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
+import org.springframework.util.StringUtils;
 
 import static com.appsmith.external.helpers.StringUtils.dotted;
 
@@ -44,6 +45,16 @@ public class NewActionCE extends BranchAwareDomain {
 
     @JsonView(Views.Public.class)
     ActionDTO publishedAction;
+
+    @Override
+    public String getDefaultId() {
+        if (this.getDefaultResources() != null
+                && StringUtils.hasLength(this.getDefaultResources().getActionId())) {
+            return this.getDefaultResources().getActionId();
+        } else {
+            return super.getDefaultId();
+        }
+    }
 
     @Override
     public void sanitiseToExportDBObject() {


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8828953698>
> Commit: 2d513699b789ce8c603dff8a6ad3ac52b5615649
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8828953698&attempt=4&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/BugTests/GitBugs_Spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
