### PR TITLE
chore: Remove incorrect and unused `update` signature

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -40,21 +40,15 @@ public abstract class BaseService<
 
     @Override
     public Mono<T> update(ID id, T resource) {
-        return update(id, resource, "id");
-    }
-
-    public Mono<T> update(ID id, T resource, String key) {
         if (id == null) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ID));
         }
 
         resource.setUpdatedAt(Instant.now());
 
-        // TODO(Shri): update happens with `key=id` and find happens with `id=id` criteria. This is incorrect, but is
-        //   too fragile to touch right now. Need to dig in slow and deep to fix this.
         return repository
                 .queryBuilder()
-                .criteria(Bridge.equal(key, (String) id))
+                .byId((String) id)
                 .updateFirst(resource)
                 .flatMap(obj -> repository.findById(id))
                 .flatMap(savedResource ->

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -49,7 +49,7 @@ public abstract class BaseService<
         return repository
                 .queryBuilder()
                 .byId((String) id)
-                .updateOne(resource)
+                .updateFirst(resource)
                 .flatMap(obj -> repository.findById(id))
                 .flatMap(savedResource ->
                         analyticsService.sendUpdateEvent(savedResource, getAnalyticsProperties(savedResource)));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/BaseService.java
@@ -49,7 +49,7 @@ public abstract class BaseService<
         return repository
                 .queryBuilder()
                 .byId((String) id)
-                .updateFirst(resource)
+                .updateOne(resource)
                 .flatMap(obj -> repository.findById(id))
                 .flatMap(savedResource ->
                         analyticsService.sendUpdateEvent(savedResource, getAnalyticsProperties(savedResource)));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -608,7 +608,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
             updates.setName(inputName);
             updatedUserMono = sessionUserService
                     .getCurrentUser()
-                    .flatMap(user -> update(user.getId(), updates)
+                    .flatMap(user -> updateWithoutPermission(user.getId(), updates)
                             .then(
                                     exchange == null
                                             ? repository.findByEmail(user.getEmail())

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -608,7 +608,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
             updates.setName(inputName);
             updatedUserMono = sessionUserService
                     .getCurrentUser()
-                    .flatMap(user -> update(user.getId(), updates, User.Fields.id)
+                    .flatMap(user -> update(user.getId(), updates)
                             .then(
                                     exchange == null
                                             ? repository.findByEmail(user.getEmail())


### PR DESCRIPTION
The `update` method with `String, T, String` signature, is not used in it's form anywhere. This is most likely owing to the implementation being off. The criteria used to find the object to be updated, is not the same as the criteria used to find the updated object to return to the caller.

The query to update is `{value of key field} = id`.

The query to find is `{value of "id" field} = id`.

This discrepency is likely why this function is not used anywhere. The `ApplicationServiceCE` alone has an overridden implementation for this signature, but that's defined with different variable names, and treats the third argument as the Git branch name, not `key`. That function is indeed used, and is unaffected by this change.

All of above is verified on EE as well. No conflicts, no build failure.

/ok-to-test tags="@tag.Sanity"

