### PR TITLE
chore: Add migration to cleanup of invalid plugins in workspaces

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration052RemoveInvalidPluginsInWorkspaces.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration052RemoveInvalidPluginsInWorkspaces.java
@@ -1,0 +1,32 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.Workspace;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+@Slf4j
+@ChangeUnit(order = "052", id = "remove-invalid-plugins-in-workspaces")
+@RequiredArgsConstructor
+public class Migration052RemoveInvalidPluginsInWorkspaces {
+
+    private final MongoTemplate mongoTemplate;
+
+    @RollbackExecution
+    public void rollbackExecution() {}
+
+    @Execution
+    public void execute() {
+        mongoTemplate.updateMulti(
+                new Query(),
+                new Update().pull(Workspace.Fields.plugins, new Document(FieldName.PLUGIN_ID, null)),
+                Workspace.class);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -182,6 +182,7 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
                 */
                 .flatMap(org -> pluginRepository
                         .findByDefaultInstall(true)
+                        .filter(plugin -> plugin.getId() != null)
                         .map(obj -> new WorkspacePlugin(obj.getId(), WorkspacePluginStatus.FREE))
                         .collect(Collectors.toSet())
                         .map(pluginList -> {


### PR DESCRIPTION
The migration takes 3.5mins on production database.

Reason and details at [Slack conversation](https://theappsmith.slack.com/archives/C02GAUE9P5H/p1714451552333709?thread_ts=1714425219.357599&cid=C02GAUE9P5H).

/ok-to-test tags="@tag.Sanity"

