### PR TITLE
feat: use zone elevatedBackground evaluated values and upgrade space distribution ux of borderless zones.

### DIFF
--- a/app/client/src/layoutSystems/anvil/common/hooks/useWidgetBorderStyles.ts
+++ b/app/client/src/layoutSystems/anvil/common/hooks/useWidgetBorderStyles.ts
@@ -4,12 +4,17 @@ import { getWidgetErrorCount } from "layoutSystems/anvil/editor/AnvilWidgetName/
 import {
   getAnvilHighlightShown,
   getAnvilSpaceDistributionStatus,
+  getWidgetsDistributingSpace,
 } from "layoutSystems/anvil/integrations/selectors";
 import { useSelector } from "react-redux";
 import { combinedPreviewModeSelector } from "selectors/editorSelectors";
 import { isWidgetFocused, isWidgetSelected } from "selectors/widgetSelectors";
 
-export function useWidgetBorderStyles(widgetId: string, widgetType: string) {
+export function useWidgetBorderStyles(
+  widgetId: string,
+  widgetType: string,
+  elevatedBackground?: boolean,
+) {
   /** Selectors */
   const isFocused = useSelector(isWidgetFocused(widgetId));
   const isSelected = useSelector(isWidgetSelected(widgetId));
@@ -28,7 +33,9 @@ export function useWidgetBorderStyles(widgetId: string, widgetType: string) {
   const isDistributingSpace: boolean = useSelector(
     getAnvilSpaceDistributionStatus,
   );
-
+  const widgetsEffectedBySpaceDistribution = useSelector(
+    getWidgetsDistributingSpace,
+  );
   const isPreviewMode = useSelector(combinedPreviewModeSelector);
 
   /** EO selectors */
@@ -37,11 +44,13 @@ export function useWidgetBorderStyles(widgetId: string, widgetType: string) {
   if (isPreviewMode) {
     return {};
   }
-
+  const isBorderLessZoneOfDistributingSection =
+    widgetsEffectedBySpaceDistribution.zones.includes(widgetId) &&
+    !elevatedBackground;
   // Show the border if the widget has widgets being dragged or redistributed inside it
   const showDraggedOnBorder =
     (highlightShown && highlightShown.canvasId === widgetId) ||
-    (isDistributingSpace && isSelected);
+    isBorderLessZoneOfDistributingSection;
 
   const onCanvasUI = WidgetFactory.getConfig(widgetType)?.onCanvasUI;
 

--- a/app/client/src/layoutSystems/anvil/editor/AnvilEditorFlexComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilEditorFlexComponent.tsx
@@ -47,6 +47,7 @@ export const AnvilEditorFlexComponent = (props: AnvilFlexComponentProps) => {
     props.widgetName,
     props.isVisible,
     props.widgetType,
+    !!props.elevatedBackground,
     ref,
   );
   useAnvilWidgetDrag(props.widgetId, props.widgetType, props.layoutId, ref);

--- a/app/client/src/layoutSystems/anvil/editor/AnvilEditorWidgetOnion.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilEditorWidgetOnion.tsx
@@ -35,6 +35,7 @@ export const AnvilEditorWidgetOnion = (props: BaseWidgetProps) => {
   }, [isPreviewMode]);
   return (
     <WidgetWrapper
+      elevatedBackground={!!props.elevatedBackground}
       flexGrow={props.flexGrow}
       isVisible={!!props.isVisible}
       layoutId={props.layoutId}

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/selectors.ts
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/selectors.ts
@@ -4,7 +4,10 @@ import { EVAL_ERROR_PATH } from "utils/DynamicBindingUtils";
 import get from "lodash/get";
 import { createSelector } from "reselect";
 import { getIsDragging } from "selectors/widgetDragSelectors";
-import { getAnvilHighlightShown } from "layoutSystems/anvil/integrations/selectors";
+import {
+  getAnvilHighlightShown,
+  getAnvilSpaceDistributionStatus,
+} from "layoutSystems/anvil/integrations/selectors";
 import { isWidgetFocused, isWidgetSelected } from "selectors/widgetSelectors";
 import { isEditOnlyModeSelector } from "selectors/editorSelectors";
 
@@ -58,14 +61,16 @@ export function shouldSelectOrFocus(widgetId: string) {
     getAnvilHighlightShown,
     isWidgetSelected(widgetId),
     isWidgetFocused(widgetId),
+    getAnvilSpaceDistributionStatus,
     (
       isEditorOpen,
       isDragging,
       highlightShown,
       isWidgetSelected,
       isWidgetFocused,
+      isDistributingSpace,
     ) => {
-      const baseCondition = isEditorOpen && !isDragging;
+      const baseCondition = isEditorOpen && !isDragging && !isDistributingSpace;
       let onCanvasUIState: NameComponentStates = "none";
       if (baseCondition) {
         if (isWidgetSelected) onCanvasUIState = "select";

--- a/app/client/src/layoutSystems/anvil/editor/canvas/AnvilEditorCanvas.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/canvas/AnvilEditorCanvas.tsx
@@ -3,16 +3,14 @@ import { AnvilViewerCanvas } from "layoutSystems/anvil/viewer/canvas/AnvilViewer
 import React, { useCallback, useEffect, useRef } from "react";
 import { useSelectWidgetListener } from "./hooks/useSelectWidgetListener";
 import { useClickToClearSelections } from "./hooks/useClickToClearSelections";
-import {
-  useAnvilGlobalDnDStates,
-  type AnvilGlobalDnDStates,
-} from "./hooks/useAnvilGlobalDnDStates";
+import type { AnvilGlobalDnDStates } from "./hooks/useAnvilGlobalDnDStates";
+import { useAnvilGlobalDnDStates } from "./hooks/useAnvilGlobalDnDStates";
 import { AnvilDragPreview } from "../canvasArenas/AnvilDragPreview";
+import { AnvilWidgetElevationProvider } from "./providers/AnvilWidgetElevationProvider";
 
 export const AnvilDnDStatesContext = React.createContext<
   AnvilGlobalDnDStates | undefined
 >(undefined);
-
 /**
  * Anvil Main Canvas is just a wrapper around AnvilCanvas.
  * Why do we need this?
@@ -58,14 +56,16 @@ export const AnvilEditorCanvas = (props: BaseWidgetProps) => {
   // using AnvilDnDStatesContext to provide the states to the child AnvilDraggingArena
   const anvilGlobalDnDStates = useAnvilGlobalDnDStates();
   return (
-    <AnvilDnDStatesContext.Provider value={anvilGlobalDnDStates}>
-      <AnvilViewerCanvas {...props} ref={canvasRef} />
-      <AnvilDragPreview
-        dragDetails={anvilGlobalDnDStates.dragDetails}
-        draggedBlocks={anvilGlobalDnDStates.draggedBlocks}
-        isDragging={anvilGlobalDnDStates.isDragging}
-        isNewWidget={anvilGlobalDnDStates.isNewWidget}
-      />
-    </AnvilDnDStatesContext.Provider>
+    <AnvilWidgetElevationProvider>
+      <AnvilDnDStatesContext.Provider value={anvilGlobalDnDStates}>
+        <AnvilViewerCanvas {...props} ref={canvasRef} />
+        <AnvilDragPreview
+          dragDetails={anvilGlobalDnDStates.dragDetails}
+          draggedBlocks={anvilGlobalDnDStates.draggedBlocks}
+          isDragging={anvilGlobalDnDStates.isDragging}
+          isNewWidget={anvilGlobalDnDStates.isNewWidget}
+        />
+      </AnvilDnDStatesContext.Provider>
+    </AnvilWidgetElevationProvider>
   );
 };

--- a/app/client/src/layoutSystems/anvil/editor/canvas/hooks/useAnvilWidgetElevationSetter.ts
+++ b/app/client/src/layoutSystems/anvil/editor/canvas/hooks/useAnvilWidgetElevationSetter.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useAnvilWidgetElevation } from "../providers/AnvilWidgetElevationProvider";
+
+export const useAnvilWidgetElevationSetter = (
+  widgetId: string,
+  elevatedBackground: boolean,
+) => {
+  const anvilWidgetElevation = useAnvilWidgetElevation();
+  const { setWidgetElevation } = anvilWidgetElevation || {};
+  useEffect(() => {
+    if (setWidgetElevation) {
+      setWidgetElevation(widgetId, elevatedBackground);
+    }
+  }, [elevatedBackground, setWidgetElevation]);
+};

--- a/app/client/src/layoutSystems/anvil/editor/canvas/providers/AnvilWidgetElevationProvider.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/canvas/providers/AnvilWidgetElevationProvider.tsx
@@ -1,0 +1,56 @@
+import React, {
+  type ReactNode,
+  createContext,
+  useState,
+  useCallback,
+  useContext,
+} from "react";
+
+interface WidgetElevationObj {
+  [key: string]: boolean;
+}
+
+interface AnvilWidgetElevationContextType {
+  elevatedWidgets: WidgetElevationObj;
+  setWidgetElevation: (widgetId: string, isElevated: boolean) => void;
+}
+
+const AnvilWidgetElevationContext = createContext<
+  AnvilWidgetElevationContextType | undefined
+>(undefined);
+
+export const useAnvilWidgetElevation = () =>
+  useContext(AnvilWidgetElevationContext);
+
+export const AnvilWidgetElevationProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [elevatedWidgets, setElevatedWidgets] = useState<WidgetElevationObj>(
+    {},
+  );
+
+  const setWidgetElevation = useCallback(
+    (widgetId: string, isElevated: boolean) => {
+      setElevatedWidgets((prev) => {
+        return {
+          ...prev,
+          [widgetId]: isElevated,
+        };
+      });
+    },
+    [setElevatedWidgets],
+  );
+
+  return (
+    <AnvilWidgetElevationContext.Provider
+      value={{
+        elevatedWidgets,
+        setWidgetElevation,
+      }}
+    >
+      {children}
+    </AnvilWidgetElevationContext.Provider>
+  );
+};

--- a/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDListenerStates.ts
+++ b/app/client/src/layoutSystems/anvil/editor/canvasArenas/hooks/useAnvilDnDListenerStates.ts
@@ -16,6 +16,7 @@ import type { AnvilGlobalDnDStates } from "../../canvas/hooks/useAnvilGlobalDnDS
 import { getWidgets } from "sagas/selectors";
 import { useMemo } from "react";
 import { ZoneWidget } from "widgets/anvil/ZoneWidget";
+import { useAnvilWidgetElevation } from "../../canvas/providers/AnvilWidgetElevationProvider";
 
 interface AnvilDnDListenerStatesProps {
   anvilGlobalDragStates: AnvilGlobalDnDStates;
@@ -96,6 +97,8 @@ export const useAnvilDnDListenerStates = ({
     mainCanvasLayoutId,
   } = anvilGlobalDragStates;
   const allWidgets = useSelector(getWidgets);
+  const anvilWidgetElevation = useAnvilWidgetElevation();
+  const elevatedWidgets = anvilWidgetElevation?.elevatedWidgets || {};
   const widgetProps = allWidgets[widgetId];
   const selectedWidgets = useSelector(getSelectedWidgets);
   /**
@@ -133,22 +136,21 @@ export const useAnvilDnDListenerStates = ({
       (each) => !allWidgets[each].detachFromLayout,
     ).length === 0;
 
-  const allSiblingsWidgets = useMemo(() => {
-    const allSiblings =
-      (widgetProps.parentId && allWidgets[widgetProps.parentId]?.children) ||
-      [];
-    return allSiblings.map((each) => allWidgets[each]);
+  const allSiblingsWidgetIds = useMemo(() => {
+    return (
+      (widgetProps.parentId && allWidgets[widgetProps.parentId]?.children) || []
+    );
   }, [widgetProps, allWidgets]);
 
   const isElevatedWidget = useMemo(() => {
     if (widgetProps.type === ZoneWidget.type) {
-      const isAnyZoneElevated = allSiblingsWidgets.some(
-        (each) => !!each.elevatedBackground,
+      const isAnyZoneElevated = allSiblingsWidgetIds.some(
+        (each) => !!elevatedWidgets[each],
       );
       return isAnyZoneElevated;
     }
-    return !!widgetProps.elevatedBackground;
-  }, [widgetProps, allSiblingsWidgets]);
+    return !!elevatedWidgets[widgetId];
+  }, [widgetProps, elevatedWidgets, allSiblingsWidgetIds]);
 
   const {
     edgeCompensatorValues,

--- a/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetStyles.ts
+++ b/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetStyles.ts
@@ -10,6 +10,7 @@ export const useAnvilWidgetStyles = (
   widgetName: string,
   isVisible = true,
   widgetType: string,
+  elevatedBackground: boolean,
   ref: React.RefObject<HTMLDivElement>, // Ref object to reference the AnvilFlexComponent
 ) => {
   // Selectors to determine whether the widget is selected or dragging
@@ -18,7 +19,11 @@ export const useAnvilWidgetStyles = (
     (state: AppState) => state.ui.widgetDragResize.isDragging,
   );
   // Get widget border styles using useWidgetBorderStyles
-  const widgetBorderStyles = useWidgetBorderStyles(widgetId, widgetType);
+  const widgetBorderStyles = useWidgetBorderStyles(
+    widgetId,
+    widgetType,
+    elevatedBackground,
+  );
 
   // Effect hook to apply widget border styles to the widget
   useEffect(() => {

--- a/app/client/src/layoutSystems/anvil/integrations/selectors.ts
+++ b/app/client/src/layoutSystems/anvil/integrations/selectors.ts
@@ -24,7 +24,11 @@ export function getDropTargetLayoutId(state: AppState, canvasId: string) {
  * Returns a boolean indicating if space distribution is in progress
  */
 export function getAnvilSpaceDistributionStatus(state: AppState) {
-  return state.ui.widgetDragResize.anvil.isDistributingSpace;
+  return state.ui.widgetDragResize.anvil.spaceDistribution.isDistributingSpace;
+}
+
+export function getWidgetsDistributingSpace(state: AppState) {
+  return state.ui.widgetDragResize.anvil.spaceDistribution.widgetsEffected;
 }
 
 /**

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/actions.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/actions.ts
@@ -1,11 +1,32 @@
 import { AnvilReduxActionTypes } from "../integrations/actions/actionTypes";
 
-export const startAnvilSpaceDistribution = (payload: {
+export const startAnvilSpaceDistributionAction = (payload: {
   section: string;
   zones: string[];
 }) => {
   return {
     type: AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_START,
     payload,
+  };
+};
+
+export const stopAnvilSpaceDistributionAction = () => {
+  return {
+    type: AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_STOP,
+  };
+};
+
+export const updateSpaceDistributionAction = (
+  sectionLayoutId: string,
+  zonesDistributed: {
+    [widgetId: string]: number;
+  },
+) => {
+  return {
+    type: AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_UPDATE,
+    payload: {
+      zonesDistributed,
+      sectionLayoutId,
+    },
   };
 };

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/actions.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/actions.ts
@@ -1,0 +1,11 @@
+import { AnvilReduxActionTypes } from "../integrations/actions/actionTypes";
+
+export const startAnvilSpaceDistribution = (payload: {
+  section: string;
+  zones: string[];
+}) => {
+  return {
+    type: AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_START,
+    payload,
+  };
+};

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/useSpaceDistributionEvents.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/useSpaceDistributionEvents.ts
@@ -1,7 +1,6 @@
 import { getAnvilWidgetDOMId } from "layoutSystems/common/utils/LayoutElementPositionsObserver/utils";
 import { useCallback, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { AnvilReduxActionTypes } from "../integrations/actions/actionTypes";
 import {
   getMouseSpeedTrackingCallback,
   getPropertyPaneZoneId,
@@ -21,7 +20,11 @@ import {
   updateWidgetCSSOnHandleMove,
   updateWidgetCSSOnMinimumLimit,
 } from "./utils/onMouseMoveUtils";
-import { startAnvilSpaceDistribution } from "./actions";
+import {
+  startAnvilSpaceDistributionAction,
+  stopAnvilSpaceDistributionAction,
+  updateSpaceDistributionAction,
+} from "./actions";
 
 interface SpaceDistributionEventsProps {
   ref: React.RefObject<HTMLDivElement>;
@@ -57,7 +60,7 @@ export const useSpaceDistributionEvents = ({
   const { selectWidget } = useWidgetSelection();
   const onSpaceDistributionStart = useCallback(() => {
     dispatch(
-      startAnvilSpaceDistribution({
+      startAnvilSpaceDistributionAction({
         section: sectionWidgetId,
         zones: zoneIds,
       }),
@@ -147,21 +150,15 @@ export const useSpaceDistributionEvents = ({
           currentFlexGrow.rightZone !== currentGrowthFactor.rightZone
         ) {
           // Dispatch action to update space distribution
-          dispatch({
-            type: AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_UPDATE,
-            payload: {
-              zonesDistributed: {
-                [leftZone]: currentGrowthFactor.leftZone,
-                [rightZone]: currentGrowthFactor.rightZone,
-              },
-              sectionLayoutId,
-            },
-          });
+          dispatch(
+            updateSpaceDistributionAction(sectionWidgetId, {
+              [leftZone]: currentGrowthFactor.leftZone,
+              [rightZone]: currentGrowthFactor.rightZone,
+            }),
+          );
         }
         // Stop space distribution process
-        dispatch({
-          type: AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_STOP,
-        });
+        dispatch(stopAnvilSpaceDistributionAction());
         resetCSSOnZones(spaceDistributed);
         removeMouseMoveHandlers();
         currentMouseSpeed.current = 0;

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/useSpaceDistributionEvents.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/useSpaceDistributionEvents.ts
@@ -21,6 +21,7 @@ import {
   updateWidgetCSSOnHandleMove,
   updateWidgetCSSOnMinimumLimit,
 } from "./utils/onMouseMoveUtils";
+import { startAnvilSpaceDistribution } from "./actions";
 
 interface SpaceDistributionEventsProps {
   ref: React.RefObject<HTMLDivElement>;
@@ -54,16 +55,19 @@ export const useSpaceDistributionEvents = ({
     getMouseSpeedTrackingCallback(currentMouseSpeed);
   const selectedWidgets = useSelector(getSelectedWidgets);
   const { selectWidget } = useWidgetSelection();
+  const onSpaceDistributionStart = useCallback(() => {
+    dispatch(
+      startAnvilSpaceDistribution({
+        section: sectionWidgetId,
+        zones: zoneIds,
+      }),
+    );
+  }, [sectionWidgetId, zoneIds]);
   const selectCorrespondingSectionWidget = useCallback(() => {
-    if (
-      !(
-        selectedWidgets.includes(sectionWidgetId) ||
-        zoneIds.some((each) => selectedWidgets.includes(each))
-      )
-    ) {
+    if (!selectedWidgets.includes(sectionWidgetId)) {
       selectWidget(SelectionRequestType.One, [sectionWidgetId]);
     }
-  }, [sectionWidgetId, selectedWidgets, zoneIds]);
+  }, [sectionWidgetId, selectedWidgets]);
   useEffect(() => {
     if (ref.current) {
       // Check if the ref to the DOM element exists
@@ -196,9 +200,7 @@ export const useSpaceDistributionEvents = ({
         e.preventDefault();
         x = e.clientX; // Store the initial mouse position
         isCurrentHandleDistributingSpace.current = true; // Set distribution flag
-        dispatch({
-          type: AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_START,
-        });
+        onSpaceDistributionStart();
         addMouseMoveHandlers();
       };
 
@@ -331,5 +333,6 @@ export const useSpaceDistributionEvents = ({
     sectionWidgetId,
     spaceDistributed,
     spaceToWorkWith,
+    onSpaceDistributionStart,
   ]);
 };

--- a/app/client/src/layoutSystems/anvil/utils/types.ts
+++ b/app/client/src/layoutSystems/anvil/utils/types.ts
@@ -5,6 +5,7 @@ import type { WidgetType } from "WidgetProvider/factory";
 export interface AnvilFlexComponentProps {
   children: ReactNode;
   className?: string;
+  elevatedBackground?: boolean;
   layoutId: string;
   parentId?: string;
   rowIndex: number;

--- a/app/client/src/reducers/uiReducers/dragResizeReducer.ts
+++ b/app/client/src/reducers/uiReducers/dragResizeReducer.ts
@@ -19,7 +19,13 @@ const initialState: WidgetDragResizeState = {
   isAutoCanvasResizing: false,
   anvil: {
     highlightShown: undefined,
-    isDistributingSpace: false,
+    spaceDistribution: {
+      isDistributingSpace: false,
+      widgetsEffected: {
+        section: "",
+        zones: [],
+      },
+    },
   },
   isDraggingDisabled: false,
   blockSelection: false,
@@ -138,13 +144,22 @@ export const widgetDraggingReducer = createImmerReducer(initialState, {
   //space distribution redux
   [AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_START]: (
     state: WidgetDragResizeState,
+    action: ReduxAction<{
+      section: string;
+      zones: string[];
+    }>,
   ) => {
-    state.anvil.isDistributingSpace = true;
+    state.anvil.spaceDistribution.widgetsEffected.section =
+      action.payload.section;
+    state.anvil.spaceDistribution.widgetsEffected.zones = action.payload.zones;
+    state.anvil.spaceDistribution.isDistributingSpace = true;
   },
   [AnvilReduxActionTypes.ANVIL_SPACE_DISTRIBUTION_STOP]: (
     state: WidgetDragResizeState,
   ) => {
-    state.anvil.isDistributingSpace = false;
+    state.anvil.spaceDistribution.isDistributingSpace = false;
+    state.anvil.spaceDistribution.widgetsEffected.section = "";
+    state.anvil.spaceDistribution.widgetsEffected.zones = [];
   },
   [AnvilReduxActionTypes.ANVIL_SET_HIGHLIGHT_SHOWN]: (
     state: WidgetDragResizeState,
@@ -175,7 +190,13 @@ export interface WidgetDragResizeState {
   isResizing: boolean;
   anvil: {
     highlightShown?: AnvilHighlightInfo;
-    isDistributingSpace: boolean;
+    spaceDistribution: {
+      isDistributingSpace: boolean;
+      widgetsEffected: {
+        section: string;
+        zones: string[];
+      };
+    };
   };
   lastSelectedWidget?: string;
   focusedWidget?: string;

--- a/app/client/src/widgets/anvil/Container.tsx
+++ b/app/client/src/widgets/anvil/Container.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import styled from "styled-components";
 import { generateClassName } from "utils/generators";
 import type { Elevations } from "./constants";
+import { useAnvilWidgetElevationSetter } from "layoutSystems/anvil/editor/canvas/hooks/useAnvilWidgetElevationSetter";
 
 /**
  * This container component wraps the Zone and Section widgets and allows Anvil to utilise tokens from the themes
@@ -22,6 +23,7 @@ const StyledContainerComponent = styled.div<
 `;
 
 export function ContainerComponent(props: ContainerComponentProps) {
+  useAnvilWidgetElevationSetter(props.widgetId, props.elevatedBackground);
   return (
     <StyledContainerComponent
       className={`${generateClassName(props.widgetId)}`}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1QS4I0hOoNK4mMZphl6PrKO7OoqLeQrQ%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=C6p2w9c)
## Description
In this PR we are making sure the evaluated values of elevatedBackground(prop that indicates if a section or zone if elevated) is used instead of the unevaluated value used so far.

For this we will need to refer to siblings as well, so fetching the data tree state and iterating to find all siblings is going to be underperformant.
Hence, creating a context for the editor alone which will collect all sections and zones current evaluated elevated background.

This context will be accessed by `useAnvilDnDListenerStates` and `useAnvilDnDCompensators` to decide compensators for a zone and section.

We have also enhanced space distribution UX.
- during explicit ditribution(distribution via the handler inbetween zones on the canvas) all on canvas ui borders are not displayed except for zones that have switched off visual separation and at the start of the action we select the section widget.
- during implicit distribution(distribution via the handler in the property pane)
  - of section, the ux on the canvas remains the same, once the action is done the section widget is still selected.
  - of zone, the ux on the canvas remains the same, once the action is done the zone widget remains selected.


Fixes #33369
Fixes #33212

_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
