### PR TITLE
chore: modify existing regex for better readability

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -20,14 +20,27 @@ public class GitUtils {
     public static final Duration RETRY_DELAY = Duration.ofSeconds(1);
     public static final Integer MAX_RETRIES = 20;
 
+    /**
+     * Pattern for validating the ssh address if that starts with a scheme
+     * Should start with ssh://
+     * may or may not have a username : e.g. ssh://domain.xy:/path/path.git
+     * username can start with any small alphabet or a _ underscore
+     * the RFC host name should have regex : ((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z0-9-]{1,63}\\.[A-Za-z]{2,6},
+     * however due to already existing leniency
+     * hostname can have all alphanumerics, -, and .  e.g. ssh://_ab-xy@ab-12.ab:/v3/newJet/ai/zilla.git
+     * the port number could be not present as well. e.g. ssh://_ab-xy@domain.com:/v3/newJet/ai/zilla
+     */
     public static final Pattern URL_PATTERN_WITH_SCHEME =
-            Pattern.compile("^ssh://git@(?<host>.+?)(:(?<port>\\d+))?/+(?<path>.+?)(\\.git)?$");
+            Pattern.compile("^ssh://([a-z_][\\w-]+@)?(?<host>[\\w-.]+?)(:(?<port>\\d*))?/+(?<path>.+?)(\\.git)?$");
 
+    /**
+     * Pattern for validating the ssh address if it strictly doesn't start with a scheme
+     * username can start with any small alphabet or a _ underscore
+     * hostname can have all alphanumerics, -, and .  e.g. ssh://_ab-xy@ab-12.ab:/v3/newJet/ai/zilla.git
+     * the port number could be not present as well. e.g. ssh://_ab-xy@domain.com:/v3/newJet/ai/zilla
+     */
     public static final Pattern URL_PATTERN_WITHOUT_SCHEME =
-            Pattern.compile("^git@(?<host>.+?):/*(?<path>.+?)(\\.git)?$");
-
-    public static final Pattern URL_PATTERN_WITH_CUSTOM_USERNAME =
-            Pattern.compile("^(ssh://)?[a-zA-Z0-9]+@(?<host>.+?):/*(?<path>.+?)(\\\\.git)?$");
+            Pattern.compile("^[a-z_][\\w-]+@(?<host>[\\w-.]+?):/*(?<path>.+?)(\\.git)?$");
 
     /**
      * Sample repo urls :
@@ -46,10 +59,6 @@ public class GitUtils {
         Matcher match = URL_PATTERN_WITH_SCHEME.matcher(sshUrl);
         if (!match.matches()) {
             match = URL_PATTERN_WITHOUT_SCHEME.matcher(sshUrl);
-        }
-
-        if (!match.matches()) {
-            match = URL_PATTERN_WITH_CUSTOM_USERNAME.matcher(sshUrl);
         }
 
         if (!match.matches()) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -31,7 +31,7 @@ public class GitUtils {
      * the port number could be not present as well. e.g. ssh://_ab-xy@domain.com:/v3/newJet/ai/zilla
      */
     public static final Pattern URL_PATTERN_WITH_SCHEME =
-            Pattern.compile("^ssh://([a-z_][\\w-]+@)?(?<host>[\\w-.]+?)(:(?<port>\\d*))?/+(?<path>.+?)(\\.git)?$");
+            Pattern.compile("^ssh://([a-z_][\\w-]+@)?(?<host>[\\w-.]+)(:(?<port>\\d*))?/+(?<path>.+?)(\\.git)?$");
 
     /**
      * Pattern for validating the ssh address if it strictly doesn't start with a scheme
@@ -40,7 +40,7 @@ public class GitUtils {
      * the port number could be not present as well. e.g. ssh://_ab-xy@domain.com:/v3/newJet/ai/zilla
      */
     public static final Pattern URL_PATTERN_WITHOUT_SCHEME =
-            Pattern.compile("^[a-z_][\\w-]+@(?<host>[\\w-.]+?):/*(?<path>.+?)(\\.git)?$");
+            Pattern.compile("^[a-z_][\\w-]+@(?<host>[\\w-.]+):/*(?<path>.+?)(\\.git)?$");
 
     /**
      * Sample repo urls :

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -3,6 +3,7 @@ package com.appsmith.server.helpers;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.AutoCommitConfig;
 import com.appsmith.server.domains.GitArtifactMetadata;
+import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -62,12 +63,27 @@ public class GitUtilsTest {
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
 
         // custom ssh username:
-        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("abc-xy@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
                 .isEqualTo("https://vs-ssh.visualstudio.com/v3/newJet/ai/zilla");
 
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
-                        "ssh://custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
+                        "ssh://cust-om@vs-ssh.visualstudio.com:/v3/newJet/ai/zilla.git"))
                 .isEqualTo("https://vs-ssh.visualstudio.com/v3/newJet/ai/zilla");
+
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("ssh://xy-ab@sub.domain.xy:/v3/xy-ab/path/path.git"))
+                .isEqualTo("https://sub.domain.xy/v3/xy-ab/path/path");
+
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("ssh://domain.xy:/path/path.git"))
+                .isEqualTo("https://domain.xy/path/path");
+
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("ssh://user@domain.com/repopath.git"))
+                .isEqualTo("https://domain.com/repopath");
+
+        AppsmithException exception = assertThrows(
+                AppsmithException.class,
+                () -> GitUtils.convertSshUrlToBrowserSupportedUrl(
+                        "ssh://cust-om@vs-ssh.visualstudio.com:v3/newJet/ai/zilla.git"));
+        assertThat(exception.getAppErrorCode()).isEqualTo(AppsmithError.INVALID_GIT_CONFIGURATION.getAppErrorCode());
     }
 
     @Test
@@ -144,8 +160,13 @@ public class GitUtilsTest {
         assertThat(GitUtils.getRepoName("custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
                 .isEqualTo("zilla");
 
-        assertThat(GitUtils.getRepoName("ssh://custom@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))
+        assertThat(GitUtils.getRepoName("ssh://custom@vs-ssh.visualstudio.com:/v3/newJet/ai/zilla"))
                 .isEqualTo("zilla");
+
+        assertThat(GitUtils.getRepoName("ssh://xy-ab@sub.domain.xy:/v3/xy-ab/path/path.git"))
+                .isEqualTo("path");
+
+        assertThat(GitUtils.getRepoName("ssh://domain.xy:/path/path.git")).isEqualTo("path");
     }
 
     @Test


### PR DESCRIPTION
## Description
 - removed of additional fallback patterns for identifying the ssh address for git connect
 - modified the existing regexes to be more precise. 


Fixes #19881

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9107246042>
> Commit: 6466e53ad5a5cfb1e2eca65af5d9f41a9f5f83b0
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9107246042&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
