### PR TITLE
chore: Remove unneeded `@Document` on GitProfile

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitProfile.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitProfile.java
@@ -5,14 +5,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Document
 public class GitProfile {
 
     String authorName;


### PR DESCRIPTION
The `GitProfile` is not used as an entity class, and doesn't need a collection/table in the database.
