### PR TITLE
feat: Anvil: Enable parent selection for focused widget

### DIFF
--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
@@ -19,6 +19,7 @@ import type { NameComponentStates } from "./types";
 import { generateDragStateForAnvilLayout } from "layoutSystems/anvil/utils/widgetUtils";
 import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
+import { isWidgetSelected } from "selectors/widgetSelectors";
 
 export function AnvilWidgetName(props: {
   widgetId: string;
@@ -42,10 +43,13 @@ export function AnvilWidgetName(props: {
     (state) => getWidgetErrorCount(state, widgetId) > 0,
   );
 
+  const isParentSelected = useSelector(isWidgetSelected(parentId || ""));
+
   const styleProps = getWidgetNameComponentStyleProps(
     widgetType,
     nameComponentState,
     showError,
+    isParentSelected,
   );
 
   const { setDraggingState } = useWidgetDragResize();

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/utils.ts
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/utils.ts
@@ -103,6 +103,7 @@ export function getWidgetNameComponentStyleProps(
   widgetType: string,
   nameComponentState: NameComponentStates,
   showError: boolean,
+  isParentSelected: boolean,
 ) {
   const config = WidgetFactory.getConfig(widgetType);
   const onCanvasUI = config?.onCanvasUI || {
@@ -121,11 +122,6 @@ export function getWidgetNameComponentStyleProps(
       ? onCanvasUI.focusColorCSSVar
       : onCanvasUI.selectionColorCSSVar;
 
-  let disableParentToggle = onCanvasUI.disableParentSelection;
-  if (nameComponentState === "focus") {
-    disableParentToggle = true;
-  }
-
   // If there is an error, show the widget name in error state
   // This includes background being the error color
   // and font color being white.
@@ -134,7 +130,8 @@ export function getWidgetNameComponentStyleProps(
     colorCSSVar = "--on-canvas-ui-white";
   }
   return {
-    disableParentToggle,
+    // disable parent toggle if the parent is already selected
+    disableParentToggle: isParentSelected || onCanvasUI.disableParentSelection,
     bGCSSVar,
     colorCSSVar,
     selectionBGCSSVar: onCanvasUI.selectionBGCSSVar,


### PR DESCRIPTION
## Description
- If the parent is already selected, disable parent selection
- Introduce the selector to check if parent is selected.


Fixes #33648 

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
