### PR TITLE
fix: remove git cd feature flag

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -25,8 +25,6 @@ export const FEATURE_FLAG = {
     "license_git_branch_protection_enabled",
   license_git_continuous_delivery_enabled:
     "license_git_continuous_delivery_enabled",
-  release_git_continuous_delivery_enabled:
-    "release_git_continuous_delivery_enabled",
   release_git_autocommit_feature_enabled:
     "release_git_autocommit_feature_enabled",
   release_git_status_granular_enabled: "release_git_status_granular_enabled",
@@ -77,7 +75,6 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_git_autocommit_feature_enabled: false,
   release_git_status_granular_enabled: false,
   license_git_continuous_delivery_enabled: false,
-  release_git_continuous_delivery_enabled: false,
   license_widget_rtl_support_enabled: false,
   release_show_partial_import_export_enabled: false,
   ab_one_click_learning_popover_enabled: false,

--- a/app/client/src/pages/Editor/gitSync/GitSettingsModal/index.test.tsx
+++ b/app/client/src/pages/Editor/gitSync/GitSettingsModal/index.test.tsx
@@ -31,7 +31,6 @@ const createInitialState = (overrideFn = (o: any) => o) => {
         featureFlag: {
           data: {
             license_git_continuous_delivery_enabled: true,
-            release_git_continuous_delivery_enabled: true,
           },
         },
       },
@@ -86,22 +85,5 @@ describe("Git Settings Modal", () => {
     expect(getByTestId(`t--tab-${GitSettingsTab.GENERAL}`)).toBeTruthy();
     expect(queryByTestId(`t--tab-${GitSettingsTab.BRANCH}`)).not.toBeTruthy();
     expect(getByTestId(`t--tab-${GitSettingsTab.CD}`)).toBeTruthy();
-  });
-
-  it("is not rendering CD when feature flag is not enabled", () => {
-    const initialState = createInitialState((initialState) => {
-      const newState = { ...initialState };
-      newState.ui.users.featureFlag.data = {
-        license_git_continuous_delivery_enabled: false,
-        release_git_continuous_delivery_enabled: false,
-      };
-      return newState;
-    });
-    const store = mockStore(initialState);
-    const { getByTestId, queryByTestId } = renderComponent(store);
-    expect(getByTestId("t--git-settings-modal")).toBeTruthy();
-    expect(getByTestId(`t--tab-${GitSettingsTab.GENERAL}`)).toBeTruthy();
-    expect(getByTestId(`t--tab-${GitSettingsTab.BRANCH}`)).toBeTruthy();
-    expect(queryByTestId(`t--tab-${GitSettingsTab.CD}`)).not.toBeTruthy();
   });
 });

--- a/app/client/src/pages/Editor/gitSync/GitSettingsModal/index.tsx
+++ b/app/client/src/pages/Editor/gitSync/GitSettingsModal/index.tsx
@@ -20,8 +20,6 @@ import {
 import TabGeneral from "./TabGeneral";
 import TabBranch from "./TabBranch";
 import GitSettingsCDTab from "@appsmith/components/gitComponents/GitSettingsCDTab";
-import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
-import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import {
   useHasManageDefaultBranchPermission,
   useHasManageProtectedBranchesPermission,
@@ -48,10 +46,6 @@ function GitSettingsModal() {
   const isModalOpen = useSelector(isGitSettingsModalOpenSelector);
   const activeTabKey = useSelector(activeGitSettingsModalTabSelector);
 
-  const isGitCDEnabled = useFeatureFlag(
-    FEATURE_FLAG.release_git_continuous_delivery_enabled,
-  );
-
   const menuOptions = useMemo(() => {
     const menuOptions = [
       {
@@ -67,15 +61,13 @@ function GitSettingsModal() {
       });
     }
 
-    if (isGitCDEnabled) {
-      menuOptions.push({
-        key: GitSettingsTab.CD,
-        title: createMessage(CONTINUOUS_DELIVERY),
-      });
-    }
+    menuOptions.push({
+      key: GitSettingsTab.CD,
+      title: createMessage(CONTINUOUS_DELIVERY),
+    });
 
     return menuOptions;
-  }, [isGitCDEnabled]);
+  }, [showBranchTab]);
 
   const dispatch = useDispatch();
 
@@ -113,9 +105,7 @@ function GitSettingsModal() {
         <ModalBody>
           {activeTabKey === GitSettingsTab.GENERAL && <TabGeneral />}
           {activeTabKey === GitSettingsTab.BRANCH && <TabBranch />}
-          {isGitCDEnabled && activeTabKey === GitSettingsTab.CD && (
-            <GitSettingsCDTab />
-          )}
+          {activeTabKey === GitSettingsTab.CD && <GitSettingsCDTab />}
         </ModalBody>
       </StyledModalContent>
     </Modal>


### PR DESCRIPTION
## Description
Removes `release_git_continuous_delivery_enabled` feature flag


Fixes #33284

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9000615669>
> Commit: f8b24490349141d3764527dabfbab23dfd087e70
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9000615669&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->







## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
