### PR TITLE
feat: remove disable overlay for incorrect js objects

### DIFF
--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -194,23 +194,26 @@ function JSResponseView(props: Props) {
       title: createMessage(DEBUGGER_RESPONSE),
       panelComponent: (
         <>
-          {(hasExecutionParseErrors ||
-            (hasJSObjectParseError && errorMessage)) && (
-            <ResponseTabErrorContainer>
-              <ResponseTabErrorContent>
-                <div className="t--js-response-parse-error-call-out">
-                  {errorMessage}
-                </div>
+          {localExecutionAllowed &&
+            (hasExecutionParseErrors ||
+              (hasJSObjectParseError && errorMessage)) && (
+              <ResponseTabErrorContainer>
+                <ResponseTabErrorContent>
+                  <div className="t--js-response-parse-error-call-out">
+                    {errorMessage}
+                  </div>
 
-                <LogHelper
-                  logType={LOG_TYPE.EVAL_ERROR}
-                  name={errorType}
-                  source={actionSource}
-                />
-              </ResponseTabErrorContent>
-            </ResponseTabErrorContainer>
-          )}
-          <ResponseTabWrapper className={errors.length ? "disable" : ""}>
+                  <LogHelper
+                    logType={LOG_TYPE.EVAL_ERROR}
+                    name={errorType}
+                    source={actionSource}
+                  />
+                </ResponseTabErrorContent>
+              </ResponseTabErrorContainer>
+            )}
+          <ResponseTabWrapper
+            className={errors.length && localExecutionAllowed ? "disable" : ""}
+          >
             <Flex px="spaces-7" width="100%">
               <>
                 {localExecutionAllowed && (


### PR DESCRIPTION
## Description
When the js functions fail to parse (eg. incomplete quotes etc), the jsresponse view is disabled with an overlay. Now since remote js run component stays as a child of the jsresponse view component and shouldn't be hidden even if the js is malformed. Refer to the issue linked for more info.

NOTE: Since this PR is only touching EE functionality, the output for CE is not changed. The tests present today shall cover this. The tests for the new experience will be added in the EE PR.

Fixes #33884 

## Automation

/ok-to-test tags="@tag.Sanity, @tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9381657328>
> Commit: 65afce97c51d6fbd5890b7199619024b434f1069
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9381657328&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message and log information display based on execution permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->