### PR TITLE
chore: Revert "chore: learnability flags turned on by default"

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -85,11 +85,11 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_global_add_pane_enabled: false,
   ab_appsmith_ai_query: false,
   release_actions_redesign_enabled: false,
-  rollout_remove_feature_walkthrough_enabled: true,
-  rollout_js_enabled_one_click_binding_enabled: true,
+  rollout_remove_feature_walkthrough_enabled: false,
+  rollout_js_enabled_one_click_binding_enabled: false,
   rollout_side_by_side_enabled: false,
-  ab_learnability_ease_of_initial_use_enabled: true,
-  ab_learnability_discoverability_collapse_all_except_data_enabled: true,
+  ab_learnability_ease_of_initial_use_enabled: false,
+  ab_learnability_discoverability_collapse_all_except_data_enabled: false,
   release_layout_conversion_enabled: false,
 };
 


### PR DESCRIPTION
Reverts appsmithorg/appsmith#33225

/ok-to-test tags="@tag.Binding,@tag.AutoHeight"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/8999564168>
> Commit: 7870a636b6fb3ffb08042d686435228e2b3a3189
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=8999564168&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



