### PR TITLE
chore: Added indices for collection id in actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration051AddNewActionCollectionIdIndex.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration051AddNewActionCollectionIdIndex.java
@@ -1,0 +1,54 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.external.models.GitSyncedDomain;
+import com.appsmith.server.domains.NewAction;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.CompoundIndexDefinition;
+import org.springframework.data.mongodb.core.index.Index;
+
+import static com.appsmith.server.migrations.DatabaseChangelog1.dropIndexIfExists;
+import static com.appsmith.server.migrations.DatabaseChangelog1.ensureIndexes;
+
+@Slf4j
+@ChangeUnit(order = "051", id = "add-idx-new-action-coll-id", author = " ")
+public class Migration051AddNewActionCollectionIdIndex {
+
+    private final MongoTemplate mongoTemplate;
+
+    public Migration051AddNewActionCollectionIdIndex(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void rollbackExecution() {}
+
+    @Execution
+    public void addMissingIndexInNewActionCollection() {
+
+        String unpublishedCollectionIdIndexName = "unpublished_collectionId_deletedAt_index";
+        String publishedCollectionIdIndexName = "published_collectionId_deletedAt_index";
+
+        // Prod index name
+        dropIndexIfExists(mongoTemplate, NewAction.class, unpublishedCollectionIdIndexName);
+        dropIndexIfExists(mongoTemplate, NewAction.class, publishedCollectionIdIndexName);
+
+        Document unpublishedDoc = new Document();
+        unpublishedDoc.put(NewAction.Fields.unpublishedAction_collectionId, 1);
+        unpublishedDoc.put(GitSyncedDomain.Fields.deletedAt, 1);
+        Index unpublishedCollectionIdIndex =
+                new CompoundIndexDefinition(unpublishedDoc).named(unpublishedCollectionIdIndexName);
+        ensureIndexes(mongoTemplate, NewAction.class, unpublishedCollectionIdIndex);
+
+        Document publishedDoc = new Document();
+        publishedDoc.put(NewAction.Fields.publishedAction_collectionId, 1);
+        publishedDoc.put(GitSyncedDomain.Fields.deletedAt, 1);
+        Index publishedCollectionIdIndex =
+                new CompoundIndexDefinition(publishedDoc).named(publishedCollectionIdIndexName);
+        ensureIndexes(mongoTemplate, NewAction.class, publishedCollectionIdIndex);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration051AddNewActionCollectionIdIndex.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration051AddNewActionCollectionIdIndex.java
@@ -35,7 +35,9 @@ public class Migration051AddNewActionCollectionIdIndex {
 
         // Prod index name
         dropIndexIfExists(mongoTemplate, NewAction.class, unpublishedCollectionIdIndexName);
+        dropIndexIfExists(mongoTemplate, NewAction.class, "unpublishedAction.collectionId_1_deletedAt_1");
         dropIndexIfExists(mongoTemplate, NewAction.class, publishedCollectionIdIndexName);
+        dropIndexIfExists(mongoTemplate, NewAction.class, "publishedAction.collectionId_1_deletedAt_1");
 
         Document unpublishedDoc = new Document();
         unpublishedDoc.put(NewAction.Fields.unpublishedAction_collectionId, 1);


### PR DESCRIPTION
## Description
Now that actions refer to collections instead of the other way around, these indices will improve query performance.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced query performance by adding compound indexes to the `NewAction` collection in MongoDB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->