### PR TITLE
chore: Add admin email domain hash to get tenant API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -12,6 +12,7 @@ import jakarta.validation.ValidatorFactory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -72,6 +73,8 @@ public class CommonConfig {
     private String mongoDBVersion;
 
     private static final String MIN_SUPPORTED_MONGODB_VERSION = "5.0.0";
+
+    private static String adminEmailDomainHash;
 
     @Bean
     public Scheduler scheduler() {
@@ -141,5 +144,19 @@ public class CommonConfig {
 
     public Long getCurrentTimeInstantEpochMilli() {
         return Instant.now().toEpochMilli();
+    }
+
+    public String getHashedAdminEmail() {
+        if (StringUtils.hasLength(adminEmailDomainHash)) {
+            return adminEmailDomainHash;
+        }
+        adminEmailDomainHash = this.adminEmails.stream()
+                .map(email -> email.split("@"))
+                .filter(emailParts -> emailParts.length == 2)
+                .findFirst()
+                .map(email -> email[1])
+                .map(DigestUtils::sha256Hex)
+                .orElse("");
+        return adminEmailDomainHash;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Tenant.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Tenant.java
@@ -27,6 +27,9 @@ public class Tenant extends BaseDomain implements Serializable {
     @Transient
     String instanceId;
 
+    @Transient
+    String adminEmailDomainHash;
+
     PricingPlan pricingPlan;
 
     TenantConfiguration tenantConfiguration;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/TenantServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/TenantServiceImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services;
 
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.helpers.FeatureFlagMigrationHelper;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.repositories.TenantRepository;
@@ -21,7 +22,8 @@ public class TenantServiceImpl extends TenantServiceCEImpl implements TenantServ
             ConfigService configService,
             @Lazy EnvManager envManager,
             FeatureFlagMigrationHelper featureFlagMigrationHelper,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
+            CacheableRepositoryHelper cacheableRepositoryHelper,
+            CommonConfig commonConfig) {
         super(
                 validator,
                 repository,
@@ -29,6 +31,7 @@ public class TenantServiceImpl extends TenantServiceCEImpl implements TenantServ
                 configService,
                 envManager,
                 featureFlagMigrationHelper,
-                cacheableRepositoryHelper);
+                cacheableRepositoryHelper,
+                commonConfig);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
@@ -3,6 +3,7 @@ package com.appsmith.server.services.ce;
 import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.FeatureMigrationType;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.constants.MigrationStatus;
@@ -42,6 +43,8 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
 
     private final CacheableRepositoryHelper cacheableRepositoryHelper;
 
+    private final CommonConfig commonConfig;
+
     public TenantServiceCEImpl(
             Validator validator,
             TenantRepository repository,
@@ -49,12 +52,14 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
             ConfigService configService,
             @Lazy EnvManager envManager,
             FeatureFlagMigrationHelper featureFlagMigrationHelper,
-            CacheableRepositoryHelper cacheableRepositoryHelper) {
+            CacheableRepositoryHelper cacheableRepositoryHelper,
+            CommonConfig commonConfig) {
         super(validator, repository, analyticsService);
         this.configService = configService;
         this.envManager = envManager;
         this.featureFlagMigrationHelper = featureFlagMigrationHelper;
         this.cacheableRepositoryHelper = cacheableRepositoryHelper;
+        this.commonConfig = commonConfig;
     }
 
     @Override
@@ -124,9 +129,11 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
 
     @Override
     public Mono<Tenant> getTenantConfiguration(Mono<Tenant> dbTenantMono) {
+        String adminEmailDomainHash = commonConfig.getHashedAdminEmail();
         Mono<Tenant> clientTenantMono = configService.getInstanceId().map(instanceId -> {
             final Tenant tenant = new Tenant();
             tenant.setInstanceId(instanceId);
+            tenant.setAdminEmailDomainHash(adminEmailDomainHash);
 
             final TenantConfiguration config = new TenantConfiguration();
             tenant.setTenantConfiguration(config);


### PR DESCRIPTION
## Description
PR to add `adminEmailDomainHash` field in GET tenant response, which will be consumed by client to add in analytics events.

Relevant thread: https://theappsmith.slack.com/archives/C04H5PFRN1H/p1715153325878529 

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9297621747>
> Commit: ee43608aadcc84e180a280d54b41906fe5ff4953
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9297621747&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
