### PR TITLE
chore: Enable entity tern server to lookup fnParams in entity definition to autocomplete function params

### DIFF
--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -1238,7 +1238,10 @@ export default new CodeMirrorTernService({
 function dotToBracketNotationAtToken(token: CodeMirror.Token) {
   return (cm: CodeMirror.Editor, hints: Hints, curr: Hint) => {
     let completion = curr.text;
-    if (token.type === "string") {
+    if (
+      token.type === "string" ||
+      ("type" in curr && curr.type === AutocompleteDataType.FUNCTION)
+    ) {
       // | represents the cursor
       // Cases like JSObject1["myV|"]
       cm.replaceRange(completion, hints.from, hints.to);

--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -126,8 +126,8 @@ const FinalObjectPathRegex = /(?:\w+\.)*\w+$/;
  *   Input: '\tconst k = PageQuery.run'
  *   Output: 'PageQuery.run'
  */
-function extractFinalObjectPath(input: string) {
-  const match = input.match(FinalObjectPathRegex);
+export function extractFinalObjectPath(input: string) {
+  const match = (input || "")?.trim().match(FinalObjectPathRegex);
   return match ? match[0] : null;
 }
 

--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -113,7 +113,7 @@ export function isCustomKeywordType(
 }
 
 // Define the regex for extracting the final object path
-const FinalObjectPathRegex = /(?:\w+\.)*\w+$/;
+const FINAL_OBJECT_PATH_REGEX = /(?:\w+\.)*\w+$/;
 
 /**
  * Extracts the final object path from a given input string.
@@ -127,7 +127,7 @@ const FinalObjectPathRegex = /(?:\w+\.)*\w+$/;
  *   Output: 'PageQuery.run'
  */
 export function extractFinalObjectPath(input: string) {
-  const match = (input || "")?.trim().match(FinalObjectPathRegex);
+  const match = (input || "")?.trim().match(FINAL_OBJECT_PATH_REGEX);
   return match ? match[0] : null;
 }
 

--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -112,6 +112,25 @@ export function isCustomKeywordType(
   );
 }
 
+// Define the regex for extracting the final object path
+const FinalObjectPathRegex = /(?:\w+\.)*\w+$/;
+
+/**
+ * Extracts the final object path from a given input string.
+ * The final object path is the rightmost dot-separated path in the string.
+ *
+ * @param {string} input - The input string from which to extract the object path.
+ * @returns {string|null} - The extracted object path or null if no match is found.
+ *
+ * Example:
+ *   Input: '\tconst k = PageQuery.run'
+ *   Output: 'PageQuery.run'
+ */
+function extractFinalObjectPath(input: string) {
+  const match = input.match(FinalObjectPathRegex);
+  return match ? match[0] : null;
+}
+
 export function getDataType(type: string): AutocompleteDataType {
   if (type === "?") return AutocompleteDataType.UNKNOWN;
   else if (type === "number") return AutocompleteDataType.NUMBER;
@@ -177,12 +196,14 @@ class CodeMirrorTernService {
     string,
     DataTreeDefEntityInformation
   >();
+  entityDef: Def;
   options: { async: boolean };
   recentEntities: string[] = [];
 
   constructor(options: { async: boolean }) {
     this.options = options;
     this.server = new TernWorkerServer(this);
+    this.entityDef = {};
   }
 
   resetServer = () => {
@@ -397,6 +418,7 @@ class CodeMirrorTernService {
       this.server.deleteDefs(name);
     }
 
+    this.entityDef = def || {};
     if (entityInfo) this.defEntityInformation = entityInfo;
   }
 
@@ -455,9 +477,21 @@ class CodeMirrorTernService {
         completion.origin === "DATA_TREE" &&
         this.defEntityInformation.has(completion.name);
       let completionText = completion.name + after;
+      const completedLine = lineValue.substring(0, from.ch) + completion.name;
+      const entityPath = extractFinalObjectPath(completedLine);
+
       if (dataType === "FUNCTION" && !completion.origin?.startsWith("LIB/")) {
         if (token.type !== "string" && token.string !== "[") {
-          completionText = completionText + "()";
+          const entityDef = entityPath && this.entityDef[entityPath];
+          if (
+            entityDef &&
+            typeof entityDef === "object" &&
+            "!fnParams" in entityDef
+          ) {
+            completionText = completionText + `(${entityDef["!fnParams"]})`;
+          } else {
+            completionText = completionText + "()";
+          }
         }
       }
       const codeMirrorCompletion: Completion<TernCompletionResult> = {

--- a/app/client/src/utils/autocomplete/__tests__/TernServer.test.ts
+++ b/app/client/src/utils/autocomplete/__tests__/TernServer.test.ts
@@ -4,6 +4,7 @@ import type {
 } from "../CodemirrorTernService";
 import CodemirrorTernService, {
   createCompletionHeader,
+  extractFinalObjectPath,
 } from "../CodemirrorTernService";
 import { AutocompleteDataType } from "../AutocompleteDataType";
 import { MockCodemirrorEditor } from "../../../../test/__mocks__/CodeMirrorEditorMock";
@@ -686,5 +687,41 @@ describe("Tern server completion", () => {
       (item) => expect.objectContaining(item),
     );
     expect(_.sortBy(result.list, "text")).toEqual(expectedContainingItems);
+  });
+});
+
+describe("extractFinalObjectPath", () => {
+  it("should extract the last dot-separated path from a string", () => {
+    expect(extractFinalObjectPath("user.profile.name")).toEqual(
+      "user.profile.name",
+    );
+    expect(extractFinalObjectPath("app.data")).toEqual("app.data");
+  });
+
+  it("should return the last path in a code line", () => {
+    expect(extractFinalObjectPath("const users = GetUsers.run")).toEqual(
+      "GetUsers.run",
+    );
+  });
+
+  it("should return the input if there are no dots", () => {
+    expect(extractFinalObjectPath("username")).toEqual("username");
+  });
+
+  it("should return null for empty or whitespace-only strings", () => {
+    expect(extractFinalObjectPath("")).toBeNull();
+    expect(extractFinalObjectPath("   ")).toBeNull();
+  });
+
+  it("should handle strings with leading and trailing whitespace", () => {
+    expect(extractFinalObjectPath("  user.profile.name  ")).toEqual(
+      "user.profile.name",
+    );
+  });
+
+  it("should return null if no valid path is found", () => {
+    expect(extractFinalObjectPath("This is a valid code string path")).toEqual(
+      "path",
+    );
   });
 });


### PR DESCRIPTION
## Description
This PR enables a functionality to autofill params any entity function like a query's run of js object's function. This autofill only has one pre-condition to work and i.e there has to be a property called `!fnParams` for the entity that should autofill.

The current use-case is for query module instances to be autofilled with the inputs defined in the modules when they are selected from the autocomplete in any code editor.


PR for https://github.com/appsmithorg/appsmith-ee/pull/4281

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9361159573>
> Commit: 4364bd80a6d83f666fee4b009df27527a3a3ca3c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9361159573&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->












## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved autocomplete functionality with enhanced completion text generation for functions.
  - Added a new feature to extract the final object path from a given input string.
  
- **Tests**
  - Added new test cases to validate Tern server completion functionality, ensuring accurate parameter identification and application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->