### PR TITLE
fix: Safari space distribution glitch

### DIFF
--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
@@ -14,7 +14,7 @@ export interface SpaceDistributionZoneDomCollection {
 }
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 // Constants for animation and speed control during handle move
-const speedLimitForAnimation = isSafari ? 0 : 4000;
+const speedLimitForAnimation = 4000;
 const baseAnimationDuration = 0.25;
 const ratioOfSpeedToAnimation = baseAnimationDuration / speedLimitForAnimation;
 
@@ -37,11 +37,12 @@ const adjustZoneFlexGrowForMagneticEffect = (
   const reflectOnPropPane = leftZonePropPaneDom && rightZonePropPaneDom;
 
   // Calculate transition duration based on mouse speed
-  const transitionStyle = `all ${
-    baseAnimationDuration -
-    Math.min(mouseSpeed, speedLimitForAnimation) * ratioOfSpeedToAnimation
-  }s ease-in-out`;
-
+  const transitionStyle = isSafari
+    ? ""
+    : `all ${
+        baseAnimationDuration -
+        Math.min(mouseSpeed, speedLimitForAnimation) * ratioOfSpeedToAnimation
+      }s ease-in-out`;
   // Apply transition styles to left and right zones
   [leftZoneDom, rightZoneDom].forEach((zoneDom) => {
     zoneDom.style.transition = transitionStyle;
@@ -96,9 +97,9 @@ const applyResistiveForceOnHandleMove = (
   // Check if the zones hit the minimum limit
   const hasHitMinimumLimit =
     isLeftZoneLessThanMinimum || isRightZoneLessThanMinimum;
-
+  const enableTransition = !isSafari && hasHitMinimumLimit;
   // Apply or remove transition based on hitting the minimum limit
-  const transitionStyle = hasHitMinimumLimit
+  const transitionStyle = enableTransition
     ? `all ${baseAnimationDuration}s ease`
     : "";
   [leftZoneDom, rightZoneDom].forEach((zoneDom) => {

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
@@ -44,7 +44,7 @@ const adjustZoneFlexGrowForMagneticEffect = (
   // Calculate transition duration based on mouse speed
   const transitionStyle = isSafari()
     ? ""
-    : `all ${
+    : `flex-basis ${
         baseAnimationDuration -
         Math.min(mouseSpeed, speedLimitForAnimation) * ratioOfSpeedToAnimation
       }s ease-in-out`;
@@ -102,10 +102,10 @@ const applyResistiveForceOnHandleMove = (
   // Check if the zones hit the minimum limit
   const hasHitMinimumLimit =
     isLeftZoneLessThanMinimum || isRightZoneLessThanMinimum;
-  const enableTransition = !isSafari() && hasHitMinimumLimit;
+  const isTransitionEnabled = !isSafari() && hasHitMinimumLimit;
   // Apply or remove transition based on hitting the minimum limit
-  const transitionStyle = enableTransition
-    ? `all ${baseAnimationDuration}s ease`
+  const transitionStyle = isTransitionEnabled
+    ? `flex-basis ${baseAnimationDuration}s ease`
     : "";
   [leftZoneDom, rightZoneDom].forEach((zoneDom) => {
     zoneDom.style.transition = transitionStyle;

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
@@ -4,6 +4,8 @@ import {
   convertFlexGrowToFlexBasis,
   convertFlexGrowToFlexBasisForPropPane,
 } from "./spaceDistributionEditorUtils";
+import { getBrowserInfo } from "utils/helpers";
+import memoize from "micro-memoize";
 
 // Interface representing the DOM elements associated with a space distribution zone
 export interface SpaceDistributionZoneDomCollection {
@@ -12,7 +14,10 @@ export interface SpaceDistributionZoneDomCollection {
   leftZonePropPaneDom: HTMLElement | null;
   rightZonePropPaneDom: HTMLElement | null;
 }
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+const isSafari = memoize(() => {
+  const browserInfo = getBrowserInfo();
+  return typeof browserInfo === "object" && browserInfo?.browser === "Safari";
+});
 // Constants for animation and speed control during handle move
 const speedLimitForAnimation = 4000;
 const baseAnimationDuration = 0.25;
@@ -37,7 +42,7 @@ const adjustZoneFlexGrowForMagneticEffect = (
   const reflectOnPropPane = leftZonePropPaneDom && rightZonePropPaneDom;
 
   // Calculate transition duration based on mouse speed
-  const transitionStyle = isSafari
+  const transitionStyle = isSafari()
     ? ""
     : `all ${
         baseAnimationDuration -
@@ -97,7 +102,7 @@ const applyResistiveForceOnHandleMove = (
   // Check if the zones hit the minimum limit
   const hasHitMinimumLimit =
     isLeftZoneLessThanMinimum || isRightZoneLessThanMinimum;
-  const enableTransition = !isSafari && hasHitMinimumLimit;
+  const enableTransition = !isSafari() && hasHitMinimumLimit;
   // Apply or remove transition based on hitting the minimum limit
   const transitionStyle = enableTransition
     ? `all ${baseAnimationDuration}s ease`

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/onMouseMoveUtils.ts
@@ -12,9 +12,9 @@ export interface SpaceDistributionZoneDomCollection {
   leftZonePropPaneDom: HTMLElement | null;
   rightZonePropPaneDom: HTMLElement | null;
 }
-
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 // Constants for animation and speed control during handle move
-const speedLimitForAnimation = 4000;
+const speedLimitForAnimation = isSafari ? 0 : 4000;
 const baseAnimationDuration = 0.25;
 const ratioOfSpeedToAnimation = baseAnimationDuration / speedLimitForAnimation;
 

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/spaceDistributionEditorUtils.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/spaceDistributionEditorUtils.ts
@@ -166,10 +166,10 @@ export const resetCSSOnZones = (spaceDistributed: {
     const zonePropDom = document.getElementById(getPropertyPaneZoneId(zoneId));
     if (zoneDom) {
       zoneDom.style.flexBasis = "";
-      zoneDom.style.transition = "all 0.3s ease";
+      zoneDom.style.transition = "flex-basis 0.3s ease";
       if (zonePropDom) {
         zonePropDom.style.flexBasis = "";
-        zonePropDom.style.transition = "all 0.3s ease";
+        zonePropDom.style.transition = "flex-basis 0.3s ease";
       }
       setTimeout(() => {
         zoneDom.style.transition = "";


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1mmGFe6r0XqRda9AKDqKKbgL0EUbwWtj4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=0_Nnh2L)
## Description

we use dynamic transition values on the zone widget to provide smooth effect when a zone is resized via space distribution.
we recently made changes of how we calculate(`convertFlexGrowToFlexBasis`) flex-basis values becuase we had introduced gap between zones via tokens. for this we had used calc.

dynamic transition and calc css values don't seem work smooth in conjunction in safari. making it a glitch experience.
hence disabling transition in safari until I figure how to get around this.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8936966895>
> Commit: db551717a9cb12fc3aaa029574c70b650b6fdc7c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8936966895&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
