### PR TITLE
fix: datasource form footer ui fix

### DIFF
--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -121,6 +121,7 @@ const SaveButtonContainer = styled.div<{
   border-color: var(--ads-v2-color-border);
   align-items: center;
   height: 68px;
+  flex-shrink: 0;
 `;
 
 const StyledAuthMessage = styled.div`

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -121,7 +121,7 @@ const SaveButtonContainer = styled.div<{
   border-color: var(--ads-v2-color-border);
   align-items: center;
   height: 68px;
-  flex-shrink: 0;
+  flex-shrink: ${(props) => (props.isInsideReconnectModal ? "unset" : "0")};
 `;
 
 const StyledAuthMessage = styled.div`


### PR DESCRIPTION
## Description
Datasource form footer height was defined to be `68px` but the height was shrinking to limited space. Adding `flex-shrink: 0` doesn't shrink the footer's height where the datasource auth buttons are present.
<img width="693" alt="Screenshot 2024-06-04 at 2 22 09 PM" src="https://github.com/appsmithorg/appsmith/assets/7565635/3bfbbcaf-469e-443f-90b3-ef6de074cf20">


Fixes #33826 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9368964611>
> Commit: 6c3de7685a79e2540b64424e71cb728147ec64e9
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9368964611&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the `SaveButtonContainer` to include `flex-shrink: 0;` for improved layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->