### PR TITLE
chore: Adding logging mechanism to find out context of redis git locks

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/constants/GitConstants.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/constants/GitConstants.java
@@ -5,4 +5,6 @@ import com.appsmith.external.git.constants.ce.GitConstantsCE;
 public class GitConstants extends GitConstantsCE {
 
     public class GitMetricConstants extends GitMetricConstantsCE {}
+
+    public class GitCommandConstants extends GitCommandConstantsCE {}
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/constants/ce/GitConstantsCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/constants/ce/GitConstantsCE.java
@@ -31,4 +31,21 @@ public class GitConstantsCE {
         public static final String ACTION_COLLECTION_BODY = "ActionCollectionBody";
         public static final String NEW_ACTION_BODY = "NewActionBody";
     }
+
+    public class GitCommandConstantsCE {
+        public static final String METADATA = "metadata";
+        public static final String AUTO_COMMIT = "autoCommit";
+        public static final String PULL = "pull";
+        public static final String PUSH = "push";
+        public static final String STATUS = "status";
+        public static final String FETCH_REMOTE = "fetchRemote";
+        public static final String COMMIT = "commit";
+        public static final String CREATE_BRANCH = "createBranch";
+        public static final String CHECKOUT_BRANCH = "checkoutBranch";
+        public static final String SYNC_BRANCH = "syncBranch";
+        public static final String LIST_BRANCH = "listBranch";
+        public static final String MERGE_BRANCH = "mergeBranch";
+        public static final String DELETE = "delete";
+        public static final String DISCARD = "discard";
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -855,7 +855,7 @@ public enum AppsmithError {
     GIT_FILE_IN_USE(
             500,
             AppsmithErrorCode.GIT_FILE_IN_USE.getCode(),
-            "We were unable to place a lock on the file system to perform #commandName command. This error can occur when another operation is in progress. Please try again later.",
+            "We were unable to place a lock on the file system to perform {0} command. This error can occur when another command {1}, which is in progress. Please try again later.",
             AppsmithErrorAction.DEFAULT,
             "Git repo is locked",
             ErrorType.GIT_ACTION_EXECUTION_ERROR,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/AutoCommitEventHandlerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/AutoCommitEventHandlerCEImpl.java
@@ -3,6 +3,7 @@ package com.appsmith.server.git;
 import com.appsmith.external.constants.AnalyticsEvents;
 import com.appsmith.external.dtos.ModifiedResources;
 import com.appsmith.external.git.GitExecutor;
+import com.appsmith.external.git.constants.GitConstants.GitCommandConstants;
 import com.appsmith.server.configurations.ProjectProperties;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.constants.FieldName;
@@ -27,7 +28,6 @@ import org.springframework.scheduling.annotation.Async;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
-import reactor.util.retry.Retry;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -38,14 +38,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.appsmith.external.git.constants.GitConstants.PAGE_LIST;
-import static com.appsmith.server.helpers.GitUtils.MAX_RETRIES;
-import static com.appsmith.server.helpers.GitUtils.RETRY_DELAY;
 import static java.lang.Boolean.TRUE;
 
 @RequiredArgsConstructor
 @Slf4j
 public class AutoCommitEventHandlerCEImpl implements AutoCommitEventHandlerCE {
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final GitRedisUtils gitRedisUtils;
     private final RedisUtils redisUtils;
     private final DSLMigrationUtils dslMigrationUtils;
     private final GitFileUtils fileUtils;
@@ -84,19 +83,6 @@ public class AutoCommitEventHandlerCEImpl implements AutoCommitEventHandlerCE {
                                 "Error during auto-commit for application: {}", event.getApplicationId(), error));
     }
 
-    private Mono<Boolean> addFileLock(String defaultApplicationId) {
-        return redisUtils
-                .addFileLock(defaultApplicationId)
-                .retryWhen(Retry.fixedDelay(MAX_RETRIES, RETRY_DELAY)
-                        .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
-                            throw new AppsmithException(AppsmithError.GIT_FILE_IN_USE);
-                        }));
-    }
-
-    private Mono<Boolean> releaseFileLock(String defaultApplicationId) {
-        return redisUtils.releaseFileLock(defaultApplicationId);
-    }
-
     private <T> Mono<T> setProgress(T result, String applicationId, int progress) {
         return redisUtils.setAutoCommitProgress(applicationId, progress).thenReturn(result);
     }
@@ -133,7 +119,8 @@ public class AutoCommitEventHandlerCEImpl implements AutoCommitEventHandlerCE {
     }
 
     public Mono<Boolean> autoCommitDSLMigration(AutoCommitEvent autoCommitEvent) {
-        return addFileLock(autoCommitEvent.getApplicationId())
+        return gitRedisUtils
+                .addFileLock(autoCommitEvent.getApplicationId(), GitCommandConstants.AUTO_COMMIT)
                 .flatMap(fileLocked ->
                         redisUtils.startAutoCommit(autoCommitEvent.getApplicationId(), autoCommitEvent.getBranchName()))
                 .flatMap(autoCommitLocked -> dslMigrationUtils.getLatestDslVersion())
@@ -175,7 +162,7 @@ public class AutoCommitEventHandlerCEImpl implements AutoCommitEventHandlerCE {
         return redisUtils
                 .finishAutoCommit(autoCommitEvent.getApplicationId())
                 .flatMap(r -> setProgress(r, autoCommitEvent.getApplicationId(), 100))
-                .flatMap(r -> releaseFileLock(autoCommitEvent.getApplicationId()))
+                .flatMap(r -> gitRedisUtils.releaseFileLock(autoCommitEvent.getApplicationId()))
                 .thenReturn(isCommitMade);
     }
 
@@ -298,7 +285,8 @@ public class AutoCommitEventHandlerCEImpl implements AutoCommitEventHandlerCE {
         // push to remote
         // release file lock
 
-        return addFileLock(defaultApplicationId)
+        return gitRedisUtils
+                .addFileLock(defaultApplicationId, GitCommandConstants.AUTO_COMMIT)
                 .flatMap(isFileLocked -> redisUtils.startAutoCommit(defaultApplicationId, branchName))
                 .flatMap(r -> setProgress(r, defaultApplicationId, 10))
                 .flatMap(autoCommitLocked -> resetUncommittedChanges(autoCommitEvent))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/AutoCommitEventHandlerImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/AutoCommitEventHandlerImpl.java
@@ -15,6 +15,7 @@ public class AutoCommitEventHandlerImpl extends AutoCommitEventHandlerCEImpl imp
 
     public AutoCommitEventHandlerImpl(
             ApplicationEventPublisher applicationEventPublisher,
+            GitRedisUtils gitRedisUtils,
             RedisUtils redisUtils,
             DSLMigrationUtils dslMigrationUtils,
             GitFileUtils fileUtils,
@@ -24,6 +25,7 @@ public class AutoCommitEventHandlerImpl extends AutoCommitEventHandlerCEImpl imp
             AnalyticsService analyticsService) {
         super(
                 applicationEventPublisher,
+                gitRedisUtils,
                 redisUtils,
                 dslMigrationUtils,
                 fileUtils,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/GitRedisUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/GitRedisUtils.java
@@ -1,38 +1,57 @@
 package com.appsmith.server.git;
 
+import com.appsmith.external.git.constants.GitSpan;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.RedisUtils;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 import static com.appsmith.server.helpers.GitUtils.MAX_RETRIES;
 import static com.appsmith.server.helpers.GitUtils.RETRY_DELAY;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GitRedisUtils {
 
     private final RedisUtils redisUtils;
+    private final ObservationRegistry observationRegistry;
 
-    public Mono<Boolean> addFileLock(String defaultApplicationId, Boolean isRetryAllowed) {
+    public Mono<Boolean> addFileLock(String defaultApplicationId, String commandName, Boolean isRetryAllowed) {
         long numberOfRetries = Boolean.TRUE.equals(isRetryAllowed) ? MAX_RETRIES : 0L;
 
+        log.info(
+                "Git command {} is trying to acquire the lock for application id {}",
+                commandName,
+                defaultApplicationId);
         return redisUtils
-                .addFileLock(defaultApplicationId)
+                .addFileLock(defaultApplicationId, commandName)
                 .retryWhen(Retry.fixedDelay(numberOfRetries, RETRY_DELAY)
                         .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
-                            throw new AppsmithException(AppsmithError.GIT_FILE_IN_USE);
-                        }));
+                            if (retrySignal.failure() instanceof AppsmithException) {
+                                throw (AppsmithException) retrySignal.failure();
+                            }
+
+                            throw new AppsmithException(AppsmithError.GIT_FILE_IN_USE, commandName);
+                        }))
+                .name(GitSpan.ADD_FILE_LOCK)
+                .tap(Micrometer.observation(observationRegistry));
     }
 
-    public Mono<Boolean> addFileLock(String defaultApplicationId) {
-        return addFileLock(defaultApplicationId, Boolean.TRUE);
+    public Mono<Boolean> addFileLock(String defaultApplicationId, String commandName) {
+        return addFileLock(defaultApplicationId, commandName, true);
     }
 
     public Mono<Boolean> releaseFileLock(String defaultApplicationId) {
-        return redisUtils.releaseFileLock(defaultApplicationId);
+        return redisUtils
+                .releaseFileLock(defaultApplicationId)
+                .name(GitSpan.RELEASE_FILE_LOCK)
+                .tap(Micrometer.observation(observationRegistry));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.git.autocommit.helpers;
 
 import com.appsmith.external.annotations.FeatureFlagged;
 import com.appsmith.external.enums.FeatureFlagEnum;
+import com.appsmith.external.git.constants.GitConstants.GitCommandConstants;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.domains.GitArtifactMetadata;
 import com.appsmith.server.domains.Layout;
@@ -55,7 +56,7 @@ public class AutoCommitEligibilityHelperImpl extends AutoCommitEligibilityHelper
                 .defaultIfEmpty(FALSE)
                 .cache();
 
-        return Mono.defer(() -> gitRedisUtils.addFileLock(defaultApplicationId, FALSE))
+        return Mono.defer(() -> gitRedisUtils.addFileLock(defaultApplicationId, GitCommandConstants.METADATA, false))
                 .then(Mono.defer(() -> isServerMigrationRequiredMonoCached))
                 .then(Mono.defer(() -> gitRedisUtils.releaseFileLock(defaultApplicationId)))
                 .then(Mono.defer(() -> isServerMigrationRequiredMonoCached))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedisUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedisUtils.java
@@ -9,6 +9,9 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 
+import static com.appsmith.external.git.constants.ce.GitConstantsCE.GitCommandConstantsCE.AUTO_COMMIT;
+import static org.springframework.util.StringUtils.hasText;
+
 @Component
 @RequiredArgsConstructor
 public class RedisUtils {
@@ -23,8 +26,18 @@ public class RedisUtils {
 
     private static final Duration AUTO_COMMIT_TIME_LIMIT = Duration.ofMinutes(3);
 
-    public Mono<Boolean> addFileLock(String key) {
-        return this.addFileLock(key, FILE_LOCK_TIME_LIMIT, new AppsmithException(AppsmithError.GIT_FILE_IN_USE));
+    public Mono<Boolean> addFileLock(String key, String gitCommand) {
+        String command = hasText(gitCommand) ? gitCommand : REDIS_FILE_LOCK_VALUE;
+        return redisOperations.hasKey(key).flatMap(isKeyPresent -> {
+            if (!Boolean.TRUE.equals(isKeyPresent)) {
+                return redisOperations.opsForValue().set(key, gitCommand, FILE_LOCK_TIME_LIMIT);
+            }
+            return redisOperations
+                    .opsForValue()
+                    .get(key)
+                    .flatMap(commandName ->
+                            Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE, command, commandName)));
+        });
     }
 
     public Mono<Boolean> addFileLock(String key, Duration expirationPeriod, AppsmithException exception) {
@@ -48,7 +61,7 @@ public class RedisUtils {
         String key = String.format(AUTO_COMMIT_KEY_FORMAT, defaultApplicationId);
         return redisOperations.hasKey(key).flatMap(isKeyPresent -> {
             if (Boolean.TRUE.equals(isKeyPresent)) {
-                return Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE));
+                return Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE, AUTO_COMMIT, AUTO_COMMIT));
             }
             return redisOperations.opsForValue().set(key, branchName, AUTO_COMMIT_TIME_LIMIT);
         });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommonGitServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommonGitServiceImpl.java
@@ -5,10 +5,10 @@ import com.appsmith.git.service.GitExecutorImpl;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.exports.internal.ExportService;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
 import com.appsmith.server.helpers.CommonGitFileUtils;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
-import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.repositories.GitDeployKeysRepository;
 import com.appsmith.server.services.ce_compatible.CommonGitServiceCECompatibleImpl;
@@ -27,7 +27,7 @@ public class CommonGitServiceImpl extends CommonGitServiceCECompatibleImpl imple
             GitDeployKeysRepository gitDeployKeysRepository,
             GitPrivateRepoHelper gitPrivateRepoHelper,
             CommonGitFileUtils commonGitFileUtils,
-            RedisUtils redisUtils,
+            GitRedisUtils gitRedisUtils,
             SessionUserService sessionUserService,
             UserDataService userDataService,
             UserService userService,
@@ -44,7 +44,7 @@ public class CommonGitServiceImpl extends CommonGitServiceCECompatibleImpl imple
                 gitDeployKeysRepository,
                 gitPrivateRepoHelper,
                 commonGitFileUtils,
-                redisUtils,
+                gitRedisUtils,
                 sessionUserService,
                 userDataService,
                 userService,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/GitServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/GitServiceImpl.java
@@ -7,10 +7,10 @@ import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.exports.internal.ExportService;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
-import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.newactions.base.NewActionService;
@@ -54,7 +54,7 @@ public class GitServiceImpl extends GitServiceCECompatibleImpl implements GitSer
             ApplicationPermission applicationPermission,
             WorkspacePermission workspacePermission,
             WorkspaceService workspaceService,
-            RedisUtils redisUtils,
+            GitRedisUtils gitRedisUtils,
             ObservationRegistry observationRegistry,
             GitPrivateRepoHelper gitPrivateRepoHelper,
             TransactionalOperator transactionalOperator,
@@ -82,7 +82,7 @@ public class GitServiceImpl extends GitServiceCECompatibleImpl implements GitSer
                 applicationPermission,
                 workspacePermission,
                 workspaceService,
-                redisUtils,
+                gitRedisUtils,
                 observationRegistry,
                 gitPrivateRepoHelper,
                 transactionalOperator,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommonGitServiceCEImpl.java
@@ -8,6 +8,7 @@ import com.appsmith.external.dtos.GitStatusDTO;
 import com.appsmith.external.dtos.MergeStatusDTO;
 import com.appsmith.external.git.GitExecutor;
 import com.appsmith.external.git.constants.GitConstants;
+import com.appsmith.external.git.constants.GitConstants.GitCommandConstants;
 import com.appsmith.external.git.constants.GitSpan;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.configurations.EmailConfig;
@@ -35,13 +36,13 @@ import com.appsmith.server.dtos.GitPullDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.exports.internal.ExportService;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
 import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.helpers.CommonGitFileUtils;
 import com.appsmith.server.helpers.GitDeployKeyGenerator;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
 import com.appsmith.server.helpers.GitUtils;
-import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.repositories.GitDeployKeysRepository;
 import com.appsmith.server.services.AnalyticsService;
@@ -70,7 +71,6 @@ import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple3;
-import reactor.util.retry.Retry;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -97,8 +97,6 @@ import static com.appsmith.external.git.constants.ce.GitSpanCE.OPS_STATUS;
 import static com.appsmith.git.constants.AppsmithBotAsset.APPSMITH_BOT_USERNAME;
 import static com.appsmith.server.constants.SerialiseArtifactObjective.VERSION_CONTROL;
 import static com.appsmith.server.constants.ce.FieldNameCE.DEFAULT;
-import static com.appsmith.server.helpers.GitUtils.MAX_RETRIES;
-import static com.appsmith.server.helpers.GitUtils.RETRY_DELAY;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
@@ -112,7 +110,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
     private final GitDeployKeysRepository gitDeployKeysRepository;
     private final GitPrivateRepoHelper gitPrivateRepoHelper;
     private final CommonGitFileUtils commonGitFileUtils;
-    private final RedisUtils redisUtils;
+    private final GitRedisUtils gitRedisUtils;
     protected final SessionUserService sessionUserService;
     private final UserDataService userDataService;
     protected final UserService userService;
@@ -132,23 +130,16 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
     private static final String ORIGIN = "origin/";
     private static final String REMOTE_NAME_REPLACEMENT = "";
 
-    private Mono<Boolean> addFileLock(String defaultArtifactId, boolean isLockRequired) {
+    private Mono<Boolean> addFileLock(String defaultArtifactId, String commandName, boolean isLockRequired) {
         if (!Boolean.TRUE.equals(isLockRequired)) {
             return Mono.just(Boolean.TRUE);
         }
 
-        return Mono.defer(() -> addFileLock(defaultArtifactId));
+        return Mono.defer(() -> addFileLock(defaultArtifactId, commandName));
     }
 
-    private Mono<Boolean> addFileLock(String defaultArtifactId) {
-        return redisUtils
-                .addFileLock(defaultArtifactId)
-                .retryWhen(Retry.fixedDelay(MAX_RETRIES, RETRY_DELAY)
-                        .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
-                            throw new AppsmithException(AppsmithError.GIT_FILE_IN_USE);
-                        }))
-                .name(GitSpan.ADD_FILE_LOCK)
-                .tap(Micrometer.observation(observationRegistry));
+    private Mono<Boolean> addFileLock(String defaultArtifactId, String commandName) {
+        return gitRedisUtils.addFileLock(defaultArtifactId, commandName);
     }
 
     private Mono<Boolean> releaseFileLock(String defaultArtifactId, boolean isLockRequired) {
@@ -160,7 +151,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
     }
 
     private Mono<Boolean> releaseFileLock(String defaultArtifactId) {
-        return redisUtils
+        return gitRedisUtils
                 .releaseFileLock(defaultArtifactId)
                 .name(GitSpan.RELEASE_FILE_LOCK)
                 .tap(Micrometer.observation(observationRegistry));
@@ -304,7 +295,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
 
         Mono<GitStatusDTO> statusMono = Mono.zip(
                         Mono.just(defaultGitMetadata), Mono.just(branchedArtifact), exportedArtifactJsonMono)
-                .flatMap(artifactAndJsonTuple3 -> addFileLock(defaultArtifactId, isFileLock)
+                .flatMap(artifactAndJsonTuple3 -> addFileLock(defaultArtifactId, GitCommandConstants.STATUS, isFileLock)
                         .elapsed()
                         .map(elapsedTuple -> {
                             log.debug("file lock took: {}", elapsedTuple.getT1());
@@ -479,7 +470,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                         return Mono.just(artifactAndJsonTuple3);
                     }
 
-                    Mono<Boolean> fileLockMono = Mono.defer(() -> addFileLock(defaultArtifactId));
+                    Mono<Boolean> fileLockMono =
+                            Mono.defer(() -> addFileLock(defaultArtifactId, GitCommandConstants.STATUS));
                     return fileLockMono.elapsed().map(elapsedTuple -> {
                         log.debug("file lock took: {}", elapsedTuple.getT1());
                         return artifactAndJsonTuple3;
@@ -624,7 +616,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
 
         Mono<Boolean> addFileLockMono = Mono.just(Boolean.TRUE);
         if (Boolean.TRUE.equals(isFileLock)) {
-            addFileLockMono = addFileLock(defaultArtifactId);
+            addFileLockMono = addFileLock(defaultArtifactId, GitCommandConstants.FETCH_REMOTE);
         }
         /*
            1. Copy resources from DB to local repo
@@ -744,7 +736,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                         return Mono.just(tuple3);
                     }
 
-                    return addFileLock(tuple3.getT1().getDefaultArtifactId()).then(Mono.just(tuple3));
+                    return addFileLock(tuple3.getT1().getDefaultArtifactId(), GitCommandConstants.FETCH_REMOTE)
+                            .then(Mono.just(tuple3));
                 })
                 .flatMap(tuple3 -> {
                     GitArtifactMetadata defaultArtifactMetadata = tuple3.getT1();
@@ -1226,7 +1219,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                 .flatMap(artifact -> {
                     GitArtifactMetadata gitData = artifact.getGitArtifactMetadata();
                     if (Boolean.TRUE.equals(isFileLock)) {
-                        return addFileLock(gitData.getDefaultArtifactId()).then(Mono.just(artifact));
+                        return addFileLock(gitData.getDefaultArtifactId(), GitCommandConstants.COMMIT)
+                                .then(Mono.just(artifact));
                     }
                     return Mono.just(artifact);
                 })
@@ -1481,7 +1475,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                         return Mono.just(artifact);
                     }
 
-                    return addFileLock(artifact.getGitArtifactMetadata().getDefaultArtifactId())
+                    return addFileLock(
+                                    artifact.getGitArtifactMetadata().getDefaultArtifactId(), GitCommandConstants.PUSH)
                             .map(status -> artifact);
                 })
                 .flatMap(artifact -> {
@@ -1642,7 +1637,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                     gitArtifactMetadata.getDefaultArtifactId(),
                     gitArtifactMetadata.getRepoName());
 
-            sourceAritfactMono = addFileLock(defaultArtifactId)
+            sourceAritfactMono = addFileLock(defaultArtifactId, GitCommandConstants.CHECKOUT_BRANCH)
                     .then(gitExecutor.listBranches(repoPath))
                     .flatMap(branchList -> releaseFileLock(defaultArtifactId).thenReturn(branchList))
                     .flatMap(gitBranchDTOList -> {
@@ -1694,7 +1689,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
 
         Mono<? extends Artifact> defaultArtifactMono =
                 gitArtifactHelper.getArtifactById(defaultArtifactId, artifactEditPermission);
-        Mono<? extends Artifact> checkoutRemoteBranchMono = addFileLock(defaultArtifactId)
+        Mono<? extends Artifact> checkoutRemoteBranchMono = addFileLock(
+                        defaultArtifactId, GitCommandConstants.CHECKOUT_BRANCH)
                 .zipWith(defaultArtifactMono)
                 .flatMap(tuple2 -> {
                     Artifact artifact = tuple2.getT2();
@@ -1924,7 +1920,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                             srcBranchGitData.getRepoName());
 
                     // Create a new branch from the parent checked out branch
-                    return addFileLock(srcBranchGitData.getDefaultArtifactId())
+                    return addFileLock(srcBranchGitData.getDefaultArtifactId(), GitCommandConstants.CREATE_BRANCH)
                             .flatMap(status -> gitExecutor.checkoutToBranch(repoSuffix, srcBranch))
                             .onErrorResume(error -> Mono.error(new AppsmithException(
                                     AppsmithError.GIT_ACTION_FAILED, "checkout", "Unable to find " + srcBranch)))
@@ -2053,7 +2049,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                     GitArtifactMetadata gitMetadata = defaultArtifact.getGitArtifactMetadata();
                     Mono<GitStatusDTO> statusMono =
                             getStatus(defaultArtifact, branchedArtifact, finalBranchName, false, true);
-                    return addFileLock(gitMetadata.getDefaultArtifactId())
+                    return addFileLock(gitMetadata.getDefaultArtifactId(), GitCommandConstants.PULL)
                             .then(Mono.zip(statusMono, Mono.just(defaultArtifact), Mono.just(branchedArtifact)));
                 })
                 .flatMap(tuple -> {
@@ -2462,7 +2458,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                     }
                     return objects.getT1();
                 })
-                .flatMap(defaultArtifact -> addFileLock(defaultArtifactId).map(status -> defaultArtifact))
+                .flatMap(defaultArtifact -> addFileLock(defaultArtifactId, GitCommandConstants.DELETE)
+                        .map(status -> defaultArtifact))
                 .flatMap(defaultArtifact -> {
                     GitArtifactMetadata gitArtifactMetadata = defaultArtifact.getGitArtifactMetadata();
                     Path repoPath = gitArtifactHelper.getRepoSuffixPath(
@@ -2550,7 +2547,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
         // Rehydrate the artifact from local file system
         discardChangeMono = branchedArtifactMonoCached
                 // Add file lock before proceeding with the git operation
-                .flatMap(branchedArtifact -> addFileLock(defaultArtifactId).thenReturn(branchedArtifact))
+                .flatMap(branchedArtifact -> addFileLock(defaultArtifactId, GitCommandConstants.DISCARD)
+                        .thenReturn(branchedArtifact))
                 .flatMap(branchedArtifact -> {
                     GitArtifactMetadata gitData = branchedArtifact.getGitArtifactMetadata();
                     if (gitData == null || StringUtils.isEmptyOrNull(gitData.getDefaultArtifactId())) {
@@ -2633,7 +2631,8 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
         Mono<MergeStatusDTO> mergeMono = defaultArtifactMono
                 .flatMap(defaultArtifact -> {
                     GitArtifactMetadata gitData = defaultArtifact.getGitArtifactMetadata();
-                    return addFileLock(gitData.getDefaultArtifactId()).then(Mono.just(defaultArtifact));
+                    return addFileLock(gitData.getDefaultArtifactId(), GitCommandConstants.MERGE_BRANCH)
+                            .then(Mono.just(defaultArtifact));
                 })
                 .flatMap(defaultArtifact -> {
                     GitArtifactMetadata gitArtifactMetadata = defaultArtifact.getGitArtifactMetadata();
@@ -2805,7 +2804,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
 
             // 1. Hydrate from db to file system for both branch Applications
             // Update function call
-            return addFileLock(defaultArtifactId)
+            return addFileLock(defaultArtifactId, GitCommandConstants.STATUS)
                     .flatMap(status -> this.getStatus(defaultArtifactId, sourceBranch, false, artifactType))
                     .flatMap(srcBranchStatus -> {
                         if (!Integer.valueOf(0).equals(srcBranchStatus.getBehindCount())) {
@@ -3165,7 +3164,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
     private Mono<String> syncDefaultBranchNameFromRemote(Artifact defaultArtifact, Path repoPath) {
         GitArtifactMetadata metadata = defaultArtifact.getGitArtifactMetadata();
         GitAuth gitAuth = metadata.getGitAuth();
-        return addFileLock(metadata.getDefaultArtifactId())
+        return addFileLock(metadata.getDefaultArtifactId(), GitCommandConstants.SYNC_BRANCH)
                 .then(gitExecutor.getRemoteDefaultBranch(
                         repoPath, metadata.getRemoteUrl(), gitAuth.getPrivateKey(), gitAuth.getPublicKey()))
                 .flatMap(defaultBranchNameInRemote -> {
@@ -3298,7 +3297,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
             String defaultBranchName,
             String currentBranch,
             boolean pruneBranches) {
-        return addFileLock(defaultArtifact.getId())
+        return addFileLock(defaultArtifact.getId(), GitCommandConstants.LIST_BRANCH)
                 .flatMap(objects -> {
                     GitArtifactMetadata gitArtifactMetadata = defaultArtifact.getGitArtifactMetadata();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
@@ -8,6 +8,7 @@ import com.appsmith.external.dtos.GitStatusDTO;
 import com.appsmith.external.dtos.MergeStatusDTO;
 import com.appsmith.external.git.GitExecutor;
 import com.appsmith.external.git.constants.GitConstants;
+import com.appsmith.external.git.constants.GitConstants.GitCommandConstants;
 import com.appsmith.external.git.constants.GitSpan;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceStorage;
@@ -43,13 +44,13 @@ import com.appsmith.server.dtos.GitPullDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.exports.internal.ExportService;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
 import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.helpers.GitDeployKeyGenerator;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
 import com.appsmith.server.helpers.GitUtils;
-import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.migrations.JsonSchemaVersions;
@@ -86,7 +87,6 @@ import reactor.core.Exceptions;
 import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -115,8 +115,6 @@ import static com.appsmith.server.constants.ArtifactType.APPLICATION;
 import static com.appsmith.server.constants.FieldName.DEFAULT;
 import static com.appsmith.server.constants.SerialiseArtifactObjective.VERSION_CONTROL;
 import static com.appsmith.server.helpers.DefaultResourcesUtils.createDefaultIdsOrUpdateWithGivenResourceIds;
-import static com.appsmith.server.helpers.GitUtils.MAX_RETRIES;
-import static com.appsmith.server.helpers.GitUtils.RETRY_DELAY;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
@@ -158,7 +156,7 @@ public class GitServiceCEImpl implements GitServiceCE {
     private final ApplicationPermission applicationPermission;
     private final WorkspacePermission workspacePermission;
     private final WorkspaceService workspaceService;
-    private final RedisUtils redisUtils;
+    private final GitRedisUtils gitRedisUtils;
     private final ObservationRegistry observationRegistry;
     private final GitPrivateRepoHelper gitPrivateRepoHelper;
     private final TransactionalOperator transactionalOperator;
@@ -434,7 +432,8 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .flatMap(application -> {
                     GitArtifactMetadata gitData = application.getGitApplicationMetadata();
                     if (TRUE.equals(isFileLock)) {
-                        return addFileLock(gitData.getDefaultApplicationId()).then(Mono.just(application));
+                        return addFileLock(gitData.getDefaultApplicationId(), GitCommandConstants.COMMIT)
+                                .then(Mono.just(application));
                     }
                     return Mono.just(application);
                 })
@@ -1021,7 +1020,8 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .flatMap(application -> {
                     if (TRUE.equals(isFileLock)) {
                         return addFileLock(
-                                        application.getGitApplicationMetadata().getDefaultApplicationId())
+                                        application.getGitApplicationMetadata().getDefaultApplicationId(),
+                                        GitCommandConstants.PUSH)
                                 .map(status -> application);
                     }
                     return Mono.just(application);
@@ -1298,7 +1298,7 @@ public class GitServiceCEImpl implements GitServiceCE {
                             srcBranchGitData.getRepoName());
                     // Create a new branch from the parent checked out branch
 
-                    return addFileLock(srcBranchGitData.getDefaultApplicationId())
+                    return addFileLock(srcBranchGitData.getDefaultApplicationId(), GitCommandConstants.CREATE_BRANCH)
                             .flatMap(status -> gitExecutor.checkoutToBranch(repoSuffix, srcBranch))
                             .onErrorResume(error -> Mono.error(new AppsmithException(
                                     AppsmithError.GIT_ACTION_FAILED, "checkout", "Unable to find " + srcBranch)))
@@ -1401,7 +1401,8 @@ public class GitServiceCEImpl implements GitServiceCE {
                 getApplicationById(defaultApplicationId, applicationPermission.getEditPermission());
         if (addFileLock) {
             rootAppMono = rootAppMono.flatMap(
-                    application -> addFileLock(defaultApplicationId).thenReturn(application));
+                    application -> addFileLock(defaultApplicationId, GitCommandConstants.CHECKOUT_BRANCH)
+                            .thenReturn(application));
         }
 
         // If the user is trying to check out remote branch, create a new branch if the branch does not exist already
@@ -1633,7 +1634,8 @@ public class GitServiceCEImpl implements GitServiceCE {
         Mono<GitPullDTO> pullMono = getApplicationById(defaultApplicationId, applicationPermission.getEditPermission())
                 .flatMap(application -> {
                     GitArtifactMetadata gitData = application.getGitApplicationMetadata();
-                    return addFileLock(gitData.getDefaultApplicationId()).then(Mono.just(application));
+                    return addFileLock(gitData.getDefaultApplicationId(), GitCommandConstants.PULL)
+                            .then(Mono.just(application));
                 })
                 .flatMap(defaultApplication -> {
                     GitArtifactMetadata defaultGitMetadata = defaultApplication.getGitApplicationMetadata();
@@ -1758,7 +1760,7 @@ public class GitServiceCEImpl implements GitServiceCE {
     private Mono<String> syncDefaultBranchNameFromRemote(Path repoPath, Application rootApp) {
         GitArtifactMetadata metadata = rootApp.getGitApplicationMetadata();
         GitAuth gitAuth = metadata.getGitAuth();
-        return addFileLock(metadata.getDefaultApplicationId())
+        return addFileLock(metadata.getDefaultApplicationId(), GitCommandConstants.SYNC_BRANCH)
                 .then(gitExecutor.getRemoteDefaultBranch(
                         repoPath, metadata.getRemoteUrl(), gitAuth.getPrivateKey(), gitAuth.getPublicKey()))
                 .flatMap(defaultBranchNameInRemote -> {
@@ -1839,7 +1841,7 @@ public class GitServiceCEImpl implements GitServiceCE {
 
     private Mono<List<GitBranchDTO>> getBranchListWithDefaultBranchName(
             Application rootApp, Path repoPath, String defaultBranchName, String currentBranch, boolean pruneBranches) {
-        return addFileLock(rootApp.getId())
+        return addFileLock(rootApp.getId(), GitCommandConstants.LIST_BRANCH)
                 .flatMap(objects -> {
                     GitArtifactMetadata gitArtifactMetadata = rootApp.getGitApplicationMetadata();
 
@@ -1926,7 +1928,7 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .flatMap(tuple3 -> {
                     Mono<Boolean> fileLockMono = Mono.empty();
                     if (isFileLock) {
-                        fileLockMono = Mono.defer(() -> addFileLock(defaultApplicationId));
+                        fileLockMono = Mono.defer(() -> addFileLock(defaultApplicationId, GitCommandConstants.STATUS));
                     }
 
                     return fileLockMono.thenReturn(tuple3);
@@ -2086,7 +2088,9 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .flatMap(gitApplicationMetadata -> {
                     if (isFileLock) {
                         // Add file lock to avoid sending wrong info on the status
-                        return addFileLock(gitApplicationMetadata.getDefaultApplicationId())
+                        return addFileLock(
+                                        gitApplicationMetadata.getDefaultApplicationId(),
+                                        GitCommandConstants.FETCH_REMOTE)
                                 .then(Mono.zip(Mono.just(gitApplicationMetadata), applicationMono));
                     }
                     return Mono.zip(Mono.just(gitApplicationMetadata), applicationMono);
@@ -2180,7 +2184,8 @@ public class GitServiceCEImpl implements GitServiceCE {
                         defaultApplicationId, applicationPermission.getEditPermission())
                 .flatMap(application -> {
                     GitArtifactMetadata gitData = application.getGitApplicationMetadata();
-                    return addFileLock(gitData.getDefaultApplicationId()).then(Mono.just(application));
+                    return addFileLock(gitData.getDefaultApplicationId(), GitCommandConstants.MERGE_BRANCH)
+                            .then(Mono.just(application));
                 })
                 .flatMap(defaultApplication -> {
                     GitArtifactMetadata gitArtifactMetadata = defaultApplication.getGitApplicationMetadata();
@@ -2345,7 +2350,7 @@ public class GitServiceCEImpl implements GitServiceCE {
 
                     // 1. Hydrate from db to file system for both branch Applications
                     // Update function call
-                    return addFileLock(defaultApplicationId)
+                    return addFileLock(defaultApplicationId, GitCommandConstants.STATUS)
                             .flatMap(status -> this.getStatus(defaultApplicationId, sourceBranch, false))
                             .flatMap(srcBranchStatus -> {
                                 if (!Integer.valueOf(0).equals(srcBranchStatus.getBehindCount())) {
@@ -2840,7 +2845,8 @@ public class GitServiceCEImpl implements GitServiceCE {
                     }
                     return objects.getT1();
                 })
-                .flatMap(application -> addFileLock(defaultApplicationId).map(status -> application))
+                .flatMap(application -> addFileLock(defaultApplicationId, GitCommandConstants.DELETE)
+                        .map(status -> application))
                 .flatMap(application -> {
                     GitArtifactMetadata gitArtifactMetadata = application.getGitApplicationMetadata();
                     Path repoPath = Paths.get(
@@ -2924,7 +2930,8 @@ public class GitServiceCEImpl implements GitServiceCE {
         // Rehydrate the application from local file system
         discardChangeMono = branchedApplicationMono
                 // Add file lock before proceeding with the git operation
-                .flatMap(application -> addFileLock(defaultApplicationId).thenReturn(application))
+                .flatMap(application -> addFileLock(defaultApplicationId, GitCommandConstants.DISCARD)
+                        .thenReturn(application))
                 .flatMap(branchedApplication -> {
                     GitArtifactMetadata gitData = branchedApplication.getGitApplicationMetadata();
                     if (gitData == null || StringUtils.isEmptyOrNull(gitData.getDefaultApplicationId())) {
@@ -3288,22 +3295,12 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .thenReturn(application));
     }
 
-    private Mono<Boolean> addFileLock(String defaultApplicationId) {
-        return redisUtils
-                .addFileLock(defaultApplicationId)
-                .retryWhen(Retry.fixedDelay(MAX_RETRIES, RETRY_DELAY)
-                        .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
-                            throw new AppsmithException(AppsmithError.GIT_FILE_IN_USE);
-                        }))
-                .name(GitSpan.ADD_FILE_LOCK)
-                .tap(Micrometer.observation(observationRegistry));
+    private Mono<Boolean> addFileLock(String defaultApplicationId, String commandName) {
+        return gitRedisUtils.addFileLock(defaultApplicationId, commandName);
     }
 
     private Mono<Boolean> releaseFileLock(String defaultApplicationId) {
-        return redisUtils
-                .releaseFileLock(defaultApplicationId)
-                .name(GitSpan.RELEASE_FILE_LOCK)
-                .tap(Micrometer.observation(observationRegistry));
+        return gitRedisUtils.releaseFileLock(defaultApplicationId);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/CommonGitServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/CommonGitServiceCECompatibleImpl.java
@@ -4,10 +4,10 @@ import com.appsmith.external.git.GitExecutor;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.exports.internal.ExportService;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
 import com.appsmith.server.helpers.CommonGitFileUtils;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
-import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.repositories.GitDeployKeysRepository;
 import com.appsmith.server.services.AnalyticsService;
@@ -29,7 +29,7 @@ public class CommonGitServiceCECompatibleImpl extends CommonGitServiceCEImpl imp
             GitDeployKeysRepository gitDeployKeysRepository,
             GitPrivateRepoHelper gitPrivateRepoHelper,
             CommonGitFileUtils commonGitFileUtils,
-            RedisUtils redisUtils,
+            GitRedisUtils gitRedisUtils,
             SessionUserService sessionUserService,
             UserDataService userDataService,
             UserService userService,
@@ -46,7 +46,7 @@ public class CommonGitServiceCECompatibleImpl extends CommonGitServiceCEImpl imp
                 gitDeployKeysRepository,
                 gitPrivateRepoHelper,
                 commonGitFileUtils,
-                redisUtils,
+                gitRedisUtils,
                 sessionUserService,
                 userDataService,
                 userService,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/GitServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/GitServiceCECompatibleImpl.java
@@ -6,10 +6,10 @@ import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.exports.internal.ExportService;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
-import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.newactions.base.NewActionService;
@@ -56,7 +56,7 @@ public class GitServiceCECompatibleImpl extends GitServiceCEImpl implements GitS
             ApplicationPermission applicationPermission,
             WorkspacePermission workspacePermission,
             WorkspaceService workspaceService,
-            RedisUtils redisUtils,
+            GitRedisUtils gitRedisUtils,
             ObservationRegistry observationRegistry,
             GitPrivateRepoHelper gitPrivateRepoHelper,
             TransactionalOperator transactionalOperator,
@@ -84,7 +84,7 @@ public class GitServiceCECompatibleImpl extends GitServiceCEImpl implements GitS
                 applicationPermission,
                 workspacePermission,
                 workspaceService,
-                redisUtils,
+                gitRedisUtils,
                 observationRegistry,
                 gitPrivateRepoHelper,
                 transactionalOperator,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/AutoCommitEventHandlerImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/AutoCommitEventHandlerImplTest.java
@@ -16,6 +16,7 @@ import com.appsmith.server.events.AutoCommitEvent;
 import com.appsmith.server.featureflags.CachedFeatures;
 import com.appsmith.server.git.AutoCommitEventHandler;
 import com.appsmith.server.git.AutoCommitEventHandlerImpl;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.helpers.CommonGitFileUtils;
 import com.appsmith.server.helpers.DSLMigrationUtils;
 import com.appsmith.server.helpers.GitFileUtils;
@@ -73,6 +74,9 @@ public class AutoCommitEventHandlerImplTest {
     @SpyBean
     RedisUtils redisUtils;
 
+    @SpyBean
+    GitRedisUtils gitRedisUtils;
+
     @Autowired
     AnalyticsService analyticsService;
 
@@ -113,6 +117,7 @@ public class AutoCommitEventHandlerImplTest {
     public void beforeTest() {
         autoCommitEventHandler = new AutoCommitEventHandlerImpl(
                 applicationEventPublisher,
+                gitRedisUtils,
                 redisUtils,
                 dslMigrationUtils,
                 gitFileUtils,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperTest.java
@@ -2,6 +2,7 @@ package com.appsmith.server.git.autocommit.helpers;
 
 import com.appsmith.external.dtos.ModifiedResources;
 import com.appsmith.external.enums.FeatureFlagEnum;
+import com.appsmith.external.git.constants.GitConstants;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.GitArtifactMetadata;
@@ -10,9 +11,9 @@ import com.appsmith.server.domains.Theme;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.AutoCommitTriggerDTO;
 import com.appsmith.server.dtos.PageDTO;
+import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.helpers.CommonGitFileUtils;
 import com.appsmith.server.helpers.DSLMigrationUtils;
-import com.appsmith.server.helpers.RedisUtils;
 import com.appsmith.server.migrations.JsonSchemaVersions;
 import com.appsmith.server.services.FeatureFlagService;
 import com.appsmith.server.testhelpers.git.GitFileSystemTestHelper;
@@ -55,7 +56,7 @@ public class AutoCommitEligibilityHelperTest {
     FeatureFlagService featureFlagService;
 
     @MockBean
-    RedisUtils redisUtils;
+    GitRedisUtils gitRedisUtils;
 
     @Autowired
     GitFileSystemTestHelper gitFileSystemTestHelper;
@@ -101,8 +102,10 @@ public class AutoCommitEligibilityHelperTest {
 
         Mockito.when(dslMigrationUtils.getLatestDslVersion()).thenReturn(Mono.just(RANDOM_DSL_VERSION_NUMBER));
 
-        Mockito.when(redisUtils.addFileLock(DEFAULT_APPLICATION_ID)).thenReturn(Mono.just(Boolean.TRUE));
-        Mockito.when(redisUtils.releaseFileLock(DEFAULT_APPLICATION_ID)).thenReturn(Mono.just(Boolean.TRUE));
+        Mockito.when(gitRedisUtils.addFileLock(
+                        DEFAULT_APPLICATION_ID, GitConstants.GitCommandConstants.METADATA, false))
+                .thenReturn(Mono.just(Boolean.TRUE));
+        Mockito.when(gitRedisUtils.releaseFileLock(DEFAULT_APPLICATION_ID)).thenReturn(Mono.just(Boolean.TRUE));
     }
 
     @Test


### PR DESCRIPTION
## Description
- Introduction of context to redis file locks for git operations. Now the lock would be aware of what command has placed the it.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9318823149>
> Commit: 278716d520d9a08e5b39bc24faf770840bf45220
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9318823149&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
