### PR TITLE
test: Updating the locator for upgrade button on admin settings

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Branding/Branding_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Branding/Branding_spec.js
@@ -32,7 +32,7 @@ const locators = {
   AdminSettingsColorInputShades: ".t--color-input-shades",
   businessTag: ".business-tag",
   upgradeBanner: ".upgrade-banner",
-  upgradeButton: "[data-testid='t--branding-upgrade-button']",
+  upgradeButton: "[data-testid='t--button-upgrade']",
 };
 
 describe("Branding", { tags: ["@tag.Settings"] }, () => {

--- a/app/client/cypress/e2e/Regression/Enterprise/AdminSettings/Admin_settings_spec.js
+++ b/app/client/cypress/e2e/Regression/Enterprise/AdminSettings/Admin_settings_spec.js
@@ -99,7 +99,7 @@ describe("Admin settings page", { tags: ["@tag.Settings"] }, function () {
       cy.get(adminsSettings.branding).click();
       cy.url().should("contain", adminSettingsHelper.routes.BRANDING);
       cy.get(adminsSettings.brandingSubmitButton).should("be.disabled");
-      cy.xpath(adminsSettings.upgrade).click();
+      agHelper.GetNClick(adminsSettings.upgrade);
       cy.get("@customerPortalPage").should("be.called");
       cy.wait(2000);
       cy.go(-1);
@@ -120,7 +120,7 @@ describe("Admin settings page", { tags: ["@tag.Settings"] }, function () {
       cy.get(adminsSettings.accessControl).click();
       cy.url().should("contain", adminSettingsHelper.routes.ACCESS_CONTROL);
       cy.stubCustomerPortalPage();
-      cy.xpath(adminsSettings.upgrade).click();
+      agHelper.GetNClick(adminsSettings.upgrade);
       cy.get("@customerPortalPage").should("be.called");
       cy.wait(2000);
       agHelper.VisitNAssert(
@@ -135,7 +135,7 @@ describe("Admin settings page", { tags: ["@tag.Settings"] }, function () {
       cy.get(adminsSettings.auditLogs).click();
       cy.url().should("contain", adminSettingsHelper.routes.AUDIT_LOGS);
       cy.stubCustomerPortalPage();
-      cy.xpath(adminsSettings.upgrade).click();
+      agHelper.GetNClick(adminsSettings.upgrade);
       cy.get("@customerPortalPage").should("be.called");
       cy.wait(2000);
       agHelper.VisitNAssert(
@@ -150,7 +150,7 @@ describe("Admin settings page", { tags: ["@tag.Settings"] }, function () {
       cy.get(adminsSettings.provisioning).click();
       cy.url().should("contain", adminSettingsHelper.routes.PROVISIONING);
       cy.stubPricingPage();
-      cy.xpath(adminsSettings.upgrade).click();
+      agHelper.GetNClick(adminsSettings.upgrade);
       cy.get("@pricingPage").should("be.called");
       cy.wait(2000);
       cy.go(-1);

--- a/app/client/cypress/locators/AdminsSettings.js
+++ b/app/client/cypress/locators/AdminsSettings.js
@@ -27,7 +27,7 @@ export default {
   formSignupDisabled: "[data-testid='APPSMITH_SIGNUP_DISABLED']",
   formLoginDisabled: "[data-testid='APPSMITH_FORM_LOGIN_DISABLED']",
   embedSettings: ".t--admin-settings-APPSMITH_ALLOWED_FRAME_ANCESTORS",
-  upgrade: "//button//span[text()='Upgrade']",
+  upgrade: "[data-testid='t--button-upgrade']",
   accessControl: ".t--settings-category-access-control",
   auditLogs: ".t--settings-category-audit-logs",
   provisioning: ".t--settings-category-provisioning",

--- a/app/client/src/ce/pages/AdminSettings/Branding/UpgradeBanner.tsx
+++ b/app/client/src/ce/pages/AdminSettings/Branding/UpgradeBanner.tsx
@@ -49,11 +49,7 @@ const UpgradeBanner = () => {
           </StyledSettingsSubHeader>
         </main>
         <aside>
-          <Button
-            data-testid="t--branding-upgrade-button"
-            onClick={onUpgrade}
-            size="md"
-          >
+          <Button data-testid="t--button-upgrade" onClick={onUpgrade} size="md">
             Upgrade
           </Button>
         </aside>


### PR DESCRIPTION
## Description

Updating the locator for upgrade button on admin settings

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9316188465>
> Commit: 34d8a389fe7a06f400f794696daad5171c4fdef7
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9316188465&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
