### PR TITLE
chore: cypress strings replaced with var names

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
@@ -16,11 +16,11 @@ describe("Api Error Debugger", { tags: ["@tag.IDE"] }, () => {
   });
   it("it shows debug button and navigates", () => {
     _.apiPage.DebugError();
-    _.debuggerHelper.AssertSelectedTab("Error");
+    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
     _.debuggerHelper.AssertErrorCount(1);
     EditorNavigation.SwitchScreenMode(EditorViewMode.SplitScreen);
     _.apiPage.DebugError();
-    _.debuggerHelper.AssertSelectedTab("Error");
+    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
     _.debuggerHelper.AssertErrorCount(1);
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
@@ -16,11 +16,15 @@ describe("Api Error Debugger", { tags: ["@tag.IDE"] }, () => {
   });
   it("it shows debug button and navigates", () => {
     _.apiPage.DebugError();
-    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_ERRORS(),
+    );
     _.debuggerHelper.AssertErrorCount(1);
     EditorNavigation.SwitchScreenMode(EditorViewMode.SplitScreen);
     _.apiPage.DebugError();
-    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_ERRORS(),
+    );
     _.debuggerHelper.AssertErrorCount(1);
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
@@ -10,7 +10,9 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.ClickDebuggerIcon();
     _.debuggerHelper.AssertOpen(PageType.Canvas);
     //Verify if selected tab is errors in tab title.
-    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_ERRORS(),
+    );
     // verify if bottom bar is closed on clicking close icon in canvas.
     _.debuggerHelper.CloseBottomBar();
     _.debuggerHelper.AssertClosed();
@@ -22,7 +24,7 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.AssertOpen(PageType.JsEditor);
     // Verify if selected tab is response.
     _.debuggerHelper.AssertSelectedTab(
-      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE(),
     );
     //Verify if bottom bar is closed on clicking close icon in JSEditor.
     _.debuggerHelper.CloseBottomBar();
@@ -32,7 +34,7 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.AssertOpen(PageType.JsEditor);
     //verify if response tab is selected on execution JSFunction.
     _.debuggerHelper.AssertSelectedTab(
-      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE(),
     );
     //verify if bottom bar is closed on switching to canvas page.
     EditorNavigation.ShowCanvas();
@@ -49,14 +51,16 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.ClickDebuggerIcon();
     _.debuggerHelper.AssertOpen(PageType.API);
     //Verify if selected tab is errors in tab title.
-    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_ERRORS(),
+    );
     //Verify if bottom bar is open on executing api.
     _.apiPage.RunAPI();
     _.agHelper.Sleep(1000);
     _.debuggerHelper.AssertOpen(PageType.API);
     //verify if response tab is selected on execution api.
     _.debuggerHelper.AssertSelectedTab(
-      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE(),
     );
   });
 
@@ -80,7 +84,7 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
         //Verify if selected tab is errors and error count is
         //Verify if selected tab is errors in tab title.
         _.debuggerHelper.AssertSelectedTab(
-          Cypress.env("MESSAGES").DEBUGGER_ERRORS,
+          Cypress.env("MESSAGES").DEBUGGER_ERRORS(),
         );
         //Verify if bottom bar is closed on clicking close icon in active datasource page.
         _.debuggerHelper.CloseBottomBar();
@@ -103,7 +107,7 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
         _.debuggerHelper.AssertOpen(PageType.Query);
         //Verify if response atb is selected on executing query.
         _.debuggerHelper.AssertSelectedTab(
-          Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+          Cypress.env("MESSAGES").DEBUGGER_RESPONSE(),
         );
         // clean up
         _.dataSources.DeleteQuery("Query1");
@@ -118,7 +122,9 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.AssertOpen(PageType.DataSources);
     //Verify if selected tab is errors and error count is
     //Verify if selected tab is errors in tab title.
-    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_ERRORS(),
+    );
     //Verify if bottom bar is closed on clicking close icon in active datasource page.
     _.debuggerHelper.CloseBottomBar();
     _.debuggerHelper.AssertClosed();
@@ -136,7 +142,7 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.AssertOpen(PageType.Query);
     //Verify if response atb is selected on executing query.
     _.debuggerHelper.AssertSelectedTab(
-      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE(),
     );
     // clean up
     _.dataSources.DeleteQuery("Query1");

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
@@ -10,7 +10,7 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.ClickDebuggerIcon();
     _.debuggerHelper.AssertOpen(PageType.Canvas);
     //Verify if selected tab is errors in tab title.
