### PR TITLE
perf: make text selectable

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
@@ -59,12 +59,12 @@ class DatasourceDBEditor extends JSONtoForm<Props> {
   };
 
   render() {
-    const { formConfig, viewMode } = this.props;
+    const { formConfig, initialized, viewMode } = this.props;
 
     // make sure this redux form has been initialized before rendering anything.
     // the initialized prop below comes from redux-form.
     // The viewMode condition is added to allow the conditons only run on the editMode
-    if (!this.props.initialized && !viewMode) {
+    if (!initialized && !viewMode) {
       return null;
     }
 
@@ -72,7 +72,8 @@ class DatasourceDBEditor extends JSONtoForm<Props> {
   }
 
   renderDataSourceConfigForm = (sections: any) => {
-    const { datasourceId, messages, pluginType, viewMode } = this.props;
+    const { datasourceId, hiddenHeader, messages, pluginType, viewMode } =
+      this.props;
 
     return (
       <Form
@@ -89,12 +90,12 @@ class DatasourceDBEditor extends JSONtoForm<Props> {
               </Callout>
             );
           })}
-        {!this.props.hiddenHeader &&
+        {!hiddenHeader &&
           cloudHosting &&
           pluginType === PluginType.DB &&
           !viewMode && (
             <Callout
-              className="mt-4"
+              className="mt-4 select-text"
               kind="info"
               links={[
                 {


### PR DESCRIPTION
## Description
Made callout text in database sources selectable.

<img width="778" alt="Screenshot 2024-05-30 at 20 30 32" src="https://github.com/appsmithorg/appsmith/assets/173164/2e796029-5442-42cf-a20c-8cfe49d22003">


Fixes #33676 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9306800336>
> Commit: 7abb5b85200e82178ff3d4aeed937aca15bc0ee8
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9306800336&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
