### PR TITLE
fix: Anvil: Drag multiple widgets from widget name component

### DIFF
--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
@@ -56,13 +56,13 @@ export function AnvilWidgetName(props: {
       e.preventDefault();
       e.stopPropagation();
       // If we're dragging a focused widget, we need to select it before dragging
-      // Otherwise, the currently selected widget will instead be dragged.
+      // Otherwise, the currently selected widget(s) will instead be dragged.
       if (nameComponentState === "focus") {
         selectWidget(SelectionRequestType.One, [widgetId]);
       }
       setDraggingState(generateDragState());
     },
-    [nameComponentState, setDraggingState],
+    [nameComponentState, setDraggingState, selectWidget, generateDragState],
   );
 
   /** Setup Floating UI logic */

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/index.tsx
@@ -57,10 +57,12 @@ export function AnvilWidgetName(props: {
       e.stopPropagation();
       // If we're dragging a focused widget, we need to select it before dragging
       // Otherwise, the currently selected widget will instead be dragged.
-      selectWidget(SelectionRequestType.One, [widgetId]);
+      if (nameComponentState === "focus") {
+        selectWidget(SelectionRequestType.One, [widgetId]);
+      }
       setDraggingState(generateDragState());
     },
-    [setDraggingState],
+    [nameComponentState, setDraggingState],
   );
 
   /** Setup Floating UI logic */


### PR DESCRIPTION
## Description
- Fixes issue where we couldn't drag multiple widgets from the widget name component

- Previous and incorrect implementation:
  - When starting a drag from the widget name component, we force selected the widget being dragged, so even if multiple widgets were selected, only one would drag.

- Fix approach
  - When starting a drag from the widget name component, we check if the widget being dragged is focused. If it is focused, we select the widget before dragging. Otherwise, we directly allow dragging without any checks.
  - The widget name component only shows up when the widget is either focused or selected. If it is selected, we don't need to select any widgets and whichever widgets are selected, they will be dragged. However, if a widget is only focused, we need to make sure that the intended widget is being dragged.


Fixes #33842 
## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9312310513>
> Commit: 171b9d3f38ad964556a2f00bd248a01125f3bd13
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9312310513&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
