### PR TITLE
chore: Move widget deprecation messages from propertyPaneView to individual Widget configurations

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneView.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneView.tsx
@@ -1,3 +1,5 @@
+import type { IPanelProps } from "@blueprintjs/core";
+import equal from "fast-deep-equal/es6";
 import type { ReactElement } from "react";
 import React, {
   useCallback,
@@ -6,47 +8,44 @@ import React, {
   useMemo,
   useRef,
 } from "react";
-import equal from "fast-deep-equal/es6";
 import { useDispatch, useSelector } from "react-redux";
 import { getWidgetPropsForPropertyPane } from "selectors/propertyPaneSelectors";
-import type { IPanelProps } from "@blueprintjs/core";
 
-import PropertyPaneTitle from "./PropertyPaneTitle";
-import PropertyControlsGenerator from "./PropertyControlsGenerator";
-import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
-import { copyWidget, deleteSelectedWidget } from "actions/widgetActions";
-import ConnectDataCTA, { actionsExist } from "./ConnectDataCTA";
-import PropertyPaneConnections from "./PropertyPaneConnections";
-import type { WidgetType } from "constants/WidgetConstants";
-import { WIDGET_ID_SHOW_WALKTHROUGH } from "constants/WidgetConstants";
-import type { InteractionAnalyticsEventDetail } from "utils/AppsmithUtils";
-import { INTERACTION_ANALYTICS_EVENT } from "utils/AppsmithUtils";
-import AnalyticsUtil from "@appsmith/utils/AnalyticsUtil";
-import { buildDeprecationWidgetMessage, isWidgetDeprecated } from "../utils";
-import { Button, Callout } from "design-system";
-import WidgetFactory from "WidgetProvider/factory";
-import { PropertyPaneTab } from "./PropertyPaneTab";
-import { renderWidgetCallouts, useSearchText } from "./helpers";
-import { PropertyPaneSearchInput } from "./PropertyPaneSearchInput";
-import { sendPropertyPaneSearchAnalytics } from "./propertyPaneSearch";
-import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
-import { AB_TESTING_EVENT_KEYS } from "@appsmith/entities/FeatureFlag";
-import localStorage from "utils/localStorage";
-import { FEATURE_WALKTHROUGH_KEYS } from "constants/WalkthroughConstants";
-import { PROPERTY_PANE_ID } from "components/editorComponents/PropertyPaneSidebar";
-import {
-  isUserSignedUpFlagSet,
-  setFeatureWalkthroughShown,
-} from "utils/storage";
 import {
   BINDING_WIDGET_WALKTHROUGH_DESC,
   BINDING_WIDGET_WALKTHROUGH_TITLE,
   createMessage,
 } from "@appsmith/constants/messages";
+import { AB_TESTING_EVENT_KEYS } from "@appsmith/entities/FeatureFlag";
+import AnalyticsUtil from "@appsmith/utils/AnalyticsUtil";
+import WidgetFactory from "WidgetProvider/factory";
+import { copyWidget, deleteSelectedWidget } from "actions/widgetActions";
+import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
+import { PROPERTY_PANE_ID } from "components/editorComponents/PropertyPaneSidebar";
+import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
+import { FEATURE_WALKTHROUGH_KEYS } from "constants/WalkthroughConstants";
+import type { WidgetType } from "constants/WidgetConstants";
+import { WIDGET_ID_SHOW_WALKTHROUGH } from "constants/WidgetConstants";
+import { Button } from "design-system";
+import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { getWidgets } from "sagas/selectors";
 import { getCurrentUser } from "selectors/usersSelectors";
+import type { InteractionAnalyticsEventDetail } from "utils/AppsmithUtils";
+import { INTERACTION_ANALYTICS_EVENT } from "utils/AppsmithUtils";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
-import { SelectionRequestType } from "sagas/WidgetSelectUtils";
+import localStorage from "utils/localStorage";
+import {
+  isUserSignedUpFlagSet,
+  setFeatureWalkthroughShown,
+} from "utils/storage";
+import ConnectDataCTA, { actionsExist } from "./ConnectDataCTA";
+import PropertyControlsGenerator from "./PropertyControlsGenerator";
+import PropertyPaneConnections from "./PropertyPaneConnections";
+import { PropertyPaneSearchInput } from "./PropertyPaneSearchInput";
+import { PropertyPaneTab } from "./PropertyPaneTab";
+import PropertyPaneTitle from "./PropertyPaneTitle";
+import { renderWidgetCallouts, useSearchText } from "./helpers";
+import { sendPropertyPaneSearchAnalytics } from "./propertyPaneSearch";
 
 // TODO(abhinav): The widget should add a flag in their configuration if they donot subscribe to data
 // Widgets where we do not want to show the CTA
@@ -242,13 +241,6 @@ function PropertyPaneView(
 
   if (!widgetProperties) return null;
 
-  // Building Deprecation Messages
-  const { isDeprecated, widgetReplacedWith } = isWidgetDeprecated(
-    widgetProperties.type,
-  );
-  // generate messages
-  const deprecationMessage = buildDeprecationWidgetMessage(widgetReplacedWith);
-
   const isContentConfigAvailable =
     WidgetFactory.getWidgetPropertyPaneContentConfig(
       widgetProperties.type,
@@ -285,11 +277,7 @@ function PropertyPaneView(
             widgetType={widgetProperties?.type}
           />
         )}
-        {isDeprecated && (
-          <Callout data-testid="t--deprecation-warning" kind="warning">
-            {deprecationMessage}
-          </Callout>
-        )}
+
         {renderWidgetCallouts(widgetProperties)}
       </div>
 

--- a/app/client/src/pages/Editor/PropertyPane/helpers.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/helpers.tsx
@@ -11,7 +11,6 @@ import React, { useCallback, useState } from "react";
 import { layoutSystemBasedPropertyFilter } from "sagas/WidgetEnhancementHelpers";
 import { isDynamicValue } from "utils/DynamicBindingUtils";
 import type { WidgetProps } from "widgets/BaseWidget";
-import { buildDeprecationWidgetMessage } from "../utils";
 
 export function useSearchText(initialVal: string) {
   const [searchText, setSearchText] = useState(initialVal);
@@ -104,20 +103,6 @@ export function updateConfigPaths(
 
 export function renderWidgetCallouts(props: WidgetProps): JSX.Element[] {
   const { getEditorCallouts } = WidgetFactory.getWidgetMethods(props.type);
-
-  const isDeprecated = WidgetFactory.getConfig(props.type)?.isDeprecated;
-  const widgetReplacedWith = WidgetFactory.getConfig(props.type)?.displayName;
-
-  if (isDeprecated) {
-    // generate messages
-    const deprecationMessage =
-      buildDeprecationWidgetMessage(widgetReplacedWith);
-    return [
-      <Callout data-testid="t--deprecation-warning" key={0} kind="warning">
-        {deprecationMessage}
-      </Callout>,
-    ];
-  }
 
   if (getEditorCallouts) {
     const callouts: WidgetCallout[] = getEditorCallouts(props);

--- a/app/client/src/pages/Editor/PropertyPane/helpers.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/helpers.tsx
@@ -1,17 +1,17 @@
+import type { WidgetCallout } from "WidgetProvider/constants";
+import WidgetFactory from "WidgetProvider/factory";
 import type {
   PropertyPaneConfig,
   PropertyPaneControlConfig,
   PropertyPaneSectionConfig,
 } from "constants/PropertyControlConstants";
-import { debounce } from "lodash";
-import { useCallback, useState } from "react";
-import { layoutSystemBasedPropertyFilter } from "sagas/WidgetEnhancementHelpers";
-import type { WidgetProps } from "widgets/BaseWidget";
 import { Callout } from "design-system";
-import React from "react";
-import WidgetFactory from "WidgetProvider/factory";
-import type { WidgetCallout } from "WidgetProvider/constants";
+import { debounce } from "lodash";
+import React, { useCallback, useState } from "react";
+import { layoutSystemBasedPropertyFilter } from "sagas/WidgetEnhancementHelpers";
 import { isDynamicValue } from "utils/DynamicBindingUtils";
+import type { WidgetProps } from "widgets/BaseWidget";
+import { buildDeprecationWidgetMessage } from "../utils";
 
 export function useSearchText(initialVal: string) {
   const [searchText, setSearchText] = useState(initialVal);
@@ -104,6 +104,21 @@ export function updateConfigPaths(
 
 export function renderWidgetCallouts(props: WidgetProps): JSX.Element[] {
   const { getEditorCallouts } = WidgetFactory.getWidgetMethods(props.type);
+
+  const isDeprecated = WidgetFactory.getConfig(props.type)?.isDeprecated;
+  const widgetReplacedWith = WidgetFactory.getConfig(props.type)?.displayName;
+
+  if (isDeprecated) {
+    // generate messages
+    const deprecationMessage =
+      buildDeprecationWidgetMessage(widgetReplacedWith);
+    return [
+      <Callout data-testid="t--deprecation-warning" key={0} kind="warning">
+        {deprecationMessage}
+      </Callout>,
+    ];
+  }
+
   if (getEditorCallouts) {
     const callouts: WidgetCallout[] = getEditorCallouts(props);
     return callouts.map((callout, index) => {

--- a/app/client/src/widgets/CircularProgressWidget/widget/index.tsx
+++ b/app/client/src/widgets/CircularProgressWidget/widget/index.tsx
@@ -152,7 +152,9 @@ class CircularProgressWidget extends BaseWidget<
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("Progress Widget"),
+            message: buildDeprecationWidgetMessage(
+              CircularProgressWidget.getConfig().name,
+            ),
           },
         ];
       },

--- a/app/client/src/widgets/CircularProgressWidget/widget/index.tsx
+++ b/app/client/src/widgets/CircularProgressWidget/widget/index.tsx
@@ -1,15 +1,20 @@
 import * as React from "react";
 
+import type {
+  AutocompletionDefinitions,
+  WidgetCallout,
+} from "WidgetProvider/constants";
+import { Colors } from "constants/Colors";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
+import type { Stylesheet } from "entities/AppTheming";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import BaseWidget from "widgets/BaseWidget";
-import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
+import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
 import type { CircularProgressComponentProps } from "../component";
 import CircularProgressComponent from "../component";
-import type { Stylesheet } from "entities/AppTheming";
-import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
-import type { AutocompletionDefinitions } from "WidgetProvider/constants";
-import { Colors } from "constants/Colors";
 import IconSVG from "../icon.svg";
 
 interface CircularProgressWidgetProps
@@ -31,6 +36,7 @@ class CircularProgressWidget extends BaseWidget<
       isDeprecated: true,
       replacement: "PROGRESS_WIDGET",
       iconSVG: IconSVG,
+      tags: [WIDGET_TAGS.CONTENT],
     };
   }
 
@@ -138,6 +144,18 @@ class CircularProgressWidget extends BaseWidget<
       "!url": "https://docs.appsmith.com/widget-reference/circular-progress",
       isVisible: DefaultAutocompleteDefinitions.isVisible,
       progress: "number",
+    };
+  }
+
+  static getMethods() {
+    return {
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("Progress Widget"),
+          },
+        ];
+      },
     };
   }
 

--- a/app/client/src/widgets/DatePickerWidget/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget/widget/index.tsx
@@ -1,17 +1,22 @@
-import React from "react";
-import type { WidgetProps, WidgetState } from "../../BaseWidget";
-import BaseWidget from "../../BaseWidget";
+import type {
+  AutocompletionDefinitions,
+  WidgetCallout,
+} from "WidgetProvider/constants";
+import type { DerivedPropertiesMap } from "WidgetProvider/factory";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
-import DatePickerComponent from "../component";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
 import type { ValidationResponse } from "constants/WidgetValidation";
 import { ISO_DATE_FORMAT, ValidationTypes } from "constants/WidgetValidation";
-import type { DerivedPropertiesMap } from "WidgetProvider/factory";
+import type { SetterConfig } from "entities/AppTheming";
 import moment from "moment";
-import type { DatePickerType } from "../constants";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import React from "react";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
 import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
-import type { AutocompletionDefinitions } from "WidgetProvider/constants";
-import type { SetterConfig } from "entities/AppTheming";
+import type { WidgetProps, WidgetState } from "../../BaseWidget";
+import BaseWidget from "../../BaseWidget";
+import DatePickerComponent from "../component";
+import type { DatePickerType } from "../constants";
 import IconSVG from "../icon.svg";
 
 function defaultDateValidation(
@@ -189,6 +194,7 @@ class DatePickerWidget extends BaseWidget<DatePickerWidgetProps, WidgetState> {
       isDeprecated: true,
       replacement: "DATE_PICKER_WIDGET2",
       needsMeta: true,
+      tags: [WIDGET_TAGS.INPUTS],
     };
   }
 
@@ -394,6 +400,18 @@ class DatePickerWidget extends BaseWidget<DatePickerWidgetProps, WidgetState> {
   static getMetaPropertiesMap(): Record<string, any> {
     return {
       selectedDate: undefined,
+    };
+  }
+
+  static getMethods() {
+    return {
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("Date Picker Widget 2"),
+          },
+        ];
+      },
     };
   }
 

