### PR TITLE
ci: Support for "all" tag in /test and allow bold

### DIFF
--- a/.github/workflows/scripts/test-tag-parser.js
+++ b/.github/workflows/scripts/test-tag-parser.js
@@ -9,8 +9,12 @@ function parseTags({core, context}) {
 
   // "/test" matcher.
   const allTags = require(process.env.GITHUB_WORKSPACE + "/app/client/cypress/tags.js").Tag;
-  const config = body.match(/^\/test\s+(.*)$/m)?.[1] ?? "";
+  const config = body.match(/^(#+\s+|\*+)?\/test\s+(.*)$/m)?.[1] ?? "";
   const concreteTags = [];
+
+  if (config.toLowerCase() === "all") {
+    return "@tag.All"
+  }
 
   for (const [rawTag] of config.matchAll(/\w+/g)) {
     console.log("Given: '" + rawTag + "'");

--- a/.github/workflows/scripts/test-tag-parser.js
+++ b/.github/workflows/scripts/test-tag-parser.js
@@ -9,7 +9,7 @@ function parseTags({core, context}) {
 
   // "/test" matcher.
   const allTags = require(process.env.GITHUB_WORKSPACE + "/app/client/cypress/tags.js").Tag;
-  const config = body.match(/^(#+\s+|\*+)?\/test\s+(.*)$/m)?.[1] ?? "";
+  const config = body.match(/^\**\/test\s+(.*)\**$/m)?.[1] ?? "";
   const concreteTags = [];
 
   if (config.toLowerCase() === "all") {


### PR DESCRIPTION
**/test all**

![shot-2024-05-26-12-15-35](https://github.com/appsmithorg/appsmith/assets/120119/70df30de-bcdf-4861-9495-ed83288a8f83)


<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9243140883>
> Commit: abf3814fd6bfa308353d1042e5df2ef75e02fd0a
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9243140883&attempt=1" target="_blank">Click here!</a>
> It seems like **no tests ran** 😔. We are not able to recognize it, please check workflow <a href="https://github.com/appsmithorg/appsmith/actions/runs/9243140883" target="_blank">here.</a>

<!-- end of auto-generated comment: Cypress test results  -->
