### PR TITLE
chore: Default search text is considered irrespective of 'allow searching' toggle value

### DIFF
--- a/app/client/src/widgets/wds/WDSTableWidget/widget/derived.js
+++ b/app/client/src/widgets/wds/WDSTableWidget/widget/derived.js
@@ -450,6 +450,7 @@ export default {
     /* skipping search when client side search is turned off */
     if (
       props.searchText &&
+      props.isVisibleSearch &&
       (!props.onSearchTextChanged || props.enableClientSideSearch)
     ) {
       searchKey = props.searchText.toLowerCase();

--- a/app/client/src/widgets/wds/WDSTableWidget/widget/derived.js
+++ b/app/client/src/widgets/wds/WDSTableWidget/widget/derived.js
@@ -450,7 +450,7 @@ export default {
     /* skipping search when client side search is turned off */
     if (
       props.searchText &&
-      props.isVisibleSearch &&
+      (props.isVisibleSearch === undefined || props.isVisibleSearch === true) &&
       (!props.onSearchTextChanged || props.enableClientSideSearch)
     ) {
       searchKey = props.searchText.toLowerCase();


### PR DESCRIPTION
Fixes #33773

/ok-to-test tags="@tag.Anvil"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9265326451>
> Commit: ce5ab34c71fa21bd56322859cd21813ed7aed7aa
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9265326451&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

