### PR TITLE
chore: Fail early when build of one component fails

### DIFF
--- a/scripts/local_testing.sh
+++ b/scripts/local_testing.sh
@@ -68,7 +68,7 @@ else
   cd "$(dirname "$0")"/..
   git fetch origin $BRANCH
   git checkout $BRANCH
-  git pull origin $BRANCH || true
+  git pull origin $BRANCH
   pretty_print "Local branch is now up to date. Starting server build ..."
 fi
 

--- a/scripts/local_testing.sh
+++ b/scripts/local_testing.sh
@@ -104,6 +104,7 @@ fi
 pretty_print "RTS build successful. Starting Docker build ..."
 
 popd
+bash "$(dirname "$0")/generate_info_json.sh"
 docker build -t appsmith/appsmith-ce:local-testing \
   --build-arg BASE="appsmith/base-$edition:release" \
   --build-arg APPSMITH_CLOUD_SERVICES_BASE_URL="${cs_url:-https://release-cs.appsmith.com}" \


### PR DESCRIPTION
Fail early when build of one of the components fails, instead of proceeding to build the Docker image and failing _much_ later.

[Slack conversation](https://theappsmith.slack.com/archives/C02MUD8DNUR/p1717484636886919).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the build process with better error handling for server, client, and RTS components, ensuring clearer messaging in case of build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->