### PR TITLE
fix: asymmetric padding for sections and zones

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilWidgetClicking_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilWidgetClicking_spec.ts
@@ -66,7 +66,7 @@ describe(
       cy.get(`${anvilLayout.mainCanvasSelector}`).within(() => {
         // For each widget check if the border-color is transparent
         // The border-color changes if a widget is selected or focused.
-        cy.get(".anvil-widget-wrapper").each(($widget) => {
+        cy.get("[data-testid=t--anvil-widget-wrapper]").each(($widget) => {
           cy.wrap($widget).should(
             "have.css",
             "outline-color",

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -251,7 +251,8 @@ export class CommonLocators {
   _fixedLayout = "#t--layout-conversion-cta:contains('fixed')";
   _forkAppToWorkspaceBtn = ".t--fork-app-to-workspace-button";
   _popoverToolTip = ".bp3-popover-content, .bp3-popover2-content";
-  _selectedWidget = "div[data-testid='t--selected']";
+  _selectedWidget =
+    "[data-testid='t--anvil-widget-wrapper'][data-selected=true]";
   _appsmithWidget = (widgetId: string) => `.appsmith_widget_${widgetId}`;
   _selectionCanvas = (canvasId: string) => `#div-selection-${canvasId}`;
   _sqlKeyword = ".cm-m-sql.cm-keyword";

--- a/app/client/packages/design-system/widgets/src/components/Flex/src/Flex.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Flex/src/Flex.tsx
@@ -5,6 +5,8 @@ import clsx from "clsx";
 
 import type { Ref } from "react";
 import type { FlexProps } from "./types";
+import type { DOMProps } from "@react-types/shared";
+import { filterDOMProps } from "@react-aria/utils";
 
 const _Flex = (props: FlexProps, ref: Ref<HTMLDivElement>) => {
   const {
@@ -19,6 +21,8 @@ const _Flex = (props: FlexProps, ref: Ref<HTMLDivElement>) => {
     ...rest
   } = props;
 
+  const domProps = filterDOMProps(rest as DOMProps);
+
   const renderFlex = () => {
     return (
       <div
@@ -28,6 +32,7 @@ const _Flex = (props: FlexProps, ref: Ref<HTMLDivElement>) => {
         onClickCapture={onClickCapture}
         ref={ref}
         style={style}
+        {...domProps}
       >
         {children}
       </div>

--- a/app/client/packages/design-system/widgets/src/components/Flex/src/Flex.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Flex/src/Flex.tsx
@@ -1,12 +1,11 @@
 import React, { forwardRef } from "react";
+import { filterDataProps } from "../../../utils";
 import { flexCss } from "./flexCss";
 import styles from "./styles.module.css";
 import clsx from "clsx";
 
 import type { Ref } from "react";
 import type { FlexProps } from "./types";
-import type { DOMProps } from "@react-types/shared";
-import { filterDOMProps } from "@react-aria/utils";
 
 const _Flex = (props: FlexProps, ref: Ref<HTMLDivElement>) => {
   const {
@@ -21,7 +20,7 @@ const _Flex = (props: FlexProps, ref: Ref<HTMLDivElement>) => {
     ...rest
   } = props;
 
-  const domProps = filterDOMProps(rest as DOMProps);
+  const dataProps = filterDataProps(rest);
 
   const renderFlex = () => {
     return (
@@ -32,7 +31,7 @@ const _Flex = (props: FlexProps, ref: Ref<HTMLDivElement>) => {
         onClickCapture={onClickCapture}
         ref={ref}
         style={style}
-        {...domProps}
+        {...dataProps}
       >
         {children}
       </div>

--- a/app/client/packages/design-system/widgets/src/index.ts
+++ b/app/client/packages/design-system/widgets/src/index.ts
@@ -22,6 +22,7 @@ export * from "./components/ButtonGroup";
 export * from "./components/Select";
 export * from "./components/ContextualHelp";
 
+export * from "./utils";
 export * from "./styles";
 
 export * from "./shared";

--- a/app/client/packages/design-system/widgets/src/index.ts
+++ b/app/client/packages/design-system/widgets/src/index.ts
@@ -22,7 +22,6 @@ export * from "./components/ButtonGroup";
 export * from "./components/Select";
 export * from "./components/ContextualHelp";
 
-export * from "./utils";
 export * from "./styles";
 
 export * from "./shared";

--- a/app/client/packages/design-system/widgets/src/utils/filterDataProps.ts
+++ b/app/client/packages/design-system/widgets/src/utils/filterDataProps.ts
@@ -1,0 +1,12 @@
+// Filters attributes starting with "data-" and remove them from the source object and returns them back.
+export const filterDataProps = (props: Record<string, unknown>) => {
+  const result: Record<string, unknown> = {};
+  Object.keys(props).forEach((key) => {
+    if (key.startsWith("data-")) {
+      result[key] = props[key];
+      delete props[key];
+    }
+  });
+
+  return result;
+};

--- a/app/client/packages/design-system/widgets/src/utils/index.ts
+++ b/app/client/packages/design-system/widgets/src/utils/index.ts
@@ -1,1 +1,0 @@
-export * from "./src";

--- a/app/client/packages/design-system/widgets/src/utils/index.ts
+++ b/app/client/packages/design-system/widgets/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { filterDataProps } from "./filterDataProps";

--- a/app/client/packages/design-system/widgets/src/utils/src/OmitRename.ts
+++ b/app/client/packages/design-system/widgets/src/utils/src/OmitRename.ts
@@ -1,7 +1,0 @@
-export type OmitRename<
-  TObj extends object,
-  TOmitKeys extends keyof TObj,
-  TSymbol extends string = "$",
-> = {
-  [K in keyof Omit<TObj, TOmitKeys> as `${TSymbol}${string & K}`]: TObj[K];
-} & Pick<TObj, TOmitKeys>;

--- a/app/client/packages/design-system/widgets/src/utils/src/PickRename.ts
+++ b/app/client/packages/design-system/widgets/src/utils/src/PickRename.ts
@@ -1,6 +1,0 @@
-export type PickRename<
-  T,
-  R extends {
-    [K in keyof R]: K extends keyof T ? PropertyKey : "Error: key not in T";
-  },
-> = { [P in keyof T as P extends keyof R ? R[P] : P]: T[P] };

--- a/app/client/packages/design-system/widgets/src/utils/src/index.ts
+++ b/app/client/packages/design-system/widgets/src/utils/src/index.ts
@@ -1,2 +1,0 @@
-export type { PickRename } from "./PickRename";
-export type { OmitRename } from "./OmitRename";

--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -248,38 +248,3 @@ div.bp3-popover-arrow {
 .reconnect-datasource-modal {
   z-index: 9 !important;
 }
-
-/** Conditional vertical margin applied to widgets.
-    If in a row of widgets (.aligned-widget-row), one of the widgets has a label ([data-field-label-wrapper]), then
-    all widgets (.anvil-widget-wrapper) in the row other than the widget with the label, will shift down using the
-    margin-block-start property. This is to ensure that the widgets are aligned vertically.
-
-    The value of the margin-block-start property is calculated based on the spacing tokens used by the labels in input like components
-*/
-.aligned-widget-row:has(.anvil-widget-wrapper [data-field-label-wrapper])
-  .anvil-widget-wrapper:not(:has([data-field-label-wrapper])) {
-  margin-block-start: calc(var(--inner-spacing-3) + var(--sizing-3));
-}
-
-/** Asymmetric Padding
-    If a section (has div[data-elevation="false"][elevation="1"]) does not have elevation,
-    then the padding is set to 0.
-    elevation="1" is used to denote that the section has elevation.
-*/
-div.anvil-widget-wrapper:has(div[data-elevation="false"][elevation="1"]) {
-  padding: var(--outer-spacing-0);
-}
-
-/** Asymmetric Padding
-    If none of the zones (has div[data-elevation="false"][elevation="2"]) in a section have elevation,
-    then the vertical padding is set to 0 for all zones.
-    elevation="2" is used to denote that the zone has elevation.
-
-    Note: we've used `div.anvil-widget-wrapper:has(div[data-elevation])` to select all zones
-    because today, we don't have nested sections. So, any widget that has `data-elevation` in another widget that has `data-elevation`
-    will be a zone.
-*/
-div.anvil-widget-wrapper:not(:has(div[data-elevation="true"][elevation="2"]))
-  div.anvil-widget-wrapper:has(div[data-elevation]) {
-  padding-block: var(--outer-spacing-0);
-}

--- a/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
@@ -106,6 +106,7 @@ export const AnvilFlexComponent = forwardRef(
         isInner
         {...flexProps}
         className={_className}
+        data-testid="t--anvil-widget-wrapper"
         data-widget-wrapper=""
         id={getAnvilWidgetDOMId(widgetId)}
         onClick={onClick}

--- a/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/common/AnvilFlexComponent.tsx
@@ -14,6 +14,7 @@ import { getAnvilWidgetDOMId } from "layoutSystems/common/utils/LayoutElementPos
 import { Layers } from "constants/Layers";
 import { noop } from "utils/AppsmithUtils";
 import { convertFlexGrowToFlexBasis } from "../sectionSpaceDistributor/utils/spaceDistributionEditorUtils";
+import styles from "./styles.module.css";
 
 const anvilWidgetStyleProps: CSSProperties = {
   position: "relative",
@@ -48,10 +49,7 @@ export const AnvilFlexComponent = forwardRef(
     }: AnvilFlexComponentProps,
     ref: any,
   ) => {
-    // The `anvil-widget-wrapper` className is necessary for the following features
-    // "Vertical Alignment" and "Asymmetric Padding". The code for the same can be found in `src/index.css`
-    // Please do not remove this class.
-    const _className = `${className} anvil-widget-wrapper`;
+    const _className = `${className} ${styles.anvilWidgetWrapper}`;
 
     const widgetConfigProps = useMemo(() => {
       const widgetConfig:
@@ -108,6 +106,7 @@ export const AnvilFlexComponent = forwardRef(
         isInner
         {...flexProps}
         className={_className}
+        data-widget-wrapper=""
         id={getAnvilWidgetDOMId(widgetId)}
         onClick={onClick}
         onClickCapture={onClickCapture}

--- a/app/client/src/layoutSystems/anvil/common/styles.module.css
+++ b/app/client/src/layoutSystems/anvil/common/styles.module.css
@@ -5,24 +5,26 @@
   [elevation="2"] — zone
 */
 .anvilWidgetWrapper {
-  /**
-    If a section or zone have elevation, then add padding.
-    Also add padding for zones without elevation if at least one zone has an elevation inside a section.
-  */
+  /** If a section or zone have elevation, then add padding */
   [data-elevation="true"][elevation="1"],
-  [data-elevation="true"][elevation="2"],
-  [elevation="1"]:has([data-elevation="true"]) [data-elevation="false"] {
+  [data-elevation="true"][elevation="2"] {
     padding-block: var(--outer-spacing-3);
     padding-inline: var(--outer-spacing-3);
   }
 
+  /** Add padding(also border) for zones without elevation if at least one zone has an elevation inside a section */
+  [elevation="1"]:has([data-elevation="true"]) [data-elevation="false"] {
+    padding-block: calc(var(--outer-spacing-3) + var(--border-width-1));
+    padding-inline: calc(var(--outer-spacing-3) + var(--border-width-1));
+  }
+
   [data-elevation="false"][elevation="2"] {
-    min-height: var(--sizing-9);
+    min-height: var(--sizing-8);
   }
 
   /** If the elevation is enabled, then set the minimum height of the zone with paddings */
   [data-elevation="true"][elevation="2"] {
-    min-height: calc(var(--sizing-9) + var(--outer-spacing-3) * 2);
+    min-height: calc(var(--sizing-8) + var(--outer-spacing-3) * 2);
   }
 
   /** Styles for the section if elevation is enabled only for section */

--- a/app/client/src/layoutSystems/anvil/common/styles.module.css
+++ b/app/client/src/layoutSystems/anvil/common/styles.module.css
@@ -7,44 +7,31 @@
 .anvilWidgetWrapper {
   /** If a section or zone have elevation, then add padding */
   [data-elevation="true"][elevation="1"],
-  [data-elevation="true"][elevation="2"] {
+  [data-elevation="true"][elevation="2"],
+  [elevation="1"]:has([data-elevation="true"]) [data-elevation="false"] {
     padding-block: var(--outer-spacing-3);
     padding-inline: var(--outer-spacing-3);
-  }
-
-  /** Add padding(also border) for zones without elevation if at least one zone has an elevation inside a section */
-  [elevation="1"]:has([data-elevation="true"]) [data-elevation="false"] {
-    padding-block: calc(var(--outer-spacing-3) + var(--border-width-1));
-    padding-inline: calc(var(--outer-spacing-3) + var(--border-width-1));
   }
 
   [data-elevation="false"][elevation="2"] {
     min-height: var(--sizing-8);
   }
 
-  /** If the elevation is enabled, then set the minimum height of the zone with paddings */
+  /**
+    1. Styles for the section if elevation is enabled only for section
+    2. Styles for the zone if elevation is enabled
+  */
+  [data-elevation="true"][elevation="1"]:has([data-elevation="false"]),
   [data-elevation="true"][elevation="2"] {
-    min-height: calc(var(--sizing-8) + var(--outer-spacing-3) * 2);
-  }
-
-  /** Styles for the section if elevation is enabled only for section */
-  [data-elevation="true"][elevation="1"]:has([data-elevation="false"]) {
     background-color: var(--color-bg-elevation-2);
     border-radius: var(--border-radius-elevation-2);
-    border: var(--border-width-1) solid var(--color-bd-elevation-2);
+    outline: var(--border-width-1) solid var(--color-bd-elevation-2);
   }
 
   /** Styles for the section if elevation is enabled for both section and zone */
   [data-elevation="true"][elevation="1"]:has([data-elevation="true"]) {
     background-color: var(--color-bg-elevation-1);
     border-radius: var(--border-radius-elevation-1);
-    border: var(--border-width-1) solid var(--color-bd-elevation-1);
-  }
-
-  /**Styles for the zone if elevation is enabled */
-  [data-elevation="true"][elevation="2"] {
-    background-color: var(--color-bg-elevation-2);
-    border-radius: var(--border-radius-elevation-2);
-    border: var(--border-width-1) solid var(--color-bd-elevation-2);
+    outline: var(--border-width-1) solid var(--color-bd-elevation-1);
   }
 }

--- a/app/client/src/layoutSystems/anvil/common/styles.module.css
+++ b/app/client/src/layoutSystems/anvil/common/styles.module.css
@@ -1,0 +1,48 @@
+/**
+  ASYMMETRIC PADDING
+  [data-elevation] — true or false, indicates whether elevation is enabled or not
+  [elevation="1"] — section
+  [elevation="2"] — zone
+*/
+.anvilWidgetWrapper {
+  /**
+    If a section or zone have elevation, then add padding.
+    Also add padding for zones without elevation if at least one zone has an elevation inside a section.
+  */
+  [data-elevation="true"][elevation="1"],
+  [data-elevation="true"][elevation="2"],
+  [elevation="1"]:has([data-elevation="true"]) [data-elevation="false"] {
+    padding-block: var(--outer-spacing-3);
+    padding-inline: var(--outer-spacing-3);
+  }
+
+  [data-elevation="false"][elevation="2"] {
+    min-height: var(--sizing-9);
+  }
+
+  /** If the elevation is enabled, then set the minimum height of the zone with paddings */
+  [data-elevation="true"][elevation="2"] {
+    min-height: calc(var(--sizing-9) + var(--outer-spacing-3) * 2);
+  }
+
+  /** Styles for the section if elevation is enabled only for section */
+  [data-elevation="true"][elevation="1"]:has([data-elevation="false"]) {
+    background-color: var(--color-bg-elevation-2);
+    border-radius: var(--border-radius-elevation-2);
+    border: var(--border-width-1) solid var(--color-bd-elevation-2);
+  }
+
+  /** Styles for the section if elevation is enabled for both section and zone */
+  [data-elevation="true"][elevation="1"]:has([data-elevation="true"]) {
+    background-color: var(--color-bg-elevation-1);
+    border-radius: var(--border-radius-elevation-1);
+    border: var(--border-width-1) solid var(--color-bd-elevation-1);
+  }
+
+  /**Styles for the zone if elevation is enabled */
+  [data-elevation="true"][elevation="2"] {
+    background-color: var(--color-bg-elevation-2);
+    border-radius: var(--border-radius-elevation-2);
+    border: var(--border-width-1) solid var(--color-bd-elevation-2);
+  }
+}

--- a/app/client/src/layoutSystems/anvil/editor/canvas/styles/anvilEditorVariables.css
+++ b/app/client/src/layoutSystems/anvil/editor/canvas/styles/anvilEditorVariables.css
@@ -36,7 +36,7 @@
   --on-canvas-ui-white: #ffffff;
 
   /* Other common parameters for on-canvas ui */
-  /* 
+  /*
     z index of ADS modal components -- 1000
     z index of ADS on-canvas ui components -- 998
     z index of WDS modal components -- 990
@@ -50,5 +50,5 @@
   --on-canvas-ui-border-width-1: 1px;
   --on-canvas-ui-border-width-2: 2px;
 
-  --on-canvas-ui-outline-offset: 3px;
+  --on-canvas-ui-outline-offset: 4px;
 }

--- a/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDCompensators.ts
+++ b/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDCompensators.ts
@@ -1,4 +1,3 @@
-import type { FlattenedWidgetProps } from "WidgetProvider/constants";
 import { getCompensatorsForHierarchy } from "../utils/dndCompensatorUtils";
 import { useThemeContext } from "@design-system/theming";
 
@@ -7,10 +6,9 @@ export const useAnvilDnDCompensators = (
   draggedWidgetHierarchy: number,
   currentWidgetHierarchy: number,
   isEmptyLayout: boolean,
-  widgetProps: FlattenedWidgetProps,
+  isElevatedWidget: boolean,
 ) => {
   const theme = useThemeContext();
-  const isElevatedWidget = !!widgetProps.elevatedBackground;
   const {
     edgeCompensatorValues,
     layoutCompensatorValues,

--- a/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDListenerStates.ts
+++ b/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDListenerStates.ts
@@ -14,6 +14,8 @@ import { useAnvilDnDCompensators } from "./useAnvilDnDCompensators";
 import { getWidgetHierarchy } from "layoutSystems/anvil/utils/paste/utils";
 import type { AnvilGlobalDnDStates } from "../../canvas/hooks/useAnvilGlobalDnDStates";
 import { getWidgets } from "sagas/selectors";
+import { useMemo } from "react";
+import { ZoneWidget } from "widgets/anvil/ZoneWidget";
 
 interface AnvilDnDListenerStatesProps {
   anvilGlobalDragStates: AnvilGlobalDnDStates;
@@ -130,6 +132,24 @@ export const useAnvilDnDListenerStates = ({
     (widgetProps.children || []).filter(
       (each) => !allWidgets[each].detachFromLayout,
     ).length === 0;
+
+  const allSiblingsWidgets = useMemo(() => {
+    const allSiblings =
+      (widgetProps.parentId && allWidgets[widgetProps.parentId]?.children) ||
+      [];
+    return allSiblings.map((each) => allWidgets[each]);
+  }, [widgetProps, allWidgets]);
+
+  const isElevatedWidget = useMemo(() => {
+    if (widgetProps.type === ZoneWidget.type) {
+      const isAnyZoneElevated = allSiblingsWidgets.some(
+        (each) => !!each.elevatedBackground,
+      );
+      return isAnyZoneElevated;
+    }
+    return !!widgetProps.elevatedBackground;
+  }, [widgetProps, allSiblingsWidgets]);
+
   const {
     edgeCompensatorValues,
     layoutCompensatorValues,
@@ -140,7 +160,7 @@ export const useAnvilDnDListenerStates = ({
     draggedWidgetHierarchy,
     currentWidgetHierarchy,
     isEmptyLayout,
-    widgetProps,
+    isElevatedWidget,
   );
 
   return {

--- a/app/client/src/layoutSystems/anvil/editor/canvasArenas/utils/dndCompensatorUtils.ts
+++ b/app/client/src/layoutSystems/anvil/editor/canvasArenas/utils/dndCompensatorUtils.ts
@@ -19,6 +19,7 @@ import { EMPTY_MODAL_PADDING } from "../AnvilModalDropArena";
  */
 const CompensationSpacingTokens = {
   MAIN_CANVAS: "4",
+  SECTION: "3",
   ZONE: "3",
   MODAL_TOP: "2",
   MODAL_LEFT: "4",
@@ -52,6 +53,9 @@ const getWidgetSpacingCSSVariableValues = (outerSpacingTokens: {
     zoneSpacing: extractFloatValuesOutOfToken(
       outerSpacingTokens[CompensationSpacingTokens.ZONE],
     ),
+    sectionSpacing: extractFloatValuesOutOfToken(
+      outerSpacingTokens[CompensationSpacingTokens.SECTION],
+    ),
   };
 };
 
@@ -84,19 +88,27 @@ const getMainCanvasCompensators = (
 /**
  * Get compensators for the section widget
  */
-const getSectionCompensators = (mainCanvasSpacing: number) => {
+const getSectionCompensators = (
+  mainCanvasSpacing: number,
+  sectionSpacing: number,
+  isElevatedWidget: boolean,
+) => {
   const widgetCompensatorValues = {
     left: mainCanvasSpacing,
     top: 0,
   };
   const edgeCompensatorValues = {
-    left: HIGHLIGHT_SIZE * 2,
+    left: HIGHLIGHT_SIZE * 2 + (isElevatedWidget ? sectionSpacing * 2 : 0),
     top: 0,
+  };
+  const layoutCompensatorValues = {
+    left: mainCanvasSpacing + (isElevatedWidget ? sectionSpacing : 0),
+    top: isElevatedWidget ? sectionSpacing : 0,
   };
   return {
     widgetCompensatorValues,
     edgeCompensatorValues,
-    layoutCompensatorValues: widgetCompensatorValues,
+    layoutCompensatorValues,
   };
 };
 /**
@@ -189,7 +201,7 @@ export const getCompensatorsForHierarchy = (
       },
     };
   }
-  const { mainCanvasSpacing, modalSpacing, zoneSpacing } =
+  const { mainCanvasSpacing, modalSpacing, sectionSpacing, zoneSpacing } =
     getWidgetSpacingCSSVariableValues(outerSpacingTokens);
   /**
    * Get compensators based on hierarchy
@@ -203,7 +215,11 @@ export const getCompensatorsForHierarchy = (
     case hierarchy === 1:
       return getModalCompensators(isEmptyLayout, modalSpacing);
     case hierarchy === 2:
-      return getSectionCompensators(mainCanvasSpacing);
+      return getSectionCompensators(
+        mainCanvasSpacing,
+        sectionSpacing,
+        isElevatedWidget,
+      );
     case hierarchy === 3:
       return getZoneCompensators(zoneSpacing, isElevatedWidget);
     default:

--- a/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetStyles.ts
+++ b/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetStyles.ts
@@ -34,7 +34,7 @@ export const useAnvilWidgetStyles = (
   useEffect(() => {
     if (ref.current) {
       ref.current.setAttribute("data-widgetname-cy", widgetName);
-      ref.current.setAttribute("data-testid", isSelected ? "t--selected" : "");
+      ref.current.setAttribute("data-selected", isSelected ? "true" : "false");
     }
   }, [widgetName, isSelected]);
   const isNewWidgetDrag = useSelector(getIsNewWidgetBeingDragged);

--- a/app/client/src/layoutSystems/anvil/layoutComponents/components/alignedWidgetRow/index.tsx
+++ b/app/client/src/layoutSystems/anvil/layoutComponents/components/alignedWidgetRow/index.tsx
@@ -7,6 +7,7 @@ import {
 import type { FlexLayoutProps } from "../FlexLayout";
 import { deriveAlignedRowHighlights } from "layoutSystems/anvil/utils/layouts/highlights/alignedRowHighlights";
 import AlignedWidgetRowComp from "./AlignedWidgetRowComp";
+import styles from "./styles.module.css";
 
 class AlignedWidgetRow extends BaseLayoutComponent {
   static type: LayoutComponentTypes = LayoutComponentTypes.ALIGNED_WIDGET_ROW;
@@ -26,7 +27,7 @@ class AlignedWidgetRow extends BaseLayoutComponent {
       direction: "row",
       wrap: "wrap",
       gap: "spacing-3",
-      className: "aligned-widget-row",
+      className: styles.alignedWidgetRow,
     };
   }
 }

--- a/app/client/src/layoutSystems/anvil/layoutComponents/components/alignedWidgetRow/styles.module.css
+++ b/app/client/src/layoutSystems/anvil/layoutComponents/components/alignedWidgetRow/styles.module.css
@@ -1,0 +1,14 @@
+.alignedWidgetRow {
+  /**
+  Conditional vertical margin applied to widgets.
+   If in a row of widgets (.aligned-widget-row), one of the widgets has a label ([data-field-label-wrapper]), then
+   all widgets (.anvil-widget-wrapper) in the row other than the widget with the label, will shift down using the
+   margin-block-start property. This is to ensure that the widgets are aligned vertically.
+
+   The value of the margin-block-start property is calculated based on the spacing tokens used by the labels in input like components
+*/
+  &:has([data-widget-wrapper] [data-field-label-wrapper])
+    [data-widget-wrapper]:not(:has([data-field-label-wrapper])) {
+    margin-block-start: calc(var(--inner-spacing-3) + var(--sizing-3));
+  }
+}

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/SpaceDistributionHandle.tsx
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/SpaceDistributionHandle.tsx
@@ -25,7 +25,7 @@ const StyledSpaceDistributionHandle = styled.div<{ left: number }>`
   height: calc(100% - 2 * ${SpaceDistributorHandleDimensions.offsetTop}px);
   top: ${SpaceDistributorHandleDimensions.offsetTop}px;
   border-radius: ${SpaceDistributorHandleDimensions.borderRadius}px;
-  padding: 0px ${SpaceDistributorHandleDimensions.padding}px;
+  padding: 0 ${SpaceDistributorHandleDimensions.padding}px;
   pointer-events: all;
   z-index: 1000;
   left: ${({ left }) => left}px;

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/constants.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/constants.ts
@@ -1,6 +1,6 @@
 export const SpaceDistributorHandleDimensions = {
-  width: 6,
-  offsetTop: 10,
+  width: 3,
+  offsetTop: 2,
   borderRadius: 4,
   padding: 2,
 };

--- a/app/client/src/widgets/anvil/Container.tsx
+++ b/app/client/src/widgets/anvil/Container.tsx
@@ -19,24 +19,6 @@ const StyledContainerComponent = styled.div<
   outline: none;
   border: none;
   position: relative;
-  /* If the elevatedBackground is true, then apply the elevation styles */
-  ${(props) => {
-    if (props.elevatedBackground) {
-      return `
-      background-color: var(--color-bg-elevation-${props.elevation});
-      border-radius: var(--border-radius-elevation-${props.elevation})};
-      border-color: var(--color-bd-elevation-${props.elevation});
-      border-width: var(--border-width-1);
-      border-style: solid;
-
-      /* Add padding to the container to maintain the visual spacing rhythm */
-      /* This is based on the hypothesis of asymmetric padding */
-        padding-block:
-        ${props.elevation === 1 ? 0 : "var(--outer-spacing-3)"};
-  padding-inline: ${props.elevation === 1 ? 0 : "var(--outer-spacing-3)"};
-      `;
-    }
-  }}
 `;
 
 export function ContainerComponent(props: ContainerComponentProps) {

--- a/app/client/src/widgets/anvil/ZoneWidget/widget/config/anvilConfig.ts
+++ b/app/client/src/widgets/anvil/ZoneWidget/widget/config/anvilConfig.ts
@@ -14,9 +14,6 @@ export const anvilConfig: AnvilConfig = {
               base: "100%",
               [`${MOBILE_BREAKPOINT}px`]: "min-content",
             },
-      minHeight: {
-        base: "sizing-12",
-      },
     };
   },
 };


### PR DESCRIPTION
## Description
Added asymmetric paddings for sections and zones.

https://github.com/appsmithorg/appsmith/assets/11555074/1959c6f2-5e26-4fdd-98e3-ea1bb5e09dae

Fixes #32209   

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8999510824>
> Commit: b714426d3185c9a75523fe98ae4ca75e26f0b249
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8999510824&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->













## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
