### PR TITLE
fix: UI segment re render caused by route change

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/UI/index.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/UI/index.tsx
@@ -44,7 +44,6 @@ const UISegment = () => {
     >
       <Switch>
         <SentryRoute
-          component={() => <AddWidgets focusSearchInput={focusSearchInput} />}
           exact
           path={[
             BUILDER_PATH_DEPRECATED,
@@ -52,17 +51,18 @@ const UISegment = () => {
             BUILDER_CUSTOM_PATH,
             `${path}${WIDGETS_EDITOR_ID_PATH}${ADD_PATH}`,
           ]}
-        />
+        >
+          <AddWidgets focusSearchInput={focusSearchInput} />
+        </SentryRoute>
         <SentryRoute
-          component={() => (
-            <ListWidgets setFocusSearchInput={setFocusSearchInput} />
-          )}
           exact
           path={[
             `${path}${WIDGETS_EDITOR_BASE_PATH}`,
             `${path}${WIDGETS_EDITOR_ID_PATH}`,
           ]}
-        />
+        >
+          <ListWidgets setFocusSearchInput={setFocusSearchInput} />
+        </SentryRoute>
       </Switch>
     </Flex>
   );


### PR DESCRIPTION
## Description

On route changes, the UI segment components were re-created  (re mounted) causing scrolls to reset. This was happening because of how we were passing the Route Components inside the React Router `Route` .

By passing these componenets as children of routes instead of a prop function, we avoid recreating the component on route changes and hence avoiding the scroll to reset


Fixes #32995

## Automation

/ok-to-test tags="@tag.IDE, @tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8972146055>
> Commit: 05851e356bce32ae864d504c56ec07b59ab29a53
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8972146055&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/Button/ButtonGroup2_spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
