### PR TITLE
fix: Updating the action check to initialize the super user sagas

### DIFF
--- a/app/client/src/ee/sagas/SuperUserSagas.tsx
+++ b/app/client/src/ee/sagas/SuperUserSagas.tsx
@@ -7,14 +7,21 @@ import {
   RestryRestartServerPoll,
   SendTestEmail,
 } from "ce/sagas/SuperUserSagas";
-import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type { User } from "constants/userConstants";
-import { takeLatest, all } from "redux-saga/effects";
+import { takeLatest, all, select } from "redux-saga/effects";
+import { getCurrentUser } from "selectors/usersSelectors";
+import type { FeatureFlags } from "@appsmith/entities/FeatureFlag";
+import { selectFeatureFlags } from "@appsmith/selectors/featureFlagsSelectors";
+import { isGACEnabled } from "@appsmith/utils/planHelpers";
+import { getShowAdminSettings } from "@appsmith/utils/BusinessFeatures/adminSettingsHelpers";
 
-export function* InitSuperUserSaga(action: ReduxAction<User>) {
-  const user = action.payload;
-  if (user.isSuperUser) {
+export function* InitSuperUserSaga() {
+  const user: User = yield select(getCurrentUser);
+  const featureFlags: FeatureFlags = yield select(selectFeatureFlags);
+  const isFeatureEnabled = isGACEnabled(featureFlags);
+
+  if (getShowAdminSettings(isFeatureEnabled, user)) {
     yield all([
       takeLatest(ReduxActionTypes.FETCH_ADMIN_SETTINGS, FetchAdminSettingsSaga),
       takeLatest(
@@ -34,7 +41,7 @@ export function* InitSuperUserSaga(action: ReduxAction<User>) {
 
 export default function* SuperUserSagas() {
   yield takeLatest(
-    ReduxActionTypes.FETCH_USER_DETAILS_SUCCESS,
+    ReduxActionTypes.END_CONSOLIDATED_PAGE_LOAD,
     InitSuperUserSaga,
   );
 }


### PR DESCRIPTION
## Description

Updating the action calls for sagas to trigger the Admin setting APIs. This was required after the consolidated API changes came in, as the API takes long time to load and `FETCH_USER_SUCCESS` call happens before `FETCH_FEATURE_FLAGS_SUCCESS` call. We need both of the actions to be successful before adding the saga. Hence updating it to the action `END_CONSOLIDATED_PAGE_LOAD` now.


Fixes [#33034](https://github.com/appsmithorg/appsmith/issues/33034)

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8877126026>
> Commit: a5f7a066af16a450d67596a732c6a00cd1c6d9ff
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8877126026&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the initialization process for super users to conditionally trigger actions based on specific feature availability.

- **Refactor**
	- Updated logic in the Super User initialization to improve how feature flags and user details are checked and utilized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->