### PR TITLE
chore: Fix warnings in ConsolidatedAPIServiceImpl

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/encryption/EncryptionHandler.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/encryption/EncryptionHandler.java
@@ -9,6 +9,7 @@ import reactor.util.annotation.NonNull;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -171,6 +172,10 @@ public class EncryptionHandler {
                             Type[] typeArguments;
                             ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
                             typeArguments = parameterizedType.getActualTypeArguments();
+                            if (typeArguments[1] instanceof WildcardType) {
+                                return;
+                            }
+
                             Class<?> subFieldType = (Class<?>) typeArguments[1];
 
                             if (this.encryptedFieldsMap.containsKey(subFieldType)) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Plugin.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Plugin.java
@@ -97,11 +97,11 @@ public class Plugin extends BaseDomain {
 
     // Stores the equivalent of editor.json for remote plugins
     @JsonView(Views.Public.class)
-    Map actionUiConfig;
+    Map<?, ?> actionUiConfig;
 
     // Stores the equivalent of form.json for remote plugins
     @JsonView(Views.Public.class)
-    Map datasourceUiConfig;
+    Map<?, ?> datasourceUiConfig;
 
     @Transient
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ConsolidatedAPIResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ConsolidatedAPIResponseDTO.java
@@ -69,7 +69,7 @@ public class ConsolidatedAPIResponseDTO {
     ResponseDTO<List<Datasource>> datasources;
 
     /* v1/plugins/{pluginId}/form - for all plugins used in app */
-    ResponseDTO<Map<String, Map>> pluginFormConfigs;
+    ResponseDTO<Map<String, Map<?, ?>>> pluginFormConfigs;
 
     /* v1/datasources/mock */
     ResponseDTO<List<MockDataSet>> mockDatasources;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCE.java
@@ -35,11 +35,11 @@ public interface PluginServiceCE extends CrudService<Plugin, String> {
 
     Plugin redisInstallPlugin(InstallPluginRedisDTO installPluginRedisDTO);
 
-    Mono<Map> getFormConfig(String pluginId);
+    Mono<Map<?, ?>> getFormConfig(String pluginId);
 
     Flux<Plugin> getAllRemotePlugins();
 
-    Mono<Map> loadPluginResource(String pluginId, String resourcePath);
+    Mono<Map<?, ?>> loadPluginResource(String pluginId, String resourcePath);
 
     Mono<Map> getEditorConfigLabelMap(String pluginId);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConsolidatedAPIServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConsolidatedAPIServiceImpl.java
@@ -1,28 +1,17 @@
 package com.appsmith.server.services;
 
 import com.appsmith.external.exceptions.ErrorDTO;
-import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.server.actioncollections.base.ActionCollectionService;
-import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.domains.ApplicationMode;
-import com.appsmith.server.domains.CustomJSLib;
 import com.appsmith.server.domains.Plugin;
-import com.appsmith.server.domains.Tenant;
-import com.appsmith.server.domains.Theme;
-import com.appsmith.server.dtos.ActionCollectionDTO;
-import com.appsmith.server.dtos.ActionCollectionViewDTO;
-import com.appsmith.server.dtos.ActionViewDTO;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.ConsolidatedAPIResponseDTO;
 import com.appsmith.server.dtos.MockDataDTO;
-import com.appsmith.server.dtos.MockDataSet;
-import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.ProductAlertResponseDTO;
 import com.appsmith.server.dtos.ResponseDTO;
-import com.appsmith.server.dtos.UserProfileDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.jslibs.base.CustomJSLibService;
@@ -31,7 +20,7 @@ import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.themes.base.ThemeService;
 import io.micrometer.observation.ObservationRegistry;
-import io.opentelemetry.api.trace.Span;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.util.Pair;
 import org.springframework.http.HttpStatus;
@@ -79,6 +68,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
     private static final String FEATURE_FLAG_RELEASE_SERVER_DSL_MIGRATIONS_ENABLED =
             "release_server_dsl_migrations_enabled";
@@ -98,45 +88,9 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
     private final ApplicationPageService applicationPageService;
     private final CustomJSLibService customJSLibService;
     private final PluginService pluginService;
-    private final ApplicationService applicationService;
     private final DatasourceService datasourceService;
     private final MockDataService mockDataService;
     private final ObservationRegistry observationRegistry;
-
-    public ConsolidatedAPIServiceImpl(
-            SessionUserService sessionUserService,
-            UserService userService,
-            UserDataService userDataService,
-            TenantService tenantService,
-            ProductAlertService productAlertService,
-            NewPageService newPageService,
-            NewActionService newActionService,
-            ActionCollectionService actionCollectionService,
-            ThemeService themeService,
-            ApplicationPageService applicationPageService,
-            CustomJSLibService customJSLibService,
-            PluginService pluginService,
-            ApplicationService applicationService,
-            DatasourceService datasourceService,
-            MockDataService mockDataService,
-            ObservationRegistry observationRegistry) {
-        this.sessionUserService = sessionUserService;
-        this.userService = userService;
-        this.userDataService = userDataService;
-        this.tenantService = tenantService;
-        this.productAlertService = productAlertService;
-        this.newPageService = newPageService;
-        this.newActionService = newActionService;
-        this.actionCollectionService = actionCollectionService;
-        this.themeService = themeService;
-        this.applicationPageService = applicationPageService;
-        this.customJSLibService = customJSLibService;
-        this.pluginService = pluginService;
-        this.applicationService = applicationService;
-        this.datasourceService = datasourceService;
-        this.mockDataService = mockDataService;
-        this.observationRegistry = observationRegistry;
-    }
 
     <T> ResponseDTO<T> getSuccessResponse(T data) {
         return new ResponseDTO<>(HttpStatus.OK.value(), data, null);
@@ -153,26 +107,23 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                             appsmithException.getTitle())));
         }
 
-        return Mono.just(new ResponseDTO<T>(
+        return Mono.just(new ResponseDTO<>(
                 INTERNAL_SERVER_ERROR_STATUS, new ErrorDTO(INTERNAL_SERVER_ERROR_CODE, error.getMessage())));
     }
 
-    @Deprecated(forRemoval = true)
-    <T> Mono<ResponseDTO<T>> getErrorResponseMono(Throwable error, Class<T> type) {
-        return getErrorResponseMono(error);
+    private <T> Mono<ResponseDTO<T>> toResponseDTO(Mono<T> mono) {
+        return mono.map(this::getSuccessResponse).onErrorResume(this::getErrorResponseMono);
     }
 
     public static String getQualifiedSpanName(String spanName, ApplicationMode mode) {
-        return ApplicationMode.PUBLISHED.equals(mode)
-                ? CONSOLIDATED_API_PREFIX + VIEW + spanName
-                : CONSOLIDATED_API_PREFIX + EDIT + spanName;
+        return CONSOLIDATED_API_PREFIX + (ApplicationMode.PUBLISHED.equals(mode) ? VIEW : EDIT) + spanName;
     }
 
     /**
      * This method is meant to be used by the client application at the time of 1st page load. Client currently makes
      * several API calls to fetch all the required data. This method consolidates all that data and returns them as
      * response hence enabling the client to fetch the required data via a single API call only.
-     *
+     * <p>
      * PLEASE TAKE CARE TO USE .cache() FOR Mono THAT GETS REUSED SO THAT FIRST PAGE LOAD PERFORMANCE DOES NOT DEGRADE.
      */
     @Override
@@ -187,36 +138,37 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
         /* This object will serve as a container to hold the response of this method*/
         ConsolidatedAPIResponseDTO consolidatedAPIResponseDTO = new ConsolidatedAPIResponseDTO();
 
+        final List<Mono<?>> fetches = new ArrayList<>();
+
         /* Get user profile data */
-        Mono<ResponseDTO<UserProfileDTO>> userProfileDTOResponseDTOMono = sessionUserService
+        fetches.add(sessionUserService
                 .getCurrentUser()
                 .flatMap(userService::buildUserProfileDTO)
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, UserProfileDTO.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setUserProfile)
                 .name(getQualifiedSpanName(USER_PROFILE_SPAN, mode))
-                .tap(Micrometer.observation(observationRegistry));
+                .tap(Micrometer.observation(observationRegistry)));
 
         /* Get all feature flags data */
-        Mono<ResponseDTO<Map>> featureFlagsForCurrentUserResponseDTOMonoCache = userDataService
+        Mono<ResponseDTO<Map<String, Boolean>>> featureFlagsForCurrentUserResponseDTOMonoCache = userDataService
                 .getFeatureFlagsForCurrentUser()
-                .map(res -> (Map) res)
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, Map.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setFeatureFlags)
                 .name(getQualifiedSpanName(FEATURE_FLAG_SPAN, mode))
                 .tap(Micrometer.observation(observationRegistry))
                 .cache();
+        fetches.add(featureFlagsForCurrentUserResponseDTOMonoCache);
 
         /* Get tenant config data */
-        ArrayList<Span> tenantSpanList = new ArrayList<>();
-        Mono<ResponseDTO<Tenant>> tenantResponseDTOMono = tenantService
+        fetches.add(tenantService
                 .getTenantConfiguration()
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, Tenant.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setTenantConfig)
                 .name(getQualifiedSpanName(TENANT_SPAN, mode))
-                .tap(Micrometer.observation(observationRegistry));
+                .tap(Micrometer.observation(observationRegistry)));
 
         /* Get any product alert info */
