### PR TITLE
fix: remove form widget settings from button widget

### DIFF
--- a/app/client/src/widgets/ButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/widget/index.tsx
@@ -262,35 +262,8 @@ class ButtonWidget extends BaseWidget<ButtonWidgetProps, ButtonWidgetState> {
             },
           },
         ],
-      },
-      // TODO: refactor widgetParentProps implementation when we address #10659
-      {
-        sectionName: "Form settings",
-        children: [
-          {
-            helpText:
-              "Disabled if the form is invalid, if this widget exists directly within a Form widget.",
-            propertyName: "disabledWhenInvalid",
-            label: "Disabled invalid forms",
-            controlType: "SWITCH",
-            isJSConvertible: true,
-            isBindProperty: true,
-            isTriggerProperty: false,
-            validation: { type: ValidationTypes.BOOLEAN },
-          },
-          {
-            helpText:
-              "Resets the fields of the form, on click, if this widget exists directly within a Form widget.",
-            propertyName: "resetFormOnClick",
-            label: "Reset form on success",
-            controlType: "SWITCH",
-            isJSConvertible: true,
-            isBindProperty: true,
-            isTriggerProperty: false,
-            validation: { type: ValidationTypes.BOOLEAN },
-          },
-        ],
-      },
+      }
+
     ];
   }
 


### PR DESCRIPTION
## Remove form widget settings from button widget
Deleted form widget settings from button widget


Fixes #33935  

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed "Form settings" options (`disabledWhenInvalid` and `resetFormOnClick`) from the Button widget to streamline its configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->