### PR TITLE
chore: Modified logging context to have only requestId and userEmail

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MDCConfig.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import static com.appsmith.external.constants.MDCConstants.OBSERVATION;
 import static com.appsmith.external.constants.MDCConstants.SPAN_ID;
-import static com.appsmith.external.constants.MDCConstants.THREAD;
 import static com.appsmith.external.constants.MDCConstants.TRACE_ID;
 
 @Configuration
@@ -84,7 +83,6 @@ public class MDCConfig {
             if (!context.isEmpty() && context.hasKey(LogHelper.CONTEXT_MAP)) {
                 Map<String, String> map = context.get(LogHelper.CONTEXT_MAP);
 
-                map.put(THREAD, Thread.currentThread().getName());
                 Optional<Observation> observationOptional = context.getOrEmpty(OBSERVATION);
                 observationOptional.ifPresent(observation -> {
                     TracingObservationHandler.TracingContext tracingContext =

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -31,7 +31,7 @@ appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:150}
 logging.level.root=info
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
-logging.pattern.console=[%d{ISO8601, UTC}] %X - %m%n
+logging.pattern.console=[%d{ISO8601, UTC}] requestId=%X{X-Appsmith-Request-Id} userEmail=%X{userEmail} traceId=%X{traceId} spanId=%X{spanId} - %m%n
 
 #Spring security
 spring.security.oauth2.client.registration.google.client-id=${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:missing_value_sentinel}


### PR DESCRIPTION
## Description
We're modifying the response headers to not hold any info on context, and the logging pattern to only display `requestId`, `userEmail`, `traceId` and `spanId`.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
