### PR TITLE
fix: Remove the feature to download docker-compose file from admin settings

### DIFF
--- a/app/client/src/ce/api/UserApi.tsx
+++ b/app/client/src/ce/api/UserApi.tsx
@@ -102,7 +102,6 @@ export class UserApi extends Api {
   static superUserURL = "v1/users/super";
   static adminSettingsURL = "v1/admin/env";
   static restartServerURL = "v1/admin/restart";
-  static downloadConfigURL = "v1/admin/env/download";
   static sendTestEmailURL = "/v1/admin/send-test-email";
 
   static async createUser(

--- a/app/client/src/ce/pages/AdminSettings/config/general.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/general.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { isEmail } from "utils/formhelpers";
-import { apiRequestConfig } from "api/Api";
-import UserApi from "@appsmith/api/UserApi";
 import type {
   AdminConfigType,
   Setting,
@@ -46,21 +44,6 @@ export const APPSMITH_ADMIN_EMAILS_SETTING: Setting = {
       return "Please enter valid email id(s)";
     }
   },
-};
-
-export const APPSMITH_DOWNLOAD_DOCKER_COMPOSE_FILE_SETTING: Setting = {
-  id: "APPSMITH_DOWNLOAD_DOCKER_COMPOSE_FILE",
-  action: () => {
-    const { host, protocol } = window.location;
-    window.open(
-      `${protocol}//${host}${apiRequestConfig.baseURL}${UserApi.downloadConfigURL}`,
-      "_blank",
-    );
-  },
-  category: SettingCategories.GENERAL,
-  controlType: SettingTypes.BUTTON,
-  label: "Generated docker compose file",
-  text: "Download",
 };
 
 export const APPSMITH_DISABLE_TELEMETRY_SETTING: Setting = {
@@ -204,7 +187,6 @@ export const config: AdminConfigType = {
   settings: [
     APPSMITH_INSTANCE_NAME_SETTING_SETTING,
     APPSMITH_ADMIN_EMAILS_SETTING,
-    APPSMITH_DOWNLOAD_DOCKER_COMPOSE_FILE_SETTING,
     APPSMITH_DISABLE_TELEMETRY_SETTING,
     APPSMITH_HIDE_WATERMARK_SETTING,
     APPSMITH_SHOW_ROLES_AND_GROUPS_SETTING,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/InstanceAdminControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/InstanceAdminControllerCE.java
@@ -36,13 +36,6 @@ public class InstanceAdminControllerCE {
         return envManager.getAllNonEmpty().map(data -> new ResponseDTO<>(HttpStatus.OK.value(), data, null));
     }
 
-    @JsonView(Views.Public.class)
-    @GetMapping("/env/download")
-    public Mono<Void> download(ServerWebExchange exchange) {
-        log.debug("Getting all env configuration");
-        return envManager.download(exchange);
-    }
-
     @Deprecated
     @JsonView(Views.Public.class)
     @PutMapping(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
@@ -4,7 +4,6 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.TestEmailConfigRequestDTO;
 import org.springframework.http.codec.multipart.Part;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -40,6 +39,4 @@ public interface EnvManagerCE {
     Mono<Void> restartWithoutAclCheck();
 
     Mono<Boolean> sendTestEmail(TestEmailConfigRequestDTO requestDTO);
-
-    Mono<Void> download(ServerWebExchange exchange);
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -24,22 +24,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(SpringExtension.class)
 @Slf4j
@@ -292,51 +286,6 @@ public class EnvManagerTest {
                         "",
                         "APPSMITH_INSTANCE_NAME='third value'",
                         "APPSMITH_DISABLE_TELEMETRY='some quotes '\"'\"'inside'\"'\"' it'");
-    }
-
-    @Test
-    public void download_UserIsNotSuperUser_ThrowsAccessDenied() {
-        User user = new User();
-        user.setEmail("sample-super-user");
-        Mockito.when(sessionUserService.getCurrentUser()).thenReturn(Mono.just(user));
-        Mockito.when(userService.findByEmail(user.getEmail())).thenReturn(Mono.just(user));
-        Mockito.when(userUtils.isCurrentUserSuperUser()).thenReturn(Mono.just(false));
-
-        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
-        ServerHttpResponse response = Mockito.mock(ServerHttpResponse.class);
-        HttpHeaders headers = new HttpHeaders();
-
-        StepVerifier.create(envManager.download(exchange))
-                .expectErrorMessage(AppsmithError.UNAUTHORIZED_ACCESS.getMessage())
-                .verify();
-    }
-
-    @Test
-    public void download_UserIsSuperUser_ReturnsZip() throws IOException {
-        User user = new User();
-        user.setEmail("sample-super-user");
-        Mockito.when(sessionUserService.getCurrentUser()).thenReturn(Mono.just(user));
-        Mockito.when(userService.findByEmail(user.getEmail())).thenReturn(Mono.just(user));
-        Mockito.when(userUtils.isCurrentUserSuperUser()).thenReturn(Mono.just(true));
-
-        // create a temp file for docker env
-        File file = File.createTempFile("envmanager-test-docker-file", "env");
-        file.deleteOnExit();
-
-        Mockito.when(commonConfig.getEnvFilePath()).thenReturn(file.getAbsolutePath());
-        Mockito.when(fileUtils.createZip(any())).thenReturn(new byte[1024]);
-
-        ServerWebExchange exchange = Mockito.mock(ServerWebExchange.class);
-        ServerHttpResponse response = Mockito.mock(ServerHttpResponse.class);
-        HttpHeaders headers = new HttpHeaders();
-        Mockito.when(response.getHeaders()).thenReturn(headers);
-        Mockito.when(exchange.getResponse()).thenReturn(response);
-        Mockito.when(response.writeWith(any())).thenReturn(Mono.empty());
-
-        StepVerifier.create(envManager.download(exchange)).verifyComplete();
-
-        assertThat(headers.getContentType().toString()).isEqualTo("application/zip");
-        assertThat(headers.getContentDisposition().toString()).containsIgnoringCase("appsmith-config.zip");
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #`Issue Number`  

## Automation

/ok-to-test tags="@tag.Settings,@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9203402018>
> Commit: 200f008e602d5173a6167209b8b7804c086e8fb8
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9203402018&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
