### PR TITLE
fix: add missing scroll to def behaviour 

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/constants.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/constants.ts
@@ -19,3 +19,5 @@ export const SlashCommandMenuOnFocusWidgetProps: { [key: string]: string[] } = {
   TABLE_WIDGET_V2: ["tableData"],
   JSON_FORM_WIDGET: ["sourceData"],
 };
+
+export const CURSOR_CLASS_NAME = "CodeMirror-cursor";

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -1026,11 +1026,11 @@ class CodeEditor extends Component<Props, State> {
         if (documentName in entitiesForNavigation) {
           let navigationData = entitiesForNavigation[documentName];
 
-          navigationTargets.forEach((navigationTarget) => {
+          for (const navigationTarget of navigationTargets) {
             if (navigationTarget in navigationData.children) {
               navigationData = navigationData.children[navigationTarget];
             }
-          });
+          }
 
           if (navigationData.url) {
             if (navigationData.type === ENTITY_TYPE.ACTION) {

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -914,6 +914,7 @@ class CodeEditor extends Component<Props, State> {
     this.editor.off("cursorActivity", this.handleCursorMovement);
     this.editor.off("cursorActivity", this.debouncedArgHints);
     this.editor.off("blur", this.handleEditorBlur);
+    this.editor.off("scrollCursorIntoView", this.handleScrollCursorIntoView);
     CodeMirror.off(
       this.editor.getWrapperElement(),
       "mousemove",
@@ -1004,8 +1005,8 @@ class CodeEditor extends Component<Props, State> {
         const navigationAttribute = event.target.attributes.getNamedItem(
           NAVIGATE_TO_ATTRIBUTE,
         );
+
         if (!navigationAttribute) return;
-        const entityToNavigate = navigationAttribute.value.split(".");
 
         if (
           document.activeElement &&
@@ -1014,39 +1015,46 @@ class CodeEditor extends Component<Props, State> {
           document.activeElement.blur();
         }
 
-        this.setState(
-          {
-            isFocused: false,
-          },
-          () => {
-            if (entityToNavigate[0] in this.props.entitiesForNavigation) {
-              let navigationData =
-                this.props.entitiesForNavigation[entityToNavigate[0]];
-              for (let i = 1; i < entityToNavigate.length; i += 1) {
-                if (entityToNavigate[i] in navigationData.children) {
-                  navigationData = navigationData.children[entityToNavigate[i]];
-                }
-              }
+        this.setState({
+          isFocused: false,
+        });
 
-              if (navigationData.url) {
-                if (navigationData.type === ENTITY_TYPE.ACTION) {
-                  AnalyticsUtil.logEvent("EDIT_ACTION_CLICK", {
-                    actionId: navigationData?.id,
-                    datasourceId: navigationData?.datasourceId,
-                    pluginName: navigationData?.pluginName,
-                    actionType: navigationData?.actionType,
-                    isMock: !!navigationData?.isMock,
-                    from: NavigationMethod.CommandClick,
-                  });
-                }
-                history.push(navigationData.url, {
-                  invokedBy: NavigationMethod.CommandClick,
-                });
-                this.hidePeekOverlay();
-              }
+        const { entitiesForNavigation } = this.props;
+        const [documentName, ...navigationTargets] =
+          navigationAttribute.value.split(".");
+
+        if (documentName in entitiesForNavigation) {
+          let navigationData = entitiesForNavigation[documentName];
+
+          navigationTargets.forEach((navigationTarget) => {
+            if (navigationTarget in navigationData.children) {
+              navigationData = navigationData.children[navigationTarget];
             }
-          },
-        );
+          });
+
+          if (navigationData.url) {
+            if (navigationData.type === ENTITY_TYPE.ACTION) {
+              AnalyticsUtil.logEvent("EDIT_ACTION_CLICK", {
+                actionId: navigationData?.id,
+                datasourceId: navigationData?.datasourceId,
+                pluginName: navigationData?.pluginName,
+                actionType: navigationData?.actionType,
+                isMock: !!navigationData?.isMock,
+                from: NavigationMethod.CommandClick,
+              });
+            }
+
+            history.push(navigationData.url, {
+              invokedBy: NavigationMethod.CommandClick,
+            });
+
+            this.hidePeekOverlay();
+
+            setTimeout(() => {
+              cm.scrollIntoView(cm.getCursor());
+            }, 0);
+          }
+        }
       }
     }
   };

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -101,6 +101,7 @@ import type { SlashCommandPayload } from "entities/Action";
 import type { Indices } from "constants/Layers";
 import { replayHighlightClass } from "globalStyles/portals";
 import {
+  CURSOR_CLASS_NAME,
   LINT_TOOLTIP_CLASS,
   LINT_TOOLTIP_JUSTIFIED_LEFT_CLASS,
   LintTooltipDirection,
@@ -725,9 +726,10 @@ class CodeEditor extends Component<Props, State> {
     const delayedWork = () => {
       if (!this.state.isFocused) return;
 
-      const cursorElement = cm
+      const [cursorElement] = cm
         .getScrollerElement()
-        .getElementsByClassName("CodeMirror-cursor")[0];
+        .getElementsByClassName(CURSOR_CLASS_NAME);
+
       if (cursorElement) {
         scrollIntoView(cursorElement, {
           block: "nearest",


### PR DESCRIPTION
## Description
When jumping to definitions, cursor now scrolls into the view accordingly.

Fixes #33420


## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9371411316>
> Commit: 24488d903548b02b9614487ca52003ee97bba44d
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9371411316&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved cursor handling in the CodeEditor component, ensuring better navigation and visibility.
- **Bug Fixes**
  - Fixed issues with event listeners to prevent potential memory leaks when the component unmounts.
- **Refactor**
  - Enhanced the navigation logic to support multiple targets and improve code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->