### PR TITLE
ci: Adding the overwrite: true parameter to actions/upload-artifact@v4 command

### DIFF
--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -220,6 +220,7 @@ jobs:
         with:
           name: combined_failed_spec_ci
           path: ~/combined_failed_spec_ci
+          overwrite: true
 
       - name: Get Latest flaky Tests
         shell: bash
@@ -337,6 +338,7 @@ jobs:
         with:
           name: combined_failed_spec_ci
           path: ~/combined_failed_spec_ci
+          overwrite: true
 
       - name: Get Latest flaky Tests
         shell: bash

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -368,6 +368,7 @@ jobs:
         with:
           name: cypress-console-logs
           path: ${{ github.workspace }}/app/client/cypress/cypress-logs
+          overwrite: true
 
       - name: Collect CI container logs
         if: failure()
@@ -383,6 +384,7 @@ jobs:
         with:
           name: dockerlogs
           path: ~/dockerlogs
+          overwrite: true
 
       - name: Rename reports
         if: failure()
@@ -396,6 +398,7 @@ jobs:
         with:
           name: results-${{github.run_attempt}}
           path: ~/results
+          overwrite: true
 
       # Set status = failedtest
       - name: Set fail if there are test failures
@@ -420,6 +423,7 @@ jobs:
         with:
           name: server-logs-${{ matrix.job }}
           path: app/server/server-logs.log
+          overwrite: true
 
       # Set status = success
       - name: Save the status of the run

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -260,6 +260,7 @@ jobs:
         with:
           name: results-${{github.run_attempt}}
           path: ~/results
+          overwrite: true
 
       - name: Upload cypress snapshots
         if: failure()
@@ -267,6 +268,7 @@ jobs:
         with:
           name: snapshots
           path: ${{ github.workspace }}/app/client/cypress/snapshots
+          overwrite: true
 
       # Set status = failedtest
       - name: Set fail if there are test failures

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -371,6 +371,7 @@ jobs:
         with:
           name: cypress-console-logs
           path: ${{ github.workspace }}/app/client/cypress/cypress-logs
+          overwrite: true
 
       - name: Upload cypress snapshots
         if: always()
@@ -378,6 +379,7 @@ jobs:
         with:
           name: snapshots
           path: ${{ github.workspace }}/app/client/cypress/snapshots
+          overwrite: true
 
       - name: Collect CI container logs
         if: failure()
@@ -393,6 +395,7 @@ jobs:
         with:
           name: dockerlogs
           path: ~/dockerlogs
+          overwrite: true
 
       - name: Rename reports
         if: failure()
@@ -406,6 +409,7 @@ jobs:
         with:
           name: results-${{github.run_attempt}}
           path: ~/results
+          overwrite: true
 
       # Set status = failedtest
       - name: Set fail if there are test failures
@@ -431,6 +435,7 @@ jobs:
         with:
           name: server-logs-${{ matrix.job }}
           path: app/server/server-logs.log
+          overwrite: true
 
       # Set status = success
       - name: Save the status of the run

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -294,6 +294,7 @@ jobs:
         with:
           name: client-build
           path: app/client/build.tar
+          overwrite: true
 
       - name: Put release build in cache
         if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           name: client-build
           path: app/client/build.tar
+          overwrite: true
 
   server-build:
     needs:
@@ -140,6 +141,7 @@ jobs:
         with:
           name: server-build
           path: app/server/dist/
+          overwrite: true
 
   rts-build:
     needs:
@@ -193,6 +195,7 @@ jobs:
         with:
           name: rts-dist
           path: app/client/packages/rts/rts-dist.tar
+          overwrite: true
 
   package:
     needs: [prelude, client-build, server-build, rts-build]

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -155,6 +155,7 @@ jobs:
         with:
           name: combined_failed_spec_ci
           path: ~/combined_failed_spec_ci
+          overwrite: true
 
       - name: Get Latest flaky Tests
         shell: bash

--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -153,6 +153,7 @@ jobs:
         with:
           name: rts-dist
           path: app/client/packages/rts/rts-dist.tar
+          overwrite: true
 
       # Set status = success
       - name: Save the status of the run

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -227,6 +227,7 @@ jobs:
           name: failed-server-tests
           path: app/server/failed-server-tests.txt
           if-no-files-found: ignore
+          overwrite: true
 
       - name: Fetch server build from cache
         if: steps.changed-files-specific.outputs.any_changed == 'false' && success()  && github.event_name != 'push' && github.event_name != 'workflow_dispatch'  && github.event_name != 'schedule'
@@ -266,6 +267,7 @@ jobs:
         with:
           name: server-build
           path: app/server/dist/
+          overwrite: true
 
       - name: Put release build in cache
         if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -261,6 +261,7 @@ jobs:
         with:
           name: combined_failed_spec_ci
           path: ~/combined_failed_spec_ci
+          overwrite: true
 
       - name: Return status for ui-matrix
         run: |


### PR DESCRIPTION
## Description
By default the value of overwrite is false. In previous versions of upload-artifact, this setting was implicit and true. Making this change to fix the error `Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run` in Github actions.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