-    _.debuggerHelper.AssertSelectedTab("Errors");
+    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
     // verify if bottom bar is closed on clicking close icon in canvas.
     _.debuggerHelper.CloseBottomBar();
     _.debuggerHelper.AssertClosed();
@@ -21,7 +21,9 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     //Verify if bottom bar opens JSEditor.
     _.debuggerHelper.AssertOpen(PageType.JsEditor);
     // Verify if selected tab is response.
-    _.debuggerHelper.AssertSelectedTab("Response");
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+    );
     //Verify if bottom bar is closed on clicking close icon in JSEditor.
     _.debuggerHelper.CloseBottomBar();
     _.debuggerHelper.AssertClosed();
@@ -29,7 +31,9 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.jsEditor.RunJSObj();
     _.debuggerHelper.AssertOpen(PageType.JsEditor);
     //verify if response tab is selected on execution JSFunction.
-    _.debuggerHelper.AssertSelectedTab("Response");
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+    );
     //verify if bottom bar is closed on switching to canvas page.
     EditorNavigation.ShowCanvas();
     _.debuggerHelper.AssertClosed();
@@ -45,13 +49,15 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.ClickDebuggerIcon();
     _.debuggerHelper.AssertOpen(PageType.API);
     //Verify if selected tab is errors in tab title.
-    _.debuggerHelper.AssertSelectedTab("Errors");
+    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
     //Verify if bottom bar is open on executing api.
     _.apiPage.RunAPI();
     _.agHelper.Sleep(1000);
     _.debuggerHelper.AssertOpen(PageType.API);
     //verify if response tab is selected on execution api.
