### PR TITLE
test: fix failing Table tests related to header order validation[CE]

### DIFF
--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
-cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/table_data_change_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,9 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
+cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
+cypress/e2e/EE/Enterprise/LicenseAndBilling/BillingDashboard_spec.ts
+cypress/e2e/EE/Enterprise/RBAC/RBACUITests/GroupAccess_spec.ts
+
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,7 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
 cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
-
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/table_data_change_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,8 +1,6 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
 cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
-cypress/e2e/EE/Enterprise/LicenseAndBilling/BillingDashboard_spec.ts
-cypress/e2e/EE/Enterprise/RBAC/RBACUITests/GroupAccess_spec.ts
 
 
 # For running all specs - uncomment below:

--- a/app/client/cypress/support/Pages/Table.ts
+++ b/app/client/cypress/support/Pages/Table.ts
@@ -39,7 +39,7 @@ export class Table {
   private _tableWrap = "//div[contains(@class,'tableWrap')]";
   private _tableHeader =
     this._tableWrap +
-    "//div[contains(@class,'thead')]//div[contains(@class,'tr')][1]";
+    "//div[contains(@class,'thead')]//div[contains(@class,'tr')]//div[contains(@class,'th')]";
   private _columnHeader = (columnName: string) =>
     this._tableWrap +
     "//div[contains(@class,'thead')]//div[contains(@class,'tr')][1]//div[@role='columnheader']//div[contains(text(),'" +


### PR DESCRIPTION
Failing tests:
cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js

RCA:
The locator used for capturing the header text of table twice in EE but was fine on CE
Here are the run details and the results.

Solution:
Header text Locator was updated such that it’s working on both CE and EE.
The method which was impacted because of this change was identified and I did a limited run both on CE and EE with those files and the tests are running