### PR TITLE
test: Fix AutoCommitEventHandlerImplTest

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/AutoCommitEventHandlerImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/AutoCommitEventHandlerImplTest.java
@@ -1,4 +1,4 @@
-package com.appsmith.server.solutions;
+package com.appsmith.server.git.autocommit;
 
 import com.appsmith.external.git.GitExecutor;
 import com.appsmith.server.configurations.ProjectProperties;
@@ -11,6 +11,8 @@ import com.appsmith.server.helpers.DSLMigrationUtils;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.services.AnalyticsService;
+import com.appsmith.server.solutions.AutoCommitEventHandler;
+import com.appsmith.server.solutions.AutoCommitEventHandlerImpl;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -61,7 +63,7 @@ public class AutoCommitEventHandlerImplTest {
     @MockBean
     GitExecutor gitExecutor;
 
-    @MockBean
+    @Autowired
     ProjectProperties projectProperties;
 
     AutoCommitEventHandler autoCommitEventHandler;


### PR DESCRIPTION
1. Move it to the same package as on EE.
2. Remove mock on `ProjectProperties` to fix NPE with Postgres.

/ok-to-test tags="@tag.Sanity"

