### PR TITLE
fix: make url selectable

### DIFF
--- a/app/client/cypress/scripts/cypress-local-setup.js
+++ b/app/client/cypress/scripts/cypress-local-setup.js
@@ -1,5 +1,5 @@
 const { execSync } = require("child_process");
-const { readFileSync, existsSync, writeFileSync } = require("fs");
+const { existsSync, readFileSync, writeFileSync } = require("fs");
 const path = require("path");
 const prompt = require("prompt-sync")();
 

--- a/app/client/src/pages/Editor/AppSettingsPane/AppSettings/PageSettings.tsx
+++ b/app/client/src/pages/Editor/AppSettingsPane/AppSettings/PageSettings.tsx
@@ -253,7 +253,7 @@ function PageSettings(props: { page: Page }) {
       {!appNeedsUpdate && (
         <UrlPreviewWrapper className="mb-2">
           <UrlPreviewScroll
-            className="py-1 pl-2 mr-0.5 text-xs break-all"
+            className="py-1 pl-2 mr-0.5 text-xs break-all select-text"
             onCopy={() => {
               navigator.clipboard.writeText(
                 location.protocol +

--- a/app/client/src/pages/Editor/DataSourceEditor/JSONtoForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/JSONtoForm.tsx
@@ -50,7 +50,7 @@ export class JSONtoForm<
   renderForm = (formContent: any) => {
     return (
       // <MainContainer>
-      <FormContainer className="t--json-to-form-wrapper">
+      <FormContainer className="t--json-to-form-wrapper select-text">
         <FormContainerBody className="t--json-to-form-body">
           {formContent}
         </FormContainerBody>


### PR DESCRIPTION
## Description
1. Make url in page settings selectable.
2. Make DataSourceEditor selectable.

Fixes [#33849](https://github.com/appsmithorg/appsmith/issues/33849)

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9363517504>
> Commit: deb311174f011191928744e0f440ab3ffe1deb09
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9363517504&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated text selection behavior in various components to improve user interaction by adding the `select-text` class.

- **Chores**
	- Reordered imports in the Cypress local setup script for better code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->