### PR TITLE
chore: hide fields in input widget when field is readonly

### DIFF
--- a/app/client/src/widgets/wds/WDSBaseInputWidget/config/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSBaseInputWidget/config/contentConfig.ts
@@ -73,6 +73,9 @@ export const propertyPaneContentConfig = [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: { type: ValidationTypes.TEXT },
+        hidden: (props: BaseInputWidgetProps) => {
+          return Boolean(props.isReadOnly);
+        },
       },
       {
         helpText: "Sets a placeholder text for the input",
@@ -83,6 +86,9 @@ export const propertyPaneContentConfig = [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: { type: ValidationTypes.TEXT },
+        hidden: (props: BaseInputWidgetProps) => {
+          return Boolean(props.isReadOnly);
+        },
       },
       {
         helpText: "Controls the visibility of the widget",
@@ -103,6 +109,9 @@ export const propertyPaneContentConfig = [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
+        hidden: (props: BaseInputWidgetProps) => {
+          return Boolean(props.isReadOnly);
+        },
       },
       {
         helpText:
@@ -135,6 +144,9 @@ export const propertyPaneContentConfig = [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
+        hidden: (props: BaseInputWidgetProps) => {
+          return Boolean(props.isReadOnly);
+        },
       },
       {
         propertyName: "allowFormatting",
@@ -153,6 +165,9 @@ export const propertyPaneContentConfig = [
   },
   {
     sectionName: "Events",
+    hidden: (props: BaseInputWidgetProps) => {
+      return Boolean(props.isReadOnly);
+    },
     children: [
       {
         helpText: "when the text is changed",

--- a/app/client/src/widgets/wds/WDSInputWidget/config/propertyPaneConfig/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSInputWidget/config/propertyPaneConfig/contentConfig.ts
@@ -76,6 +76,9 @@ export const propertyPaneContentConfig = [
   },
   {
     sectionName: "Validation",
+    hidden: (props: InputWidgetProps) => {
+      return Boolean(props.isReadOnly);
+    },
     children: [
       {
         propertyName: "isRequired",


### PR DESCRIPTION
Fixes #33192

/ok-to-test tags="@tag.Anvil"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9173647447>
> Commit: dfcc9ca09ad310f6ecad93c7ac924c61cbb4d50e
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9173647447&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

