### PR TITLE
fix: [IDE] Page switch and State switch have deep links to entity to avoid interim load state

### DIFF
--- a/app/client/src/ce/navigation/FocusElements/AppIDE.ts
+++ b/app/client/src/ce/navigation/FocusElements/AppIDE.ts
@@ -76,17 +76,13 @@ import {
 import { getDebuggerContext } from "selectors/debuggerSelectors";
 import { setDebuggerContext } from "actions/debuggerActions";
 import { DefaultDebuggerContext } from "reducers/uiReducers/debuggerReducer";
-import { NavigationMethod } from "../../../utils/history";
+import { NavigationMethod } from "utils/history";
 import { JSEditorTab } from "reducers/uiReducers/jsPaneReducer";
-import {
-  getSelectedDatasourceId,
-  getSelectedSegment,
-} from "@appsmith/navigation/FocusSelectors";
+import { getSelectedDatasourceId } from "@appsmith/navigation/FocusSelectors";
 import {
   setSelectedDatasource,
   setSelectedJSObject,
   setSelectedQuery,
-  setSelectedSegment,
 } from "@appsmith/navigation/FocusSetters";
 import { getFirstDatasourceId } from "selectors/datasourceSelectors";
 import { FocusElement, FocusElementConfigType } from "navigation/FocusElements";
@@ -94,6 +90,7 @@ import type { FocusElementsConfigList } from "sagas/FocusRetentionSaga";
 import { getJSTabs, getQueryTabs } from "selectors/ideSelectors";
 import { setJSTabs, setQueryTabs } from "actions/ideActions";
 import { ActionExecutionResizerHeight } from "pages/Editor/APIEditor/constants";
+import history from "../../../utils/history";
 
 export const AppIDEFocusElements: FocusElementsConfigList = {
   [FocusEntity.DATASOURCE_LIST]: [
@@ -296,9 +293,9 @@ export const AppIDEFocusElements: FocusElementsConfigList = {
   [FocusEntity.EDITOR]: [
     {
       type: FocusElementConfigType.URL,
-      name: FocusElement.SelectedSegment,
-      selector: getSelectedSegment,
-      setter: setSelectedSegment,
+      name: FocusElement.SelectedEntity,
+      selector: (url) => url,
+      setter: history.push,
     },
     {
       type: FocusElementConfigType.Redux,

--- a/app/client/src/ce/navigation/FocusElements/AppIDE.ts
+++ b/app/client/src/ce/navigation/FocusElements/AppIDE.ts
@@ -78,9 +78,13 @@ import { setDebuggerContext } from "actions/debuggerActions";
 import { DefaultDebuggerContext } from "reducers/uiReducers/debuggerReducer";
 import { NavigationMethod } from "utils/history";
 import { JSEditorTab } from "reducers/uiReducers/jsPaneReducer";
-import { getSelectedDatasourceId } from "@appsmith/navigation/FocusSelectors";
+import {
+  getSelectedDatasourceId,
+  getSelectedEntityUrl,
+} from "@appsmith/navigation/FocusSelectors";
 import {
   setSelectedDatasource,
+  setSelectedEntityUrl,
   setSelectedJSObject,
   setSelectedQuery,
 } from "@appsmith/navigation/FocusSetters";
@@ -90,7 +94,6 @@ import type { FocusElementsConfigList } from "sagas/FocusRetentionSaga";
 import { getJSTabs, getQueryTabs } from "selectors/ideSelectors";
 import { setJSTabs, setQueryTabs } from "actions/ideActions";
 import { ActionExecutionResizerHeight } from "pages/Editor/APIEditor/constants";
-import history from "../../../utils/history";
 
 export const AppIDEFocusElements: FocusElementsConfigList = {
   [FocusEntity.DATASOURCE_LIST]: [
@@ -294,8 +297,8 @@ export const AppIDEFocusElements: FocusElementsConfigList = {
     {
       type: FocusElementConfigType.URL,
       name: FocusElement.SelectedEntity,
-      selector: (url) => url,
-      setter: history.push,
+      selector: getSelectedEntityUrl,
+      setter: setSelectedEntityUrl,
     },
     {
       type: FocusElementConfigType.Redux,

--- a/app/client/src/ce/navigation/FocusSelectors.ts
+++ b/app/client/src/ce/navigation/FocusSelectors.ts
@@ -1,10 +1,3 @@
-import { matchPath } from "react-router";
-import {
-  BUILDER_CUSTOM_PATH,
-  BUILDER_PATH,
-  BUILDER_PATH_DEPRECATED,
-} from "constants/routes";
-import { EditorEntityTab } from "@appsmith/entities/IDE/constants";
 import { FocusEntity, identifyEntityFromPath } from "navigation/FocusEntity";
 
 export const getSelectedDatasourceId = (path: string): string | undefined => {
@@ -12,27 +5,4 @@ export const getSelectedDatasourceId = (path: string): string | undefined => {
   if (entityInfo.entity === FocusEntity.DATASOURCE) {
     return entityInfo.id;
   }
-};
-
-export const getSelectedSegment = (path: string): string | undefined => {
-  const match = matchPath<{ entity: string }>(path, {
-    path: [
-      BUILDER_PATH_DEPRECATED + "/:entity",
-      BUILDER_PATH + "/:entity",
-      BUILDER_CUSTOM_PATH + "/:entity",
-    ],
-    exact: false,
-  });
-  if (!match) return undefined;
-  if (match.params.entity === "jsObjects") {
-    return EditorEntityTab.JS;
-  }
-  if (
-    match.params.entity === "queries" ||
-    match.params.entity === "api" ||
-    match.params.entity === "saas"
-  ) {
-    return EditorEntityTab.QUERIES;
-  }
-  return EditorEntityTab.UI;
 };

--- a/app/client/src/ce/navigation/FocusSelectors.ts
+++ b/app/client/src/ce/navigation/FocusSelectors.ts
@@ -1,8 +1,20 @@
 import { FocusEntity, identifyEntityFromPath } from "navigation/FocusEntity";
+import { getBaseUrlsForIDEType, getIDETypeByUrl } from "../entities/IDE/utils";
+import { matchPath } from "react-router";
 
 export const getSelectedDatasourceId = (path: string): string | undefined => {
   const entityInfo = identifyEntityFromPath(path);
   if (entityInfo.entity === FocusEntity.DATASOURCE) {
     return entityInfo.id;
+  }
+};
+
+export const getSelectedEntityUrl = (path: string): string | undefined => {
+  const ideType = getIDETypeByUrl(path);
+  const basePaths = getBaseUrlsForIDEType(ideType);
+  const entityPaths = basePaths.map((p) => `${p}/:entity*`);
+  const match = matchPath<{ entity: string }>(path, entityPaths);
+  if (match) {
+    return match.params.entity;
   }
 };

--- a/app/client/src/ce/navigation/FocusSetters.ts
+++ b/app/client/src/ce/navigation/FocusSetters.ts
@@ -1,5 +1,6 @@
 import history, { NavigationMethod } from "utils/history";
 import {
+  builderURL,
   curlImportPageURL,
   datasourcesEditorIdURL,
   jsCollectionIdURL,
@@ -54,6 +55,15 @@ export function setSelectedJSObject(focusInfo?: FocusEntityInfo) {
       jsCollectionIdURL({
         collectionId: focusInfo.id,
       }),
+      { invokedBy: NavigationMethod.ContextSwitching },
     );
+  }
+}
+
+export function setSelectedEntityUrl(url?: string) {
+  if (url) {
+    history.replace(builderURL({ suffix: url }), {
+      invokedBy: NavigationMethod.ContextSwitching,
+    });
   }
 }

--- a/app/client/src/ce/navigation/FocusSetters.ts
+++ b/app/client/src/ce/navigation/FocusSetters.ts
@@ -1,15 +1,10 @@
 import history, { NavigationMethod } from "utils/history";
 import {
-  builderURL,
   curlImportPageURL,
   datasourcesEditorIdURL,
   jsCollectionIdURL,
-  jsCollectionListURL,
-  queryListURL,
-  widgetListURL,
 } from "@appsmith/RouteBuilder";
 import { PluginType } from "entities/Action";
-import { EditorEntityTab } from "@appsmith/entities/IDE/constants";
 import type { FocusEntityInfo } from "navigation/FocusEntity";
 import { FocusEntity } from "navigation/FocusEntity";
 import { getQueryEntityItemUrl } from "../pages/Editor/IDE/EditorPane/Query/utils";
@@ -60,31 +55,5 @@ export function setSelectedJSObject(focusInfo?: FocusEntityInfo) {
         collectionId: focusInfo.id,
       }),
     );
-  }
-}
-
-export function setSelectedSegment(tab?: EditorEntityTab) {
-  if (tab) {
-    switch (tab) {
-      case EditorEntityTab.JS:
-        history.replace(jsCollectionListURL({ persistExistingParams: true }), {
-          invokedBy: NavigationMethod.ContextSwitching,
-        });
-        break;
-      case EditorEntityTab.QUERIES:
-        history.replace(queryListURL({ persistExistingParams: true }), {
-          invokedBy: NavigationMethod.ContextSwitching,
-        });
-        break;
-      case EditorEntityTab.UI:
-        history.replace(widgetListURL({ persistExistingParams: true }), {
-          invokedBy: NavigationMethod.ContextSwitching,
-        });
-        break;
-      default:
-        history.replace(builderURL({ persistExistingParams: true }), {
-          invokedBy: NavigationMethod.ContextSwitching,
-        });
-    }
   }
 }

--- a/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
+++ b/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
@@ -81,8 +81,10 @@ const isPageChange = (prevPath: string, currentPath: string) => {
   );
 };
 
+export const createEditorFocusInfoKey = (pageId: string, branch?: string) =>
+  `EDITOR_STATE.${pageId}#${branch}`;
 export const createEditorFocusInfo = (pageId: string, branch?: string) => ({
-  key: `EDITOR_STATE.${pageId}#${branch}`,
+  key: createEditorFocusInfoKey(pageId, branch),
   entityInfo: {
     id: `EDITOR.${pageId}`,
     appState: EditorState.EDITOR,

--- a/app/client/src/ee/navigation/FocusStrategy/AppIDEFocusStrategy.ts
+++ b/app/client/src/ee/navigation/FocusStrategy/AppIDEFocusStrategy.ts
@@ -1,0 +1,1 @@
+export * from "ce/navigation/FocusStrategy/AppIDEFocusStrategy";

--- a/app/client/src/navigation/FocusElements.ts
+++ b/app/client/src/navigation/FocusElements.ts
@@ -24,7 +24,7 @@ export enum FocusElement {
   InputField = "InputField",
   SelectedQuery = "SelectedQuery",
   SelectedJSObject = "SelectedJSObject",
-  SelectedSegment = "SelectedSegment",
+  SelectedEntity = "SelectedEntity",
   IDETabs = "IDETabs",
   QueryDebugger = "QueryDebugger",
   ApiDebugger = "ApiDebugger",

--- a/app/client/src/pages/Editor/IDE/hooks.test.tsx
+++ b/app/client/src/pages/Editor/IDE/hooks.test.tsx
@@ -16,18 +16,20 @@ describe("useGetPageFocusUrl", () => {
   const focusHistory = {
     [page1FocusHistory.key]: {
       entityInfo: page1FocusHistory.entityInfo,
-      state: { SelectedEntity: "app/app_id/page/page_id/edit/jsObjects/js_id" },
+      state: {
+        SelectedEntity: "jsObjects/js_id",
+      },
     },
     [page2FocusHistory.key]: {
       entityInfo: page2FocusHistory.entityInfo,
       state: {
-        SelectedEntity: "app/app_id/page/page_id/edit/widgets/widgetId",
+        SelectedEntity: "widgets/widgetId",
       },
     },
     [page3FocusHistory.key]: {
       entityInfo: page3FocusHistory.entityInfo,
       state: {
-        SelectedEntity: "app/app_id/page/page_id/edit/queries/query_id",
+        SelectedEntity: "queries/query_id",
       },
     },
   };
@@ -43,7 +45,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "app/app_id/page/page_id/edit/jsObjects/js_id",
+      "/app/application/page-page_id_1/edit/jsObjects/js_id",
     );
   });
 
@@ -53,7 +55,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "app/app_id/page/page_id/edit/widgets/widgetId",
+      "/app/application/page-page_id_2/edit/widgets/widgetId",
     );
   });
 
@@ -63,7 +65,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "app/app_id/page/page_id/edit/queries/query_id",
+      "/app/application/page-page_id_3/edit/queries/query_id",
     );
   });
 
@@ -88,7 +90,7 @@ describe("useGetPageFocusUrl", () => {
         [page1FocusHistoryWithBranch.key]: {
           entityInfo: page1FocusHistoryWithBranch.entityInfo,
           state: {
-            SelectedEntity: "app/app_id/page/page_id/edit/widgets/widgetId2",
+            SelectedEntity: "widgets/widgetId2",
           },
         },
       },
@@ -102,7 +104,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "app/app_id/page/page_id/edit/widgets/widgetId2",
+      "/app/application/page-page_id_1/edit/widgets/widgetId2",
     );
   });
 });

