### PR TITLE
fix: add isPreviewMode check for showing bb onboarding

### DIFF
--- a/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
@@ -98,7 +98,7 @@ describe("OnBoarding - Non-AirGap Edition", () => {
       ui: {
         ...storeToUseWithDragDropBuildingBlocksEnabled.ui,
         gitSync: {
-          protectedBranches: true,
+          protectedBranches: false,
         },
         editor: {
           isPreviewMode: true,
@@ -107,10 +107,14 @@ describe("OnBoarding - Non-AirGap Edition", () => {
     };
     render(BaseComponentRender(previewModeStore));
 
-    const onboardingElement = screen.queryByText(
+    const buildingBlockOnboardingElement = screen.queryByText(
       createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_BUILDING_BLOCK_HINT.TITLE),
     );
-    expect(onboardingElement).not.toBeInTheDocument();
+    const onboardingElement = screen.queryByText(
+      createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_WIDGET_HINT),
+    );
+    expect(buildingBlockOnboardingElement).not.toBeInTheDocument();
+    expect(onboardingElement).toBeInTheDocument();
   });
 });
 
@@ -170,10 +174,14 @@ describe("OnBoarding - AirGap Edition", () => {
     };
     render(BaseComponentRender(previewModeStore));
 
-    const onboardingElement = screen.queryByText(
+    const buildingBlockOnboardingElement = screen.queryByText(
       createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_BUILDING_BLOCK_HINT.TITLE),
     );
-    expect(onboardingElement).not.toBeInTheDocument();
+    const onboardingElement = screen.queryByText(
+      createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_WIDGET_HINT),
+    );
+    expect(buildingBlockOnboardingElement).not.toBeInTheDocument();
+    expect(onboardingElement).toBeInTheDocument();
   });
 });
 
@@ -185,7 +193,7 @@ const baseStoreForSpec = {
       isDraggingBuildingBlocksToCanvas: false,
     },
     gitSync: {
-      protectedBranch: false,
+      protectedBranches: false,
     },
     editor: {
       isPreviewMode: false,

--- a/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
@@ -188,7 +188,7 @@ const baseStoreForSpec = {
       protectedBranch: false,
     },
     editor: {
-      isPreviewModel: false,
+      isPreviewMode: false,
     },
     users: {
       featureFlag: {

--- a/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
@@ -90,6 +90,28 @@ describe("OnBoarding - Non-AirGap Edition", () => {
     );
     expect(onboardingElement).toBeInTheDocument();
   });
+
+  it("6. does not render onboarding component when in preview mode", () => {
+    mockUseCurrentEditorStatePerTestCase(EditorEntityTab.UI);
+    const previewModeStore = {
+      ...storeToUseWithDragDropBuildingBlocksEnabled,
+      ui: {
+        ...storeToUseWithDragDropBuildingBlocksEnabled.ui,
+        gitSync: {
+          protectedBranches: true,
+        },
+        editor: {
+          isPreviewMode: true,
+        },
+      },
+    };
+    render(BaseComponentRender(previewModeStore));
+
+    const onboardingElement = screen.queryByText(
+      createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_BUILDING_BLOCK_HINT.TITLE),
+    );
+    expect(onboardingElement).not.toBeInTheDocument();
+  });
 });
 
 describe("OnBoarding - AirGap Edition", () => {
@@ -131,6 +153,28 @@ describe("OnBoarding - AirGap Edition", () => {
     render(BaseComponentRender(storeToUseWithDragDropBuildingBlocksEnabled));
     assertOnboardingElement();
   });
+
+  it("6. [Airgap] does not render onboarding component when in preview mode", () => {
+    mockUseCurrentEditorStatePerTestCase(EditorEntityTab.UI);
+    const previewModeStore = {
+      ...storeToUseWithDragDropBuildingBlocksEnabled,
+      ui: {
+        ...storeToUseWithDragDropBuildingBlocksEnabled.ui,
+        gitSync: {
+          protectedBranches: true,
+        },
+        editor: {
+          isPreviewMode: true,
+        },
+      },
+    };
+    render(BaseComponentRender(previewModeStore));
+
+    const onboardingElement = screen.queryByText(
+      createMessage(EMPTY_CANVAS_HINTS.DRAG_DROP_BUILDING_BLOCK_HINT.TITLE),
+    );
+    expect(onboardingElement).not.toBeInTheDocument();
+  });
 });
 
 const baseStoreForSpec = {
@@ -139,6 +183,12 @@ const baseStoreForSpec = {
     ...unitTestBaseMockStore.ui,
     buildingBlocks: {
       isDraggingBuildingBlocksToCanvas: false,
+    },
+    gitSync: {
+      protectedBranch: false,
+    },
+    editor: {
+      isPreviewModel: false,
     },
     users: {
       featureFlag: {

--- a/app/client/src/layoutSystems/common/dropTarget/OnBoarding/index.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/OnBoarding/index.tsx
@@ -15,9 +15,12 @@ import {
 import React, { useMemo } from "react";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import BuildingBlockExplorerDropTarget from "../buildingBlockExplorerDropTarget";
+import { useSelector } from "react-redux";
+import { combinedPreviewModeSelector } from "selectors/editorSelectors";
 
 function Onboarding() {
   const appState = useCurrentAppState();
+  const isPreviewMode = useSelector(combinedPreviewModeSelector);
   const isAirgappedInstance = isAirgapped();
   const { segment } = useCurrentEditorState();
 
@@ -33,11 +36,13 @@ function Onboarding() {
       !isAirgappedInstance &&
       isEditorState &&
       isUISegment &&
+      !isPreviewMode &&
       releaseDragDropBuildingBlocksEnabled,
     [
       isEditorState,
       releaseDragDropBuildingBlocksEnabled,
       isUISegment,
+      isPreviewMode,
       isAirgappedInstance,
     ],
   );


### PR DESCRIPTION
## Description
Building blocks onboarding banner was showing to users while in preview mode. This PR checks for isPreviewMode and sets the building blocks onboarding to hide when in preview mode.


Fixes #33954

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9364855811>
> Commit: e7c0ee51484adbe1e73d3941dc7e99469ae7fdc3
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9364855811&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Onboarding component now respects the preview mode setting, ensuring it does not render when in preview mode.

- **Tests**
  - Added test cases to verify that the onboarding component does not render in preview mode for both "Non-AirGap Edition" and "AirGap Edition".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->