--- a/app/client/src/widgets/DatePickerWidget/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget/widget/index.tsx
@@ -408,7 +408,9 @@ class DatePickerWidget extends BaseWidget<DatePickerWidgetProps, WidgetState> {
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("Date Picker Widget 2"),
+            message: buildDeprecationWidgetMessage(
+              DatePickerWidget.getConfig().name,
+            ),
           },
         ];
       },

--- a/app/client/src/widgets/DropdownWidget/widget/index.tsx
+++ b/app/client/src/widgets/DropdownWidget/widget/index.tsx
@@ -100,7 +100,9 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("Select Widget"),
+            message: buildDeprecationWidgetMessage(
+              DropdownWidget.getConfig().name,
+            ),
           },
         ];
       },

--- a/app/client/src/widgets/DropdownWidget/widget/index.tsx
+++ b/app/client/src/widgets/DropdownWidget/widget/index.tsx
@@ -1,29 +1,31 @@
-import React from "react";
-import type { WidgetProps, WidgetState } from "../../BaseWidget";
-import BaseWidget from "../../BaseWidget";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
-import DropDownComponent from "../component";
-import _ from "lodash";
-import type { DropdownOption } from "../constants";
-import type { ValidationResponse } from "constants/WidgetValidation";
-import { ValidationTypes } from "constants/WidgetValidation";
-import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
-import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
-import { MinimumPopupWidthInPercentage } from "WidgetProvider/constants";
-import { LabelPosition } from "components/constants";
 import { Alignment } from "@blueprintjs/core";
