### PR TITLE
chore: Icon property field stretches beyond the property pane boundary

### DIFF
--- a/app/client/src/components/propertyControls/IconSelectControlV2.tsx
+++ b/app/client/src/components/propertyControls/IconSelectControlV2.tsx
@@ -124,7 +124,8 @@ export interface IconSelectControlState {
 }
 
 const NONE = "(none)";
-type IconType = Required<IconProps>["name"] | typeof NONE;
+const EMPTY = "";
+type IconType = Required<IconProps>["name"] | typeof NONE | typeof EMPTY;
 const ICON_NAMES = Object.keys(ICONS) as any as IconType[];
 const icons = new Set(ICON_NAMES);
 
@@ -247,7 +248,8 @@ class IconSelectControlV2 extends BaseControl<
             tabIndex={0}
           >
             <span>
-              {iconName !== NONE &&
+              {iconName !== "" &&
+                iconName !== NONE &&
                 iconName !== undefined &&
                 iconName !== null && <Icon name={iconName} />}
             </span>
@@ -439,7 +441,7 @@ class IconSelectControlV2 extends BaseControl<
           active={modifiers.active}
           key={icon}
           onClick={handleClick}
-          text={icon === NONE ? NONE : <Icon name={icon} />}
+          text={icon === NONE || icon === EMPTY ? NONE : <Icon name={icon} />}
           textClassName={icon === NONE ? "bp3-icon-(none)" : ""}
         />
       </Tooltip>


### PR DESCRIPTION
Fixes #33302

/ok-to-test tags="@tag.Anvil"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9265300420>
> Commit: 5c9aedab4a27061b197e4a9ef89111dabc0f9d0f
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9265300420&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

