### PR TITLE
fix: fetch actions and plugins before choosing which GQL editor tab to focus

### DIFF
--- a/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.test.ts
+++ b/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.test.ts
@@ -2,7 +2,7 @@ import { runSaga } from "redux-saga";
 import { AppIDEFocusStrategy } from "./AppIDEFocusStrategy";
 import { NavigationMethod } from "utils/history";
 import { getIDETestState } from "test/factories/AppIDEFactoryUtils";
-import { take } from "redux-saga/effects";
+import { all, take } from "redux-saga/effects";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 
 describe("AppIDEFocusStrategy", () => {
@@ -247,6 +247,20 @@ describe("AppIDEFocusStrategy", () => {
       );
 
       expect(pageChangeGen.next().value).toEqual(undefined);
+    });
+
+    it("waits for actions and plugins to be loaded in case of first page load", () => {
+      const pageChangeGen = AppIDEFocusStrategy.waitForPathLoad(
+        "/app/appSlug/pageSlug-pageId/edit/api/actionId",
+        "",
+      );
+
+      expect(pageChangeGen.next().value).toEqual(
+        all([
+          take(ReduxActionTypes.FETCH_ACTIONS_SUCCESS),
+          take(ReduxActionTypes.FETCH_PLUGINS_SUCCESS),
+        ]),
+      );
     });
   });
 });

--- a/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
+++ b/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
@@ -1,4 +1,4 @@
-import { select, take } from "redux-saga/effects";
+import { all, select, take } from "redux-saga/effects";
 import type { FocusPath, FocusStrategy } from "sagas/FocusRetentionSaga";
 import type { AppsmithLocationState } from "utils/history";
 import { NavigationMethod } from "utils/history";
@@ -220,6 +220,14 @@ export const AppIDEFocusStrategy: FocusStrategy = {
       if (isPageChange(previousPath, currentPath)) {
         yield take(ReduxActionTypes.FETCH_PAGE_SUCCESS);
       }
+    } else {
+      // Wait for the application's actions and plugins to be fetched
+      // so we know if we should focus the Headers or Body tab in the API Editor,
+      // which depends on the action type.
+      yield all([
+        take(ReduxActionTypes.FETCH_ACTIONS_SUCCESS),
+        take(ReduxActionTypes.FETCH_PLUGINS_SUCCESS),
+      ]);
     }
   },
 };


### PR DESCRIPTION
## Description
[`FocusRetentionSaga`](https://github.com/appsmithorg/appsmith/blob/d71e050fa6ad1da1aed222d756fb2c523c75d322/app/client/src/sagas/FocusRetentionSaga.ts) is not respecting the GraphQL API editor [subtype](https://github.com/appsmithorg/appsmith/blob/release/app/client/src/ce/navigation/FocusElements/AppIDE.ts#L162-L164) when the page is being loaded because it's running its focus management logic before knowing that the action being edited is in fact a GraphQL plugin action.

So now I am waiting for the app's actions and plugins to be loaded before the [focus retention logic](https://github.com/appsmithorg/appsmith/blob/d71e050fa6ad1da1aed222d756fb2c523c75d322/app/client/src/sagas/FocusRetentionSaga.ts#L183-L210) is run.

<table>
<tr>
 <td><strong>Before
 <td><strong>After
<tr>
 <td>

https://github.com/appsmithorg/appsmith/assets/1488378/22350e6e-c8e8-42d9-82da-aa2034279808

 <td>

https://github.com/appsmithorg/appsmith/assets/1488378/9c126a01-76de-4c4f-9c05-fbd566399e22

</table>


Fixes #33695

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
