### PR TITLE
fix: hide gs from airgap from most popular section

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/CreateNewDatasourceTab.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/CreateNewDatasourceTab.tsx
@@ -147,6 +147,8 @@ function CreateNewDatasource({
     }
   }, [active]);
 
+  const isAirgappedInstance = isAirgapped();
+
   return (
     <div id="new-datasources" ref={newDatasourceRef}>
       <Text kind="heading-m">
@@ -158,6 +160,7 @@ function CreateNewDatasource({
         editorId={editorId}
         editorType={editorType}
         history={history}
+        isAirgappedInstance={isAirgappedInstance}
         isCreating={isCreating}
         location={location}
         parentEntityId={parentEntityId || (isOnboardingScreen && pageId) || ""}

--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceHome.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceHome.tsx
@@ -129,6 +129,7 @@ interface DatasourceHomeScreenProps {
   showMostPopularPlugins?: boolean;
   isCreating?: boolean;
   showUnsupportedPluginDialog: (callback: any) => void;
+  isAirgappedInstance?: boolean;
 }
 
 interface ReduxDispatchProps {
@@ -287,13 +288,20 @@ class DatasourceHomeScreen extends React.Component<Props> {
 
 const mapStateToProps = (
   state: AppState,
-  props: { showMostPopularPlugins?: boolean },
+  props: { showMostPopularPlugins?: boolean; isAirgappedInstance?: boolean },
 ) => {
   const { datasources } = state.entities;
+  const mostPopularPlugins = getMostPopularPlugins(state);
+  const filteredMostPopularPlugins: Plugin[] = !!props?.isAirgappedInstance
+    ? mostPopularPlugins.filter(
+        (plugin: Plugin) =>
+          plugin?.packageName !== PluginPackageName.GOOGLE_SHEETS,
+      )
+    : mostPopularPlugins;
   return {
     pluginImages: getPluginImages(state),
     plugins: !!props?.showMostPopularPlugins
-      ? getMostPopularPlugins(state)
+      ? filteredMostPopularPlugins
       : getDBPlugins(state),
     currentApplication: getCurrentApplication(state),
     isSaving: datasources.loading,

--- a/app/client/src/pages/Editor/IntegrationEditor/NewQuery.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/NewQuery.tsx
@@ -29,6 +29,7 @@ interface QueryHomeScreenProps {
   };
   showMostPopularPlugins?: boolean;
   showUnsupportedPluginDialog: (callback: any) => void;
+  isAirgappedInstance?: boolean;
 }
 
 class QueryHomeScreen extends React.Component<QueryHomeScreenProps> {
@@ -37,6 +38,7 @@ class QueryHomeScreen extends React.Component<QueryHomeScreenProps> {
       editorId,
       editorType,
       history,
+      isAirgappedInstance,
       isCreating,
       location,
       parentEntityId,
@@ -51,6 +53,7 @@ class QueryHomeScreen extends React.Component<QueryHomeScreenProps> {
           editorId={editorId}
           editorType={editorType}
           history={history}
+          isAirgappedInstance={isAirgappedInstance}
           isCreating={isCreating}
           location={location}
           parentEntityId={parentEntityId}


### PR DESCRIPTION
## Description
This PR hides google sheets from most popular section of datasources page for airgapped version of appsmith.

Note: jest unit test would be added as part of https://github.com/appsmithorg/appsmith/issues/33596


Fixes #33590  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9158106089>
> Commit: a49094af46de1ba40ec27489a570a7723236d2e0
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9158106089&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
