### PR TITLE
test: ConnectionErrors_Spec.ts - created common error for connection failure

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
@@ -102,9 +102,7 @@ describe(
           dataManager.dsValues[dataManager.defaultEnviorment].mysql_username,
         );
         dataSources.TestDatasource(false);
-        agHelper.ValidateToastMessage(
-          "Access denied for user 'root'@'172.17.0.1'",
-        );
+        agHelper.ValidateToastMessage("Access denied for user");
         propPane.AssertPropertiesDropDownValues("SSL mode", [
           "Default",
           "Required",

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
Fixed failing test of ConnectionErrors_spec.ts in CI

Test 2 : Test throws access denied error which test is asserting but different text expected - Access denied for user 'root'@'17.17.0.1 but got Access denied for user 'root'@'ip-172-17-0-1.ec2.internal'. As we should not be exposing IP addresses, this will be worked on from server. We are making this as a general error than with specific IP.

More details: https://theappsmith.slack.com/archives/C04C1A774RJ/p1717659544117009


Fixes #34022 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated validation message in tests for datasource connection errors.
  - Changed test spec reference from client-side template to server-side datasource connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->