### PR TITLE
test: updated widget commands by removing unused commands

### DIFF
--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/postgres_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/postgres_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -70,10 +70,6 @@ Cypress.Commands.add(
   },
 );
 
-Cypress.Commands.add("switchToPaginationTab", () => {
-  cy.get(apiwidget.paginationTab).first().click({ force: true });
-});
-
 Cypress.Commands.add("selectDateFormat", (value) => {
   cy.get(
     ".t--property-control-dateformat .ads-v2-select > .rc-select-selector",
@@ -111,21 +107,6 @@ Cypress.Commands.add("assertDateFormat", () => {
           expect(firstTxt).not.to.equal(secondText);
         });
     });
-});
-
-Cypress.Commands.add("selectPaginationType", (option) => {
-  cy.xpath(option).click({ force: true });
-});
-
-Cypress.Commands.add("copyJSObjectToPage", (pageName) => {
-  cy.xpath(apiwidget.popover).last().click({ force: true });
-  cy.get(apiwidget.copyTo).click({ force: true });
-  cy.get(apiwidget.page).contains(pageName).click();
-  cy.wait("@createNewJSCollection").should(
-    "have.nested.property",
-    "response.body.responseMeta.status",
-    201,
-  );
 });
 
 Cypress.Commands.add("AddActionWithModal", () => {
@@ -234,11 +215,6 @@ Cypress.Commands.add("verifyUpdatedWidgetName", (text, txtToVerify) => {
   cy.wait(2000); //for widget name to reflect!
 });
 
-Cypress.Commands.add("verifyWidgetText", (text, inputcss, innercss) => {
-  cy.get(inputcss).first().trigger("mouseover", { force: true });
-  cy.contains(innercss, text);
-});
-
 Cypress.Commands.add("editColName", (text) => {
   cy.get(commonlocators.editColTitle)
     .click({ force: true })
@@ -247,29 +223,11 @@ Cypress.Commands.add("editColName", (text) => {
   cy.get(commonlocators.editColText).should("have.text", text);
 });
 
-Cypress.Commands.add("invalidWidgetText", () => {
-  // checking invalid widget name
-  cy.get(commonlocators.propertyPaneTitle)
-    .click({ force: true })
-    .type("download")
-    .type("{enter}");
-  cy.get(commonlocators.toastmsg).contains("download is already being used.");
-});
-
 Cypress.Commands.add("EvaluateDataType", (dataType) => {
   cy.get(commonlocators.evaluatedType)
     .first()
     .should("be.visible")
     .contains(dataType);
-});
-
-Cypress.Commands.add("getCodeMirror", () => {
-  cy.EnableAllCodeEditors();
-  return cy
-    .get(".CodeMirror textarea")
-    .first()
-    .focus()
-    .type("{ctrl}{shift}{downarrow}");
 });
 
 Cypress.Commands.add("testCodeMirror", (value) => {
@@ -357,33 +315,6 @@ Cypress.Commands.add("updateComputedValueV2", (value) => {
   });
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(1000);
-});
-
-Cypress.Commands.add("testCodeMirrorWithIndex", (value, index) => {
-  cy.EnableAllCodeEditors();
-  cy.get(".CodeMirror textarea")
-    .eq(index)
-    .focus()
-    .type("{ctrl}{shift}{downarrow}", { force: true })
-    .then(($cm) => {
-      if ($cm.val() !== "") {
-        cy.get(".CodeMirror textarea").eq(index).clear({
-          force: true,
-        });
-      }
-
-      cy.get(".CodeMirror textarea")
-        .eq(index)
-        .type("{ctrl}{shift}{downarrow}", { force: true })
-        .clear({ force: true })
-        .type(value, {
-          force: true,
-          parseSpecialCharSequences: false,
-        });
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(200);
-      cy.get(".CodeMirror textarea").eq(index).should("have.value", value);
-    });
 });
 
 Cypress.Commands.add("testCodeMirrorLast", (value) => {
@@ -604,34 +535,6 @@ Cypress.Commands.add("toggleJsAndUpdate", (endp, value) => {
   cy.wait(200);
 });
 
-Cypress.Commands.add("toggleJsAndUpdateWithIndex", (endp, value, index) => {
-  cy.get(".CodeMirror textarea")
-    .eq(index)
-    .focus({ force: true })
-    .type("{uparrow}", { force: true })
-    .type("{ctrl}{shift}{downarrow}", { force: true });
-  cy.focused().then(($cm) => {
-    if ($cm.contents !== "") {
-      cy.log("The field is empty");
-      cy.get(".CodeMirror textarea").eq(index).clear({
-        force: true,
-      });
-    }
-    cy.get(".CodeMirror textarea").eq(index).type(value, {
-      force: true,
-      parseSpecialCharSequences: false,
-    });
-  });
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(200);
-});
-
-Cypress.Commands.add("assertControlVisibility", (endp) => {
-  cy.get(".t--property-control-" + endp + " .CodeMirror")
-    .first()
-    .should("not.be.visible");
-});
-
 Cypress.Commands.add("tableColumnDataValidation", (columnName) => {
   cy.backFromPropertyPanel();
   cy.get("[data-rbd-draggable-id='" + columnName + "'] input")
@@ -813,13 +716,6 @@ Cypress.Commands.add("evaluateErrorMessage", (value) => {
     });
 });
 
-Cypress.Commands.add("addAction", (value, property) => {
-  cy.get(`.t--add-action-${property}`).click();
-  cy.get(`.single-select:contains('Show alert')`).click();
-
-  cy.enterActionValue(value, property);
-});
-
 // Cypress.Commands.add("addSuccessMessage", (value) => {
 //   cy.get(commonlocators.chooseMsgType).last().click({ force: true });
 //   cy.get(commonlocators.chooseAction).children().contains("Success").click();
@@ -867,53 +763,6 @@ Cypress.Commands.add("enterActionValue", (value, property) => {
     });
 });
 
-Cypress.Commands.add("enterEventValue", (value) => {
-  cy.get(commonlocators.optionchangetextDropdown)
-    .focus()
-    .type("{ctrl}{shift}{downarrow}")
-    .then(($cm) => {
-      if ($cm.val() !== "") {
-        cy.get(commonlocators.optionchangetextDropdown).clear({
-          force: true,
-        });
-      }
-
-      cy.get(commonlocators.optionchangetextDropdown).type(value, {
-        force: true,
-        parseSpecialCharSequences: false,
-      });
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(200);
-    });
-});
-
-Cypress.Commands.add("enterNavigatePageName", (value) => {
-  cy.get("ul.tree")
-    .children()
-    .first()
-    .within(() => {
-      cy.get(".CodeMirror textarea")
-        .first()
-        .focus()
-        .type("{ctrl}{shift}{downarrow}")
-        .then(($cm) => {
-          if ($cm.val() !== "") {
-            cy.get(".CodeMirror textarea").first().clear({
-              force: true,
-            });
-          }
-          cy.get(".CodeMirror textarea").first().type(value, {
-            force: true,
-            parseSpecialCharSequences: false,
-          });
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(200);
-          cy.get(".CodeMirror textarea").first().should("have.value", value);
-        });
-      cy.root();
-    });
-});
-
 Cypress.Commands.add("ClearDate", () => {
   cy.get(".t--property-control-defaultdate input").clear();
   cy.assertPageSave();
@@ -924,11 +773,6 @@ Cypress.Commands.add("ClearDateFooter", () => {
     .contains("Clear")
     .click({ force: true });
   //cy.assertPageSave();
-});
-
-Cypress.Commands.add("DeleteModal", () => {
-  cy.get(widgetsPage.textbuttonWidget).dblclick("topRight", { force: true });
-  cy.get(widgetsPage.deleteWidget).first().click({ force: true });
 });
 
 Cypress.Commands.add("Createpage", (pageName, navigateToCanvasPage = true) => {
@@ -948,15 +792,6 @@ Cypress.Commands.add("Createpage", (pageName, navigateToCanvasPage = true) => {
     const pageId = xhr.response.body.data.id;
     cy.wrap(pageId).as("currentPageId");
   });
-});
-
-Cypress.Commands.add("dropdownDynamic", (text) => {
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(2000);
-  cy.get("ul.bp3-menu")
-    .contains(text)
-    .click({ force: true })
-    .should("have.text", text);
 });
 
 Cypress.Commands.add("dropdownMultiSelectDynamic", (text) => {
@@ -984,13 +819,6 @@ Cypress.Commands.add("treeMultiSelectDropdown", (text) => {
     .contains(text)
     .click({ force: true })
     .should("have.text", text);
-});
-
-Cypress.Commands.add("dropdownDynamicUpdated", (text) => {
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(2000);
-  cy.get(commonlocators.dropdownmenu).contains(text).click({ force: true });
-  cy.xpath(commonlocators.dropDownOptSelected).should("have.text", text);
 });
 
 Cypress.Commands.add("selectTextSize", (text) => {
@@ -1024,24 +852,6 @@ Cypress.Commands.add("togglebar", (value) => {
 Cypress.Commands.add("togglebarDisable", (value) => {
   cy.get(value).uncheck({ force: true }).should("not.checked");
 });
-
-Cypress.Commands.add("addQueryFromLightningMenu", (QueryName) => {
-  cy.get(commonlocators.dropdownSelectButton)
-    .first()
-    .click({ force: true })
-    .selectOnClickOption("Execute a query")
-    .selectOnClickOption(QueryName);
-});
-
-Cypress.Commands.add(
-  "addAPIFromLightningMenu",
-  (ApiName, eventName = "onClick") => {
-    ObjectsRegistry.PropertyPane.AddAction(eventName);
-    cy.get(ObjectsRegistry.CommonLocators._dropDownValue("Execute a query"))
-      .click()
-      .selectOnClickOption(ApiName);
-  },
-);
 
 Cypress.Commands.add("radioInput", (index, text) => {
   cy.get(widgetsPage.RadioInput)
@@ -1171,18 +981,6 @@ Cypress.Commands.add("UpdateChartType", (typeOfChart) => {
   ).should("have.text", typeOfChart);
 });
 
-Cypress.Commands.add("alertValidate", (text) => {
-  cy.get(commonlocators.success).should("be.visible").and("have.text", text);
-});
-
-Cypress.Commands.add("ExportVerify", (togglecss, name) => {
-  cy.togglebar(togglecss);
-  cy.get(".t--draggable-tablewidget button")
-    .invoke("attr", "aria-label")
-    .should("contain", name);
-  cy.togglebarDisable(togglecss);
-});
-
 Cypress.Commands.add("getTableDataSelector", (rowNum, colNum) => {
   const selector = `.t--widget-tablewidget .tbody .td[data-rowindex=${rowNum}][data-colindex=${colNum}] div div`;
   return selector;
@@ -1273,12 +1071,6 @@ Cypress.Commands.add("tablefirstdataRow", () => {
   return tabVal;
 });
 
-Cypress.Commands.add("scrollTabledataPublish", (rowNum, colNum) => {
-  const selector = `.t--widget-tablewidget .tbody .td[data-rowindex=${rowNum}][data-colindex=${colNum}] div div`;
-  const tabVal = cy.get(selector).scrollIntoView().invoke("text");
-  return tabVal;
-});
-
 Cypress.Commands.add("readTableLinkPublish", (rowNum, colNum) => {
   const selector = `.t--widget-tablewidget .tbody .td[data-rowindex=${rowNum}][data-colindex=${colNum}] div .image-cell-wrapper .image-cell`;
   const bgUrl = cy.get(selector).should("have.css", "background-image");
@@ -1291,26 +1083,9 @@ Cypress.Commands.add("readTableV2LinkPublish", (rowNum, colNum) => {
   return bgUrl;
 });
 
-Cypress.Commands.add("assertEvaluatedValuePopup", (expectedType) => {
-  cy.get(commonlocators.evaluatedTypeTitle).first().find("span").click();
-  cy.get(dynamicInputLocators.evaluatedValue)
-    .should("be.visible")
-    .find("pre")
-    .first()
-    .should("have.text", expectedType);
-});
-
 Cypress.Commands.add("validateToastMessage", (value) => {
   cy.get(commonlocators.toastMsg).should("contain.text", value);
 });
-
-Cypress.Commands.add(
-  "validateWidgetExists",
-  { prevSubject: true },
-  (selector) => {
-    cy.get(selector).should("exist");
-  },
-);
 
 Cypress.Commands.add("clearPropertyValue", (value) => {
   cy.EnableAllCodeEditors();
@@ -1375,18 +1150,6 @@ Cypress.Commands.add("getTableCellHeight", (x, y) => {
     .invoke("css", "height");
 });
 
-Cypress.Commands.add("hoverTableCell", (x, y) => {
-  return cy.get(`[data-colindex="${x}"][data-rowindex="${y}"]`).then((ele) => {
-    const { left, top } = ele[0].getBoundingClientRect();
-    cy.get(
-      `[data-colindex=${x}][data-rowindex=${y}] .t--table-text-cell`,
-    ).trigger("mousemove", top + 5, left + 5, {
-      eventConstructor: "MouseEvent",
-      force: true,
-    });
-  });
-});
-
 Cypress.Commands.add("editTableCell", (x, y) => {
   cy.get(`[data-colindex="${x}"][data-rowindex="${y}"] .t--editable-cell-icon`)
     .invoke("show")
@@ -1447,16 +1210,6 @@ Cypress.Commands.add("saveTableRow", (x, y) => {
   ).click({ force: true });
 });
 
-Cypress.Commands.add("AssertTableRowSavable", (x, y) => {
-  cy.get(
-    `[data-colindex="${x}"][data-rowindex="${y}"] button span:contains('Save')`,
-  ).should("exist");
-
-  cy.get(
-    `[data-colindex="${x}"][data-rowindex="${y}"] button span:contains('Save')`,
-  ).should("not.be.disabled");
-});
-
 Cypress.Commands.add("discardTableRow", (x, y) => {
   cy.get(
     `[data-colindex="${x}"][data-rowindex="${y}"] button span:contains('Discard')`,
@@ -1469,73 +1222,6 @@ Cypress.Commands.add("moveToStyleTab", () => {
 
 Cypress.Commands.add("moveToContentTab", () => {
   cy.get(commonlocators.propertyContent).first().click({ force: true });
-});
-
-Cypress.Commands.add("openPropertyPaneWithIndex", (widgetType, index) => {
-  const selector = `.t--draggable-${widgetType}`;
-  cy.wait(500);
-  cy.get(selector)
-    .eq(index)
-    .scrollIntoView()
-    .trigger("mouseover", { force: true })
-    .wait(500);
-  cy.get(`${selector}:first-of-type`)
-    .eq(index)
-    .scrollIntoView()
-    .click({ force: true })
-    .wait(500);
-  cy.get(".t--widget-propertypane-toggle > .t--widget-name")
-    .first()
-    .click({ force: true });
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(1000);
-});
-
-Cypress.Commands.add("changeLayoutHeight", (locator) => {
-  cy.get(commonlocators.heightProperty)
-    .last()
-    .scrollIntoView()
-    .click({ force: true });
-  cy.get(commonlocators.heightPropertyOption)
-    .contains(locator)
-    .click({ force: true });
-  cy.wait("@updateLayout").should(
-    "have.nested.property",
-    "response.body.responseMeta.status",
-    200,
-  );
-});
-
-Cypress.Commands.add("changeLayoutHeightWithoutWait", (locator) => {
-  cy.get(commonlocators.heightProperty)
-    .last()
-    .scrollIntoView()
-    .click({ force: true });
-  cy.get(commonlocators.heightPropertyOption)
-    .contains(locator)
-    .click({ force: true });
-});
-
-Cypress.Commands.add("checkMinDefaultValue", (endp, value) => {
-  cy.get(".cm-m-null")
-    .first()
-    .invoke("text")
-    .then((text) => {
-      const someText = text;
-      cy.log(someText);
-      expect(someText).to.equal(value);
-    });
-});
-
-Cypress.Commands.add("checkMaxDefaultValue", (endp, value) => {
-  cy.get(".cm-m-null")
-    .last()
-    .invoke("text")
-    .then((text) => {
-      const someText = text;
-      cy.log(someText);
-      expect(someText).to.equal(value);
-    });
 });
 
 Cypress.Commands.add("freezeColumnFromDropdown", (columnName, direction) => {

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1325,3 +1325,13 @@ Cypress.Commands.add("resizeColumn", (columnName, resizeAmount) => {
     .trigger("mousemove", { x: resizeAmount, y: 0, force: true })
     .trigger("mouseup");
 });
+
+Cypress.Commands.add("AssertTableRowSavable", (x, y) => {
+  cy.get(
+    `[data-colindex="${x}"][data-rowindex="${y}"] button span:contains('Save')`,
+  ).should("exist");
+
+  cy.get(
+    `[data-colindex="${x}"][data-rowindex="${y}"] button span:contains('Save')`,
+  ).should("not.be.disabled");
+});


### PR DESCRIPTION
RCA: There are many unused commands within widgetCommands.js file

Solution:
Checked the widgetCommands in both CE and EE repository and we are removing those commands which are not used in any tests as part of cleanup activity

Equivalent EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4280 run was successful

/ok-to-test tags="@tag.All"<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9177941076>
> Commit: 7c0db4762795f1fa7e028d4e717f5e5b88f83723
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9177941076&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/postgres_spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->


