### PR TITLE
fix: Scroll issues in Add tab

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/JS/Add.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/JS/Add.tsx
@@ -41,6 +41,7 @@ const AddJS = ({ containerProps, innerContainerProps }: AddProps) => {
   return (
     <Flex
       data-testid="t--ide-add-pane"
+      height="100%"
       justifyContent="center"
       p="spaces-3"
       {...containerProps}

--- a/app/client/src/pages/Editor/IDE/EditorPane/Query/Add.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/Query/Add.tsx
@@ -17,6 +17,7 @@ const AddQuery = ({ containerProps, innerContainerProps }: AddProps) => {
   return (
     <Flex
       data-testid="t--ide-add-pane"
+      height="100%"
       justifyContent="center"
       p="spaces-3"
       {...containerProps}

--- a/app/client/src/pages/Editor/JSEditor/JSAddState.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSAddState.tsx
@@ -4,7 +4,7 @@ import AddJS from "pages/Editor/IDE/EditorPane/JS/Add";
 
 const JSAddState = () => {
   return (
-    <Flex justifyContent="center">
+    <Flex height="100%" justifyContent="center">
       <AddJS
         containerProps={{
           px: "spaces-4",

--- a/app/client/src/pages/Editor/QueryEditor/QueriesAddState.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueriesAddState.tsx
@@ -4,7 +4,7 @@ import AddQuery from "pages/Editor/IDE/EditorPane/Query/Add";
 
 const QueriesAddState = () => {
   return (
-    <Flex justifyContent="center">
+    <Flex height="100%" justifyContent="center">
       <AddQuery
         containerProps={{
           px: "spaces-4",


### PR DESCRIPTION
## Description
Ensures the parents of lists in add pane are defined in height so that the scrolling of lists can happen


Fixes #33585

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9157711114>
> Commit: d148c704866263ab5ceab6ca57c9414aeb2d1f09
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9157711114&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
