### PR TITLE
feat: add errors to wrong mssql configuration

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -363,30 +363,47 @@ public class MssqlPlugin extends BasePlugin {
         public Set<String> validateDatasource(@NonNull DatasourceConfiguration datasourceConfiguration) {
             Set<String> invalids = new HashSet<>();
 
-            if (isEmpty(datasourceConfiguration.getEndpoints())) {
-                invalids.add(MssqlErrorMessages.DS_MISSING_ENDPOINT_ERROR_MSG);
-            }
+            validateConnectionMode(datasourceConfiguration, invalids);
+            validateEndpoints(datasourceConfiguration, invalids);
+            validateAuthentication(datasourceConfiguration, invalids);
+            return invalids;
+        }
 
+        private void validateConnectionMode(DatasourceConfiguration datasourceConfiguration, Set<String> invalids) {
             if (datasourceConfiguration.getConnection() != null
                     && datasourceConfiguration.getConnection().getMode() == null) {
                 invalids.add(MssqlErrorMessages.DS_MISSING_CONNECTION_MODE_ERROR_MSG);
             }
+        }
 
+        private void validateEndpoints(DatasourceConfiguration datasourceConfiguration, Set<String> invalids) {
+            if (StringUtils.isEmpty(datasourceConfiguration.getUrl())
+                    && isEmpty(datasourceConfiguration.getEndpoints())) {
+                invalids.add(MssqlErrorMessages.DS_MISSING_ENDPOINT_ERROR_MSG);
+            } else if (!isEmpty(datasourceConfiguration.getEndpoints())) {
+                for (final Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
+                    if (endpoint.getHost() == null || endpoint.getHost().isBlank()) {
+                        invalids.add(MssqlErrorMessages.DS_MISSING_HOSTNAME_ERROR_MSG);
+                    }
+                }
+            }
+        }
+
+        private void validateAuthentication(DatasourceConfiguration datasourceConfiguration, Set<String> invalids) {
             DBAuth auth = (DBAuth) datasourceConfiguration.getAuthentication();
             if (auth == null) {
                 invalids.add(MssqlErrorMessages.DS_MISSING_AUTHENTICATION_DETAILS_ERROR_MSG);
-
             } else {
-                if (StringUtils.isEmpty(auth.getUsername())) {
+                if (auth.getUsername() == null || auth.getUsername().isBlank()) {
                     invalids.add(MssqlErrorMessages.DS_MISSING_USERNAME_ERROR_MSG);
                 }
-
-                if (StringUtils.isEmpty(auth.getPassword())) {
+                if (auth.getPassword() == null || auth.getPassword().isBlank()) {
                     invalids.add(MssqlErrorMessages.DS_MISSING_PASSWORD_ERROR_MSG);
                 }
+                if (auth.getDatabaseName() == null || auth.getDatabaseName().isBlank()) {
+                    invalids.add(MssqlErrorMessages.DS_MISSING_DATABASE_NAME_ERROR_MSG);
+                }
             }
-
-            return invalids;
         }
 
         @Override
@@ -593,12 +610,26 @@ public class MssqlPlugin extends BasePlugin {
         hikariConfig.setJdbcUrl(urlBuilder.toString());
 
         try {
+            // Try to establish a connection to validate the configuration
+            DriverManager.getConnection(
+                            hikariConfig.getJdbcUrl(), hikariConfig.getUsername(), hikariConfig.getPassword())
+                    .close();
+        } catch (SQLException e) {
+            // If connection fails, throw an exception with the error message
+            String errorMessage = e.getMessage();
+            if (errorMessage.contains("Connection refused")) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
+                        "Connection refused : Invalid Port Number Specified");
+            } else {
+                throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, e.getMessage());
+            }
+        }
+
+        try {
             hikariDatasource = new HikariDataSource(hikariConfig);
         } catch (HikariPool.PoolInitializationException e) {
-            throw new AppsmithPluginException(
-                    AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
-                    MssqlErrorMessages.CONNECTION_POOL_CREATION_FAILED_ERROR_MSG,
-                    e.getMessage());
+            throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, e.getMessage());
         }
 
         return hikariDatasource;

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/exceptions/MssqlErrorMessages.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/exceptions/MssqlErrorMessages.java
@@ -26,9 +26,9 @@ public class MssqlErrorMessages extends BasePluginErrorMessages {
     ************************************************************************************************************************************************
     */
     public static final String DS_MISSING_ENDPOINT_ERROR_MSG = "Missing endpoint.";
-
+    public static final String DS_MISSING_HOSTNAME_ERROR_MSG = "Host value cannot be empty.";
+    public static final String DS_MISSING_DATABASE_NAME_ERROR_MSG = "Missing database name.";
     public static final String DS_MISSING_CONNECTION_MODE_ERROR_MSG = "Missing connection mode.";
-
     public static final String DS_MISSING_AUTHENTICATION_DETAILS_ERROR_MSG = "Missing authentication details.";
 
     public static final String DS_MISSING_USERNAME_ERROR_MSG = "Missing username for authentication.";

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -15,6 +15,7 @@ import com.appsmith.external.models.Property;
 import com.appsmith.external.models.PsParameterDTO;
 import com.appsmith.external.models.RequestParamDTO;
 import com.appsmith.external.models.SSLDetails;
+import com.external.plugins.exceptions.MssqlErrorMessages;
 import com.external.plugins.exceptions.MssqlPluginError;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -229,6 +230,50 @@ public class MssqlPluginTest {
         StepVerifier.create(dsConnectionMono)
                 .expectErrorMatches(throwable -> throwable instanceof AppsmithPluginException)
                 .verify();
+    }
+
+    @Test
+    void testValidateDatasource_NullCredentials_returnsWithInvalids() {
+
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+
+        dsConfig.setConnection(new Connection());
+        DBAuth auth = (DBAuth) dsConfig.getAuthentication();
+        auth.setUsername(null);
+        auth.setPassword(null);
+        auth.setDatabaseName(null);
+
+        Set<String> expectedOutput = mssqlPluginExecutor.validateDatasource(dsConfig);
+        assertTrue(expectedOutput.contains(MssqlErrorMessages.DS_MISSING_USERNAME_ERROR_MSG));
+        assertTrue(expectedOutput.contains(MssqlErrorMessages.DS_MISSING_PASSWORD_ERROR_MSG));
+        assertTrue(expectedOutput.contains(MssqlErrorMessages.DS_MISSING_DATABASE_NAME_ERROR_MSG));
+    }
+
+    @Test
+    void testValidateDatasource_NullEndPoint() {
+
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setEndpoints(null);
+        Set<String> output = mssqlPluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.contains(MssqlErrorMessages.DS_MISSING_ENDPOINT_ERROR_MSG));
+    }
+
+    @Test
+    void testValidateDatasource_NullHost() {
+
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setEndpoints(List.of(new Endpoint("", 1433L)));
+        Set<String> output = mssqlPluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.contains(MssqlErrorMessages.DS_MISSING_HOSTNAME_ERROR_MSG));
+    }
+
+    @Test
+    void testValidateDatasource_NullAuthentication() {
+
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setAuthentication(null);
+        Set<String> output = mssqlPluginExecutor.validateDatasource(dsConfig);
+        assertTrue(output.contains(MssqlErrorMessages.DS_MISSING_AUTHENTICATION_DETAILS_ERROR_MSG));
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #24726  

This PR contains : 

- Displaying correct error messages for incorrect mssql configuration details 
- Validation checks for the empty fields

## Video Description 
[Video Link](https://drive.google.com/file/d/1XyGWjqhnNl62LPQyhNzXmtJg2OZkwuLb/view?usp=sharing)

## Screenshots 
Error message when user enters wrong Port Number: 
![incrct_port_numner_mssql](https://github.com/appsmithorg/appsmith/assets/119922471/ac256aa9-ea8e-415d-a9b8-e194bf573f7f)

Error message when user enters wrong local host: 
![incrct_hostadd](https://github.com/appsmithorg/appsmith/assets/119922471/25fc17ce-2bb1-4e0a-9fa6-11e1c12925ea)

Error message when user entered wrong database name:  
![wrongdb_conn](https://github.com/appsmithorg/appsmith/assets/119922471/11dd976b-cd3e-4df6-a2a0-362ec2ef1d79)

Error message when user entered wrong username or password  : 
![wrong_username](https://github.com/appsmithorg/appsmith/assets/119922471/32530a4f-9683-4dec-b947-f3c39206bbff)

Validation check if user , missed database field : 
![missing_db_mssql](https://github.com/appsmithorg/appsmith/assets/119922471/b9122dcc-58e4-42ba-9c63-24c453391b7f)

Validation check if user , missed hostaddress : 
![emptyhostvalue](https://github.com/appsmithorg/appsmith/assets/119922471/21830f69-d474-4a91-8ba2-a2cb19af53fe)


Thank you



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for missing hostname and database name during datasource validation.
  - Enhanced connection validation logic to provide specific error messages for connection failures.

- **Tests**
  - Added new test cases to ensure robust validation of datasource configurations, including checks for missing credentials, endpoints, and authentication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->