### PR TITLE
fix: new API getting added into the NA group

### DIFF
--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -680,11 +680,13 @@ export function* createDefaultApiActionPayload(
   const pluginId: string = yield select(getPluginIdOfPackageName, apiType);
   // Default Config is Rest Api Plugin Config
   let defaultConfig: any = DEFAULT_CREATE_API_CONFIG;
+  let pluginType: PluginType = PluginType.API;
   if (apiType === PluginPackageName.GRAPHQL) {
     defaultConfig = DEFAULT_CREATE_GRAPHQL_CONFIG;
   }
   if (apiType === PluginPackageName.APPSMITH_AI) {
     defaultConfig = DEFAULT_CREATE_APPSMITH_AI_CONFIG;
+    pluginType = PluginType.AI;
     yield call(checkAndGetPluginFormConfigsSaga, pluginId);
   }
 
@@ -697,6 +699,7 @@ export function* createDefaultApiActionPayload(
       workspaceId,
       datasourceConfiguration: defaultConfig.datasource.datasourceConfiguration,
     },
+    pluginType,
     eventData: {
       actionType: defaultConfig.eventData.actionType,
       from: from,


### PR DESCRIPTION
## Description

Alternate solution to #33627 to fix the `NA` group of newly created Rest API actions


Fixes #33583

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9218802021>
> Commit: 74c7bd40f21cc47754bde9a44d4ae47728063bb8
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9218802021&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