-import type { Stylesheet } from "entities/AppTheming";
-import {
-  DefaultAutocompleteDefinitions,
-  isCompactMode,
-} from "widgets/WidgetUtils";
 import type {
   AutocompletionDefinitions,
   PropertyUpdates,
   SnipingModeProperty,
+  WidgetCallout,
 } from "WidgetProvider/constants";
+import { MinimumPopupWidthInPercentage } from "WidgetProvider/constants";
+import { LabelPosition } from "components/constants";
+import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import { WIDGET_TAGS, layoutConfigurations } from "constants/WidgetConstants";
+import type { ValidationResponse } from "constants/WidgetValidation";
+import { ValidationTypes } from "constants/WidgetValidation";
+import type { Stylesheet } from "entities/AppTheming";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
+import _ from "lodash";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import React from "react";
+import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
+import {
+  DefaultAutocompleteDefinitions,
+  isCompactMode,
+} from "widgets/WidgetUtils";
+import type { WidgetProps, WidgetState } from "../../BaseWidget";
+import BaseWidget from "../../BaseWidget";
+import DropDownComponent from "../component";
+import type { DropdownOption } from "../constants";
 import IconSVG from "../icon.svg";
-import { layoutConfigurations } from "constants/WidgetConstants";
 
 function defaultOptionValueValidation(value: unknown): ValidationResponse {
   if (typeof value === "string") return { isValid: true, parsed: value.trim() };
@@ -52,6 +54,7 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
       hideCard: true,
       isDeprecated: true,
       replacement: "SELECT_WIDGET",
+      tags: [WIDGET_TAGS.SELECT],
     };
   }
 
