### PR TITLE
chore: added cache miss solution

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -401,7 +401,9 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                     datasourceContextMonoMap.remove(datasourceContextIdentifier);
 
                     if (!datasourceContextMap.containsKey(datasourceContextIdentifier)) {
-                        log.debug("datasourceContextMap does not contain any entry for datasource storage with id: {} ", datasourceStorage.getId());
+                        log.info(
+                                "datasourceContextMap does not contain any entry for datasource storage with id: {} ",
+                                datasourceStorage.getId());
                         return Mono.empty();
                     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -374,6 +374,11 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
         });
     }
 
+    /**
+     * removes the datasource context entry from the contextMaps. may return an empty mono
+     * @param datasourceStorage
+     * @return removed datasourceContext
+     */
     @Override
     public Mono<DatasourceContext<?>> deleteDatasourceContext(DatasourceStorage datasourceStorage) {
 
@@ -390,11 +395,17 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
         }
         return pluginExecutorHelper
                 .getPluginExecutor(pluginService.findById(datasourceStorage.getPluginId()))
-                .map(pluginExecutor -> {
+                .flatMap(pluginExecutor -> {
                     log.info("Clearing datasource context for datasource storage ID {}.", datasourceStorage.getId());
                     pluginExecutor.datasourceDestroy(datasourceContext.getConnection());
                     datasourceContextMonoMap.remove(datasourceContextIdentifier);
-                    return datasourceContextMap.remove(datasourceContextIdentifier);
+
+                    if (!datasourceContextMap.containsKey(datasourceContextIdentifier)) {
+                        log.debug("datasourceContextMap does not contain any entry for datasource storage with id: {} ", datasourceStorage.getId());
+                        return Mono.empty();
+                    }
+
+                    return Mono.just(datasourceContextMap.remove(datasourceContextIdentifier));
                 });
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -770,9 +770,7 @@ public class DatasourceContextServiceTest {
         MockPluginExecutor mockPluginExecutor = new MockPluginExecutor();
         MockPluginExecutor spyMockPluginExecutor = spy(mockPluginExecutor);
         StepVerifier.create(datasourceContextService.deleteDatasourceContext(datasourceStorage))
-            .expectNextCount(0)
-            .verifyComplete();
-
+                .expectNextCount(0)
+                .verifyComplete();
     }
-
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -754,4 +754,25 @@ public class DatasourceContextServiceTest {
                 })
                 .verify();
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void verifyDeleteDatasourceContext_whenContextDoesNotExist_returnsEmptyMono() {
+
+        String sampleDatasourceId = UUID.randomUUID().toString();
+        String samplePluginId = UUID.randomUUID().toString();
+
+        DatasourceStorage datasourceStorage = new DatasourceStorage();
+        datasourceStorage.setDatasourceId(sampleDatasourceId);
+        datasourceStorage.setEnvironmentId(defaultEnvironmentId);
+        datasourceStorage.setPluginId(samplePluginId);
+
+        MockPluginExecutor mockPluginExecutor = new MockPluginExecutor();
+        MockPluginExecutor spyMockPluginExecutor = spy(mockPluginExecutor);
+        StepVerifier.create(datasourceContextService.deleteDatasourceContext(datasourceStorage))
+            .expectNextCount(0)
+            .verifyComplete();
+
+    }
+
 }


### PR DESCRIPTION
## Description
> Due to cache miss, deletion of datasource context was throwing NPE. fixed it with a Mono.empty()

Link to slack: https://theappsmith.slack.com/archives/C0423TJFUJK/p1714728711536249
Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8966314390>
> Commit: 40a6c4d6445fedee8acc4c352d365d636ed2af26
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8966314390&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
