### PR TITLE
chore: remove cypress hardcoded strings and waits

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/SwitchBranches_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/SwitchBranches_spec.js
@@ -23,7 +23,7 @@ let parentBranchKey = "ParentBranch",
   branchQueryKey = "branch";
 
 let repoName;
-describe("Git sync:", { tags: ["@tag.Git"] }, function () {
+describe("Git sync:", { tags: ["@tag.Git"] }, function() {
   before(() => {
     gitSync.CreateNConnectToGit();
     cy.get("@gitRepoName").then((repName) => {
@@ -31,7 +31,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function () {
     });
   });
 
-  it("1. create branch input", function () {
+  it("1. create branch input", function() {
     PageLeftPane.switchSegment(PagePaneSegment.UI);
     cy.get(gitSyncLocators.branchButton).click();
 
@@ -59,7 +59,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function () {
     cy.get(gitSyncLocators.closeBranchList).click();
   });
 
-  it("2. creates a new branch and create branch specific resources", function () {
+  it("2. creates a new branch and create branch specific resources", function() {
     cy.get(commonLocators.canvas).click({ force: true });
     //cy.createGitBranch(parentBranchKey);
     gitSync.CreateGitBranch(parentBranchKey, true);
@@ -114,7 +114,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function () {
   });
 
   // rename entities
-  it("3. makes branch specific resource updates", function () {
+  it("3. makes branch specific resource updates", function() {
     cy.switchGitBranch(childBranchKey);
     EditorNavigation.SelectEntityByName("ParentPage1", EntityType.Page);
     entityExplorer.RenameEntityFromExplorer(
@@ -123,7 +123,10 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function () {
       false,
       EntityItems.Page,
     );
-    agHelper.RemoveUIElement("Tooltip", "Add a new query/JS Object");
+    agHelper.RemoveUIElement(
+      "Tooltip",
+      Cypress.env("MESSAGES").ADD_QUERY_JS_TOOLTIP(),
+    );
     PageLeftPane.switchSegment(PagePaneSegment.Queries);
     entityExplorer.RenameEntityFromExplorer("ParentApi1", "ParentApiRenamed");
 
@@ -215,7 +218,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function () {
   });
 
   // Validate the error faced when user switches between the branches
-  it("6. no error faced when user switches branch with new page", function () {
+  it("6. no error faced when user switches branch with new page", function() {
     deployMode.NavigateBacktoEditor(); //Adding since skipping 6th case
     cy.generateUUID().then((uuid) => {
       gitSync.CreateGitBranch(childBranchKey, true);
@@ -233,7 +236,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function () {
     agHelper.RefreshPage();
   });
 
-  it("7. branch list search", function () {
+  it("7. branch list search", function() {
     cy.get(".ads-v2-spinner").should("not.exist");
     PageLeftPane.switchSegment(PagePaneSegment.UI);
     cy.get(commonLocators.canvas).click({ force: true });

--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/SwitchBranches_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/SwitchBranches_spec.js
@@ -23,7 +23,7 @@ let parentBranchKey = "ParentBranch",
   branchQueryKey = "branch";
 
 let repoName;
-describe("Git sync:", { tags: ["@tag.Git"] }, function() {
+describe("Git sync:", { tags: ["@tag.Git"] }, function () {
   before(() => {
     gitSync.CreateNConnectToGit();
     cy.get("@gitRepoName").then((repName) => {
@@ -31,7 +31,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function() {
     });
   });
 
-  it("1. create branch input", function() {
+  it("1. create branch input", function () {
     PageLeftPane.switchSegment(PagePaneSegment.UI);
     cy.get(gitSyncLocators.branchButton).click();
 
@@ -59,7 +59,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function() {
     cy.get(gitSyncLocators.closeBranchList).click();
   });
 
-  it("2. creates a new branch and create branch specific resources", function() {
+  it("2. creates a new branch and create branch specific resources", function () {
     cy.get(commonLocators.canvas).click({ force: true });
     //cy.createGitBranch(parentBranchKey);
     gitSync.CreateGitBranch(parentBranchKey, true);
@@ -114,7 +114,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function() {
   });
 
   // rename entities
-  it("3. makes branch specific resource updates", function() {
+  it("3. makes branch specific resource updates", function () {
     cy.switchGitBranch(childBranchKey);
     EditorNavigation.SelectEntityByName("ParentPage1", EntityType.Page);
     entityExplorer.RenameEntityFromExplorer(
@@ -218,7 +218,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function() {
   });
 
   // Validate the error faced when user switches between the branches
-  it("6. no error faced when user switches branch with new page", function() {
+  it("6. no error faced when user switches branch with new page", function () {
     deployMode.NavigateBacktoEditor(); //Adding since skipping 6th case
     cy.generateUUID().then((uuid) => {
       gitSync.CreateGitBranch(childBranchKey, true);
@@ -236,7 +236,7 @@ describe("Git sync:", { tags: ["@tag.Git"] }, function() {
     agHelper.RefreshPage();
   });
 
-  it("7. branch list search", function() {
+  it("7. branch list search", function () {
     cy.get(".ads-v2-spinner").should("not.exist");
     PageLeftPane.switchSegment(PagePaneSegment.UI);
     cy.get(commonLocators.canvas).click({ force: true });

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_Editor_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_Editor_spec.js
@@ -9,7 +9,7 @@ import {
   dataSources,
 } from "../../../../support/Objects/ObjectsCore";
 
-describe("Undo/Redo functionality", function() {
+describe("Undo/Redo functionality", function () {
   const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
   let postgresDatasourceName;
 
@@ -43,7 +43,7 @@ describe("Undo/Redo functionality", function() {
     });
   });
 
-  it("2. Checks undo/redo for Api pane", function() {
+  it("2. Checks undo/redo for Api pane", function () {
     cy.CreateAPI("FirstAPI");
     cy.get(`${apiwidget.resourceUrl} .CodeMirror-placeholder`).should(
       "have.text",

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_Editor_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_Editor_spec.js
@@ -9,7 +9,7 @@ import {
   dataSources,
 } from "../../../../support/Objects/ObjectsCore";
 
-describe("Undo/Redo functionality", function () {
+describe("Undo/Redo functionality", function() {
   const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
   let postgresDatasourceName;
 
@@ -43,14 +43,17 @@ describe("Undo/Redo functionality", function () {
     });
   });
 
-  it("2. Checks undo/redo for Api pane", function () {
+  it("2. Checks undo/redo for Api pane", function() {
     cy.CreateAPI("FirstAPI");
     cy.get(`${apiwidget.resourceUrl} .CodeMirror-placeholder`).should(
       "have.text",
       "https://mock-api.appsmith.com/users", //testing placeholder!
     );
     cy.enterDatasourceAndPath(testdata.baseUrl, testdata.methods);
-    agHelper.RemoveUIElement("Tooltip", "Add a new query/JS Object");
+    agHelper.RemoveUIElement(
+      "Tooltip",
+      Cypress.env("MESSAGES").ADD_QUERY_JS_TOOLTIP(),
+    );
     cy.get(`${apiwidget.headerKey}`).type("Authorization");
     cy.get("body").click(0, 0);
     cy.get(apiwidget.settings).click({ force: true });

--- a/app/client/cypress/support/Pages/ApiPage.ts
+++ b/app/client/cypress/support/Pages/ApiPage.ts
@@ -105,7 +105,10 @@ export class ApiPage {
       PageLeftPane.switchSegment(PagePaneSegment.Queries);
       this.agHelper.GetHoverNClick(this.locator._createNew);
       this.agHelper.GetNClick(this._blankAPI, 0, true);
-      this.agHelper.RemoveUIElement("Tooltip", "Add a new query/JS Object");
+      this.agHelper.RemoveUIElement(
+        "Tooltip",
+        Cypress.env("MESSAGES").ADD_QUERY_JS_TOOLTIP(),
+      );
     }
     this.assertHelper.AssertNetworkStatus("@createNewApi", 201);
 

--- a/app/client/cypress/support/Pages/ApiPage.ts
+++ b/app/client/cypress/support/Pages/ApiPage.ts
@@ -141,7 +141,7 @@ export class ApiPage {
   ) {
     this.CreateApi(apiName, apiVerb, aftDSSaved);
     this.EnterURL(url, "", toVerifySave);
-    this.agHelper.Sleep(); //Is needed for the entered url value to be registered, else failing locally & CI
+    this.assertHelper.AssertNetworkStatus("@saveAction", 200);
     this.AssertRunButtonDisability();
     if (queryTimeout != 10000) this.SetAPITimeout(queryTimeout, toVerifySave);
   }

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -107,7 +107,10 @@ export class JSEditor {
     PageLeftPane.switchSegment(PagePaneSegment.JS);
     cy.get(this._newJSobj).eq(0).click({ force: true });
 
-    this.agHelper.RemoveUIElement("Tooltip", "Add a new query/JS Object");
+    this.agHelper.RemoveUIElement(
+      "Tooltip",
+      Cypress.env("MESSAGES").ADD_QUERY_JS_TOOLTIP(),
+    );
     //Checking JS object was created successfully
     this.assertHelper.AssertNetworkStatus("@jsCollections", 200);
     this.agHelper.AssertElementVisibility(this._jsObjTxt);


### PR DESCRIPTION
## Description
Removed some hardcoded strings and static waits


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS, @tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9107889730>
> Commit: 9afff27a153f3c6cf47a016b2a8e5c46bc3ee10d
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9107889730&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