@@ -91,6 +94,13 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
             propertyPath: "options",
             propertyValue: propValueMap.data,
             isDynamicPropertyPath: true,
+          },
+        ];
+      },
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("Select Widget"),
           },
         ];
       },

--- a/app/client/src/widgets/FilepickerWidget/widget/index.tsx
+++ b/app/client/src/widgets/FilepickerWidget/widget/index.tsx
@@ -1,26 +1,29 @@
-import React from "react";
 import type { Uppy } from "@uppy/core";
-import type { WidgetProps, WidgetState } from "../../BaseWidget";
-import BaseWidget from "../../BaseWidget";
-import FilePickerComponent from "../component";
-import { ValidationTypes } from "constants/WidgetValidation";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
-import type { DerivedPropertiesMap } from "WidgetProvider/factory";
 import type Dashboard from "@uppy/dashboard";
-import shallowequal from "shallowequal";
-import _ from "lodash";
-import FileDataTypes from "./FileDataTypes";
-import log from "loglevel";
-import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
-import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
 import type {
   AutocompletionDefinitions,
   PropertyUpdates,
   SnipingModeProperty,
+  WidgetCallout,
 } from "WidgetProvider/constants";
-import { importUppy, isUppyLoaded } from "utils/importUppy";
+import type { DerivedPropertiesMap } from "WidgetProvider/factory";
+import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
+import { ValidationTypes } from "constants/WidgetValidation";
 import type { SetterConfig } from "entities/AppTheming";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
+import _ from "lodash";
+import log from "loglevel";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import React from "react";
+import shallowequal from "shallowequal";
+import { importUppy, isUppyLoaded } from "utils/importUppy";
+import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
+import type { WidgetProps, WidgetState } from "../../BaseWidget";
+import BaseWidget from "../../BaseWidget";
+import FilePickerComponent from "../component";
 import IconSVG from "../icon.svg";
+import FileDataTypes from "./FileDataTypes";
 
 class FilePickerWidget extends BaseWidget<
   FilePickerWidgetProps,
@@ -44,6 +47,7 @@ class FilePickerWidget extends BaseWidget<
       hideCard: true,
       isDeprecated: true,
       replacement: "FILE_PICKER_WIDGET_V2",
+      tags: [WIDGET_TAGS.INPUTS],
     };
   }
 
@@ -77,6 +81,13 @@ class FilePickerWidget extends BaseWidget<
             propertyPath: "onFilesSelected",
             propertyValue: propValueMap.run,
             isDynamicPropertyPath: true,
+          },
+        ];
+      },
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("File Picker Widget V2"),
           },
         ];
       },

--- a/app/client/src/widgets/FilepickerWidget/widget/index.tsx
+++ b/app/client/src/widgets/FilepickerWidget/widget/index.tsx
@@ -87,7 +87,9 @@ class FilePickerWidget extends BaseWidget<
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("File Picker Widget V2"),
+            message: buildDeprecationWidgetMessage(
+              FilePickerWidget.getConfig().name,
+            ),
           },
         ];
       },

