### PR TITLE
ci: Move check for new JS Cypress tests to GitHub script

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: "false"
-      check-test-files:
-        description: "This is a boolean value in case the workflow is being called in build deploy-preview"
-        required: false
-        type: string
-        default: "false"
       branch:
         description: "This is the branch to be used for the build."
         required: false
@@ -27,10 +22,15 @@ on:
         type: string
         default: "true"
 
-# Change the working directory for all the jobs in this workflow
+permissions:
+  contents: read
+  pull-requests: write
+
+# Change the working directory for all "run" steps in this workflow
 defaults:
   run:
     working-directory: app/client
+    shell: bash
 
 jobs:
   client-build:
@@ -42,10 +42,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'repository_dispatch' ||
       github.event_name == 'schedule'
-    defaults:
-      run:
-        working-directory: app/client
-        shell: bash
 
     steps:
       # The checkout steps MUST happen first because the default directory is set according to the code base.
@@ -90,41 +86,13 @@ jobs:
 
       # get all the files changes in the cypress/e2e folder
       - name: Get added files in cypress/e2e folder
-        if: inputs.pr != 0 && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-        id: files
-        uses: umani/changed-files@v4.1.0
+        if: inputs.pr != 0 && steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: actions/github-script@v7
+        env:
+          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
         with:
-          repo-token: ${{ secrets.APPSMITH_CI_TEST_PAT }}
-          pattern: "app/client/cypress/e2e/.*"
-          pr-number: ${{ inputs.pr }}
-
-      # Check all the newly added files are in ts
-      - name: Check the newly added files are written in ts
-        if: inputs.check-test-files == 'true' && inputs.pr != 0 && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-        id: check_files
-        run: |
-          files=(${{steps.files.outputs.files_created}})
-          non_ts_files=()
-          for file in "${files[@]}"; do
-            if [[ $file != *.ts ]]; then
-              non_ts_files+=("<li>$file")
-            fi
-          done
-          echo "non_ts_files=${non_ts_files[@]}" >> $GITHUB_OUTPUT
-          echo "non_ts_files_count=${#non_ts_files[@]}" >> $GITHUB_OUTPUT
-
-      # Comment in PR if test files are not written in ts and fail the workflow
-      - name: Comment in PR if test files are not written in ts
-        if: steps.check_files.outputs.non_ts_files_count != 0 && inputs.check-test-files == 'true' && inputs.pr != 0 && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ inputs.pr }}
-          body: |
-            <b>Below new test files are written in js 🔴 </b>
-            <b>Expected format ts. Please fix and retrigger ok-to-test:</b>
-            <ol>${{ steps.check_files.outputs.non_ts_files }}</ol>
-      - if: steps.check_files.outputs.non_ts_files_count != 0 && inputs.check-test-files == 'true' && inputs.pr != 0 && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-        run: exit 1
+          script: |
+            await require("client-build-compliance.js")({core, github, context})
 
       - name: Get all the added or changed files in client/src folder
         if: inputs.ads-compliant-check == 'true' && inputs.pr != 0 && github.pull_request.base.ref == 'release' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -27,7 +27,6 @@ jobs:
     secrets: inherit
     with:
       pr: ${{ github.event.number }}
-      check-test-files: "true"
 
   rts-build:
     if: success()

--- a/.github/workflows/scripts/client-build-compliance.js
+++ b/.github/workflows/scripts/client-build-compliance.js
@@ -1,0 +1,28 @@
+module.exports = async ({core, github, context}) => {
+  const prNumber = context.payload.inputs.pr;
+
+  const affectedFiles = await github.paginate(github.rest.pulls.listFiles, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber,
+    per_page: 100,
+  });
+  console.log(affectedFiles);
+
+  const nonTsFiles = affectedFiles.filter(f => f.status === "added" && f.filename.startsWith("app/client/cypress/e2e/") && !f.filename.endsWith(".ts"));
+  console.log(nonTsFiles);
+
+  if (nonTsFiles.length > 0) {
+    const body = [
+      "🔴 There's new test files in JS, please port to TS and re-trigger Cypress tests:",
+      `1. ${nonTsFiles.map(f => f.filename).join("\n1. ")}`,
+    ].join("\n");
+    github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      body,
+    });
+    core.setFailed("There's new test files in JS\n" + body);
+  }
+};


### PR DESCRIPTION
We have a check when running Cypress tests to ensure that no new `.js` files are added under Cypress folder. This PR moves this check to a separate JS file. There's another check that does some ADS compliance, which I'll port in a follow-up PR.

Why am I hitting on this? One, to move away from `umani/changed-files` workflow, which has randomly failed for us in the past, and id doesn't do so much special for us anyway. Two, this workflow is the last usage of `APPSMITH_CI_TEST_PAT` secret, so I should be able to remove that secret as well. One less secret.

/ok-to-test tags="@tag.Sanity"

