### PR TITLE
chore: add `PROPERTY` color constant in `CodeEditorColors`

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/constants.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/constants.ts
@@ -13,6 +13,18 @@ export const VALID_JS_OBJECT_BINDING_POSITION: Position = {
   ch: JS_OBJECT_START_STATEMENT.length,
 };
 
+export const CodeEditorColors = {
+  KEYWORD: "#304eaa",
+  FOLD_MARKER: "#442334",
+  STRING: "#1659df",
+  OPERATOR: "#009595",
+  NUMBER: "#555",
+  COMMENT: "var(--ads-v2-color-gray-400)",
+  FUNCTION_ARGS: "hsl(288, 44%, 44%)",
+  TOOLTIP_FN_ARGS: "#DB6E33",
+  PROPERTY: "hsl(21, 70%, 53%)",
+};
+
 // For now we want to enable this functionality only for table and json widget for data property
 // In future we can modify this object for other widgets and props too
 export const SlashCommandMenuOnFocusWidgetProps: { [key: string]: string[] } = {

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -5,6 +5,7 @@ import {
   EditorSize,
   EditorTheme,
 } from "components/editorComponents/CodeEditor/EditorConfig";
+import { CodeEditorColors } from "components/editorComponents/CodeEditor/constants";
 import type { Theme } from "constants/DefaultTheme";
 import { Skin } from "constants/DefaultTheme";
 import { Colors } from "constants/Colors";
@@ -27,17 +28,6 @@ const getBorderStyle = (
     return "var(--ads-v2-color-border)";
   }
   return "transparent";
-};
-
-export const CodeEditorColors = {
-  KEYWORD: "#304eaa",
-  FOLD_MARKER: "#442334",
-  STRING: "#1659df",
-  OPERATOR: "#009595",
-  NUMBER: "#555",
-  COMMENT: "var(--ads-v2-color-gray-400)",
-  FUNCTION_ARGS: "hsl(288, 44%, 44%)",
-  TOOLTIP_FN_ARGS: "#DB6E33",
 };
 
 export const EditorWrapper = styled.div<{
@@ -137,7 +127,7 @@ export const EditorWrapper = styled.div<{
         }
       }
       .cm-property {
-        color: hsl(21, 70%, 53%);
+        color: ${CodeEditorColors.PROPERTY};
       }
       .cm-keyword {
         color: ${CodeEditorColors.KEYWORD};
@@ -172,7 +162,7 @@ export const EditorWrapper = styled.div<{
 
       /* json response in the debugger */
       .cm-string.cm-property {
-        color: hsl(21, 70%, 53%);
+        color: ${CodeEditorColors.PROPERTY};
       }
 
       // /* +, =>, -, etc. operators */

--- a/app/client/src/components/editorComponents/LazyCodeEditor/styles.tsx
+++ b/app/client/src/components/editorComponents/LazyCodeEditor/styles.tsx
@@ -1,6 +1,6 @@
 import styled, { keyframes } from "styled-components";
 import { ContentKind } from "./types";
-import { CodeEditorColors } from "../CodeEditor/styledComponents";
+import { CodeEditorColors } from "../CodeEditor/constants";
 
 export const HighlighedCodeContainer = styled("div")<{
   contentKind: ContentKind;

--- a/app/client/src/globalStyles/CodemirrorHintStyles.ts
+++ b/app/client/src/globalStyles/CodemirrorHintStyles.ts
@@ -1,8 +1,10 @@
 import { createGlobalStyle } from "styled-components";
 import type { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
 import type { Theme } from "constants/DefaultTheme";
-import { LINT_TOOLTIP_JUSTIFIED_LEFT_CLASS } from "components/editorComponents/CodeEditor/constants";
-import { CodeEditorColors } from "components/editorComponents/CodeEditor/styledComponents";
+import {
+  CodeEditorColors,
+  LINT_TOOLTIP_JUSTIFIED_LEFT_CLASS,
+} from "components/editorComponents/CodeEditor/constants";
 
 export const CodemirrorHintStyles = createGlobalStyle<{
   editorTheme: EditorTheme;

--- a/app/client/src/utils/autocomplete/ternDocTooltip.tsx
+++ b/app/client/src/utils/autocomplete/ternDocTooltip.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { ternDocsInfo } from "@appsmith/utils/autocomplete/EntityDefinitions";
 import type { Completion, TernCompletionResult } from "./CodemirrorTernService";
-import { CodeEditorColors } from "components/editorComponents/CodeEditor/styledComponents";
+import { CodeEditorColors } from "components/editorComponents/CodeEditor/constants";
 import { Link } from "design-system";
 
 export function renderTernTooltipContent(


### PR DESCRIPTION
## Description

The color for a code property is being used more than once but not available as a constant. This PR changes that.
I also moved the `CodeEditorColors` enum to a file where it's less likely to cause circular dependencies. It was moved from `{...}/CodeEditor/styledComponents.ts` to `{...}/CodeEditor/constants.ts`.

_Not related to an existing issue._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
