### PR TITLE
chore: Adds airgapped handling of empty canvas hints

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -16,7 +16,7 @@ import {
   EMPTY_CANVAS_HINTS,
 } from "../../../../../src/ce/constants/messages";
 
-describe("Page Load tests", { tags: ["@tag.IDE", "@tag.Templates"] }, () => {
+describe("Page Load tests", { tags: ["@tag.IDE"] }, () => {
   afterEach(() => {
     agHelper.SaveLocalStorageCache();
   });

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -29,12 +29,12 @@ describe("Page Load tests", { tags: ["@tag.IDE", "@tag.Templates"] }, () => {
     agHelper.AddDsl("PageLoadDsl");
     PageList.AddNewPage();
     if (Cypress.env("AIRGAPPED")) {
-      cy.get("span").contains(
-        createMessage(STARTER_TEMPLATE_PAGE_LAYOUTS.header),
-      );
-    } else {
       cy.get("h2").contains(
         createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_WIDGET_HINT),
+      );
+    } else {
+      cy.get("span").contains(
+        createMessage(STARTER_TEMPLATE_PAGE_LAYOUTS.header),
       );
     }
   });

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -13,6 +13,7 @@ import { EntityItems } from "../../../../support/Pages/AssertHelper";
 import {
   createMessage,
   STARTER_TEMPLATE_PAGE_LAYOUTS,
+  EMPTY_CANVAS_HINTS,
 } from "../../../../../src/ce/constants/messages";
 
 describe("Page Load tests", { tags: ["@tag.IDE", "@tag.Templates"] }, () => {
@@ -27,9 +28,15 @@ describe("Page Load tests", { tags: ["@tag.IDE", "@tag.Templates"] }, () => {
   before(() => {
     agHelper.AddDsl("PageLoadDsl");
     PageList.AddNewPage();
-    cy.get("span").contains(
-      createMessage(STARTER_TEMPLATE_PAGE_LAYOUTS.header),
-    );
+    if (Cypress.env("AIRGAPPED")) {
+      cy.get("span").contains(
+        createMessage(STARTER_TEMPLATE_PAGE_LAYOUTS.header),
+      );
+    } else {
+      cy.get("h2").contains(
+        createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_WIDGET_HINT),
+      );
+    }
   });
 
   it("1. Published page loads correctly", () => {


### PR DESCRIPTION
## Description
Fixes airgapped condition for empty canvas state.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9077312350>
> Commit: 71a84f22d3c2b652a47707a603bdb462dec24e42
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9077312350&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
