### PR TITLE
test: Running jest test cases if no PR is present as part of RTS build

### DIFF
--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -119,7 +119,7 @@ jobs:
 
       # Run the Jest tests only if the workflow has been invoked in a PR
       - name: Run the jest tests
-        if: steps.run_result.outputs.run_result != 'success' && inputs.pr != 0 && inputs.skip-tests != 'true'
+        if: steps.run_result.outputs.run_result != 'success' && inputs.skip-tests != 'true'
         run: yarn run test:unit
 
       - name: Build


### PR DESCRIPTION
## Description
This is being done to ensure that RTS jest test cases are run in TBP on release as well as master.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