-    _.debuggerHelper.AssertSelectedTab("Response");
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+    );
   });
 
   it("4. Bottom bar in Datasource", () => {
@@ -73,7 +79,9 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
         _.debuggerHelper.AssertOpen(PageType.DataSources);
         //Verify if selected tab is errors and error count is
         //Verify if selected tab is errors in tab title.
-        _.debuggerHelper.AssertSelectedTab("Errors");
+        _.debuggerHelper.AssertSelectedTab(
+          Cypress.env("MESSAGES").DEBUGGER_ERRORS,
+        );
         //Verify if bottom bar is closed on clicking close icon in active datasource page.
         _.debuggerHelper.CloseBottomBar();
         _.debuggerHelper.AssertClosed();
@@ -94,7 +102,9 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
         //Verify if bottom bar is open on executing query.
         _.debuggerHelper.AssertOpen(PageType.Query);
         //Verify if response atb is selected on executing query.
-        _.debuggerHelper.AssertSelectedTab("Response");
+        _.debuggerHelper.AssertSelectedTab(
+          Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+        );
         // clean up
         _.dataSources.DeleteQuery("Query1");
         _.dataSources.DeleteDatasourceFromWithinDS(dbName);
@@ -108,7 +118,7 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     _.debuggerHelper.AssertOpen(PageType.DataSources);
     //Verify if selected tab is errors and error count is
     //Verify if selected tab is errors in tab title.
-    _.debuggerHelper.AssertSelectedTab("Errors");
+    _.debuggerHelper.AssertSelectedTab(Cypress.env("MESSAGES").DEBUGGER_ERRORS);
     //Verify if bottom bar is closed on clicking close icon in active datasource page.
     _.debuggerHelper.CloseBottomBar();
     _.debuggerHelper.AssertClosed();
@@ -125,7 +135,9 @@ describe("Entity bottom bar", { tags: ["@tag.IDE"] }, () => {
     //Verify if bottom bar is open on executing query.
     _.debuggerHelper.AssertOpen(PageType.Query);
     //Verify if response atb is selected on executing query.
-    _.debuggerHelper.AssertSelectedTab("Response");
+    _.debuggerHelper.AssertSelectedTab(
+      Cypress.env("MESSAGES").DEBUGGER_RESPONSE,
+    );
     // clean up
     _.dataSources.DeleteQuery("Query1");
     cy.get("@dsName").then(($dsName) => {

--- a/app/client/cypress/support/Pages/DebuggerHelper.ts
+++ b/app/client/cypress/support/Pages/DebuggerHelper.ts
@@ -110,21 +110,7 @@ export class DebuggerHelper {
         this.agHelper.AssertElementVisibility(
           this.locators._bottomPaneContainer[pageType],
         );
-        // this.agHelper.AssertHeight(
-        //   this.locators._bottomPaneContainer[pageType],
-        //   this.bottomPaneHeight,
-        // );
         break;
-      // case PageType.Query:
-      // case PageType.DataSources:
-      //   this.agHelper.AssertElementVisibility(
-      //     this.locators._bottomPaneContainer[pageType],
-      //   );
-      //   // this.agHelper.AssertHeight(
-      //   //   this.locators._bottomPaneContainer[pageType],
-      //   //   this.bottomPaneHeight - 1, // -1 to offset error
-      //   // );
-      //   break;
     }
   }
 

--- a/app/client/cypress/support/Pages/DebuggerHelper.ts
+++ b/app/client/cypress/support/Pages/DebuggerHelper.ts
@@ -150,12 +150,7 @@ export class DebuggerHelper {
   }
 
   LogStateContains(text: string, index?: number) {
-    this.agHelper.GetNAssertContains(
-      this.locators._logState,
-      text,
-      "exist",
-      index,
-    );
+    this.agHelper.GetNAssertContains(this.locators._logState, text, "exist");
   }
 
   AssertErrorCount(count: number) {

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -540,6 +540,7 @@ export const LOGS_FILTER_OPTION_SYSTEM = () => "System logs";
 export const NO_LOGS = () => "No logs to show";
 export const NO_ERRORS = () => "No signs of trouble here!";
 export const DEBUGGER_ERRORS = () => "Errors";
+export const DEBUGGER_RESPONSE = () => "Response";
 export const DEBUGGER_LOGS = () => "Logs";
 export const INSPECT_ENTITY = () => "Inspect entity";
 export const INSPECT_ENTITY_BLANK_STATE = () => "Select an entity to inspect";

--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -14,6 +14,7 @@ import {
   createMessage,
   DEBUGGER_ERRORS,
   DEBUGGER_LOGS,
+  DEBUGGER_RESPONSE,
   EMPTY_RESPONSE_FIRST_HALF,
   EMPTY_RESPONSE_LAST_HALF,
 } from "@appsmith/constants/messages";
@@ -367,7 +368,7 @@ function ApiResponseView(props: Props) {
   const tabs: BottomTab[] = [
     {
       key: "response",
-      title: "Response",
+      title: createMessage(DEBUGGER_RESPONSE),
       panelComponent: (
         <ResponseTabWrapper>
           <ApiResponseMeta

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -17,6 +17,7 @@ import {
   createMessage,
   DEBUGGER_ERRORS,
   DEBUGGER_LOGS,
+  DEBUGGER_RESPONSE,
   EXECUTING_FUNCTION,
   NO_JS_FUNCTION_RETURN_VALUE,
   UPDATING_JS_COLLECTION,
@@ -227,7 +228,7 @@ function JSResponseView(props: Props) {
   const tabs: BottomTab[] = [
     {
       key: "response",
-      title: "Response",
+      title: createMessage(DEBUGGER_RESPONSE),
       panelComponent: (
         <>
           {(hasExecutionParseErrors ||

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -11,6 +11,7 @@ import styled from "styled-components";
 import FormRow from "components/editorComponents/FormRow";
 import {
   createMessage,
+  DEBUGGER_RESPONSE,
   DOCUMENTATION,
   DOCUMENTATION_TOOLTIP,
 } from "@appsmith/constants/messages";
@@ -246,7 +247,7 @@ export function EditorJSONtoForm(props: Props) {
     if (currentActionConfig) {
       responseTabs.push({
         key: "response",
-        title: "Response",
+        title: createMessage(DEBUGGER_RESPONSE),
         panelComponent: (
           <QueryResponseTab
             actionSource={actionSource}

--- a/app/client/src/pages/Editor/QueryEditor/QueryDebuggerTabs.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryDebuggerTabs.tsx
@@ -14,6 +14,7 @@ import { DEBUGGER_TAB_KEYS } from "components/editorComponents/Debugger/helpers"
 import {
   DEBUGGER_ERRORS,
   DEBUGGER_LOGS,
+  DEBUGGER_RESPONSE,
   createMessage,
 } from "@appsmith/constants/messages";
 import DebuggerLogs from "components/editorComponents/Debugger/DebuggerLogs";
@@ -216,7 +217,7 @@ function QueryDebuggerTabs({
   if (currentActionConfig) {
     responseTabs.unshift({
       key: "response",
-      title: "Response",
+      title: createMessage(DEBUGGER_RESPONSE),
       panelComponent: (
         <QueryResponseTab
           actionSource={actionSource}


### PR DESCRIPTION
## Description
Updated cypress tests by replacing hard coded strings with variables. Also removed unused commented code from DebuggerHelper and an extra var


Fixes #33256 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9092019864>
> Commit: e66c44b9e17a2bedb33ecf4d84b84fc6f8860fe0
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9092019864&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
