### PR TITLE
[Prototype] Anvil widget name component fixes

### DIFF
--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/AnvilWidgetNameComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/AnvilWidgetNameComponent.tsx
@@ -1,4 +1,4 @@
-import type { ForwardedRef } from "react";
+import type { CSSProperties, ForwardedRef } from "react";
 import React, { forwardRef, useCallback, useMemo } from "react";
 import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
@@ -10,6 +10,25 @@ import {
 import { createMessage } from "@appsmith/constants/messages";
 import { debugWidget } from "layoutSystems/anvil/integrations/actions";
 import { useDispatch } from "react-redux";
+import styled from "styled-components";
+
+const styles: CSSProperties = {
+  display: "inline-flex",
+  height: "32px", // This is 2px more than the ones in the designs.
+  width: "max-content",
+  position: "fixed",
+  top: 0,
+  left: 0,
+  visibility: "hidden",
+  isolation: "isolate",
+  background: "transparent",
+};
+
+const SplitButtonWrapper = styled.div`
+  & > div {
+    margin-block-end: 8px;
+  }
+`;
 
 /**
  *
@@ -72,16 +91,21 @@ export function _AnvilWidgetNameComponent(
   }, [props.showError, handleDebugClick]);
 
   return (
-    <SplitButton
-      bGCSSVar={props.bGCSSVar}
-      colorCSSVar={props.colorCSSVar}
-      leftToggle={leftToggle}
-      onClick={handleSelectWidget}
+    <SplitButtonWrapper
+      draggable
       onDragStart={props.onDragStart}
       ref={ref}
-      rightToggle={rightToggle}
-      text={props.name}
-    />
+      style={styles}
+    >
+      <SplitButton
+        bGCSSVar={props.bGCSSVar}
+        colorCSSVar={props.colorCSSVar}
+        leftToggle={leftToggle}
+        onClick={handleSelectWidget}
+        rightToggle={rightToggle}
+        text={props.name}
+      />
+    </SplitButtonWrapper>
   );
 }
 

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/SplitButton.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/SplitButton.tsx
@@ -1,19 +1,7 @@
-import type { ForwardedRef, CSSProperties } from "react";
-import React, { forwardRef } from "react";
+import React from "react";
 import styled from "styled-components";
 import { UpArrowSVG } from "./UpArrowIcon";
 import { ErrorSVG } from "./ErrorIcon";
-
-const styles: CSSProperties = {
-  display: "inline-flex",
-  height: "24px", // This is 2px more than the ones in the designs.
-  width: "max-content",
-  position: "fixed",
-  top: 0,
-  left: 0,
-  visibility: "hidden",
-  isolation: "isolate",
-};
 
 const SplitButtonWrapper = styled.div<{
   $BGCSSVar: string;
@@ -25,6 +13,9 @@ const SplitButtonWrapper = styled.div<{
   color: var(${(props) => props.$ColorCSSVar});
   fill: var(${(props) => props.$ColorCSSVar});
   stroke: var(${(props) => props.$ColorCSSVar});
+  height: 24px;
+  width: max-content;
+  display: inline-flex;
 
   touch-action: manipulation;
   user-select: none;
@@ -32,7 +23,7 @@ const SplitButtonWrapper = styled.div<{
   gap: 1px;
 
   & button {
-    cursor: pointer;
+    cursor: grab;
     appearance: none;
     background: none;
     border: none;
@@ -47,8 +38,9 @@ const SplitButtonWrapper = styled.div<{
     font-size: inherit;
     font-weight: 500;
 
-    padding-block: 1.25ch;
-    padding-inline: 2ch;
+    padding-block: 3px;
+    padding-inline: 5px;
+    line-height: 17px;
 
     color: var(${(props) => props.$ColorCSSVar});
     outline-color: var(${(props) => props.$BGCSSVar});
@@ -62,7 +54,8 @@ const SplitButtonWrapper = styled.div<{
   }
 
   & span {
-    inline-size: 3ch;
+    inline-size: 2.4ch;
+    block-size: 100%;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
@@ -85,10 +78,10 @@ const SplitButtonWrapper = styled.div<{
     &:active {
       filter: brightness(0.6);
     }
-  }
 
-  & > svg {
-    stroke: var(${(props) => props.$ColorCSSVar});
+    & > svg {
+      stroke: var(${(props) => props.$ColorCSSVar});
+    }
   }
 
   & span:nth-of-type(${(props) => (props.$isLeftToggleDisabled ? 1 : 2)}) {
@@ -100,36 +93,28 @@ const SplitButtonWrapper = styled.div<{
   }
 `;
 
-export function _SplitButton(
-  props: {
-    text: string;
+export function SplitButton(props: {
+  text: string;
+  onClick: React.MouseEventHandler;
+  bGCSSVar: string;
+  colorCSSVar: string;
+  leftToggle: {
+    disable: boolean;
     onClick: React.MouseEventHandler;
-    bGCSSVar: string;
-    colorCSSVar: string;
-    leftToggle: {
-      disable: boolean;
-      onClick: React.MouseEventHandler;
-      title: string;
-    };
-    rightToggle: {
-      disable: boolean;
-      onClick: React.MouseEventHandler;
-      title: string;
-    };
-    onDragStart: React.DragEventHandler;
-  },
-  ref: ForwardedRef<HTMLDivElement>,
-) {
+    title: string;
+  };
+  rightToggle: {
+    disable: boolean;
+    onClick: React.MouseEventHandler;
+    title: string;
+  };
+}) {
   return (
     <SplitButtonWrapper
       $BGCSSVar={props.bGCSSVar}
       $ColorCSSVar={props.colorCSSVar}
       $isLeftToggleDisabled={props.leftToggle.disable}
       $isRightToggleDisabled={props.rightToggle.disable}
-      draggable
-      onDragStart={props.onDragStart}
-      ref={ref}
-      style={styles}
     >
       {!props.leftToggle.disable && (
         <span
@@ -155,5 +140,3 @@ export function _SplitButton(
     </SplitButtonWrapper>
   );
 }
-
-export const SplitButton = forwardRef(_SplitButton);

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/utils.ts
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/utils.ts
@@ -65,44 +65,47 @@ export function handleWidgetUpdate(
   widgetsEditorElement: HTMLDivElement,
   nameComponentState: NameComponentStates,
 ) {
-  return autoUpdate(widgetElement, widgetNameComponent, () => {
-    computePosition(widgetElement as HTMLDivElement, widgetNameComponent, {
-      placement: "top-start",
-      strategy: "fixed",
-      middleware: [
-        flip(),
-        shift(),
-        offset({ mainAxis: 8, crossAxis: -5 }),
-        getOverflowMiddleware(widgetsEditorElement as HTMLDivElement),
-        hide({ strategy: "referenceHidden" }),
-        hide({ strategy: "escaped" }),
-      ],
-    }).then(({ middlewareData, x, y }) => {
-      let shiftOffset = 0;
-      if (middlewareData.containWithinCanvas.overflowAmount > 0) {
-        shiftOffset = middlewareData.containWithinCanvas.overflowAmount + 5;
-      }
+  return autoUpdate(
+    widgetElement,
+    widgetNameComponent,
+    () => {
+      computePosition(widgetElement as HTMLDivElement, widgetNameComponent, {
+        placement: "top-start",
+        strategy: "fixed",
+        middleware: [
+          flip(),
+          shift(),
+          offset({ mainAxis: 0, crossAxis: -5 }),
+          getOverflowMiddleware(widgetsEditorElement as HTMLDivElement),
+          hide({ strategy: "referenceHidden" }),
+          hide({ strategy: "escaped" }),
+        ],
+      }).then(({ middlewareData, x, y }) => {
+        let shiftOffset = 0;
+        if (middlewareData.containWithinCanvas.overflowAmount > 0) {
+          shiftOffset = middlewareData.containWithinCanvas.overflowAmount + 5;
+        }
 
-      Object.assign(widgetNameComponent.style, {
-        left: `${x - shiftOffset}px`,
-        top: `${y}px`,
-        visibility:
-          nameComponentState === "none" || middlewareData.hide?.referenceHidden
-            ? "hidden"
-            : "visible",
-        zIndex:
-          nameComponentState === "focus"
-            ? "calc(var(--on-canvas-ui-zindex) + 1)"
-            : "var(--on-canvas-ui-zindex)",
+        Object.assign(widgetNameComponent.style, {
+          left: `${x - shiftOffset}px`,
+          top: `${y}px`,
+          visibility: "visible",
+          zIndex:
+            nameComponentState === "focus"
+              ? "calc(var(--on-canvas-ui-zindex) + 1)"
+              : "var(--on-canvas-ui-zindex)",
+        });
       });
-    });
-  });
+    },
+    { animationFrame: true },
+  );
 }
 
 export function getWidgetNameComponentStyleProps(
   widgetType: string,
   nameComponentState: NameComponentStates,
   showError: boolean,
+  isParentSelected: boolean,
 ) {
   const config = WidgetFactory.getConfig(widgetType);
   const onCanvasUI = config?.onCanvasUI || {
@@ -121,11 +124,6 @@ export function getWidgetNameComponentStyleProps(
       ? onCanvasUI.focusColorCSSVar
       : onCanvasUI.selectionColorCSSVar;
 
-  let disableParentToggle = onCanvasUI.disableParentSelection;
-  if (nameComponentState === "focus") {
-    disableParentToggle = true;
-  }
-
   // If there is an error, show the widget name in error state
   // This includes background being the error color
   // and font color being white.
@@ -134,7 +132,7 @@ export function getWidgetNameComponentStyleProps(
     colorCSSVar = "--on-canvas-ui-white";
   }
   return {
-    disableParentToggle,
+    disableParentToggle: isParentSelected || onCanvasUI.disableParentSelection,
     bGCSSVar,
     colorCSSVar,
     selectionBGCSSVar: onCanvasUI.selectionBGCSSVar,

--- a/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetHover.ts
+++ b/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetHover.ts
@@ -47,7 +47,7 @@ export const useAnvilWidgetHover = (
   // Callback function for handling mouseleave events
   const handleMouseLeave = useCallback(() => {
     // On leaving a widget, reset the focused widget
-    focusWidget && focusWidget();
+    // focusWidget && focusWidget();
   }, [focusWidget]);
 
   // Effect hook to add and remove mouseover and mouseleave event listeners

--- a/app/client/src/pages/Editor/Canvas.tsx
+++ b/app/client/src/pages/Editor/Canvas.tsx
@@ -2,7 +2,7 @@ import log from "loglevel";
 import React from "react";
 import styled from "styled-components";
 import * as Sentry from "@sentry/react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import type { CanvasWidgetStructure } from "WidgetProvider/constants";
 import useWidgetFocus from "utils/hooks/useWidgetFocus";
 import { combinedPreviewModeSelector } from "selectors/editorSelectors";
@@ -19,6 +19,7 @@ import type { WidgetProps } from "widgets/BaseWidget";
 import { getAppThemeSettings } from "@appsmith/selectors/applicationSelectors";
 import CodeModeTooltip from "pages/Editor/WidgetsEditor/components/CodeModeTooltip";
 import { getIsAnvilLayout } from "layoutSystems/anvil/integrations/selectors";
+import { focusWidget } from "actions/widgetActions";
 
 interface CanvasProps {
   widgetsStructure: CanvasWidgetStructure;
@@ -64,6 +65,10 @@ const Canvas = (props: CanvasProps) => {
   // so that fixedLayout theme does not break because of calculations done in useTheme
   const { theme } = useTheme(isAnvilLayout ? wdsThemeProps : {});
 
+  const dispatch = useDispatch();
+  const deselectAllWidgets = () => {
+    dispatch(focusWidget());
+  };
   /**
    * background for canvas
    */
@@ -93,6 +98,7 @@ const Canvas = (props: CanvasProps) => {
           )}`}
           data-testid={"t--canvas-artboard"}
           id={CANVAS_ART_BOARD}
+          onMouseLeave={deselectAllWidgets}
           ref={isAnvilLayout ? undefined : focusRef}
           width={canvasWidth}
         >


### PR DESCRIPTION
- Fix padding of widget name component
- Make sure users can hover and drag a focused widget from the widget name component
- Refresh widget name component more frequently to prevent glitchiness when scrolling

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
