### PR TITLE
chore: Don't deserialize any request body to `Layout`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Layout.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Layout.java
@@ -7,7 +7,6 @@ import com.appsmith.external.views.Git;
 import com.appsmith.external.views.Views;
 import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.helpers.CompareDslActionDTO;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -50,7 +49,6 @@ public class Layout {
 
     // this attribute will be used to display errors caused white calculating allOnLoadAction
     // PageLoadActionsUtilCEImpl.java
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @JsonView({Views.Public.class, Views.Export.class})
     List<ErrorDTO> layoutOnLoadActionErrors;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageCreationDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageCreationDTO.java
@@ -1,22 +1,34 @@
 package com.appsmith.server.dtos;
 
+import com.appsmith.external.dtos.DslExecutableDTO;
 import com.appsmith.server.domains.Layout;
 import com.appsmith.server.meta.validations.FileName;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
+import net.minidev.json.JSONObject;
 
 import java.util.List;
+import java.util.Set;
 
 public record PageCreationDTO(
         @FileName(message = "Page names must be valid file names", isNullValid = false) @Size(max = 30) String name,
         @NotEmpty @Size(min = 24, max = 50) String applicationId,
-        @NotEmpty List<Layout> layouts) {
+        @NotEmpty List<LayoutDTO> layouts) {
+
+    public record LayoutDTO(JSONObject dsl, List<Set<DslExecutableDTO>> layoutOnLoadActions) {}
 
     public PageDTO toPageDTO() {
         final PageDTO page = new PageDTO();
         page.setName(name.trim());
         page.setApplicationId(applicationId);
-        page.setLayouts(layouts);
+        page.setLayouts(layouts.stream()
+                .map(layoutDto -> {
+                    final Layout l = new Layout();
+                    l.setDsl(layoutDto.dsl);
+                    l.setLayoutOnLoadActions(layoutDto.layoutOnLoadActions);
+                    return l;
+                })
+                .toList());
         return page;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UpdateMultiplePageLayoutDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UpdateMultiplePageLayoutDTO.java
@@ -1,10 +1,10 @@
 package com.appsmith.server.dtos;
 
-import com.appsmith.server.domains.Layout;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import net.minidev.json.JSONObject;
 
 import java.util.List;
 
@@ -22,6 +22,8 @@ public class UpdateMultiplePageLayoutDTO {
 
         @NotNull private String layoutId;
 
-        private Layout layout;
+        private LayoutDTO layout;
     }
+
+    public record LayoutDTO(JSONObject dsl) {}
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/layouts/UpdateLayoutServiceCEImpl.java
@@ -244,12 +244,10 @@ public class UpdateLayoutServiceCEImpl implements UpdateLayoutServiceCE {
         List<Mono<LayoutDTO>> monoList = new ArrayList<>();
         for (UpdateMultiplePageLayoutDTO.UpdatePageLayoutDTO pageLayout :
                 updateMultiplePageLayoutDTO.getPageLayouts()) {
+            final Layout layout = new Layout();
+            layout.setDsl(pageLayout.getLayout().dsl());
             Mono<LayoutDTO> updatedLayoutMono = this.updateLayout(
-                    pageLayout.getPageId(),
-                    defaultApplicationId,
-                    pageLayout.getLayoutId(),
-                    pageLayout.getLayout(),
-                    branchName);
+                    pageLayout.getPageId(), defaultApplicationId, pageLayout.getLayoutId(), layout, branchName);
             monoList.add(updatedLayoutMono);
         }
         return Flux.merge(monoList).then(Mono.just(monoList.size()));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -1023,13 +1023,13 @@ public class LayoutActionServiceTest {
 
         for (int i = 0; i < testPages.size(); i++) {
             PageDTO page = testPages.get(i);
-            Layout layout = page.getLayouts().get(0);
-            layout.setDsl(createTestDslWithTestWidget("Layout" + (i + 1)));
+            final UpdateMultiplePageLayoutDTO.LayoutDTO layout =
+                    new UpdateMultiplePageLayoutDTO.LayoutDTO(createTestDslWithTestWidget("Layout" + (i + 1)));
 
             UpdateMultiplePageLayoutDTO.UpdatePageLayoutDTO pageLayoutDTO =
                     new UpdateMultiplePageLayoutDTO.UpdatePageLayoutDTO();
             pageLayoutDTO.setPageId(page.getId());
-            pageLayoutDTO.setLayoutId(layout.getId());
+            pageLayoutDTO.setLayoutId(page.getLayouts().get(0).getId());
             pageLayoutDTO.setLayout(layout);
             multiplePageLayoutDTO.getPageLayouts().add(pageLayoutDTO);
         }


### PR DESCRIPTION
The presence of `@JsonProperty` screws up the way objects are stored in Postgres. This PR gets rid of it for the `Layout` class.

**/test sanity**

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9416336191>
> Commit: 3256d44dfdf436c8eec6fd9db81e5cbfc98758cd
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9416336191&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved serialization and deserialization process for layouts by updating annotations and introducing a new `LayoutDTO` class.
  - Simplified page layout updates by using `LayoutDTO` instead of `Layout`.

- **Tests**
  - Updated tests to accommodate changes in layout handling, ensuring consistency and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->