### PR TITLE
chore: added unit test cases for disableLogs and microDiff

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.test.ts
+++ b/app/client/src/sagas/EvaluationsSaga.test.ts
@@ -1,0 +1,70 @@
+import { evaluateTreeSaga, evalWorker } from "./EvaluationsSaga";
+import { expectSaga } from "redux-saga-test-plan";
+import { EVAL_WORKER_ACTIONS } from "@appsmith/workers/Evaluation/evalWorkerActions";
+import { select } from "redux-saga/effects";
+import { getMetaWidgets, getWidgets, getWidgetsMeta } from "./selectors";
+import { getAllActionValidationConfig } from "@appsmith//selectors/entitiesSelector";
+import { getSelectedAppTheme } from "selectors/appThemingSelectors";
+import { getAppMode } from "@appsmith/selectors/applicationSelectors";
+import * as log from "loglevel";
+jest.mock("loglevel");
+
+describe("evaluateTreeSaga", () => {
+  afterAll(() => {
+    jest.unmock("loglevel");
+  });
+  test("should set 'shouldRespondWithLogs'to evaluations when the log level is debug", async () => {
+    (log.getLevel as any).mockReturnValue(log.levels.DEBUG);
+    const unEvalAndConfigTree = { unEvalTree: {}, configTree: {} };
+    return expectSaga(evaluateTreeSaga, unEvalAndConfigTree)
+      .provide([
+        [select(getAllActionValidationConfig), {}],
+        [select(getWidgets), {}],
+        [select(getMetaWidgets), {}],
+        [select(getSelectedAppTheme), {}],
+        [select(getAppMode), false],
+        [select(getWidgetsMeta), {}],
+      ])
+      .call(evalWorker.request, EVAL_WORKER_ACTIONS.EVAL_TREE, {
+        unevalTree: unEvalAndConfigTree,
+        widgetTypeConfigMap: undefined,
+        widgets: {},
+        theme: {},
+        shouldReplay: true,
+        allActionValidationConfig: {},
+        forceEvaluation: false,
+        metaWidgets: {},
+        appMode: false,
+        widgetsMeta: {},
+        shouldRespondWithLogs: true,
+      })
+      .run();
+  });
+  test("should set 'shouldRespondWithLogs' to false when the log level is not debug", async () => {
+    (log.getLevel as any).mockReturnValue(log.levels.INFO);
+    const unEvalAndConfigTree = { unEvalTree: {}, configTree: {} };
+    return expectSaga(evaluateTreeSaga, unEvalAndConfigTree)
+      .provide([
+        [select(getAllActionValidationConfig), {}],
+        [select(getWidgets), {}],
+        [select(getMetaWidgets), {}],
+        [select(getSelectedAppTheme), {}],
+        [select(getAppMode), false],
+        [select(getWidgetsMeta), {}],
+      ])
+      .call(evalWorker.request, EVAL_WORKER_ACTIONS.EVAL_TREE, {
+        unevalTree: unEvalAndConfigTree,
+        widgetTypeConfigMap: undefined,
+        widgets: {},
+        theme: {},
+        shouldReplay: true,
+        allActionValidationConfig: {},
+        forceEvaluation: false,
+        metaWidgets: {},
+        appMode: false,
+        widgetsMeta: {},
+        shouldRespondWithLogs: false,
+      })
+      .run();
+  });
+});


### PR DESCRIPTION
## Description
Added missing unit test cases for these prs [disableLogs](https://github.com/appsmithorg/appsmith/pull/32892) and [microDiff](https://github.com/appsmithorg/appsmith/pull/32581).

Fixes #33291

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9001043422>
> Commit: e3bb0247e1bbe8c13de994c21b090ec02746224d
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9001043422&attempt=3" target="_blank">Click here!</a>
> It seems like **no tests ran** 😔. We are not able to recognize it, please check workflow <a href="https://github.com/appsmithorg/appsmith/actions/runs/9001043422" target="_blank">here.</a>

<!-- end of auto-generated comment: Cypress test results  -->







## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
