### PR TITLE
fix: datasources headings fixed for IA redesign panel

### DIFF
--- a/app/client/src/ce/selectors/entitiesSelector.ts
+++ b/app/client/src/ce/selectors/entitiesSelector.ts
@@ -84,7 +84,8 @@ export const getDatasources = (state: AppState): Datasource[] => {
 export const getPlugins = (state: AppState) => state.entities.plugins.list;
 
 export enum PluginCategory {
-  Integrations = "Integrations",
+  SAAS = "SaaS integrations",
+  AI = "AI integrations",
   Databases = "Databases",
   APIs = "APIs",
   Others = "Others",
@@ -112,11 +113,11 @@ export const getDatasourcesGroupedByPluginCategory = createSelector(
       const plugin = groupedPlugins[d.pluginId];
       if (
         plugin.type === PluginType.SAAS ||
-        plugin.type === PluginType.REMOTE ||
-        plugin.type === PluginType.AI
+        plugin.type === PluginType.REMOTE
       ) {
-        return PluginCategory.Integrations;
+        return PluginCategory.SAAS;
       }
+      if (plugin.type === PluginType.AI) return PluginCategory.AI;
       if (plugin.type === PluginType.DB) return PluginCategory.Databases;
       if (plugin.type === PluginType.API) return PluginCategory.APIs;
       return PluginCategory.Others;


### PR DESCRIPTION
## Description
This PR fixes the inconsistency in the IA redesign side panel for data sources.

Fixes #28898 

## Automation

/ok-to-test tags="@tag.IDE,@tag.Datasource,@tag.GenerateCRUD"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8873315346>
> Commit: f86f3904195d48bf6e56de28da3899b01450d3b6
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8873315346&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated plugin categorization to include specific types: "SaaS integrations" and "AI integrations" for improved user experience in selecting plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->