### PR TITLE
task: remove learning popover

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -24,8 +24,6 @@ export const FEATURE_FLAG = {
   release_git_autocommit_feature_enabled:
     "release_git_autocommit_feature_enabled",
   license_widget_rtl_support_enabled: "license_widget_rtl_support_enabled",
-  ab_one_click_learning_popover_enabled:
-    "ab_one_click_learning_popover_enabled",
   release_side_by_side_ide_enabled: "release_side_by_side_ide_enabled",
   release_global_add_pane_enabled: "release_global_add_pane_enabled",
   ab_appsmith_ai_query: "ab_appsmith_ai_query",
@@ -66,7 +64,6 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_git_autocommit_feature_enabled: false,
   license_git_continuous_delivery_enabled: false,
   license_widget_rtl_support_enabled: false,
-  ab_one_click_learning_popover_enabled: false,
   release_side_by_side_ide_enabled: false,
   release_global_add_pane_enabled: false,
   ab_appsmith_ai_query: false,

--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -12761,7 +12761,6 @@ export const defaultAppState = {
           license_widget_rtl_support_enabled: false,
           release_show_new_sidebar_announcement_enabled: false,
           rollout_app_sidebar_enabled: false,
-          ab_one_click_learning_popover_enabled: false,
           release_side_by_side_ide_enabled: false,
           release_global_add_pane_enabled: false,
           license_git_unlimited_repo_enabled: false,

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -173,9 +173,7 @@ const PropertyControl = memo((props: Props) => {
 
   const propertyValue = _.get(widgetProperties, props.propertyName);
 
-  const experimentalJSToggle = useFeatureFlag(
-    FEATURE_FLAG.ab_one_click_learning_popover_enabled,
-  );
+  const experimentalJSToggle = false;
 
   /**
    * checks if property value is deviated or not.

--- a/app/client/src/widgets/ButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/widget/index.tsx
@@ -262,35 +262,8 @@ class ButtonWidget extends BaseWidget<ButtonWidgetProps, ButtonWidgetState> {
             },
           },
         ],
-      },
-      // TODO: refactor widgetParentProps implementation when we address #10659
-      {
-        sectionName: "Form settings",
-        children: [
-          {
-            helpText:
-              "Disabled if the form is invalid, if this widget exists directly within a Form widget.",
-            propertyName: "disabledWhenInvalid",
-            label: "Disabled invalid forms",
-            controlType: "SWITCH",
-            isJSConvertible: true,
-            isBindProperty: true,
-            isTriggerProperty: false,
-            validation: { type: ValidationTypes.BOOLEAN },
-          },
-          {
-            helpText:
-              "Resets the fields of the form, on click, if this widget exists directly within a Form widget.",
-            propertyName: "resetFormOnClick",
-            label: "Reset form on success",
-            controlType: "SWITCH",
-            isJSConvertible: true,
-            isBindProperty: true,
-            isTriggerProperty: false,
-            validation: { type: ValidationTypes.BOOLEAN },
-          },
-        ],
-      },
+      }
+
     ];
   }
 


### PR DESCRIPTION
## Task: remove learning popover

Fixes #33810   
## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Removed the "Form settings" section from the ButtonWidget, including `disabledWhenInvalid` and `resetFormOnClick` properties.

- **Bug Fixes**
  - Hardcoded the `experimentalJSToggle` feature flag to `false` to ensure consistent behavior.

- **Chores**
  - Removed the `ab_one_click_learning_popover_enabled` feature flag from the codebase for cleaner configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->