### PR TITLE
fix: WDS, increase perceived darkness of modal overlay

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -330,10 +330,10 @@ export class DarkModeTheme implements ColorModeTheme {
     // Overlay behind modal dialogue
     const color = this.bgNeutral.clone();
 
-    color.alpha = 0.5;
+    color.alpha = 0.7;
 
-    if (color.oklch.l > 0.15) {
-      color.oklch.l = 0.15;
+    if (color.oklch.l > 0.12) {
+      color.oklch.l = 0.12;
     }
 
     return color;

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -330,7 +330,7 @@ export class LightModeTheme implements ColorModeTheme {
     // Overlay behind modal dialogue
     const color = this.bgNeutral.clone();
 
-    color.alpha = 0.5;
+    color.alpha = 0.6;
 
     if (color.oklch.l > 0.15) {
       color.oklch.l = 0.15;

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -214,7 +214,7 @@ describe("bgNeutralOpacity color", () => {
     const { bgNeutralOpacity } = new DarkModeTheme(
       "oklch(0.51 0.24 279)",
     ).getColors();
-    expect(bgNeutralOpacity).toEqual("rgb(3.6355% 4.017% 7.6512% / 0.5)");
+    expect(bgNeutralOpacity).toEqual("rgb(1.7871% 1.9891% 5.049% / 0.7)");
   });
 });
 

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -231,7 +231,7 @@ describe("bgNeutralOpacity color", () => {
     const { bgNeutralOpacity } = new LightModeTheme(
       "oklch(0.51 0.24 279)",
     ).getColors();
-    expect(bgNeutralOpacity).toEqual("rgb(4.2704% 4.3279% 4.6942% / 0.5)");
+    expect(bgNeutralOpacity).toEqual("rgb(4.2704% 4.3279% 4.6942% / 0.6)");
   });
 });
 


### PR DESCRIPTION
## Description
Closes #33276 
By far the biggest impact on perceived darkness is dependent on transparency, adjusted it in light mode too just a little bit.
<img width="1392" alt="Screenshot 2024-05-15 at 10 59 31" src="https://github.com/appsmithorg/appsmith/assets/80973/27072d6b-fef5-422e-8b4e-36c678915b40">

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9092935034>
> Commit: d135655d1154590fc5889621697993b968d4b18c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9092935034&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
