### PR TITLE
chore: Remove deprecated start-https.sh message

### DIFF
--- a/app/client/start-caddy.sh
+++ b/app/client/start-caddy.sh
@@ -7,6 +7,15 @@ if [[ -n ${TRACE-} ]]; then
     set -o xtrace
 fi
 
+{
+  echo
+  echo "-----------------------------------"
+  echo " ⚠️ This script is WIP. Please use start-https.sh instead."
+  echo "-----------------------------------"
+  echo
+} >&2
+
+
 cd "$(dirname "$0")"
 
 if [[ ${1-} =~ ^-*h(elp)?$ ]]; then

--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -7,14 +7,6 @@ if [[ -n ${TRACE-} ]]; then
     set -o xtrace
 fi
 
-{
-  echo
-  echo "-----------------------------------"
-  echo " ⚠️ This script is deprecated. Please 'brew install caddy' and use start-caddy.sh instead."
-  echo "-----------------------------------"
-  echo
-} >&2
-
 cd "$(dirname "$0")"
 
 if [[ ${1-} =~ ^-*h(elp)?$ ]]; then


### PR DESCRIPTION
## Description

- Remove the deprecated message in `start-https.sh` script and suggestion to use caddy as it is still work in progress. 


## Automation

/test perf

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9305335810>
> Commit: f3be0a2e583ac409d32dcdbdc50f67e168fa0215
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9305335810&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
