### PR TITLE
fix: Animation glitchiness in property pane for preview mode

### DIFF
--- a/app/client/src/components/editorComponents/PropertyPaneSidebar.tsx
+++ b/app/client/src/components/editorComponents/PropertyPaneSidebar.tsx
@@ -122,10 +122,10 @@ export const PropertyPaneSidebar = memo((props: Props) => {
   }, [isWalkthroughOpened]);
 
   return (
-    <div className="relative h-full">
+    <div className="relative h-full bg-white border-l ">
       {/* PROPERTY PANE */}
       <div
-        className="js-property-pane-sidebar t--property-pane-sidebar flex h-full border-l bg-white"
+        className="js-property-pane-sidebar t--property-pane-sidebar flex h-full"
         id={PROPERTY_PANE_ID}
         ref={sidebarRef}
       >

--- a/app/client/src/pages/Editor/IDE/index.tsx
+++ b/app/client/src/pages/Editor/IDE/index.tsx
@@ -40,16 +40,7 @@ function IDE() {
           <LeftPane />
         </div>
         <MainPane id="app-body" />
-        <div
-          className={classNames({
-            [`transition-transform transform duration-400 ${tailwindLayers.propertyPane}`]:
-              true,
-            relative: !isCombinedPreviewMode,
-            "translate-x-full fixed right-0": isCombinedPreviewMode,
-          })}
-        >
-          <RightPane />
-        </div>
+        <RightPane />
       </EditorWrapperContainer>
       <BottomBar viewMode={isPreviewMode} />
     </>

--- a/app/client/src/pages/Editor/WidgetsEditor/components/PropertyPaneWrapper.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/components/PropertyPaneWrapper.tsx
@@ -4,6 +4,9 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { getPropertyPaneWidth } from "selectors/propertyPaneSelectors";
 import { CreateNewQueryModal } from "pages/Editor/IDE/RightPane/components/CreateNewQueryModal";
+import classNames from "classnames";
+import { tailwindLayers } from "constants/Layers";
+import { combinedPreviewModeSelector } from "selectors/editorSelectors";
 
 /**
  * PropertyPaneWrapper
@@ -30,16 +33,24 @@ function PropertyPaneWrapper() {
   const onRightSidebarWidthChange = useCallback((newWidth) => {
     dispatch(setPropertyPaneWidthAction(newWidth));
   }, []);
+  const isCombinedPreviewMode = useSelector(combinedPreviewModeSelector);
 
   return (
-    <>
+    <div
+      className={classNames({
+        [`transition-transform transform duration-400 h-full ${tailwindLayers.propertyPane}`]:
+          true,
+        relative: !isCombinedPreviewMode,
+        "translate-x-full fixed right-0": isCombinedPreviewMode,
+      })}
+    >
       <PropertyPaneSidebar
         onDragEnd={onRightSidebarDragEnd}
         onWidthChange={onRightSidebarWidthChange}
         width={propertyPaneWidth}
       />
       <CreateNewQueryModal />
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description

Moves the animation of preview mode into the property pane from the IDE level to fix the glitchy beahviour


Fixes #30542


## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9208787780>
> Commit: f000e5ce48b94b92267cafb4e443f600153b95f3
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9208787780&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
