### PR TITLE
chore: Remove API to get all objects

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCE.java
@@ -7,6 +7,7 @@ import com.appsmith.server.dtos.ApplicationAccessDTO;
 import com.appsmith.server.dtos.GitAuthDTO;
 import com.appsmith.server.services.CrudService;
 import org.springframework.http.codec.multipart.Part;
+import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -16,21 +17,17 @@ import java.util.Optional;
 
 public interface ApplicationServiceCE extends CrudService<Application, String> {
 
+    Flux<Application> get(MultiValueMap<String, String> params);
+
     Mono<Application> findByIdAndBranchName(String id, List<String> projectionFieldNames, String branchName);
 
     Mono<Application> findById(String id);
 
     Mono<Application> findById(String id, AclPermission aclPermission);
 
-    Mono<Application> findById(String id, Optional<AclPermission> aclPermission);
-
-    Mono<Application> findByIdAndWorkspaceId(String id, String workspaceId, AclPermission permission);
-
     Flux<Application> findByWorkspaceId(String workspaceId, AclPermission permission);
 
     Flux<Application> findByWorkspaceIdAndDefaultApplicationsInRecentlyUsedOrder(String workspaceId);
-
-    Flux<Application> findByClonedFromApplicationId(String applicationId, AclPermission permission);
 
     Mono<Application> findByName(String name, AclPermission permission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
@@ -35,7 +35,6 @@ import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.AssetService;
 import com.appsmith.server.services.BaseService;
-import com.appsmith.server.services.ConfigService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
@@ -78,7 +77,6 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         implements ApplicationServiceCE {
 
     private final PolicySolution policySolution;
-    private final ConfigService configService;
     private final ResponseUtils responseUtils;
     private final PermissionGroupService permissionGroupService;
     private final NewActionRepository newActionRepository;
@@ -99,7 +97,6 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
             ApplicationRepository repository,
             AnalyticsService analyticsService,
             PolicySolution policySolution,
-            ConfigService configService,
             ResponseUtils responseUtils,
             PermissionGroupService permissionGroupService,
             NewActionRepository newActionRepository,
@@ -113,7 +110,6 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
 
         super(validator, repository, analyticsService);
         this.policySolution = policySolution;
-        this.configService = configService;
         this.responseUtils = responseUtils;
         this.permissionGroupService = permissionGroupService;
         this.newActionRepository = newActionRepository;
@@ -175,16 +171,6 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
     }
 
     @Override
-    public Mono<Application> findById(String id, Optional<AclPermission> aclPermission) {
-        return repository.findById(id, aclPermission).flatMap(this::setTransientFields);
-    }
-
-    @Override
-    public Mono<Application> findByIdAndWorkspaceId(String id, String workspaceId, AclPermission permission) {
-        return repository.findByIdAndWorkspaceId(id, workspaceId, permission).flatMap(this::setTransientFields);
-    }
-
-    @Override
     public Flux<Application> findByWorkspaceId(String workspaceId, AclPermission permission) {
         return setTransientFields(repository.findByWorkspaceId(workspaceId, permission));
     }
@@ -238,11 +224,6 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
                                     || GitUtils.isDefaultBranchedApplication(application);
                         })
                         .map(responseUtils::updateApplicationWithDefaultResources)));
-    }
-
-    @Override
-    public Flux<Application> findByClonedFromApplicationId(String applicationId, AclPermission permission) {
-        return repository.findByClonedFromApplicationId(applicationId, permission);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
@@ -165,7 +165,6 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
     }
 
     @Override
-    @Deprecated
     public Mono<Application> findById(String id, AclPermission aclPermission) {
         return repository.findById(id, aclPermission).flatMap(this::setTransientFields);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceImpl.java
@@ -5,7 +5,6 @@ import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.AssetService;
-import com.appsmith.server.services.ConfigService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
@@ -28,7 +27,6 @@ public class ApplicationServiceImpl extends ApplicationServiceCECompatibleImpl i
             ApplicationRepository repository,
             AnalyticsService analyticsService,
             PolicySolution policySolution,
-            ConfigService configService,
             ResponseUtils responseUtils,
             PermissionGroupService permissionGroupService,
             NewActionRepository newActionRepository,
@@ -45,7 +43,6 @@ public class ApplicationServiceImpl extends ApplicationServiceCECompatibleImpl i
                 repository,
                 analyticsService,
                 policySolution,
-                configService,
                 responseUtils,
                 permissionGroupService,
                 newActionRepository,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
@@ -573,8 +573,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
         Optional<AclPermission> optionalAclPermission = Optional.empty();
         Mono<Application> applicationMonoWithOutPermission = applicationService
                 .findBranchedApplicationId(optionalBranchName, srcApplicationId, optionalAclPermission)
-                .flatMap(branchedApplicationId ->
-                        applicationService.findById(branchedApplicationId, optionalAclPermission))
+                .flatMap(branchedApplicationId -> applicationService.findById(branchedApplicationId, null))
                 .switchIfEmpty(Mono.error(new AppsmithException(
                         AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, srcApplicationId)));
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -78,14 +78,6 @@ public abstract class BaseService<
     }
 
     @Override