--- a/app/client/src/widgets/FormButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/FormButtonWidget/widget/index.tsx
@@ -79,7 +79,9 @@ class FormButtonWidget extends ButtonWidget {
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("Button Widget"),
+            message: buildDeprecationWidgetMessage(
+              FormButtonWidget.getConfig().name,
+            ),
           },
         ];
       },

--- a/app/client/src/widgets/FormButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/FormButtonWidget/widget/index.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
-import type { ExecutionResult } from "constants/AppsmithActionConstants/ActionConstants";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
-import type { ButtonType } from "widgets/ButtonWidget/component";
-import ButtonComponent from "widgets/ButtonWidget/component";
-import { ValidationTypes } from "constants/WidgetValidation";
-import ButtonWidget from "widgets/ButtonWidget";
+import { Alignment } from "@blueprintjs/core";
+import type { IconName } from "@blueprintjs/icons";
+import type {
+  AutocompletionDefinitions,
+  PropertyUpdates,
+  SnipingModeProperty,
+  WidgetCallout,
+} from "WidgetProvider/constants";
 import type {
   ButtonBorderRadius,
   ButtonVariant,
@@ -16,16 +16,19 @@ import {
   ButtonVariantTypes,
   RecaptchaTypes,
 } from "components/constants";
-import type { IconName } from "@blueprintjs/icons";
-import { Alignment } from "@blueprintjs/core";
-import type { ButtonWidgetProps } from "widgets/ButtonWidget/widget";
+import type { ExecutionResult } from "constants/AppsmithActionConstants/ActionConstants";
+import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
+import { ValidationTypes } from "constants/WidgetValidation";
 import type { Stylesheet } from "entities/AppTheming";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import React from "react";
+import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
+import ButtonWidget from "widgets/ButtonWidget";
+import type { ButtonType } from "widgets/ButtonWidget/component";
+import ButtonComponent from "widgets/ButtonWidget/component";
+import type { ButtonWidgetProps } from "widgets/ButtonWidget/widget";
 import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
-import type {
-  AutocompletionDefinitions,
-  PropertyUpdates,
-  SnipingModeProperty,
-} from "WidgetProvider/constants";
 import IconSVG from "../icon.svg";
 
 class FormButtonWidget extends ButtonWidget {
@@ -43,6 +46,7 @@ class FormButtonWidget extends ButtonWidget {
       isDeprecated: true,
       replacement: "BUTTON_WIDGET",
       needsMeta: true,
+      tags: [WIDGET_TAGS.BUTTONS],
     } as any; // TODO (Sangeeth): Type error
   }
 
@@ -69,6 +73,13 @@ class FormButtonWidget extends ButtonWidget {
             propertyPath: "onClick",
             propertyValue: propValueMap.run,
             isDynamicPropertyPath: true,
+          },
+        ];
+      },
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("Button Widget"),
           },
         ];
       },

--- a/app/client/src/widgets/IconWidget/widget/index.tsx
+++ b/app/client/src/widgets/IconWidget/widget/index.tsx
@@ -44,7 +44,7 @@ class IconWidget extends BaseWidget<IconWidgetProps, WidgetState> {
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("Icon Button Widget"),
+            message: buildDeprecationWidgetMessage(IconWidget.getConfig().name),
           },
         ];
       },

--- a/app/client/src/widgets/IconWidget/widget/index.tsx
+++ b/app/client/src/widgets/IconWidget/widget/index.tsx
@@ -1,13 +1,16 @@
-import React from "react";
-import type { WidgetProps, WidgetState } from "../../BaseWidget";
-import BaseWidget from "../../BaseWidget";
-import styled from "styled-components";
-import type { IconType } from "../component";
-import IconComponent from "../component";
+import type { WidgetCallout } from "WidgetProvider/constants";
+import type { DerivedPropertiesMap } from "WidgetProvider/factory";
 import type { ExecutionResult } from "constants/AppsmithActionConstants/ActionConstants";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import React from "react";
+import styled from "styled-components";
+import type { WidgetProps, WidgetState } from "../../BaseWidget";
+import BaseWidget from "../../BaseWidget";
+import type { IconType } from "../component";
+import IconComponent from "../component";
 import IconSVG from "../icon.svg";
