### PR TITLE
fix: Adding back the function call for triggering audit log event on JS action execution on EE

### DIFF
--- a/app/client/src/ce/sagas/JSActionSagas.ts
+++ b/app/client/src/ce/sagas/JSActionSagas.ts
@@ -74,6 +74,11 @@ import { handleJSEntityRedirect } from "sagas/IDESaga";
 import { getIDETypeByUrl } from "@appsmith/entities/IDE/utils";
 import { IDE_TYPE } from "@appsmith/entities/IDE/constants";
 import { CreateNewActionKey } from "@appsmith/entities/Engine/actionHelpers";
+import type {
+  TriggerKind,
+  TriggerSource,
+} from "constants/AppsmithActionConstants/ActionConstants";
+import type { TMessage } from "utils/MessageUtil";
 
 export function* fetchJSCollectionsSaga(
   action: EvaluationReduxAction<FetchActionsPayload>,
@@ -499,4 +504,21 @@ export function* closeJSActionTabSaga(
   yield call(FocusRetention.handleRemoveFocusHistory, currentUrl);
   yield call(handleJSEntityRedirect, id);
   yield put(closeJsActionTabSuccess({ id }));
+}
+
+export function* logJSFunctionExecution(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  message: TMessage<{
+    data: {
+      jsFnFullName: string;
+      isSuccess: boolean;
+      triggerMeta: {
+        source: TriggerSource;
+        triggerPropertyName: string | undefined;
+        triggerKind: TriggerKind | undefined;
+      };
+    }[];
+  }>,
+) {
+  /* This is intentionally left blank and has a definition on EE for audit logs, since this function needs to be called in a common file. */
 }

--- a/app/client/src/sagas/EvalWorkerActionSagas.ts
+++ b/app/client/src/sagas/EvalWorkerActionSagas.ts
@@ -24,6 +24,8 @@ import { sortJSExecutionDataByCollectionId } from "workers/Evaluation/JSObject/u
 import type { LintTreeSagaRequestData } from "plugins/Linting/types";
 import { evalErrorHandler } from "./EvalErrorHandler";
 import { getUnevaluatedDataTree } from "selectors/dataTreeSelectors";
+import { logJSFunctionExecution } from "@appsmith/sagas/JSActionSagas";
+
 export interface UpdateDataTreeMessageData {
   workerResponse: EvalTreeResponseData;
   unevalTree: UnEvalTree;
@@ -122,6 +124,10 @@ export function* handleEvalWorkerMessage(message: TMessage<any>) {
     }
     case MAIN_THREAD_ACTION.PROCESS_STORE_UPDATES: {
       yield call(handleStoreOperations, data);
+      break;
+    }
+    case MAIN_THREAD_ACTION.LOG_JS_FUNCTION_EXECUTION: {
+      yield call(logJSFunctionExecution, message);
       break;
     }
     case MAIN_THREAD_ACTION.PROCESS_BATCHED_TRIGGERS: {


### PR DESCRIPTION
## Description

Adding back the function call for triggering audit log event on JS action execution on EE

Fixes [#4013](https://github.com/appsmithorg/appsmith-ee/issues/4013)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8881877825>
> Commit: 6cb9398e847525a92d075c518731033e03358716
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8881877825&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities for JavaScript function executions to improve debugging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->