-        Mono<ResponseDTO<ProductAlertResponseDTO>> productAlertResponseDTOMono = productAlertService
+        fetches.add(productAlertService
                 .getSingleApplicableMessage()
                 .map(messages -> {
                     if (!messages.isEmpty()) {
@@ -225,27 +177,13 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
 
                     return new ProductAlertResponseDTO();
                 })
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, ProductAlertResponseDTO.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setProductAlert)
                 .name(getQualifiedSpanName(PRODUCT_ALERT_SPAN, mode))
-                .tap(Micrometer.observation(observationRegistry));
+                .tap(Micrometer.observation(observationRegistry)));
 
         if (isBlank(defaultPageId) && isBlank(applicationId)) {
-
-            List<Mono<?>> listOfCommonResponseMono = List.of(
-                    userProfileDTOResponseDTOMono,
-                    featureFlagsForCurrentUserResponseDTOMonoCache,
-                    tenantResponseDTOMono,
-                    productAlertResponseDTOMono);
-
-            return Mono.zip(listOfCommonResponseMono, responseArray -> {
-                consolidatedAPIResponseDTO.setUserProfile((ResponseDTO<UserProfileDTO>) responseArray[0]);
-                consolidatedAPIResponseDTO.setFeatureFlags((ResponseDTO<Map<String, Boolean>>) responseArray[1]);
-                consolidatedAPIResponseDTO.setTenantConfig((ResponseDTO<Tenant>) responseArray[2]);
-                consolidatedAPIResponseDTO.setProductAlert((ResponseDTO<ProductAlertResponseDTO>) responseArray[3]);
-
-                return consolidatedAPIResponseDTO;
-            });
+            return Mono.when(fetches).thenReturn(consolidatedAPIResponseDTO);
         }
 
         /* Get view mode - EDIT or PUBLISHED */
