### PR TITLE
chore: Remove unexpected fields in action update payload

### DIFF
--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { HttpMethod } from "api/Api";
 import API from "api/Api";
 import type { ApiResponse } from "./ApiResponses";
@@ -11,33 +12,9 @@ import type { OtlpSpan } from "UITelemetry/generateTraces";
 import { wrapFnWithParentTraceContext } from "UITelemetry/generateTraces";
 import type { ActionParentEntityTypeInterface } from "@appsmith/entities/Engine/actionHelpers";
 
-export interface CreateActionRequest<T> extends APIRequest {
-  datasourceId: string;
-  pageId: string;
-  name: string;
-  actionConfiguration: T;
-}
-
-export interface UpdateActionRequest<T> extends CreateActionRequest<T> {
-  actionId: string;
-}
-
 export interface Property {
   key: string;
   value?: string;
-}
-
-export interface BodyFormData {
-  editable: boolean;
-  mandatory: boolean;
-  description: string;
-  key: string;
-  value?: string;
-  type: string;
-}
-
-export interface QueryConfig {
-  queryString: string;
 }
 
 export type ActionCreateUpdateResponse = ApiResponse & {
@@ -64,10 +41,6 @@ export interface ExecuteActionRequest extends APIRequest {
   >;
   analyticsProperties?: Record<string, boolean>;
 }
-
-export type ExecuteActionResponse = ApiResponse & {
-  actionId: string;
-};
 
 export interface ActionApiResponseReq {
   headers: Record<string, string[]>;
@@ -133,11 +106,6 @@ export interface PluginErrorDetails {
 export interface MoveActionRequest {
   action: Action;
   destinationPageId: string;
-}
-
-export interface CopyActionRequest {
-  action: Action;
-  pageId: string;
 }
 
 export interface UpdateActionNameRequest {

--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -7,7 +7,6 @@ import axios from "axios";
 import type { Action, ActionViewMode } from "entities/Action";
 import type { APIRequest } from "constants/AppsmithActionConstants/ActionConstants";
 import type { WidgetType } from "constants/WidgetConstants";
-import { omit } from "lodash";
 import type { OtlpSpan } from "UITelemetry/generateTraces";
 import { wrapFnWithParentTraceContext } from "UITelemetry/generateTraces";
 import type { ActionParentEntityTypeInterface } from "@appsmith/entities/Engine/actionHelpers";
@@ -193,11 +192,13 @@ class ActionAPI extends API {
       ActionAPI.apiUpdateCancelTokenSource.cancel();
     }
     ActionAPI.apiUpdateCancelTokenSource = axios.CancelToken.source();
-    let action = Object.assign({}, apiConfig);
+    const action: any = Object.assign({}, apiConfig);
     // While this line is not required, name can not be changed from this endpoint
     delete action.name;
     // Removing datasource storages from the action object since embedded datasources don't have storages
-    action = omit(action, ["datasource.datasourceStorages"]);
+    delete action.datasource?.datasourceStorages;
+    delete action.datasource?.isValid;
+    delete action.entityReferenceType;
     return API.put(`${ActionAPI.url}/${action.id}`, action, undefined, {
       cancelToken: ActionAPI.apiUpdateCancelTokenSource.token,
     });

--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -160,13 +160,18 @@ class ActionAPI extends API {
       ActionAPI.apiUpdateCancelTokenSource.cancel();
     }
     ActionAPI.apiUpdateCancelTokenSource = axios.CancelToken.source();
-    const action: any = Object.assign({}, apiConfig);
-    // While this line is not required, name can not be changed from this endpoint
-    delete action.name;
-    // Removing datasource storages from the action object since embedded datasources don't have storages
-    delete action.datasource?.datasourceStorages;
-    delete action.datasource?.isValid;
-    delete action.entityReferenceType;
+    const action: Partial<Action & { entityReferenceType: unknown }> = {
+      ...apiConfig,
+      name: undefined,
+      entityReferenceType: undefined,
+    };
+    if (action.datasource != null) {
+      action.datasource = {
+        ...(action as any).datasource,
+        datasourceStorages: undefined,
+        isValid: undefined,
+      };
+    }
     return API.put(`${ActionAPI.url}/${action.id}`, action, undefined, {
       cancelToken: ActionAPI.apiUpdateCancelTokenSource.token,
     });


### PR DESCRIPTION
For action update API, client is sending in some fields that the server isn't expecting. As part of tightening what the server accepts in APIs for better security testing, this PR removes these unexpected fields, and sends only what the server knows about, and expects.

/test sanity datasource

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9250048039>
> Commit: f0f19256da15996a2dbf3acc9bf18483c9a3c3b2
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9250048039&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



