### PR TITLE
fix: code split for run history resize issue in workflows editor

### DIFF
--- a/app/client/src/ce/components/RunHistory/index.tsx
+++ b/app/client/src/ce/components/RunHistory/index.tsx
@@ -1,0 +1,3 @@
+export default function RunHistory({}: any) {
+  return null;
+}

--- a/app/client/src/ee/components/RunHistory/index.tsx
+++ b/app/client/src/ee/components/RunHistory/index.tsx
@@ -1,0 +1,3 @@
+export * from "ce/components/RunHistory";
+import { default as CE_RunHistory } from "ce/components/RunHistory";
+export default CE_RunHistory;

--- a/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
@@ -61,6 +61,7 @@ import {
 } from "@appsmith/utils/BusinessFeatures/permissionPageHelpers";
 import { ApiEditorContext } from "./ApiEditorContext";
 import ActionRightPane from "components/editorComponents/ActionRightPane";
+import RunHistory from "@appsmith/components/RunHistory";
 
 const Form = styled.form`
   position: relative;
@@ -746,6 +747,7 @@ function CommonEditorForm(props: CommonFormPropsWithExtraParams) {
                 responseDisplayFormat={responseDisplayFormat}
                 theme={theme}
               />
+              <RunHistory />
             </SecondaryWrapper>
           </div>
           <ActionRightPane

--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -71,7 +71,7 @@ import {
 } from "@appsmith/utils/BusinessFeatures/permissionPageHelpers";
 import type { JSCollectionData } from "@appsmith/reducers/entityReducers/jsActionsReducer";
 import { DEBUGGER_TAB_KEYS } from "../../../components/editorComponents/Debugger/helpers";
-
+import RunHistory from "@appsmith/components/RunHistory";
 interface JSFormProps {
   jsCollectionData: JSCollectionData;
   contextMenu: React.ReactNode;
@@ -441,6 +441,7 @@ function JSEditorForm({
                   }}
                   theme={theme}
                 />
+                <RunHistory />
               </SecondaryWrapper>
             </div>
           </Wrapper>

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -40,6 +40,7 @@ import QueryEditorHeader from "./QueryEditorHeader";
 import ActionEditor from "../IDE/EditorPane/components/ActionEditor";
 import QueryResponseTab from "./QueryResponseTab";
 import DatasourceSelector from "./DatasourceSelector";
+import RunHistory from "@appsmith/components/RunHistory";
 
 const QueryFormContainer = styled.form`
   flex: 1;
@@ -386,6 +387,7 @@ export function EditorJSONtoForm(props: Props) {
                 runErrorMessage={runErrorMessage}
                 showSchema={showSchema}
               />
+              <RunHistory />
             </SecondaryWrapper>
           </div>
           <ActionRightPane


### PR DESCRIPTION
## Description
Run history for workflows is a system wide pane but due to the nature of the panes in appsmith, a pane has to be individually imported to each editor (jsobject, query,data and api). This PR is the code split PR which imports the pane into the respective component. The logic for the pane is in EE and can only be opened by a trigger that is only in workflow editor. [EE PR](https://github.com/appsmithorg/appsmith-ee/pull/4366) for reference.

Fixes #33024 

## Automation

/test ide

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9403599136>
> Commit: 3d5d2c136c4c1cd343fd0f310d7832d120318e13
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9403599136&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `RunHistory` component to track and display run history in various editors.

- **Enhancements**
  - Added `RunHistory` component to API Editor, JS Editor, and Query Editor for improved user experience.

These updates aim to provide better visibility and tracking of run histories across different sections of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->