### PR TITLE
fix: Anvil: Always show parent toggle in widget name component

### DIFF
--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
@@ -19,7 +19,6 @@ import type { NameComponentStates } from "./types";
 import { generateDragStateForAnvilLayout } from "layoutSystems/anvil/utils/widgetUtils";
 import { SelectionRequestType } from "sagas/WidgetSelectUtils";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
-import { isWidgetSelected } from "selectors/widgetSelectors";
 
 export function AnvilWidgetName(props: {
   widgetId: string;
@@ -43,13 +42,10 @@ export function AnvilWidgetName(props: {
     (state) => getWidgetErrorCount(state, widgetId) > 0,
   );
 
-  const isParentSelected = useSelector(isWidgetSelected(parentId));
-
   const styleProps = getWidgetNameComponentStyleProps(
     widgetType,
     nameComponentState,
     showError,
-    isParentSelected,
   );
 
   const { setDraggingState } = useWidgetDragResize();

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/utils.ts
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/utils.ts
@@ -107,7 +107,6 @@ export function getWidgetNameComponentStyleProps(
   widgetType: string,
   nameComponentState: NameComponentStates,
   showError: boolean,
-  isParentSelected: boolean,
 ) {
   const config = WidgetFactory.getConfig(widgetType);
   const onCanvasUI = config?.onCanvasUI || {
@@ -134,8 +133,7 @@ export function getWidgetNameComponentStyleProps(
     colorCSSVar = "--on-canvas-ui-white";
   }
   return {
-    // disable parent toggle if the parent is already selected
-    disableParentToggle: isParentSelected || onCanvasUI.disableParentSelection,
+    disableParentToggle: onCanvasUI.disableParentSelection,
     bGCSSVar,
     colorCSSVar,
     selectionBGCSSVar: onCanvasUI.selectionBGCSSVar,


### PR DESCRIPTION
## Description
Even if the parent widget is already selected, show the parent widget selection toggle in widget name components

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9284066525>
> Commit: b6832ad46fa0866e5f89963ab02d08e8b2585139
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9284066525&attempt=2" target="_blank">Click here!</a>
> It seems like **no tests ran** 😔. We are not able to recognize it, please check workflow <a href="https://github.com/appsmithorg/appsmith/actions/runs/9284066525" target="_blank">here.</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