@@ -266,135 +204,91 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
         /* Get all pages in application */
         Mono<ResponseDTO<ApplicationPagesDTO>> applicationPagesDTOResponseDTOMonoCache = applicationIdMonoCache
                 .flatMap(appId -> newPageService.findApplicationPages(appId, null, branchName, mode))
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, ApplicationPagesDTO.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setPages)
                 .name(getQualifiedSpanName(PAGES_SPAN, mode))
                 .tap(Micrometer.observation(observationRegistry))
                 .cache();
+        fetches.add(applicationPagesDTOResponseDTOMonoCache);
 
         /* Get current theme */
-        Mono<ResponseDTO<Theme>> applicationThemeResponseDTOMono = applicationIdMonoCache
+        fetches.add(applicationIdMonoCache
                 .flatMap(appId -> themeService.getApplicationTheme(appId, mode, branchName))
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, Theme.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setCurrentTheme)
                 .name(getQualifiedSpanName(CURRENT_THEME_SPAN, mode))
-                .tap(Micrometer.observation(observationRegistry));
+                .tap(Micrometer.observation(observationRegistry)));
 
         /* Get all themes */
-        Mono<ResponseDTO<List>> ThemesListResponseDTOMono = applicationIdMonoCache
+        fetches.add(applicationIdMonoCache
                 .flatMap(appId ->
                         themeService.getApplicationThemes(appId, branchName).collectList())
-                .map(res -> (List) res)
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setThemes)
                 .name(getQualifiedSpanName(THEMES_SPAN, mode))
-                .tap(Micrometer.observation(observationRegistry));
+                .tap(Micrometer.observation(observationRegistry)));
 
         /* Get all custom JS libraries installed in the application */
