### PR TITLE
fix: authenticationType field saved to database

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -1,6 +1,7 @@
 package com.appsmith.external.models;
 
 import com.appsmith.external.constants.Authentication;
+import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -40,7 +41,7 @@ public class AuthenticationDTO implements AppsmithDomain {
         IN_PROGRESS_PERMISSIONS_GRANTED
     };
 
-    @JsonView(Views.Public.class)
+    @JsonView({Views.Public.class, FromRequest.class})
     String authenticationType;
 
     @JsonView(Views.Public.class)


### PR DESCRIPTION
## Description
With the introduction of FromRequest for the create datasource API in [this](https://github.com/appsmithorg/appsmith/pull/33039) PR, we have restricted the fields that will be accepted from the client in the request body. Due to this the `authenticationType` field was not getting accepted from the client in the create datasource API, which lead to the failure of airtable queries. 

This PR allows the acceptance of `authenticationType` field from the client. 
Discussions [here](https://theappsmith.slack.com/archives/CTHN8GX5Y/p1714974437746959).

Fixes #33184   

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8966382606>
> Commit: a292aa075d3598389410b5c201f58c489fd2dfc2
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8966382606&attempt=3&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/QueryPane/DSDocs_Spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
