### PR TITLE
chore: Don't use `Layout` class for parsing request payloads

### DIFF
--- a/.github/workflows/scripts/test-tag-parser.js
+++ b/.github/workflows/scripts/test-tag-parser.js
@@ -9,7 +9,7 @@ function parseTags({core, context}) {
 
   // "/test" matcher.
   const allTags = require(process.env.GITHUB_WORKSPACE + "/app/client/cypress/tags.js").Tag;
-  const config = body.match(/^\**\/test\s+(.*)\**$/m)?.[1] ?? "";
+  const config = body.match(/^\**\/test\s+(.+?)\**$/m)?.[1] ?? "";
   const concreteTags = [];
 
   if (config.toLowerCase() === "all") {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
@@ -4,7 +4,12 @@ import com.appsmith.external.views.Views;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.constants.Url;
 import com.appsmith.server.domains.Layout;
-import com.appsmith.server.dtos.*;
+import com.appsmith.server.dtos.EntityType;
+import com.appsmith.server.dtos.LayoutDTO;
+import com.appsmith.server.dtos.LayoutUpdateDTO;
+import com.appsmith.server.dtos.RefactorEntityNameDTO;
+import com.appsmith.server.dtos.ResponseDTO;
+import com.appsmith.server.dtos.UpdateMultiplePageLayoutDTO;
 import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.refactors.applications.RefactoringService;
 import com.appsmith.server.services.LayoutService;
@@ -13,7 +18,13 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import reactor.core.publisher.Mono;
 
 @RequestMapping(Url.LAYOUT_URL)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
@@ -62,11 +62,11 @@ public class LayoutControllerCE {
             @PathVariable String pageId,
             @RequestParam String applicationId,
             @PathVariable String layoutId,
-            @RequestBody Layout layout,
+            @RequestBody LayoutUpdateDTO dto,
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
         log.debug("update layout received for page {}", pageId);
         return updateLayoutService
-                .updateLayout(pageId, applicationId, layoutId, layout, branchName)
+                .updateLayout(pageId, applicationId, layoutId, dto.toLayout(), branchName)
                 .map(created -> new ResponseDTO<>(HttpStatus.OK.value(), created, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/LayoutControllerCE.java
@@ -4,11 +4,7 @@ import com.appsmith.external.views.Views;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.constants.Url;
 import com.appsmith.server.domains.Layout;
-import com.appsmith.server.dtos.EntityType;
-import com.appsmith.server.dtos.LayoutDTO;
-import com.appsmith.server.dtos.RefactorEntityNameDTO;
-import com.appsmith.server.dtos.ResponseDTO;
-import com.appsmith.server.dtos.UpdateMultiplePageLayoutDTO;
+import com.appsmith.server.dtos.*;
 import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.refactors.applications.RefactoringService;
 import com.appsmith.server.services.LayoutService;
@@ -17,14 +13,7 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 @RequestMapping(Url.LAYOUT_URL)
@@ -43,16 +32,6 @@ public class LayoutControllerCE {
         this.service = layoutService;
         this.updateLayoutService = updateLayoutService;
         this.refactoringService = refactoringService;
-    }
-
-    @JsonView(Views.Public.class)
-    @PostMapping("/pages/{defaultPageId}")
-    public Mono<ResponseDTO<Layout>> createLayout(
-            @PathVariable String defaultPageId,
-            @Valid @RequestBody Layout layout,
-            @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
-        return service.createLayout(defaultPageId, layout, branchName)
-                .map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
     }
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/LayoutUpdateDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/LayoutUpdateDTO.java
@@ -1,0 +1,12 @@
+package com.appsmith.server.dtos;
+
+import com.appsmith.server.domains.Layout;
+import net.minidev.json.JSONObject;
+
+public record LayoutUpdateDTO(JSONObject dsl) {
+    public Layout toLayout() {
+        Layout layout = new Layout();
+        layout.setDsl(dsl);
+        return layout;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutServiceCE.java
@@ -7,8 +7,6 @@ public interface LayoutServiceCE {
 
     Mono<Layout> createLayout(String pageId, Layout layout);
 
-    Mono<Layout> createLayout(String defaultPageId, Layout layout, String branchName);
-
     Mono<Layout> getLayout(String pageId, String layoutId, Boolean viewMode);
 
     Mono<Layout> getLayout(String defaultPageId, String layoutId, Boolean viewMode, String branchName);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutServiceCEImpl.java
@@ -61,17 +61,6 @@ public class LayoutServiceCEImpl implements LayoutServiceCE {
     }
 
     @Override
-    public Mono<Layout> createLayout(String defaultPageId, Layout layout, String branchName) {
-        if (StringUtils.isEmpty(branchName)) {
-            return createLayout(defaultPageId, layout);
-        }
-        return newPageService
-                .findByBranchNameAndDefaultPageId(branchName, defaultPageId, pagePermission.getEditPermission())
-                .flatMap(branchedPage -> createLayout(branchedPage.getId(), layout))
-                .map(responseUtils::updateLayoutWithDefaultResources);
-    }
-
-    @Override
     public Mono<Layout> getLayout(String pageId, String layoutId, Boolean viewMode) {
         return newPageService
                 .findByIdAndLayoutsId(pageId, layoutId, pagePermission.getReadPermission(), viewMode)


### PR DESCRIPTION
Goal is to remove `Layout` class being used to deserialise request payloads. There's two routs in `LayoutControllerCE` that are doing this.

1. The `POST /api/v1/layouts/pages/{pageId}` seems unused, so removing that.
2. The `PUT /api/v1/layouts/{layoutId}/pages/{pageId}` only gets a single field in the JSON body, called `dsl`. So we introduce a `record` to accept just that.

All in an effort towards remove `@JsonProperty` from `Layout`, so it can work correctly with Postgres.

**/test all**

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9254557613>
> Commit: a8ebac28e571d3c89ec8a5fcb6ac9cdc1e8f308f
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9254557613&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





