### PR TITLE
fix: Tabs UI updates

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorTabs/Container.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/Container.tsx
@@ -7,7 +7,7 @@ const Container = (props: { children: ReactNode }) => {
     <Flex
       alignItems="center"
       backgroundColor="#FFFFFF"
-      borderBottom="1px solid var(--ads-v2-color-border)"
+      borderBottom="1px solid var(--ads-v2-color-border-muted)"
       gap="spaces-2"
       maxHeight="32px"
       minHeight="32px"

--- a/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.tsx
@@ -22,6 +22,8 @@ interface Props {
   onClose: (actionId?: string) => void;
 }
 
+const FILE_TABS_CONTAINER_ID = "file-tabs-container";
+
 const FileTabs = (props: Props) => {
   const { navigateToTab, onClose, tabs } = props;
   const { segment, segmentMode } = useCurrentEditorState();
@@ -40,9 +42,7 @@ const FileTabs = (props: Props) => {
   }, [tabs, segmentMode]);
 
   useEffect(() => {
-    const ele = document.getElementById(
-      "t--tabs-overflow-check",
-    )?.parentElement;
+    const ele = document.getElementById(FILE_TABS_CONTAINER_ID)?.parentElement;
     if (ele && ele.scrollWidth > ele.clientWidth) {
       ele.style.borderRight = "1px solid var(--ads-v2-color-border)";
     } else if (ele) {
@@ -67,7 +67,7 @@ const FileTabs = (props: Props) => {
       }}
       size={"sm"}
     >
-      <Flex gap="spaces-2" height="100%" id="t--tabs-overflow-check">
+      <Flex gap="spaces-2" height="100%" id={FILE_TABS_CONTAINER_ID}>
         {tabs.map((tab: EntityItem) => (
           <StyledTab
             className={clsx(

--- a/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import clsx from "classnames";
 import { Flex, Icon, ScrollArea } from "design-system";
@@ -25,6 +25,7 @@ interface Props {
 const FileTabs = (props: Props) => {
   const { navigateToTab, onClose, tabs } = props;
   const { segment, segmentMode } = useCurrentEditorState();
+  const [showDivider, setShowDivider] = useState(false);
 
   const location = useLocation();
 
@@ -38,6 +39,13 @@ const FileTabs = (props: Props) => {
       });
     }
   }, [tabs, segmentMode]);
+
+  useEffect(() => {
+    const ele = document.getElementById("t--tabs-overflow-check");
+    if (ele && ele.scrollWidth > ele.clientWidth) {
+      setShowDivider(true);
+    }
+  }, [tabs]);
 
   const onCloseClick = (e: React.MouseEvent, id?: string) => {
     e.stopPropagation();
@@ -56,7 +64,14 @@ const FileTabs = (props: Props) => {
       }}
       size={"sm"}
     >
-      <Flex gap="spaces-2" height="100%">
+      <Flex
+        className={clsx({
+          "border-r-[1px]": showDivider,
+        })}
+        gap="spaces-2"
+        height="100%"
+        id="t--tabs-overflow-check"
+      >
         {tabs.map((tab: EntityItem) => (
           <StyledTab
             className={clsx(

--- a/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useLocation } from "react-router";
 import clsx from "classnames";
 import { Flex, Icon, ScrollArea } from "design-system";
@@ -25,7 +25,6 @@ interface Props {
 const FileTabs = (props: Props) => {
   const { navigateToTab, onClose, tabs } = props;
   const { segment, segmentMode } = useCurrentEditorState();
-  const [showDivider, setShowDivider] = useState(false);
 
   const location = useLocation();
 
@@ -41,9 +40,13 @@ const FileTabs = (props: Props) => {
   }, [tabs, segmentMode]);
 
   useEffect(() => {
-    const ele = document.getElementById("t--tabs-overflow-check");
+    const ele = document.getElementById(
+      "t--tabs-overflow-check",
+    )?.parentElement;
     if (ele && ele.scrollWidth > ele.clientWidth) {
-      setShowDivider(true);
+      ele.style.borderRight = "1px solid var(--ads-v2-color-border)";
+    } else if (ele) {
+      ele.style.borderRight = "unset";
     }
   }, [tabs]);
 
@@ -64,14 +67,7 @@ const FileTabs = (props: Props) => {
       }}
       size={"sm"}
     >
-      <Flex
-        className={clsx({
-          "border-r-[1px]": showDivider,
-        })}
-        gap="spaces-2"
-        height="100%"
-        id="t--tabs-overflow-check"
-      >
+      <Flex gap="spaces-2" height="100%" id="t--tabs-overflow-check">
         {tabs.map((tab: EntityItem) => (
           <StyledTab
             className={clsx(

--- a/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/StyledComponents.tsx
@@ -28,23 +28,15 @@ export const StyledTab = styled(Flex)`
   align-items: center;
   justify-content: center;
   padding: var(--ads-v2-spaces-3);
-
-  // After element - the seperator in between tabs
-  &:not(&.active):not(:has(+ .active)):after {
-    content: "";
-    position: absolute;
-    right: 0;
-    top: 8px;
-    width: 1px;
-    height: 40%;
-    background-color: var(--ads-v2-color-border);
-  }
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+  border-top: 2px solid transparent;
 
   &.active {
     background: var(--ads-v2-colors-control-field-default-bg);
-    border-top: 2px solid var(--ads-v2-color-bg-brand);
-    border-left: 1px solid var(--ads-v2-color-border);
-    border-right: 1px solid var(--ads-v2-color-border);
+    border-top-color: var(--ads-v2-color-bg-brand);
+    border-left-color: var(--ads-v2-color-border-muted);
+    border-right-color: var(--ads-v2-color-border-muted);
   }
 
   & > .tab-close {


### PR DESCRIPTION
## Description

- Added separator before add button when it reaches the end and tabs starts scrolling.
- Changed tabs bottom border color.
- Fixed tabs jumping effect while switching.


Fixes #33521  


## Automation

/ok-to-test tags="@tag.Sanity, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9126293732>
> Commit: 8384629a70ce3b075d6aaff9a43d10041ddb5b98
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9126293732&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->







## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
