### PR TITLE
chore: Remove `@JsonView` on `hasExpired` method

### DIFF
--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -2429,9 +2429,6 @@ export const defaultAppState = {
                   authType: "SCRAM_SHA_1",
                   username: "mockdb-admin",
                   databaseName: "movies",
-                  hasExpired: {
-                    scanAvailable: true,
-                  },
                 },
                 properties: [
                   {
@@ -2490,9 +2487,6 @@ export const defaultAppState = {
                   authenticationType: "dbAuth",
                   username: "users",
                   databaseName: "users",
-                  hasExpired: {
-                    scanAvailable: true,
-                  },
                 },
               },
               isConfigured: true,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -56,7 +56,6 @@ public class AuthenticationDTO implements AppsmithDomain {
     @JsonView(Views.Internal.class)
     AuthenticationResponse authenticationResponse;
 
-    @JsonView(Views.Public.class)
     public Mono<Boolean> hasExpired() {
         return Mono.just(Boolean.FALSE);
     }


### PR DESCRIPTION
The `hasExpired` method has a `@JsonView` annotation, that causes it to be included in JSON responses. But the return type of this method is `Mono<Boolean>`, so obviously, it doesn't produce anything useful in the resulting JSON:

This is from the response of updating an authenticated API with basic auth.

![shot-2024-05-27-13-43-26](https://github.com/appsmithorg/appsmith/assets/120119/6ab47d3e-5911-45d6-840a-1e37c41a415a)

Client doesn't care for this field in the response.

This is failing to be serialized at all, when saving to database in Postgres.

**/test sanity datasource**

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9256537717>
> Commit: 9204d9f01c62d2981eb03c3603a7294a9cc5b41d
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9256537717&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

