### PR TITLE
Mirror/make body tab the default on reload gql query

### DIFF
--- a/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.test.ts
+++ b/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.test.ts
@@ -2,7 +2,7 @@ import { runSaga } from "redux-saga";
 import { AppIDEFocusStrategy } from "./AppIDEFocusStrategy";
 import { NavigationMethod } from "utils/history";
 import { getIDETestState } from "test/factories/AppIDEFactoryUtils";
-import { take } from "redux-saga/effects";
+import { all, take } from "redux-saga/effects";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 
 describe("AppIDEFocusStrategy", () => {
@@ -247,6 +247,20 @@ describe("AppIDEFocusStrategy", () => {
       );
 
       expect(pageChangeGen.next().value).toEqual(undefined);
+    });
+
+    it("waits for actions and plugins to be loaded in case of first page load", () => {
+      const pageChangeGen = AppIDEFocusStrategy.waitForPathLoad(
+        "/app/appSlug/pageSlug-pageId/edit/api/actionId",
+        "",
+      );
+
+      expect(pageChangeGen.next().value).toEqual(
+        all([
+          take(ReduxActionTypes.FETCH_ACTIONS_SUCCESS),
+          take(ReduxActionTypes.FETCH_PLUGINS_SUCCESS),
+        ]),
+      );
     });
   });
 });

--- a/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
+++ b/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
@@ -1,4 +1,4 @@
-import { select, take } from "redux-saga/effects";
+import { all, select, take } from "redux-saga/effects";
 import type { FocusPath, FocusStrategy } from "sagas/FocusRetentionSaga";
 import type { AppsmithLocationState } from "utils/history";
 import { NavigationMethod } from "utils/history";
@@ -220,6 +220,14 @@ export const AppIDEFocusStrategy: FocusStrategy = {
       if (isPageChange(previousPath, currentPath)) {
         yield take(ReduxActionTypes.FETCH_PAGE_SUCCESS);
       }
+    } else {
+      // Wait for the application's actions and plugins to be fetched
+      // so we know if we should focus the Headers or Body tab in the API Editor,
+      // which depends on the action type.
+      yield all([
+        take(ReduxActionTypes.FETCH_ACTIONS_SUCCESS),
+        take(ReduxActionTypes.FETCH_PLUGINS_SUCCESS),
+      ]);
     }
   },
 };


### PR DESCRIPTION
Mirror of https://github.com/appsmithorg/appsmith/pull/33697 to be able to run tests

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9373803740>
> Commit: 4a3d5ecf3a502fc1a1a7feddfe956a5356dac77f
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9373803740&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced focus strategy in the API Editor to wait for specific actions and plugins to be fetched before determining which tab to focus on.
  
- **Tests**
  - Added a new test case to ensure actions and plugins are loaded correctly during the first page load scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->