--- a/app/client/src/pages/Editor/IDE/hooks.test.tsx
+++ b/app/client/src/pages/Editor/IDE/hooks.test.tsx
@@ -3,7 +3,6 @@ import { hookWrapper } from "test/testUtils";
 import { getIDETestState } from "test/factories/AppIDEFactoryUtils";
 import { PageFactory } from "test/factories/PageFactory";
 import { useGetPageFocusUrl } from "./hooks";
-import { EditorEntityTab } from "@appsmith/entities/IDE/constants";
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { createEditorFocusInfo } from "../../../ce/navigation/FocusStrategy/AppIDEFocusStrategy";
 
@@ -17,15 +16,19 @@ describe("useGetPageFocusUrl", () => {
   const focusHistory = {
     [page1FocusHistory.key]: {
       entityInfo: page1FocusHistory.entityInfo,
-      state: { SelectedSegment: EditorEntityTab.JS },
+      state: { SelectedEntity: "app/app_id/page/page_id/edit/jsObjects/js_id" },
     },
     [page2FocusHistory.key]: {
       entityInfo: page2FocusHistory.entityInfo,
-      state: { SelectedSegment: EditorEntityTab.UI },
+      state: {
+        SelectedEntity: "app/app_id/page/page_id/edit/widgets/widgetId",
+      },
     },
     [page3FocusHistory.key]: {
       entityInfo: page3FocusHistory.entityInfo,
-      state: { SelectedSegment: EditorEntityTab.QUERIES },
+      state: {
+        SelectedEntity: "app/app_id/page/page_id/edit/queries/query_id",
+      },
     },
   };
 
@@ -40,7 +43,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "/app/application/page-page_id_1/edit/jsObjects",
+      "app/app_id/page/page_id/edit/jsObjects/js_id",
     );
   });
 
