### PR TITLE
fix: when cloning only run onLoad actions for new page

### DIFF
--- a/app/client/src/ce/sagas/PageSagas.tsx
+++ b/app/client/src/ce/sagas/PageSagas.tsx
@@ -978,11 +978,6 @@ export function* clonePageSaga(
       }
 
       yield put(selectWidgetInitAction(SelectionRequestType.Empty));
-      yield put(
-        fetchAllPageEntityCompletion([
-          executePageLoadActions(ActionExecutionContext.CLONE_PAGE),
-        ]),
-      );
 
       // TODO: Update URL params here.
 


### PR DESCRIPTION
## Description
When cloning a page, onLoad actions occur twice: once for the page being cloned and once for the new page. As the cloned page is loaded immediately after cloning, removing this part of the clone procedure seems to fix the issue.

Fixes #27019 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency by removing redundant `fetchAllPageEntityCompletion` call in page cloning process.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->