### PR TITLE
chore: Add search method to Bridge API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
@@ -30,6 +30,13 @@ public final class Bridge {
         return q;
     }
 
+    public static <T extends BaseDomain> BridgeQuery<T> or(Collection<BridgeQuery<T>> items) {
+        final BridgeQuery<T> q = new BridgeQuery<>();
+        q.checks.add(
+                new Criteria().orOperator(items.stream().map(c -> (Criteria) c).toList()));
+        return q;
+    }
+
     @SafeVarargs
     public static <T extends BaseDomain> BridgeQuery<T> and(BridgeQuery<T>... items) {
         final BridgeQuery<T> q = new BridgeQuery<>();
@@ -72,6 +79,7 @@ public final class Bridge {
         return Bridge.<T>query().equal(key, value);
     }
 
+    @Deprecated
     public static <T extends BaseDomain> BridgeQuery<T> regexMatchIgnoreCase(@NonNull String key, String regexPattern) {
         return Bridge.<T>query().regexMatchIgnoreCase(key, regexPattern);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
@@ -84,6 +84,10 @@ public final class Bridge {
         return Bridge.<T>query().regexMatchIgnoreCase(key, regexPattern);
     }
 
+    public static <T extends BaseDomain> BridgeQuery<T> searchIgnoreCase(@NonNull String key, @NonNull String needle) {
+        return Bridge.<T>query().searchIgnoreCase(key, needle);
+    }
+
     public static <T extends BaseDomain> BridgeQuery<T> in(@NonNull String key, @NonNull Collection<String> value) {
         return Bridge.<T>query().in(key, value);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
@@ -63,6 +63,15 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
         return this;
     }
 
+    public BridgeQuery<T> searchIgnoreCase(String key, String needle) {
+        if (key.contains(".")) {
+            throw new UnsupportedOperationException("Search-ignore-case is not supported for nested fields");
+        }
+
+        checks.add(Criteria.where(key).regex(".*" + Pattern.quote(needle) + ".*", "i"));
+        return this;
+    }
+
     public BridgeQuery<T> in(@NonNull String key, @NonNull Collection<String> value) {
         checks.add(Criteria.where(key).in(value));
         return this;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
@@ -63,7 +63,7 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
         return this;
     }
 
-    public BridgeQuery<T> searchIgnoreCase(String key, String needle) {
+    public BridgeQuery<T> searchIgnoreCase(@NonNull String key, @NonNull String needle) {
         if (key.contains(".")) {
             throw new UnsupportedOperationException("Search-ignore-case is not supported for nested fields");
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/searchentities/SearchEntitySolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/searchentities/SearchEntitySolutionCEImpl.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.searchentities;
 
 import com.appsmith.server.applications.base.ApplicationService;
-import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.SearchEntityDTO;
@@ -65,7 +64,7 @@ public class SearchEntitySolutionCEImpl implements SearchEntitySolutionCE {
         if (shouldSearchEntity(Workspace.class, entities)) {
             workspacesMono = workspaceService
                     .filterByEntityFieldsWithoutPublicAccess(
-                            List.of(FieldName.NAME),
+                            List.of(Workspace.Fields.name),
                             searchString,
                             pageable,
                             sort,
@@ -77,7 +76,7 @@ public class SearchEntitySolutionCEImpl implements SearchEntitySolutionCE {
         if (shouldSearchEntity(Application.class, entities)) {
             applicationsMono = applicationService
                     .filterByEntityFieldsWithoutPublicAccess(
-                            List.of(FieldName.NAME),
+                            List.of(Application.Fields.name),
                             searchString,
                             pageable,
                             sort,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -15,17 +15,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -154,13 +153,15 @@ public abstract class BaseService<
         if (searchableEntityFields == null || searchableEntityFields.isEmpty()) {
             return Flux.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, ENTITY_FIELDS));
         }
-        List<Criteria> criteriaList = searchableEntityFields.stream()
-                .map(fieldName -> Criteria.where(fieldName).regex(".*" + Pattern.quote(searchString) + ".*", "i"))
-                .toList();
-        Criteria criteria = new Criteria().orOperator(criteriaList);
+
+        List<BridgeQuery<T>> criteria = new ArrayList<>();
+        for (String fieldName : searchableEntityFields) {
+            criteria.add(Bridge.<T>query().searchIgnoreCase(fieldName, searchString));
+        }
+
         Flux<T> result = repository
                 .queryBuilder()
-                .criteria(criteria)
+                .criteria(Bridge.or(criteria))
                 .permission(permission)
                 .sort(sort)
                 .all();
@@ -190,14 +191,15 @@ public abstract class BaseService<
         if (searchableEntityFields == null || searchableEntityFields.isEmpty()) {
             return Flux.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, ENTITY_FIELDS));
         }
-        List<Criteria> criteriaList = searchableEntityFields.stream()
-                .map(fieldName -> Criteria.where(fieldName).regex(".*" + Pattern.quote(searchString) + ".*", "i"))
-                .toList();
-        Criteria criteria = new Criteria().orOperator(criteriaList);
+
+        List<BridgeQuery<T>> criteria = new ArrayList<>();
+        for (String fieldName : searchableEntityFields) {
+            criteria.add(Bridge.<T>query().searchIgnoreCase(fieldName, searchString));
+        }
 
         Flux<T> result = repository
                 .queryBuilder()
-                .criteria(criteria)
+                .criteria(Bridge.or(criteria))
                 .permission(permission)
                 .sort(sort)
                 .includeAnonymousUserPermissions(false)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -156,7 +156,7 @@ public abstract class BaseService<
 
         List<BridgeQuery<T>> criteria = new ArrayList<>();
         for (String fieldName : searchableEntityFields) {
-            criteria.add(Bridge.<T>query().searchIgnoreCase(fieldName, searchString));
+            criteria.add(Bridge.searchIgnoreCase(fieldName, searchString));
         }
 
         Flux<T> result = repository
@@ -194,7 +194,7 @@ public abstract class BaseService<
 
         List<BridgeQuery<T>> criteria = new ArrayList<>();
         for (String fieldName : searchableEntityFields) {
-            criteria.add(Bridge.<T>query().searchIgnoreCase(fieldName, searchString));
+            criteria.add(Bridge.searchIgnoreCase(fieldName, searchString));
         }
 
         Flux<T> result = repository


### PR DESCRIPTION
We're abstracting the search function here, as a search query, instead of a generic regex query, so that is can be implemented with regex on MongoDB, but with SQL's `LIKE` operator on Postgres.

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8859444126>
> Commit: 60f0086858a8add161f483572d0cd0dbd41e9217
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8859444126&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new methods for enhanced search capabilities, including case-insensitive searches.
  - Improved entity field filtering using custom query methods.

- **Refactor**
  - Updated entity field references in `Workspace` and `Application` for consistency.
  - Replaced traditional criteria with custom query classes to simplify logic in filtering processes.

- **Deprecations**
  - Deprecated older methods for case-insensitive regex matching in favor of new search methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->