@@ -50,7 +53,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "/app/application/page-page_id_2/edit/widgets",
+      "app/app_id/page/page_id/edit/widgets/widgetId",
     );
   });
 
@@ -60,7 +63,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "/app/application/page-page_id_3/edit/queries",
+      "app/app_id/page/page_id/edit/queries/query_id",
     );
   });
 
@@ -84,7 +87,9 @@ describe("useGetPageFocusUrl", () => {
         ...focusHistory,
         [page1FocusHistoryWithBranch.key]: {
           entityInfo: page1FocusHistoryWithBranch.entityInfo,
-          state: { SelectedSegment: EditorEntityTab.UI },
+          state: {
+            SelectedEntity: "app/app_id/page/page_id/edit/widgets/widgetId2",
+          },
         },
       },
       branch,
@@ -97,7 +102,7 @@ describe("useGetPageFocusUrl", () => {
     });
 
     expect(result.current).toEqual(
-      "/app/application/page-page_id_1/edit/widgets",
+      "app/app_id/page/page_id/edit/widgets/widgetId2",
     );
   });
 });

--- a/app/client/src/pages/Editor/IDE/hooks.ts
+++ b/app/client/src/pages/Editor/IDE/hooks.ts
@@ -186,7 +186,7 @@ export const useGetPageFocusUrl = (pageId: string): string => {
       const lastSelectedEntity =
         editorStateFocusInfo.state[FocusElement.SelectedEntity];
 
-      setFocusPageUrl(lastSelectedEntity);
+      setFocusPageUrl(builderURL({ pageId, suffix: lastSelectedEntity }));
     }
   }, [editorStateFocusInfo, branch]);
 

