### PR TITLE
chore: Pin NodeJS version to the one in package.json

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -44,7 +44,7 @@ RUN set -o xtrace \
 # Install NodeJS
 RUN set -o xtrace \
   && mkdir -p /opt/node \
-  && version="$(node -e 'console.log(JSON.parse(require("fs").readFileSync("app/client/package.json")).engines.node.match(/[.\d]+/)?.[0] ?? "")')" \
+  && version="$(cat app/client/package.json | tr -d '\n' | grep -Eo '"engines".+?"node".+?".+?"' | grep -Eo '[.0-9]+')" \
   && test -n "$version" \
   && curl "https://nodejs.org/dist/v$version/node-v$version-linux-$(uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/').tar.gz" \
   | tar -xz -C /opt/node --strip-components 1

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -44,8 +44,10 @@ RUN set -o xtrace \
 # Install NodeJS
 RUN set -o xtrace \
   && mkdir -p /opt/node \
-  && file="$(curl -sS 'https://nodejs.org/dist/latest-v20.x/' | awk -F\" '$2 ~ /linux-'"$(uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/')"'.tar.gz/ {print $2}')" \
-  && curl "https://nodejs.org/dist/latest-v20.x/$file" | tar -xz -C /opt/node --strip-components 1
+  && version="$(node -e 'console.log(JSON.parse(require("fs").readFileSync("app/client/package.json")).engines.node.match(/[.\d]+/)?.[0] ?? "")')" \
+  && test -n "$version" \
+  && curl "https://nodejs.org/dist/v$version/node-v$version-linux-$(uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/').tar.gz" \
+  | tar -xz -C /opt/node --strip-components 1
 
 # Install Caddy
 RUN set -o xtrace \


### PR DESCRIPTION
The newer NodeJS version `20.13` requires a more recent version of glibc, one which isn't available on Ubuntu 20.04 yet. We need to stick to NodeJS v20.11 until we can update Ubuntu itself to 22.04, or the updated glibc shows up in Ubuntu 20.04.

Pinning NodeJS version for now to unblock.

/test sanity

<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/9203860279>
> Commit: 4d0f6063e063660f8502b493e2f07f04d6beb6ce
> Workflow: `PR Automation test suite`
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->
