### PR TITLE
chore: Add time to logs from entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ COPY ./app/client/build editor/
 # Add RTS - Application Layer
 COPY ./app/client/packages/rts/dist rts/
 
-ENV PATH /opt/appsmith/utils/node_modules/.bin:/opt/java/bin:/opt/node/bin:$PATH
+ENV PATH /opt/bin:/opt/appsmith/utils/node_modules/.bin:/opt/java/bin:/opt/node/bin:$PATH
 
 RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd - \
-  && chmod +x *.sh /watchtower-hooks/*.sh \
+  && chmod +x /opt/bin/* *.sh /watchtower-hooks/*.sh \
   # Disable setuid/setgid bits for the files inside container.
   && find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true \
   && mkdir -p /.mongodb/mongosh /appsmith-stacks \

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "Running as: $(id)"
+tlog "Running as: $(id)"
 
 stacks_path=/appsmith-stacks
 
@@ -48,7 +48,7 @@ init_env_file() {
   # Build an env file with current env variables. We single-quote the values, as well as escaping any single-quote characters.
   printenv | grep -E '^APPSMITH_|^MONGO_' | sed "s/'/'\\\''/g; s/=/='/; s/$/'/" > "$TMP/pre-define.env"
 
-  echo "Initialize .env file"
+  tlog "Initialize .env file"
   if ! [[ -e "$ENV_PATH" ]]; then
     # Generate new docker.env file when initializing container for first time or in Heroku which does not have persistent volume
     echo "Generating default configuration file"
@@ -74,7 +74,7 @@ init_env_file() {
   fi
 
 
-  echo "Load environment configuration"
+  tlog "Load environment configuration"
   set -o allexport
   . "$ENV_PATH"
   . "$TMP/pre-define.env"
@@ -111,20 +111,20 @@ if [[ -n "${FILESTORE_IP_ADDRESS-}" ]]; then
   FILESTORE_IP_ADDRESS="$(echo "$FILESTORE_IP_ADDRESS" | xargs)"
   FILE_SHARE_NAME="$(echo "$FILE_SHARE_NAME" | xargs)"
 
-  echo "Running appsmith for cloudRun"
-  echo "creating mount point"
+  tlog "Running appsmith for cloudRun"
+  tlog "creating mount point"
   mkdir -p "$stacks_path"
-  echo "Mounting File Sytem"
+  tlog "Mounting File Sytem"
   mount -t nfs -o nolock "$FILESTORE_IP_ADDRESS:/$FILE_SHARE_NAME" /appsmith-stacks
-  echo "Mounted File Sytem"
-  echo "Setting HOSTNAME for Cloudrun"
+  tlog "Mounted File Sytem"
+  tlog "Setting HOSTNAME for Cloudrun"
   export HOSTNAME="cloudrun"
 fi
 
 
 function get_maximum_heap() {
     resource=$(ulimit -u)
-    echo "Resource : $resource"
+    tlog "Resource : $resource"
     if [[ "$resource" -le 256 ]]; then
         maximum_heap=128
     elif [[ "$resource" -le 512 ]]; then
@@ -140,7 +140,7 @@ function setup_backend_heap_arg() {
 
 unset_unused_variables() {
   # Check for enviroment vairalbes
-  echo "Checking environment configuration"
+  tlog "Checking environment configuration"
   if [[ -z "${APPSMITH_MAIL_ENABLED}" ]]; then
     unset APPSMITH_MAIL_ENABLED # If this field is empty is might cause application crash
   fi
@@ -169,7 +169,7 @@ unset_unused_variables() {
 }
 
 configure_database_connection_url() {
-  echo "Configuring database connection URL"
+  tlog "Configuring database connection URL"
   isPostgresUrl=0
   isMongoUrl=0
   # Check if APPSMITH_DB_URL is not set
@@ -186,17 +186,17 @@ configure_database_connection_url() {
 }
 
 check_db_uri() {
-  echo "Checking APPSMITH_DB_URL"
+  tlog "Checking APPSMITH_DB_URL"
   isUriLocal=1
   if [[ $APPSMITH_DB_URL == *"localhost"* || $APPSMITH_DB_URL == *"127.0.0.1"* ]]; then
-    echo "Detected local DB"
+    tlog "Detected local DB"
     isUriLocal=0
   fi
 }
 
 init_mongodb() {
   if [[ $isUriLocal -eq 0 ]]; then
-    echo "Initializing local database"
+    tlog "Initializing local database"
     MONGO_DB_PATH="$stacks_path/data/mongodb"
     MONGO_LOG_PATH="$MONGO_DB_PATH/log"
     MONGO_DB_KEY="$MONGO_DB_PATH/key"
@@ -213,7 +213,7 @@ init_mongodb() {
 }
 
 init_replica_set() {
-  echo "Checking initialized database"
+  tlog "Checking initialized database"
   shouldPerformInitdb=1
   for path in \
     "$MONGO_DB_PATH/WiredTiger" \
@@ -227,21 +227,21 @@ init_replica_set() {
   done
 
   if [[ $isUriLocal -gt 0 && -f /proc/cpuinfo ]] && ! grep --quiet avx /proc/cpuinfo; then
-    echo "====================================================================================================" >&2
-    echo "==" >&2
-    echo "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
-    echo "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
-    echo "==" >&2
-    echo "====================================================================================================" >&2
+    tlog "====================================================================================================" >&2
+    tlog "==" >&2
+    tlog "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
+    tlog "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
+    tlog "==" >&2
+    tlog "====================================================================================================" >&2
   fi
 
   if [[ $shouldPerformInitdb -gt 0 && $isUriLocal -eq 0 ]]; then
-    echo "Initializing Replica Set for local database"
+    tlog "Initializing Replica Set for local database"
     # Start installed MongoDB service - Dependencies Layer
     mongod --fork --port 27017 --dbpath "$MONGO_DB_PATH" --logpath "$MONGO_LOG_PATH"
-    echo "Waiting 10s for MongoDB to start"
+    tlog "Waiting 10s for MongoDB to start"
     sleep 10
-    echo "Creating MongoDB user"
+    tlog "Creating MongoDB user"
     mongosh "127.0.0.1/appsmith" --eval "db.createUser({
         user: '$APPSMITH_MONGODB_USER',
         pwd: '$APPSMITH_MONGODB_PASSWORD',
@@ -251,20 +251,20 @@ init_replica_set() {
         }, 'readWrite']
       }
     )"
-    echo "Enabling Replica Set"
+    tlog "Enabling Replica Set"
     mongod --dbpath "$MONGO_DB_PATH" --shutdown || true
     mongod --fork --port 27017 --dbpath "$MONGO_DB_PATH" --logpath "$MONGO_LOG_PATH" --replSet mr1 --keyFile "$MONGODB_TMP_KEY_PATH" --bind_ip localhost
-    echo "Waiting 10s for MongoDB to start with Replica Set"
+    tlog "Waiting 10s for MongoDB to start with Replica Set"
     sleep 10
     mongosh "$APPSMITH_DB_URL" --eval 'rs.initiate()'
     mongod --dbpath "$MONGO_DB_PATH" --shutdown || true
   fi
 
   if [[ $isUriLocal -gt 0 ]]; then
-    echo "Checking Replica Set of external MongoDB"
+    tlog "Checking Replica Set of external MongoDB"
 
     if appsmithctl check-replica-set; then
-      echo "MongoDB ReplicaSet is enabled"
+      tlog "MongoDB ReplicaSet is enabled"
     else
       echo -e "\033[0;31m***************************************************************************************\033[0m"
       echo -e "\033[0;31m*      MongoDB Replica Set is not enabled                                             *\033[0m"
@@ -301,7 +301,7 @@ check_setup_custom_ca_certificates() {
       if is_empty_directory "$container_ca_certs_path"; then
         rmdir -v "$container_ca_certs_path"
       else
-        echo "The 'ca-certificates' directory inside the container is not empty. Please clear it and restart to use certs from 'stacks/ca-certs' directory." >&2
+        tlog "The 'ca-certificates' directory inside the container is not empty. Please clear it and restart to use certs from 'stacks/ca-certs' directory." >&2
         return
       fi
     fi
@@ -325,11 +325,11 @@ setup-custom-ca-certificates() (
   rm -f "$store" "$opts_file"
 
   if [[ -n "$(ls "$stacks_ca_certs_path"/*.pem 2>/dev/null)" ]]; then
-    echo "Looks like you have some '.pem' files in your 'ca-certs' folder. Please rename them to '.crt' to be picked up automatically.".
+    tlog "Looks like you have some '.pem' files in your 'ca-certs' folder. Please rename them to '.crt' to be picked up automatically.".
   fi
 
   if ! [[ -d "$stacks_ca_certs_path" && "$(find "$stacks_ca_certs_path" -maxdepth 1 -type f -name '*.crt' | wc -l)" -gt 0 ]]; then
-    echo "No custom CA certificates found."
+    tlog "No custom CA certificates found."
     return
   fi
 
@@ -389,7 +389,7 @@ check_redis_compatible_page_size() {
       --data '{ "userId": "'"$HOSTNAME"'", "event":"RedisCompile" }' \
       https://api.segment.io/v1/track \
       || true
-    echo "Compile Redis stable with page size of $page_size"
+    tlog "Compile Redis stable with page size of $page_size"
     apt-get update
     apt-get install --yes build-essential
     curl --connect-timeout 5 --location https://download.redis.io/redis-stable.tar.gz | tar -xz -C /tmp
@@ -399,15 +399,14 @@ check_redis_compatible_page_size() {
     popd
     rm -rf /tmp/redis-stable
   else
-    echo "Redis is compatible with page size of $page_size"
+    tlog "Redis is compatible with page size of $page_size"
   fi
 }
 
 init_postgres() {
   # Initialize embedded postgres by default; set APPSMITH_ENABLE_EMBEDDED_DB to 0, to use existing cloud postgres mockdb instance
   if [[ ${APPSMITH_ENABLE_EMBEDDED_DB: -1} != 0 ]]; then
-    echo ""
-    echo "Checking initialized local postgres"
+    tlog "Checking initialized local postgres"
     POSTGRES_DB_PATH="$stacks_path/data/postgres/main"
 
     mkdir -p "$POSTGRES_DB_PATH" "$TMP/pg-runtime"
@@ -416,9 +415,9 @@ init_postgres() {
     chown -R postgres:postgres "$POSTGRES_DB_PATH" "$TMP/pg-runtime"
 
     if [[ -e "$POSTGRES_DB_PATH/PG_VERSION" ]]; then
-      echo "Found existing Postgres, Skipping initialization"
+      tlog "Found existing Postgres, Skipping initialization"
     else
-      echo "Initializing local postgresql database"
+      tlog "Initializing local postgresql database"
       mkdir -p "$POSTGRES_DB_PATH"
 
       # Postgres does not allow it's server to be run with super user access, we use user postgres and the file system owner also needs to be the same user postgres
@@ -510,11 +509,11 @@ check_db_uri
 if [[ -z "${DYNO}" ]]; then
   if [[ $isMongoUrl -eq 1 ]]; then
     # Setup MongoDB and initialize replica set
-    echo "Initializing MongoDB"
+    tlog "Initializing MongoDB"
     init_mongodb
     init_replica_set
   elif [[ $isPostgresUrl -eq 1 ]]; then
-    echo "Initializing Postgres"
+    tlog "Initializing Postgres"
     # init_postgres
   fi
 else

--- a/deploy/docker/fs/opt/bin/tlog
+++ b/deploy/docker/fs/opt/bin/tlog
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Running this with `sh` since it's very tiny, and doesn't need the big bash.
+
+# Printing time in UTC.
+echo "$(date -u +%FT%T.%3NZ)" "$@"


### PR DESCRIPTION
Logs messages from `entrypoint.sh` and the other `run-*.sh` scripts don't show timestamp today, and its getting hard to see the order of things in the logs, especially between different processes.

This PR adds a command `tlog` to print logs with UTC timestamp prefixed. We're only using it in `entrypoint.sh` now, but follow-up PR(s) will add it to the other `run-*` scripts as well.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile to include `/opt/bin` in the `PATH` and modified permissions settings for executable files.

- **Refactor**
  - Enhanced logging in the entrypoint script by replacing `echo` statements with `tlog` for better clarity and debugging.

- **New Features**
  - Introduced `tlog`, a new shell script for consistent and timestamped logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->