### PR TITLE
fix: fixing null check failure on pg branch

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
@@ -50,6 +50,9 @@ public class NewPage extends BranchAwareDomain implements Context {
     @JsonView(Views.Internal.class)
     @Override
     public Layout getLayout() {
+        if (this.getPublishedPage() == null || this.getPublishedPage().getLayouts() == null) {
+            return null;
+        }
         List<Layout> layouts = this.getUnpublishedPage().getLayouts();
         return (layouts != null && !layouts.isEmpty()) ? layouts.get(0) : null;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/NewPage.java
@@ -50,11 +50,11 @@ public class NewPage extends BranchAwareDomain implements Context {
     @JsonView(Views.Internal.class)
     @Override
     public Layout getLayout() {
-        if (this.getPublishedPage() == null || this.getPublishedPage().getLayouts() == null) {
+        if (this.getUnpublishedPage() == null || this.getUnpublishedPage().getLayouts() == null) {
             return null;
         }
         List<Layout> layouts = this.getUnpublishedPage().getLayouts();
-        return (layouts != null && !layouts.isEmpty()) ? layouts.get(0) : null;
+        return !layouts.isEmpty() ? layouts.get(0) : null;
     }
 
     public static class Fields extends BranchAwareDomain.Fields {


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the stability of the layout retrieval process by adding null checks for both `publishedPage` and `unpublishedPage` and their respective `layouts`. This prevents potential errors when these elements are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->