### PR TITLE
fix: NOOP spans when context is missing

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ObservationHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ObservationHelperImpl.java
@@ -8,6 +8,7 @@ import io.micrometer.tracing.Tracer;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static com.appsmith.external.constants.MDCConstants.SPAN_ID;
@@ -26,14 +27,19 @@ public class ObservationHelperImpl implements ObservationHelper {
 
     @Override
     public Span createSpan(String name) {
-        TraceContext traceContext = tracer.traceContextBuilder()
-                .traceId(MDC.getCopyOfContextMap().get(TRACE_ID))
-                .spanId(MDC.get(SPAN_ID))
-                .build();
+        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        if (contextMap != null && contextMap.containsKey(TRACE_ID) && contextMap.containsKey(SPAN_ID)) {
+            TraceContext traceContext = tracer.traceContextBuilder()
+                    .traceId(contextMap.get(TRACE_ID))
+                    .spanId(contextMap.get(SPAN_ID))
+                    .build();
 
-        Span span = tracer.spanBuilder().setParent(traceContext).name(name).start();
+            Span span = tracer.spanBuilder().setParent(traceContext).name(name).start();
 
-        return span;
+            return span;
+        } else {
+            return Span.NOOP;
+        }
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ObservationHelperTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ObservationHelperTest.java
@@ -1,0 +1,58 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.external.helpers.ObservationHelper;
+import io.micrometer.tracing.Span;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+
+import static com.appsmith.external.constants.MDCConstants.SPAN_ID;
+import static com.appsmith.external.constants.MDCConstants.TRACE_ID;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class ObservationHelperTest {
+
+    @Autowired
+    ObservationHelper observationHelper;
+
+    @Test
+    void testCreateSpan_withNoMDC_returnsNOOP() {
+        try (var mockStatic = Mockito.mockStatic(MDC.class)) {
+            mockStatic.when(MDC::getCopyOfContextMap).thenReturn(null);
+
+            Span span = observationHelper.createSpan("span_withNoMDC");
+
+            Assertions.assertThat(span.isNoop()).isTrue();
+        }
+    }
+
+    @Test
+    void testCreateSpan_withNoTraceIdInMDC_returnsNOOP() {
+        try (var mockStatic = Mockito.mockStatic(MDC.class)) {
+            mockStatic.when(MDC::getCopyOfContextMap).thenReturn(Map.of(SPAN_ID, "testSpanId"));
+
+            Span span = observationHelper.createSpan("span_withNoTraceIdInMDC");
+
+            Assertions.assertThat(span.isNoop()).isTrue();
+        }
+    }
+
+    @Test
+    void testCreateSpan_withNoSpanIdInMDC_returnsNOOP() {
+        try (var mockStatic = Mockito.mockStatic(MDC.class)) {
+            mockStatic.when(MDC::getCopyOfContextMap).thenReturn(Map.of(TRACE_ID, "testTraceId"));
+
+            Span span = observationHelper.createSpan("span_withNoSpanIdInMDC");
+
+            Assertions.assertThat(span.isNoop()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Description

When auto-commits are triggered, the execution starts with no MDC context established. The observation helper assumed that this context would always be present and would hence error out during such events. This PR handles scenarios when context is absent by skipping the span entirely. 

If we wish to log auto-commit related spans, we will need to take that up separately by figuring out which trace we'd like to attach the span to.

Fixes #30721 

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
