### PR TITLE
feat: Extend character limit for API, query, and datasource names

### DIFF
--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, {memo} from "react";
 import { useSelector } from "react-redux";
 
 import { useParams } from "react-router-dom";
@@ -115,6 +115,8 @@ function ActionNameEditor(props: ActionNameEditorProps) {
               underline
               updating={saveStatus.isSaving}
               valueTransform={removeSpecialChars}
+              maxLength={256}
+              useFullWidth
             />
           </Flex>
         </NameWrapper>

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -111,12 +111,9 @@ function NameEditor(props: NameEditorProps) {
 
   const isInvalidNameForEntity = useCallback(
     (name: string): string | boolean => {
-      if (!name || name.trim().length === 0) {
+      if (!name?.trim()) {
         return createMessage(ACTION_INVALID_NAME_ERROR);
-      } else if (name !== entityName && hasActionNameConflict(name)) {
-        return createMessage(suffixErrorMessage, name);
-      }
-      return false;
+      }  return (name !== entityName && hasActionNameConflict(name)) ? createMessage(suffixErrorMessage, name) : false;
     },
     [hasActionNameConflict, entityName],
   );
@@ -127,7 +124,7 @@ function NameEditor(props: NameEditorProps) {
         dispatch(dispatchAction({ id: entityId, name }));
       }
     },
-    [dispatch, isInvalidNameForEntity, entityId, entityName],
+    [hasActionNameConflict, entityName, suffixErrorMessage],
   );
 
   useEffect(() => {

--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -10,7 +10,7 @@ import {
 } from "@appsmith/selectors/entitiesSelector";
 import { useSelector, useDispatch } from "react-redux";
 import type { Datasource } from "entities/Datasource";
-import { isNameValid } from "utils/helpers";
+import { isNameValid, removeSpecialChars } from "utils/helpers";
 import {
   saveDatasourceName,
   updateDatasourceName,
@@ -143,12 +143,14 @@ function FormTitle(props: FormTitleProps) {
         forceDefault={forceUpdate}
         isEditingDefault={props.focusOnMount}
         isInvalid={isInvalidDatasourceName}
-        maxLength={30}
+        maxLength={256}
         onTextChanged={handleDatasourceNameChange}
         placeholder="Datasource name"
         type="text"
         underline
         updating={saveStatus.isSaving}
+        valueTransform={removeSpecialChars}
+        useFullWidth
       />
     </Wrapper>
   );

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -172,13 +172,9 @@ function removeClass(ele: HTMLElement, cls: string) {
   }
 }
 
-export const removeSpecialChars = (value: string, limit?: number) => {
-  const separatorRegex = /\W+/;
-  return value
-    .split(separatorRegex)
-    .join("_")
-    .slice(0, limit || 30);
-};
+export const removeSpecialChars = (value: string) => {
+  return value.replace(/\W+/g, '_'); 
+}
 
 export const flashElement = (
   el: HTMLElement,


### PR DESCRIPTION

## Description of the PR
 I have raised this PR inorder to `To extends the character limit for API, query, and datasource names, allowing for more descriptive and clearer identifiers in the system.`

### 📸 Screenshoots
#### here we gave query name more than 30 characters
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/147f2ab1-7c90-4cab-b8a5-6cd24853ce2e)

#### When you hover over a query that isn't visible, a tooltip appears displaying the query's name as below.
![querynamesimage](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/417f6191-b1d0-4e16-987a-28374dc10392)