### PR TITLE
chore: Don't hit the database when permission is non-null but permission groups is empty

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -108,6 +108,13 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         if (permission == null) {
             return null;
         }
+
+        if (permissionGroups == null || permissionGroups.isEmpty()) {
+            // Just a check that's known to always fail. When permission groups is empty, the below `elemMatch`
+            // condition always fails. This is an experiment to confirm that in the product as well.
+            return Criteria.where("_id").isNull();
+        }
+
         // Check if the permission is being provided by any of the permission groups
         return Criteria.where(BaseDomain.Fields.policies)
                 .elemMatch(Criteria.where("permissionGroups")

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -108,13 +108,6 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         if (permission == null) {
             return null;
         }
-
-        if (permissionGroups == null || permissionGroups.isEmpty()) {
-            // Just a check that's known to always fail. When permission groups is empty, the below `elemMatch`
-            // condition always fails. This is an experiment to confirm that in the product as well.
-            return Criteria.where("_id").isNull();
-        }
-
         // Check if the permission is being provided by any of the permission groups
         return Criteria.where(BaseDomain.Fields.policies)
                 .elemMatch(Criteria.where("permissionGroups")
@@ -240,8 +233,17 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
     public <P> Flux<P> queryAllExecute(QueryAllParams<T> params, Class<P> projectionClass) {
         return ensurePermissionGroupsInParams(params).thenMany(Flux.defer(() -> {
-            final Query query = createQueryWithPermission(
-                    params.getCriteria(), params.getFields(), params.getPermissionGroups(), params.getPermission());
+            final AclPermission permission = params.getPermission();
+            final Set<String> permissionGroups = params.getPermissionGroups();
+
+            if (permission != null && CollectionUtils.isEmpty(permissionGroups)) {
+                // There's a permission we want to check, but there's zero permission groups to check against. The
+                // resulting query will _always_ be `false`. So returning an early response, without hitting the DB.
+                return Flux.empty();
+            }
+
+            final Query query =
+                    createQueryWithPermission(params.getCriteria(), params.getFields(), permissionGroups, permission);
 
             if (params.getSkip() > NO_SKIP) {
                 query.skip(params.getSkip());
@@ -269,33 +271,64 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
     }
 
     public <P> Mono<P> queryOneExecute(QueryAllParams<T> params, Class<P> projectionClass) {
-        return ensurePermissionGroupsInParams(params).then(Mono.defer(() -> mongoOperations
-                .query(genericDomain)
-                .as(projectionClass)
-                .matching(createQueryWithPermission(
-                                params.getCriteria(),
-                                params.getFields(),
-                                params.getPermissionGroups(),
-                                params.getPermission())
-                        .cursorBatchSize(10_000))
-                .one()));
+        return ensurePermissionGroupsInParams(params).then(Mono.defer(() -> {
+            final AclPermission permission = params.getPermission();
+            final Set<String> permissionGroups = params.getPermissionGroups();
+
+            if (permission != null && CollectionUtils.isEmpty(permissionGroups)) {
+                // There's a permission we want to check, but there's zero permission groups to check against. The
+                // resulting query will _always_ be `false`. So returning an early response, without hitting the DB.
+                return Mono.empty();
+            }
+
+            final Query query =
+                    createQueryWithPermission(params.getCriteria(), params.getFields(), permissionGroups, permission);
+
+            return mongoOperations
+                    .query(genericDomain)
+                    .as(projectionClass)
+                    .matching(query.cursorBatchSize(10_000))
+                    .one();
+        }));
     }
 
     public Mono<T> queryFirstExecute(QueryAllParams<T> params) {
-        return ensurePermissionGroupsInParams(params).then(Mono.defer(() -> mongoOperations
-                .query(this.genericDomain)
-                .matching(createQueryWithPermission(
-                        params.getCriteria(), params.getFields(), params.getPermissionGroups(), params.getPermission()))
-                .first()
-                .flatMap(obj -> setUserPermissionsInObject(obj, params.getPermissionGroups()))));
+        return ensurePermissionGroupsInParams(params).then(Mono.defer(() -> {
+            final AclPermission permission = params.getPermission();
+            final Set<String> permissionGroups = params.getPermissionGroups();
+
+            if (permission != null && CollectionUtils.isEmpty(permissionGroups)) {
+                // There's a permission we want to check, but there's zero permission groups to check against. The
+                // resulting query will _always_ be `false`. So returning an early response, without hitting the DB.
+                return Mono.empty();
+            }
+
+            final Query query =
+                    createQueryWithPermission(params.getCriteria(), params.getFields(), permissionGroups, permission);
+
+            return mongoOperations
+                    .query(this.genericDomain)
+                    .matching(query)
+                    .first()
+                    .flatMap(obj -> setUserPermissionsInObject(obj, permissionGroups));
+        }));
     }
 
     public Mono<Long> countExecute(QueryAllParams<T> params) {
-        return ensurePermissionGroupsInParams(params)
-                .then(Mono.defer(() -> mongoOperations.count(
-                        createQueryWithPermission(
-                                params.getCriteria(), params.getPermissionGroups(), params.getPermission()),
-                        this.genericDomain)));
+        return ensurePermissionGroupsInParams(params).then(Mono.defer(() -> {
+            final AclPermission permission = params.getPermission();
+            final Set<String> permissionGroups = params.getPermissionGroups();
+
+            if (permission != null && CollectionUtils.isEmpty(permissionGroups)) {
+                // There's a permission we want to check, but there's zero permission groups to check against. The
+                // resulting query will _always_ be `false`. So returning an early response, without hitting the DB.
+                return Mono.just(0L);
+            }
+
+            final Query query = createQueryWithPermission(params.getCriteria(), permissionGroups, permission);
+
+            return mongoOperations.count(query, this.genericDomain);
+        }));
     }
 
     public Mono<Integer> updateExecute(@NonNull QueryAllParams<T> params, @NonNull T resource) {
@@ -323,19 +356,29 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "fields"));
         }
 
-        return ensurePermissionGroupsInParams(params)
-                .then(Mono.defer(() -> {
-                    final Query query = createQueryWithPermission(
-                            params.getCriteria(), null, params.getPermissionGroups(), params.getPermission());
-                    if (QueryAllParams.Scope.ALL.equals(params.getScope())) {
-                        return mongoOperations.updateMulti(query, update, genericDomain);
-                    } else if (QueryAllParams.Scope.FIRST.equals(params.getScope())) {
-                        return mongoOperations.updateFirst(query, update, genericDomain);
-                    } else {
-                        return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "scope"));
-                    }
-                }))
-                .map(updateResult -> Math.toIntExact(updateResult.getMatchedCount()));
+        return ensurePermissionGroupsInParams(params).then(Mono.defer(() -> {
+            final AclPermission permission = params.getPermission();
+            final Set<String> permissionGroups = params.getPermissionGroups();
+
+            if (permission != null && CollectionUtils.isEmpty(permissionGroups)) {
+                // There's a permission we want to check, but there's zero permission groups to check against. The
+                // resulting query will _always_ be `false`. So returning an early response, without hitting the DB.
+                return Mono.just(0);
+            }
+
+            final Query query = createQueryWithPermission(params.getCriteria(), null, permissionGroups, permission);
+            if (QueryAllParams.Scope.ALL.equals(params.getScope())) {
+                return mongoOperations
+                        .updateMulti(query, update, genericDomain)
+                        .map(updateResult -> Math.toIntExact(updateResult.getMatchedCount()));
+            } else if (QueryAllParams.Scope.FIRST.equals(params.getScope())) {
+                return mongoOperations
+                        .updateFirst(query, update, genericDomain)
+                        .map(updateResult -> Math.toIntExact(updateResult.getMatchedCount()));
+            } else {
+                return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "scope"));
+            }
+        }));
     }
 
     public Mono<T> updateExecuteAndFind(@NonNull QueryAllParams<T> params, @NonNull UpdateDefinition update) {


### PR DESCRIPTION
In the `userAcl` function, we build the criteria to do a permission check, on the permission groups. The query turns out to be something like this:

```
{policies: {$elemMatch: {permissionGroups: {$in: ["6303edf184daf727dddb003d", "6303edf184daf727dddb003e"]}}}}
```

Where that list of ID strings is the permission group IDs we're trying to match against.

Now, when the permission group list is empty, we end up with a query like this:

```
{policies: {$elemMatch: {permissionGroups: {$in: []}}}}
```

Which, is always `false`. It never matches any documents. Behaviour equivalent to "no permissions".

In this PR, we avoid hitting the DB at all, when `permissionGroups` is empty, but `permission` is not `null`.

One example where this scenario happens, is the tiny test `TenantServiceCETest#setMapsKeyWithoutAuthentication`. This leads me to believe that several API calls are dealing with this case:
![shot-2024-05-27-12-25-53](https://github.com/appsmithorg/appsmith/assets/120119/964ef710-b029-4294-9ca9-3a42ca0f1a30)

All unit and Cypress tests pass on EE, no conflicts and doesn't break build.


/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9243092434>
> Commit: dd7bb14be82b664f6a7fa1be05cca537c8bafdc0
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9243092434&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance by adding conditional checks to prevent unnecessary database queries when no permission groups are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->