### PR TITLE
feat: add support to capture info of more cloud-providers

### DIFF
--- a/deploy/docker/fs/opt/appsmith/generate-infra-details.sh
+++ b/deploy/docker/fs/opt/appsmith/generate-infra-details.sh
@@ -14,6 +14,12 @@ function get_cloud_provider() {
      cloud_provider="azure";
   elif [[ $release_details == *"cloud"* ]];then
      cloud_provider="gcp";
+  elif [[ $release_details == *"generic"* ]];then
+     cloud_provider="digitalocean"
+  elif [[ $release_details == *"ecs"* ]];then
+     cloud_provider="alibaba"
+  elif [[ ! -z "${DYNO}" ]];then
+     cloud_provider="heroku"
   else
      cloud_provider="local";
   fi


### PR DESCRIPTION
Output in Digital Ocean:
```
root@eebb561a4259:/opt/appsmith# ./generate-infra-details.sh
/tmp/appsmith/infra.json
{"cloudProvider":"digitalocean","tool":"docker","efs":"absent","hostname":"eebb561a4259", "currentTime": "2024-05-22T07:20:54+00:00"}
root@eebb561a4259:/opt/appsmith# cat /tmp/appsmith/infra.json
{"cloudProvider":"digitalocean","tool":"docker","efs":"absent","hostname":"eebb561a4259", "currentTime": "2024-05-22T07:20:54+00:00"}
```
