### PR TITLE
fix: Add anonymous user check while registering the edit mode pulses

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -17,6 +17,9 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
 import reactor.core.publisher.Mono;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 @RequiredArgsConstructor
 public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
 
@@ -42,11 +45,13 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
     public Mono<UsagePulse> createPulse(UsagePulseDTO usagePulseDTO) {
         if (null == usagePulseDTO.getViewMode()) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.VIEW_MODE));
+        } else if (FALSE.equals(usagePulseDTO.getViewMode()) && usagePulseDTO.getAnonymousUserId() != null) {
+            // We don't expect anonymous user to have access to edit mode
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ANONYMOUS_USER_ID));
         }
 
-        // Remove usage pulse logging for appsmith-cloud until multi-tenancy is introduced
         // TODO remove this condition after multi-tenancy is introduced
-        if (Boolean.TRUE.equals(commonConfig.isCloudHosting())) {
+        if (TRUE.equals(commonConfig.isCloudHosting())) {
             return Mono.just(new UsagePulse());
         }
 


### PR DESCRIPTION
## Description
PR to check if the usage is fired from an anonymous user in edit mode. Ideally, we don't expect the client to allow access in edit mode for anonymous user. We are also discussing if there are any cracks on client-side implementation in a separate [thread](https://theappsmith.slack.com/archives/C04H5PFRN1H/p1711965410411119?thread_ts=1711608528.724769&cid=C04H5PFRN1H).

Fixes https://github.com/appsmithorg/cloud-services/issues/1643  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8989771788>
> Commit: 675a0b2f0c47187cb2104e6fc6debfd0fa38da17
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8989771788&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
