### PR TITLE
fix: make individual words in label selectable #22110

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/LogItem.tsx
+++ b/app/client/src/components/editorComponents/Debugger/LogItem.tsx
@@ -88,10 +88,6 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
-      -webkit-user-select: all; /* Chrome 49+ */
-      -moz-user-select: all; /* Firefox 43+ */
-      -ms-user-select: all; /* No support yet */
-      user-select: all; /* Likely future */
     }
     .debugger-entity {
       color: var(--ads-v2-color-fg-emphasis);


### PR DESCRIPTION
## Description
Individual words in debugger messages can now be selected.
<img width="851" alt="Screenshot 2024-06-03 at 12 21 27" src="https://github.com/appsmithorg/appsmith/assets/173164/d9644e3d-2e2d-4e1b-abb3-963171f5a1cc">

Fixes #22110

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9370104155>
> Commit: 2fe182144e71e0b5fc610d680a38caadc0fe557e
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9370104155&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
