### PR TITLE
chore: push webworker latencies as a root span

### DIFF
--- a/app/client/src/UITelemetry/generateTraces.ts
+++ b/app/client/src/UITelemetry/generateTraces.ts
@@ -4,13 +4,22 @@ import { context } from "@opentelemetry/api";
 import { trace } from "@opentelemetry/api";
 
 const GENERATOR_TRACE = "generator-tracer";
-export function startRootSpan(spanName: string, spanAttributes?: Attributes) {
+export function startRootSpan(
+  spanName: string,
+  spanAttributes?: Attributes,
+  startTime?: TimeInput,
+) {
   const tracer = trace.getTracer(GENERATOR_TRACE);
   if (!spanName) {
     return;
   }
   const attributes = spanAttributes ?? { attributes: spanAttributes };
-  return tracer?.startSpan(spanName, { kind: SpanKind.CLIENT, ...attributes });
+  const startTimeAttr = startTime ? { startTime } : {};
+  return tracer?.startSpan(spanName, {
+    kind: SpanKind.CLIENT,
+    ...attributes,
+    ...startTimeAttr,
+  });
 }
 export const generateContext = (span: Span) => {
   return trace.setSpan(context.active(), span);

--- a/app/client/src/UITelemetry/generateWebWorkerTraces.ts
+++ b/app/client/src/UITelemetry/generateWebWorkerTraces.ts
@@ -45,9 +45,11 @@ export const convertWebworkerSpansToRegularSpans = (
   parentSpan: Span,
   allSpans: Record<string, WebworkerSpanData> = {},
 ) => {
-  for (const spanData of Object.values(allSpans)) {
-    const { attributes, endTime, spanName, startTime } = spanData;
-    const span = startNestedSpan(spanName, parentSpan, attributes, startTime);
-    span?.end(endTime);
-  }
+  Object.values(allSpans)
+    .filter(({ endTime, startTime }) => startTime && endTime)
+    .forEach((spanData) => {
+      const { attributes, endTime, spanName, startTime } = spanData;
+      const span = startNestedSpan(spanName, parentSpan, attributes, startTime);
+      span?.end(endTime);
+    });
 };

--- a/app/client/src/plugins/Linting/linters/worker.ts
+++ b/app/client/src/plugins/Linting/linters/worker.ts
@@ -7,7 +7,7 @@ import { handlerMap } from "../handlers";
 export function messageListener(e: MessageEvent<TMessage<LintRequest>>) {
   const { messageType } = e.data;
   if (messageType !== MessageType.REQUEST) return;
-  const startTime = performance.now();
+  const startTime = Date.now();
   const { body, messageId } = e.data;
   const { data, method } = body;
   if (!method) return;
@@ -15,8 +15,8 @@ export function messageListener(e: MessageEvent<TMessage<LintRequest>>) {
   if (typeof messageHandler !== "function") return;
   const responseData = messageHandler(data);
   if (!responseData) return;
-  const endTime = performance.now();
-  WorkerMessenger.respond(messageId, responseData, endTime - startTime);
+  const endTime = Date.now();
+  WorkerMessenger.respond(messageId, responseData, startTime, endTime);
 }
 
 self.onmessage = messageListener;

--- a/app/client/src/sagas/ReplaySaga.ts
+++ b/app/client/src/sagas/ReplaySaga.ts
@@ -194,13 +194,14 @@ export function* undoRedoSaga(action: ReduxAction<UndoRedoPayload>) {
     if (!workerResponse) return;
 
     const {
+      endTime,
       event,
       logs,
       paths,
       replay,
       replayEntity,
       replayEntityType,
-      timeTaken,
+      startTime,
     } = workerResponse;
 
     logs && logs.forEach((evalLog: any) => log.debug(evalLog));
@@ -213,7 +214,10 @@ export function* undoRedoSaga(action: ReduxAction<UndoRedoPayload>) {
     switch (replayEntityType) {
       case ENTITY_TYPE.WIDGET: {
         const isPropertyUpdate = replay.widgets && replay.propertyUpdates;
-        AnalyticsUtil.logEvent(event, { paths, timeTaken });
+        AnalyticsUtil.logEvent(event, {
+          paths,
+          timeTaken: endTime - startTime,
+        });
 
         yield call(updateAndSaveAnvilLayout, replayEntity.widgets, {
           isRetry: false,

--- a/app/client/src/utils/WorkerUtil.ts
+++ b/app/client/src/utils/WorkerUtil.ts
@@ -214,10 +214,10 @@ export class GracefulWorkerService {
 
       const completeWebworkerComputationRoot = startRootSpan(
         "completeWebworkerComputationRoot",
-        { method },
+        undefined,
         startTime,
       );
-
+      completeWebworkerComputationRoot?.setAttribute("taskType", method);
       completeWebworkerComputationRoot?.end(endTime);
 
       rootSpan &&

--- a/app/client/src/utils/WorkerUtil.ts
+++ b/app/client/src/utils/WorkerUtil.ts
@@ -5,12 +5,14 @@ import { uniqueId } from "lodash";
 import log from "loglevel";
 import type { TMessage } from "./MessageUtil";
 import { MessageType, sendMessage } from "./MessageUtil";
+import type { OtlpSpan } from "UITelemetry/generateTraces";
 import { endSpan, startRootSpan } from "UITelemetry/generateTraces";
 import type { WebworkerSpanData } from "UITelemetry/generateWebWorkerTraces";
 import {
   convertWebworkerSpansToRegularSpans,
   newWebWorkerSpanData,
 } from "UITelemetry/generateWebWorkerTraces";
+
 /**
  * Wrap a webworker to provide a synchronous request-response semantic.
  *
@@ -147,6 +149,51 @@ export class GracefulWorkerService {
     });
   }
 
+  private addChildSpansToRootSpan({
+    endTime,
+    method,
+    rootSpan,
+    startTime,
+    webworkerTelemetry,
+  }: {
+    webworkerTelemetry: Record<string, WebworkerSpanData>;
+    rootSpan: OtlpSpan | undefined;
+    method: string;
+    startTime: number;
+    endTime: number;
+  }) {
+    const webworkerTelemetryResponse = webworkerTelemetry as Record<
+      string,
+      WebworkerSpanData
+    >;
+
+    if (webworkerTelemetryResponse) {
+      const { transferDataToMainThread } = webworkerTelemetryResponse;
+      if (transferDataToMainThread) {
+        transferDataToMainThread.endTime = Date.now();
+      }
+      /// Add the completeWebworkerComputation span to the root span
+      webworkerTelemetryResponse["completeWebworkerComputation"] = {
+        startTime,
+        endTime,
+        attributes: {},
+        spanName: "completeWebworkerComputation",
+      };
+    }
+    //we are attaching the child spans to the root span over here
+    rootSpan &&
+      convertWebworkerSpansToRegularSpans(rootSpan, webworkerTelemetryResponse);
+
+    //genereate separate completeWebworkerComputationRoot root span
+    // this span does not contain any child spans, it just captures the webworker computation alone
+    const completeWebworkerComputationRoot = startRootSpan(
+      "completeWebworkerComputationRoot",
+      undefined,
+      startTime,
+    );
+    completeWebworkerComputationRoot?.setAttribute("taskType", method);
+    completeWebworkerComputationRoot?.end(endTime);
+  }
   /**
    * Send a request to the worker for processing.
    * If the worker isn't ready, we wait for it to become ready.
@@ -194,47 +241,23 @@ export class GracefulWorkerService {
       // The `this._broker` method is listening to events and will pass response to us over this channel.
       const response = yield take(ch);
       const { data, endTime, startTime } = response;
-
-      const webworkerTelemetryResponse = data.webworkerTelemetry as Record<
-        string,
-        WebworkerSpanData
-      >;
-
-      if (webworkerTelemetryResponse) {
-        webworkerTelemetryResponse["transferDataToMainThread"].endTime =
-          Date.now();
-
-        webworkerTelemetryResponse["completeWebworkerComputation"] = {
-          startTime,
-          endTime,
-          attributes: {},
-          spanName: "completeWebworkerComputation",
-        };
-      }
-
-      const completeWebworkerComputationRoot = startRootSpan(
-        "completeWebworkerComputationRoot",
-        undefined,
+      const { webworkerTelemetry } = data;
+      this.addChildSpansToRootSpan({
+        webworkerTelemetry,
+        rootSpan,
+        method,
         startTime,
-      );
-      completeWebworkerComputationRoot?.setAttribute("taskType", method);
-      completeWebworkerComputationRoot?.end(endTime);
-
-      rootSpan &&
-        convertWebworkerSpansToRegularSpans(
-          rootSpan,
-          webworkerTelemetryResponse,
-        );
+        endTime,
+      });
 
       timeTaken = endTime - startTime;
       return data;
     } finally {
-      endSpan(rootSpan);
-
       // Log perf of main thread and worker
       const mainThreadEndTime = Date.now();
       const timeTakenOnMainThread = mainThreadEndTime - mainThreadStartTime;
       if (yield cancelled()) {
+        rootSpan?.setAttribute("cancelled", true);
         log.debug(`Main ${method} cancelled in ${timeTakenOnMainThread}ms`);
       } else {
         log.debug(`Main ${method} took ${timeTakenOnMainThread}ms`);
@@ -245,6 +268,7 @@ export class GracefulWorkerService {
         log.debug(` Worker ${method} took ${timeTaken}ms`);
         log.debug(` Transfer ${method} took ${transferTime}ms`);
       }
+      endSpan(rootSpan);
       // Cleanup
       ch.close();
       this._channels.delete(messageId);

--- a/app/client/src/utils/WorkerUtil.ts
+++ b/app/client/src/utils/WorkerUtil.ts
@@ -204,13 +204,21 @@ export class GracefulWorkerService {
         webworkerTelemetryResponse["transferDataToMainThread"].endTime =
           Date.now();
 
-        webworkerTelemetryResponse["completeWebworkerComplutation"] = {
+        webworkerTelemetryResponse["completeWebworkerComputation"] = {
           startTime,
           endTime,
           attributes: {},
-          spanName: "completeWebworkerComplutation",
+          spanName: "completeWebworkerComputation",
         };
       }
+
+      const completeWebworkerComputationRoot = startRootSpan(
+        "completeWebworkerComputationRoot",
+        { method },
+        startTime,
+      );
+
+      completeWebworkerComputationRoot?.end(endTime);
 
       rootSpan &&
         convertWebworkerSpansToRegularSpans(

--- a/app/client/src/workers/Evaluation/evaluation.worker.ts
+++ b/app/client/src/workers/Evaluation/evaluation.worker.ts
@@ -16,7 +16,7 @@ function syncRequestMessageListener(
 ) {
   const { messageType } = e.data;
   if (messageType !== MessageType.REQUEST) return;
-  const startTime = performance.now();
+  const startTime = Date.now();
   const { body, messageId } = e.data;
   const { method } = body;
   if (!method) return;
@@ -24,11 +24,12 @@ function syncRequestMessageListener(
   if (typeof messageHandler !== "function") return;
   const responseData = messageHandler(body);
   const transmissionErrorHandler = transmissionErrorHandlerMap[method];
-  const endTime = performance.now();
+  const endTime = Date.now();
   WorkerMessenger.respond(
     messageId,
     responseData,
-    endTime - startTime,
+    startTime,
+    endTime,
     transmissionErrorHandler,
   );
 }
@@ -38,19 +39,20 @@ async function asyncRequestMessageListener(
 ) {
   const { messageType } = e.data;
   if (messageType !== MessageType.REQUEST) return;
-  const start = performance.now();
+  const start = Date.now();
   const { body, messageId } = e.data;
   const { method } = body;
   if (!method) return;
   const messageHandler = asyncHandlerMap[method];
   if (typeof messageHandler !== "function") return;
   const data = await messageHandler(body);
-  const end = performance.now();
+  const end = Date.now();
   const transmissionErrorHandler = transmissionErrorHandlerMap[method];
   WorkerMessenger.respond(
     messageId,
     data,
-    end - start,
+    start,
+    end,
     transmissionErrorHandler,
   );
 }

--- a/app/client/src/workers/Evaluation/fns/utils/Messenger.ts
+++ b/app/client/src/workers/Evaluation/fns/utils/Messenger.ts
@@ -28,14 +28,16 @@ async function responseHandler(requestId: string): Promise<TPromiseResponse> {
 
 export type TransmissionErrorHandler = (
   messageId: string,
-  timeTaken: number,
+  startTime: number,
+  endTime: number,
   responseData: unknown,
   e: unknown,
 ) => void;
 
 const defaultErrorHandler: TransmissionErrorHandler = (
   messageId: string,
-  timeTaken: number,
+  startTime: number,
+  endTime: number,
   responseData: unknown,
   e: unknown,
 ) => {
@@ -44,7 +46,8 @@ const defaultErrorHandler: TransmissionErrorHandler = (
     messageId,
     messageType: MessageType.RESPONSE,
     body: {
-      timeTaken: timeTaken.toFixed(2),
+      startTime,
+      endTime,
       data: {
         errors: [
           {
@@ -102,21 +105,22 @@ export class WorkerMessenger {
   static respond(
     messageId: string,
     data: unknown,
-    timeTaken: number,
+    startTime: number,
+    endTime: number,
     onErrorHandler?: TransmissionErrorHandler,
   ) {
     try {
       sendMessage.call(self, {
         messageId,
         messageType: MessageType.RESPONSE,
-        body: { data, timeTaken },
+        body: { data, startTime, endTime },
       });
     } catch (e) {
       const errorHandler = onErrorHandler || defaultErrorHandler;
       try {
-        errorHandler(messageId, timeTaken, data, e);
+        errorHandler(messageId, startTime, endTime, data, e);
       } catch {
-        defaultErrorHandler(messageId, timeTaken, data, e);
+        defaultErrorHandler(messageId, startTime, endTime, data, e);
       }
     }
   }

--- a/app/client/src/workers/Evaluation/handlers/__tests__/evalTree.test.ts
+++ b/app/client/src/workers/Evaluation/handlers/__tests__/evalTree.test.ts
@@ -37,6 +37,8 @@ jest.mock("utils/MessageUtil", () => {
 
 describe("test", () => {
   it("calls custom evalTree error handler", () => {
+    const startTime = Date.now();
+    const endTime = startTime + 1000;
     const UNSERIALIZABLE_DATA = {
       response: () => {},
       logs: {
@@ -46,7 +48,8 @@ describe("test", () => {
     WorkerMessenger.respond(
       "TEST",
       UNSERIALIZABLE_DATA,
-      4,
+      startTime,
+      endTime,
       evalTreeTransmissionErrorHandler,
     );
     // Since response is unserializable, expect EvalErrorHandler to be called

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -315,14 +315,15 @@ export function evalTree(request: EvalWorkerSyncRequest) {
 
 export const evalTreeTransmissionErrorHandler: TransmissionErrorHandler = (
   messageId: string,
-  timeTaken: number,
+  startTime: number,
+  endTime: number,
   responseData: unknown,
 ) => {
   const sanitizedData = JSON.parse(JSON.stringify(responseData));
   sendMessage.call(self, {
     messageId,
     messageType: MessageType.RESPONSE,
-    body: { data: sanitizedData, timeTaken },
+    body: { data: sanitizedData, startTime, endTime },
   });
 };
 


### PR DESCRIPTION
## Description
We are capturing the complete webworker latency as a separate root span and pushing this OTLP telemetry data. We are also attaching this span as a sub span to the EVAL_TREE spans as well.

Fixes #33127  

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8965108873>
> Commit: 7176101e021c93b2c53bf3c5d500560729ed45be
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8965108873&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->














## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
