### PR TITLE
feat: Extend character limit for API, query, and datasource names

### DIFF
--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo  } from "react";
 import { useSelector } from "react-redux";
 
 import { useParams } from "react-router-dom";
@@ -45,7 +45,6 @@ interface ActionNameEditorProps {
 
 function ActionNameEditor(props: ActionNameEditorProps) {
   const params = useParams<{ apiId?: string; queryId?: string }>();
-
   const currentActionConfig = useSelector((state: AppState) =>
     getAction(state, params.apiId || params.queryId || ""),
   );
@@ -115,6 +114,8 @@ function ActionNameEditor(props: ActionNameEditorProps) {
               underline
               updating={saveStatus.isSaving}
               valueTransform={removeSpecialChars}
+              maxLength={256}
+              useFullWidth
             />
           </Flex>
         </NameWrapper>

--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -1,4 +1,4 @@
-import React, { memo  } from "react";
+import React, {memo} from "react";
 import { useSelector } from "react-redux";
 
 import { useParams } from "react-router-dom";

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -84,7 +84,7 @@ const EditableTextWrapper = styled.div<{
     useFullWidth &&
     `
     > div {
-    width: 100%;
+    width: 90%;
     }
   `}
 `;

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -111,16 +111,14 @@ function NameEditor(props: NameEditorProps) {
 
   const isInvalidNameForEntity = useCallback(
     (name: string): string | boolean => {
-      if (!name || name.trim().length === 0) {
+      if (!name?.trim()) {
         return createMessage(ACTION_INVALID_NAME_ERROR);
-      } else if (name !== entityName && hasActionNameConflict(name)) {
-        return createMessage(suffixErrorMessage, name);
       }
-      return false;
+      return (name !== entityName && hasActionNameConflict(name)) ? createMessage(suffixErrorMessage, name) : false;
     },
-    [hasActionNameConflict, entityName],
+    [hasActionNameConflict, entityName, suffixErrorMessage],
   );
-
+    
   const handleNameChange = useCallback(
     (name: string) => {
       if (name !== entityName && !isInvalidNameForEntity(name)) {

--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -10,7 +10,7 @@ import {
 } from "@appsmith/selectors/entitiesSelector";
 import { useSelector, useDispatch } from "react-redux";
 import type { Datasource } from "entities/Datasource";
-import { isNameValid } from "utils/helpers";
+import { isNameValid, removeSpecialChars } from "utils/helpers";
 import {
   saveDatasourceName,
   updateDatasourceName,
@@ -143,12 +143,14 @@ function FormTitle(props: FormTitleProps) {
         forceDefault={forceUpdate}
         isEditingDefault={props.focusOnMount}
         isInvalid={isInvalidDatasourceName}
-        maxLength={30}
+        maxLength={256}
         onTextChanged={handleDatasourceNameChange}
         placeholder="Datasource name"
         type="text"
         underline
         updating={saveStatus.isSaving}
+        valueTransform={removeSpecialChars}
+        useFullWidth
       />
     </Wrapper>
   );

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -172,12 +172,12 @@ function removeClass(ele: HTMLElement, cls: string) {
   }
 }
 
-export const removeSpecialChars = (value: string, limit?: number) => {
+export const removeSpecialChars = (value: string) => {
   const separatorRegex = /\W+/;
   return value
     .split(separatorRegex)
     .join("_")
-    .slice(0, limit || 30);
+    
 };
 
 export const flashElement = (

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -173,11 +173,7 @@ function removeClass(ele: HTMLElement, cls: string) {
 }
 
 export const removeSpecialChars = (value: string) => {
-  const separatorRegex = /\W+/;
-  return value
-    .split(separatorRegex)
-    .join("_")
-    
+  return value.replace(/\W+/g, '_');  
 };
 
 export const flashElement = (


### PR DESCRIPTION

## Description of the PR
 I have raised this PR inorder to `To extends the character limit for API, query, and datasource names, allowing for more descriptive and clearer identifiers in the system.`

### 📸 Screenshoots
#### here we gave query name more than 30 characters
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/147f2ab1-7c90-4cab-b8a5-6cd24853ce2e)

#### When you hover over a query that isn't visible, a tooltip appears displaying the query's name as below.
![querynamesimage](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/417f6191-b1d0-4e16-987a-28374dc10392)

