### PR TITLE
chore: Use CS to get Appsmith server IP

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CloudServicesConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CloudServicesConfig.java
@@ -11,12 +11,6 @@ import org.springframework.context.annotation.Configuration;
 public class CloudServicesConfig {
     private String baseUrl;
 
-    @Value("${appsmith.cloud_services.username}")
-    private String username;
-
-    @Value("${appsmith.cloud_services.password}")
-    private String password;
-
     @Value("${appsmith.cloud_services.template_upload_auth_header}")
     private String templateUploadAuthHeader;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/NetworkUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/NetworkUtils.java
@@ -1,7 +1,12 @@
 package com.appsmith.server.helpers;
 
+import com.appsmith.server.configurations.CloudServicesConfig;
 import com.appsmith.server.helpers.ce.NetworkUtilsCE;
 import org.springframework.stereotype.Component;
 
 @Component
-public class NetworkUtils extends NetworkUtilsCE {}
+public class NetworkUtils extends NetworkUtilsCE {
+    public NetworkUtils(CloudServicesConfig cloudServicesConfig) {
+        super(cloudServicesConfig);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/NetworkUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/NetworkUtilsCE.java
@@ -1,22 +1,23 @@
 package com.appsmith.server.helpers.ce;
 
+import com.appsmith.server.configurations.CloudServicesConfig;
+import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.util.WebClientUtils;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
 import java.time.Duration;
 
 @Slf4j
+@RequiredArgsConstructor
 public class NetworkUtilsCE {
 
-    private static final URI GET_IP_URI = URI.create("https://api64.ipify.org");
+    private final CloudServicesConfig cloudServicesConfig;
 
     protected static String cachedAddress = null;
 
     protected static final String FALLBACK_IP = "unknown";
-
-    protected NetworkUtilsCE() {}
 
     /**
      * This method hits an API endpoint that returns the external IP address of this server instance.
@@ -30,12 +31,12 @@ public class NetworkUtilsCE {
 
         return WebClientUtils.create()
                 .get()
-                .uri(GET_IP_URI)
+                .uri(cloudServicesConfig.getBaseUrl() + "/api/v1/ip")
                 .retrieve()
-                .bodyToMono(String.class)
+                .bodyToMono(ResponseDTO.class)
                 .map(address -> {
-                    cachedAddress = address;
-                    return address;
+                    cachedAddress = (String) address.getData();
+                    return cachedAddress;
                 })
                 .timeout(Duration.ofSeconds(60))
                 .onErrorResume(throwable -> {

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -83,8 +83,6 @@ emails.welcome.enabled = ${APPSMITH_EMAILS_WELCOME_ENABLED:true}
 # Appsmith Cloud Services
 appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:}
 appsmith.cloud_services.signature_base_url = ${APPSMITH_CLOUD_SERVICES_SIGNATURE_BASE_URL:}
-appsmith.cloud_services.username = ${APPSMITH_CLOUD_SERVICES_USERNAME:}
-appsmith.cloud_services.password = ${APPSMITH_CLOUD_SERVICES_PASSWORD:}
 appsmith.cloud_services.template_upload_auth_header = ${APPSMITH_CLOUD_SERVICES_TEMPLATE_UPLOAD_AUTH:}
 github_repo = ${APPSMITH_GITHUB_REPO:}
 

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -15,7 +15,7 @@ mkdir -pv "$SUPERVISORD_CONF_TARGET" "$WWW_PATH"
 # As we want derived props alongwith the ip address we are sharing the ip address in separate keys
 # https://help.mixpanel.com/hc/en-us/articles/360001355266-Event-Properties
 if [[ -n ${APPSMITH_SEGMENT_CE_KEY-} ]]; then
-  ip="$(curl -sS https://api64.ipify.org || echo unknown)"
+  ip="$(set -o pipefail; curl -sS https://cs.appsmith.com/api/v1/ip | grep -Eo '\d+(\.\d+){3}' || echo "unknown")"
   curl \
     --user "$APPSMITH_SEGMENT_CE_KEY:" \
     --header 'Content-Type: application/json' \


### PR DESCRIPTION
We're currently relying on ipify.org for this, and this PR will move to using CS for this information. This is so that all external communication from the core of the product's backend, is only to cs.appsmith.com, which makes whitelisting easier for users.

Also removing the unused variables `APPSMITH_CLOUD_SERVICES_USERNAME` and `APPSMITH_CLOUD_SERVICES_PASSWORD`.

⚠️ This will cause conflicts on sync.

/ok-to-test tags="@tag.Sanity"
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8859016811>
> Commit: 46576ca46adcba288693c3d5aaa9cc547c1e8f57
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8859016811&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed username and password fields from cloud services configuration to enhance security.
  - Updated network utilities to initialize with new cloud services configuration, improving integration and functionality.
  
- **Bug Fixes**
  - Adjusted the method of fetching and handling IP address data to improve reliability and accuracy of network services.

- **Chores**
  - Updated application properties and deployment scripts to align with the new configuration and address retrieval methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->