-        Mono<ResponseDTO<List>> allJSLibsInContextDTOResponseDTOMono = applicationIdMonoCache
+        fetches.add(applicationIdMonoCache
                 .flatMap(appId -> customJSLibService.getAllJSLibsInContext(
                         appId, CreatorContextType.APPLICATION, branchName, isViewMode))
-                .map(res -> (List) res)
-                .map(this::getSuccessResponse)
-                .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                .as(this::toResponseDTO)
+                .doOnSuccess(consolidatedAPIResponseDTO::setCustomJSLibraries)
                 .name(getQualifiedSpanName(CUSTOM_JS_LIB_SPAN, mode))
-                .tap(Micrometer.observation(observationRegistry));
+                .tap(Micrometer.observation(observationRegistry)));
 
         /* Check if release_server_dsl_migrations_enabled flag is true for the user */
         Mono<Boolean> migrateDslMonoCache = featureFlagsForCurrentUserResponseDTOMonoCache
                 .map(responseDTO -> {
                     if (INTERNAL_SERVER_ERROR_STATUS
                             == responseDTO.getResponseMeta().getStatus()) {
-                        return Map.of();
+                        return false;
                     }
 
-                    return responseDTO.getData();
-                })
-                .map(flagsMap -> {
+                    Map<String, Boolean> flagsMap = responseDTO.getData();
                     if (!flagsMap.containsKey(FEATURE_FLAG_RELEASE_SERVER_DSL_MIGRATIONS_ENABLED)) {
                         return false;
                     }
 
-                    return (Boolean) flagsMap.get(FEATURE_FLAG_RELEASE_SERVER_DSL_MIGRATIONS_ENABLED);
+                    return flagsMap.get(FEATURE_FLAG_RELEASE_SERVER_DSL_MIGRATIONS_ENABLED);
                 })
                 .cache();
 
-        Mono<ResponseDTO<PageDTO>> currentPageDTOResponseDTOMono = Mono.empty();
         if (!isBlank(defaultPageId)) {
             /* Get current page */
-            currentPageDTOResponseDTOMono = migrateDslMonoCache
+            fetches.add(migrateDslMonoCache
                     .flatMap(migrateDsl -> applicationPageService.getPageAndMigrateDslByBranchAndDefaultPageId(
                             defaultPageId, branchName, isViewMode, migrateDsl))
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, PageDTO.class))
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setPageWithMigratedDsl)
                     .name(getQualifiedSpanName(CURRENT_PAGE_SPAN, mode))
-                    .tap(Micrometer.observation(observationRegistry));
+                    .tap(Micrometer.observation(observationRegistry)));
         }
 
         /* Fetch view specific data */
         if (isViewMode) {
             /* Get list of all actions in view mode */
-            Mono<ResponseDTO<List>> listOfActionViewResponseDTOMono = applicationIdMonoCache
+            fetches.add(applicationIdMonoCache
                     .flatMap(appId -> newActionService
                             .getActionsForViewMode(appId, branchName)
                             .collectList())
-                    .map(res -> (List) res)
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setPublishedActions)
                     .name(getQualifiedSpanName(ACTIONS_SPAN, mode))
-                    .tap(Micrometer.observation(observationRegistry));
+                    .tap(Micrometer.observation(observationRegistry)));
 
             /* Get list of all action collections in view mode */
-            Mono<ResponseDTO<List>> listOfActionCollectionViewResponseDTOMono = applicationIdMonoCache
+            fetches.add(applicationIdMonoCache
                     .flatMap(appId -> actionCollectionService
                             .getActionCollectionsForViewMode(appId, branchName)
                             .collectList())
-                    .map(res -> (List) res)
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, List.class))
-                    .name(getQualifiedSpanName(ACTION_COLLECTIONS_SPAN, mode));
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setPublishedActionCollections)
+                    .name(getQualifiedSpanName(ACTION_COLLECTIONS_SPAN, mode)));
 
