### PR TITLE
fix: Confirmation popup not dismissing after deleting a datasource

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/DSFormHeader.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DSFormHeader.tsx
@@ -183,6 +183,7 @@ export const DSFormHeader = (props: DSFormHeaderProps) => {
           {canDeleteDatasource && (
             <MenuWrapper
               className="t--datasource-menu-option"
+              key={datasourceId}
               onClick={(e) => {
                 e.stopPropagation();
               }}


### PR DESCRIPTION
## Description
This PR addresses the issue where the confirmation popup does not dismiss after deleting a datasource. The issue was resolved by adding a key attribute to the MenuWrapper component, ensuring that React properly re-renders the component.

### Changes:
- Added key={datasourceId} to the MenuWrapper component in order to force React to re-render the component correctly.


Fixes #32954  

## Automation
### Testing:
- Verified that the confirmation popup now dismisses properly after a datasource is deleted.
- Ensured that there are no regressions in related functionality.
- Video link - https://www.loom.com/share/35bb795e4ec04cbf807635b064ef3d1d?sid=9013d1a7-d528-453d-87e4-79d555321c98
/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
