### PR TITLE
fix: preview mode canvas cutoff

### DIFF
--- a/app/client/src/layoutSystems/common/mainContainerResizer/MainContainerResizer.tsx
+++ b/app/client/src/layoutSystems/common/mainContainerResizer/MainContainerResizer.tsx
@@ -60,17 +60,17 @@ export function MainContainerResizer({
   enableMainCanvasResizer,
   isPageInitiated,
   isPreview,
+  navigationHeight,
 }: {
   isPageInitiated: boolean;
-  shouldHaveTopMargin: boolean;
   isPreview: boolean;
   currentPageId: string;
   enableMainCanvasResizer: boolean;
+  navigationHeight?: number;
 }) {
   const appLayout = useSelector(getCurrentApplicationLayout);
   const ref = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
-  const topHeaderHeight = "48px";
   useEffect(() => {
     const ele: HTMLElement | null = document.getElementById(CANVAS_VIEWPORT);
 
@@ -170,8 +170,8 @@ export function MainContainerResizer({
       }}
       ref={ref}
       style={{
-        top: isPreview ? topHeaderHeight : "0",
-        height: isPreview ? `calc(100% - ${topHeaderHeight})` : "100%",
+        top: isPreview ? navigationHeight : "0",
+        height: isPreview ? `calc(100% - ${navigationHeight})` : "100%",
       }}
     >
       <div className="canvas-resizer-icon">

--- a/app/client/src/pages/Editor/WidgetsEditor/components/MainContainerWrapper.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/components/MainContainerWrapper.tsx
@@ -134,8 +134,6 @@ function MainContainerWrapper(props: MainCanvasWrapperProps) {
     useMainContainerResizer();
   const isAnvilLayout = useSelector(getIsAnvilLayout);
 
-  const headerHeight = "40px";
-
   useEffect(() => {
     return () => {
       dispatch(forceOpenWidgetPanel(false));
@@ -206,7 +204,7 @@ function MainContainerWrapper(props: MainCanvasWrapperProps) {
         isPreviewingNavigation={isPreviewingNavigation}
         navigationHeight={navigationHeight}
         style={{
-          height: isPreviewMode ? `calc(100% - ${headerHeight})` : "auto",
+          height: isPreviewMode ? `calc(100% - ${navigationHeight})` : "auto",
           fontFamily: fontFamily,
           pointerEvents: isAutoCanvasResizing ? "none" : "auto",
         }}
@@ -229,7 +227,7 @@ function MainContainerWrapper(props: MainCanvasWrapperProps) {
         enableMainCanvasResizer={enableMainContainerResizer && canShowResizer}
         isPageInitiated={!isPageInitializing && !!widgetsStructure}
         isPreview={isPreviewMode || isProtectedMode}
-        shouldHaveTopMargin={shouldHaveTopMargin}
+        navigationHeight={navigationHeight}
       />
     </>
   );


### PR DESCRIPTION
## Description
Fix canvas and resizer height with and without navigation.

Fixes #32301 

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9381694039>
> Commit: 5c630f59f3f6b8787ade1a9fe14619f1750f2d92
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9381694039&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->









## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved layout responsiveness by using `navigationHeight` for dynamic styling in preview mode.
  - Simplified height calculations in the editor by replacing `headerHeight` with `navigationHeight`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->