### PR TITLE
fix: Enable atomic pushes in git using an environment configuration

### DIFF
--- a/app/client/src/ce/constants/tenantConstants.ts
+++ b/app/client/src/ce/constants/tenantConstants.ts
@@ -6,7 +6,7 @@ export const tenantConfigConnection: string[] = [
   "showRolesAndGroups",
   "hideWatermark",
   "userSessionTimeoutInMinutes",
-  "isAtomicPushAllowed"
+  "isAtomicPushAllowed",
 ];
 
 export const RESTART_POLL_TIMEOUT = 2 * 150 * 1000;

--- a/app/client/src/ce/constants/tenantConstants.ts
+++ b/app/client/src/ce/constants/tenantConstants.ts
@@ -6,6 +6,7 @@ export const tenantConfigConnection: string[] = [
   "showRolesAndGroups",
   "hideWatermark",
   "userSessionTimeoutInMinutes",
+  "isAtomicPushAllowed"
 ];
 
 export const RESTART_POLL_TIMEOUT = 2 * 150 * 1000;

--- a/app/client/src/ce/pages/AdminSettings/config/general.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/general.tsx
@@ -115,10 +115,17 @@ export const APPSMITH_USER_SESSION_TIMEOUT_SETTING: Setting = {
   subText:
     "* Default duration is 30 days. To change, enter the new duration in DD:HH:MM format",
   helpText:
-    "Users' session will automatically end if there's no activity for the specified duration, requiring them to log in again for security. The duration can be set between 1 minute and 30 days.",
-  isFeatureEnabled: false,
-  isEnterprise: true,
-  isDisabled: () => true,
+    "Users' session will automatically end if there's no activity for the specified duration, requiring them to log in again for security. The duration can be set between 1 minute and 30 days."
+};
+
+export const APPSMITH_IS_ATOMIC_PUSH_ALLOWED: Setting = {
+  id: "isAtomicPushAllowed",
+  name: "isAtomicPushAllowed",
+  category: SettingCategories.GENERAL,
+  controlType: SettingTypes.CHECKBOX,
+  label: "Allow atomic pushes",
+  text:
+    "Git operations on this tenant should attempt to perform pushes atomically"
 };
 
 export const APPSMITH_ALLOWED_FRAME_ANCESTORS_SETTING: Setting = {
@@ -201,6 +208,7 @@ export const config: AdminConfigType = {
     APPSMITH_SHOW_ROLES_AND_GROUPS_SETTING,
     APPSMITH_SINGLE_USER_PER_SESSION_SETTING,
     APPSMITH_USER_SESSION_TIMEOUT_SETTING,
+    APPSMITH_IS_ATOMIC_PUSH_ALLOWED,
     APPSMITH_ALLOWED_FRAME_ANCESTORS_SETTING,
   ],
 } as AdminConfigType;

