### PR TITLE
fix: added fix for disabling the autocommit feature without feature flag

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
@@ -91,6 +91,7 @@ public class AutoCommitEligibilityHelperImpl extends AutoCommitEligibilityHelper
     }
 
     @Override
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_git_autocommit_feature_enabled)
     public Mono<AutoCommitTriggerDTO> isAutoCommitRequired(
             String workspaceId, GitArtifactMetadata gitArtifactMetadata, PageDTO pageDTO) {
 


### PR DESCRIPTION
## Description
- Added @featureFlagged annotation `(release_git_autocommit_enabled)` to the interface method `isAutoCommitRequired` for `AutocommitEligibilityHelper` to disable the autocommit as a feature

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/9397519853>
> Commit: 55da1e6d3eaf332c2f678d595936b601329227e5
> Workflow: `PR Automation test suite`
> Tags: `@tag.Git`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced feature flagging for the auto-commit functionality to provide more control over its deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->