### PR TITLE
chore: don't trigger onFocus for readonly currency input widget

### DIFF
--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
@@ -189,7 +189,7 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
   };
 
   onFocusChange = (isFocused?: boolean) => {
-    // We don't want to deformat orthe text or trigger
+    // We don't want to deformat or the text or trigger
     // any event on focus if the widget is read only
     if (Boolean(this.props.isReadOnly)) return;
 

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
@@ -189,14 +189,20 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
   };
 
   onFocusChange = (isFocused?: boolean) => {
+    // We don't want to deformat orthe text or trigger
+    // any event on focus if the widget is read only
+    if (Boolean(this.props.isReadOnly)) return;
+
     try {
       if (isFocused) {
         const text = this.props.text || "";
+
         const deFormattedValue = text.replace(
           new RegExp("\\" + getLocaleThousandSeparator(), "g"),
           "",
         );
         this.props.updateWidgetMetaProperty("text", deFormattedValue);
+
         this.props.updateWidgetMetaProperty("isFocused", isFocused, {
           triggerPropertyName: "onFocus",
           dynamicString: this.props.onFocus,


### PR DESCRIPTION
Fixes #31604

/ok-to-test tags="@tag.Anvil"




<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9202493096>
> Commit: 9f675180c1efd31a272f73dfa9193192710222de
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9202493096&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->







