### PR TITLE
fix: hide skip button if the application object is not present in the onboarding screen

### DIFF
--- a/app/client/src/ce/pages/Applications/CreateNewAppsOption.test.tsx
+++ b/app/client/src/ce/pages/Applications/CreateNewAppsOption.test.tsx
@@ -1,0 +1,116 @@
+import "@testing-library/jest-dom/extend-expect";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { lightTheme } from "selectors/themeSelectors";
+import { ThemeProvider } from "styled-components";
+import CreateNewAppsOption from "./CreateNewAppsOption";
+import { BrowserRouter as Router } from "react-router-dom";
+import { unitTestBaseMockStore } from "layoutSystems/common/dropTarget/unitTestUtils";
+
+const defaultStoreState = {
+  ...unitTestBaseMockStore,
+  entities: {
+    ...unitTestBaseMockStore.entities,
+    plugins: {
+      list: [],
+    },
+    datasources: {
+      list: [],
+      mockDatasourceList: [],
+    },
+  },
+  ui: {
+    ...unitTestBaseMockStore.ui,
+    selectedWorkspace: {
+      ...unitTestBaseMockStore.ui.selectedWorkspace,
+      applications: [unitTestBaseMockStore.ui.applications.currentApplication],
+    },
+    debugger: {
+      isOpen: false,
+    },
+    editor: {
+      loadingStates: {},
+      isProtectedMode: true,
+      zoomLevel: 1,
+    },
+    gitSync: {
+      globalGitConfig: {},
+      branches: [],
+      localGitConfig: {},
+      disconnectingGitApp: {},
+    },
+    users: {
+      loadingStates: {},
+      list: [],
+      users: [],
+      error: "",
+      currentUser: {},
+      featureFlag: {
+        data: {},
+        isFetched: true,
+        overriddenFlags: {},
+      },
+      productAlert: {
+        config: {},
+      },
+    },
+    apiPane: {
+      isCreating: false,
+      isRunning: {},
+      isSaving: {},
+      isDeleting: {},
+      isDirty: {},
+      extraformData: {},
+      selectedConfigTabIndex: 0,
+      debugger: {
+        open: false,
+      },
+    },
+  },
+};
+const mockStore = configureStore([]);
+describe("CreateNewAppsOption", () => {
+  let store: any;
+  it("Should not render skip button if no application is present", () => {
+    store = mockStore(defaultStoreState);
+
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <Router>
+            <CreateNewAppsOption currentApplicationIdForCreateNewApp="test" />
+          </Router>
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    const button = screen.queryAllByTestId("t--create-new-app-option-skip");
+
+    // Check that the skip button to be absent in the document
+    expect(button).toHaveLength(0);
+  });
+
+  it("Should render skip button if application is present", () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <Router>
+            <CreateNewAppsOption currentApplicationIdForCreateNewApp="659d2e15d0cbfb0c5e0a7428" />
+          </Router>
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    const button = screen.queryAllByTestId("t--create-new-app-option-skip");
+
+    // Check that the skip button to be present in the document
+    expect(button).toHaveLength(1);
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+    store.clearActions();
+  });
+});

--- a/app/client/src/ce/pages/Applications/CreateNewAppsOption.tsx
+++ b/app/client/src/ce/pages/Applications/CreateNewAppsOption.tsx
@@ -140,25 +140,24 @@ const CreateNewAppsOption = ({
   };
 
   const onClickSkipButton = () => {
-    if (application) {
-      urlBuilder.updateURLParams(
-        {
-          applicationSlug: application.slug,
-          applicationVersion: application.applicationVersion,
-          applicationId: application.id,
-        },
-        application.pages.map((page) => ({
-          pageSlug: page.slug,
-          customSlug: page.customSlug,
-          pageId: page.id,
-        })),
-      );
-      history.push(
-        builderURL({
-          pageId: application.pages[0].id,
-        }),
-      );
-    }
+    const applicationObject = application!;
+    urlBuilder.updateURLParams(
+      {
+        applicationSlug: applicationObject.slug,
+        applicationVersion: applicationObject.applicationVersion,
+        applicationId: applicationObject.id,
+      },
+      applicationObject.pages.map((page) => ({
+        pageSlug: page.slug,
+        customSlug: page.customSlug,
+        pageId: page.id,
+      })),
+    );
+    history.push(
+      builderURL({
+        pageId: applicationObject.pages[0].id,
+      }),
+    );
 
     addAnalyticEventsForSkip();
   };
@@ -214,15 +213,16 @@ const CreateNewAppsOption = ({
         >
           {createMessage(GO_BACK)}
         </LinkWrapper>
-
-        <LinkWrapper
-          className="t--create-new-app-option-skip"
-          data-testid="t--create-new-app-option-skip"
-          endIcon="arrow-right-line"
-          onClick={onClickSkipButton}
-        >
-          {createMessage(SKIP_START_WITH_USE_CASE_TEMPLATES)}
-        </LinkWrapper>
+        {application && (
+          <LinkWrapper
+            className="t--create-new-app-option-skip"
+            data-testid="t--create-new-app-option-skip"
+            endIcon="arrow-right-line"
+            onClick={onClickSkipButton}
+          >
+            {createMessage(SKIP_START_WITH_USE_CASE_TEMPLATES)}
+          </LinkWrapper>
+        )}
       </BackWrapper>
       <Flex flexDirection="column" pl="spaces-3" pr="spaces-3">
         <Header


### PR DESCRIPTION
## Description
Removing `Skip this step, I ll do it later` button if the application object is not present. 
As earlier the skip button was rendering but there was a check in the onClick handler that if the application object is not present then do nothing, which does not make sense. There should be no if block without else block.
Link to the conversation thread : https://theappsmith.slack.com/archives/C0134BAVDB4/p1712125023745899

Fixes #32380 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.ImportExport, @tag.Workspace, @tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9405536613>
> Commit: c913d05e889eaea1d5562818b5bca257f959c55c
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9405536613&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Added unit tests for the `CreateNewAppsOption` component to ensure proper rendering based on application states.
- **Bug Fixes**
	- Enhanced the `onClickSkipButton` function to prevent errors by ensuring the `application` object is not null.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->