### PR TITLE
chore: Dummy to run CI on external contributor's PR : add support for Google Cloud Storage in S3 plugin

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -103,8 +103,10 @@ import static com.external.plugins.constants.S3PluginConstants.ACCESS_DENIED_ERR
 import static com.external.plugins.constants.S3PluginConstants.AWS_S3_SERVICE_PROVIDER;
 import static com.external.plugins.constants.S3PluginConstants.BASE64_DELIMITER;
 import static com.external.plugins.constants.S3PluginConstants.CUSTOM_ENDPOINT_INDEX;
+import static com.external.plugins.constants.S3PluginConstants.DEFAULT_BUCKET_PROPERTY_INDEX;
 import static com.external.plugins.constants.S3PluginConstants.DEFAULT_FILE_NAME;
 import static com.external.plugins.constants.S3PluginConstants.DEFAULT_URL_EXPIRY_IN_MINUTES;
+import static com.external.plugins.constants.S3PluginConstants.GOOGLE_CLOUD_SERVICE_PROVIDER;
 import static com.external.plugins.constants.S3PluginConstants.NO;
 import static com.external.plugins.constants.S3PluginConstants.S3_DRIVER;
 import static com.external.plugins.constants.S3PluginConstants.S3_SERVICE_PROVIDER_PROPERTY_INDEX;
@@ -948,36 +950,97 @@ public class AmazonS3Plugin extends BasePlugin {
                 invalids.add(S3ErrorMessages.DS_MANDATORY_PARAMETER_ENDPOINT_URL_MISSING_ERROR_MSG);
             }
 
+            if (datasourceConfiguration != null) {
+                String serviceProvider = (String)
+                        properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX).getValue();
+                if (GOOGLE_CLOUD_SERVICE_PROVIDER.equals(serviceProvider)) {
+                    String defaultBucket = (String)
+                            properties.get(DEFAULT_BUCKET_PROPERTY_INDEX).getValue();
+                    if (StringUtils.isNullOrEmpty(defaultBucket)) {
+                        invalids.add(S3ErrorMessages.DS_MANDATORY_PARAMETER_DEFAULT_BUCKET_MISSING_ERROR_MSG);
+                    }
+                }
+            }
+
             return invalids;
         }
 
         @Override
