### PR TITLE
test: Refactor tests ahead of upgrading Spring

### DIFF
--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/DSLTransformHelperTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/DSLTransformHelperTest.java
@@ -7,8 +7,6 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,13 +17,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@ExtendWith(SpringExtension.class)
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class DSLTransformHelperTest {
 
     private Map<String, JSONObject> jsonMap;
     private Map<String, List<String>> pathMapping;
-
-    String path = "src/test/resources";
 
     @BeforeEach
     public void setup() {
@@ -259,10 +256,6 @@ public class DSLTransformHelperTest {
 
         JSONObject result = DSLTransformerHelper.appendChildren(parent, childWidgets);
 
-        JSONArray expectedChildren = new JSONArray()
-                .put(new JSONObject().put(CommonConstants.WIDGET_NAME, "Child1"))
-                .put(new JSONObject().put(CommonConstants.WIDGET_NAME, "Child2"));
-
         JSONArray actualChildren = result.optJSONArray(CommonConstants.CHILDREN);
 
         Assertions.assertEquals(actualChildren.length(), 2);
@@ -295,11 +288,11 @@ public class DSLTransformHelperTest {
         for (Map.Entry<String, JSONObject> entry : flattenedWidgets.entrySet()) {
             JSONObject widget = entry.getValue();
             String relativePath = entry.getKey();
-            Assertions.assertEquals(relativePath.contains("Tabs1"), true);
+            assertThat(relativePath.contains("Tabs1")).isTrue();
             if (widget.getString(CommonConstants.WIDGET_NAME).equals("Button1")) {
-                Assertions.assertEquals(relativePath.endsWith("Button1"), true);
+                assertThat(relativePath.endsWith("Button1")).isTrue();
             } else if (widget.getString(CommonConstants.WIDGET_NAME).equals("CurrencyInput1")) {
-                Assertions.assertEquals(relativePath.endsWith("CurrencyInput1"), true);
+                assertThat(relativePath.endsWith("CurrencyInput1")).isTrue();
             }
         }
     }

--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
@@ -14,10 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -32,24 +29,20 @@ import static com.appsmith.git.constants.GitDirectories.ACTION_COLLECTION_DIRECT
 import static com.appsmith.git.constants.GitDirectories.ACTION_DIRECTORY;
 import static com.appsmith.git.constants.GitDirectories.PAGE_DIRECTORY;
 
-@ExtendWith(SpringExtension.class)
 public class FileUtilsImplTest {
     private FileUtilsImpl fileUtils;
 
-    @MockBean
     private GitExecutorImpl gitExecutor;
 
-    private FileOperations fileOperations;
-
-    private GitServiceConfig gitServiceConfig;
     private static final String localTestDirectory = "localTestDirectory";
     private static final Path localTestDirectoryPath = Path.of(localTestDirectory);
 
     @BeforeEach
     public void setUp() {
-        gitServiceConfig = new GitServiceConfig();
+        gitExecutor = Mockito.mock(GitExecutorImpl.class);
+        GitServiceConfig gitServiceConfig = new GitServiceConfig();
         gitServiceConfig.setGitRootPath(localTestDirectoryPath.toString());
-        fileOperations =
+        FileOperations fileOperations =
                 new FileOperationsImpl(gitServiceConfig, gitExecutor, new GsonBuilder(), null, ObservationHelper.NOOP);
         fileUtils = new FileUtilsImpl(gitServiceConfig, gitExecutor, fileOperations, ObservationHelper.NOOP);
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/SecurityTestConfig.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/SecurityTestConfig.java
@@ -12,6 +12,6 @@ public class SecurityTestConfig {
 
     @Bean
     public SecurityWebFilterChain testSecurityWebFilterChain(ServerHttpSecurity http) {
-        return http.csrf().disable().build();
+        return http.csrf(csrf -> csrf.disable()).build();
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.server.MockWebSession;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
@@ -92,6 +93,8 @@ public class UserSignupTest {
                 tenantService);
 
         exchange = Mockito.mock(ServerWebExchange.class);
+        Mockito.when(exchange.getSession()).thenReturn(Mono.just(new MockWebSession()));
+
         tenant = new Tenant();
         TenantConfiguration configuration = new TenantConfiguration();
         tenant.setTenantConfiguration(configuration);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -86,7 +86,6 @@ class ActionExecutionSolutionCEImplTest {
     @MockBean
     ActionPermission actionPermission;
 
-    @MockBean
     ObservationRegistry observationRegistry;
 
     @SpyBean
@@ -140,6 +139,8 @@ class ActionExecutionSolutionCEImplTest {
 
     @BeforeEach
     public void beforeEach() {
+        observationRegistry = Mockito.mock(ObservationRegistry.class);
+
         actionExecutionSolution = new ActionExecutionSolutionCEImpl(
                 newActionService,
                 actionPermission,
@@ -282,9 +283,6 @@ class ActionExecutionSolutionCEImplTest {
 
         ActionExecutionSolutionCE executionSolutionSpy = spy(actionExecutionSolution);
 
-        Mono<ActionExecutionResult> actionExecutionResultMono =
-                executionSolutionSpy.executeAction(partsFlux, null, null, null, Boolean.FALSE);
-
         ActionExecutionResult mockResult = new ActionExecutionResult();
         mockResult.setIsExecutionSuccess(true);
         mockResult.setBody("test body");
@@ -304,6 +302,9 @@ class ActionExecutionSolutionCEImplTest {
         doReturn(Mono.just(newAction))
                 .when(newActionService)
                 .findByBranchNameAndDefaultActionId(any(), any(), Mockito.anyBoolean(), any());
+
+        Mono<ActionExecutionResult> actionExecutionResultMono =
+                executionSolutionSpy.executeAction(partsFlux, null, null, null, Boolean.FALSE);
 
         StepVerifier.create(actionExecutionResultMono)
                 .assertNext(response -> {
@@ -342,9 +343,6 @@ class ActionExecutionSolutionCEImplTest {
 
         ActionExecutionSolutionCE executionSolutionSpy = spy(actionExecutionSolution);
 
-        Mono<ActionExecutionResult> actionExecutionResultMono =
-                executionSolutionSpy.executeAction(partsFlux, null, null, null, Boolean.FALSE);
-
         ActionExecutionResult mockResult = new ActionExecutionResult();
         mockResult.setIsExecutionSuccess(true);
         mockResult.setBody("test body");
@@ -364,6 +362,9 @@ class ActionExecutionSolutionCEImplTest {
         doReturn(Mono.just(newAction))
                 .when(newActionService)
                 .findByBranchNameAndDefaultActionId(any(), any(), Mockito.anyBoolean(), any());
+
+        Mono<ActionExecutionResult> actionExecutionResultMono =
+                executionSolutionSpy.executeAction(partsFlux, null, null, null, Boolean.FALSE);
 
         StepVerifier.create(actionExecutionResultMono)
                 .assertNext(response -> {


### PR DESCRIPTION
Only refactors, only in tests, needed to get these tests to work/pass with the upgraded Spring coming up separately.

/ok-to-test tags="@tag.Sanity"

