### PR TITLE
fix: Anvil only: Fix issue where Modal Widget doesn't open with `showModal` action

### DIFF
--- a/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
@@ -60,6 +60,12 @@ class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
     return config.methodsConfig;
   }
 
+  static getDerivedPropertiesMap() {
+    return {
+      name: "{{this.widgetName}}",
+    };
+  }
+
   static *performPasteOperation(
     allWidgets: CanvasWidgetsReduxState,
     copiedWidgets: CopiedWidgetData[],


### PR DESCRIPTION
## Description
- Fixes issue where `showModal` action doesn't work as it is looking for `Modal1.name` where `Modal1` is the name of the modal widget.

Fixes #`Issue Number`  
_or_  

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9030692185>
> Commit: 475f22b7c48b93a6637eef6f14a898ad88ae22dc
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9030692185&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
