### PR TITLE
chore: Add admin email domain hash and user tracking to analytics events

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/AnalyticsConstants.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/AnalyticsConstants.java
@@ -7,4 +7,5 @@ public interface AnalyticsConstants {
     String IP = "ip";
     String IP_ADDRESS = "ipAddress";
     String EMAIL_DOMAIN_HASH = "emailDomainHash";
+    String ADMIN_EMAIL_DOMAIN_HASH = "adminEmailDomainHash";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -146,7 +146,7 @@ public class CommonConfig {
         return Instant.now().toEpochMilli();
     }
 
-    public String getHashedAdminEmail() {
+    public String getAdminEmailDomainHash() {
         if (StringUtils.hasLength(adminEmailDomainHash)) {
             return adminEmailDomainHash;
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
@@ -17,6 +17,7 @@ import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.util.StringUtils;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -96,6 +97,9 @@ public class User extends BaseDomain implements UserDetails, OidcUser {
     // e.g. AnonymousUser is created by the system migration during the first time startup.
     @JsonView(Views.Internal.class)
     Boolean isSystemGenerated;
+
+    @JsonView(Views.Internal.class)
+    Instant lastActiveAt;
 
     // TODO: Populate these attributes for a user. Generally required for OAuth2 logins
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/UserRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/UserRepositoryCE.java
@@ -6,6 +6,7 @@ import com.appsmith.server.repositories.CustomUserRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
 import java.util.Set;
 
 public interface UserRepositoryCE extends BaseRepository<User, String>, CustomUserRepository {
@@ -24,6 +25,9 @@ public interface UserRepositoryCE extends BaseRepository<User, String>, CustomUs
      * @return  The count of all users that are not deleted and are not system generated.
      */
     Mono<Long> countByDeletedAtIsNullAndIsSystemGeneratedIsNot(Boolean excludeSystemGenerated);
+
+    Mono<Long> countByDeletedAtIsNullAndLastActiveAtGreaterThanAndIsSystemGeneratedIsNot(
+            Instant lastActiveAt, Boolean excludeSystemGenerated);
 
     Mono<User> findByEmailAndTenantId(String email, String tenantId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.appsmith.external.constants.AnalyticsConstants.ADMIN_EMAIL_DOMAIN_HASH;
 import static com.appsmith.external.constants.AnalyticsConstants.EMAIL_DOMAIN_HASH;
 import static com.appsmith.external.constants.AnalyticsConstants.GOAL;
 import static com.appsmith.external.constants.AnalyticsConstants.IP;
@@ -80,7 +81,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
     }
 
     private String hash(String value) {
-        return value == null ? "" : DigestUtils.sha256Hex(value);
+        return StringUtils.isEmpty(value) ? "" : DigestUtils.sha256Hex(value);
     }
 
     private String getEmailDomainHash(String email) {
@@ -252,7 +253,9 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
                         String email = analyticsProperties.get(EMAIL) != null
                                 ? analyticsProperties.get(EMAIL).toString()
                                 : "";
-                        analyticsProperties.put(EMAIL_DOMAIN_HASH, getEmailDomainHash(email));
+                        String domainHash = getEmailDomainHash(email);
+                        analyticsProperties.put(EMAIL_DOMAIN_HASH, domainHash);
+                        analyticsProperties.put(ADMIN_EMAIL_DOMAIN_HASH, domainHash);
                     } else {
                         analyticsProperties.put(EMAIL_DOMAIN_HASH, emailDomainHash);
                     }
@@ -269,7 +272,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
                             "hostname", ObjectUtils.defaultIfNull(deploymentProperties.getHostname(), ""));
                     analyticsProperties.put(
                             "deployedAt", ObjectUtils.defaultIfNull(deploymentProperties.getDeployedAt(), ""));
-                    analyticsProperties.put("adminEmailDomainHash", commonConfig.getHashedAdminEmail());
+                    analyticsProperties.put(ADMIN_EMAIL_DOMAIN_HASH, commonConfig.getAdminEmailDomainHash());
 
                     messageBuilder = messageBuilder.properties(analyticsProperties);
                     analytics.enqueue(messageBuilder);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -269,6 +269,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
                             "hostname", ObjectUtils.defaultIfNull(deploymentProperties.getHostname(), ""));
                     analyticsProperties.put(
                             "deployedAt", ObjectUtils.defaultIfNull(deploymentProperties.getDeployedAt(), ""));
+                    analyticsProperties.put("adminEmailDomainHash", commonConfig.getHashedAdminEmail());
 
                     messageBuilder = messageBuilder.properties(analyticsProperties);
                     analytics.enqueue(messageBuilder);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -258,6 +258,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
                         analyticsProperties.put(ADMIN_EMAIL_DOMAIN_HASH, domainHash);
                     } else {
                         analyticsProperties.put(EMAIL_DOMAIN_HASH, emailDomainHash);
+                        analyticsProperties.put(ADMIN_EMAIL_DOMAIN_HASH, commonConfig.getAdminEmailDomainHash());
                     }
                     analyticsProperties.put("originService", "appsmith-server");
                     analyticsProperties.put("instanceId", instanceId);
@@ -272,7 +273,6 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
                             "hostname", ObjectUtils.defaultIfNull(deploymentProperties.getHostname(), ""));
                     analyticsProperties.put(
                             "deployedAt", ObjectUtils.defaultIfNull(deploymentProperties.getDeployedAt(), ""));
-                    analyticsProperties.put(ADMIN_EMAIL_DOMAIN_HASH, commonConfig.getAdminEmailDomainHash());
 
                     messageBuilder = messageBuilder.properties(analyticsProperties);
                     analytics.enqueue(messageBuilder);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
@@ -129,7 +129,7 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
 
     @Override
     public Mono<Tenant> getTenantConfiguration(Mono<Tenant> dbTenantMono) {
-        String adminEmailDomainHash = commonConfig.getHashedAdminEmail();
+        String adminEmailDomainHash = commonConfig.getAdminEmailDomainHash();
         Mono<Tenant> clientTenantMono = configService.getInstanceId().map(instanceId -> {
             final Tenant tenant = new Tenant();
             tenant.setInstanceId(instanceId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PingScheduledTaskCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PingScheduledTaskCEImpl.java
@@ -25,11 +25,16 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
-import reactor.util.function.Tuple6;
+import reactor.util.function.Tuple7;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
+import static com.appsmith.external.constants.AnalyticsConstants.ADMIN_EMAIL_DOMAIN_HASH;
+import static com.appsmith.external.constants.AnalyticsConstants.EMAIL_DOMAIN_HASH;
 import static java.util.Map.entry;
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 /**
  * This class represents a scheduled task that pings a data point indicating that this server installation is live.
@@ -55,6 +60,12 @@ public class PingScheduledTaskCEImpl implements PingScheduledTaskCE {
     private final DeploymentProperties deploymentProperties;
     private final NetworkUtils networkUtils;
     private final PermissionGroupService permissionGroupService;
+
+    enum UserTrackingType {
+        DAU,
+        WAU,
+        MAU
+    }
 
     /**
      * Gets the external IP address of this server and pings a data point to indicate that this server instance is live.
@@ -132,13 +143,14 @@ public class PingScheduledTaskCEImpl implements PingScheduledTaskCE {
                 .countByDeletedAtIsNullAndIsSystemGeneratedIsNot(true)
                 .defaultIfEmpty(0L);
 
-        Mono<Tuple6<Long, Long, Long, Long, Long, Long>> nonDeletedObjectsCountMono = Mono.zip(
+        Mono<Tuple7<Long, Long, Long, Long, Long, Long, Map<String, Long>>> nonDeletedObjectsCountMono = Mono.zip(
                 workspaceRepository.countByDeletedAtNull().defaultIfEmpty(0L),
                 applicationRepository.countByDeletedAtNull().defaultIfEmpty(0L),
                 newPageRepository.countByDeletedAtNull().defaultIfEmpty(0L),
                 newActionRepository.countByDeletedAtNull().defaultIfEmpty(0L),
                 datasourceRepository.countByDeletedAtNull().defaultIfEmpty(0L),
-                userCountMono);
+                userCountMono,
+                getUserTrackingDetails());
 
         publicPermissionGroupIdMono
                 .flatMap(publicPermissionGroupId -> Mono.zip(
@@ -148,22 +160,26 @@ public class PingScheduledTaskCEImpl implements PingScheduledTaskCE {
                         applicationRepository.getAllApplicationsCountAccessibleToARoleWithPermission(
                                 AclPermission.READ_APPLICATIONS, publicPermissionGroupId)))
                 .flatMap(statsData -> {
-                    Map<String, String> propertiesMap = Map.ofEntries(
+                    Map<String, Object> propertiesMap = new java.util.HashMap<>(Map.ofEntries(
                             entry("instanceId", statsData.getT1()),
-                            entry("numOrgs", statsData.getT3().getT1().toString()),
-                            entry("numApps", statsData.getT3().getT2().toString()),
-                            entry("numPages", statsData.getT3().getT3().toString()),
-                            entry("numActions", statsData.getT3().getT4().toString()),
-                            entry("numDatasources", statsData.getT3().getT5().toString()),
-                            entry("numUsers", statsData.getT3().getT6().toString()),
-                            entry("numPublicApps", statsData.getT4().toString()),
+                            entry("numOrgs", statsData.getT3().getT1()),
+                            entry("numApps", statsData.getT3().getT2()),
+                            entry("numPages", statsData.getT3().getT3()),
+                            entry("numActions", statsData.getT3().getT4()),
+                            entry("numDatasources", statsData.getT3().getT5()),
+                            entry("numUsers", statsData.getT3().getT6()),
+                            entry("numPublicApps", statsData.getT4()),
                             entry("version", projectProperties.getVersion()),
                             entry("edition", deploymentProperties.getEdition()),
-                            entry("cloudProvider", deploymentProperties.getCloudProvider()),
-                            entry("efs", deploymentProperties.getEfs()),
-                            entry("tool", deploymentProperties.getTool()),
-                            entry("hostname", deploymentProperties.getHostname()),
-                            entry("deployedAt", deploymentProperties.getDeployedAt()));
+                            entry("cloudProvider", defaultIfEmpty(deploymentProperties.getCloudProvider(), "")),
+                            entry("efs", defaultIfEmpty(deploymentProperties.getEfs(), "")),
+                            entry("tool", defaultIfEmpty(deploymentProperties.getTool(), "")),
+                            entry("hostname", defaultIfEmpty(deploymentProperties.getHostname(), "")),
+                            entry("deployedAt", defaultIfEmpty(deploymentProperties.getDeployedAt(), "")),
+                            entry(ADMIN_EMAIL_DOMAIN_HASH, commonConfig.getAdminEmailDomainHash()),
+                            entry(EMAIL_DOMAIN_HASH, commonConfig.getAdminEmailDomainHash())));
+
+                    propertiesMap.putAll(statsData.getT3().getT7());
 
                     final String ipAddress = statsData.getT2();
                     return WebClientUtils.create("https://api.segment.io")
@@ -186,5 +202,27 @@ public class PingScheduledTaskCEImpl implements PingScheduledTaskCE {
                 .doOnError(error -> log.error("Error sending anonymous counts {0}", error))
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe();
+    }
+
+    private Mono<Map<String, Long>> getUserTrackingDetails() {
+
+        Mono<Long> dauCountMono = userRepository
+                .countByDeletedAtIsNullAndLastActiveAtGreaterThanAndIsSystemGeneratedIsNot(
+                        Instant.now().minus(1, ChronoUnit.DAYS), true)
+                .defaultIfEmpty(0L);
+        Mono<Long> wauCountMono = userRepository
+                .countByDeletedAtIsNullAndLastActiveAtGreaterThanAndIsSystemGeneratedIsNot(
+                        Instant.now().minus(7, ChronoUnit.DAYS), true)
+                .defaultIfEmpty(0L);
+        Mono<Long> mauCountMono = userRepository
+                .countByDeletedAtIsNullAndLastActiveAtGreaterThanAndIsSystemGeneratedIsNot(
+                        Instant.now().minus(30, ChronoUnit.DAYS), true)
+                .defaultIfEmpty(0L);
+
+        return Mono.zip(dauCountMono, wauCountMono, mauCountMono)
+                .map(tuple -> Map.of(
+                        UserTrackingType.DAU.name(), tuple.getT1(),
+                        UserTrackingType.WAU.name(), tuple.getT2(),
+                        UserTrackingType.MAU.name(), tuple.getT3()));
     }
 }


### PR DESCRIPTION
## Description
PR to enhance analytics:
- User tracking: DAU, WAU, MAU  
- Hashed admin email domain

Update `instance_stats` properties for ref:
```
{
  "event": "instance_stats",
  "properties": {
	    "DAU": 2,
	    "MAU": 3,
	    "WAU": 3,
	    "adminEmailDomainHash": "eb93d881805376ef5297d8ac6fe95970f47d7bbd8d849b3a0d9c7af188caf648",
	    "cloudProvider": "",
	    "deployedAt": "",
	    "edition": "CE",
	    "efs": "",
	    "emailDomainHash": "eb93d881805376ef5297d8ac6fe95970f47d7bbd8d849b3a0d9c7af188caf648",
	    "hostname": "",
	    "instanceId": "6656f32dd841a66006d1ddc3",
	    "numActions": "8",
	    "numApps": "2",
	    "numDatasources": "2",
	    "numOrgs": "2",
	    "numPages": "2",
	    "numPublicApps": "0",
	    "numUsers": "3",
	    "tool": "",
	    "version": "UNKNOWN"
  },
  "receivedAt": "2024-05-31T11:48:35.831Z",
  "timestamp": "2024-05-31T11:48:35.831Z",
  "type": "track",
  "userId": "6656f32dd841a66006d1ddc3"
}
```

Fixes https://github.com/appsmithorg/appsmith/issues/33714

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9318669278>
> Commit: fcacaf3e8b3608eeb8ff5a6d1437a8567c397a0e
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9318669278&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
