### PR TITLE
fix: Filter fields with `@Transient` annotation embedded within jsonb column during DB serialisation

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/CustomTransientSerializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/CustomTransientSerializer.java
@@ -14,17 +14,17 @@ import java.util.List;
 
 /**
  *  This class is used to serialize the entity object by ignoring the fields annotated with @Transient. We need
- *  the custom serializer here as the columns with `jsonb` type is not able to ignore the fields annotated with
- *  @Transient by default.
+ *  the custom serializer here as the nested fields within the columns with `jsonb` type is not able to ignore the
+ *  fields annotated with `@Transient` by default.
  */
 @Slf4j
-public class TransientAnnotationSerializer<T> extends StdSerializer<T> {
+public class CustomTransientSerializer<T> extends StdSerializer<T> {
 
-    public TransientAnnotationSerializer() {
+    public CustomTransientSerializer() {
         this(null);
     }
 
-    public TransientAnnotationSerializer(Class<T> t) {
+    public CustomTransientSerializer(Class<T> t) {
         super(t);
     }
 
@@ -39,10 +39,10 @@ public class TransientAnnotationSerializer<T> extends StdSerializer<T> {
         gen.writeStartObject();
         for (final Field field : allFields) {
             field.setAccessible(true);
-            if (field.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
             try {
+                if (field.isAnnotationPresent(Transient.class) || field.get(value) == null) {
+                    continue;
+                }
                 gen.writeObjectField(field.getName(), field.get(value));
             } catch (IllegalAccessException e) {
                 log.error("Error serializing field: {}", field.getName(), e);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/TransientAnnotationSerializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/TransientAnnotationSerializer.java
@@ -1,0 +1,64 @@
+package com.appsmith.external.converters;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import jakarta.persistence.Transient;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ *  This class is used to serialize the entity object by ignoring the fields annotated with @Transient. We need
+ *  the custom serializer here as the columns with `jsonb` type is not able to ignore the fields annotated with
+ *  @Transient by default.
+ */
+@Slf4j
+public class TransientAnnotationSerializer<T> extends StdSerializer<T> {
+
+    public TransientAnnotationSerializer() {
+        this(null);
+    }
+
+    public TransientAnnotationSerializer(Class<T> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        if (value == null) {
+            return;
+        }
+
+        List<Field> allFields = getAllFields(value.getClass());
+
+        gen.writeStartObject();
+        for (final Field field : allFields) {
+            field.setAccessible(true);
+            if (field.isAnnotationPresent(Transient.class)) {
+                continue;
+            }
+            try {
+                gen.writeObjectField(field.getName(), field.get(value));
+            } catch (IllegalAccessException e) {
+                log.error("Error serializing field: {}", field.getName(), e);
+            }
+        }
+        gen.writeEndObject();
+    }
+
+    // Method to get all fields including superclasses
+    private List<Field> getAllFields(Class<?> clazz) {
+        List<Field> fields =
+                new ArrayList<>(Arrays.stream(clazz.getDeclaredFields()).toList());
+        Class<?> superClass = clazz.getSuperclass();
+        if (superClass != null && !superClass.equals(Object.class)) {
+            fields.addAll(getAllFields(superClass));
+        }
+        return fields;
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
@@ -1,8 +1,11 @@
 package com.appsmith.external.helpers;
 
+import com.appsmith.external.converters.TransientAnnotationSerializer;
+import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.views.Views;
 import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 
 /**
@@ -13,6 +16,8 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
  * solution than hunting down the exact version that works.
  */
 public final class CustomJsonType extends JsonBinaryType {
+    static final TransientAnnotationSerializer<Object> serializer = new TransientAnnotationSerializer<>();
+
     public CustomJsonType() {
         super(makeObjectMapperForDatabaseSerialization());
     }
@@ -20,7 +25,11 @@ public final class CustomJsonType extends JsonBinaryType {
     private static ObjectMapper makeObjectMapperForDatabaseSerialization() {
         final ObjectMapper om = new ObjectMapper();
 
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(ActionDTO.class, serializer);
+
         return SerializationUtils.configureObjectMapper(om)
+                .registerModule(module)
                 .setConfig(om.getSerializationConfig().withView(Views.Internal.class));
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
@@ -16,7 +16,6 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
  * solution than hunting down the exact version that works.
  */
 public final class CustomJsonType extends JsonBinaryType {
-    static final TransientAnnotationSerializer<Object> serializer = new TransientAnnotationSerializer<>();
 
     public CustomJsonType() {
         super(makeObjectMapperForDatabaseSerialization());
@@ -26,10 +25,14 @@ public final class CustomJsonType extends JsonBinaryType {
         final ObjectMapper om = new ObjectMapper();
 
         SimpleModule module = new SimpleModule();
-        module.addSerializer(ActionDTO.class, serializer);
+        module.addSerializer(ActionDTO.class, getSerializer(ActionDTO.class));
 
         return SerializationUtils.configureObjectMapper(om)
                 .registerModule(module)
                 .setConfig(om.getSerializationConfig().withView(Views.Internal.class));
+    }
+
+    private static <T> TransientAnnotationSerializer<T> getSerializer(Class<T> tClass) {
+        return new TransientAnnotationSerializer<>(tClass);
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
@@ -1,7 +1,7 @@
 package com.appsmith.external.helpers;
 
-import com.appsmith.external.converters.TransientAnnotationSerializer;
-import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.converters.CustomTransientSerializer;
+import com.appsmith.external.markers.TransientAware;
 import com.appsmith.external.views.Views;
 import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,14 +25,14 @@ public final class CustomJsonType extends JsonBinaryType {
         final ObjectMapper om = new ObjectMapper();
 
         SimpleModule module = new SimpleModule();
-        module.addSerializer(ActionDTO.class, getSerializer(ActionDTO.class));
+        module.addSerializer(TransientAware.class, getSerializer(TransientAware.class));
 
         return SerializationUtils.configureObjectMapper(om)
                 .registerModule(module)
                 .setConfig(om.getSerializationConfig().withView(Views.Internal.class));
     }
 
-    private static <T> TransientAnnotationSerializer<T> getSerializer(Class<T> tClass) {
-        return new TransientAnnotationSerializer<>(tClass);
+    private static <T> CustomTransientSerializer<T> getSerializer(Class<T> tClass) {
+        return new CustomTransientSerializer<>(tClass);
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/CustomJsonType.java
@@ -25,14 +25,10 @@ public final class CustomJsonType extends JsonBinaryType {
         final ObjectMapper om = new ObjectMapper();
 
         SimpleModule module = new SimpleModule();
-        module.addSerializer(TransientAware.class, getSerializer(TransientAware.class));
+        module.addSerializer(TransientAware.class, new CustomTransientSerializer<>(TransientAware.class));
 
         return SerializationUtils.configureObjectMapper(om)
                 .registerModule(module)
                 .setConfig(om.getSerializationConfig().withView(Views.Internal.class));
-    }
-
-    private static <T> CustomTransientSerializer<T> getSerializer(Class<T> tClass) {
-        return new CustomTransientSerializer<>(tClass);
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/markers/TransientAware.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/markers/TransientAware.java
@@ -1,0 +1,10 @@
+package com.appsmith.external.markers;
+
+import com.appsmith.external.converters.CustomTransientSerializer;
+
+/**
+ * This is a marker interface to indicate that the implementing class contains transient field and should not be
+ * persisted in the database.
+ * Please refer to {@link CustomTransientSerializer} for more details.
+ */
+public interface TransientAware {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionDTO.java
@@ -1,5 +1,6 @@
 package com.appsmith.external.models;
 
+import com.appsmith.external.markers.TransientAware;
 import com.appsmith.external.models.ce.ActionCE_DTO;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -14,6 +15,6 @@ import lombok.experimental.FieldNameConstants;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @FieldNameConstants
-public class ActionDTO extends ActionCE_DTO {
+public class ActionDTO extends ActionCE_DTO implements TransientAware {
     public static class Fields extends ActionCE_DTO.Fields {}
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.dtos;
 
+import com.appsmith.external.markers.TransientAware;
 import com.appsmith.external.models.DefaultResources;
 import com.appsmith.external.models.Policy;
 import com.appsmith.external.views.Git;
@@ -7,12 +8,12 @@ import com.appsmith.external.views.Views;
 import com.appsmith.server.domains.Layout;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonView;
+import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
 
 import java.time.Instant;
 import java.util.HashSet;
@@ -24,7 +25,7 @@ import java.util.Set;
 @NoArgsConstructor
 @ToString
 @FieldNameConstants
-public class PageDTO {
+public class PageDTO implements TransientAware {
 
     @Transient
     @JsonView({Views.Public.class})


### PR DESCRIPTION
### Description

As we are using `CustomJsonType` to serialise the jsonb column, it's not respecting the `@Transient` to remove these fields while saving the object to DB. To address this issue we need to implement the custom serialiser which uses reflections to filter fields based on annotation.   