### PR TITLE
feat: Move to class based projections 

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/CustomTransientSerializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/CustomTransientSerializer.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+
+import static com.appsmith.external.helpers.ReflectionHelpers.getAllFields;
 
 /**
  *  This class is used to serialize the entity object by ignoring the fields annotated with @Transient. We need
@@ -49,16 +49,5 @@ public class CustomTransientSerializer<T> extends StdSerializer<T> {
             }
         }
         gen.writeEndObject();
-    }
-
-    // Method to get all fields including superclasses
-    private List<Field> getAllFields(Class<?> clazz) {
-        List<Field> fields =
-                new ArrayList<>(Arrays.stream(clazz.getDeclaredFields()).toList());
-        Class<?> superClass = clazz.getSuperclass();
-        if (superClass != null && !superClass.equals(Object.class)) {
-            fields.addAll(getAllFields(superClass));
-        }
-        return fields;
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/ReflectionHelpers.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/ReflectionHelpers.java
@@ -1,0 +1,24 @@
+package com.appsmith.external.helpers;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ReflectionHelpers {
+    /**
+     * Returns all fields of the given class including the fields of the super classes.
+     * @param clazz The class whose fields are to be returned
+     *
+     * @return  The list of fields of the given class
+     */
+    public static List<Field> getAllFields(Class<?> clazz) {
+        List<Field> fields =
+                new ArrayList<>(Arrays.stream(clazz.getDeclaredFields()).toList());
+        Class<?> superClass = clazz.getSuperclass();
+        if (superClass != null && !superClass.equals(Object.class)) {
+            fields.addAll(getAllFields(superClass));
+        }
+        return fields;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/ReflectionHelpers.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/ReflectionHelpers.java
@@ -1,0 +1,56 @@
+package com.appsmith.server.helpers.ce;
+
+import org.springframework.util.CollectionUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReflectionHelpers {
+
+    /**
+     * Maps a tuple to an object of the given type using the constructor of the type. The order of the tuple should be
+     * the same as the order of the fields in the type constructor.
+     * @param type          The type of the object to be created
+     * @param tuple         The tuple to be mapped to the object
+     * @param tupleTypes    The types of the tuple elements. If not provided, the types of the fields of the type are used.
+     *
+     * @return      The object of the given type
+     * @param <T>   The type of the object to be created
+     */
+    public static <T> T map(Object[] tuple, Class<T> type, List<Class<?>> tupleTypes) {
+        if (CollectionUtils.isEmpty(tupleTypes)) {
+            tupleTypes = new ArrayList<>();
+            for (Field field : type.getDeclaredFields()) {
+                tupleTypes.add(field.getType());
+            }
+        }
+        try {
+            Constructor<T> constructor = type.getConstructor(tupleTypes.toArray(new Class<?>[tuple.length]));
+            return constructor.newInstance(tuple);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Maps a list of tuples to a list of objects of the given type using the constructor of the type.
+     * @param type      The type of the object to be created
+     * @param records   The list of tuples to be mapped to the objects
+     *
+     * @return      The list of objects of the given type
+     * @param <T>   The type of the object to be created
+     */
+    public static <T> List<T> map(List<Object[]> records, Class<T> type) {
+        List<T> result = new ArrayList<>();
+        List<Class<?>> tupleTypes = new ArrayList<>();
+        for (Field field : type.getDeclaredFields()) {
+            tupleTypes.add(field.getType());
+        }
+        for (Object[] record : records) {
+            result.add(map(record, type, tupleTypes));
+        }
+        return result;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/ReflectionHelpers.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/ReflectionHelpers.java
@@ -19,7 +19,7 @@ public class ReflectionHelpers {
      * @return      The object of the given type
      * @param <T>   The type of the object to be created
      */
-    public static <T> T map(Object[] tuple, Class<T> type, List<Class<?>> tupleTypes) {
+    private static <T> T map(Object[] tuple, Class<T> type, List<Class<?>> tupleTypes) {
         if (CollectionUtils.isEmpty(tupleTypes)) {
             tupleTypes = new ArrayList<>();
             for (Field field : type.getDeclaredFields()) {
@@ -32,6 +32,10 @@ public class ReflectionHelpers {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static <T> T map(Object[] tuple, Class<T> type) {
+        return map(tuple, type, null);
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/UserRecentlyUsedEntitiesProjection.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/UserRecentlyUsedEntitiesProjection.java
@@ -1,13 +1,7 @@
 package com.appsmith.server.projections;
 
 import com.appsmith.server.dtos.RecentlyUsedEntityDTO;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-public class UserRecentlyUsedEntitiesProjection {
-    List<RecentlyUsedEntityDTO> recentlyUsedEntityIds;
-}
+public record UserRecentlyUsedEntitiesProjection(List<RecentlyUsedEntityDTO> recentlyUsedEntityIds) {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/UserRecentlyUsedEntitiesProjection.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/UserRecentlyUsedEntitiesProjection.java
@@ -1,0 +1,13 @@
+package com.appsmith.server.projections;
+
+import com.appsmith.server.dtos.RecentlyUsedEntityDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class UserRecentlyUsedEntitiesProjection {
+    List<RecentlyUsedEntityDTO> recentlyUsedEntityIds;
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -302,6 +302,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
 
                     if (!projectionClass.getSimpleName().equals(genericDomain.getSimpleName())) {
                         List<Selection<?>> projectionFields = new ArrayList<>();
+                        // TODO: Nested fields are not supported yet.
                         getAllFields(projectionClass).forEach(f -> projectionFields.add(root.get(f.getName())));
                         cq.multiselect(projectionFields);
                     }
@@ -312,7 +313,6 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
                         query.setMaxResults(params.getLimit());
                     }
 
-                    // All public access is via a single permission group. Fetch the same and set the cache with it.
                     return Mono.fromSupplier(query::getResultList)
                             .map(tuple -> {
                                 if (genericDomain.getSimpleName().equals(projectionClass.getSimpleName())) {
@@ -361,22 +361,12 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
                     if (!projectionClass.getSimpleName().equals(genericDomain.getSimpleName())) {
                         List<Selection<?>> projectionFields = new ArrayList<>();
                         getAllFields(projectionClass).forEach(f -> {
-                            /*
-                            Throws java.lang.IllegalStateException: Basic paths cannot be dereferenced from
-                            org.hibernate.metamodel.model.domain.internal.BasicSqmPathSource.findSubPathSource(BasicSqmPathSource.java:38)
-                            if (f.getType().getPackageName().contains("projection") && f.getType().getDeclaredFields().length > 0) {
-                                getAllFields(f.getType())
-                                    .forEach(nestedField -> {
-                                        projectionFields.add(root.get(f.getName()).get(nestedField.getName()));
-                                    });
-                            }
-                             */
+                            // TODO: Nested fields are not supported yet.
                             projectionFields.add(root.get(f.getName()));
                         });
                         cq.multiselect(projectionFields);
                     }
 
-                    // All public access is via a single permission group. Fetch the same and set the cache with it.
                     return Mono.fromSupplier(entityManager.createQuery(cq)::getSingleResult)
                             .map(tuple -> {
                                 if (genericDomain.getSimpleName().equals(projectionClass.getSimpleName())) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -249,6 +249,10 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
     }
 
     public List<T> queryAllExecute(QueryAllParams<T> params) {
+        if (CollectionUtils.isEmpty(params.getPermissionGroups())) {
+            params.permissionGroups(
+                    getCurrentUserPermissionGroupsIfRequired(Optional.ofNullable(params.getPermission())));
+        }
         return queryAllExecute(params, genericDomain).stream()
                 .map(obj -> setUserPermissionsInObject(obj, params.getPermissionGroups()))
                 .toList();
@@ -312,6 +316,10 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
     }
 
     public Optional<T> queryOneExecute(QueryAllParams<T> params) {
+        if (CollectionUtils.isEmpty(params.getPermissionGroups())) {
+            params.permissionGroups(
+                    getCurrentUserPermissionGroupsIfRequired(Optional.ofNullable(params.getPermission())));
+        }
         return queryOneExecute(params, genericDomain)
                 .map(obj -> setUserPermissionsInObject(obj, params.getPermissionGroups()));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -382,7 +382,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
                                 if (genericDomain.getSimpleName().equals(projectionClass.getSimpleName())) {
                                     return (P) tuple;
                                 }
-                                return map((Object[]) tuple, projectionClass, null);
+                                return map((Object[]) tuple, projectionClass);
                             })
                             .onErrorResume(NoResultException.class, e -> Mono.empty());
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -281,7 +281,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
                         predicate = cb.and(Specification.allOf(specifications).toPredicate(root, cq, cb), predicate);
                     }
                     predicate =
-                            addPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
+                            getPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
 
                     cq.where(predicate);
 
@@ -355,7 +355,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
                         predicate = cb.and(Specification.allOf(specifications).toPredicate(root, cq, cb), predicate);
                     }
                     predicate =
-                            addPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
+                            getPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
 
                     cq.where(predicate);
                     if (!projectionClass.getSimpleName().equals(genericDomain.getSimpleName())) {
@@ -402,7 +402,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
                         predicate = cb.and(Specification.allOf(specifications).toPredicate(root, cq, cb), predicate);
                     }
                     predicate =
-                            addPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
+                            getPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
 
                     cq.where(predicate);
                     cq.select(cb.count(root));
@@ -483,7 +483,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
         if (!specifications.isEmpty()) {
             predicate = cb.and(Specification.allOf(specifications).toPredicate(root, cq, cb), predicate);
         }
-        predicate = addPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
+        predicate = getPermissionGroupsPredicate(permissionGroups, params.getPermission(), cb, root, predicate);
 
         cu.where(predicate);
 
@@ -622,7 +622,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> impleme
         return cacheableRepositoryHelper.getPermissionGroupsOfAnonymousUser();
     }
 
-    private Predicate addPermissionGroupsPredicate(
+    private Predicate getPermissionGroupsPredicate(
             ArrayList<String> permissionGroups,
             AclPermission permission,
             CriteriaBuilder cb,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -3,6 +3,7 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.domains.UserData;
 import com.appsmith.server.dtos.RecentlyUsedEntityDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
+import com.appsmith.server.projections.UserRecentlyUsedEntitiesProjection;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaUpdate;
@@ -67,8 +68,7 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
     public Optional<String> fetchMostRecentlyUsedWorkspaceId(String userId) {
         return queryBuilder()
                 .criteria(Bridge.equal(UserData.Fields.userId, userId))
-                .fields(UserData.Fields.recentlyUsedEntityIds)
-                .one()
+                .one(UserRecentlyUsedEntitiesProjection.class)
                 .map(userData -> {
                     final List<RecentlyUsedEntityDTO> recentlyUsedWorkspaceIds = userData.getRecentlyUsedEntityIds();
                     return CollectionUtils.isEmpty(recentlyUsedWorkspaceIds)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -70,7 +70,7 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
                 .criteria(Bridge.equal(UserData.Fields.userId, userId))
                 .one(UserRecentlyUsedEntitiesProjection.class)
                 .map(userData -> {
-                    final List<RecentlyUsedEntityDTO> recentlyUsedWorkspaceIds = userData.getRecentlyUsedEntityIds();
+                    final List<RecentlyUsedEntityDTO> recentlyUsedWorkspaceIds = userData.recentlyUsedEntityIds();
                     return CollectionUtils.isEmpty(recentlyUsedWorkspaceIds)
                             ? ""
                             : recentlyUsedWorkspaceIds.get(0).getWorkspaceId();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -24,7 +24,10 @@ public class QueryAllParams<T extends BaseDomain> {
     // TODO(Shri): There's a cyclic dependency between the repository and this class. Remove it.
     private final BaseAppsmithRepositoryCEImpl<T> repo;
     private final List<Specification<T>> specifications = new ArrayList<>();
+
+    @Deprecated
     private final List<String> fields = new ArrayList<>();
+
     private AclPermission permission;
     private Set<String> permissionGroups;
     private Sort sort;
@@ -47,8 +50,16 @@ public class QueryAllParams<T extends BaseDomain> {
         return repo.queryAllExecute(this);
     }
 
+    public <P> List<P> all(Class<P> projectionClass) {
+        return repo.queryAllExecute(this, projectionClass);
+    }
+
     public Optional<T> one() {
         return repo.queryOneExecute(this);
+    }
+
+    public <P> Optional<P> one(Class<P> projectionClass) {
+        return repo.queryOneExecute(this, projectionClass);
     }
 
     public Optional<T> first() {
@@ -104,10 +115,22 @@ public class QueryAllParams<T extends BaseDomain> {
                         : (root, cq, cb) -> cb.equal(root.get(FieldName.ID), id));
     }
 
+    /**
+     * @deprecated Use {@link #fields(Collection)} instead.
+     * @param fields
+     * @return
+     */
+    @Deprecated(forRemoval = true)
     public QueryAllParams<T> fields(String... fields) {
         return fields(List.of(fields));
     }
 
+    /**
+     * @deprecated Use {@link #fields(Collection)} instead.
+     * @param fields
+     * @return
+     */
+    @Deprecated(forRemoval = true)
     public QueryAllParams<T> fields(Collection<String> fields) {
         if (fields == null) {
             return this;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -116,7 +116,8 @@ public class QueryAllParams<T extends BaseDomain> {
     }
 
     /**
-     * @deprecated Use {@link #fields(Collection)} instead.
+     * @deprecated Use class based projections instead.
+     * Refer to {@link #all(Class)} and {@link #one(Class)}.
      * @param fields
      * @return
      */
@@ -126,7 +127,8 @@ public class QueryAllParams<T extends BaseDomain> {
     }
 
     /**
-     * @deprecated Use {@link #fields(Collection)} instead.
+     * @deprecated Use class based projections instead.
+     * Refer to {@link #all(Class)} and {@link #one(Class)}.
      * @param fields
      * @return
      */

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomUserDataRepositoryTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomUserDataRepositoryTest.java
@@ -161,4 +161,35 @@ public class CustomUserDataRepositoryTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    public void fetchMostRecentlyUsedWorkspaceId_withAndWithoutRecentlyUsedIds_success() {
+        String randomId = UUID.randomUUID().toString();
+        String firstId = "first_" + randomId, photoId = "photo_" + randomId;
+
+        UserData userData = new UserData();
+        userData.setUserId(firstId);
+        userData.setProfilePhotoAssetId(photoId);
+
+        // Assert when no recently used entity ids are present
+        userData = userDataRepository.save(userData).block();
+        StepVerifier.create(userDataRepository.fetchMostRecentlyUsedWorkspaceId(firstId))
+                .assertNext(workspaceId -> {
+                    assertThat(workspaceId).isEmpty();
+                })
+                .verifyComplete();
+
+        // Recently used entity ids are present
+        RecentlyUsedEntityDTO recentlyUsedEntityDTO = new RecentlyUsedEntityDTO();
+        recentlyUsedEntityDTO.setWorkspaceId("123");
+        recentlyUsedEntityDTO.setApplicationIds(List.of("456"));
+        assert userData != null : "userData can't be null";
+        userData.setRecentlyUsedEntityIds(List.of(recentlyUsedEntityDTO));
+        userDataRepository.save(userData).block();
+        StepVerifier.create(userDataRepository.fetchMostRecentlyUsedWorkspaceId(firstId))
+                .assertNext(workspaceId -> {
+                    assertThat(workspaceId).isEqualTo("123");
+                })
+                .verifyComplete();
+    }
 }


### PR DESCRIPTION
### Description
PR to add support for class-based projection. 
Method signature: 
```
public <P> List<P> all(Class<P> projectionClass) {
        return repo.queryAllExecute(this, projectionClass);
    }

public <P> Optional<P> one(Class<P> projectionClass) {
        return repo.queryOneExecute(this, projectionClass);
    }
```
Todos: 
1. This change can work with top-level fields only
```
e.g. class EntityClass {
	String id;
	String topLevelField;
	NestedObject nestedObject;
}

class NestedObject {
	String field1;
}

With this setup we can project `nestedObject` but not `nestedobject.field1`
```

We expect to move to separate tables for the JSONB columns going forward hence not putting efforts here. 