### PR TITLE
fix: Gsheet UI breaking in 110% zoom level

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -308,7 +308,7 @@ export function EditorJSONtoForm(props: Props) {
         />
         {notification}
         <Wrapper>
-          <div className="flex flex-1">
+          <div className="flex flex-1 w-full">
             <SecondaryWrapper>
               <TabContainerView>
                 <Tabs


### PR DESCRIPTION
## Description

This PR fix the buttons and text getting cut off when the zoom level is changed for gsheet query.


Fixes #31381  


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9111892238>
> Commit: d7f3c8c96417e5d134f9b6fa274029f1e9340aff
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9111892238&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
