### PR TITLE
chore: creating super user bean through bean

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/UserConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/UserConfig.java
@@ -1,0 +1,129 @@
+package com.appsmith.server.configurations;
+
+import com.appsmith.server.acl.PolicyGenerator;
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.Config;
+import com.appsmith.server.domains.PermissionGroup;
+import com.appsmith.server.domains.Tenant;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.helpers.TextUtils;
+import com.appsmith.server.helpers.UpdateSuperUserHelper;
+import com.appsmith.server.repositories.CacheableRepositoryHelper;
+import com.appsmith.server.repositories.ConfigRepository;
+import com.appsmith.server.repositories.PermissionGroupRepository;
+import com.appsmith.server.repositories.TenantRepository;
+import com.appsmith.server.repositories.UserRepository;
+import com.appsmith.server.solutions.PolicySolution;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.appsmith.server.constants.EnvVariables.APPSMITH_ADMIN_EMAILS;
+import static com.appsmith.server.constants.ce.FieldNameCE.DEFAULT_PERMISSION_GROUP;
+import static com.appsmith.server.helpers.CollectionUtils.findSymmetricDiff;
+
+@Configuration
+@Slf4j
+@AllArgsConstructor
+public class UserConfig {
+    private final CacheableRepositoryHelper cacheableRepositoryHelper;
+    private final PolicySolution policySolution;
+    private final PolicyGenerator policyGenerator;
+    private final UserRepository userRepository;
+    private final PermissionGroupRepository permissionGroupRepository;
+    private final ConfigRepository configRepository;
+    private final TenantRepository tenantRepository;
+    private final UpdateSuperUserHelper updateSuperUserHelper = new UpdateSuperUserHelper();
+
+    /**
+     * Responsible for creating super-users based on the admin emails provided in the environment.
+     */
+    @Bean
+    public void createSuperUsers() {
+        // Read the admin emails from the environment and update the super-users accordingly
+        String adminEmailsStr = System.getenv(String.valueOf(APPSMITH_ADMIN_EMAILS));
+
+        Set<String> adminEmails = TextUtils.csvToSet(adminEmailsStr);
+
+        Optional<Config> instanceAdminConfigurationOptional = configRepository.findByName(FieldName.INSTANCE_CONFIG);
+        if (instanceAdminConfigurationOptional.isEmpty()) {
+            log.error("Instance configuration not found. Cannot create super users.");
+            return;
+        }
+        Config instanceAdminConfiguration = instanceAdminConfigurationOptional.get();
+
+        String instanceAdminPermissionGroupId =
+                (String) instanceAdminConfiguration.getConfig().get(DEFAULT_PERMISSION_GROUP);
+
+        Optional<PermissionGroup> instanceAdminPGOptional =
+                permissionGroupRepository.findById(instanceAdminPermissionGroupId);
+        if (instanceAdminPGOptional.isEmpty()) {
+            log.error("Instance admin permission group not found. Cannot create super users.");
+            return;
+        }
+        PermissionGroup instanceAdminPG = instanceAdminPGOptional.get();
+
+        Optional<Tenant> tenantOptional = tenantRepository.findBySlug("default");
+        if (tenantOptional.isEmpty()) {
+            log.error("Default tenant not found. Cannot create super users.");
+            return;
+        }
+        Tenant tenant = tenantOptional.get();
+
+        Set<String> userIds = adminEmails.stream()
+                .map(String::trim)
+                .map(String::toLowerCase)
+                .map(email -> {
+                    User user = null;
+                    Optional<User> userOptional = userRepository.findByEmail(email);
+                    if (userOptional.isPresent()) {
+                        user = userOptional.get();
+                    }
+
+                    if (user == null) {
+                        log.info("Creating super user with username {}", email);
+                        user = updateSuperUserHelper.createNewUser(
+                                email,
+                                tenant,
+                                instanceAdminPG,
+                                userRepository,
+                                permissionGroupRepository,
+                                policySolution,
+                                policyGenerator);
+                    }
+
+                    return user.getId();
+                })
+                .collect(Collectors.toSet());
+
+        Set<String> oldSuperUsers = instanceAdminPG.getAssignedToUserIds();
+        if (oldSuperUsers == null || oldSuperUsers.isEmpty()) {
+            oldSuperUsers = Set.of();
+        }
+        Set<String> updatedUserIds = findSymmetricDiff(oldSuperUsers, userIds);
+        evictPermissionCacheForUsers(updatedUserIds, userRepository, cacheableRepositoryHelper);
+
+        instanceAdminPG.setAssignedToUserIds(userIds);
+        permissionGroupRepository.save(instanceAdminPG);
+    }
+
+    public static void evictPermissionCacheForUsers(
+            Set<String> userIds, UserRepository userRepository, CacheableRepositoryHelper cacheableRepositoryHelper) {
+
+        if (userIds == null || userIds.isEmpty()) {
+            // Nothing to do here.
+            return;
+        }
+
+        userIds.forEach(userId -> {
+            userRepository.findById(userId).ifPresent(user -> cacheableRepositoryHelper
+                    .evictPermissionGroupsUser(user.getEmail(), user.getTenantId())
+                    .block());
+        });
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/UpdateSuperUserHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/UpdateSuperUserHelper.java
@@ -1,0 +1,7 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.helpers.ce.UpdateSuperUserHelperCE;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class UpdateSuperUserHelper extends UpdateSuperUserHelperCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UpdateSuperUserHelperCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UpdateSuperUserHelperCE.java
@@ -1,0 +1,79 @@
+package com.appsmith.server.helpers.ce;
+
+import com.appsmith.external.models.Policy;
+import com.appsmith.server.acl.PolicyGenerator;
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.PermissionGroup;
+import com.appsmith.server.domains.Tenant;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.Permission;
+import com.appsmith.server.repositories.PermissionGroupRepository;
+import com.appsmith.server.repositories.UserRepository;
+import com.appsmith.server.solutions.PolicySolution;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
+import static com.appsmith.server.acl.AclPermission.READ_USERS;
+import static com.appsmith.server.acl.AclPermission.RESET_PASSWORD_USERS;
+
+public class UpdateSuperUserHelperCE {
+    protected Set<Policy> generateUserPolicy(
+            User user,
+            PermissionGroup userManagementRole,
+            PermissionGroup instanceAdminRole,
+            Tenant tenant,
+            PolicySolution policySolution,
+            PolicyGenerator policyGenerator) {
+        Policy readUserPolicy = Policy.builder()
+                .permission(READ_USERS.getValue())
+                .permissionGroups(Set.of(userManagementRole.getId()))
+                .build();
+        Policy manageUserPolicy = Policy.builder()
+                .permission(MANAGE_USERS.getValue())
+                .permissionGroups(Set.of(userManagementRole.getId()))
+                .build();
+        Policy resetPwdPolicy = Policy.builder()
+                .permission(RESET_PASSWORD_USERS.getValue())
+                .permissionGroups(Set.of(userManagementRole.getId()))
+                .build();
+
+        return new HashSet<>(Set.of(readUserPolicy, manageUserPolicy, resetPwdPolicy));
+    }
+
+    public User createNewUser(
+            String email,
+            Tenant tenant,
+            PermissionGroup instanceAdminRole,
+            UserRepository userRepository,
+            PermissionGroupRepository permissionGroupRepository,
+            PolicySolution policySolution,
+            PolicyGenerator policyGenerator) {
+        User user = new User();
+        user.setEmail(email);
+        user.setIsEnabled(false);
+        user.setTenantId(tenant.getId());
+        user.setCreatedAt(Instant.now());
+        user = userRepository.save(user);
+
+        // Assign the user to the default permissions
+        PermissionGroup userManagementPermissionGroup = new PermissionGroup();
+        userManagementPermissionGroup.setName(user.getUsername() + FieldName.SUFFIX_USER_MANAGEMENT_ROLE);
+        // Add CRUD permissions for user to the group
+        userManagementPermissionGroup.setPermissions(Set.of(new Permission(user.getId(), MANAGE_USERS)));
+
+        // Assign the permission group to the user
+        userManagementPermissionGroup.setAssignedToUserIds(Set.of(user.getId()));
+
+        PermissionGroup savedPermissionGroup = permissionGroupRepository.save(userManagementPermissionGroup);
+
+        Set<Policy> userPolicies = this.generateUserPolicy(
+                user, savedPermissionGroup, instanceAdminRole, tenant, policySolution, policyGenerator);
+
+        user.setPolicies(userPolicies);
+
+        return userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## Description
This PR replaces repeating updateSuperUser migration that was existing on MongoDB, and instead create bean for the same because of dependency injection used in migration previously.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
