### PR TITLE
ci: Disable manual run on limited test workflow

### DIFF
--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -3,14 +3,6 @@ name: Build Client, Server & Run only Cypress
 on:
   repository_dispatch:
     types: [ci-test-limit-command]
-  # This workflow can be triggered manually from the GitHub Actions page
-  workflow_dispatch:
-    inputs:
-      previous_run_id:
-        description: "Run id to download the docker image artifact:"
-        required: false
-        type: string
-        default: "0"
 
 jobs:
   file-check:
@@ -33,19 +25,6 @@ jobs:
             echo "matrix_count=[0, 1, 2]" >> $GITHUB_OUTPUT
           else
             echo "matrix_count=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Get the PR number if workflow is triggered manually
-        id: fetch_pr
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          res=`curl -s -H "Authorization: Bearer ${{ secrets.APPSMITH_CI_TEST_PAT}}" https://api.github.com/repos/${{ github.repository }}/pulls?head=appsmithorg:${{ github.ref_name }}`
-          response_length=`echo "$res" | jq -r 'length'`
-          if [[ $response_length -ne 0 ]]; then
-            pr_number=`echo $res | jq -r '.[0] | .number'`
-            echo "pr=$pr_number" >> $GITHUB_OUTPUT
-          else
-            echo "pr=0" >> $GITHUB_OUTPUT
           fi
 
       - name: Set args

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -21,26 +21,17 @@ jobs:
       - name: Set matrix jobs
         id: matrix
         run: |
-          if [[ ${{github.event_name}} == 'repository_dispatch' ]]; then
-            echo "matrix_count=[0, 1, 2]" >> $GITHUB_OUTPUT
-          else
-            echo "matrix_count=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]" >> $GITHUB_OUTPUT
-          fi
+          echo "matrix_count=[0, 1, 2]" >> $GITHUB_OUTPUT
 
       - name: Set args
         id: args
         run: |
-          if [[ ${{github.event_name}} == 'repository_dispatch' ]]; then
-            echo "pr=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
-            checkArg=`echo '${{toJSON(github.event.client_payload.slash_command.args.named)}}' | jq 'has("runId")'`
-            if [[ $checkArg == 'true' ]]; then
-              echo "runId=${{ github.event.client_payload.slash_command.args.named.runId }}" >> $GITHUB_OUTPUT
-            else
-              echo "runId=0" >> $GITHUB_OUTPUT
-            fi
+          echo "pr=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
+          checkArg=`echo '${{toJSON(github.event.client_payload.slash_command.args.named)}}' | jq 'has("runId")'`
+          if [[ $checkArg == 'true' ]]; then
+            echo "runId=${{ github.event.client_payload.slash_command.args.named.runId }}" >> $GITHUB_OUTPUT
           else
-            echo "runId=${{ inputs.previous_run_id }}" >> $GITHUB_OUTPUT
-            echo "pr=${{ steps.fetch_pr.outputs.pr }}" >> $GITHUB_OUTPUT
+            echo "runId=0" >> $GITHUB_OUTPUT
           fi
 
       - name: Get the diff from base branch


### PR DESCRIPTION
The step to get the PR number when run manually has error in its code. The `res=` line doesn't work, in that it'll mangle the JSON output from the `curl` command, before setting it into the variable. It should've been

```sh
res="$(curl ...)"
```

Considering we don't use this functionality today, and it doesn't work either, we're removing it.

This workflow is only used with `repository_dispatch`, and we make that explicit.
