### PR TITLE
fix: Adjust WDS button font weight

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Button/src/Button.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Button/src/Button.tsx
@@ -33,7 +33,7 @@ const _Button = (props: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
         <span aria-hidden={isLoading ? true : undefined} data-content="">
           {icon && <Icon name={icon} size={size as keyof typeof SIZES} />}
           {Boolean(children) && (
-            <Text data-text="" fontWeight={600} lineClamp={1}>
+            <Text data-text="" fontWeight={500} lineClamp={1}>
               {children}
             </Text>
           )}


### PR DESCRIPTION
## Description
Fixes #33481 
More follow-ups may be in order, but on buttons it really stood out (especially in dark mode, we should consider different weights for different light modes in the future).

| Before | After |
|--------|--------|
| ![Screenshot 2024-05-15 at 16-40-23 Untitled application 1 Editor Appsmith](https://github.com/appsmithorg/appsmith/assets/80973/bc941bf1-2e19-4ce0-a0f6-72bb9e1f0b6e) | ![Screenshot 2024-05-15 at 16-38-32 Untitled application 1 Editor Appsmith](https://github.com/appsmithorg/appsmith/assets/80973/7ffdea83-267b-4ba0-9d4e-3bcdb801d6e1) |
| ![Screenshot 2024-05-15 at 16-40-09 Untitled application 1 Editor Appsmith](https://github.com/appsmithorg/appsmith/assets/80973/eef64705-9b43-48b4-91e0-5b92af3dde11) | ![Screenshot 2024-05-15 at 16-38-56 Untitled application 1 Editor Appsmith](https://github.com/appsmithorg/appsmith/assets/80973/a25e0eb1-dcef-42e0-a022-ebe461f7d11e) |

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9097777062>
> Commit: 22bfd39789137204508bcc699cd9eed3abed7180
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9097777062&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
