### PR TITLE
chore: Update postgres version references

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -28,6 +28,8 @@ RUN set -o xtrace \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 \
+  # Create a symlink to the current version of PostgreSQL
+  && ln -s /usr/lib/postgresql/13 /usr/lib/postgresql/current_version \
   && apt-get clean
 
 # Install Java

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -29,7 +29,7 @@ RUN set -o xtrace \
   && apt update \
   && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 \
   # Create a symlink to the current version of PostgreSQL
-  && ln -s /usr/lib/postgresql/13 /usr/lib/postgresql/current_version \
+  && ln -s /usr/lib/postgresql/13 /usr/lib/postgresql/current \
   && apt-get clean
 
 # Install Java

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -424,17 +424,18 @@ init_postgres() {
       # Postgres does not allow it's server to be run with super user access, we use user postgres and the file system owner also needs to be the same user postgres
       chown postgres:postgres "$POSTGRES_DB_PATH"
 
+      # Please refer to base.Dockerfile for the installation of postgres
       # Initialize the postgres db file system
-      su postgres -c "/usr/lib/postgresql/13/bin/initdb -D $POSTGRES_DB_PATH"
+      su postgres -c "/usr/lib/postgresql/current_version/bin/initdb -D $POSTGRES_DB_PATH"
       sed -Ei "s,^#(unix_socket_directories =).*,\\1 '$TMP/pg-runtime'," "$POSTGRES_DB_PATH/postgresql.conf"
 
       # Start the postgres server in daemon mode
-      su postgres -c "/usr/lib/postgresql/13/bin/pg_ctl -D $POSTGRES_DB_PATH start"
+      su postgres -c "/usr/lib/postgresql/current_version/bin/pg_ctl -D $POSTGRES_DB_PATH start"
 
       # Create mockdb db and user and populate it with the data
       seed_embedded_postgres
       # Stop the postgres daemon
-      su postgres -c "/usr/lib/postgresql/13/bin/pg_ctl stop -D $POSTGRES_DB_PATH"
+      su postgres -c "/usr/lib/postgresql/current_version/bin/pg_ctl stop -D $POSTGRES_DB_PATH"
     fi
   else
     runEmbeddedPostgres=0
@@ -446,14 +447,14 @@ seed_embedded_postgres(){
     # Create mockdb database
     psql -U postgres -c "CREATE DATABASE mockdb;"
     # Create mockdb superuser
-    su postgres -c "/usr/lib/postgresql/13/bin/createuser mockdb -s"
+    su postgres -c "/usr/lib/postgresql/current_version/bin/createuser mockdb -s"
     # Dump the sql file containing mockdb data
     psql -U postgres -d mockdb --file='/opt/appsmith/templates/mockdb_postgres.sql'
 
     # Create users database
     psql -U postgres -c "CREATE DATABASE users;"
     # Create users superuser
-    su postgres -c "/usr/lib/postgresql/13/bin/createuser users -s"
+    su postgres -c "/usr/lib/postgresql/current_version/bin/createuser users -s"
     # Dump the sql file containing mockdb data
     psql -U postgres -d users --file='/opt/appsmith/templates/users_postgres.sql'
 }

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -424,18 +424,18 @@ init_postgres() {
       # Postgres does not allow it's server to be run with super user access, we use user postgres and the file system owner also needs to be the same user postgres
       chown postgres:postgres "$POSTGRES_DB_PATH"
 
-      # Please refer to base.Dockerfile for the installation of postgres
+      # Please refer to base.dockerfile for the installation of postgres
       # Initialize the postgres db file system
-      su postgres -c "/usr/lib/postgresql/current_version/bin/initdb -D $POSTGRES_DB_PATH"
+      su postgres -c "/usr/lib/postgresql/current/bin/initdb -D $POSTGRES_DB_PATH"
       sed -Ei "s,^#(unix_socket_directories =).*,\\1 '$TMP/pg-runtime'," "$POSTGRES_DB_PATH/postgresql.conf"
 
       # Start the postgres server in daemon mode
-      su postgres -c "/usr/lib/postgresql/current_version/bin/pg_ctl -D $POSTGRES_DB_PATH start"
+      su postgres -c "/usr/lib/postgresql/current/bin/pg_ctl -D $POSTGRES_DB_PATH start"
 
       # Create mockdb db and user and populate it with the data
       seed_embedded_postgres
       # Stop the postgres daemon
-      su postgres -c "/usr/lib/postgresql/current_version/bin/pg_ctl stop -D $POSTGRES_DB_PATH"
+      su postgres -c "/usr/lib/postgresql/current/bin/pg_ctl stop -D $POSTGRES_DB_PATH"
     fi
   else
     runEmbeddedPostgres=0
@@ -447,14 +447,14 @@ seed_embedded_postgres(){
     # Create mockdb database
     psql -U postgres -c "CREATE DATABASE mockdb;"
     # Create mockdb superuser
-    su postgres -c "/usr/lib/postgresql/current_version/bin/createuser mockdb -s"
+    su postgres -c "/usr/lib/postgresql/current/bin/createuser mockdb -s"
     # Dump the sql file containing mockdb data
     psql -U postgres -d mockdb --file='/opt/appsmith/templates/mockdb_postgres.sql'
 
     # Create users database
     psql -U postgres -c "CREATE DATABASE users;"
     # Create users superuser
-    su postgres -c "/usr/lib/postgresql/current_version/bin/createuser users -s"
+    su postgres -c "/usr/lib/postgresql/current/bin/createuser users -s"
     # Dump the sql file containing mockdb data
     psql -U postgres -d users --file='/opt/appsmith/templates/users_postgres.sql'
 }

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -424,7 +424,7 @@ init_postgres() {
       # Postgres does not allow it's server to be run with super user access, we use user postgres and the file system owner also needs to be the same user postgres
       chown postgres:postgres "$POSTGRES_DB_PATH"
 
-      # Please refer to base.dockerfile for the installation of postgres
+      # Please refer to base.dockerfile for the installation of Postgres
       # Initialize the postgres db file system
       su postgres -c "/usr/lib/postgresql/current/bin/initdb -D $POSTGRES_DB_PATH"
       sed -Ei "s,^#(unix_socket_directories =).*,\\1 '$TMP/pg-runtime'," "$POSTGRES_DB_PATH/postgresql.conf"

--- a/deploy/docker/fs/opt/appsmith/run-postgres.sh
+++ b/deploy/docker/fs/opt/appsmith/run-postgres.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 rm -f /appsmith-stacks/data/postgres/main/core.*
-exec /usr/lib/postgresql/13/bin/postgres -D "/appsmith-stacks/data/postgres/main" -c listen_addresses=127.0.0.1
+exec /usr/lib/postgresql/current_version/bin/postgres -D "/appsmith-stacks/data/postgres/main" -c listen_addresses=127.0.0.1

--- a/deploy/docker/fs/opt/appsmith/run-postgres.sh
+++ b/deploy/docker/fs/opt/appsmith/run-postgres.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 rm -f /appsmith-stacks/data/postgres/main/core.*
-exec /usr/lib/postgresql/current_version/bin/postgres -D "/appsmith-stacks/data/postgres/main" -c listen_addresses=127.0.0.1
+exec /usr/lib/postgresql/current/bin/postgres -D "/appsmith-stacks/data/postgres/main" -c listen_addresses=127.0.0.1


### PR DESCRIPTION
## Description
PR to update the version references for postgres. This will help us in keeping the diff minimum between release and pg branch as we will be upgrading the postgres version to 15 on pg branch.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker scripts to use a generic placeholder for PostgreSQL version, enhancing flexibility and future-proofing the setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->