### PR TITLE
fix: getting outer spacing tokens from theme context.

### DIFF
--- a/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDCompensators.ts
+++ b/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDCompensators.ts
@@ -1,6 +1,6 @@
 import type { FlattenedWidgetProps } from "WidgetProvider/constants";
 import { getCompensatorsForHierarchy } from "../utils/dndCompensatorUtils";
-import { useTheme } from "@design-system/theming";
+import { useThemeContext } from "@design-system/theming";
 
 export const useAnvilDnDCompensators = (
   canActivate: boolean,
@@ -9,7 +9,7 @@ export const useAnvilDnDCompensators = (
   isEmptyLayout: boolean,
   widgetProps: FlattenedWidgetProps,
 ) => {
-  const { theme } = useTheme();
+  const theme = useThemeContext();
   const isElevatedWidget = !!widgetProps.elevatedBackground;
   const {
     edgeCompensatorValues,


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1NK45FRmvZzAPkNRX5mHsR46AKZhvo5kU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=MS8RSFK)
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #33012
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8874781095>
> Commit: 98690639dde31b627557a8a2dac779cd660ac8a5
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8874781095&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the method of accessing the theme in the drag-and-drop functionality to enhance consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->