### PR TITLE
chore: Fix typo in request field name

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ApplicationCreationDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ApplicationCreationDTO.java
@@ -14,7 +14,7 @@ public record ApplicationCreationDTO(
         @IconName String icon,
         @Pattern(regexp = "#[A-F0-9]{6}") String color,
         Application.AppPositioning positioningType,
-        Boolean showNavBar) {
+        Boolean showNavbar) {
 
     public Application toApplication() {
         final Application application = new Application();
@@ -29,7 +29,7 @@ public record ApplicationCreationDTO(
         applicationDetail.setAppPositioning(positioningType);
 
         final Application.NavigationSetting navigationSetting = new Application.NavigationSetting();
-        navigationSetting.setShowNavbar(showNavBar);
+        navigationSetting.setShowNavbar(showNavbar);
         applicationDetail.setNavigationSetting(navigationSetting);
 
         return application;


### PR DESCRIPTION
Test for this is already there, `AnvilAppNavigation_spec`, which is currently marked as flaky. Will unmark once we merge this in, verified to pass locally. It's the _only_ functionality in the product that uses this field in the request body today.

/test sanity

