### PR TITLE
chore: Fix failing spec with updated string

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -27,7 +27,9 @@ describe("Page Load tests", { tags: ["@tag.IDE, @tag.Templates"] }, () => {
   before(() => {
     agHelper.AddDsl("PageLoadDsl");
     PageList.AddNewPage();
-    cy.get("span").contains(createMessage(STARTER_TEMPLATE_PAGE_LAYOUTS.header));
+    cy.get("span").contains(
+      createMessage(STARTER_TEMPLATE_PAGE_LAYOUTS.header),
+    );
   });
 
   it("1. Published page loads correctly", () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -10,8 +10,12 @@ import {
 } from "../../../../support/Objects/ObjectsCore";
 import PageList from "../../../../support/Pages/PageList";
 import { EntityItems } from "../../../../support/Pages/AssertHelper";
+import {
+  createMessage,
+  STARTER_TEMPLATE_PAGE_LAYOUTS,
+} from "../../../../../src/ce/constants/messages";
 
-describe("Page Load tests", { tags: ["@tag.IDE"] }, () => {
+describe("Page Load tests", { tags: ["@tag.IDE, @tag.Templates"] }, () => {
   afterEach(() => {
     agHelper.SaveLocalStorageCache();
   });
@@ -23,7 +27,7 @@ describe("Page Load tests", { tags: ["@tag.IDE"] }, () => {
   before(() => {
     agHelper.AddDsl("PageLoadDsl");
     PageList.AddNewPage();
-    cy.get("span").contains("Choose a template");
+    cy.get("span").contains(createMessage(STARTER_TEMPLATE_PAGE_LAYOUTS.header));
   });
 
   it("1. Published page loads correctly", () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -10,7 +10,7 @@ import {
 } from "../../../../support/Objects/ObjectsCore";
 import PageList from "../../../../support/Pages/PageList";
 import { EntityItems } from "../../../../support/Pages/AssertHelper";
-
+import { createMessage } from "../../../../support/Objects/CommonErrorMessages";
 describe("Page Load tests", { tags: ["@tag.IDE"] }, () => {
   afterEach(() => {
     agHelper.SaveLocalStorageCache();
@@ -23,7 +23,7 @@ describe("Page Load tests", { tags: ["@tag.IDE"] }, () => {
   before(() => {
     agHelper.AddDsl("PageLoadDsl");
     PageList.AddNewPage();
-    cy.get("h2").contains("Drag and drop a widget here");
+    cy.get("span").contains("Choose a template");
   });
 
   it("1. Published page loads correctly", () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -15,7 +15,7 @@ import {
   STARTER_TEMPLATE_PAGE_LAYOUTS,
 } from "../../../../../src/ce/constants/messages";
 
-describe("Page Load tests", { tags: ["@tag.IDE, @tag.Templates"] }, () => {
+describe("Page Load tests", { tags: ["@tag.IDE", "@tag.Templates"] }, () => {
   afterEach(() => {
     agHelper.SaveLocalStorageCache();
   });

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -10,7 +10,7 @@ import {
 } from "../../../../support/Objects/ObjectsCore";
 import PageList from "../../../../support/Pages/PageList";
 import { EntityItems } from "../../../../support/Pages/AssertHelper";
-import { createMessage } from "../../../../support/Objects/CommonErrorMessages";
+
 describe("Page Load tests", { tags: ["@tag.IDE"] }, () => {
   afterEach(() => {
     agHelper.SaveLocalStorageCache();


### PR DESCRIPTION
## Description
Since `ab_show_templates_instead_of_blank_canvas_enabled` flag is GA, we removed its ref from code and updated empty canvas to have a differnt layout. 

Updated the spec to reflect that.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9061366694>
> Commit: ea00dcc8527463b9d5cd3ea093d0213ac502cd0c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9061366694&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
