### PR TITLE
fix: removed change country code

### DIFF
--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -204,17 +204,7 @@ class PhoneInputWidget extends BaseInputWidget<
               validation: {
                 type: ValidationTypes.TEXT,
               },
-            },
-            {
-              propertyName: "allowDialCodeChange",
-              label: "Change country code",
-              helpText: "Search by country",
-              controlType: "SWITCH",
-              isJSConvertible: true,
-              isBindProperty: true,
-              isTriggerProperty: false,
-              validation: { type: ValidationTypes.BOOLEAN },
-            },
+            }
           ],
         },
         {


### PR DESCRIPTION
### Description

### [Remove country code Bug](https://github.com/appsmithorg/appsmith/issues/34055)

 I have raised this Pr `In order to remove the country code switch Phone widget`

### 📸 Screenshot
 
#### Before removing `change country code`
![image](https://github.com/appsmithorg/appsmith/assets/122865888/19e76a46-83da-4e70-986f-6dcccf8e3c1b)

### After removing `change country code`
![image](https://github.com/appsmithorg/appsmith/assets/122865888/36961c67-aa9d-437b-89e5-9a545cff5d94)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `allowDialCodeChange` property from the Phone Input Widget to streamline the widget's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->