### PR TITLE
fix: added serialization for LicenseCE

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/LicenseCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/LicenseCE.java
@@ -3,7 +3,9 @@ package com.appsmith.server.domains.ce;
 import com.appsmith.server.constants.LicensePlan;
 import lombok.Data;
 
+import java.io.Serializable;
+
 @Data
-public class LicenseCE {
+public class LicenseCE implements Serializable {
     LicensePlan plan;
 }


### PR DESCRIPTION
## Description
After merging the PR https://github.com/appsmithorg/appsmith/pull/33309, we started to store the Tenant Information in the Redis cache. Redis needs to serialize the objects upon storing and deserialize post fetching.
To do that we need to implement serialization for all the nested user defined Domains.
This was missed for the LicenseCE and Payment object.
Corresponding EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4191

Fixes #33486   

## Automation

/ok-to-test tags="@tag.Settings, @tag.LicenseAndBilling"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9096922670>
> Commit: 559bcd6ef3559e2568369bc5ed65304915802f7c
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9096922670&attempt=3&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/ProductRamps/PrivateEmbedRamp_spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
