### PR TITLE
fix: Show custom widget icon reliably when no widget is found

### DIFF
--- a/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
@@ -110,7 +110,7 @@ function UIEntitySidebar({
         />
       </div>
       <Flex
-        className="flex-grow px-3 overflow-y-scroll"
+        className="flex-grow px-3 overflow-y-scroll flex-col"
         data-testid="t--widget-sidebar-scrollable-wrapper"
         pt="spaces-2"
       >


### PR DESCRIPTION

Steps To Reproduce
go to edit mode of the application
In the entity explorer section click on UI tab
search for the widget name which is not present
The custom widget icon will be displayed but seems like broken as in attached screenshot


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._