### PR TITLE
fix: allow building blocks to be dropped inside containers

### DIFF
--- a/app/client/src/layoutSystems/common/dropTarget/OnBoarding/index.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/OnBoarding/index.tsx
@@ -18,7 +18,6 @@ import { getIsMobileCanvasLayout } from "selectors/editorSelectors";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import BuildingBlockExplorerDropTarget from "../buildingBlockExplorerDropTarget";
 import StarterBuildingBlocks from "../starterBuildingBlocks";
-
 function Onboarding() {
   const isMobileCanvas = useSelector(getIsMobileCanvasLayout);
   const appState = useCurrentAppState();

--- a/app/client/src/sagas/BuildingBlockSagas/BuildingBlockAdditionSagas.ts
+++ b/app/client/src/sagas/BuildingBlockSagas/BuildingBlockAdditionSagas.ts
@@ -5,7 +5,6 @@ import {
   WidgetReduxActionTypes,
 } from "@appsmith/constants/ReduxActionConstants";
 import AnalyticsUtil from "@appsmith/utils/AnalyticsUtil";
-import { selectWidgetInitAction } from "actions/widgetSelectionActions";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { cloneDeep, isString } from "lodash";
 import log from "loglevel";
@@ -29,7 +28,6 @@ import { generateAutoHeightLayoutTreeAction } from "actions/autoHeightActions";
 import type { DataTree } from "entities/DataTree/dataTreeTypes";
 import { nextAvailableRowInContainer } from "entities/Widget/utils";
 import type { GridProps, SpaceMap } from "reflow/reflowTypes";
-import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { getDataTree } from "selectors/dataTreeSelectors";
 import { flashElementsById } from "utils/helpers";
 import history from "utils/history";
@@ -48,9 +46,7 @@ import type { CopiedWidgetGroup } from "../WidgetOperationUtils";
 import {
   getBoundaryWidgetsFromCopiedGroups,
   getNextWidgetName,
-  getParentWidgetIdForPasting,
   getReflowedPositions,
-  getSelectedWidgetWhenPasting,
   handleSpecificCasesWhilePasting,
 } from "../WidgetOperationUtils";
 
@@ -93,6 +89,8 @@ import { postPageAdditionSaga } from "../TemplatesSagas";
 import { addChildSaga } from "../WidgetAdditionSagas";
 import { calculateNewWidgetPosition } from "../WidgetOperationSagas";
 import { getDragDetails, getWidgetByName } from "../selectors";
+import { selectWidgetInitAction } from "actions/widgetSelectionActions";
+import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 
 function* addBuildingBlockActionsToApplication(dragDetails: DragDetails) {
   const applicationId: string = yield select(getCurrentApplicationId);
@@ -214,16 +212,19 @@ export function* loadBuildingBlocksIntoApplication(
         type: WidgetReduxActionTypes.WIDGET_SINGLE_DELETE,
         payload: {
           widgetId: skeletonLoaderId,
-          parentId: MAIN_CONTAINER_WIDGET_ID,
+          parentId: buildingBlockWidget.widgetId,
           disallowUndo: true,
           isShortcut: false,
         },
       });
 
-      yield pasteBuildingBlockWidgetsSaga({
-        top: topRow,
-        left: leftColumn,
-      });
+      yield pasteBuildingBlockWidgetsSaga(
+        {
+          top: topRow,
+          left: leftColumn,
+        },
+        buildingBlockWidget.widgetId,
+      );
 
       const timeTakenToDropWidgetsInSeconds =
         (Date.now() - buildingBlockDragStartTimestamp) / 1000;
@@ -286,7 +287,7 @@ export function* loadBuildingBlocksIntoApplication(
       type: WidgetReduxActionTypes.WIDGET_SINGLE_DELETE,
       payload: {
         widgetId: skeletonLoaderId,
-        parentId: MAIN_CONTAINER_WIDGET_ID,
+        parentId: buildingBlockWidget.widgetId,
         disallowUndo: true,
         isShortcut: false,
       },
@@ -315,7 +316,6 @@ export function* addBuildingBlockToCanvasSaga(
       ...addEntityAction.payload,
       type: "SKELETON_WIDGET",
       widgetName: skeletonWidgetName,
-      widgetId: MAIN_CONTAINER_WIDGET_ID,
       // so that the skeleton loader does not get included when the users uses the undo/redo
       shouldReplay: false,
     },
@@ -364,7 +364,6 @@ export function* addAndMoveBuildingBlockToCanvasSaga(
         ...actionPayload.payload.newWidget,
         type: "SKELETON_WIDGET",
         widgetName: skeletonWidgetName,
-        widgetId: MAIN_CONTAINER_WIDGET_ID,
       },
     },
   });