--- a/app/client/src/pages/Editor/IDE/hooks.ts
+++ b/app/client/src/pages/Editor/IDE/hooks.ts
@@ -19,9 +19,7 @@ import {
   queryListURL,
   widgetListURL,
 } from "@appsmith/RouteBuilder";
-import isEmpty from "lodash/isEmpty";
-import pickBy from "lodash/pickBy";
-import { getFocusInfo } from "selectors/focusHistorySelectors";
+import { getCurrentFocusInfo } from "selectors/focusHistorySelectors";
 import { getCurrentGitBranch } from "selectors/gitSyncSelectors";
 import {
   DEFAULT_EDITOR_PANE_WIDTH,
@@ -34,6 +32,8 @@ import { useQueryAdd } from "@appsmith/pages/Editor/IDE/EditorPane/Query/hooks";
 import { TabSelectors } from "./EditorTabs/constants";
 import { closeJSActionTab } from "actions/jsActionActions";
 import { closeQueryActionTab } from "actions/pluginActionActions";
+import { createEditorFocusInfoKey } from "@appsmith/navigation/FocusStrategy/AppIDEFocusStrategy";
+import { FocusElement } from "../../../navigation/FocusElements";
 
 export const useCurrentAppState = () => {
   const [appState, setAppState] = useState(EditorState.EDITOR);
@@ -172,40 +172,23 @@ export const useSegmentNavigation = (): {
 };
 
 export const useGetPageFocusUrl = (pageId: string): string => {
-  const editorStateString = "EDITOR_STATE.";
-  const focusInfo = useSelector(getFocusInfo);
-  const branch = useSelector(getCurrentGitBranch);
   const [focusPageUrl, setFocusPageUrl] = useState(
     builderURL({ pageId: pageId }),
   );
 
+  const branch = useSelector(getCurrentGitBranch);
+  const editorStateFocusInfo = useSelector((appState) =>
+    getCurrentFocusInfo(appState, createEditorFocusInfoKey(pageId, branch)),
+  );
+
   useEffect(() => {
-    const editorState = pickBy(
-      focusInfo,
-      (v, k) =>
-        k === editorStateString + pageId + "#" + (branch || "undefined"),
-    );
+    if (editorStateFocusInfo) {
+      const lastSelectedEntity =
+        editorStateFocusInfo.state[FocusElement.SelectedEntity];
 
-    if (isEmpty(editorState)) {
-      return;
+      setFocusPageUrl(lastSelectedEntity);
     }
-
-    const segment = Object.values(editorState)[0].state?.SelectedSegment;
-
-    switch (segment) {
-      case EditorEntityTab.UI:
-        setFocusPageUrl(widgetListURL({ pageId: pageId }));
-        break;
-      case EditorEntityTab.JS:
-        setFocusPageUrl(jsCollectionListURL({ pageId: pageId }));
-        break;
-      case EditorEntityTab.QUERIES:
-        setFocusPageUrl(queryListURL({ pageId: pageId }));
-        break;
-      default:
-        setFocusPageUrl(widgetListURL({ pageId: pageId }));
-    }
-  }, [focusInfo, branch]);
+  }, [editorStateFocusInfo, branch]);
 
   return focusPageUrl;
 };


### PR DESCRIPTION
## Description
Page and State switches would navigate to the last selected segment which in turn would navigate to the last selected entity in that segment. This was causing a split second delay showing the segment in a loading / blank state till the entity navigation was processed. By changing the navigation links, we will now navigate directly to the last selected entity, avoiding multiple url changes and hence renders in intermediate states

Fixes #31556

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8847779176>
> Commit: 0cd085a4daf6b4749dd10712f04af3251bb67c8d
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8847779176&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->









## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced navigation and focus elements for improved user experience.
- **New Features**
	- Streamlined focus management with a new key generation function in the IDE.
- **Bug Fixes**
	- Corrected issues in focus management logic for accurate page navigation and entity selection.
- **Documentation**
	- Simplified focus element usage instructions and removed outdated references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->