### PR TITLE
test:replace assertPageSave with AssertAutoSave

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/Input_NavigateTo_validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/Input_NavigateTo_validation_spec.js
@@ -51,7 +51,7 @@ describe(
       cy.get(commonlocators.singleSelectMenuItem)
         .contains(pageid)
         .click({ force: true });
-      cy.assertPageSave();
+      agHelper.AssertAutoSave();
     });
 
     it("3. Validate NavigateTo Page functionality ", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2Widgets_NavigateTo_Validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2Widgets_NavigateTo_Validation_spec.js
@@ -55,7 +55,7 @@ describe(
       cy.get(commonlocators.singleSelectMenuItem)
         .contains(pageid)
         .click({ force: true });
-      cy.assertPageSave();
+      agHelper.AssertAutoSave();
     });
 
     it("2. Validate NavigateTo Page functionality ", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/TableWidgets_NavigateTo_Validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/TableWidgets_NavigateTo_Validation_spec.js
@@ -51,7 +51,7 @@ describe(
       cy.get(commonlocators.singleSelectMenuItem)
         .contains(pageid)
         .click({ force: true });
-      cy.assertPageSave();
+      agHelper.AssertAutoSave();
       //Validate NavigateTo Page functionality
       cy.wait(2000);
       deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Drag_Drop_Building_Blocks_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Drag_Drop_Building_Blocks_spec.ts
@@ -238,7 +238,7 @@ describe(
             });
         });
       cy.wait("@blockImport").then(() => {
-        cy.assertPageSave();
+        agHelper.AssertAutoSave();
         // check that the widgets are present on the canvas
         agHelper.AssertElementVisibility('[data-testid="t--ide-list"]');
         agHelper

--- a/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/Basic_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/Basic_spec.js
@@ -32,10 +32,10 @@ describe("App Theming funtionality", { tags: ["@tag.Theme"] }, function () {
     appSettings.OpenAppSettings();
     appSettings.GoToThemeSettings();
     cy.get(commonlocators.changeThemeBtn).click({ force: true });
-    cy.assertPageSave();
+    agHelper.AssertAutoSave();
     // select a theme
     cy.get(commonlocators.themeCard).last().click({ force: true });
-    cy.assertPageSave();
+    agHelper.AssertAutoSave();
     // check for alert
     cy.get(`${commonlocators.themeCard}`)
       .last()
@@ -81,7 +81,7 @@ describe("App Theming funtionality", { tags: ["@tag.Theme"] }, function () {
 
     // change app border radius
     cy.get(commonlocators.themeAppBorderRadiusBtn).eq(1).click({ force: true });
-    cy.assertPageSave();
+    agHelper.AssertAutoSave();
     // check if border radius is changed on button
     cy.get(commonlocators.themeAppBorderRadiusBtn)
       .eq(1)
@@ -656,7 +656,7 @@ describe("App Theming funtionality", { tags: ["@tag.Theme"] }, function () {
       "rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
     );
 
-    cy.assertPageSave();
+    agHelper.AssertAutoSave();
 
     //Add deploy mode verification here also!
     deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/Button_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/Button_spec.js
@@ -89,7 +89,7 @@ describe(
       //Changing the text on the Button
       cy.testJsontext("label", this.dataSet.ButtonLabel);
 
-      cy.assertPageSave();
+      _.agHelper.AssertAutoSave();
 
       //Verify the Button name and label
       cy.get(widgetsPage.buttonWidget).trigger("mouseover");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
@@ -1,3 +1,5 @@
+import { agHelper } from "../../../../../support/Objects/ObjectsCore";
+
 const widgetName = "inputwidgetv2";
 const widgetInput = `.t--widget-${widgetName} input`;
 
@@ -364,7 +366,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
       ".t--property-control-text",
       "{{appsmith.store.textPayloadOnSubmit}}",
     );
-    cy.assertPageSave();
+    agHelper.AssertAutoSave();
 
     cy.closePropertyPane();
     cy.get(widgetInput).clear();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicChildWidgetInteraction_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicChildWidgetInteraction_spec.js
@@ -64,7 +64,7 @@ describe(
         x: 250,
         y: 50,
       });
-      cy.assertPageSave();
+      _.agHelper.AssertAutoSave();
 
       // Verify drop
       cy.get(publishLocators.inputWidget).should("exist");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_spec.js
@@ -68,7 +68,7 @@ describe(
           entityExplorer.DragDropWidgetNVerify(widget);
           //cy.dragAndDropToWidget(widget, "listwidgetv2", { x: 350, y: 50 });
           agHelper.GetNClick(propPane._deleteWidget);
-          cy.assertPageSave();
+          agHelper.AssertAutoSave();
           cy.wait(800);
         });
       },
@@ -86,10 +86,10 @@ describe(
           entityExplorer.DragDropWidgetNVerify(widget);
 
           //cy.dragAndDropToWidget(widget, "listwidgetv2", { x: 350, y: 50 });
-          cy.assertPageSave();
+          agHelper.AssertAutoSave();
           cy.get(`.t--draggable-${widget}`).should("exist");
           cy.get(widgetsPage.removeWidget).click({ force: true });
-          cy.assertPageSave();
+          agHelper.AssertAutoSave();
           cy.wait(800);
         });
       },

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_spec.js
@@ -48,7 +48,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
     cy.get(Layoutpage.tabContainer)
       .scrollIntoView({ easing: "linear" })
       .should("be.visible");
-    cy.assertPageSave();
+    agHelper.AssertAutoSave();
     deployMode.DeployApp();
   });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Color_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Color_spec.js
