### PR TITLE
ci: Removing outdated Github action actions-cache

### DIFF
--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -416,13 +416,11 @@ jobs:
       # Force store previous run result to cache
       - name: Store the previous run result
         if: failure()
-        uses: martijnhols/actions-cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: |
             ~/run_result
           key: ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
 
       # Upload the log artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server logs bundle on failure

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -245,13 +245,11 @@ jobs:
       # Force save the CI failed spec list into a cache
       - name: Store the combined run result for CI
         if: needs.ci-test.result != 'success'
-        uses: martijnhols/actions-cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: |
             ~/combined_failed_spec_ci
           key: ${{ github.run_id }}-"ci-test-result"
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}
 
       # Upload combined failed CI spec list to a file
       # This is done for debugging.


### PR DESCRIPTION
Using actions/cache/save which is the supported version now.

