### PR TITLE
fix(validation): update email validation to accept TLDs up to 6 characters

### DIFF
--- a/app/client/src/widgets/InputWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.js
@@ -72,7 +72,7 @@ export default {
          *  https://stackoverflow.com/questions/15017052/understanding-email-validation-using-javascript
          * */
         const emailRegex = new RegExp(
-          /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+$/,
+          /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,6})+$/,
         );
         if (!emailRegex.test(value)) {
           /* email should conform to generic email regex */

--- a/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
@@ -168,6 +168,11 @@ describe("Derived property - ", () => {
           inputText: "test@appsmith.com",
           isRequired: true,
         },
+        {
+          inputType: InputTypes.EMAIL,
+          inputText: "test@test.school",
+          isRequired: true,
+        },
         null,
         _,
       );

--- a/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
@@ -168,6 +168,14 @@ describe("Derived property - ", () => {
           inputText: "test@appsmith.com",
           isRequired: true,
         },
+        null,
+        _,
+      );
+
+      expect(isValid).toBeFalsy();
+
+      //Email input with required true and valid value
+      isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
           inputText: "test@test.school",


### PR DESCRIPTION
## Fix input field for Email not validating long TLD

After reviewing issue #33837 I changed the default email validation logic to accept TLDs up to 6 letters long. Also added a test to test the test@test.school email.

Fixes #33837 

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated email validation to support longer top-level domains (up to 6 characters).

- **Tests**
  - Added a new test case to ensure email validation works with longer top-level domains (e.g., "test@test.school").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->