### PR TITLE
chore: Fix extra space at the end of multi-line input widget #33099

### DIFF
--- a/app/client/packages/design-system/headless/src/components/TextArea/src/TextArea.tsx
+++ b/app/client/packages/design-system/headless/src/components/TextArea/src/TextArea.tsx
@@ -48,10 +48,20 @@ function TextArea(props: TextAreaProps, ref: TextAreaRef) {
       }
       input.style.alignSelf = "start";
       input.style.height = "auto";
-      // offsetHeight - clientHeight accounts for the border/padding.
+
       // Also, adding 1px to fix a bug in browser where there is a scrolllbar on certain heights
       input.style.height = `${
-        input.scrollHeight + (input.offsetHeight - input.clientHeight) + 1
+        // subtract comptued padding and border to get the actual content height
+        input.scrollHeight -
+        (getComputedStyle(input).paddingTop.replace(
+          "px",
+          "",
+        ) as unknown as number) -
+        (getComputedStyle(input).paddingBottom.replace(
+          "px",
+          "",
+        ) as unknown as number) +
+        1
       }px`;
       input.style.overflow = prevOverflow;
       input.style.alignSelf = prevAlignment;

--- a/app/client/packages/design-system/headless/src/components/TextArea/src/TextArea.tsx
+++ b/app/client/packages/design-system/headless/src/components/TextArea/src/TextArea.tsx
@@ -49,18 +49,15 @@ function TextArea(props: TextAreaProps, ref: TextAreaRef) {
       input.style.alignSelf = "start";
       input.style.height = "auto";
 
-      // Also, adding 1px to fix a bug in browser where there is a scrolllbar on certain heights
+      const computedStyle = getComputedStyle(input);
+      const paddingTop = parseFloat(computedStyle.paddingTop);
+      const paddingBottom = parseFloat(computedStyle.paddingBottom);
       input.style.height = `${
         // subtract comptued padding and border to get the actual content height
         input.scrollHeight -
-        (getComputedStyle(input).paddingTop.replace(
-          "px",
-          "",
-        ) as unknown as number) -
-        (getComputedStyle(input).paddingBottom.replace(
-          "px",
-          "",
-        ) as unknown as number) +
+        paddingTop -
+        paddingBottom +
+        // Also, adding 1px to fix a bug in browser where there is a scrolllbar on certain heights
         1
       }px`;
       input.style.overflow = prevOverflow;

--- a/app/client/packages/design-system/headless/src/components/TextArea/src/TextArea.tsx
+++ b/app/client/packages/design-system/headless/src/components/TextArea/src/TextArea.tsx
@@ -49,8 +49,9 @@ function TextArea(props: TextAreaProps, ref: TextAreaRef) {
       input.style.alignSelf = "start";
       input.style.height = "auto";
       // offsetHeight - clientHeight accounts for the border/padding.
+      // Also, adding 1px to fix a bug in browser where there is a scrolllbar on certain heights
       input.style.height = `${
-        input.scrollHeight + (input.offsetHeight - input.clientHeight)
+        input.scrollHeight + (input.offsetHeight - input.clientHeight) + 1
       }px`;
       input.style.overflow = prevOverflow;
       input.style.alignSelf = prevAlignment;

--- a/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
+++ b/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
@@ -28,7 +28,7 @@
       var(--body-line-height) + var(--body-margin-start) +
         var(--body-margin-end)
     );
-    padding-block: var(--inner-spacing-3);
+    margin-block: var(--inner-spacing-3);
 
     &:autofill,
     &:autofill:hover,

--- a/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
+++ b/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
@@ -23,12 +23,12 @@
     text-overflow: ellipsis;
     max-inline-size: 100%;
     width: 100%;
-    box-sizing: border-box;
+    box-sizing: content-box;
     block-size: calc(
       var(--body-line-height) + var(--body-margin-start) +
         var(--body-margin-end)
     );
-    margin-block: var(--inner-spacing-3);
+    padding-block: var(--inner-spacing-3);
 
     &:autofill,
     &:autofill:hover,

--- a/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
+++ b/app/client/packages/design-system/widgets/src/styles/src/text-input.module.css
@@ -23,7 +23,7 @@
     text-overflow: ellipsis;
     max-inline-size: 100%;
     width: 100%;
-    box-sizing: content-box;
+    box-sizing: border-box;
     block-size: calc(
       var(--body-line-height) + var(--body-margin-start) +
         var(--body-margin-end)


### PR DESCRIPTION
Fixes #33099

/ok-to-test tags="@tag.Anvil"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9318021083>
> Commit: 5f1ea63400f06fa9d22e0aa41c81e44fdf7b1deb
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9318021083&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

