### PR TITLE
test: fix flaky iconButton2 spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/IconButton_2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/IconButton_2_spec.ts
@@ -270,13 +270,22 @@ describe(
       propPane.ToggleJSMode("onClick", true);
       propPane.UpdatePropertyFieldValue(
         "onClick",
-        `{{navigateTo('www.yahoo.com', {}, 'SAME_WINDOW');}}`,
+        `{{navigateTo('http://host.docker:4200/', {}, 'NEW_WINDOW');}}`,
       );
       deployMode.DeployApp(
         locators._widgetInDeployed(draggableWidgets.ICONBUTTON),
       );
-      agHelper.GetNClick(`${locators._widgetInDeployed("iconbuttonwidget")}`);
-      agHelper.AssertURL("yahoo.com");
+      cy.window().then((win) => {
+        // Stub `window.open` to prevent new tabs
+        agHelper.GetNClick(`${locators._widgetInDeployed("iconbuttonwidget")}`);
+        cy.stub(win, "open").as("windowOpenStub");
+        agHelper
+          .GetElement(locators._widgetInDeployed("iconbuttonwidget"))
+          .then(($link) => {
+            cy.wrap($link).click();
+            cy.get("@windowOpenStub").should("have.been.called");
+          });
+      });
     });
   },
 );

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/Others/IconButton_2_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
RCA: exeternal website used in this case "[Yahoo.com](http://yahoo.com/)"

Solution:

so replacing third party url should fix our problem.
Will use intercept/TED link to solve this as we did for our flaky tests earlier