### PR TITLE
fix: WDS bgNeutralOpacity 

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -327,10 +327,14 @@ export class DarkModeTheme implements ColorModeTheme {
   }
 
   private get bgNeutralOpacity() {
+    // Overlay behind modal dialogue
     const color = this.bgNeutral.clone();
 
-    color.oklch.l = 0.15;
     color.alpha = 0.5;
+
+    if (color.oklch.l > 0.15) {
+      color.oklch.l = 0.15;
+    }
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -298,21 +298,13 @@ export class LightModeTheme implements ColorModeTheme {
     return color;
   }
 
-  private get bgNeutralOpacity() {
-    const color = this.bgNeutral.clone();
-
-    color.alpha = 0.5;
-
-    return color;
-  }
-
   private get bgNeutral() {
     // Low chroma, but not 0, if possible, to produce harmony with accents in the UI
     const color = this.bgAccent.clone();
 
     // For bright accents it helps to make neutral a bit darker to differentiate with bgAccent
     if (this.bgAccent.oklch.l >= 0.85) {
-      color.oklch.l -= 0.02;
+      color.oklch.l -= 0.2;
     }
 
     if (this.bgAccent.oklch.l > 0.25 && this.bgAccent.oklch.l < 0.85) {
@@ -329,6 +321,19 @@ export class LightModeTheme implements ColorModeTheme {
 
     if (!this.seedIsCold && !this.seedIsAchromatic) {
       color.oklch.c = 0.001;
+    }
+
+    return color;
+  }
+
+  private get bgNeutralOpacity() {
+    // Overlay behind modal dialogue
+    const color = this.bgNeutral.clone();
+
+    color.alpha = 0.5;
+
+    if (color.oklch.l > 0.15) {
+      color.oklch.l = 0.15;
     }
 
     return color;

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -231,7 +231,7 @@ describe("bgNeutralOpacity color", () => {
     const { bgNeutralOpacity } = new LightModeTheme(
       "oklch(0.51 0.24 279)",
     ).getColors();
-    expect(bgNeutralOpacity).toEqual("rgb(29.012% 29.087% 29.559% / 0.5)");
+    expect(bgNeutralOpacity).toEqual("rgb(4.2704% 4.3279% 4.6942% / 0.5)");
   });
 });
 


### PR DESCRIPTION
Closes #32306

Making sure the overlay background is sufficiently dark, fixed spotted error with `bgNeutral` too.
Screenshot from Storybook because I'm having temporary problems with running Docker local dev setup. 😬

<img width="882" alt="Screenshot 2024-05-02 at 17 17 45" src="https://github.com/appsmithorg/appsmith/assets/80973/010a14b1-81db-4082-884f-928be6ac1d72">
