### PR TITLE
test: flay table header validation

### DIFF
--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/table_data_change_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,7 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/table_data_change_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/support/Pages/Table.ts
+++ b/app/client/cypress/support/Pages/Table.ts
@@ -37,9 +37,7 @@ export class Table {
   private assertHelper = ObjectsRegistry.AssertHelper;
 
   private _tableWrap = "//div[contains(@class,'tableWrap')]";
-  private _tableHeader =
-    this._tableWrap +
-    "//div[contains(@class,'thead')]//div[contains(@class,'tr')][1]";
+  private _tableHeader = ".thead div[role=columnheader]";
   private _columnHeader = (columnName: string) =>
     this._tableWrap +
     "//div[contains(@class,'thead')]//div[contains(@class,'tr')][1]//div[@role='columnheader']//div[contains(text(),'" +
@@ -258,7 +256,7 @@ export class Table {
   }
 
   public AssertTableHeaderOrder(expectedOrder: string) {
-    cy.get(".thead div[role=columnheader]")
+    cy.get(this._tableHeader)
       .invoke("text")
       .then((x) => {
         expect(x).to.eq(expectedOrder);

--- a/app/client/cypress/support/Pages/Table.ts
+++ b/app/client/cypress/support/Pages/Table.ts
@@ -258,7 +258,7 @@ export class Table {
   }
 
   public AssertTableHeaderOrder(expectedOrder: string) {
-    cy.xpath(this._tableHeader)
+    cy.get(".thead div[role=columnheader]")
       .invoke("text")
       .then((x) => {
         expect(x).to.eq(expectedOrder);


### PR DESCRIPTION
Xpath used to read the header text is flaky.

Solution:
Replacing xpath with css locator to make it stable

EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4382
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated spec names and file paths for tests related to Community Issues and TableV2 widget.

- **Refactor**
  - Simplified the selector for table headers to improve readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->