### PR TITLE
revert: "fix: Remove the strict check for mongo url"

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonDBConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonDBConfig.java
@@ -30,8 +30,7 @@ public class CommonDBConfig {
     @Primary
     @Profile("!test")
     public MongoProperties configureMongoDB() {
-        log.debug("Configuring MongoDB with url: {}", appsmithDbUrl);
-        if (!appsmithDbUrl.contains("mongodb")) {
+        if (!appsmithDbUrl.startsWith("mongodb")) {
             return null;
         }
         log.info("Found MongoDB uri configuring now");

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -183,7 +183,6 @@ configure_database_connection_url() {
   elif [[ "${APPSMITH_DB_URL}" == "mongodb"* ]]; then
     isMongoUrl=1
   fi
-  echo "Configured database connection URL is $APPSMITH_DB_URL"
 }
 
 check_db_uri() {


### PR DESCRIPTION
Reverts appsmithorg/appsmith#33652

Reverting the change as the root cause was different https://theappsmith.slack.com/archives/C0134BAVDB4/p1716393908273869?thread_ts=1716375955.137629&cid=C0134BAVDB4

## Automation

/ok-to-test tags="@tag.Sanity"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9201290830>
> Commit: 8e623fa37565078c23f1a307cbdfa416cfa89ed0
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9201290830&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

