### PR TITLE
fix: Reverting the previous fix for table scrollbar and hiding vertical scrollbar when needed

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/Table.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/Table.tsx
@@ -297,15 +297,9 @@ export function Table(props: TableProps) {
 
   const scrollContainerStyles = useMemo(() => {
     return {
-      height:
-        props.data.length < props.pageSize
-          ? "100%"
-          : isHeaderVisible
-            ? props.height -
-              tableSizes.TABLE_HEADER_HEIGHT -
-              TABLE_SCROLLBAR_HEIGHT +
-              SCROLL_BAR_OFFSET
-            : props.height - TABLE_SCROLLBAR_HEIGHT - SCROLL_BAR_OFFSET,
+      height: isHeaderVisible
+        ? props.height - tableSizes.TABLE_HEADER_HEIGHT - TABLE_SCROLLBAR_HEIGHT
+        : props.height - TABLE_SCROLLBAR_HEIGHT - SCROLL_BAR_OFFSET,
       width: props.width,
     };
   }, [
@@ -313,8 +307,6 @@ export function Table(props: TableProps) {
     props.height,
     tableSizes.TABLE_HEADER_HEIGHT,
     props.width,
-    props.data.length,
-    props.pageSize,
   ]);
 
   const shouldUseVirtual =

--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -187,7 +187,9 @@ export default {
         tableSizes.COLUMN_HEADER_HEIGHT) /
       tableSizes.ROW_HEIGHT;
 
-    return pageSize % 1 > 0.3 ? Math.ceil(pageSize) : Math.floor(pageSize);
+    return pageSize % 1 > 0.3 && props.tableData.length > pageSize
+      ? Math.ceil(pageSize)
+      : Math.floor(pageSize);
   },
   //
   getProcessedTableData: (props, moment, _) => {


### PR DESCRIPTION
## Description

Reverting the previous fix for table scrollbar and hiding vertical scrollbar when needed

Fixes [#33774](https://github.com/appsmithorg/appsmith/issues/33774) [#33557](https://github.com/appsmithorg/appsmith/issues/33557)

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