--- a/app/client/src/ce/pages/AdminSettings/config/general.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/general.tsx
@@ -115,7 +115,10 @@ export const APPSMITH_USER_SESSION_TIMEOUT_SETTING: Setting = {
   subText:
     "* Default duration is 30 days. To change, enter the new duration in DD:HH:MM format",
   helpText:
-    "Users' session will automatically end if there's no activity for the specified duration, requiring them to log in again for security. The duration can be set between 1 minute and 30 days."
+    "Users' session will automatically end if there's no activity for the specified duration, requiring them to log in again for security. The duration can be set between 1 minute and 30 days.",
+  isFeatureEnabled: false,
+  isEnterprise: true,
+  isDisabled: () => true,
 };
 
 export const APPSMITH_IS_ATOMIC_PUSH_ALLOWED: Setting = {
@@ -124,8 +127,7 @@ export const APPSMITH_IS_ATOMIC_PUSH_ALLOWED: Setting = {
   category: SettingCategories.GENERAL,
   controlType: SettingTypes.CHECKBOX,
   label: "Allow atomic pushes",
-  text:
-    "Git operations on this tenant should attempt to perform pushes atomically"
+  text: "Git operations on this tenant should attempt to perform pushes atomically",
 };
 
 export const APPSMITH_ALLOWED_FRAME_ANCESTORS_SETTING: Setting = {

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.git.service;
 
+import com.appsmith.external.configurations.git.GitConfig;
 import com.appsmith.external.git.GitExecutor;
 import com.appsmith.git.configurations.GitServiceConfig;
 import com.appsmith.git.service.ce.GitExecutorCEImpl;
@@ -12,8 +13,8 @@ import org.springframework.stereotype.Component;
 @Primary
 @Slf4j
 public class GitExecutorImpl extends GitExecutorCEImpl implements GitExecutor {
-
-    public GitExecutorImpl(GitServiceConfig gitServiceConfig, ObservationRegistry observationRegistry) {
-        super(gitServiceConfig, observationRegistry);
+    public GitExecutorImpl(
+            GitServiceConfig gitServiceConfig, GitConfig gitConfig, ObservationRegistry observationRegistry) {
+        super(gitServiceConfig, gitConfig, observationRegistry);
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/connectionpool/ConnectionPoolConfig.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/connectionpool/ConnectionPoolConfig.java
@@ -1,3 +1,3 @@
-package com.appsmith.external.connectionpoolconfig.configurations;
+package com.appsmith.external.configurations.connectionpool;
 
 public interface ConnectionPoolConfig extends ConnectionPoolConfigCECompatible {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/connectionpool/ConnectionPoolConfigCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/connectionpool/ConnectionPoolConfigCE.java
@@ -1,4 +1,4 @@
-package com.appsmith.external.connectionpoolconfig.configurations;
+package com.appsmith.external.configurations.connectionpool;
 
 import reactor.core.publisher.Mono;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/connectionpool/ConnectionPoolConfigCECompatible.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/connectionpool/ConnectionPoolConfigCECompatible.java
@@ -1,3 +1,3 @@
-package com.appsmith.external.connectionpoolconfig.configurations;
+package com.appsmith.external.configurations.connectionpool;
 
 public interface ConnectionPoolConfigCECompatible extends ConnectionPoolConfigCE {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/git/GitConfig.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/git/GitConfig.java
@@ -1,0 +1,3 @@
+package com.appsmith.external.configurations.git;
+
+public interface GitConfig extends GitConfigCECompatible {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/git/GitConfigCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/git/GitConfigCE.java
@@ -1,0 +1,7 @@
+package com.appsmith.external.configurations.git;
+
+import reactor.core.publisher.Mono;
+
+public interface GitConfigCE {
+    Mono<Boolean> getIsAtomicPushAllowed();
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/git/GitConfigCECompatible.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/configurations/git/GitConfigCECompatible.java
@@ -1,0 +1,3 @@
+package com.appsmith.external.configurations.git;
+
+public interface GitConfigCECompatible extends GitConfigCE {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/AppsmithBeanUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/AppsmithBeanUtils.java
@@ -6,10 +6,13 @@ import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.PropertyAccessorFactory;
 
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public final class AppsmithBeanUtils {
 
@@ -123,5 +126,17 @@ public final class AppsmithBeanUtils {
         }
 
         return values;
+    }
+
+    public static Stream<Field> getAllFields(Class<?> currentType) {
+
+        Set<Class<?>> classes = new HashSet<>();
+
+        while (currentType != null) {
+            classes.add(currentType);
+            currentType = currentType.getSuperclass();
+        }
+
+        return classes.stream().flatMap(currentClass -> Arrays.stream(currentClass.getDeclaredFields()));
     }
 }

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -1,6 +1,6 @@
 package com.external.plugins;
 
-import com.appsmith.external.connectionpoolconfig.configurations.ConnectionPoolConfig;
+import com.appsmith.external.configurations.connectionpool.ConnectionPoolConfig;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.datatypes.AppsmithType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
@@ -89,7 +89,6 @@ import static com.appsmith.external.helpers.PluginUtils.getIdenticalColumns;
 import static com.appsmith.external.helpers.PluginUtils.getPSParamLabel;
 import static com.appsmith.external.helpers.Sizeof.sizeof;
 import static com.appsmith.external.helpers.SmartSubstitutionHelper.replaceQuestionMarkWithDollarIndex;
-import static com.appsmith.external.models.SSLDetails.AuthType.VERIFY_CA;
 import static com.external.plugins.utils.PostgresDataTypeUtils.DataType.BOOL;
 import static com.external.plugins.utils.PostgresDataTypeUtils.DataType.DATE;
 import static com.external.plugins.utils.PostgresDataTypeUtils.DataType.DECIMAL;

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -1,6 +1,6 @@
 package com.external.plugins;
 
-import com.appsmith.external.connectionpoolconfig.configurations.ConnectionPoolConfig;
+import com.appsmith.external.configurations.connectionpool.ConnectionPoolConfig;
 import com.appsmith.external.datatypes.ClientDataType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/ApplicationGitFileUtilsCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/ApplicationGitFileUtilsCEImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.applications.git;
 
 import com.appsmith.external.git.FileInterface;
+import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.ApplicationGitReference;
 import com.appsmith.external.models.ArtifactGitReference;
@@ -40,14 +41,12 @@ import reactor.core.publisher.Mono;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.appsmith.external.git.constants.GitConstants.NAME_SEPARATOR;
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
@@ -141,7 +140,7 @@ public class ApplicationGitFileUtilsCEImpl implements ArtifactGitFileUtilsCE<App
     private void setApplicationMetadataInApplicationReference(
             ApplicationJson applicationJson, ApplicationGitReference applicationReference) {
         // Pass metadata
-        Iterable<String> keys = getAllFields(applicationJson)
+        Iterable<String> keys = AppsmithBeanUtils.getAllFields(applicationJson.getClass())
                 .map(Field::getName)
                 .filter(name -> !getBlockedMetadataFields().contains(name))
                 .collect(Collectors.toList());
@@ -302,19 +301,6 @@ public class ApplicationGitFileUtilsCEImpl implements ArtifactGitFileUtilsCE<App
                 });
         applicationReference.setActions(resourceMap);
         applicationReference.setActionBody(resourceMapBody);
-    }
-
-    protected Stream<Field> getAllFields(ApplicationJson applicationJson) {
-        Class<?> currentType = applicationJson.getClass();
-
-        Set<Class<?>> classes = new HashSet<>();
-
-        while (currentType != null) {
-            classes.add(currentType);
-            currentType = currentType.getSuperclass();
-        }
-
-        return classes.stream().flatMap(currentClass -> Arrays.stream(currentClass.getDeclaredFields()));
     }
 
     private void removeUnwantedFieldsFromApplication(Application application) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/connectionpool/ConnectionPoolConfigCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/connectionpool/ConnectionPoolConfigCECompatibleImpl.java
@@ -1,6 +1,6 @@
-package com.appsmith.server.connectionpoolconfig.configurations;
+package com.appsmith.server.configurations.connectionpool;
 
-import com.appsmith.external.connectionpoolconfig.configurations.ConnectionPoolConfigCECompatible;
+import com.appsmith.external.configurations.connectionpool.ConnectionPoolConfigCECompatible;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/connectionpool/ConnectionPoolConfigCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/connectionpool/ConnectionPoolConfigCEImpl.java
@@ -1,6 +1,6 @@
-package com.appsmith.server.connectionpoolconfig.configurations;
+package com.appsmith.server.configurations.connectionpool;
 
-import com.appsmith.external.connectionpoolconfig.configurations.ConnectionPoolConfigCE;
+import com.appsmith.external.configurations.connectionpool.ConnectionPoolConfigCE;
 import reactor.core.publisher.Mono;
 
 public class ConnectionPoolConfigCEImpl implements ConnectionPoolConfigCE {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/connectionpool/ConnectionPoolConfigImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/connectionpool/ConnectionPoolConfigImpl.java
@@ -1,6 +1,6 @@
-package com.appsmith.server.connectionpoolconfig.configurations;
+package com.appsmith.server.configurations.connectionpool;
 
-import com.appsmith.external.connectionpoolconfig.configurations.ConnectionPoolConfig;
+import com.appsmith.external.configurations.connectionpool.ConnectionPoolConfig;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCECompatibleImpl.java
@@ -1,7 +1,12 @@
 package com.appsmith.server.configurations.git;
 
 import com.appsmith.external.configurations.git.GitConfigCECompatible;
+import com.appsmith.server.services.TenantService;
 import org.springframework.stereotype.Component;
 
 @Component
-public class GitConfigCECompatibleImpl extends GitConfigCEImpl implements GitConfigCECompatible {}
+public class GitConfigCECompatibleImpl extends GitConfigCEImpl implements GitConfigCECompatible {
+    public GitConfigCECompatibleImpl(TenantService tenantService) {
+        super(tenantService);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCECompatibleImpl.java
@@ -1,0 +1,7 @@
+package com.appsmith.server.configurations.git;
+
+import com.appsmith.external.configurations.git.GitConfigCECompatible;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GitConfigCECompatibleImpl extends GitConfigCEImpl implements GitConfigCECompatible {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCEImpl.java
@@ -1,0 +1,20 @@
+package com.appsmith.server.configurations.git;
+
+import com.appsmith.external.configurations.git.GitConfigCE;
+import com.appsmith.server.services.TenantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Component
+public class GitConfigCEImpl implements GitConfigCE {
+
+    TenantService tenantService;
+
+    @Override
+    public Mono<Boolean> getIsAtomicPushAllowed() {
+        return tenantService.getTenantConfiguration().map(tenant -> tenant.getTenantConfiguration()
+                .getIsAtomicPushAllowed());
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigCEImpl.java
@@ -10,7 +10,7 @@ import reactor.core.publisher.Mono;
 @Component
 public class GitConfigCEImpl implements GitConfigCE {
 
-    TenantService tenantService;
+    private final TenantService tenantService;
 
     @Override
     public Mono<Boolean> getIsAtomicPushAllowed() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigImpl.java
@@ -1,7 +1,12 @@
 package com.appsmith.server.configurations.git;
 
 import com.appsmith.external.configurations.git.GitConfig;
+import com.appsmith.server.services.TenantService;
 import org.springframework.stereotype.Component;
 
 @Component
-public class GitConfigImpl extends GitConfigCECompatibleImpl implements GitConfig {}
+public class GitConfigImpl extends GitConfigCECompatibleImpl implements GitConfig {
+    public GitConfigImpl(TenantService tenantService) {
+        super(tenantService);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/git/GitConfigImpl.java
@@ -1,0 +1,7 @@
+package com.appsmith.server.configurations.git;
+
+import com.appsmith.external.configurations.git.GitConfig;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GitConfigImpl extends GitConfigCECompatibleImpl implements GitConfig {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/TenantConfigurationCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/TenantConfigurationCE.java
@@ -53,6 +53,8 @@ public class TenantConfigurationCE {
 
     Boolean isStrongPasswordPolicyEnabled;
 
+    private Boolean isAtomicPushAllowed;
+
     public void addThirdPartyAuth(String auth) {
         if (thirdPartyAuths == null) {
             thirdPartyAuths = new ArrayList<>();
@@ -77,6 +79,7 @@ public class TenantConfigurationCE {
         featuresWithPendingMigration = tenantConfiguration.getFeaturesWithPendingMigration();
         migrationStatus = tenantConfiguration.getMigrationStatus();
         isStrongPasswordPolicyEnabled = tenantConfiguration.getIsStrongPasswordPolicyEnabled();
+        isAtomicPushAllowed = tenantConfiguration.getIsAtomicPushAllowed();
     }
 
     public Boolean isEmailVerificationEnabled() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration055AddIsAtomicPushAllowedEnvVarToTenantConfiguration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration055AddIsAtomicPushAllowedEnvVarToTenantConfiguration.java
@@ -35,7 +35,9 @@ public class Migration055AddIsAtomicPushAllowedEnvVarToTenantConfiguration {
         boolean isAtomicPushAllowed = false;
 
         TenantConfiguration defaultTenantConfiguration = new TenantConfiguration();
-        assert defaultTenant != null : "Default tenant not found";
+        if (defaultTenant == null) {
+            throw new IllegalStateException("Default tenant not found");
+        }
         if (Objects.nonNull(defaultTenant.getTenantConfiguration())) {
             defaultTenantConfiguration = defaultTenant.getTenantConfiguration();
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration055AddIsAtomicPushAllowedEnvVarToTenantConfiguration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration055AddIsAtomicPushAllowedEnvVarToTenantConfiguration.java
@@ -1,0 +1,46 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.server.domains.Tenant;
+import com.appsmith.server.domains.TenantConfiguration;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Slf4j
+@ChangeUnit(order = "055", id = "add-is-atomic-push-allowed-env-variable-tenant-configuration")
+public class Migration055AddIsAtomicPushAllowedEnvVarToTenantConfiguration {
+    private final MongoTemplate mongoTemplate;
+
+    public Migration055AddIsAtomicPushAllowedEnvVarToTenantConfiguration(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void executionRollback() {}
+
+    @Execution
+    public void executeMigration() throws IOException {
+        Query tenantQuery = new Query();
+        tenantQuery.addCriteria(where(Tenant.Fields.slug).is("default"));
+        Tenant defaultTenant = mongoTemplate.findOne(tenantQuery, Tenant.class);
+
+        boolean isAtomicPushAllowed = false;
+
+        TenantConfiguration defaultTenantConfiguration = new TenantConfiguration();
+        assert defaultTenant != null : "Default tenant not found";
+        if (Objects.nonNull(defaultTenant.getTenantConfiguration())) {
+            defaultTenantConfiguration = defaultTenant.getTenantConfiguration();
+        }
+        defaultTenantConfiguration.setIsAtomicPushAllowed(isAtomicPushAllowed);
+        defaultTenant.setTenantConfiguration(defaultTenantConfiguration);
+        mongoTemplate.save(defaultTenant);
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/connectionpoolconfig/configurations/ConnectionPoolConfigCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/connectionpoolconfig/configurations/ConnectionPoolConfigCETest.java
@@ -1,6 +1,6 @@
 package com.appsmith.server.connectionpoolconfig.configurations;
 
-import com.appsmith.external.connectionpoolconfig.configurations.ConnectionPoolConfig;
+import com.appsmith.external.configurations.connectionpool.ConnectionPoolConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## Description
Since on-prem Bitbucket needs atomic git pushes to be used for operations from Appsmith, this PR introduces the property as a tenant level configuration that is turned off by default. Users can turn this on to allow git operations to succeed on Bitbucket again.


Fixes #33054

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9072140454>
> Commit: e1d4325ad751f6b6152c8289d1eb68ed29a5d768
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9072140454&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