@@ -35,7 +35,7 @@ describe(
       // select the green color
 
       cy.wait("@updateLayout");
-      cy.assertPageSave();
+      _.agHelper.AssertAutoSave();
       _.deployMode.DeployApp();
       cy.wait(4000);
 
@@ -56,7 +56,7 @@ describe(
         .clear({ force: true })
         .type("purple", { force: true, delay: 0 });
       cy.wait("@updateLayout");
-      cy.assertPageSave();
+      _.agHelper.AssertAutoSave();
       _.deployMode.DeployApp();
       cy.wait(4000);
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Color_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Color_spec.js
@@ -43,7 +43,7 @@ describe(
       // select the green color
 
       cy.wait("@updateLayout");
-      cy.assertPageSave();
+      _.agHelper.AssertAutoSave();
       _.deployMode.DeployApp();
       cy.wait(4000);
 

--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_ContextMenu_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_ContextMenu_spec.js
@@ -8,6 +8,7 @@ const testdata = require("../../../../fixtures/testdata.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 
 import {
+  agHelper,
   apiPage,
   entityExplorer,
 } from "../../../../support/Objects/ObjectsCore";
@@ -20,7 +21,7 @@ describe(
       cy.Createpage("SecondPage");
       cy.CreateAPI("FirstAPI");
       cy.enterDatasourceAndPath(testdata.baseUrl, "{{ '/random' }}");
-      cy.assertPageSave();
+      agHelper.AssertAutoSave();
       cy.get("body").click(0, 0);
       PageLeftPane.switchSegment(PagePaneSegment.Queries);
       entityExplorer.ActionContextMenuByEntityName({

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
@@ -58,7 +58,7 @@ describe(
           widgetsPage.inputWidget,
           widgetsPage.widgetNameSpan,
         );
-        cy.assertPageSave();
+        agHelper.AssertAutoSave();
       },
     );
 
@@ -85,7 +85,7 @@ describe(
           widgetsPage.inputWidget,
           widgetsPage.widgetNameSpan,
         );
-        cy.assertPageSave();
+        agHelper.AssertAutoSave();
       },
     );
 

--- a/app/client/cypress/support/ApiCommands.js
+++ b/app/client/cypress/support/ApiCommands.js
@@ -30,7 +30,7 @@ Cypress.Commands.add("enterDatasource", (datasource) => {
     .type(datasource, { parseSpecialCharSequences: false });
   //.type("{esc}}");
   cy.wait(2000);
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 });
 
 Cypress.Commands.add("ResponseStatusCheck", (statusCode) => {

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -919,16 +919,6 @@ Cypress.Commands.add("CheckForPageSaveError", () => {
   });
 });
 
-Cypress.Commands.add("assertPageSave", (validateSavedState = true) => {
-  if (validateSavedState) {
-    cy.CheckForPageSaveError();
-    cy.get(commonlocators.saveStatusContainer).should("not.exist", {
-      timeout: 30000,
-    });
-  }
-  //assertHelper.AssertNetworkStatus("@sucessSave", 200);
-});
-
 Cypress.Commands.add(
   "validateCodeEditorContent",
   (selector, contentToValidate) => {

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -485,7 +485,7 @@ Cypress.Commands.add("dragAndDropToCanvas", (widgetType, { x, y }) => {
     .trigger("mousemove", x, y, option)
     .trigger("mousemove", x, y, option)
     .trigger("mouseup", x, y, option);
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 });
 
 Cypress.Commands.add(

--- a/app/client/cypress/support/gitSync.js
+++ b/app/client/cypress/support/gitSync.js
@@ -20,7 +20,7 @@ Cypress.Commands.add("latestDeployPreview", () => {
   // Wait before publish
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(2000);
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 
   // Stubbing window.open to open in the same tab
   cy.window().then((window) => {

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -141,7 +141,7 @@ Cypress.Commands.add("createModal", (ModalName, property) => {
   cy.wait(2000);
   cy.get(modalWidgetPage.createModalButton).click({ force: true });
   cy.wait(3000);
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
   // changing the model name verify
   // cy.widgetText(
   //   ModalName,
@@ -162,7 +162,7 @@ Cypress.Commands.add("createModal", (ModalName, property) => {
   cy.testCodeMirror(ModalName);
   cy.moveToStyleTab();
   cy.xpath(widgetsPage.textCenterAlign).first().click({ force: true });
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
   cy.get(".bp3-overlay-backdrop").last().click({ force: true });
 });
 
@@ -186,14 +186,14 @@ Cypress.Commands.add("CheckWidgetProperties", (checkboxCss) => {
   cy.get(checkboxCss).check({
     force: true,
   });
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 });
 
 Cypress.Commands.add("UncheckWidgetProperties", (checkboxCss) => {
   cy.get(checkboxCss).uncheck({
     force: true,
   });
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 });
 
 Cypress.Commands.add("EditWidgetPropertiesUsingJS", (checkboxCss, inputJS) => {
@@ -202,7 +202,7 @@ Cypress.Commands.add("EditWidgetPropertiesUsingJS", (checkboxCss, inputJS) => {
     .should("exist")
     .dblclick({ force: true })
     .type(inputJS);
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 });
 
 Cypress.Commands.add(
@@ -228,7 +228,7 @@ Cypress.Commands.add("verifyUpdatedWidgetName", (text, txtToVerify) => {
     .click({ force: true })
     .type(text)
     .type("{enter}");
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
   if (!txtToVerify) cy.get(".editable-text-container").contains(text);
   else cy.get(".editable-text-container").contains(txtToVerify);
   cy.wait(2000); //for widget name to reflect!
@@ -840,7 +840,7 @@ Cypress.Commands.add("SetDateToToday", () => {
   cy.get(".react-datepicker .react-datepicker__day--today").click({
     force: true,
   });
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 });
 
 Cypress.Commands.add("enterActionValue", (value, property) => {
@@ -916,7 +916,7 @@ Cypress.Commands.add("enterNavigatePageName", (value) => {
 
 Cypress.Commands.add("ClearDate", () => {
   cy.get(".t--property-control-defaultdate input").clear();
-  cy.assertPageSave();
+  agHelper.AssertAutoSave();
 });
 
 Cypress.Commands.add("ClearDateFooter", () => {


### PR DESCRIPTION
This replaces assertPageSave with AssertAutoSave from Ts helper
EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4345

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated Cypress tests to use `agHelper.AssertAutoSave()` instead of `cy.assertPageSave()` for validating auto-save functionality. This change enhances the reliability of auto-save assertions across multiple test scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9370053807>
> Commit: ca1541550f26d71a9c5991b1eca4f42f607fe659
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9370053807&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



