### PR TITLE
chore: Add override context during runtime params eval

### DIFF
--- a/app/client/src/ce/workers/Evaluation/generateOverrideContext.ts
+++ b/app/client/src/ce/workers/Evaluation/generateOverrideContext.ts
@@ -1,0 +1,14 @@
+import type { DataTree } from "entities/DataTree/dataTreeTypes";
+
+export interface GenerateOverrideContextProps {
+  bindings: string[];
+  dataTree: DataTree;
+  executionParams: Record<string, unknown>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function generateOverrideContext(props: GenerateOverrideContextProps) {
+  return {};
+}
+
+export default generateOverrideContext;

--- a/app/client/src/ee/workers/Evaluation/generateOverrideContext.ts
+++ b/app/client/src/ee/workers/Evaluation/generateOverrideContext.ts
@@ -1,0 +1,3 @@
+export * from "ce/workers/Evaluation/generateOverrideContext";
+import { default as CE_generateOverrideContext } from "ce/workers/Evaluation/generateOverrideContext";
+export default CE_generateOverrideContext;

--- a/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
+++ b/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
@@ -1,4 +1,7 @@
-import evaluate, { evaluateAsync } from "workers/Evaluation/evaluate";
+import evaluate, {
+  createEvaluationContext,
+  evaluateAsync,
+} from "workers/Evaluation/evaluate";
 import type { WidgetEntity } from "@appsmith/entities/DataTree/types";
 import type { DataTree } from "entities/DataTree/dataTreeTypes";
 import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
@@ -7,6 +10,7 @@ import setupEvalEnv from "../handlers/setupEvalEnv";
 import { resetJSLibraries } from "workers/common/JSLibrary/resetJSLibraries";
 import { EVAL_WORKER_ACTIONS } from "@appsmith/workers/Evaluation/evalWorkerActions";
 import { convertAllDataTypesToString } from "../errorModifier";
+import { get } from "lodash";
 
 describe("evaluateSync", () => {
   const widget: WidgetEntity = {
@@ -278,4 +282,387 @@ describe("convertAllDataTypesToString", () => {
       expect(result).toStrictEqual(expected);
     },
   );
+});
+
+describe("createEvaluationContext", () => {
+  const dataTree = {
+    MainContainer: {
+      ENTITY_TYPE: "WIDGET",
+      widgetName: "MainContainer",
+      backgroundColor: "none",
+      rightColumn: 4896,
+      snapColumns: 64,
+      widgetId: "0",
+      topRow: 0,
+      bottomRow: 380,
+      containerStyle: "none",
+      snapRows: 124,
+      parentRowSpace: 1,
+      canExtend: true,
+      minHeight: 1292,
+      parentColumnSpace: 1,
+      leftColumn: 0,
+      meta: {},
+      isLoading: false,
+      componentHeight: 380,
+      componentWidth: 4896,
+      type: "CANVAS_WIDGET",
+      borderColor: "",
+      borderRadius: "",
+      boxShadow: "",
+    },
+    appsmith: {
+      user: {
+        email: "ashit@appsmith.com",
+        username: "ashit@appsmith.com",
+        name: "Ashit Rath",
+        useCase: "work project",
+        enableTelemetry: true,
+        roles: ["Enable Programmatic access control in Admin Settings"],
+        groups: ["Enable Programmatic access control in Admin Settings"],
+        accountNonExpired: true,
+        accountNonLocked: true,
+        credentialsNonExpired: true,
+        emptyInstance: false,
+        isAnonymous: false,
+        isEnabled: true,
+        isSuperUser: true,
+        isConfigurable: true,
+        adminSettingsVisible: true,
+        isIntercomConsentGiven: false,
+      },
+      URL: {
+        fullPath:
+          "https://ee-4304.dp.appsmith.com/app/my-first-application/page1-6656b06a3145e404b78300f1/edit?environment=production",
+        host: "ee-4304.dp.appsmith.com",
+        hostname: "ee-4304.dp.appsmith.com",
+        queryParams: {
+          environment: "production",
+        },
+        protocol: "https:",
+        pathname:
+          "/app/my-first-application/page1-6656b06a3145e404b78300f1/edit",
+        port: "",
+        hash: "",
+      },
+      store: {},
+      geolocation: {
+        canBeRequested: true,
+        currentPosition: {},
+      },
+      workflows: {},
+      mode: "EDIT",
+      theme: {
+        colors: {
+          primaryColor: "#553DE9",
+          backgroundColor: "#F8FAFC",
+        },
+        borderRadius: {
+          appBorderRadius: "0.375rem",
+        },
+        boxShadow: {
+          appBoxShadow:
+            "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)",
+        },
+        fontFamily: {
+          appFont: "System Default",
+        },
+      },
+      ENTITY_TYPE: "APPSMITH",
+    },
+    _$GetUsersModule1$_GetUsersModule: {
+      actionId: "6656b0bd3145e404b783010f",
+      run: {},
+      clear: {},
+      data: [
+        {
+          id: 14,
+          gender: "female",
+          latitude: "6.8074",
+          longitude: "-128.4713",
+          dob: "1949-05-23T09:56:35.254Z",
+          phone: "05-6736-4492",
+          email: "delores.little@example.com",
+          image:
+            "https://mkorostoff.github.io/hundred-thousand-faces/img/f/86.jpg",
+          country: "Australia",
+          name: "Delores Little",
+          created_at: "2023-01-09T14:17:19Z",
+          updated_at: "2023-05-03T06:33:20Z",
+        },
+        {
+          id: 16,
+          gender: "female",
+          latitude: "75.8821",
+          longitude: "-110.4223",
+          dob: "1946-01-24T18:21:06.109Z",
+          phone: "260-381-6755",
+          email: "brielle.roy@example.com",
+          image:
+            "https://mkorostoff.github.io/hundred-thousand-faces/img/f/41.jpg",
+          country: "Canada",
+          name: "Brielle Roy",
+          created_at: "2023-01-03T10:42:51Z",
+          updated_at: "2023-05-01T15:31:39Z",
+        },
+        {
+          id: 24,
+          gender: "female",
+          latitude: "73.632",
+          longitude: "-167.3976",
+          dob: "1995-11-22T02:25:20.419Z",
+          phone: "016973 12222",
+          email: "caroline.daniels@example.com",
+          image:
+            "https://mkorostoff.github.io/hundred-thousand-faces/img/f/91.jpg",
+          country: "United Kingdom",
+          name: "Caroline Daniels",
+          created_at: "2023-01-15T07:28:08Z",
+          updated_at: "2023-05-04T18:50:05Z",
+        },
+        {
+          id: 25,
+          gender: "female",
+          latitude: "38.7394",
+          longitude: "-31.7919",
+          dob: "1955-10-07T11:31:49.823Z",
+          phone: "(817)-164-4040",
+          email: "shiva.duijf@example.com",
+          image:
+            "https://mkorostoff.github.io/hundred-thousand-faces/img/f/88.jpg",
+          country: "Netherlands",
+          name: "Shiva Duijf",
+          created_at: "2023-03-19T10:19:50Z",
+          updated_at: "2023-05-21T11:27:33Z",
+        },
+        {
+          id: 30,
+          gender: "female",
+          latitude: "26.3703",
+          longitude: "6.4839",
+          dob: "1974-09-20T22:40:48.642Z",
+          phone: "05-9569-7428",
+          email: "heather.diaz@example.com",
+          image:
+            "https://mkorostoff.github.io/hundred-thousand-faces/img/f/77.jpg",
+          country: "Australia",
+          name: "Heather Diaz",
+          created_at: "2023-02-02T00:16:10Z",
+          updated_at: "2023-05-09T11:10:43Z",
+        },
+      ],
+      isLoading: false,
+      responseMeta: {
+        isExecutionSuccess: true,
+      },
+      ENTITY_TYPE: "ACTION",
+      datasourceUrl: "",
+      name: "_$GetUsersModule1$_GetUsersModule",
+    },
+    GetUsersModule1: {
+      actionId: "6656b0bd3145e404b783010f",
+      clear: {},
+      data: [
+        {
+          id: 14,
+          gender: "female",
+          latitude: "6.8074",
+          longitude: "-128.4713",
+          dob: "1949-05-23T09:56:35.254Z",
+          phone: "05-6736-4492",
+          email: "delores.little@example.com",
+          image:
+            "https://mkorostoff.github.io/hundred-thousand-faces/img/f/86.jpg",
+          country: "Australia",
+          name: "Delores Little",
+          created_at: "2023-01-09T14:17:19Z",
+          updated_at: "2023-05-03T06:33:20Z",
+        },
+      ],
+      ENTITY_TYPE: "MODULE_INSTANCE",
+      inputs: {
+        gender: "female",
+        limit: "2",
+      },
+      isLoading: false,
+      moduleId: "6656b0b63145e404b7830109",
+      moduleInstanceId: "6656b0bd3145e404b783010e",
+      run: {},
+      type: "QUERY_MODULE",
+      isValid: true,
+      name: "GetUsersModule1",
+    },
+    JSObject1: {
+      myVar1: [],
+      myVar2: {},
+      myFun2:
+        'async function () {\n  return await GetUsersModule1.run({\n    limit: 5,\n    gender: "female"\n  });\n}',
+      myFun1: "function () {}",
+      body: "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1 () {\n\t\t//\twrite code here\n\t\t//\tJSObject1.myVar1 = [1,2,3]\n\t},\n\tasync myFun2 () {\n\t\t//\tuse async-await or promises\n\t\t//\tawait storeValue('varName', 'hello world')\n\t\treturn await GetUsersModule1.run({ limit: 5, gender: \"female\" })\n\t}\n}",
+      ENTITY_TYPE: "JSACTION",
+      actionId: "6656b0cb3145e404b7830117",
+      "myFun2.data": {},
+      "myFun1.data": {},
+    },
+    Text1: {
+      ENTITY_TYPE: "WIDGET",
+      isVisible: true,
+      text: "Hello Ashit Rath",
+      fontSize: "1rem",
+      fontStyle: "BOLD",
+      textAlign: "LEFT",
+      textColor: "#231F20",
+      widgetName: "Text1",
+      shouldTruncate: false,
+      overflow: "NONE",
+      animateLoading: true,
+      responsiveBehavior: "fill",
+      minWidth: 450,
+      minDynamicHeight: 4,
+      maxDynamicHeight: 9000,
+      dynamicHeight: "AUTO_HEIGHT",
+      key: "g1jfl6n25o",
+      needsErrorInfo: false,
+      onCanvasUI: {
+        selectionBGCSSVar: "--on-canvas-ui-widget-selection",
+        focusBGCSSVar: "--on-canvas-ui-widget-focus",
+        selectionColorCSSVar: "--on-canvas-ui-widget-focus",
+        focusColorCSSVar: "--on-canvas-ui-widget-selection",
+        disableParentSelection: false,
+      },
+      widgetId: "surhpczu7k",
+      truncateButtonColor: "#553DE9",
+      fontFamily: "System Default",
+      borderRadius: "0.375rem",
+      isLoading: false,
+      parentColumnSpace: 36.234375,
+      parentRowSpace: 10,
+      leftColumn: 19,
+      rightColumn: 35,
+      topRow: 27,
+      bottomRow: 31,
+      mobileLeftColumn: 14,
+      mobileRightColumn: 30,
+      mobileTopRow: 30,
+      mobileBottomRow: 34,
+      value: "Hello Ashit Rath",
+      meta: {},
+      componentHeight: 40,
+      componentWidth: 579.75,
+      type: "TEXT_WIDGET",
+    },
+  } as unknown as DataTree;
+  it("Validate that overrideContext values with deeper nested paths are correctly set in EVAL_CONTEXT using the set function", () => {
+    const context = {
+      thisContext: {
+        $params: {
+          limit: 5,
+          gender: "female",
+        },
+      },
+      globalContext: {
+        executionParams: {
+          limit: 5,
+          gender: "female",
+        },
+      },
+      overrideContext: {
+        "GetUsersModule1.inputs.limit": 5,
+        "GetUsersModule1.inputs.gender": "female",
+      },
+    };
+
+    // Pre overriding
+    expect(get(dataTree, "GetUsersModule1.inputs.limit")).toEqual(
+      get(dataTree, "GetUsersModule1.inputs.limit"),
+    );
+    expect(get(dataTree, "GetUsersModule1.inputs.gender")).toEqual(
+      get(dataTree, "GetUsersModule1.inputs.gender"),
+    );
+
+    const evalContext = createEvaluationContext({
+      dataTree,
+      context,
+      isTriggerBased: false,
+    });
+
+    // Post overriding
+    expect(get(evalContext, "GetUsersModule1.inputs.limit")).toEqual(5);
+    expect(get(evalContext, "GetUsersModule1.inputs.gender")).toEqual("female");
+
+    // Post overriding, dataTree shouldn't be mutated
+    expect(get(dataTree, "GetUsersModule1.inputs.limit")).toEqual(
+      get(dataTree, "GetUsersModule1.inputs.limit"),
+    );
+    expect(get(dataTree, "GetUsersModule1.inputs.gender")).toEqual(
+      get(dataTree, "GetUsersModule1.inputs.gender"),
+    );
+  });
+
+  it("should handle undefined or null inputs gracefully", () => {
+    const evalContext = createEvaluationContext({
+      dataTree: {},
+      context: undefined,
+      configTree: undefined,
+      evalArguments: undefined,
+      isTriggerBased: true,
+    });
+    expect(evalContext).toBeDefined();
+    expect(evalContext.ARGUMENTS).toBeUndefined();
+    expect(evalContext.THIS_CONTEXT).toEqual({});
+  });
+
+  it("should assign THIS_CONTEXT from context.thisContext", () => {
+    const context = {
+      thisContext: {
+        $params: {
+          limit: 5,
+          gender: "female",
+        },
+      },
+      globalContext: {
+        executionParams: {
+          limit: 5,
+          gender: "female",
+        },
+      },
+    };
+    const evalContext = createEvaluationContext({
+      dataTree,
+      context,
+      isTriggerBased: false,
+    });
+    expect(evalContext.THIS_CONTEXT).toEqual(context.thisContext);
+  });
+
+  it("should merge globalContext into EVAL_CONTEXT when provided in context", () => {
+    const context = {
+      thisContext: {
+        $params: {
+          limit: 5,
+          gender: "female",
+        },
+      },
+      globalContext: {
+        executionParams: {
+          limit: 5,
+          gender: "female",
+        },
+      },
+    };
+    const isTriggerBased = false;
+
+    const evalContext = createEvaluationContext({
+      dataTree,
+      context,
+      isTriggerBased,
+    });
+
+    expect(evalContext.executionParams.limit).toEqual(
+      context.globalContext.executionParams.limit,
+    );
+    expect(evalContext.executionParams.gender).toEqual(
+      context.globalContext.executionParams.gender,
+    );
+  });
 });

--- a/app/client/src/workers/Evaluation/evaluate.ts
+++ b/app/client/src/workers/Evaluation/evaluate.ts
@@ -26,6 +26,7 @@ import {
 import { addDataTreeToContext } from "@appsmith/workers/Evaluation/Actions";
 import { set } from "lodash";
 import { klona } from "klona";
+import { getEntityNameAndPropertyPath } from "@appsmith/workers/Evaluation/evaluationUtils";
 
 export interface EvalResult {
   result: any;
@@ -214,7 +215,7 @@ const overrideEvalContext = (
     const entitiesClonedSoFar = new Set();
 
     Object.keys(overrideContext).forEach((path) => {
-      const [entityName] = path.split(".");
+      const { entityName } = getEntityNameAndPropertyPath(path);
 
       if (entityName in EVAL_CONTEXT && !entitiesClonedSoFar.has(entityName)) {
         entitiesClonedSoFar.add(entityName);

--- a/app/client/src/workers/Evaluation/evaluate.ts
+++ b/app/client/src/workers/Evaluation/evaluate.ts
@@ -24,6 +24,7 @@ import {
   TypeErrorModifier,
 } from "./errorModifier";
 import { addDataTreeToContext } from "@appsmith/workers/Evaluation/Actions";
+import { set } from "lodash";
 
 export interface EvalResult {
   result: any;
@@ -186,6 +187,12 @@ export const createEvaluationContext = (args: createEvaluationContextArgs) => {
     isTriggerBased,
   });
 
+  if (context?.overrideContext) {
+    Object.entries(context?.overrideContext).forEach(([path, value]) => {
+      set(EVAL_CONTEXT, path, value);
+    });
+  }
+
   return EVAL_CONTEXT;
 };
 
@@ -208,6 +215,7 @@ export interface EvaluateContext {
   requestId?: string;
   eventType?: EventType;
   triggerMeta?: TriggerMeta;
+  overrideContext?: Record<string, unknown>;
 }
 
 export const getUserScriptToEvaluate = (

--- a/app/client/src/workers/Evaluation/evaluate.ts
+++ b/app/client/src/workers/Evaluation/evaluate.ts
@@ -25,6 +25,7 @@ import {
 } from "./errorModifier";
 import { addDataTreeToContext } from "@appsmith/workers/Evaluation/Actions";
 import { set } from "lodash";
+import { klona } from "klona";
 
 export interface EvalResult {
   result: any;
@@ -141,6 +142,7 @@ export const getScriptToEval = (
 const beginsWithLineBreakRegex = /^\s+|\s+$/;
 
 export type EvalContext = Record<string, any>;
+
 export interface createEvaluationContextArgs {
   dataTree: DataTree;
   configTree?: ConfigTree;
@@ -153,6 +155,79 @@ export interface createEvaluationContextArgs {
    */
   removeEntityFunctions?: boolean;
 }
+
+/**
+ * overrideContext is a set of key-value pairs where they key is a path
+ * and the value is any value.
+ *
+ * The purpose of overrideContext is to update the EVAL_CONTEXT's entity properties
+ * with new value during runtime.
+ * An example of runtime would be execution of a query where some parameters are passed
+ * to the .run function.
+ * This enables to override the entities and their values in EVAL_CONTEXT without any side-effects
+ * to the actual dataTree since this is a non-persistent transient state of evaluation.
+ *
+ * Example:
+ * overrideContext = {
+ *  "Input1.text": "hello"
+ * }
+ * // before overriding
+ * EVAL_CONTEXT = {
+ *  "Input1": {
+ *    "text": "Hey!"
+ *  }
+ * "Text1": {
+ *    "text": "YOLO"
+ *  }
+ * }
+ *
+ * // after overriding just for the particular evaluation
+ * EVAL_CONTEXT = {
+ *  "Input1": {
+ *    "text": "Hello"
+ *  },
+ * "Text1": {
+ *  "text": "YOLO"
+ * }
+ *
+ * Where is this overriding actually used?
+ * At the time of writing this, the use case originated to evaluate run-time params of a
+ * query module instance as pass them off as inputs.
+ * Eg. QueryModule1.run({ input1: "10" }) and the bindings for this could be QueryModule1.inputs.input1
+ * So the executionParams needs to be put in the EVAL_CONTEXT with the above path and the supplied value.
+ * Therefore an overriding of the EVAL_CONTEXT is required during runtime execution.
+ *
+ * Why klona is used to cloned here?
+ * Since EVAL_CONTEXT is build from the dataTree by adding the entities directly referentially
+ * Eg. EVAL_CONTEXT["Input1"] = dataTree["Input1"]
+ * Overriding the EVAL_CONTEXT directly using set(EVAL_CONTEXT, path, value); would mutate the dataTree
+ * thus polluting the dataTree for the next evaluation.
+ * To avoid this, all the unique entities of present in the overrideContext is identified and cloned once for
+ * the particular entities only. This avoid unnecessary cloning of every entity and further multiple times.
+ *
+ */
+const overrideEvalContext = (
+  EVAL_CONTEXT: EvalContext,
+  overrideContext?: Record<string, unknown>,
+) => {
+  if (overrideContext) {
+    const entitiesClonedSoFar = new Set();
+
+    Object.keys(overrideContext).forEach((path) => {
+      const [entityName] = path.split(".");
+
+      if (entityName in EVAL_CONTEXT && !entitiesClonedSoFar.has(entityName)) {
+        entitiesClonedSoFar.add(entityName);
+        EVAL_CONTEXT[entityName] = klona(EVAL_CONTEXT[entityName]);
+      }
+    });
+
+    Object.entries(overrideContext).forEach(([path, value]) => {
+      set(EVAL_CONTEXT, path, value);
+    });
+  }
+};
+
 /**
  * This method created an object with dataTree and appsmith's framework actions that needs to be added to worker global scope for the JS code evaluation to then consume it.
  *
@@ -187,11 +262,7 @@ export const createEvaluationContext = (args: createEvaluationContextArgs) => {
     isTriggerBased,
   });
 
-  if (context?.overrideContext) {
-    Object.entries(context?.overrideContext).forEach(([path, value]) => {
-      set(EVAL_CONTEXT, path, value);
-    });
-  }
+  overrideEvalContext(EVAL_CONTEXT, context?.overrideContext);
 
   return EVAL_CONTEXT;
 };

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -138,6 +138,7 @@ import {
   type WebworkerSpanData,
 } from "UITelemetry/generateWebWorkerTraces";
 import type { AffectedJSObjects } from "sagas/EvaluationsSagaUtils";
+import generateOverrideContext from "@appsmith/workers/Evaluation/generateOverrideContext";
 
 type SortedDependencies = Array<string>;
 export interface EvalProps {
@@ -1714,11 +1715,13 @@ export default class DataTreeEvaluator {
     bindings: string[],
     executionParams?: Record<string, unknown> | string,
   ) {
+    const dataTree = klona(this.evalTree);
     // We might get execution params as an object or as a string.
     // If the user has added a proper object (valid case) it will be an object
     // If they have not added any execution params or not an object
     // it would be a string (invalid case)
     let evaluatedExecutionParams: Record<string, any> = {};
+    let overrideContext: Record<string, unknown>;
     if (executionParams && isObject(executionParams)) {
       evaluatedExecutionParams = this.getDynamicValue(
         `{{${JSON.stringify(executionParams)}}}`,
@@ -1726,9 +1729,13 @@ export default class DataTreeEvaluator {
         this.oldConfigTree,
         EvaluationSubstitutionType.TEMPLATE,
       );
-    }
 
-    const dataTree = klona(this.evalTree);
+      overrideContext = generateOverrideContext({
+        bindings,
+        executionParams,
+        dataTree,
+      });
+    }
 
     return bindings.map((binding) => {
       // Replace any reference of 'this.params' to 'executionParams' (backwards compatibility)
@@ -1751,6 +1758,7 @@ export default class DataTreeEvaluator {
           globalContext: {
             [EXECUTION_PARAM_KEY]: evaluatedExecutionParams,
           },
+          overrideContext,
         },
       );
     });


### PR DESCRIPTION
## Description
Adds `overrideContent` to be set during the execution of actions during runtime with execution params. This features enables to override properties/paths of entities during runtime and not affecting the dataTree. For now, this will be used for module instance execution in EE

PR for https://github.com/appsmithorg/appsmith-ee/pull/4304


## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9312695760>
> Commit: aed3c9944144a00c353d490ff8ef0fa117e20c06
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9312695760&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->












## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
