### PR TITLE
chore: Remove UpdateDefinition from MongoDB API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
@@ -2,8 +2,8 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.helpers.ce.bridge.BridgeUpdate;
 import com.appsmith.server.repositories.ce.params.QueryAllParams;
-import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -18,13 +18,15 @@ public interface AppsmithRepository<T extends BaseDomain> {
 
     Mono<T> updateById(String id, T resource, AclPermission permission);
 
+    Mono<Integer> updateByIdWithoutPermissionCheck(String id, BridgeUpdate update);
+
     QueryAllParams<T> queryBuilder();
 
     Mono<T> setUserPermissionsInObject(T obj, Set<String> permissionGroups);
 
     Mono<T> setUserPermissionsInObject(T obj);
 
-    Mono<T> updateAndReturn(String id, UpdateDefinition updateObj, Optional<AclPermission> permission);
+    Mono<T> updateAndReturn(String id, BridgeUpdate updateObj, Optional<AclPermission> permission);
 
     /**
      * This method uses the mongodb bulk operation to save a list of new actions. When calling this method, please note

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -9,6 +9,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
+import com.appsmith.server.helpers.ce.bridge.BridgeUpdate;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.repositories.ce.params.QueryAllParams;
 import com.mongodb.BasicDBObject;
@@ -143,6 +144,10 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         update.keySet().forEach(entry -> updateObj.set(entry, update.get(entry)));
 
         return queryBuilder().byId(id).permission(permission).updateFirstAndFind(updateObj);
+    }
+
+    public Mono<Integer> updateByIdWithoutPermissionCheck(@NonNull String id, BridgeUpdate update) {
+        return queryBuilder().byId(id).updateFirst(update);
     }
 
     public Mono<Integer> updateFieldByDefaultIdAndBranchName(
@@ -455,7 +460,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
      *
      * @see FindAndModifyOptions
      */
-    public Mono<T> updateAndReturn(String id, UpdateDefinition updateObj, Optional<AclPermission> permission) {
+    public Mono<T> updateAndReturn(String id, BridgeUpdate updateObj, Optional<AclPermission> permission) {
         Query query = new Query(Criteria.where("id").is(id));
 
         FindAndModifyOptions findAndModifyOptions =

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
@@ -5,7 +5,6 @@ import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.repositories.AppsmithRepository;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -50,6 +49,4 @@ public interface CustomActionCollectionRepositoryCE extends AppsmithRepository<A
             String contextId, CreatorContextType contextType, AclPermission permission);
 
     Flux<ActionCollection> findByPageIdAndViewMode(String pageId, boolean viewMode, AclPermission permission);
-
-    Mono<Integer> updateById(String id, UpdateDefinition updateObj);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -7,14 +7,11 @@ import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.dtos.ActionCollectionDTO;
-import com.appsmith.server.exceptions.AppsmithError;
-import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -242,13 +239,5 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
         }
 
         return queryBuilder().criteria(query).permission(permission).all();
-    }
-
-    @Override
-    public Mono<Integer> updateById(String id, UpdateDefinition updateObj) {
-        if (id == null) {
-            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ID));
-        }
-        return queryBuilder().byId(id).updateFirst(updateObj);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -327,7 +327,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
 
             updateObj.set(path, actionCollectionDTO.getBody());
 
-            return actionCollectionRepository.updateById(dbActionCollection.getId(), updateObj);
+            return actionCollectionRepository.updateByIdWithoutPermissionCheck(dbActionCollection.getId(), updateObj);
         });
     }
 


### PR DESCRIPTION
Reduce usage of MongoDB-specific APIs. Needed for Postgres. 

/test sanity

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9159562023>
> Commit: 563b633b814562a6d300cf09a5ac233b0ecee54b
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9159562023&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

