### PR TITLE
fix: added regex 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -26,8 +26,8 @@ public class GitUtils {
     public static final Pattern URL_PATTERN_WITHOUT_SCHEME =
             Pattern.compile("^git@(?<host>.+?):/*(?<path>.+?)(\\.git)?$");
 
-    public static final Pattern URL_PATTERN_WITHOUT_GIT_PREFIX =
-            Pattern.compile("^[a-zA-Z0-9]+@(?<host>.+?):/*(?<path>.+?)(\\.git)?$");
+    public static final Pattern URL_PATTERN_WITH_CUSTOM_USERNAME =
+            Pattern.compile("^(ssh://)?[a-zA-Z0-9]+@(?<host>.+?):/*(?<path>.+?)(\\\\.git)?$");
 
     /**
      * Sample repo urls :
@@ -49,7 +49,7 @@ public class GitUtils {
         }
 
         if (!match.matches()) {
-            match = URL_PATTERN_WITHOUT_GIT_PREFIX.matcher(sshUrl);
+            match = URL_PATTERN_WITH_CUSTOM_USERNAME.matcher(sshUrl);
         }
 
         if (!match.matches()) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -26,6 +26,9 @@ public class GitUtils {
     public static final Pattern URL_PATTERN_WITHOUT_SCHEME =
             Pattern.compile("^git@(?<host>.+?):/*(?<path>.+?)(\\.git)?$");
 
+    public static final Pattern URL_PATTERN_WITHOUT_GIT_PREFIX =
+            Pattern.compile("^[a-zA-Z0-9]+@(?<host>.+?):/*(?<path>.+?)(\\.git)?$");
+
     /**
      * Sample repo urls :
      * git@example.com:user/repoName.git
@@ -43,6 +46,10 @@ public class GitUtils {
         Matcher match = URL_PATTERN_WITH_SCHEME.matcher(sshUrl);
         if (!match.matches()) {
             match = URL_PATTERN_WITHOUT_SCHEME.matcher(sshUrl);
+        }
+
+        if (!match.matches()) {
+            match = URL_PATTERN_WITHOUT_GIT_PREFIX.matcher(sshUrl);
         }
 
         if (!match.matches()) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -60,6 +60,10 @@ public class GitUtilsTest {
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
                         "ssh://git@tim.tam.example.com:9876/v3/sladeping/pyhe/SpaceJunk"))
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
+
+        // custom ssh username:
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
+                .isEqualTo("https://vs-ssh.visualstudio.com/v3/newJet/ai/zilla");
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -64,6 +64,10 @@ public class GitUtilsTest {
         // custom ssh username:
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
                 .isEqualTo("https://vs-ssh.visualstudio.com/v3/newJet/ai/zilla");
+
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
+                        "ssh://custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
+                .isEqualTo("https://vs-ssh.visualstudio.com/v3/newJet/ai/zilla");
     }
 
     @Test
@@ -135,6 +139,13 @@ public class GitUtilsTest {
         assertThat(GitUtils.getRepoName("user@host.xz:path/to/repo.git")).isEqualTo("repo");
         assertThat(GitUtils.getRepoName("org-987654321@github.com:org_name/repository_name.git"))
                 .isEqualTo("repository_name");
+
+        // custom ssh username:
+        assertThat(GitUtils.getRepoName("custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
+                .isEqualTo("zilla");
+
+        assertThat(GitUtils.getRepoName("ssh://custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
+                .isEqualTo("zilla");
     }
 
     @Test


### PR DESCRIPTION
## Description
> Added regex for supporting custom usernames in ssh

Fixes #19881
## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9090239144>
> Commit: 05f2b6f8e6bbbbd6f05e70d9fa9194a07c89d86d
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9090239144&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
