### PR TITLE
fix: rest api body binary tab placeholder updated

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -152,7 +152,7 @@ function PostBodyData(props: Props) {
               dataTreePath={`${dataTreePath}.body`}
               mode={EditorModes.TEXT_WITH_BINDING}
               name="actionConfiguration.body"
-              placeholder={`{{\n\t{name: inputName.property, preference: dropdownName.property}\n}}`}
+              placeholder={`{{\n\t// File contents should be in base64, Please select data format as base64 in File picker widget\n\tfilePickerName.files[0].data\n}}`}
               size={EditorSize.EXTENDED}
               tabBehaviour={TabBehaviour.INDENT}
               theme={theme}

--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -152,7 +152,7 @@ function PostBodyData(props: Props) {
               dataTreePath={`${dataTreePath}.body`}
               mode={EditorModes.TEXT_WITH_BINDING}
               name="actionConfiguration.body"
-              placeholder={`{{\n\t// File contents should be in base64, Please select data format as base64 in File picker widget\n\tfilePickerName.files[0].data\n}}`}
+              placeholder={`{{\n\t// Make sure to select the 'Base64' in the Data Format property of the Filepicker widget as the file contents are expected to be in Base64 format\n\tfilePickerName.files[0].data\n}}`}
               size={EditorSize.EXTENDED}
               tabBehaviour={TabBehaviour.INDENT}
               theme={theme}


### PR DESCRIPTION
## Description
This PR updates the REST API body tab binary's placeholder text to indicate that this requires input as file contents in base64 format. This can help users in debugging in case REST API file upload does not work out for them.
New placeholder text changes are as below:
<img width="1136" alt="Screenshot 2024-05-08 at 1 54 24 PM" src="https://github.com/appsmithorg/appsmith/assets/30018882/65d289af-4a35-4e2f-ba0b-85877424db95">



Fixes #33266
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9000998032>
> Commit: 3baffcb02ffd9173a8382a148154a0ac7dfc70d8
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9000998032&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
