### PR TITLE
test: fix hung tests in CI

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CacheableTemplateHelperTemplateJsonDataTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CacheableTemplateHelperTemplateJsonDataTest.java
@@ -1,8 +1,34 @@
 package com.appsmith.server.helpers;
 
+import com.appsmith.server.constants.ArtifactType;
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.dtos.ApplicationJson;
+import com.appsmith.server.dtos.CacheableApplicationJson;
+import com.appsmith.server.solutions.ApplicationPermission;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * This test is written based on the inspiration from the tutorial:
@@ -11,155 +37,139 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class CacheableTemplateHelperTemplateJsonDataTest {
-    //    private static final ObjectMapper objectMapper = new ObjectMapper();
-    //    private static MockWebServer mockCloudServices;
-    //
-    //    @MockBean
-    //    ApplicationPermission applicationPermission;
-    //
-    //    @MockBean
-    //    private CloudServicesConfig cloudServicesConfig;
-    //
-    //    @Autowired
-    //    CacheableTemplateHelper cacheableTemplateHelper;
-    //
-    //    @SpyBean
-    //    CacheableTemplateHelper spyCacheableTemplateHelper;
-    //
-    //    @BeforeAll
-    //    public static void setUp() throws IOException {
-    //        mockCloudServices = new MockWebServer();
-    //        mockCloudServices.start();
-    //    }
-    //
-    //    @AfterAll
-    //    public static void tearDown() throws IOException {
-    //        mockCloudServices.shutdown();
-    //    }
-    //
-    //    @BeforeEach
-    //    public void initialize() {
-    //        String baseUrl = String.format("http://localhost:%s", mockCloudServices.getPort());
-    //
-    //        // mock the cloud services config so that it returns mock server url as cloud
-    //        // service base url
-    //        Mockito.when(cloudServicesConfig.getBaseUrl()).thenReturn(baseUrl);
-    //    }
-    //
-    //    private ApplicationTemplate create(String id, String title) {
-    //        ApplicationTemplate applicationTemplate = new ApplicationTemplate();
-    //        applicationTemplate.setId(id);
-    //        applicationTemplate.setTitle(title);
-    //        return applicationTemplate;
-    //    }
-    //
-    //    /* Scenarios covered via this test:
-    //     * 1. CacheableTemplateHelper doesn't have the POJO or has an empty POJO.
-    //     * 2. Fetch the templates via the normal flow by mocking CS.
-    //     * 3. Check if the CacheableTemplateHelper.getApplicationTemplateList() is the same as the object returned by
-    // the normal flow function. This will ensure that the cache is being set correctly.
-    //     * 4. From the above steps we now have the cache set.
-    //     * 5. Fetch the templates again, verify the data is the same as the one fetched in step 2.
-    //     * 6. Verify the cache is used and not the mock. This is done by asserting the lastUpdated time of the cache.
-    //     */
-    //    @Test
-    //    public void getApplicationJson_cacheIsEmpty_VerifyDataSavedInCache() throws JsonProcessingException {
-    //        ApplicationJson applicationJson = new ApplicationJson();
-    //        applicationJson.setArtifactJsonType(ArtifactType.APPLICATION);
-    //        applicationJson.setExportedApplication(new Application());
-    //
-    //        assertThat(cacheableTemplateHelper.getCacheableApplicationJsonMap().size())
-    //                .isEqualTo(0);
-    //
-    //        // mock the server to return a template when it's called
-    //        mockCloudServices.enqueue(new MockResponse()
-    //                .setBody(objectMapper.writeValueAsString(applicationJson))
-    //                .addHeader("Content-Type", "application/json"));
-    //
-    //        Mono<CacheableApplicationJson> templateListMono =
-    //                cacheableTemplateHelper.getApplicationByTemplateId("templateId",
-    // cloudServicesConfig.getBaseUrl());
-    //
-    //        final Instant[] timeFromCache = {Instant.now()};
-    //        // make sure we've received the response returned by the mockCloudServices
-    //        StepVerifier.create(templateListMono)
-    //                .assertNext(cacheableApplicationJson1 -> {
-    //                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
-    //                    timeFromCache[0] = cacheableApplicationJson1.getCacheExpiryTime();
-    //                })
-    //                .verifyComplete();
-    //
-    //        // Fetch the same application json again and verify the time stamp to confirm value is coming from POJO
-    //        StepVerifier.create(cacheableTemplateHelper.getApplicationByTemplateId(
-    //                        "templateId", cloudServicesConfig.getBaseUrl()))
-    //                .assertNext(cacheableApplicationJson1 -> {
-    //                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
-    //                    assertThat(cacheableApplicationJson1.getCacheExpiryTime()).isEqualTo(timeFromCache[0]);
-    //                })
-    //                .verifyComplete();
-    //        assertThat(cacheableTemplateHelper.getCacheableApplicationJsonMap().size())
-    //                .isEqualTo(1);
-    //    }
-    //
-    //    /* Scenarios covered via this test:
-    //     * 1. Mock the cache isCacheValid to return false, so the cache is invalidated
-    //     * 2. Fetch the templates again, verify the data is from the mock and not from the cache.
-    //     */
-    //    @Test
-    //    public void getApplicationJson_cacheIsDirty_verifyDataIsFetchedFromSource() {
-    //        ApplicationJson applicationJson = new ApplicationJson();
-    //        Application test = new Application();
-    //        test.setName("New Application");
-    //        applicationJson.setArtifactJsonType(ArtifactType.APPLICATION);
-    //        applicationJson.setExportedApplication(test);
-    //
-    //        // mock the server to return the above three templates
-    //        mockCloudServices.enqueue(new MockResponse()
-    //                .setBody(new Gson().toJson(applicationJson))
-    //                .addHeader("Content-Type", "application/json"));
-    //
-    //        Mockito.doReturn(false).when(spyCacheableTemplateHelper).isCacheValid(any());
-    //
-    //        // make sure we've received the response returned by the mock
-    //        StepVerifier.create(spyCacheableTemplateHelper.getApplicationByTemplateId(
-    //                        "templateId", cloudServicesConfig.getBaseUrl()))
-    //                .assertNext(cacheableApplicationJson1 -> {
-    //                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
-    //                    assertThat(cacheableApplicationJson1
-    //                                    .getApplicationJson()
-    //                                    .getExportedApplication()
-    //                                    .getName())
-    //                            .isEqualTo("New Application");
-    //                })
-    //                .verifyComplete();
-    //    }
-    //
-    //    @Test
-    //    public void getApplicationJson_cacheKeyIsMissing_verifyDataIsFetchedFromSource() {
-    //        ApplicationJson applicationJson1 = new ApplicationJson();
-    //        Application application = new Application();
-    //        application.setName("Test Application");
-    //        applicationJson1.setArtifactJsonType(ArtifactType.APPLICATION);
-    //        applicationJson1.setExportedApplication(application);
-    //
-    //        assertThat(cacheableTemplateHelper.getCacheableApplicationJsonMap().size())
-    //                .isEqualTo(1);
-    //
-    //        mockCloudServices.enqueue(new MockResponse()
-    //                .setBody(new Gson().toJson(applicationJson1))
-    //                .addHeader("Content-Type", "application/json"));
-    //
-    //        // make sure we've received the response returned by the mock
-    //        StepVerifier.create(cacheableTemplateHelper.getApplicationByTemplateId(
-    //                        "templateId1", cloudServicesConfig.getBaseUrl()))
-    //                .assertNext(cacheableApplicationJson1 -> {
-    //                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
-    //                    assertThat(cacheableApplicationJson1
-    //                                    .getApplicationJson()
-    //                                    .getExportedApplication()
-    //                                    .getName())
-    //                            .isEqualTo("Test Application");
-    //                })
-    //                .verifyComplete();
-    //    }
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static MockWebServer mockCloudServices;
+
+    @MockBean
+    ApplicationPermission applicationPermission;
+
+    @Autowired
+    CacheableTemplateHelper cacheableTemplateHelper;
+
+    @SpyBean
+    CacheableTemplateHelper spyCacheableTemplateHelper;
+
+    String baseUrl;
+
+    @BeforeAll
+    public static void setUp() throws IOException {
+        mockCloudServices = new MockWebServer();
+        mockCloudServices.start();
+    }
+
+    @AfterAll
+    public static void tearDown() throws IOException {
+        mockCloudServices.shutdown();
+    }
+
+    @BeforeEach
+    public void initialize() {
+        baseUrl = String.format("http://localhost:%s", mockCloudServices.getPort());
+    }
+
+    /* Scenarios covered via this test:
+        * 1. CacheableTemplateHelper doesn't have the POJO or has an empty POJO.
+        * 2. Fetch the templates via the normal flow by mocking CS.
+        * 3. Check if the CacheableTemplateHelper.getApplicationTemplateList() is the same as the object returned by
+    the normal flow function. This will ensure that the cache is being set correctly.
+        * 4. From the above steps we now have the cache set.
+        * 5. Fetch the templates again, verify the data is the same as the one fetched in step 2.
+        * 6. Verify the cache is used and not the mock. This is done by asserting the lastUpdated time of the cache.
+        */
+    @Test
+    public void getApplicationJson_cacheIsEmpty_VerifyDataSavedInCache() throws JsonProcessingException {
+        ApplicationJson applicationJson = new ApplicationJson();
+        applicationJson.setArtifactJsonType(ArtifactType.APPLICATION);
+        applicationJson.setExportedApplication(new Application());
+
+        assertThat(cacheableTemplateHelper.getCacheableApplicationJsonMap().size())
+                .isEqualTo(0);
+
+        // mock the server to return a template when it's called
+        mockCloudServices.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(applicationJson))
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<CacheableApplicationJson> templateListMono =
+                cacheableTemplateHelper.getApplicationByTemplateId("templateId", baseUrl);
+
+        final Instant[] timeFromCache = {Instant.now()};
+        // make sure we've received the response returned by the mockCloudServices
+        StepVerifier.create(templateListMono)
+                .assertNext(cacheableApplicationJson1 -> {
+                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
+                    timeFromCache[0] = cacheableApplicationJson1.getCacheExpiryTime();
+                })
+                .verifyComplete();
+
+        // Fetch the same application json again and verify the time stamp to confirm value is coming from POJO
+        StepVerifier.create(cacheableTemplateHelper.getApplicationByTemplateId("templateId", baseUrl))
+                .assertNext(cacheableApplicationJson1 -> {
+                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
+                    assertThat(cacheableApplicationJson1.getCacheExpiryTime()).isEqualTo(timeFromCache[0]);
+                })
+                .verifyComplete();
+        assertThat(cacheableTemplateHelper.getCacheableApplicationJsonMap().size())
+                .isEqualTo(1);
+    }
+
+    /* Scenarios covered via this test:
+     * 1. Mock the cache isCacheValid to return false, so the cache is invalidated
+     * 2. Fetch the templates again, verify the data is from the mock and not from the cache.
+     */
+    @Test
+    public void getApplicationJson_cacheIsDirty_verifyDataIsFetchedFromSource() {
+        ApplicationJson applicationJson = new ApplicationJson();
+        Application test = new Application();
+        test.setName("New Application");
+        applicationJson.setArtifactJsonType(ArtifactType.APPLICATION);
+        applicationJson.setExportedApplication(test);
+
+        // mock the server to return the above three templates
+        mockCloudServices.enqueue(new MockResponse()
+                .setBody(new Gson().toJson(applicationJson))
+                .addHeader("Content-Type", "application/json"));
+
+        Mockito.doReturn(false).when(spyCacheableTemplateHelper).isCacheValid(any());
+
+        // make sure we've received the response returned by the mock
+        StepVerifier.create(spyCacheableTemplateHelper.getApplicationByTemplateId("templateId", baseUrl))
+                .assertNext(cacheableApplicationJson1 -> {
+                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
+                    assertThat(cacheableApplicationJson1
+                                    .getApplicationJson()
+                                    .getExportedApplication()
+                                    .getName())
+                            .isEqualTo("New Application");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void getApplicationJson_cacheKeyIsMissing_verifyDataIsFetchedFromSource() {
+        ApplicationJson applicationJson1 = new ApplicationJson();
+        Application application = new Application();
+        application.setName("Test Application");
+        applicationJson1.setArtifactJsonType(ArtifactType.APPLICATION);
+        applicationJson1.setExportedApplication(application);
+
+        assertThat(cacheableTemplateHelper.getCacheableApplicationJsonMap().size())
+                .isEqualTo(1);
+
+        mockCloudServices.enqueue(new MockResponse()
+                .setBody(new Gson().toJson(applicationJson1))
+                .addHeader("Content-Type", "application/json"));
+
+        // make sure we've received the response returned by the mock
+        StepVerifier.create(cacheableTemplateHelper.getApplicationByTemplateId("templateId1", baseUrl))
+                .assertNext(cacheableApplicationJson1 -> {
+                    assertThat(cacheableApplicationJson1.getApplicationJson()).isNotNull();
+                    assertThat(cacheableApplicationJson1
+                                    .getApplicationJson()
+                                    .getExportedApplication()
+                                    .getName())
+                            .isEqualTo("Test Application");
+                })
+                .verifyComplete();
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CacheableTemplateHelperTemplateMetadataTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CacheableTemplateHelperTemplateMetadataTest.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.helpers;
 
-import com.appsmith.server.configurations.CloudServicesConfig;
 import com.appsmith.server.dtos.ApplicationTemplate;
 import com.appsmith.server.dtos.CacheableApplicationTemplate;
 import com.appsmith.server.solutions.ApplicationPermission;
@@ -11,7 +10,6 @@ import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -32,7 +30,6 @@ import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
-@Disabled
 public class CacheableTemplateHelperTemplateMetadataTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -41,14 +38,13 @@ public class CacheableTemplateHelperTemplateMetadataTest {
     @MockBean
     ApplicationPermission applicationPermission;
 
-    @MockBean
-    private CloudServicesConfig cloudServicesConfig;
-
     @Autowired
     CacheableTemplateHelper cacheableTemplateHelper;
 
     @SpyBean
     CacheableTemplateHelper spyCacheableTemplateHelper;
+
+    String baseUrl;
 
     @BeforeAll
     public static void setUp() throws IOException {
@@ -63,11 +59,7 @@ public class CacheableTemplateHelperTemplateMetadataTest {
 
     @BeforeEach
     public void initialize() {
-        String baseUrl = String.format("http://localhost:%s", mockCloudServices.getPort());
-
-        // mock the cloud services config so that it returns mock server url as cloud
-        // service base url
-        Mockito.when(cloudServicesConfig.getBaseUrl()).thenReturn(baseUrl);
+        baseUrl = String.format("http://localhost:%s", mockCloudServices.getPort());
     }
 
     private ApplicationTemplate create(String id, String title) {
@@ -99,7 +91,7 @@ public class CacheableTemplateHelperTemplateMetadataTest {
                 .addHeader("Content-Type", "application/json"));
 
         Mono<CacheableApplicationTemplate> templateListMono =
-                cacheableTemplateHelper.getTemplates("recently-used", cloudServicesConfig.getBaseUrl());
+                cacheableTemplateHelper.getTemplates("recently-used", baseUrl);
 
         final Instant[] timeFromCache = {Instant.now()};
         StepVerifier.create(templateListMono)
@@ -114,7 +106,7 @@ public class CacheableTemplateHelperTemplateMetadataTest {
                 .verifyComplete();
 
         // Fetch again and verify the time stamp to confirm value is coming from POJO
-        StepVerifier.create(cacheableTemplateHelper.getTemplates("recently-used", cloudServicesConfig.getBaseUrl()))
+        StepVerifier.create(cacheableTemplateHelper.getTemplates("recently-used", baseUrl))
                 .assertNext(cacheableApplicationTemplate1 -> {
                     assertThat(cacheableApplicationTemplate1.getApplicationTemplateList())
                             .hasSize(3);
@@ -141,7 +133,7 @@ public class CacheableTemplateHelperTemplateMetadataTest {
                 .setBody(objectMapper.writeValueAsString(List.of(templateFour, templateFive, templateSix)))
                 .addHeader("Content-Type", "application/json"));
 
-        StepVerifier.create(spyCacheableTemplateHelper.getTemplates("recently-used", cloudServicesConfig.getBaseUrl()))
+        StepVerifier.create(spyCacheableTemplateHelper.getTemplates("recently-used", baseUrl))
                 .assertNext(cacheableApplicationTemplate1 -> {
                     assertThat(cacheableApplicationTemplate1.getApplicationTemplateList())
                             .hasSize(3);


### PR DESCRIPTION
## Description
Fix hung tests on the CI


Fixes #34026 

## Automation

/ok-to-test tags="@tag.Templates"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9399386015>
> Commit: c3c9ab9db85850d7323658b364e65a095d769e9c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9399386015&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved test setup and scenarios in caching-related tests.
  - Replaced `cloudServicesConfig` with `baseUrl` for better clarity and maintainability in test methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->