### PR TITLE
fix: add customJS control for currency, notation and thousand separator

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Data.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Data.ts
@@ -395,6 +395,7 @@ export default {
       enableSearch: true,
       dropdownHeight: "156px",
       controlType: "DROP_DOWN",
+      customJSControl: "TABLE_COMPUTE_VALUE",
       searchPlaceholderText: "Search by code or name",
       options: CurrencyDropdownOptions,
       virtual: true,
@@ -402,11 +403,16 @@ export default {
       isBindProperty: true,
       isTriggerProperty: false,
       validation: {
-        type: ValidationTypes.TEXT,
+        type: ValidationTypes.ARRAY_OF_TYPE_OR_TYPE,
         params: {
-          default: "USD",
-          required: true,
-          allowedValues: CurrencyDropdownOptions.map((option) => option.value),
+          type: ValidationTypes.TEXT,
+          params: {
+            default: "USD",
+            required: true,
+            allowedValues: CurrencyDropdownOptions.map(
+              (option) => option.value,
+            ),
+          },
         },
       },
       hidden: (props: TableWidgetProps, propertyPath: string) => {
@@ -459,11 +465,17 @@ export default {
       helpText: "formats the currency with a thousand separator",
       label: "Thousand separator",
       controlType: "SWITCH",
+      customJSControl: "TABLE_COMPUTE_VALUE",
       dependencies: ["primaryColumns", "columnType"],
       isJSConvertible: true,
       isBindProperty: true,
       isTriggerProperty: false,
-      validation: { type: ValidationTypes.BOOLEAN },
+      validation: {
+        type: ValidationTypes.ARRAY_OF_TYPE_OR_TYPE,
+        params: {
+          type: ValidationTypes.BOOLEAN,
+        },
+      },
       hidden: (props: TableWidgetProps, propertyPath: string) => {
         const baseProperty = getBasePropertyPath(propertyPath);
         const columnType = get(props, `${baseProperty}.columnType`, "");
@@ -475,6 +487,7 @@ export default {
       helpText: "Displays the currency in standard or compact notation",
       label: "Notation",
       controlType: "DROP_DOWN",
+      customJSControl: "TABLE_COMPUTE_VALUE",
       options: [
         {
           label: "Standard",
@@ -490,8 +503,14 @@ export default {
       isBindProperty: true,
       isTriggerProperty: false,
       validation: {
-        type: ValidationTypes.TEXT,
-        params: { default: "standard", allowedValues: ["standard", "compact"] },
+        type: ValidationTypes.ARRAY_OF_TYPE_OR_TYPE,
+        params: {
+          type: ValidationTypes.TEXT,
+          params: {
+            default: "standard",
+            allowedValues: ["standard", "compact"],
+          },
+        },
       },
       hidden: (props: TableWidgetProps, propertyPath: string) => {
         const baseProperty = getBasePropertyPath(propertyPath);

--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
@@ -518,8 +518,11 @@ export const getCellProperties = (
         true,
       ),
       decimals: columnProperties.decimals,
-      thousandSeparator: !!columnProperties.thousandSeparator,
-      notation: columnProperties.notation,
+      thousandSeparator: getBooleanPropertyValue(
+        columnProperties.thousandSeparator,
+        rowIndex,
+      ),
+      notation: getPropertyValue(columnProperties.notation, rowIndex, true),
     } as CellLayoutProperties;
   }
   return {} as CellLayoutProperties;


### PR DESCRIPTION
Fixes #33858

/ok-to-test tags="@tag.Table"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9318008514>
> Commit: 1ea0a6325c234a41c431c92329e3fa8e9d4fdf45
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9318008514&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



