### PR TITLE
chore: Conditional initialization of the Postgres docker for running server tests

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -139,8 +139,10 @@ jobs:
           java-version: "17"
 
       - name: Conditionally start PostgreSQL
+        env:
+          IS_PG_BUILD: ${{ inputs.is-pg-build }}
         run: |
-          if [[ inputs.is-pg-build == 'true' ]]; then
+          if [[ $IS_PG_BUILD == 'true' ]]; then
             docker run --name appsmith-pg -p 5432:5432 -d -e POSTGRES_PASSWORD=password postgres:alpine
           fi
 


### PR DESCRIPTION
## Description
In GH actions `inputs` can't be interpreted in the run command, moving that to env and then conditionally applying the logic works as expected.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9204642490>
> Commit: f694a10b0e32089dc4dda9d02ac9edc733bc718e
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9204642490&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
