### PR TITLE
chore: move cypress strings to vars

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Query_Datasource_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Query_Datasource_spec.js
@@ -18,7 +18,7 @@ let datasourceName;
 describe(
   "Entity explorer tests related to query and datasource",
   { tags: ["@tag.IDE"] },
-  function () {
+  function() {
     before(() => {
       cy.generateUUID().then((uid) => {
         datasourceName = uid;
@@ -29,7 +29,7 @@ describe(
       cy.startRoutesForDatasource();
     });
 
-    it("1. Create a page/moveQuery/rename/delete in explorer", function () {
+    it("1. Create a page/moveQuery/rename/delete in explorer", function() {
       cy.Createpage(pageid);
       cy.wait(2000);
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
@@ -43,7 +43,7 @@ describe(
         .clear()
         .type("download", { force: true })
         .blur();
-      cy.get(".Toastify").should("contain", "Invalid name");
+      cy.get(".Toastify").should("contain", Cypress.env("MESSAGES").INVALID_NAME_ERROR());
 
       // checking a valid name
       cy.get(".t--edit-datasource-name").click();
@@ -83,7 +83,7 @@ describe(
         entityNameinLeftSidebar: "Query1",
         action: "Show bindings",
       });
-      cy.get(apiwidget.propertyList).then(function ($lis) {
+      cy.get(apiwidget.propertyList).then(function($lis) {
         expect($lis).to.have.length(5);
         expect($lis.eq(0)).to.contain("{{Query1.isLoading}}");
         expect($lis.eq(1)).to.contain("{{Query1.data}}");

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Query_Datasource_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Query_Datasource_spec.js
@@ -18,7 +18,7 @@ let datasourceName;
 describe(
   "Entity explorer tests related to query and datasource",
   { tags: ["@tag.IDE"] },
-  function() {
+  function () {
     before(() => {
       cy.generateUUID().then((uid) => {
         datasourceName = uid;
@@ -29,7 +29,7 @@ describe(
       cy.startRoutesForDatasource();
     });
 
-    it("1. Create a page/moveQuery/rename/delete in explorer", function() {
+    it("1. Create a page/moveQuery/rename/delete in explorer", function () {
       cy.Createpage(pageid);
       cy.wait(2000);
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
@@ -86,7 +86,7 @@ describe(
         entityNameinLeftSidebar: "Query1",
         action: "Show bindings",
       });
-      cy.get(apiwidget.propertyList).then(function($lis) {
+      cy.get(apiwidget.propertyList).then(function ($lis) {
         expect($lis).to.have.length(5);
         expect($lis.eq(0)).to.contain("{{Query1.isLoading}}");
         expect($lis.eq(1)).to.contain("{{Query1.data}}");

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Query_Datasource_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Query_Datasource_spec.js
@@ -43,7 +43,10 @@ describe(
         .clear()
         .type("download", { force: true })
         .blur();
-      cy.get(".Toastify").should("contain", Cypress.env("MESSAGES").INVALID_NAME_ERROR());
+      cy.get(".Toastify").should(
+        "contain",
+        Cypress.env("MESSAGES").INVALID_NAME_ERROR(),
+      );
 
       // checking a valid name
       cy.get(".t--edit-datasource-name").click();

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Firestore_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Firestore_Basic_Spec.ts
@@ -35,8 +35,7 @@ describe("Validate Firestore DS", { tags: ["@tag.Datasource"] }, () => {
     agHelper.GetNAssertContains(locators._dsName, "Untitled datasource");
     agHelper.GetNClick(locators._dsName);
     agHelper.ClearTextField(locators._dsNameTxt); //removing ds name
-    agHelper.AssertTooltip("Please enter a valid name");
-    //agHelper.ValidateToastMessage("Invalid name");
+    agHelper.AssertTooltip(Cypress.env("MESSAGES").ACTION_INVALID_NAME_ERROR());
     agHelper.TypeText(locators._dsNameTxt, dsName);
     agHelper.PressEnter();
     agHelper.AssertAttribute(

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
@@ -37,8 +37,7 @@ describe("Validate Oracle DS", { tags: ["@tag.Datasource"] }, () => {
     agHelper.GetNAssertContains(locators._dsName, "Untitled datasource");
     agHelper.GetNClick(locators._dsName);
     agHelper.ClearTextField(locators._dsNameTxt); //removing ds name
-    agHelper.AssertTooltip("Please enter a valid name");
-    //agHelper.ValidateToastMessage("Invalid name");
+    agHelper.AssertTooltip(Cypress.env("MESSAGES").ACTION_INVALID_NAME_ERROR());
     agHelper.TypeText(locators._dsNameTxt, dataSourceName);
     agHelper.PressEnter();
     agHelper.AssertAttribute(

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -160,6 +160,7 @@ export const ERROR_403 = (entity: string, userEmail: string) =>
 export const PAGE_NOT_FOUND_ERROR = () =>
   `The page you’re looking for either does not exist, or cannot be found`;
 export const INVALID_URL_ERROR = () => `Invalid URL`;
+export const INVALID_NAME_ERROR = () => `Invalid name`;
 export const MAKE_APPLICATION_PUBLIC = () => "Make application public";
 export const MAKE_APPLICATION_PUBLIC_TOOLTIP = () =>
   "A public app is accessible to anyone who can access your instance of appsmith";

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -7,6 +7,10 @@ import {
 import styled from "styled-components";
 import _ from "lodash";
 import { Button, Spinner, toast, Tooltip } from "design-system";
+import {
+  INVALID_NAME_ERROR,
+  createMessage,
+} from "@appsmith/constants/messages";
 
 export enum EditInteractionKind {
   SINGLE,
@@ -195,7 +199,7 @@ export function EditableText(props: EditableTextProps) {
         onTextChanged(_value);
         setIsEditing(false);
       } else {
-        toast.show(customErrorTooltip || "Invalid name", {
+        toast.show(customErrorTooltip || createMessage(INVALID_NAME_ERROR), {
           kind: "error",
         });
       }


### PR DESCRIPTION
## Description
Replaced strings of cypress tests to variables

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity, @tag.IDE, @tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8996892379>
> Commit: 3badf854bd74903b7689fc4f2fa5fdae6a670704
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8996892379&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
