### PR TITLE
chore: Add cypress run duration in PR description

### DIFF
--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -222,12 +222,21 @@ jobs:
             > Workflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
             > Commit: ${{ github.event.pull_request.head.sha }}
             > Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}" target="_blank">Click here!</a>
+            > Cypress run Duration: ${{ steps.get_duration.outputs.duration }}
 
             <!-- end of auto-generated comment: Cypress test results  -->
 
           regex: "<!-- This is an auto-generated comment: Cypress test results  -->.*?<!-- end of auto-generated comment: Cypress test results  -->"
           regexFlags: ims
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get workflow duration
+        uses: channyein87/workflow-duration-action@v1
+        id: get_duration
+        with:
+          repository: actions/checkout
+          workflow: ./.github/workflows/ci-test-custom-script.yml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check ci-test set status
         if: needs.ci-test.result != 'success'


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