-            /* This list contains the Mono objects corresponding to all the data points required for view mode. All
-             * the Mono objects in this list will be evaluated via Mono.zip operator.
-             */
-            List<Mono<?>> listOfMonoForPublishedApp = new ArrayList<>(List.of(
-                    userProfileDTOResponseDTOMono,
-                    tenantResponseDTOMono,
-                    featureFlagsForCurrentUserResponseDTOMonoCache,
-                    applicationPagesDTOResponseDTOMonoCache,
-                    applicationThemeResponseDTOMono,
-                    ThemesListResponseDTOMono,
-                    listOfActionViewResponseDTOMono,
-                    listOfActionCollectionViewResponseDTOMono,
-                    allJSLibsInContextDTOResponseDTOMono,
-                    productAlertResponseDTOMono));
-
-            if (!isBlank(defaultPageId)) {
-                listOfMonoForPublishedApp.add(currentPageDTOResponseDTOMono);
-            }
-
-            return Mono.zip(listOfMonoForPublishedApp, responseArray -> {
-                consolidatedAPIResponseDTO.setUserProfile((ResponseDTO<UserProfileDTO>) responseArray[0]);
-                consolidatedAPIResponseDTO.setTenantConfig((ResponseDTO<Tenant>) responseArray[1]);
-                consolidatedAPIResponseDTO.setFeatureFlags((ResponseDTO<Map<String, Boolean>>) responseArray[2]);
-                consolidatedAPIResponseDTO.setPages((ResponseDTO<ApplicationPagesDTO>) responseArray[3]);
-                consolidatedAPIResponseDTO.setCurrentTheme((ResponseDTO<Theme>) responseArray[4]);
-                consolidatedAPIResponseDTO.setThemes((ResponseDTO<List<Theme>>) responseArray[5]);
-                consolidatedAPIResponseDTO.setPublishedActions((ResponseDTO<List<ActionViewDTO>>) responseArray[6]);
-                consolidatedAPIResponseDTO.setPublishedActionCollections(
-                        (ResponseDTO<List<ActionCollectionViewDTO>>) responseArray[7]);
-                consolidatedAPIResponseDTO.setCustomJSLibraries((ResponseDTO<List<CustomJSLib>>) responseArray[8]);
-                consolidatedAPIResponseDTO.setProductAlert((ResponseDTO<ProductAlertResponseDTO>) responseArray[9]);
-
-                if (!isBlank(defaultPageId)) {
-                    consolidatedAPIResponseDTO.setPageWithMigratedDsl((ResponseDTO<PageDTO>) responseArray[10]);
-                }
-
-                return consolidatedAPIResponseDTO;
-            });
         } else {
             /* Get all actions in edit mode */
-            Mono<ResponseDTO<List>> listOfActionResponseDTOMono = applicationIdMonoCache
+            fetches.add(applicationIdMonoCache
                     .flatMap(appId -> {
                         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
                         params.add(APPLICATION_ID, appId);
@@ -402,30 +296,27 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                                 .getUnpublishedActions(params, branchName, false)
                                 .collectList();
                     })
-                    .map(res -> (List) res)
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setUnpublishedActions)
                     .name(getQualifiedSpanName(ACTIONS_SPAN, mode))
-                    .tap(Micrometer.observation(observationRegistry));
+                    .tap(Micrometer.observation(observationRegistry)));
 
             /* Get all action collections in edit mode */
-            Mono<ResponseDTO<List>> listOfActionCollectionResponseDTOMono = applicationIdMonoCache
-                    .flatMap(appId -> {
+            fetches.add(applicationIdMonoCache
+                    .flatMapMany(appId -> {
                         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
                         params.add(APPLICATION_ID, appId);
-                        return actionCollectionService
-                                .getPopulatedActionCollectionsByViewMode(params, false, branchName)
-                                .collectList()
-                                .map(res -> (List) res)
-                                .map(this::getSuccessResponse);
+                        return actionCollectionService.getPopulatedActionCollectionsByViewMode(
+                                params, false, branchName);
                     })
-                    .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                    .collectList()
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setUnpublishedActionCollections)
                     .name(getQualifiedSpanName(ACTION_COLLECTIONS_SPAN, mode))
-                    .tap(Micrometer.observation(observationRegistry));
+                    .tap(Micrometer.observation(observationRegistry)));
 
             /* Get all pages in edit mode post apply migrate DSL changes */
-            ArrayList<Span> pagesPostMigrateDslSpanList = new ArrayList<>();
-            Mono<ResponseDTO<List>> listOfAllPageResponseDTOMono = migrateDslMonoCache
+            fetches.add(migrateDslMonoCache
                     .flatMap(migrateDsl -> applicationPagesDTOResponseDTOMonoCache
                             .map(ResponseDTO::getData)
                             .map(ApplicationPagesDTO::getPages)
@@ -433,11 +324,10 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                             .flatMap(page -> applicationPageService.getPageAndMigrateDslByBranchAndDefaultPageId(
                                     page.getDefaultPageId(), branchName, false, migrateDsl))
                             .collect(Collectors.toList()))
-                    .map(res -> (List) res)
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setPagesWithMigratedDsl)
                     .name(getQualifiedSpanName(PAGES_DSL_SPAN, mode))
-                    .tap(Micrometer.observation(observationRegistry));
+                    .tap(Micrometer.observation(observationRegistry)));
 
             /* Get all workspace id */
             Mono<String> workspaceIdMonoCache = applicationPagesDTOResponseDTOMonoCache
