### PR TITLE
chore: Remove `unreadCommentThreads`

### DIFF
--- a/app/client/src/ce/api/ApplicationApi.tsx
+++ b/app/client/src/ce/api/ApplicationApi.tsx
@@ -204,7 +204,6 @@ export interface UpdateApplicationResponse {
   isPublic: boolean;
   pages: PageDefaultMeta[];
   appIsExample: boolean;
-  unreadCommentThreads: number;
   color: string;
   icon: IconNames;
   slug: string;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -65,10 +65,6 @@ public class Application extends BaseDomain implements Artifact {
     @JsonView({Views.Public.class, Git.class})
     boolean appIsExample = false;
 
-    @Transient
-    @JsonView(Views.Public.class)
-    long unreadCommentThreads;
-
     @JsonView(Views.Internal.class)
     String clonedFromApplicationId;
 


### PR DESCRIPTION
Not removing this field from Cypress test resources, so that we continue to test with past export files.

/test all

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9344945556>
> Commit: b97cece10c2e20d9552ac0942badd9d9a9e47850
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9344945556&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->





