### PR TITLE
chore: add first load telemetry to evaluations

### DIFF
--- a/app/client/src/ce/workers/common/types.ts
+++ b/app/client/src/ce/workers/common/types.ts
@@ -1,4 +1,5 @@
 import type { WebworkerSpanData } from "UITelemetry/generateWebWorkerTraces";
+import type { SpanAttributes } from "UITelemetry/generateTraces";
 
 export enum AppsmithWorkers {
   LINT_WORKER = "LINT_WORKER",
@@ -12,5 +13,5 @@ export enum WorkerErrorTypes {
 export interface WorkerRequest<TData, TActions> {
   method: TActions;
   data: TData;
-  webworkerTelemetry: Record<string, WebworkerSpanData>;
+  webworkerTelemetry: Record<string, WebworkerSpanData | SpanAttributes>;
 }

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -1662,7 +1662,9 @@ function* handleUpdateActionData(
     EVAL_WORKER_ACTIONS.UPDATE_ACTION_DATA,
     actionDataPayload,
   );
-  endSpan(parentSpan);
+  if (parentSpan) {
+    endSpan(parentSpan);
+  }
 }
 
 export function* watchPluginActionExecutionSagas() {

--- a/app/client/src/utils/WorkerUtil.ts
+++ b/app/client/src/utils/WorkerUtil.ts
@@ -5,11 +5,16 @@ import { uniqueId } from "lodash";
 import log from "loglevel";
 import type { TMessage } from "./MessageUtil";
 import { MessageType, sendMessage } from "./MessageUtil";
-import type { OtlpSpan } from "UITelemetry/generateTraces";
-import { endSpan, startRootSpan } from "UITelemetry/generateTraces";
+import type { OtlpSpan, SpanAttributes } from "UITelemetry/generateTraces";
+import {
+  endSpan,
+  setAttributesToSpan,
+  startRootSpan,
+} from "UITelemetry/generateTraces";
 import type { WebworkerSpanData } from "UITelemetry/generateWebWorkerTraces";
 import {
   convertWebworkerSpansToRegularSpans,
+  filterSpanData,
   newWebWorkerSpanData,
 } from "UITelemetry/generateWebWorkerTraces";
 
@@ -156,33 +161,35 @@ export class GracefulWorkerService {
     startTime,
     webworkerTelemetry,
   }: {
-    webworkerTelemetry: Record<string, WebworkerSpanData>;
+    webworkerTelemetry:
+      | Record<string, WebworkerSpanData | SpanAttributes>
+      | undefined;
     rootSpan: OtlpSpan | undefined;
     method: string;
     startTime: number;
     endTime: number;
   }) {
-    const webworkerTelemetryResponse = webworkerTelemetry as Record<
-      string,
-      WebworkerSpanData
-    >;
-
-    if (webworkerTelemetryResponse) {
-      const { transferDataToMainThread } = webworkerTelemetryResponse;
-      if (transferDataToMainThread) {
-        transferDataToMainThread.endTime = Date.now();
-      }
-      /// Add the completeWebworkerComputation span to the root span
-      webworkerTelemetryResponse["completeWebworkerComputation"] = {
-        startTime,
-        endTime,
-        attributes: {},
-        spanName: "completeWebworkerComputation",
-      };
+    if (!webworkerTelemetry) {
+      return;
     }
+
+    const { transferDataToMainThread } = webworkerTelemetry;
+    if (transferDataToMainThread) {
+      transferDataToMainThread.endTime = Date.now();
+    }
+    /// Add the completeWebworkerComputation span to the root span
+    webworkerTelemetry["completeWebworkerComputation"] = {
+      startTime,
+      endTime,
+      attributes: {},
+      spanName: "completeWebworkerComputation",
+    };
     //we are attaching the child spans to the root span over here
     rootSpan &&
-      convertWebworkerSpansToRegularSpans(rootSpan, webworkerTelemetryResponse);
+      convertWebworkerSpansToRegularSpans(
+        rootSpan,
+        filterSpanData(webworkerTelemetry),
+      );
 
     //genereate separate completeWebworkerComputationRoot root span
     // this span does not contain any child spans, it just captures the webworker computation alone
@@ -218,11 +225,15 @@ export class GracefulWorkerService {
     let timeTaken;
     const rootSpan = startRootSpan(method);
 
-    const webworkerTelemetryData: Record<string, WebworkerSpanData> = {
+    const webworkerTelemetryData: Record<
+      string,
+      WebworkerSpanData | SpanAttributes
+    > = {
       transferDataToWorkerThread: newWebWorkerSpanData(
         "transferDataToWorkerThread",
         {},
       ),
+      __spanAttributes: {},
     };
 
     const body = {
@@ -230,6 +241,11 @@ export class GracefulWorkerService {
       data,
       webworkerTelemetry: webworkerTelemetryData,
     };
+
+    let webworkerTelemetryResponse: Record<
+      string,
+      WebworkerSpanData | SpanAttributes
+    > = {};
 
     try {
       sendMessage.call(this._Worker, {
@@ -241,9 +257,10 @@ export class GracefulWorkerService {
       // The `this._broker` method is listening to events and will pass response to us over this channel.
       const response = yield take(ch);
       const { data, endTime, startTime } = response;
-      const { webworkerTelemetry } = data;
+      webworkerTelemetryResponse = data.webworkerTelemetry;
+
       this.addChildSpansToRootSpan({
-        webworkerTelemetry,
+        webworkerTelemetry: webworkerTelemetryResponse,
         rootSpan,
         method,
         startTime,
@@ -268,6 +285,14 @@ export class GracefulWorkerService {
         log.debug(` Worker ${method} took ${timeTaken}ms`);
         log.debug(` Transfer ${method} took ${transferTime}ms`);
       }
+
+      if (webworkerTelemetryResponse) {
+        setAttributesToSpan(
+          rootSpan,
+          webworkerTelemetryResponse.__spanAttributes as SpanAttributes,
+        );
+      }
+
       endSpan(rootSpan);
       // Cleanup
       ch.close();

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -34,6 +34,7 @@ import {
   profileFn,
   newWebWorkerSpanData,
 } from "UITelemetry/generateWebWorkerTraces";
+import type { SpanAttributes } from "UITelemetry/generateTraces";
 import type { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
 import type { MetaWidgetsReduxState } from "reducers/entityReducers/metaWidgetsReducer";
 
@@ -85,6 +86,9 @@ export function evalTree(request: EvalWorkerSyncRequest) {
   let isNewTree = false;
 
   try {
+    (webworkerTelemetry.__spanAttributes as SpanAttributes)["firstEvaluation"] =
+      !dataTreeEvaluator;
+
     if (!dataTreeEvaluator) {
       isCreateFirstTree = true;
       replayMap = replayMap || {};

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -16,6 +16,7 @@ import type { WorkerRequest } from "@appsmith/workers/common/types";
 import type { DataTreeDiff } from "@appsmith/workers/Evaluation/evaluationUtils";
 import type { APP_MODE } from "entities/App";
 import type { WebworkerSpanData } from "UITelemetry/generateWebWorkerTraces";
+import type { SpanAttributes } from "UITelemetry/generateTraces";
 import type { AffectedJSObjects } from "sagas/EvaluationsSagaUtils";
 
 export type EvalWorkerSyncRequest<T = any> = WorkerRequest<
@@ -59,6 +60,6 @@ export interface EvalTreeResponseData {
   isNewWidgetAdded: boolean;
   undefinedEvalValuesMap: Record<string, boolean>;
   jsVarsCreatedEvent?: { path: string; type: string }[];
-  webworkerTelemetry?: Record<string, WebworkerSpanData>;
+  webworkerTelemetry?: Record<string, WebworkerSpanData | SpanAttributes>;
   updates: string;
 }

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -137,6 +137,7 @@ import {
   profileFn,
   type WebworkerSpanData,
 } from "UITelemetry/generateWebWorkerTraces";
+import type { SpanAttributes } from "UITelemetry/generateTraces";
 import type { AffectedJSObjects } from "sagas/EvaluationsSagaUtils";
 import generateOverrideContext from "@appsmith/workers/Evaluation/generateOverrideContext";
 
@@ -233,7 +234,7 @@ export default class DataTreeEvaluator {
   setupFirstTree(
     unEvalTree: any,
     configTree: ConfigTree,
-    webworkerTelemetry: Record<string, WebworkerSpanData> = {},
+    webworkerTelemetry: Record<string, WebworkerSpanData | SpanAttributes> = {},
   ): {
     jsUpdates: Record<string, JSUpdate>;
     evalOrder: string[];
@@ -489,7 +490,7 @@ export default class DataTreeEvaluator {
   setupUpdateTree(
     unEvalTree: any,
     configTree: ConfigTree,
-    webworkerTelemetry: Record<string, WebworkerSpanData> = {},
+    webworkerTelemetry: Record<string, WebworkerSpanData | SpanAttributes> = {},
     affectedJSObjects: AffectedJSObjects = { isAllAffected: false, ids: [] },
   ): {
     unEvalUpdates: DataTreeDiff[];


### PR DESCRIPTION
## Description
This PR adds an attribute to evaluations span that tells whether the evaluation is first evaluation on page load or a subsequent one.

This attribute will help us filter evaluations and measure gains in update evaluations and first page load evaluations separately.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9381739425>
> Commit: 4cdd01dc24c70aa29b908420e60c984d20b2494d
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9381739425&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a conditional check before calling `endSpan` to handle `parentSpan` in action execution.

- **Refactor**
  - Updated types and interfaces related to telemetry data handling to enhance type safety and clarity.
  - Adjusted telemetry data processing to accommodate new `SpanAttributes`.

- **New Features**
  - Introduced filtering for telemetry span data to exclude specific entries, improving data management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->