@@ -459,14 +349,15 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                     .flatMap(workspaceId -> EMPTY_WORKSPACE_ID_ON_ERROR.equals(workspaceId)
                             ? Mono.empty()
                             : pluginService.getInWorkspace(workspaceId).collectList())
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(this::getErrorResponseMono)
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setPlugins)
                     .name(getQualifiedSpanName(PLUGINS_SPAN, mode))
                     .tap(Micrometer.observation(observationRegistry))
                     .cache();
+            fetches.add(listOfPluginsResponseDTOMonoCache);
 
             /* Get all datasources in workspace */
-            Mono<ResponseDTO<List>> listOfDatasourcesResponseDTOMonoCache = workspaceIdMonoCache
+            Mono<ResponseDTO<List<Datasource>>> listOfDatasourcesResponseDTOMonoCache = workspaceIdMonoCache
                     .flatMap(workspaceId -> {
                         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
                         if (!EMPTY_WORKSPACE_ID_ON_ERROR.equals(workspaceId)) {
@@ -474,20 +365,19 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                         }
                         return datasourceService.getAllWithStorages(params).collectList();
                     })
-                    .map(res -> (List) res)
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setDatasources)
                     .name(getQualifiedSpanName(DATASOURCES_SPAN, mode))
                     .tap(Micrometer.observation(observationRegistry))
                     .cache();
+            fetches.add(listOfDatasourcesResponseDTOMonoCache);
 
             /* Get form config for all relevant plugins by following this rule:
              *   (a) there is at least one datasource of the plugin type alive in the workspace
              *   (b) include REST API and GraphQL API plugin always
              *   (c) ignore any other plugin
              *  */
-            Mono<ResponseDTO<Map>> listOfFormConfigsResponseDTOMono = Mono.zip(
-                            listOfPluginsResponseDTOMonoCache, listOfDatasourcesResponseDTOMonoCache)
+            fetches.add(Mono.zip(listOfPluginsResponseDTOMonoCache, listOfDatasourcesResponseDTOMonoCache)
                     .map(tuple2 -> {
                         Set<String> setOfAllPluginIdsToGetFormConfig = new HashSet<>();
                         List<Plugin> pluginList = tuple2.getT1().getData();
@@ -497,10 +387,8 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                                 .filter(datasource -> !isBlank(datasource.getPluginId()))
                                 .forEach(datasource -> setOfAllPluginIdsToGetFormConfig.add(datasource.getPluginId()));
 
-                        /**
-                         * There are some plugins that allow query to be created without creating a datasource. For
-                         * such datasources, form config is required by the client at the time of page load.
-                         */
+                        // There are some plugins that allow query to be created without creating a datasource. For
+                        // such datasources, form config is required by the client at the time of page load.
                         pluginList.stream()
                                 .filter(this::isPossibleToCreateQueryWithoutDatasource)
                                 .forEach(plugin -> setOfAllPluginIdsToGetFormConfig.add(plugin.getId()));
@@ -512,80 +400,31 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
                             pluginService.getFormConfig(pluginId).map(formConfig -> Pair.of(pluginId, formConfig)))
                     .collectList()
                     .map(listOfFormConfig -> {
-                        Map<String, Map> pluginIdToFormConfigMap = new HashMap<>();
-                        listOfFormConfig.stream().forEach(individualConfigMap -> {
+                        Map<String, Map<?, ?>> pluginIdToFormConfigMap = new HashMap<>();
+                        listOfFormConfig.forEach(individualConfigMap -> {
                             String pluginId = individualConfigMap.getFirst();
-                            Map config = individualConfigMap.getSecond();
+                            Map<?, ?> config = individualConfigMap.getSecond();
                             pluginIdToFormConfigMap.put(pluginId, config);
                         });
 
                         return pluginIdToFormConfigMap;
                     })
-                    .map(res -> (Map) res)
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, Map.class))
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setPluginFormConfigs)
                     .name(getQualifiedSpanName(FORM_CONFIG_SPAN, mode))
-                    .tap(Micrometer.observation(observationRegistry));
+                    .tap(Micrometer.observation(observationRegistry)));
 
             /* List of mock datasources available to the user */
