### PR TITLE
fix: Remove error for window fetch API

### DIFF
--- a/app/client/src/plugins/Linting/constants.ts
+++ b/app/client/src/plugins/Linting/constants.ts
@@ -59,6 +59,7 @@ export const IGNORED_LINT_ERRORS = ["E041", "W032"];
 export const SUPPORTED_WEB_APIS = {
   console: true,
   crypto: true,
+  fetch: true,
 };
 export enum CustomLintErrorCode {
   INVALID_ENTITY_PROPERTY = "INVALID_ENTITY_PROPERTY",

--- a/app/client/src/plugins/Linting/tests/getLintingErrors.test.ts
+++ b/app/client/src/plugins/Linting/tests/getLintingErrors.test.ts
@@ -1,0 +1,105 @@
+import { getScriptType } from "workers/Evaluation/evaluate";
+import getLintingErrors from "../utils/getLintingErrors";
+
+describe("getLintingErrors", () => {
+  describe("1. Verify lint errors are not shown for supported window APIs", () => {
+    const data = {};
+
+    it("1. For fetch API", () => {
+      const originalBinding = "{{fetch()}}";
+      const script = "fetch()";
+
+      const scriptType = getScriptType(false, true);
+
+      const lintErrors = getLintingErrors({
+        data,
+        originalBinding,
+        script,
+        scriptType,
+      });
+
+      expect(Array.isArray(lintErrors)).toBe(true);
+      expect(lintErrors.length).toEqual(0);
+    });
+    it("2. For setTimeout", () => {
+      const originalBinding = "{{setTimeout()}}";
+      const script = "setTimeout()";
+
+      const scriptType = getScriptType(false, true);
+
+      const lintErrors = getLintingErrors({
+        data,
+        originalBinding,
+        script,
+        scriptType,
+      });
+
+      expect(Array.isArray(lintErrors)).toBe(true);
+      expect(lintErrors.length).toEqual(0);
+    });
+    it("3. For console", () => {
+      const originalBinding = "{{console.log()}}";
+      const script = "console.log()";
+
+      const scriptType = getScriptType(false, true);
+
+      const lintErrors = getLintingErrors({
+        data,
+        originalBinding,
+        script,
+        scriptType,
+      });
+
+      expect(lintErrors.length).toEqual(0);
+    });
+  });
+
+  describe("2. Verify lint errors are shown for unsupported window APIs", () => {
+    const data = {};
+    it("1. For window", () => {
+      const originalBinding = "{{window}}";
+      const script = "window";
+
+      const scriptType = getScriptType(false, true);
+
+      const lintErrors = getLintingErrors({
+        data,
+        originalBinding,
+        script,
+        scriptType,
+      });
+
+      expect(lintErrors.length).toEqual(1);
+    });
+    it("2. For document", () => {
+      const originalBinding = "{{document}}";
+      const script = "document";
+
+      const scriptType = getScriptType(false, true);
+
+      const lintErrors = getLintingErrors({
+        data,
+        originalBinding,
+        script,
+        scriptType,
+      });
+
+      expect(lintErrors.length).toEqual(1);
+    });
+    it("3. For dom", () => {
+      const originalBinding = "{{dom}}";
+      const script = "dom";
+
+      const scriptType = getScriptType(false, true);
+
+      const lintErrors = getLintingErrors({
+        data,
+        originalBinding,
+        script,
+        scriptType,
+      });
+
+      expect(lintErrors.length).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fix linting error for `fetch` window API 

Fixes https://github.com/appsmithorg/appsmith/issues/33268

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9023762582>
> Commit: f235c91a7d3437eca91b0f900f05a28b42da3226
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9023762582&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