@@ -395,10 +394,13 @@ export function* addAndMoveBuildingBlockToCanvasSaga(
  *
  * @param gridPosition - The position of the grid where the widgets will be pasted.
  */
-export function* pasteBuildingBlockWidgetsSaga(gridPosition: {
-  top: number;
-  left: number;
-}) {
+export function* pasteBuildingBlockWidgetsSaga(
+  gridPosition: {
+    top: number;
+    left: number;
+  },
+  parentWidgetId: string,
+) {
   const {
     flexLayers,
     widgets: copiedWidgets,
@@ -412,17 +414,14 @@ export function* pasteBuildingBlockWidgetsSaga(gridPosition: {
   const newlyCreatedWidgetIds: string[] = [];
   const canvasWidgets: CanvasWidgetsReduxState = yield select(getWidgets);
   let widgets: CanvasWidgetsReduxState = canvasWidgets;
-  const selectedWidget: FlattenedWidgetProps<undefined> =
-    yield getSelectedWidgetWhenPasting();
 
   const isMobile: boolean = yield select(getIsAutoLayoutMobileBreakPoint);
   const mainCanvasWidth: number = yield select(getCanvasWidth);
 
+  // add another entry key and value to canvasWidgets
+
   try {
-    let pastingIntoWidgetId: string = yield getParentWidgetIdForPasting(
-      canvasWidgets,
-      selectedWidget,
-    );
+    const pastingIntoWidgetId: string = parentWidgetId;
 
     const isThereACollision = false;
 
@@ -447,7 +446,6 @@ export function* pasteBuildingBlockWidgetsSaga(gridPosition: {
     // new pasting positions, the variables are undefined if the positions cannot be calculated,
     // then it pastes the regular way at the bottom of the canvas
     const {
-      canvasId,
       gridProps,
       newPastingPositionMap,
       reflowedMovementMap,
@@ -464,8 +462,6 @@ export function* pasteBuildingBlockWidgetsSaga(gridPosition: {
       leftMostWidget.leftColumn,
       { gridPosition },
     );
-
-    if (canvasId) pastingIntoWidgetId = canvasId;
 
     for (const widgetGroup of copiedWidgetGroups) {
       //This is required when you cut the widget as CanvasWidgetState doesn't have the widget anymore


### PR DESCRIPTION
## Description
**Problem**
Previously, the implementation of building blocks was limited in functionality: building blocks could not be placed into containers. This restriction constrained building blocks to be solely draggable items on the canvas, reducing their versatility and utility.

**Solution**
To address this limitation, we have improved the paste logic for building blocks. The updated logic now allows building blocks to be dropped into other containers.

**Key changes include:**
1. Simplification of the `pastingIntoWidgetId` determination process. The paste logic previously had multiple conditions to determine this ID.
2. Direct passing of the parent widget ID into the `pasteBuildingBlockWidgetsSaga` function, streamlining the process and reducing complexity.
These enhancements significantly increase the flexibility of building blocks, enabling more complex and nested designs.

Fixes #33606

## Automation

/ok-to-test tags="@tag.Templates, @tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