-            Mono<ResponseDTO<List>> mockDataListResponseDTOMono = mockDataService
+            fetches.add(mockDataService
                     .getMockDataSet()
                     .map(MockDataDTO::getMockdbs)
-                    .map(res -> (List) res)
-                    .map(this::getSuccessResponse)
-                    .onErrorResume(error -> getErrorResponseMono(error, List.class))
+                    .as(this::toResponseDTO)
+                    .doOnSuccess(consolidatedAPIResponseDTO::setMockDatasources)
                     .name(getQualifiedSpanName(MOCK_DATASOURCES_SPAN, mode))
-                    .tap(Micrometer.observation(observationRegistry));
-
-            /* This list contains the Mono objects corresponding to all the data points required for edit mode. All
-             * the Mono objects in this list will be evaluated via Mono.zip operator
-             */
-            List<Mono<?>> listOfMonoForEditMode = new ArrayList<>(List.of(
-                    userProfileDTOResponseDTOMono,
-                    tenantResponseDTOMono,
-                    featureFlagsForCurrentUserResponseDTOMonoCache,
-                    applicationPagesDTOResponseDTOMonoCache,
-                    applicationThemeResponseDTOMono,
-                    ThemesListResponseDTOMono,
-                    allJSLibsInContextDTOResponseDTOMono,
-                    productAlertResponseDTOMono,
-                    listOfActionResponseDTOMono,
-                    listOfActionCollectionResponseDTOMono,
-                    listOfAllPageResponseDTOMono,
-                    listOfPluginsResponseDTOMonoCache,
-                    listOfDatasourcesResponseDTOMonoCache,
-                    listOfFormConfigsResponseDTOMono,
-                    mockDataListResponseDTOMono));
-
-            if (!isBlank(defaultPageId)) {
-                listOfMonoForEditMode.add(currentPageDTOResponseDTOMono);
-            }
-
-            return Mono.zip(listOfMonoForEditMode, responseArray -> {
-                consolidatedAPIResponseDTO.setUserProfile((ResponseDTO<UserProfileDTO>) responseArray[0]);
-                consolidatedAPIResponseDTO.setTenantConfig((ResponseDTO<Tenant>) responseArray[1]);
-                consolidatedAPIResponseDTO.setFeatureFlags((ResponseDTO<Map<String, Boolean>>) responseArray[2]);
-                consolidatedAPIResponseDTO.setPages((ResponseDTO<ApplicationPagesDTO>) responseArray[3]);
-                consolidatedAPIResponseDTO.setCurrentTheme((ResponseDTO<Theme>) responseArray[4]);
-                consolidatedAPIResponseDTO.setThemes((ResponseDTO<List<Theme>>) responseArray[5]);
-                consolidatedAPIResponseDTO.setCustomJSLibraries((ResponseDTO<List<CustomJSLib>>) responseArray[6]);
-                consolidatedAPIResponseDTO.setProductAlert((ResponseDTO<ProductAlertResponseDTO>) responseArray[7]);
-                consolidatedAPIResponseDTO.setUnpublishedActions((ResponseDTO<List<ActionDTO>>) responseArray[8]);
-                consolidatedAPIResponseDTO.setUnpublishedActionCollections(
-                        (ResponseDTO<List<ActionCollectionDTO>>) responseArray[9]);
-                consolidatedAPIResponseDTO.setPagesWithMigratedDsl((ResponseDTO<List<PageDTO>>) responseArray[10]);
-                consolidatedAPIResponseDTO.setPlugins((ResponseDTO<List<Plugin>>) responseArray[11]);
-                consolidatedAPIResponseDTO.setDatasources((ResponseDTO<List<Datasource>>) responseArray[12]);
-                consolidatedAPIResponseDTO.setPluginFormConfigs((ResponseDTO<Map<String, Map>>) responseArray[13]);
-                consolidatedAPIResponseDTO.setMockDatasources((ResponseDTO<List<MockDataSet>>) responseArray[14]);
-
-                if (!isBlank(defaultPageId)) {
-                    consolidatedAPIResponseDTO.setPageWithMigratedDsl((ResponseDTO<PageDTO>) responseArray[15]);
-                }
-
-                return consolidatedAPIResponseDTO;
-            });
+                    .tap(Micrometer.observation(observationRegistry)));
         }
