### PR TITLE
fix: Widget selection issues - part 1

### DIFF
--- a/app/client/src/layoutSystems/anvil/common/hooks/detachedWidgetHooks.ts
+++ b/app/client/src/layoutSystems/anvil/common/hooks/detachedWidgetHooks.ts
@@ -99,7 +99,6 @@ export function useAddBordersToDetachedWidgets(
   if (element) {
     element.style.outlineOffset = borderStyled.outlineOffset ?? "unset";
     element.style.outline = borderStyled.outline ?? "none";
-    element.style.borderRadius = borderStyled.borderRadius ?? "unset";
   }
 }
 

--- a/app/client/src/layoutSystems/anvil/common/hooks/useWidgetBorderStyles.ts
+++ b/app/client/src/layoutSystems/anvil/common/hooks/useWidgetBorderStyles.ts
@@ -52,7 +52,7 @@ export function useWidgetBorderStyles(widgetId: string, widgetType: string) {
   let borderColor = "transparent";
   let borderWidth = "var(--on-canvas-ui-border-width-2)";
   // If widget is focused, use the thin borders
-  if (isFocused) {
+  if (isFocused && !isSelected) {
     borderColor = `var(${onCanvasUI.selectionBGCSSVar})`;
     borderWidth = "var(--on-canvas-ui-border-width-1)";
   }

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/AnvilWidgetNameComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/AnvilWidgetNameComponent.tsx
@@ -9,6 +9,7 @@ import {
 } from "layoutSystems/anvil/common/messages";
 import { createMessage } from "@appsmith/constants/messages";
 import { debugWidget } from "layoutSystems/anvil/integrations/actions";
+import { useDispatch } from "react-redux";
 
 /**
  *
@@ -36,6 +37,7 @@ export function _AnvilWidgetNameComponent(
   },
   ref: ForwardedRef<HTMLDivElement>,
 ) {
+  const dispatch = useDispatch();
   const { parentId } = props;
 
   /** Widget Selection Handlers */
@@ -49,7 +51,7 @@ export function _AnvilWidgetNameComponent(
   }, [props.widgetId]);
 
   const handleDebugClick = useCallback(() => {
-    debugWidget(props.widgetId);
+    dispatch(debugWidget(props.widgetId));
   }, [props.widgetId]);
   /** EO Widget Selection Handlers */
 


### PR DESCRIPTION
## Description
This fixes part of the widget selection issues from #33138 

Specifically, the following:
-  [x]  Modal border radius goes away in preview mode.
-  [x]  When a widget is selected and we hover over it, the border thickness reduces.
-  [x]  When clicking on the error button, the property control with the error is not focused.


## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8939093222>
> Commit: a94a7ad57d7bcf65f3c17ee158ff612b41d77f57
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8939093222&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
