### PR TITLE
fix: Empty plugin ids in workspaces are breaking application load

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
@@ -51,6 +51,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -118,6 +119,7 @@ public class PluginServiceCEImpl extends BaseService<PluginRepository, Plugin, S
 
                     Set<String> pluginIds = workspace.getPlugins().stream()
                             .map(WorkspacePlugin::getPluginId)
+                            .filter(Objects::nonNull)
                             .collect(Collectors.toUnmodifiableSet());
 
                     return repository.findAllById(pluginIds);


### PR DESCRIPTION
## Description
Cherry picks a fix to allow application load for certain workspaces.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
