### PR TITLE
chore: Updating version of ejs in package.json

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -377,7 +377,7 @@
     "browserslist": "4.20.3",
     "chokidar": "3.5.3",
     "css-select": "4.1.3",
-    "ejs": "3.1.7",
+    "ejs": "3.1.10",
     "fast-csv": "4.3.6",
     "json-schema": "0.4.0",
     "node-fetch": "2.6.7",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -17865,14 +17865,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejs@npm:3.1.7":
-  version: 3.1.7
-  resolution: "ejs@npm:3.1.7"
+"ejs@npm:3.1.10":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
   dependencies:
     jake: ^10.8.5
   bin:
     ejs: bin/cli.js
-  checksum: fe40764af39955ce8f8b116716fc8b911959946698edb49ecab85df597746c07aa65d5b74ead28a1e2ffa75b0f92d9bedd752f1c29437da6137b3518271e988c
+  checksum: ce90637e9c7538663ae023b8a7a380b2ef7cc4096de70be85abf5a3b9641912dde65353211d05e24d56b1f242d71185c6d00e02cb8860701d571786d92c71f05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This resolves a dependabot update.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9395058064>
> Commit: eaa57f225ec92925d9e07bc3db999c52439d0844
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9395058064&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `ejs` dependency version from `3.1.7` to `3.1.10` for improved security and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->