### PR TITLE
chore: Switched key factory for RSA to BC as well

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/SshTransportConfigCallback.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/SshTransportConfigCallback.java
@@ -87,7 +87,7 @@ public class SshTransportConfigCallback implements TransportConfigCallback {
                 PublicKey generatedPublicKey;
 
                 if (publicKey.startsWith(RSA_TYPE)) {
-                    keyFactory = KeyFactory.getInstance(RSA_KEY_FACTORY_IDENTIFIER);
+                    keyFactory = KeyFactory.getInstance(RSA_KEY_FACTORY_IDENTIFIER, new BouncyCastleProvider());
 
                     generatedPublicKey = keyFactory.generatePublic(CryptoUtil.decodeOpenSSHRSA(publicKey.getBytes()));
 


### PR DESCRIPTION
## Description
RSA with default JCE does not support OpenSSH format which is needed for backwards compatibility with Azure repos and the SHA1 keys we used to generate for them earlier.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9185405942>
> Commit: ddc01b0473d48c4c9a7e8ed310f6bbedc15fe920
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9185405942&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