-import type { DerivedPropertiesMap } from "WidgetProvider/factory";
 
 const IconWrapper = styled.div`
   display: flex;
@@ -23,6 +26,7 @@ class IconWidget extends BaseWidget<IconWidgetProps, WidgetState> {
       hideCard: true,
       isDeprecated: true,
       replacement: "ICON_BUTTON_WIDGET",
+      tags: [WIDGET_TAGS.BUTTONS],
     };
   }
 
@@ -32,6 +36,18 @@ class IconWidget extends BaseWidget<IconWidgetProps, WidgetState> {
       rows: 4,
       columns: 4,
       version: 1,
+    };
+  }
+
+  static getMethods() {
+    return {
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("Icon Button Widget"),
+          },
+        ];
+      },
     };
   }
 

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -193,7 +193,9 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("Input Widget"),
+            message: buildDeprecationWidgetMessage(
+              InputWidget.getConfig().name,
+            ),
           },
         ];
       },

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -1,45 +1,51 @@
-import React from "react";
-import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
-import BaseWidget from "widgets/BaseWidget";
-import { Alignment } from "@blueprintjs/core";
-import type { IconName } from "@blueprintjs/icons";
-import type { TextSize } from "constants/WidgetConstants";
-import { GridDefaults, RenderModes } from "constants/WidgetConstants";
-import type { InputComponentProps } from "../component";
-import InputComponent from "../component";
-import type { ExecutionResult } from "constants/AppsmithActionConstants/ActionConstants";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
-import type { ValidationResponse } from "constants/WidgetValidation";
-import { ValidationTypes } from "constants/WidgetValidation";
 import {
-  createMessage,
   FIELD_REQUIRED_ERROR,
   INPUT_DEFAULT_TEXT_MAX_CHAR_ERROR,
+  createMessage,
 } from "@appsmith/constants/messages";
-import type { DerivedPropertiesMap } from "WidgetProvider/factory";
-import type { InputType } from "../constants";
-import { InputTypes } from "../constants";
+import { Alignment } from "@blueprintjs/core";
+import type { IconName } from "@blueprintjs/icons";
+import type {
+  AutocompletionDefinitions,
+  PropertyUpdates,
+  SnipingModeProperty,
+  WidgetCallout,
+} from "WidgetProvider/constants";
 import { COMPACT_MODE_MIN_ROWS } from "WidgetProvider/constants";
-import { ISDCodeDropdownOptions } from "../component/ISDCodeDropdown";
-import { CurrencyDropdownOptions } from "../component/CurrencyCodeDropdown";
+import type { DerivedPropertiesMap } from "WidgetProvider/factory";
+import { LabelPosition } from "components/constants";
+import type { ExecutionResult } from "constants/AppsmithActionConstants/ActionConstants";
+import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import type { TextSize } from "constants/WidgetConstants";
+import {
+  GridDefaults,
+  RenderModes,
+  WIDGET_TAGS,
+} from "constants/WidgetConstants";
+import type { ValidationResponse } from "constants/WidgetValidation";
+import { ValidationTypes } from "constants/WidgetValidation";
+import type { SetterConfig, Stylesheet } from "entities/AppTheming";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import React from "react";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
+import { checkInputTypeTextByProps } from "widgets/BaseInputWidget/utils";
+import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
+import BaseWidget from "widgets/BaseWidget";
+import {
+  DefaultAutocompleteDefinitions,
+  isCompactMode,
+} from "widgets/WidgetUtils";
+import type { InputComponentProps } from "../component";
+import InputComponent from "../component";
+import { CurrencyDropdownOptions } from "../component/CurrencyCodeDropdown";
+import { ISDCodeDropdownOptions } from "../component/ISDCodeDropdown";
 import {
   formatCurrencyNumber,
   getDecimalSeparator,
   getLocale,
 } from "../component/utilities";
-import { LabelPosition } from "components/constants";
-import type { SetterConfig, Stylesheet } from "entities/AppTheming";
-import { checkInputTypeTextByProps } from "widgets/BaseInputWidget/utils";
-import {
-  DefaultAutocompleteDefinitions,
-  isCompactMode,
-} from "widgets/WidgetUtils";
-import type {
-  AutocompletionDefinitions,
-  PropertyUpdates,
-  SnipingModeProperty,
-} from "WidgetProvider/constants";
+import type { InputType } from "../constants";
+import { InputTypes } from "../constants";
 import IconSVG from "../icon.svg";
 
 export function defaultValueValidation(
@@ -144,6 +150,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
       hideCard: true,
       isDeprecated: true,
       replacement: "INPUT_WIDGET_V2",
+      tags: [WIDGET_TAGS.SUGGESTED_WIDGETS, WIDGET_TAGS.INPUTS],
     };
   }
 
@@ -180,6 +187,13 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
             propertyPath: "defaultText",
             propertyValue: propValueMap.data,
             isDynamicPropertyPath: true,
+          },
+        ];
+      },
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("Input Widget"),
           },
         ];
       },

--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -1,14 +1,35 @@
+import type { PrivateWidgets } from "@appsmith/entities/DataTree/types";
+import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
+import type {
+  AnvilConfig,
+  AutocompletionDefinitions,
+  PropertyUpdates,
+  SnipingModeProperty,
+  WidgetCallout,
+} from "WidgetProvider/constants";
+import {
+  BlueprintOperationTypes,
+  type DSLWidget,
+  type FlattenedWidgetProps,
+} from "WidgetProvider/constants";
+import WidgetFactory from "WidgetProvider/factory";
+import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import { ASSETS_CDN_URL } from "constants/ThirdPartyConstants";
+import {
+  GridDefaults,
+  RenderModes,
+  WIDGET_TAGS,
+} from "constants/WidgetConstants";
+import { ValidationTypes } from "constants/WidgetValidation";
+import { FILL_WIDGET_MIN_WIDTH } from "constants/minWidthConstants";
+import type { SetterConfig, Stylesheet } from "entities/AppTheming";
+import equal from "fast-deep-equal/es6";
+import { klona } from "klona/lite";
+import { renderAppsmithCanvas } from "layoutSystems/CanvasFactory";
 import {
   Positioning,
   ResponsiveBehavior,
 } from "layoutSystems/common/utils/constants";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
-import { GridDefaults, RenderModes } from "constants/WidgetConstants";
-import { ValidationTypes } from "constants/WidgetValidation";
-import type { SetterConfig, Stylesheet } from "entities/AppTheming";
-import type { PrivateWidgets } from "@appsmith/entities/DataTree/types";
-import equal from "fast-deep-equal/es6";
-import { klona } from "klona/lite";
 import {
   cloneDeep,
   compact,
@@ -26,24 +47,19 @@ import {
 } from "lodash";
 import log from "loglevel";
 import memoizeOne from "memoize-one";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
 import React from "react";
 import shallowEqual from "shallowequal";
 import {
   combineDynamicBindings,
   getDynamicBindings,
 } from "utils/DynamicBindingUtils";
-import { removeFalsyEntries } from "utils/helpers";
-import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
-import { generateTypeDef } from "utils/autocomplete/defCreatorUtils";
 import type { ExtraDef } from "utils/autocomplete/defCreatorUtils";
-import WidgetFactory from "WidgetProvider/factory";
+import { generateTypeDef } from "utils/autocomplete/defCreatorUtils";
+import { removeFalsyEntries } from "utils/helpers";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import BaseWidget from "widgets/BaseWidget";
-import {
-  BlueprintOperationTypes,
-  type FlattenedWidgetProps,
-  type DSLWidget,
-} from "WidgetProvider/constants";
+import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
 import ListComponent, {
   ListComponentEmpty,
   ListComponentLoading,
@@ -51,22 +67,12 @@ import ListComponent, {
 import ListPagination, {
   ServerSideListPagination,
 } from "../component/ListPagination";
+import IconSVG from "../icon.svg";
 import derivedProperties from "./parseDerivedProperties";
 import {
   PropertyPaneContentConfig,
   PropertyPaneStyleConfig,
 } from "./propertyConfig";
-import type {
-  AnvilConfig,
-  AutocompletionDefinitions,
-  PropertyUpdates,
-  SnipingModeProperty,
-} from "WidgetProvider/constants";
-import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
-import { ASSETS_CDN_URL } from "constants/ThirdPartyConstants";
-import { FILL_WIDGET_MIN_WIDTH } from "constants/minWidthConstants";
-import IconSVG from "../icon.svg";
-import { renderAppsmithCanvas } from "layoutSystems/CanvasFactory";
 
 const LIST_WIDGET_PAGINATION_HEIGHT = 36;
 
@@ -92,6 +98,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       hideCard: true,
       replacement: "LIST_WIDGET_V2",
       needsHeightForContent: true,
+      tags: [WIDGET_TAGS.DISPLAY],
     };
   }
 
@@ -495,6 +502,13 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
             propertyPath: "listData",
             propertyValue: propValueMap.data,
             isDynamicPropertyPath: true,
+          },
+        ];
+      },
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("List Widget V2"),
           },
         ];
       },

--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -508,7 +508,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("List Widget V2"),
+            message: buildDeprecationWidgetMessage(ListWidget.getConfig().name),
           },
         ];
       },

--- a/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
@@ -103,7 +103,9 @@ class MultiSelectWidget extends BaseWidget<
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("MultiSelect Widget V2"),
+            message: buildDeprecationWidgetMessage(
+              MultiSelectWidget.getConfig().name,
+            ),
           },
         ];
       },

--- a/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
@@ -7,23 +7,27 @@ import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import BaseWidget from "widgets/BaseWidget";
 
 import { Alignment } from "@blueprintjs/core";
+import type {
+  AutocompletionDefinitions,
+  WidgetCallout,
+} from "WidgetProvider/constants";
+import { MinimumPopupWidthInPercentage } from "WidgetProvider/constants";
 import { LabelPosition } from "components/constants";
 import { Layers } from "constants/Layers";
+import { WIDGET_TAGS, layoutConfigurations } from "constants/WidgetConstants";
+import { FILL_WIDGET_MIN_WIDTH } from "constants/minWidthConstants";
 import type { SetterConfig, Stylesheet } from "entities/AppTheming";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
+import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
 import type { DraftValueType } from "rc-select/lib/Select";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
-import { MinimumPopupWidthInPercentage } from "WidgetProvider/constants";
-import MultiSelectComponent from "../component";
 import {
   DefaultAutocompleteDefinitions,
   isCompactMode,
 } from "widgets/WidgetUtils";
-import type { AutocompletionDefinitions } from "WidgetProvider/constants";
-import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
+import MultiSelectComponent from "../component";
 import IconSVG from "../icon.svg";
-import { FILL_WIDGET_MIN_WIDTH } from "constants/minWidthConstants";
-import { layoutConfigurations } from "constants/WidgetConstants";
 
 function defaultOptionValueValidation(value: unknown): ValidationResponse {
   let values: string[] = [];
@@ -64,6 +68,7 @@ class MultiSelectWidget extends BaseWidget<
       hideCard: true,
       isDeprecated: true,
       replacement: "MULTI_SELECT_WIDGET_V2",
+      tags: [WIDGET_TAGS.SELECT],
     };
   }
 
@@ -90,6 +95,18 @@ class MultiSelectWidget extends BaseWidget<
       placeholderText: "Select option(s)",
       responsiveBehavior: ResponsiveBehavior.Fill,
       minWidth: FILL_WIDGET_MIN_WIDTH,
+    };
+  }
+
+  static getMethods() {
+    return {
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("MultiSelect Widget V2"),
+          },
+        ];
+      },
     };
   }
 

--- a/app/client/src/widgets/ProgressBarWidget/widget/index.tsx
+++ b/app/client/src/widgets/ProgressBarWidget/widget/index.tsx
@@ -1,18 +1,23 @@
 import React from "react";
 
+import type { DerivedPropertiesMap } from "WidgetProvider/factory";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import BaseWidget from "widgets/BaseWidget";
-import type { DerivedPropertiesMap } from "WidgetProvider/factory";
 import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
 
 import ProgressBarComponent from "../component";
 
-import { ValidationTypes } from "constants/WidgetValidation";
+import type {
+  AutocompletionDefinitions,
+  WidgetCallout,
+} from "WidgetProvider/constants";
 import { Colors } from "constants/Colors";
-import { BarType } from "../constants";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
+import { ValidationTypes } from "constants/WidgetValidation";
 import type { Stylesheet } from "entities/AppTheming";
-import type { AutocompletionDefinitions } from "WidgetProvider/constants";
 import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
+import { buildDeprecationWidgetMessage } from "pages/Editor/utils";
+import { BarType } from "../constants";
 import IconSVG from "../icon.svg";
 
 class ProgressBarWidget extends BaseWidget<
@@ -30,6 +35,7 @@ class ProgressBarWidget extends BaseWidget<
       iconSVG: IconSVG,
       needsMeta: false, // Defines if this widget adds any meta properties
       isCanvas: false, // Defines if this widget has a canvas within in which we can drop other widgets
+      tags: [WIDGET_TAGS.CONTENT],
     };
   }
 
@@ -45,6 +51,18 @@ class ProgressBarWidget extends BaseWidget<
       steps: 1,
       version: 1,
       responsiveBehavior: ResponsiveBehavior.Fill,
+    };
+  }
+
+  static getMethods() {
+    return {
+      getEditorCallouts(): WidgetCallout[] {
+        return [
+          {
+            message: buildDeprecationWidgetMessage("Progress Widget"),
+          },
+        ];
+      },
     };
   }
 

--- a/app/client/src/widgets/ProgressBarWidget/widget/index.tsx
+++ b/app/client/src/widgets/ProgressBarWidget/widget/index.tsx
@@ -59,7 +59,9 @@ class ProgressBarWidget extends BaseWidget<
       getEditorCallouts(): WidgetCallout[] {
         return [
           {
-            message: buildDeprecationWidgetMessage("Progress Widget"),
+            message: buildDeprecationWidgetMessage(
+              ProgressBarWidget.getConfig().name,
+            ),
           },
         ];
       },


### PR DESCRIPTION
@rajatagrawal 

## Description
- In this PR I have added **getEditorCallout** method which can also used to return deprecataed messages. 
- I have updated above method for these deprecated widgets:
  -   InputWidget
  -   DropdownWidget
  -   DatePickerWidget
  -   IconWidget
  -   FilePickerWidget
  -   MultiSelectWidget
  -   FormButtonWidget
  -   ProgressBarWidget
  -   CircularProgressWidget
  -   ListWidget

**OUTPUT:**
![Screenshot from 2024-05-23 17-08-08](https://github.com/zemoso-int/appsmith-from-the-business/assets/127818049/813adfaa-f6ee-446b-831a-2b96167d6b9f)
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes [26526](https://github.com/appsmithorg/appsmith/issues/26526)  
_or_  
Fixes `https://github.com/appsmithorg/appsmith/issues/26526`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
