### PR TITLE
chore: Updating the nomenclature for version in analytics from `appsmithVersion` to `version`

### DIFF
--- a/app/client/src/ce/utils/AnalyticsUtil.tsx
+++ b/app/client/src/ce/utils/AnalyticsUtil.tsx
@@ -245,7 +245,7 @@ class AnalyticsUtil {
             ? {
                 id: AnalyticsUtil.cachedAnonymoustId,
                 email: userData.email,
-                appsmithVersion: `Appsmith ${appVersion.edition} ${appVersion.id}`,
+                version: `Appsmith ${appVersion.edition} ${appVersion.id}`,
                 instanceId: AnalyticsUtil.instanceId,
               }
             : {}),


### PR DESCRIPTION
## Description

Updating the nomenclature for version in analytics from `appsmithVersion` to `version`.

Fixes [#1672](https://github.com/appsmithorg/cloud-services/pull/1672)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9206459797>
> Commit: e3c1923a57deda96f88945a2be8cdba1c395ccba
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9206459797&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
