### PR TITLE
chore: Remove duplicate Table tag from the list of tags

### DIFF
--- a/app/client/cypress/tags.js
+++ b/app/client/cypress/tags.js
@@ -36,7 +36,6 @@ module.exports = {
     "@tag.Progress",
     "@tag.Video",
     "@tag.Container",
-    "@tag.Table",
     "@tag.Camera",
     "@tag.Image",
     "@tag.Tab",


### PR DESCRIPTION
## Description
Unable to run ok to test with tag Table due to duplication. This should help make Table tag available as well.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
