### PR TITLE
chore: Refactor RTSCaller API signatures for more flexibility

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DSLMigrationUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DSLMigrationUtils.java
@@ -19,7 +19,7 @@ public class DSLMigrationUtils {
                 new ParameterizedTypeReference<>() {};
         return rtsCaller
                 .get("/rts-api/v1/dsl/version")
-                .flatMap(spec -> spec.bodyToMono(parameterizedTypeReference))
+                .flatMap(spec -> spec.retrieve().bodyToMono(parameterizedTypeReference))
                 .map(responseDTO -> responseDTO.getData().getVersion());
     }
 
@@ -34,7 +34,7 @@ public class DSLMigrationUtils {
 
         return rtsCaller
                 .post("/rts-api/v1/dsl/migrate", pageDsl)
-                .flatMap(spec -> spec.bodyToMono(parameterizedTypeReference))
+                .flatMap(spec -> spec.retrieve().bodyToMono(parameterizedTypeReference))
                 .map(responseDTO -> responseDTO.getData());
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RTSCaller.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RTSCaller.java
@@ -44,7 +44,7 @@ public class RTSCaller {
                 .build();
     }
 
-    private Mono<WebClient.ResponseSpec> makeRequest(HttpMethod method, String path, Object requestBody) {
+    private Mono<WebClient.RequestBodySpec> makeRequest(HttpMethod method, String path, Object requestBody) {
         final WebClient.RequestBodySpec spec = webClient.method(method).uri(path);
 
         if (requestBody != null) {
@@ -64,15 +64,19 @@ public class RTSCaller {
                 }
             }
 
-            return spec.retrieve();
+            return spec;
         });
     }
 
-    public Mono<WebClient.ResponseSpec> get(@NonNull String path) {
+    public Mono<WebClient.RequestBodySpec> get(@NonNull String path) {
         return makeRequest(HttpMethod.GET, path, null);
     }
 
-    public Mono<WebClient.ResponseSpec> post(@NonNull String path, @NonNull Object requestBody) {
+    public Mono<WebClient.RequestBodySpec> post(@NonNull String path, @NonNull Object requestBody) {
         return makeRequest(HttpMethod.POST, path, requestBody);
+    }
+
+    public Mono<WebClient.RequestBodySpec> put(@NonNull String path, @NonNull Object requestBody) {
+        return makeRequest(HttpMethod.PUT, path, requestBody);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/InstanceConfigHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/InstanceConfigHelperCEImpl.java
@@ -27,7 +27,6 @@ import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
@@ -185,7 +184,7 @@ public class InstanceConfigHelperCEImpl implements InstanceConfigHelperCE {
 
         return rtsCaller
                 .get("/rts-api/v1/health-check")
-                .flatMap(WebClient.ResponseSpec::toBodilessEntity)
+                .flatMap((spec) -> spec.retrieve().toBodilessEntity())
                 .doOnNext(nextSignal -> {
                     log.debug("RTS health check succeeded");
                     this.isRtsAccessible = true;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -118,7 +118,8 @@ public class AstServiceCEImpl implements AstServiceCE {
         }
         return rtsCaller
                 .post("/rts-api/v1/ast/multiple-script-data", new GetIdentifiersRequestBulk(bindingValues, evalVersion))
-                .flatMapMany(spec -> spec.bodyToMono(GetIdentifiersResponseBulk.class)
+                .flatMapMany(spec -> spec.retrieve()
+                        .bodyToMono(GetIdentifiersResponseBulk.class)
                         .retryWhen(Retry.max(3))
                         .flatMapIterable(getIdentifiersResponse -> getIdentifiersResponse.data)
                         .index())
@@ -147,7 +148,7 @@ public class AstServiceCEImpl implements AstServiceCE {
                             bindingValue.getValue(), oldName, newName, evalVersion, isJSObject);
                     return rtsCaller
                             .post("/rts-api/v1/ast/entity-refactor", entityRefactorRequest)
-                            .flatMap(spec -> spec.toEntity(EntityRefactorResponse.class))
+                            .flatMap(spec -> spec.retrieve().toEntity(EntityRefactorResponse.class))
                             .flatMap(entityRefactorResponseResponseEntity -> {
                                 if (HttpStatus.OK.equals(entityRefactorResponseResponseEntity.getStatusCode())) {
                                     return Mono.just(


### PR DESCRIPTION
We need this flexibility for some API calls in the EE, and it doesn't make much sense to have separate API signatures for CE/EE.

/test sanity

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9173253978>
> Commit: 422aaa8863aa3aa0039ac60cb46e370ea89127f7
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9173253978&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->
