### PR TITLE
chore: added function overloading to remove redundant db call

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCE.java
@@ -14,6 +14,8 @@ public interface TenantServiceCE extends CrudService<Tenant, String> {
 
     Mono<Tenant> findById(String tenantId, AclPermission permission);
 
+    Mono<Tenant> getTenantConfiguration(Mono<Tenant> dbTenantMono);
+
     Mono<Tenant> getTenantConfiguration();
 
     Mono<Tenant> getDefaultTenant();


### PR DESCRIPTION
## Description
This PR overloads the function `getTenantConfiguration()` to avoid calling `getDefaultTenant()` multiple times and eventually reducing the number of database calls. 
Subsequent EE PR - https://github.com/appsmithorg/appsmith-ee/pull/4073

Fixes #https://github.com/appsmithorg/appsmith-ee/issues/4061 

## Automation

/ok-to-test tags="@tag.Settings,@tag.Perf,@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8893900698>
> Commit: 446e4f7c38525568249496bd6bd1ba5d1a920486
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8893900698&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
