### PR TITLE
fix: Fix OAuth2 client secret showing up in UI

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -56,7 +56,7 @@ public class OAuth2 extends AuthenticationDTO {
     @JsonView({Views.Public.class, FromRequest.class})
     String clientId;
 
-    @Encrypted @JsonView({Views.Public.class, FromRequest.class})
+    @Encrypted @JsonView(FromRequest.class)
     String clientSecret;
 
     @JsonView({Views.Public.class, FromRequest.class})


### PR DESCRIPTION
/ok-to-test tags="@tag.Sanity"

