### PR TITLE
fix: Fixes CREATE_JS_ACTION_ERROR error that disallows creating js objects or updating actions on certain git connected apps

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -635,7 +635,7 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
         NewAction newAction = newActionService.generateActionDomain(action);
         newAction.setUnpublishedAction(action);
 
-        Set<Policy> actionCollectionPolicies = new HashSet();
+        Set<Policy> actionCollectionPolicies = new HashSet<>();
         actionCollection.getPolicies().forEach(policy -> {
             Policy actionPolicy = Policy.builder()
                     .permission(policy.getPermission())

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -7,7 +7,6 @@ import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.domains.Layout;
-import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.ActionCollectionMoveDTO;
@@ -151,33 +150,25 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
         actionCollection.setUnpublishedCollection(collectionDTO);
 
         return newPageService
-                .findById(collectionDTO.getPageId(), pagePermission.getActionCreatePermission())
-                .flatMap(newPage -> {
+                .findByBranchNameAndDefaultPageId(
+                        branchName, collectionDTO.getPageId(), pagePermission.getActionCreatePermission())
+                .map(branchedPage -> {
                     // Insert defaultPageId and defaultAppId from page
-                    DefaultResources defaultResources = newPage.getDefaultResources();
+                    DefaultResources defaultResources = branchedPage.getDefaultResources();
                     defaultResources.setBranchName(branchName);
                     collectionDTO.setDefaultResources(defaultResources);
                     actionCollection.setDefaultResources(defaultResources);
-                    actionCollectionService.generateAndSetPolicies(newPage, actionCollection);
+                    actionCollectionService.generateAndSetPolicies(branchedPage, actionCollection);
                     actionCollection.setUnpublishedCollection(collectionDTO);
-                    return Mono.zip(
-                            newPageService.findByBranchNameAndDefaultPageId(
-                                    branchName, defaultResources.getPageId(), pagePermission.getEditPermission()),
-                            Mono.just(actionCollection));
-                })
-                .flatMap(tuple -> {
-                    NewPage branchedPage = tuple.getT1();
-                    ActionCollection updatedActionCollection = tuple.getT2();
 
-                    ActionCollectionDTO unpublishedCollection = updatedActionCollection.getUnpublishedCollection();
                     // Update the page and application id with branched resource
-                    unpublishedCollection.setApplicationId(branchedPage.getApplicationId());
-                    unpublishedCollection.setPageId(branchedPage.getId());
+                    collectionDTO.setApplicationId(branchedPage.getApplicationId());
+                    collectionDTO.setPageId(branchedPage.getId());
 
-                    updatedActionCollection.setWorkspaceId(collectionDTO.getWorkspaceId());
-                    updatedActionCollection.setApplicationId(branchedPage.getApplicationId());
+                    actionCollection.setWorkspaceId(collectionDTO.getWorkspaceId());
+                    actionCollection.setApplicationId(branchedPage.getApplicationId());
 
-                    return Mono.just(updatedActionCollection);
+                    return actionCollection;
                 });
     }
 
@@ -363,18 +354,10 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
                                 actionDTO.setCollectionId(null);
                                 // Client only knows about the default action ID, fetch branched action id to update the
                                 // action
-                                Mono<String> branchedActionIdMono = StringUtils.isEmpty(branchName)
-                                        ? Mono.just(actionDTO.getId())
-                                        : newActionService
-                                                .findByBranchNameAndDefaultActionId(
-                                                        branchName,
-                                                        actionDTO.getId(),
-                                                        false,
-                                                        actionPermission.getEditPermission())
-                                                .map(NewAction::getId);
+                                String defaultActionId = actionDTO.getId();
                                 actionDTO.setId(null);
-                                return branchedActionIdMono.flatMap(
-                                        actionId -> layoutActionService.updateSingleAction(actionId, actionDTO));
+                                return layoutActionService.updateSingleActionWithBranchName(
+                                        defaultActionId, actionDTO, branchName);
                             }
                         })
                         .collect(toMap(
@@ -423,8 +406,8 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
                                 .flatMap(actionCollectionDTO2 -> actionCollectionService
                                         .saveLastEditInformationInParent(actionCollectionDTO2)
                                         .thenReturn(actionCollectionDTO2))))
-                .map(responseUtils::updateCollectionDTOWithDefaultResources)
-                .flatMap(branchedActionCollection -> sendErrorReportsFromPageToCollection(branchedActionCollection));
+                .flatMap(branchedActionCollection -> sendErrorReportsFromPageToCollection(branchedActionCollection))
+                .map(responseUtils::updateCollectionDTOWithDefaultResources);
     }
 
     private Mono<ActionCollectionDTO> sendErrorReportsFromPageToCollection(


### PR DESCRIPTION
## Description
When a user develops on a feature branch, merges to master, and then deletes the original branch, the "default entity" associated to all the entities created in the feature branch would now be pointing to a resource that has been deleted on the database. These entities could be NewPage, NewAction, ActionCollection, or ModuleInstances. 

The issue that this PR fixes had to do with the fact that any create or update operation on collections and actions respectively would attempt to first retrieve one such deleted resource that was the default entity wrt the current branch and failures in this operation would not even cause exceptions in the flow but simply return to the client side with 2xx responses.

It is possible that other operations of this nature might exist through the code base, but we'll pick them up on an as needed basis since we're hoping to remove all need for such manipulation with the default resources tech debt resolution.

Fixes https://github.com/appsmithorg/appsmith/issues/30868

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9007055258>
> Commit: 57b3311aeaf307a6d3d2f53febb576ef1396fd21
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9007055258&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