-    public Flux<T> get(MultiValueMap<String, String> params) {
-        // In the base service we aren't handling the query parameters. In order to filter records using the query
-        // params,
-        // each service must implement it for their usecase. Need to come up with a better strategy for doing this.
-        return repository.findAll();
-    }
-
-    @Override
     public Mono<T> getById(ID id) {
         if (id == null) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ID));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CrudService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CrudService.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -12,8 +11,6 @@ import java.util.List;
 import java.util.Map;
 
 public interface CrudService<T extends BaseDomain, ID> {
-
-    Flux<T> get(MultiValueMap<String, String> params);
 
     Mono<T> create(T resource);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -986,7 +986,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                     // Application is accessed without any application permission over here.
                     // previously it was getting accessed only with read permission.
                     Mono<Application> applicationMono = applicationService
-                            .findById(page.getApplicationId(), readApplicationPermission)
+                            .findById(page.getApplicationId(), readApplicationPermission.orElse(null))
                             .switchIfEmpty(Mono.error(
                                     new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, id)))
                             .flatMap(application -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -53,7 +53,6 @@ import org.springframework.security.web.server.DefaultServerRedirectStrategy;
 import org.springframework.security.web.server.ServerRedirectStrategy;
 import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
@@ -626,12 +625,6 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
 
         AppsmithBeanUtils.copyNewFieldValuesIntoOldObject(userUpdate, existingUser);
         return repository.save(existingUser);
-    }
-
-    @Override
-    public Flux<User> get(MultiValueMap<String, String> params) {
-        // Get All Users should not be supported. Return an error
-        return Flux.error(new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION));
     }
 
     private boolean validateName(String name) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -37,7 +37,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.codec.multipart.Part;
 import org.springframework.stereotype.Service;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -112,18 +111,6 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
         this.workspacePermission = workspacePermission;
         this.permissionGroupPermission = permissionGroupPermission;
         this.workspaceServiceHelper = workspaceServiceHelper;
-    }
-
-    @Override
-    public Flux<Workspace> get(MultiValueMap<String, String> params) {
-        return sessionUserService.getCurrentUser().flatMapMany(user -> {
-            Set<String> workspaceIds = user.getWorkspaceIds();
-            if (workspaceIds == null || workspaceIds.isEmpty()) {
-                log.error("No workspace set for user: {}. Returning empty list of workspaces", user.getEmail());
-                return Flux.empty();
-            }
-            return repository.findAllById(workspaceIds);
-        });
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/ApplicationServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/ApplicationServiceCECompatibleImpl.java
@@ -6,7 +6,6 @@ import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.AssetService;
-import com.appsmith.server.services.ConfigService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
@@ -26,7 +25,6 @@ public class ApplicationServiceCECompatibleImpl extends ApplicationServiceCEImpl
             ApplicationRepository repository,
             AnalyticsService analyticsService,
             PolicySolution policySolution,
-            ConfigService configService,
             ResponseUtils responseUtils,
             PermissionGroupService permissionGroupService,
             NewActionRepository newActionRepository,
@@ -42,7 +40,6 @@ public class ApplicationServiceCECompatibleImpl extends ApplicationServiceCEImpl
                 repository,
                 analyticsService,
                 policySolution,
-                configService,
                 responseUtils,
                 permissionGroupService,
                 newActionRepository,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/base/ThemeServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/base/ThemeServiceCEImpl.java
@@ -17,7 +17,6 @@ import com.appsmith.server.services.BaseService;
 import com.appsmith.server.solutions.ApplicationPermission;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -65,12 +64,6 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
     public Mono<Theme> getById(String s) {
         // we don't allow to get a theme by id from DB
         throw new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION);
-    }
-
-    @Override
-    public Flux<Theme> get(MultiValueMap<String, String> params) {
-        // we return all system themes
-        return repository.getSystemThemes();
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -44,9 +44,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.CollectionUtils;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
@@ -360,20 +357,9 @@ public class UserServiceTest {
                 })
                 .verifyComplete();
 
-        Workspace deletedWorkspace = workspaceMono
+        workspaceMono
                 .flatMap(workspace1 -> workspaceService.archiveById(workspace1.getId()))
                 .block();
-    }
-
-    @Test
-    @WithUserDetails(value = "api_user")
-    public void getAllUsersTest() {
-        Flux<User> userFlux = userService.get(CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>()));
-
-        StepVerifier.create(userFlux)
-                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
-                        && throwable.getMessage().equals(AppsmithError.UNSUPPORTED_OPERATION.getMessage()))
-                .verify();
     }
 
     @Test


### PR DESCRIPTION
The `.get(params)` method in `BaseService` has a dangerous default implementation. It loads _all_ objects from the DB and returns them. Although it's not used by any services in that form, it's nevertheless a liability, and not an asset.

For example, the User service explicitly overrides it and always responds with an error.

This PR removes this method, and we add the signature to just those services that leverage it.

EE at https://github.com/appsmithorg/appsmith-ee/pull/3698. Tests and Cypress pass.

/ok-to-test tags="@tag.Sanity"