+
+        return Mono.when(fetches).thenReturn(consolidatedAPIResponseDTO);
     }
 
     private boolean isPossibleToCreateQueryWithoutDatasource(Plugin plugin) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ConsolidatedAPIServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ConsolidatedAPIServiceImplTest.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import static com.appsmith.external.constants.PluginConstants.PackageName.APPSMITH_AI_PLUGIN;
 import static com.appsmith.external.constants.PluginConstants.PackageName.GRAPHQL_PLUGIN;
 import static com.appsmith.external.constants.PluginConstants.PackageName.REST_API_PLUGIN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -124,7 +125,7 @@ public class ConsolidatedAPIServiceImplTest {
         Mono<ConsolidatedAPIResponseDTO> consolidatedInfoForPageLoad =
                 consolidatedAPIService.getConsolidatedInfoForPageLoad("pageId", null, null, null);
         StepVerifier.create(consolidatedInfoForPageLoad).verifyErrorSatisfies(error -> {
-            assertTrue(error instanceof AppsmithException);
+            assertThat(error).isInstanceOf(AppsmithException.class);
             assertEquals("Please enter a valid parameter appMode.", error.getMessage());
         });
     }
@@ -447,7 +448,7 @@ public class ConsolidatedAPIServiceImplTest {
         sampleDatasource.setPluginId("samplePluginId");
         when(mockDatasourceService.getAllWithStorages(any())).thenReturn(Flux.just(sampleDatasource));
 
-        Map<String, Map> sampleFormConfig = new HashMap<>();
+        Map<String, Map<?, ?>> sampleFormConfig = new HashMap<>();
         sampleFormConfig.put("key", Map.of());
         when(mockPluginService.getFormConfig(anyString())).thenReturn(Mono.just(sampleFormConfig));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PluginServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PluginServiceTest.java
@@ -74,7 +74,7 @@ public class PluginServiceTest {
         Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("dependency.json")))
                 .thenReturn(Mono.error(new AppsmithException(AppsmithError.PLUGIN_LOAD_FORM_JSON_FAIL)));
 
-        Mono<Map> formConfig = pluginService.getFormConfig("random-plugin-id");
+        Mono<Map<?, ?>> formConfig = pluginService.getFormConfig("random-plugin-id");
 
         StepVerifier.create(formConfig).expectError(AppsmithException.class).verify();
     }
@@ -95,7 +95,7 @@ public class PluginServiceTest {
         Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("dependency.json")))
                 .thenReturn(Mono.error(new AppsmithException(AppsmithError.PLUGIN_LOAD_FORM_JSON_FAIL)));
 
-        Mono<Map> formConfig = pluginService.getFormConfig("random-plugin-id");
+        Mono<Map<?, ?>> formConfig = pluginService.getFormConfig("random-plugin-id");
         StepVerifier.create(formConfig)
                 .assertNext(form -> {
                     assertThat(form).isNotNull();
@@ -130,7 +130,7 @@ public class PluginServiceTest {
         Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("dependency.json")))
                 .thenReturn(Mono.just(dependencyMap));
 
-        Mono<Map> formConfig = pluginService.getFormConfig("random-plugin-id");
+        Mono<Map<?, ?>> formConfig = pluginService.getFormConfig("random-plugin-id");
         StepVerifier.create(formConfig)
                 .assertNext(form -> {
                     assertThat(form).isNotNull();


### PR DESCRIPTION
This is an effort to reduce warnings from `javac`, towards adding a linter to the backend.

I recently had to troubleshoot some code in this class and the array based zipping of 10+ Monos was very hard to parse and debug. This PR simplifies that implementation as well as fixes all/most warnings in this class.

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8918809242>
> Commit: f37ef41d41b9925de233f10ca300f89bc3ffe044
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8918809242&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




