### PR TITLE
fix: Remove atomic pushes temporarily (#33052)

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/ce/GitExecutorCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/ce/GitExecutorCEImpl.java
@@ -225,7 +225,6 @@ public class GitExecutorCEImpl implements GitExecutor {
 
                         StringBuilder result = new StringBuilder("Pushed successfully with status : ");
                         git.push()
-                                .setAtomic(true)
                                 .setTransportConfigCallback(transportConfigCallback)
                                 .setRemote(remoteUrl)
                                 .call()


### PR DESCRIPTION
## Description
Cherry picking fix for Azure repo issue

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
