### PR TITLE
chore: added unique index for slug field in tenant (#33377)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration056AddUniqueIndexForSlugInTenant.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration056AddUniqueIndexForSlugInTenant.java
@@ -22,6 +22,6 @@ public class Migration056AddUniqueIndexForSlugInTenant {
 
     @Execution
     public void executeMigration() {
-        ensureIndexes(mongoTemplate, Tenant.class, makeIndex(Tenant.Fields.slug));
+        ensureIndexes(mongoTemplate, Tenant.class, makeIndex(Tenant.Fields.slug).unique());
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration056AddUniqueIndexForSlugInTenant.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration056AddUniqueIndexForSlugInTenant.java
@@ -1,0 +1,27 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.server.domains.Tenant;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import static com.appsmith.server.migrations.DatabaseChangelog1.ensureIndexes;
+import static com.appsmith.server.migrations.DatabaseChangelog1.makeIndex;
+
+@ChangeUnit(order = "056", id = "add-unique-index-for-slug-in-tenant")
+public class Migration056AddUniqueIndexForSlugInTenant {
+    private final MongoTemplate mongoTemplate;
+
+    public Migration056AddUniqueIndexForSlugInTenant(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void executionRollback() {}
+
+    @Execution
+    public void executeMigration() {
+        ensureIndexes(mongoTemplate, Tenant.class, makeIndex(Tenant.Fields.slug));
+    }
+}


### PR DESCRIPTION
## Description
> This PR adds a unique index for slug field in tenant collection.

Fixes #33377 

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