-        public Mono<DatasourceTestResult> testDatasource(AmazonS3 connection) {
-            return Mono.fromCallable(() -> {
-                        /*
-                         * - Please note that as of 28 Jan 2021, the way AmazonS3 client works, creating a connection
-                         *   object with wrong credentials does not throw any exception.
-                         * - Hence, adding a listBuckets() method call to test the connection.
-                         */
-                        connection.listBuckets();
-                        return new DatasourceTestResult();
-                    })
-                    .onErrorResume(error -> {
-                        if (error instanceof AmazonS3Exception
-                                && ACCESS_DENIED_ERROR_CODE.equals(((AmazonS3Exception) error).getErrorCode())) {
-                            /**
-                             * Sometimes a valid account credential may not have permission to run listBuckets action
-                             * . In this case `AccessDenied` error is returned.
-                             * That fact that the credentials caused `AccessDenied` error instead of invalid access key
-                             * id or signature mismatch error means that the credentials are valid, we are able to
-                             * establish a connection as well, but the account does not have permission to run
-                             * listBuckets.
-                             */
-                            return Mono.just(new DatasourceTestResult());
-                        }
+        public Mono<DatasourceTestResult> testDatasource(DatasourceConfiguration datasourceConfiguration) {
+            if (datasourceConfiguration == null) {
+                return Mono.just(new DatasourceTestResult(
+                        S3ErrorMessages.DS_AT_LEAST_ONE_MANDATORY_PARAMETER_MISSING_ERROR_MSG));
+            }
 
-                        return Mono.just(new DatasourceTestResult(amazonS3ErrorUtils.getReadableError(error)));
-                    });
+            List<Property> properties = datasourceConfiguration.getProperties();
+            String s3Provider =
+                    (String) properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX).getValue();
+
+            // Handle Google Cloud Storage in a separate method if necessary
+            if (GOOGLE_CLOUD_SERVICE_PROVIDER.equals(s3Provider)) {
+                return testGoogleCloudStorage(datasourceConfiguration);
+            }
+
+            // For Amazon S3 or other providers, perform a standard test by listing buckets in Amazon S3
+            return datasourceCreate(datasourceConfiguration)
+                    .flatMap(connection -> Mono.fromCallable(() -> {
+                                /*
+                                 * - Please note that as of 28 Jan 2021, the way AmazonS3 client works, creating a connection
+                                 *   object with wrong credentials does not throw any exception.
+                                 * - Hence, adding a listBuckets() method call to test the connection.
+                                 */
+                                connection.listBuckets();
+                                return new DatasourceTestResult();
+                            })
+                            .onErrorResume(error -> {
+                                if (error instanceof AmazonS3Exception
+                                        && ACCESS_DENIED_ERROR_CODE.equals(
+                                                ((AmazonS3Exception) error).getErrorCode())) {
+                                    /**
+                                     * Sometimes a valid account credential may not have permission to run listBuckets action
+                                     * . In this case `AccessDenied` error is returned.
+                                     * That fact that the credentials caused `AccessDenied` error instead of invalid access key
+                                     * id or signature mismatch error means that the credentials are valid, we are able to
+                                     * establish a connection as well, but the account does not have permission to run
+                                     * listBuckets.
+                                     */
+                                    return Mono.just(new DatasourceTestResult());
+                                }
+
+                                return Mono.just(new DatasourceTestResult(amazonS3ErrorUtils.getReadableError(error)));
+                            })
+                            .doFinally(signalType -> connection.shutdown()))
+                    .onErrorResume(error -> Mono.just(new DatasourceTestResult(error.getMessage())))
+                    .subscribeOn(scheduler);
+        }
+
+        private Mono<DatasourceTestResult> testGoogleCloudStorage(DatasourceConfiguration datasourceConfiguration) {
+            List<Property> properties = datasourceConfiguration.getProperties();
+            String defaultBucket =
+                    (String) properties.get(DEFAULT_BUCKET_PROPERTY_INDEX).getValue();
+            if (StringUtils.isNullOrEmpty(defaultBucket)) {
+                return Mono.just(new DatasourceTestResult(
+                        S3ErrorMessages.DS_MANDATORY_PARAMETER_DEFAULT_BUCKET_MISSING_ERROR_MSG));
+            }
+
+            return datasourceCreate(datasourceConfiguration)
+                    .flatMap(connection -> Mono.fromCallable(() -> {
+                                connection.listObjects(defaultBucket);
+                                return new DatasourceTestResult();
+                            })
+                            .onErrorResume(error -> {
+                                if (error instanceof AmazonS3Exception
+                                        && ((AmazonS3Exception) error).getStatusCode() == 404) {
+                                    return Mono.just(
+                                            new DatasourceTestResult(S3ErrorMessages.NON_EXITED_BUCKET_ERROR_MSG));
+                                } else {
+                                    return Mono.just(
+                                            new DatasourceTestResult(amazonS3ErrorUtils.getReadableError(error)));
+                                }
+                            })
+                            .doFinally(signalType -> connection.shutdown()))
+                    .onErrorResume(error -> Mono.just(new DatasourceTestResult(error.getMessage())))
+                    .subscribeOn(scheduler);
         }
 
         /**

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -5,7 +5,6 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -842,22 +841,16 @@ public class AmazonS3Plugin extends BasePlugin {
                         e.getMessage());
             }
 
-            DeleteObjectsRequest deleteObjectsRequest = getDeleteObjectsRequest(bucketName, listOfFiles);
-            try {
-                connection.deleteObjects(deleteObjectsRequest);
-            } catch (SdkClientException e) {
-                throw new AppsmithPluginException(
-                        S3PluginError.AMAZON_S3_QUERY_EXECUTION_FAILED,
-                        S3ErrorMessages.FILE_CANNOT_BE_DELETED_ERROR_MSG,
-                        e.getMessage());
+            for (String filePath : listOfFiles) {
+                try {
+                    connection.deleteObject(bucketName, filePath);
+                } catch (SdkClientException e) {
+                    throw new AppsmithPluginException(
+                            S3PluginError.AMAZON_S3_QUERY_EXECUTION_FAILED,
+                            S3ErrorMessages.FILE_CANNOT_BE_DELETED_ERROR_MSG,
+                            e.getMessage());
+                }
             }
-        }
-
-        private DeleteObjectsRequest getDeleteObjectsRequest(String bucketName, List<String> listOfFiles) {
-            DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucketName);
-
-            /* Ref: https://stackoverflow.com/questions/9863742/how-to-pass-an-arraylist-to-a-varargs-method-parameter */
-            return deleteObjectsRequest.withKeys(listOfFiles.toArray(new String[0]));
         }
 
         @Override

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/S3PluginConstants.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/S3PluginConstants.java
@@ -4,6 +4,8 @@ public class S3PluginConstants {
     public static final String S3_DRIVER = "com.amazonaws.services.s3.AmazonS3";
     public static final int S3_SERVICE_PROVIDER_PROPERTY_INDEX = 1;
     public static final int CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX = 2;
+
+    public static final int DEFAULT_BUCKET_PROPERTY_INDEX = 3;
     public static final int CUSTOM_ENDPOINT_INDEX = 0;
     public static final String DEFAULT_URL_EXPIRY_IN_MINUTES = "5"; // max 7 days is possible
     public static final String YES = "YES";
@@ -12,4 +14,6 @@ public class S3PluginConstants {
     public static final String AWS_S3_SERVICE_PROVIDER = "amazon-s3";
     public static String DEFAULT_FILE_NAME = "MyFile.txt";
     public static final String ACCESS_DENIED_ERROR_CODE = "AccessDenied";
+    public static final String GOOGLE_CLOUD_SERVICE_PROVIDER = "google-cloud-storage";
+    public static final String AUTO = "auto";
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/exceptions/S3ErrorMessages.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/exceptions/S3ErrorMessages.java
@@ -18,6 +18,9 @@ public class S3ErrorMessages extends BasePluginErrorMessages {
             "Appsmith has encountered an unexpected error when getting bucket name. Please reach out to "
                     + "Appsmith customer support to resolve this.";
 
+    public static final String NON_EXITED_BUCKET_ERROR_MSG =
+            "Appsmith has encountered an unexpected error when getting bucket name. The specified bucket does not exist in Google Cloud Storage. ";
+
     public static final String EMPTY_PREFIX_ERROR_MSG =
             "Appsmith has encountered an unexpected error when getting path prefix. Please reach out to "
                     + "Appsmith customer support to resolve this.";
@@ -126,4 +129,9 @@ public class S3ErrorMessages extends BasePluginErrorMessages {
             "Required parameter 'Endpoint URL' is empty. Did you forget to edit the 'Endpoint"
                     + " URL' field in the datasource creation form ? You need to fill it with "
                     + "the endpoint URL of your S3 instance.";
+
+    public static final String DS_MANDATORY_PARAMETER_DEFAULT_BUCKET_MISSING_ERROR_MSG =
+            "Required parameter 'Default Bucket' is empty. Did you forget to edit the 'Default Bucket' "
+                    + "field in the datasource creation form? You need to fill it with the default bucket name "
+                    + "for your Google Cloud Storage instance.";
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/DatasourceUtils.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/DatasourceUtils.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 
 import static com.amazonaws.regions.Regions.DEFAULT_REGION;
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
+import static com.external.plugins.constants.S3PluginConstants.AUTO;
 import static com.external.plugins.constants.S3PluginConstants.CUSTOM_ENDPOINT_INDEX;
 import static com.external.plugins.constants.S3PluginConstants.CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX;
 import static com.external.plugins.constants.S3PluginConstants.S3_SERVICE_PROVIDER_PROPERTY_INDEX;
@@ -67,6 +68,7 @@ public class DatasourceUtils {
         DIGITAL_OCEAN_SPACES("digital-ocean-spaces"),
         DREAM_OBJECTS("dream-objects"),
         MINIO("minio"),
+        GOOGLE_CLOUD_STORAGE("google-cloud-storage"),
         OTHER("other");
 
         private String name;
@@ -95,7 +97,7 @@ public class DatasourceUtils {
      * @param datasourceConfiguration
      * @return AmazonS3ClientBuilder object
      * @throws AppsmithPluginException when (1) there is an error with parsing credentials (2) required
-     * datasourceConfiguration properties are missing (3) endpoint URL is found incorrect.
+     *                                 datasourceConfiguration properties are missing (3) endpoint URL is found incorrect.
      */
     public static AmazonS3ClientBuilder getS3ClientBuilder(DatasourceConfiguration datasourceConfiguration)
             throws AppsmithPluginException {
@@ -136,7 +138,6 @@ public class DatasourceUtils {
 
         S3ServiceProvider s3ServiceProvider = S3ServiceProvider.fromString(
                 (String) properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX).getValue());
-
         /**
          * AmazonS3 provides an attribute `forceGlobalBucketAccessEnabled` that automatically routes the request to a
          * region such that request should succeed.
@@ -168,6 +169,9 @@ public class DatasourceUtils {
                     /* This case can never be reached because of the if condition above. Just adding for sake of
                     completeness. */
 
+                    break;
+                case GOOGLE_CLOUD_STORAGE:
+                    region = AUTO;
                     break;
                 case UPCLOUD:
                     region = getRegionFromEndpointPattern(
@@ -233,8 +237,8 @@ public class DatasourceUtils {
     /**
      * This method checks if the S3 endpoint URL has correct format and extracts region information from it.
      *
-     * @param endpoint : endpoint URL
-     * @param regex : expected endpoint URL pattern
+     * @param endpoint         : endpoint URL
+     * @param regex            : expected endpoint URL pattern
      * @param regionGroupIndex : pattern group index for region string
      * @return S3 object storage region.
      * @throws AppsmithPluginException when then endpoint URL does not match the expected regex pattern.

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
@@ -44,6 +44,10 @@
               "value": "minio"
             },
             {
+              "label": "Google Cloud Storage",
+              "value": "google-cloud-storage"
+            },
+            {
               "label": "Other",
               "value": "other"
             }
@@ -105,6 +109,19 @@
                 "value": "minio"
               }
             ]
+          }
+        },
+        {
+          "label": "Default Bucket",
+          "configProperty": "datasourceConfiguration.properties[3].value",
+          "controlType": "INPUT_TEXT",
+          "initialValue": "",
+          "placeholderText": "Enter default bucket name",
+          "isRequired": true,
+          "hidden": {
+            "path": "datasourceConfiguration.properties[1].value",
+            "comparison": "NOT_EQUALS",
+            "value": "google-cloud-storage"
           }
         }
       ]


### PR DESCRIPTION
## Description
The original PR is https://github.com/appsmithorg/appsmith/pull/33938

CI cannot be run on PR which is from a fork other than appsmith. Also, dp and further testing will be done on this PR.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9465389106>
> Commit: c9639a494fe440a738977422a131e92f8995923e
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9465389106&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->









## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Google Cloud Storage as a service provider.
  - Introduced a new configuration option for setting a default bucket in Google Cloud Storage.

- **Bug Fixes**
  - Enhanced validation for default bucket parameters in Google Cloud Storage configurations.

- **Tests**
  - Added tests for validating datasource configurations for Google Cloud Storage, including missing regions and default buckets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->