### PR TITLE
chore: Validate tag before doing anything

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,8 +1,7 @@
 name: Appsmith Github Release Workflow
 
 # This workflow builds Docker images for server and client, and then pushes them to Docker Hub.
-# The docker-tag with which this push happens is the release tag (e.g., v1.2.3 etc.).
-# In addition to the above tag, unless the git-tag matches `*beta*`, we also push to the `latest` docker-tag.
+# The docker-tag with which this push happens is `latest` and the release tag (e.g., v1.2.3 etc.).
 # This workflow does NOT run tests.
 # This workflow is automatically triggered when a release is created on GitHub.
 
@@ -19,7 +18,6 @@ jobs:
 
     outputs:
       tag: ${{ steps.get_version.outputs.tag }}
-      is_beta: ${{ steps.get_version.outputs.is_beta }}
 
     steps:
       - name: Environment details
@@ -32,13 +30,11 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-          if [[ $tag == *"beta"* ]]; then
-            echo "is_beta=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_beta=false" >> $GITHUB_OUTPUT
+          if ! [[ ${GITHUB_REF-} =~ ^refs/tags/v[[:digit:]]\.[[:digit:]]+(\.[[:digit:]]+)?$ ]]; then
+            echo "Invalid tag: '${GITHUB_REF-}'. Has to be like `v1.22`, `v1.22.33` only."
+            exit 1
           fi
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
   client-build:
     needs:
@@ -246,9 +242,7 @@ jobs:
 
       - name: Generate info.json
         run: |
-          if [[ -f scripts/generate_info_json.sh ]]; then
-            scripts/generate_info_json.sh
-          fi
+          scripts/generate_info_json.sh
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -267,17 +261,4 @@ jobs:
             BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:nightly
           tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:${{needs.prelude.outputs.tag}}
-
-      # Only build & tag with latest if the tag doesn't contain beta
-      - name: Build and push fat image latest
-        if: needs.prelude.outputs.is_beta == 'false'
-        uses: depot/build-push-action@v1
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64,linux/amd64
-          build-args: |
-            APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
-            BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:nightly
-          tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:latest

--- a/deploy/docker/fs/opt/appsmith/utils/bin/backup.test.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/backup.test.js
@@ -88,9 +88,6 @@ it('Checks for the current Appsmith Version.', async () => {
   });
   const res = await utils.getCurrentAppsmithVersion()
   expect(res).toBe("v0.0.0-SNAPSHOT")
-  console.log(res)
-  fsPromises.readFile = jest.fn().mockImplementation(async () => `{"githubRef":"refs/tags/v1.2.3"}`);
-  await expect(utils.getCurrentAppsmithVersion()).resolves.toBe("v1.2.3")
 })
 
 test('If MONGODB and Encryption env values are being removed', () => {

--- a/deploy/docker/fs/opt/appsmith/utils/bin/backup.test.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/backup.test.js
@@ -81,7 +81,7 @@ test('Test ln command generation', async () => {
 it('Checks for the current Appsmith Version.', async () => {
   fsPromises.readFile = jest.fn().mockImplementation(async (path) => {
     if (path === "/opt/appsmith/info.json") {
-      return `{"githubRef": "v0.0.0-SNAPSHOT"}`
+      return `{"version": "v0.0.0-SNAPSHOT"}`
     } else {
       throw new Error("Unexpected file to read: " + path)
     }

--- a/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
@@ -99,7 +99,7 @@ async function getLastBackupErrorMailSentInMilliSec() {
 async function getCurrentAppsmithVersion() {
   const version = JSON.parse(await fsPromises.readFile("/opt/appsmith/info.json", "utf8")).version;
   // This will be of the form "refs/tags/v1.2.3".
-  return version.split("/").pop() ?? "";
+  return version ?? "";
 }
 
 function preprocessMongoDBURI(uri /* string */) {

--- a/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
@@ -97,9 +97,9 @@ async function getLastBackupErrorMailSentInMilliSec() {
 }
 
 async function getCurrentAppsmithVersion() {
-  const githubRef = JSON.parse(await fsPromises.readFile("/opt/appsmith/info.json", "utf8")).githubRef;
+  const version = JSON.parse(await fsPromises.readFile("/opt/appsmith/info.json", "utf8")).version;
   // This will be of the form "refs/tags/v1.2.3".
-  return githubRef.split("/").pop() ?? "";
+  return version.split("/").pop() ?? "";
 }
 
 function preprocessMongoDBURI(uri /* string */) {

--- a/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/utils.js
@@ -97,9 +97,7 @@ async function getLastBackupErrorMailSentInMilliSec() {
 }
 
 async function getCurrentAppsmithVersion() {
-  const version = JSON.parse(await fsPromises.readFile("/opt/appsmith/info.json", "utf8")).version;
-  // This will be of the form "refs/tags/v1.2.3".
-  return version ?? "";
+  return JSON.parse(await fsPromises.readFile("/opt/appsmith/info.json", "utf8")).version ?? "";
 }
 
 function preprocessMongoDBURI(uri /* string */) {


### PR DESCRIPTION
1. Add validation for the tag before building the image or doing anything. This is strict case-sensitive validation, that will allow only three numbers in the version, and the first number has to be a single digit. Support for `-beta` versions is also being removed, as we just don't use it. Thanks to removing this, we'll build the `latest` and `v1.2.3` images together, instead of building two separate images.
2. The server and client are reading version from `version` key in `info.json`, but RTS is reading it from `githubRef` key in `info.json`. This discrepancy is debt, and has no reason to exist. We fix RTS to also read the version from the `version` field.

Why are we doing this? [Slack conversation](https://theappsmith.slack.com/archives/C0341RERY4R/p1714098736865219?thread_ts=1714066995.288859&cid=C0341RERY4R).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified the Docker image tagging process and improved version tag extraction logic.
	- Updated how the app version is determined to enhance accuracy.
	- Renamed a variable in the `getCurrentAppsmithVersion` function for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->