### PR TITLE
fix: Consider heroku deployment while generating Caddyfile

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -146,7 +146,7 @@ parts.push(`
 }
 
 # We bind to http on 80, so that localhost requests don't get redirected to https.
-:80 {
+:${process.env.PORT || 80} {
   import all-config
 }
 `)


### PR DESCRIPTION
## Description

Looks like while replacing NGINX with Caddy, Heroku deployment usecase was missed.
Updated Caddyfile generation to use `$PORT` if available.

Fixes #33555 

Tested on Heroku Standard-2x Dyno.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
