### PR TITLE
fix: added fix for vanishing appdetails

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ImportExportUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ImportExportUtils.java
@@ -5,7 +5,6 @@ import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
-import com.appsmith.server.domains.ApplicationDetail;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.ArtifactExchangeJson;
 import lombok.extern.slf4j.Slf4j;
@@ -78,37 +77,6 @@ public class ImportExportUtils {
         }
 
         return "";
-    }
-
-    /**
-     * This function sets the current applicationDetail properties to null if the user wants to discard the changes
-     * and accept from the git repo which doesn't contain these.
-     * @param importedApplicationDetail
-     * @param existingApplicationDetail
-     */
-    private static void setPropertiesToApplicationDetail(
-            ApplicationDetail importedApplicationDetail, ApplicationDetail existingApplicationDetail) {
-        // If the initial commit to git doesn't contain these keys and if we want to discard the changes,
-        // the function copyNestedNonNullProperties ignore these properties and the changes are not discarded
-
-        // this case would be handled when the bean would be copied
-        if (existingApplicationDetail == null) {
-            return;
-        }
-
-        Application.AppPositioning appPositioning = null;
-        Application.NavigationSetting navigationSetting = null;
-        Application.ThemeSetting themeSetting = null;
-
-        if (importedApplicationDetail == null) {
-            appPositioning = importedApplicationDetail.getAppPositioning();
-            navigationSetting = importedApplicationDetail.getNavigationSetting();
-            themeSetting = importedApplicationDetail.getThemeSetting();
-        }
-
-        existingApplicationDetail.setAppPositioning(appPositioning);
-        existingApplicationDetail.setNavigationSetting(navigationSetting);
-        existingApplicationDetail.setThemeSetting(themeSetting);
     }
 
     public static void setPropertiesToExistingApplication(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ImportExportUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ImportExportUtils.java
@@ -90,29 +90,34 @@ public class ImportExportUtils {
             ApplicationDetail importedApplicationDetail, ApplicationDetail existingApplicationDetail) {
         // If the initial commit to git doesn't contain these keys and if we want to discard the changes,
         // the function copyNestedNonNullProperties ignore these properties and the changes are not discarded
-        if (importedApplicationDetail != null && existingApplicationDetail != null) {
-            if (importedApplicationDetail.getAppPositioning() == null) {
-                existingApplicationDetail.setAppPositioning(null);
-            }
 
-            if (importedApplicationDetail.getNavigationSetting() == null) {
-                existingApplicationDetail.setNavigationSetting(null);
-            }
-
-            if (importedApplicationDetail.getThemeSetting() == null) {
-                existingApplicationDetail.setThemeSetting(null);
-            }
+        // this case would be handled when the bean would be copied
+        if (existingApplicationDetail == null) {
+            return;
         }
+
+        Application.AppPositioning appPositioning = null;
+        Application.NavigationSetting navigationSetting = null;
+        Application.ThemeSetting themeSetting = null;
+
+        if (importedApplicationDetail == null) {
+            appPositioning = importedApplicationDetail.getAppPositioning();
+            navigationSetting = importedApplicationDetail.getNavigationSetting();
+            themeSetting = importedApplicationDetail.getThemeSetting();
+        }
+
+        existingApplicationDetail.setAppPositioning(appPositioning);
+        existingApplicationDetail.setNavigationSetting(navigationSetting);
+        existingApplicationDetail.setThemeSetting(themeSetting);
     }
 
     public static void setPropertiesToExistingApplication(
             Application importedApplication, Application existingApplication) {
         importedApplication.setId(existingApplication.getId());
 
-        ApplicationDetail importedUnpublishedAppDetail = importedApplication.getUnpublishedApplicationDetail();
-        ApplicationDetail importedPublishedAppDetail = importedApplication.getPublishedApplicationDetail();
-        ApplicationDetail existingUnpublishedAppDetail = existingApplication.getUnpublishedApplicationDetail();
-        ApplicationDetail existingPublishedAppDetail = existingApplication.getPublishedApplicationDetail();
+        // Since we don't want to merge the ApplicationDetailObjects we would just assign the imported values directly
+        existingApplication.setPublishedApplicationDetail(importedApplication.getPublishedApplicationDetail());
+        existingApplication.setUnpublishedApplicationDetail(importedApplication.getUnpublishedApplicationDetail());
 
         // For the existing application we don't need to default
         // value of the flag
@@ -125,21 +130,12 @@ public class ImportExportUtils {
         // These properties are not present in the application when it is created, hence the initial commit
         // to git doesn't contain these keys and if we want to discard the changes, the function
         // copyNestedNonNullProperties ignore these properties and the changes are not discarded
-        if (importedUnpublishedAppDetail == null) {
-            existingApplication.setUnpublishedApplicationDetail(null);
-        }
-        if (importedPublishedAppDetail == null) {
-            existingApplication.setPublishedApplicationDetail(null);
-        }
         if (importedApplication.getPublishedAppLayout() == null) {
             existingApplication.setPublishedAppLayout(null);
         }
         if (importedApplication.getUnpublishedAppLayout() == null) {
             existingApplication.setUnpublishedAppLayout(null);
         }
-
-        setPropertiesToApplicationDetail(importedUnpublishedAppDetail, existingUnpublishedAppDetail);
-        setPropertiesToApplicationDetail(importedPublishedAppDetail, existingPublishedAppDetail);
 
         copyNestedNonNullProperties(importedApplication, existingApplication);
     }


### PR DESCRIPTION
## Description
- modified logic to copy the ApplicationDetails object of the importedApplication to existing application

Fixes #24920

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9207111058>
> Commit: 9d426c0ab94360ad964fbaaa267ee2485c10a322
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9207111058&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
