### PR TITLE
chore: learnability flags turned on by default

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -86,10 +86,10 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   ab_appsmith_ai_query: false,
   release_actions_redesign_enabled: false,
   rollout_remove_feature_walkthrough_enabled: false,
-  rollout_js_enabled_one_click_binding_enabled: false,
+  rollout_js_enabled_one_click_binding_enabled: true,
   rollout_side_by_side_enabled: false,
-  ab_learnability_ease_of_initial_use_enabled: false,
-  ab_learnability_discoverability_collapse_all_except_data_enabled: false,
+  ab_learnability_ease_of_initial_use_enabled: true,
+  ab_learnability_discoverability_collapse_all_except_data_enabled: true,
   release_layout_conversion_enabled: false,
 };
 

--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -85,7 +85,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_global_add_pane_enabled: false,
   ab_appsmith_ai_query: false,
   release_actions_redesign_enabled: false,
-  rollout_remove_feature_walkthrough_enabled: false,
+  rollout_remove_feature_walkthrough_enabled: true,
   rollout_js_enabled_one_click_binding_enabled: true,
   rollout_side_by_side_enabled: false,
   ab_learnability_ease_of_initial_use_enabled: true,


### PR DESCRIPTION
## Description
For the airgapped testing, we need to remove all the feature flags which are already rolled out to 100% of the users. As part of this task, we have 3 flags in activation/learnability initiatives:
1. rollout_js_enabled_one_click_binding_enabled
2. ab_learnability_ease_of_initial_use_enabled
3. ab_learnability_discoverability_collapse_all_except_data_enabled
4. rollout_remove_feature_walkthrough_enabled

As immediate measure, we are turning default values of these flags to be true, later on we can plan to completely remove the flags from the code.


Fixes #`Issue Number`  
_or_  
Fixes [`Issue URL`](https://github.com/appsmithorg/appsmith/issues/33224)
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8996740514>
> Commit: 08169331cb7b35c3d1ca11f7c97231478816a60f
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8996740514&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
