### PR TITLE
test: Removed startRoutesForDatasource command

### DIFF
--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -623,13 +623,6 @@ Cypress.Commands.add("setTinyMceContent", (tinyMceId, content) => {
   });
 });
 
-Cypress.Commands.add("startRoutesForDatasource", () => {
-  //cy.server();
-  cy.intercept("POST", "/api/v1/datasources").as("saveDatasource");
-  cy.intercept("POST", "/api/v1/datasources/test").as("testDatasource");
-  cy.intercept("PUT", "/api/v1/datasources/*").as("updateDatasource");
-});
-
 Cypress.Commands.add("startServerAndRoutes", () => {
   //To update route with intercept after working on alias wrt wait and alias
   //cy.server();


### PR DESCRIPTION
- Removed startRoutesForDatasource from Commands file and replaced with StartDataSourceRoutes from support/Pages/DataSources.
- StartDataSourceRoutes can be used for all the routes associated with DataSources.[Save/Test/udpate]

