### PR TITLE
chore: removing branch protection trigger from git connect flow

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/GitBranchProtect_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/GitBranchProtect_spec.ts
@@ -1,4 +1,3 @@
-import { featureFlagIntercept } from "../../../../../support/Objects/FeatureFlags";
 import * as _ from "../../../../../support/Objects/ObjectsCore";
 import {
   AppSidebar,
@@ -17,17 +16,25 @@ describe("Git Branch Protection", { tags: ["@tag.Git"] }, function () {
       const appName = "GitBranchProtect-2" + uid;
       _.homePage.CreateNewWorkspace(wsName, true);
       _.homePage.CreateAppInWorkspace(wsName, appName);
+      _.gitSync.CreateNConnectToGit("repoprotect", true, true);
       cy.wait(1000);
 
       cy.intercept({
         method: "POST",
         url: /\/api\/v1\/git\/branch\/app\/.*\/protected/,
       }).as("gitProtectApi");
-
-      _.gitSync.CreateNConnectToGit("repoprotect", true, true, false);
       cy.get("@gitRepoName").then((repName) => {
         repoName = repName;
+        _.gitSync.OpenGitSettingsModal();
+        _.agHelper.GetNClick(_.gitSync._settingsTabBranch);
+        _.agHelper.GetNClick(_.gitSync._protectedBranchesSelect);
+        _.agHelper.GetNClick(
+          `${_.gitSync._protectedBranchesSelect} .rc-select-item`,
+          0,
+        );
+        _.agHelper.GetNClick(_.gitSync._branchProtectionUpdateBtn);
         cy.wait("@gitProtectApi").then((res1) => {
+          _.agHelper.GetNClick(_.gitSync._closeGitSettingsModal);
           expect(res1.response).to.have.property("statusCode", 200);
           _.agHelper.AssertElementVisibility(
             AppSidebar.locators.sidebar,

--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/RepoLimitExceededErrorModal_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/RepoLimitExceededErrorModal_spec.js
@@ -32,26 +32,26 @@ describe(
       homePage.NavigateToHome();
       homePage.CreateNewApplication();
       onboarding.closeIntroModal();
-      gitSync.CreateNConnectToGit(repoName1, true, true, false);
+      gitSync.CreateNConnectToGit(repoName1, true, true);
       cy.get("@gitRepoName").then((repName) => {
         repoName1 = repName;
       });
       homePage.NavigateToHome();
       homePage.CreateNewApplication();
       onboarding.closeIntroModal();
-      gitSync.CreateNConnectToGit(repoName2, true, true, false);
+      gitSync.CreateNConnectToGit(repoName2, true, true);
       cy.get("@gitRepoName").then((repName) => {
         repoName2 = repName;
       });
       homePage.NavigateToHome();
       homePage.CreateNewApplication();
-      gitSync.CreateNConnectToGit(repoName3, true, true, false);
+      gitSync.CreateNConnectToGit(repoName3, true, true);
       cy.get("@gitRepoName").then((repName) => {
         repoName3 = repName;
       });
       homePage.NavigateToHome();
       homePage.CreateNewApplication();
-      gitSync.CreateNConnectToGit(repoName4, false, true, false);
+      gitSync.CreateNConnectToGit(repoName4, false, true);
       cy.get("@gitRepoName").then((repName) => {
         repoName4 = repName;
       });

--- a/app/client/cypress/support/Pages/GitSync.ts
+++ b/app/client/cypress/support/Pages/GitSync.ts
@@ -12,7 +12,7 @@ export class GitSync {
   public _gitSyncModal = "[data-testid=t--git-sync-modal]";
   private _closeGitSyncModal =
     "//div[@data-testid='t--git-sync-modal']//button[@aria-label='Close']";
-  private _closeGitSettingsModal =
+  public _closeGitSettingsModal =
     "//div[@data-testid='t--git-settings-modal']//button[@aria-label='Close']";
   //private _closeGitSyncModal = ".ads-v2-modal__content-header-close-button";
   private _gitRepoInput =
@@ -118,7 +118,6 @@ export class GitSync {
     repoName = "Repo",
     assertConnect = true,
     privateFlag = false,
-    removeDefaultBranchProtection = true,
   ) {
     this.agHelper.GenerateUUID();
     cy.get("@guid").then((uid) => {
@@ -179,19 +178,6 @@ export class GitSync {
         this.assertHelper.AssertNetworkStatus("@connectGitLocalRepo");
         this.agHelper.GetNClick(this.startUsingGitButton);
         this.agHelper.AssertElementExist(this._bottomBarCommit, 0, 30000);
-      }
-
-      if (removeDefaultBranchProtection) {
-        cy.wait([`@protected-${repoName}`, `@branches-${repoName}`]).then(
-          (interceptions) => {
-            if (
-              interceptions[0]?.response?.statusCode === 200 &&
-              interceptions[1]?.response?.statusCode === 200
-            ) {
-              this.clearBranchProtection();
-            }
-          },
-        );
       }
 
       cy.wrap(repoName).as("gitRepoName");

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -115,7 +115,7 @@
     "d3-geo": "^3.1.0",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",
-    "design-system": "npm:@appsmithorg/design-system@2.1.41",
+    "design-system": "npm:@appsmithorg/design-system@2.1.42",
     "design-system-old": "npm:@appsmithorg/design-system-old@1.1.17",
     "downloadjs": "^1.4.7",
     "echarts": "^5.4.2",

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1138,6 +1138,8 @@ export const GIT_CONNECT_SUCCESS_PROTECTION_MSG = () =>
   "We recommend protecting your default branch to have a seamless collaboration.";
 export const GIT_CONNECT_SUCCESS_REPO_NAME = () => "Repository name";
 export const GIT_CONNECT_SUCCESS_DEFAULT_BRANCH = () => "Default branch";
+export const GIT_CONNECT_SUCCESS_DEFAULT_BRANCH_TOOLTIP = () =>
+  "This is the base branch of the app. Users launching the app from the dashboard will see the deployed version from this branch.";
 export const GIT_CONNECT_SUCCESS_PROTECTION_DOC_CTA = () =>
   "Learn more about branch protection";
 // Git Connection Success end

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1066,12 +1066,6 @@ export const HOW_TO_ADD_DEPLOY_KEY = () =>
 export const CONSENT_ADDED_DEPLOY_KEY = () =>
   "I've added the deploy key and gave it write access";
 export const PREVIOUS_STEP = () => "Previous step";
-export const GIT_CONNECT_SUCCESS_TITLE = () =>
-  "Successfully connected to your Git remote repository";
-export const GIT_CONNECT_SUCCESS_MESSAGE = () =>
-  "Now you can start collaborating with your team members by committing, merging and deploying your app";
-export const START_USING_GIT = () => "Start using Git";
-export const OPEN_GIT_SETTINGS = () => "Open Git settings";
 export const GIT_AUTHOR = () => "Git author";
 export const DISCONNECT_GIT = () => "Disconnect Git";
 export const DISCONNECT_GIT_MESSAGE = () =>
@@ -1114,16 +1108,6 @@ export const DEFAULT_BRANCH_DESC = () =>
 export const BRANCH_PROTECTION = () => "Branch protection";
 export const BRANCH_PROTECTION_DESC = () =>
   "Protected branches enable you to enforce Git workflows. Changes to the app are not allowed in the protected branches.";
-export const BRANCH_PROTECTION_RULES_AS_FOLLOWS = () =>
-  "Branch protection rules follow as,";
-export const BRANCH_PROTECTION_RULE_1 = () =>
-  "Commit and merge are not allowed.";
-export const BRANCH_PROTECTION_RULE_2 = () =>
-  "Users can’t create or edit queries, widgets, and JS Objects.";
-export const BRANCH_PROTECTION_RULE_3 = () =>
-  "You can still pull the latest changes and create new branches to edit the app.";
-export const BRANCH_PROTECTION_CHANGE_RULE = () =>
-  "You can remove protection on your default branch in Git settings.";
 export const GO_TO_SETTINGS = () => "Go to settings";
 export const NOW_PROTECT_BRANCH = () =>
   "You can now protect your default branch.";
@@ -1141,8 +1125,22 @@ export const BRANCH_PROTECTION_CALLOUT_UNPROTECT = () => "Unprotect branch";
 export const BRANCH_PROTECTION_CALLOUT_UNPROTECT_LOADING = () =>
   "Unprotecting branch ...";
 export const BRANCH_PROTECTION_PROTECTED = () => "Protected";
-
 // Git Branch Protection end
+
+// Git Connection Success
+export const GIT_CONNECT_SUCCESS_TITLE = () => "Successfully connected to Git";
+export const GIT_CONNECT_SUCCESS_MESSAGE = () =>
+  "Now you can start collaborating with your team members by committing, merging and deploying your app";
+export const GIT_CONNECT_SUCCESS_ACTION_CONTINUE = () =>
+  "Continue to edit application";
+export const GIT_CONNECT_SUCCESS_ACTION_SETTINGS = () => "Protect your branch";
+export const GIT_CONNECT_SUCCESS_PROTECTION_MSG = () =>
+  "We recommend protecting your default branch to have a seamless collaboration.";
+export const GIT_CONNECT_SUCCESS_REPO_NAME = () => "Repository name";
+export const GIT_CONNECT_SUCCESS_DEFAULT_BRANCH = () => "Default branch";
+export const GIT_CONNECT_SUCCESS_PROTECTION_DOC_CTA = () =>
+  "Learn more about branch protection";
+// Git Connection Success end
 
 export const GENERAL = () => "General";
 export const BRANCH = () => "Branch";

--- a/app/client/src/pages/Editor/IDE/index.tsx
+++ b/app/client/src/pages/Editor/IDE/index.tsx
@@ -13,8 +13,8 @@ import MainPane from "./MainPane";
 import RightPane from "./RightPane";
 import classNames from "classnames";
 import { tailwindLayers } from "constants/Layers";
-import ProtectedCallout from "./ProtectedCallout";
 import { protectedModeSelector } from "selectors/gitSyncSelectors";
+import ProtectedCallout from "./ProtectedCallout";
 
 /**
  * OldName: MainContainer

--- a/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
@@ -12,6 +12,7 @@ import {
   GIT_CONNECT_SUCCESS_PROTECTION_DOC_CTA,
   GIT_CONNECT_SUCCESS_DEFAULT_BRANCH,
   GIT_CONNECT_SUCCESS_REPO_NAME,
+  GIT_CONNECT_SUCCESS_DEFAULT_BRANCH_TOOLTIP,
 } from "@appsmith/constants/messages";
 import {
   Button,
@@ -20,6 +21,7 @@ import {
   ModalFooter,
   Text,
   Link,
+  Tooltip,
 } from "design-system";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -28,8 +30,14 @@ import { getCurrentAppGitMetaData } from "@appsmith/selectors/applicationSelecto
 import AnalyticsUtil from "@appsmith/utils/AnalyticsUtil";
 import { GitSettingsTab } from "reducers/uiReducers/gitSyncReducer";
 import { DOCS_BRANCH_PROTECTION_URL } from "constants/ThirdPartyConstants";
+import { importRemixIcon } from "design-system-old";
 
-const Container = styled.div``;
+const GitRepositoryLineIcon = importRemixIcon(
+  async () => import("remixicon-react/GitRepositoryLineIcon"),
+);
+const GitBranchLineIcon = importRemixIcon(
+  async () => import("remixicon-react/GitBranchLineIcon"),
+);
 
 const TitleContainer = styled.div`
   display: flex;
@@ -78,7 +86,7 @@ function ConnectionSuccessBody() {
       <div className="flex gap-x-4 mb-6">
         <DetailContainer>
           <div className="flex items-center">
-            <Icon className="mr-1" name="file-list-line" size="md" />
+            <GitRepositoryLineIcon className="mr-1" size={18} />
             <Text isBold renderAs="p">
               {createMessage(GIT_CONNECT_SUCCESS_REPO_NAME)}
             </Text>
@@ -87,10 +95,22 @@ function ConnectionSuccessBody() {
         </DetailContainer>
         <DetailContainer>
           <div className="flex items-center">
-            <InlineIcon className="mr-1" name="git-branch" size="md" />
+            <GitBranchLineIcon className="mr-1" size={18} />
             <Text isBold renderAs="p">
               {createMessage(GIT_CONNECT_SUCCESS_DEFAULT_BRANCH)}
             </Text>
+            <Tooltip
+              content={createMessage(
+                GIT_CONNECT_SUCCESS_DEFAULT_BRANCH_TOOLTIP,
+              )}
+              trigger="hover"
+            >
+              <InlineIcon
+                className="ml-1 cursor-pointer"
+                name="info"
+                size="md"
+              />
+            </Tooltip>
           </div>
           <Text renderAs="p">{gitMetadata?.defaultBranchName || "-"}</Text>
         </DetailContainer>
@@ -170,10 +190,8 @@ function ConnectionSuccess() {
   return (
     <>
       <ModalBody data-testid="t--git-success-modal-body">
-        <Container>
-          <ConnectionSuccessTitle />
-          <ConnectionSuccessBody />
-        </Container>
+        <ConnectionSuccessTitle />
+        <ConnectionSuccessBody />
       </ModalBody>
       <ModalFooter>
         <ConnectionSuccessActions />

--- a/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
@@ -4,23 +4,30 @@ import {
   setIsGitSyncModalOpen,
 } from "actions/gitSyncActions";
 import {
-  BRANCH_PROTECTION_CHANGE_RULE,
-  BRANCH_PROTECTION_RULES_AS_FOLLOWS,
-  BRANCH_PROTECTION_RULE_1,
-  BRANCH_PROTECTION_RULE_2,
-  BRANCH_PROTECTION_RULE_3,
+  GIT_CONNECT_SUCCESS_PROTECTION_MSG,
   GIT_CONNECT_SUCCESS_TITLE,
-  OPEN_GIT_SETTINGS,
-  START_USING_GIT,
+  GIT_CONNECT_SUCCESS_ACTION_SETTINGS,
+  GIT_CONNECT_SUCCESS_ACTION_CONTINUE,
   createMessage,
+  GIT_CONNECT_SUCCESS_PROTECTION_DOC_CTA,
+  GIT_CONNECT_SUCCESS_DEFAULT_BRANCH,
+  GIT_CONNECT_SUCCESS_REPO_NAME,
 } from "@appsmith/constants/messages";
-import { Button, Icon, ModalBody, ModalFooter, Tag, Text } from "design-system";
+import {
+  Button,
+  Icon,
+  ModalBody,
+  ModalFooter,
+  Text,
+  Link,
+} from "design-system";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import { getCurrentAppGitMetaData } from "@appsmith/selectors/applicationSelectors";
 import AnalyticsUtil from "@appsmith/utils/AnalyticsUtil";
 import { GitSettingsTab } from "reducers/uiReducers/gitSyncReducer";
+import { DOCS_BRANCH_PROTECTION_URL } from "constants/ThirdPartyConstants";
 
 const Container = styled.div``;
 
@@ -35,43 +42,74 @@ const TitleText = styled(Text)`
   font-weight: 600;
 `;
 
-const StyledIcon = styled(Icon)`
-  margin-right: 8px;
-`;
-
-const FeatureList = styled.ul`
-  margin-bottom: 16px;
-`;
-const FeatureItem = styled.li`
-  display: flex;
-  margin-bottom: 4px;
-`;
-
-const FeatureIcon = styled(Icon)`
-  display: inline-flex;
-  align-items: center;
-  margin-right: 4px;
-`;
-
-const BranchTag = styled(Tag)`
+const InlineIcon = styled(Icon)`
   display: inline-flex;
 `;
 
-const DefaultBranchMessage = styled(Text)`
-  margin-bottom: 16px;
+const DetailContainer = styled.div`
+  width: 172px;
 `;
 
-const ProtectionRulesTitle = styled(Text)`
-  margin-bottom: 8px;
+const LinkText = styled(Text)`
+  span {
+    font-weight: 500;
+  }
 `;
 
-const features = [
-  createMessage(BRANCH_PROTECTION_RULE_1),
-  createMessage(BRANCH_PROTECTION_RULE_2),
-  createMessage(BRANCH_PROTECTION_RULE_3),
-];
+function ConnectionSuccessTitle() {
+  return (
+    <TitleContainer>
+      <Icon className="mr-1" color="#059669" name="oval-check" size="lg" />
+      <TitleText
+        data-testid="t--git-success-modal-title"
+        kind="heading-s"
+        renderAs="h3"
+      >
+        {createMessage(GIT_CONNECT_SUCCESS_TITLE)}
+      </TitleText>
+    </TitleContainer>
+  );
+}
 
-function ConnectionSuccess() {
+function ConnectionSuccessBody() {
+  const gitMetadata = useSelector(getCurrentAppGitMetaData);
+  return (
+    <>
+      <div className="flex gap-x-4 mb-6">
+        <DetailContainer>
+          <div className="flex items-center">
+            <Icon className="mr-1" name="file-list-line" size="md" />
+            <Text isBold renderAs="p">
+              {createMessage(GIT_CONNECT_SUCCESS_REPO_NAME)}
+            </Text>
+          </div>
+          <Text renderAs="p">{gitMetadata?.repoName || "-"}</Text>
+        </DetailContainer>
+        <DetailContainer>
+          <div className="flex items-center">
+            <InlineIcon className="mr-1" name="git-branch" size="md" />
+            <Text isBold renderAs="p">
+              {createMessage(GIT_CONNECT_SUCCESS_DEFAULT_BRANCH)}
+            </Text>
+          </div>
+          <Text renderAs="p">{gitMetadata?.defaultBranchName || "-"}</Text>
+        </DetailContainer>
+      </div>
+      <div className="mb-1">
+        <Text renderAs="p">
+          {createMessage(GIT_CONNECT_SUCCESS_PROTECTION_MSG)}
+        </Text>
+      </div>
+      <LinkText isBold renderAs="p">
+        <Link href={DOCS_BRANCH_PROTECTION_URL}>
+          {createMessage(GIT_CONNECT_SUCCESS_PROTECTION_DOC_CTA)}
+        </Link>
+      </LinkText>
+    </>
+  );
+}
+
+function ConnectionSuccessActions() {
   const gitMetadata = useSelector(getCurrentAppGitMetaData);
   const dispatch = useDispatch();
 
@@ -99,7 +137,7 @@ function ConnectionSuccess() {
     dispatch(
       setGitSettingsModalOpenAction({
         open: true,
-        tab: GitSettingsTab.GENERAL,
+        tab: GitSettingsTab.BRANCH,
       }),
     );
     AnalyticsUtil.logEvent("GS_OPEN_GIT_SETTINGS", {
@@ -107,76 +145,39 @@ function ConnectionSuccess() {
     });
   };
 
-  const branchProtectionContent = () => {
-    return (
-      <>
-        <DefaultBranchMessage renderAs="p">
-          Right now,{" "}
-          <BranchTag isClosable={false}>
-            {gitMetadata?.defaultBranchName}
-          </BranchTag>{" "}
-          is set as the default branch and it is protected.
-        </DefaultBranchMessage>
-        <ProtectionRulesTitle renderAs="p">
-          {createMessage(BRANCH_PROTECTION_RULES_AS_FOLLOWS)}
-        </ProtectionRulesTitle>
-        <FeatureList>
-          {features.map((feature) => (
-            <FeatureItem key={feature}>
-              <FeatureIcon
-                color="var(--ads-v2-color-blue-600)"
-                name="oval-check"
-                size="md"
-              />
-              <Text>{feature}</Text>
-            </FeatureItem>
-          ))}
-        </FeatureList>
-        <Text>{createMessage(BRANCH_PROTECTION_CHANGE_RULE)}</Text>
-      </>
-    );
-  };
+  return (
+    <>
+      <Button
+        data-testid="t--git-success-modal-open-settings-cta"
+        kind="secondary"
+        onClick={handleOpenSettings}
+        size="md"
+      >
+        {createMessage(GIT_CONNECT_SUCCESS_ACTION_SETTINGS)}
+      </Button>
+      <Button
+        data-testid="t--git-success-modal-start-using-git-cta"
+        onClick={handleStartGit}
+        size="md"
+      >
+        {createMessage(GIT_CONNECT_SUCCESS_ACTION_CONTINUE)}
+      </Button>
+    </>
+  );
+}
 
-  const branchProtectionActions = () => {
-    return (
-      <>
-        <Button
-          data-testid="t--git-success-modal-start-using-git-cta"
-          kind="secondary"
-          onClick={handleStartGit}
-          size="md"
-        >
-          {createMessage(START_USING_GIT)}
-        </Button>
-        <Button
-          data-testid="t--git-success-modal-open-settings-cta"
-          onClick={handleOpenSettings}
-          size="md"
-        >
-          {createMessage(OPEN_GIT_SETTINGS)}
-        </Button>
-      </>
-    );
-  };
-
+function ConnectionSuccess() {
   return (
     <>
       <ModalBody data-testid="t--git-success-modal-body">
         <Container>
-          <TitleContainer>
-            <StyledIcon color="#059669" name="oval-check" size="lg" />
-            <TitleText
-              data-testid="t--git-success-modal-title"
-              kind="heading-s"
-              renderAs="h3"
-            >
-              {createMessage(GIT_CONNECT_SUCCESS_TITLE)}
-            </TitleText>
-          </TitleContainer>
-          {branchProtectionContent()}
+          <ConnectionSuccessTitle />
+          <ConnectionSuccessBody />
         </Container>
       </ModalBody>
-      <ModalFooter>{branchProtectionActions()}</ModalFooter>
+      <ModalFooter>
+        <ConnectionSuccessActions />
+      </ModalFooter>
     </>
   );
 }

--- a/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
@@ -30,32 +30,10 @@ import { getCurrentAppGitMetaData } from "@appsmith/selectors/applicationSelecto
 import AnalyticsUtil from "@appsmith/utils/AnalyticsUtil";
 import { GitSettingsTab } from "reducers/uiReducers/gitSyncReducer";
 import { DOCS_BRANCH_PROTECTION_URL } from "constants/ThirdPartyConstants";
-import { importRemixIcon } from "design-system-old";
-
-const GitRepositoryLineIcon = importRemixIcon(
-  async () => import("remixicon-react/GitRepositoryLineIcon"),
-);
-const GitBranchLineIcon = importRemixIcon(
-  async () => import("remixicon-react/GitBranchLineIcon"),
-);
-
-const TitleContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 16px;
-`;
 
 const TitleText = styled(Text)`
   flex: 1;
   font-weight: 600;
-`;
-
-const InlineIcon = styled(Icon)`
-  display: inline-flex;
-`;
-
-const DetailContainer = styled.div`
-  width: 172px;
 `;
 
 const LinkText = styled(Text)`
@@ -66,7 +44,7 @@ const LinkText = styled(Text)`
 
 function ConnectionSuccessTitle() {
   return (
-    <TitleContainer>
+    <div className="flex items-center mb-4">
       <Icon className="mr-1" color="#059669" name="oval-check" size="lg" />
       <TitleText
         data-testid="t--git-success-modal-title"
@@ -75,7 +53,7 @@ function ConnectionSuccessTitle() {
       >
         {createMessage(GIT_CONNECT_SUCCESS_TITLE)}
       </TitleText>
-    </TitleContainer>
+    </div>
   );
 }
 
@@ -84,18 +62,18 @@ function ConnectionSuccessBody() {
   return (
     <>
       <div className="flex gap-x-4 mb-6">
-        <DetailContainer>
+        <div className="w-44">
           <div className="flex items-center">
-            <GitRepositoryLineIcon className="mr-1" size={18} />
+            <Icon className="mr-1" name="git-repository" size="md" />
             <Text isBold renderAs="p">
               {createMessage(GIT_CONNECT_SUCCESS_REPO_NAME)}
             </Text>
           </div>
           <Text renderAs="p">{gitMetadata?.repoName || "-"}</Text>
-        </DetailContainer>
-        <DetailContainer>
+        </div>
+        <div className="w-44">
           <div className="flex items-center">
-            <GitBranchLineIcon className="mr-1" size={18} />
+            <Icon className="mr-1" name="git-branch" size="md" />
             <Text isBold renderAs="p">
               {createMessage(GIT_CONNECT_SUCCESS_DEFAULT_BRANCH)}
             </Text>
@@ -105,15 +83,15 @@ function ConnectionSuccessBody() {
               )}
               trigger="hover"
             >
-              <InlineIcon
-                className="ml-1 cursor-pointer"
+              <Icon
+                className="inline-fix ml-1 cursor-pointer"
                 name="info"
                 size="md"
               />
             </Tooltip>
           </div>
           <Text renderAs="p">{gitMetadata?.defaultBranchName || "-"}</Text>
-        </DetailContainer>
+        </div>
       </div>
       <div className="mb-1">
         <Text renderAs="p">

--- a/app/client/src/pages/Editor/gitSync/Tabs/__tests__/ConnectionSuccess.test.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/__tests__/ConnectionSuccess.test.tsx
@@ -51,7 +51,7 @@ describe("Connection Success Modal", () => {
     expect(getByTestId("t--git-success-modal-open-settings-cta")).toBeTruthy();
   });
 
-  it("go to settings cta button is working", () => {
+  it("'Settings' cta button is working", () => {
     const store = mockStore(initialState);
     const { queryByTestId } = render(
       <Provider store={store}>
@@ -68,11 +68,11 @@ describe("Connection Success Modal", () => {
     });
     expect(dispatch).toHaveBeenNthCalledWith(4, {
       type: ReduxActionTypes.GIT_SET_SETTINGS_MODAL_OPEN,
-      payload: { open: true, tab: GitSettingsTab.GENERAL },
+      payload: { open: true, tab: GitSettingsTab.BRANCH },
     });
   });
 
-  it("start using git cta button is working", () => {
+  it("'Continue' cta button is working", () => {
     const store = mockStore(initialState);
     const { queryByTestId } = render(
       <Provider store={store}>

--- a/app/client/src/pages/Editor/gitSync/Tabs/__tests__/ConnectionSuccess.test.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/__tests__/ConnectionSuccess.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { GitSettingsTab } from "reducers/uiReducers/gitSyncReducer";
+import { BrowserRouter } from "react-router-dom";
 
 const initialState = {
   ui: {
@@ -36,14 +37,20 @@ jest.mock("react-redux", () => {
   };
 });
 
-describe("Connection Success Modal", () => {
-  it("is rendered properly", () => {
-    const store = mockStore(initialState);
-    const { getByTestId } = render(
+const renderComponent = () => {
+  const store = mockStore(initialState);
+  return render(
+    <BrowserRouter>
       <Provider store={store}>
         <ConnectionSuccess />
-      </Provider>,
-    );
+      </Provider>
+    </BrowserRouter>,
+  );
+};
+
+describe("Connection Success Modal", () => {
+  it("is rendered properly", () => {
+    const { getByTestId } = renderComponent();
     expect(getByTestId("t--git-success-modal-body")).toBeTruthy();
     expect(
       getByTestId("t--git-success-modal-start-using-git-cta"),
@@ -52,12 +59,7 @@ describe("Connection Success Modal", () => {
   });
 
   it("'Settings' cta button is working", () => {
-    const store = mockStore(initialState);
-    const { queryByTestId } = render(
-      <Provider store={store}>
-        <ConnectionSuccess />
-      </Provider>,
-    );
+    const { queryByTestId } = renderComponent();
     expect(dispatch).toHaveBeenNthCalledWith(1, {
       type: ReduxActionTypes.FETCH_BRANCHES_INIT,
     });
@@ -73,12 +75,7 @@ describe("Connection Success Modal", () => {
   });
 
   it("'Continue' cta button is working", () => {
-    const store = mockStore(initialState);
-    const { queryByTestId } = render(
-      <Provider store={store}>
-        <ConnectionSuccess />
-      </Provider>,
-    );
+    const { queryByTestId } = renderComponent();
     expect(dispatch).toHaveBeenNthCalledWith(1, {
       type: ReduxActionTypes.FETCH_BRANCHES_INIT,
     });

--- a/app/client/src/sagas/GitSyncSagas.ts
+++ b/app/client/src/sagas/GitSyncSagas.ts
@@ -37,7 +37,6 @@ import type {
 } from "actions/gitSyncActions";
 import {
   fetchGitProtectedBranchesInit,
-  updateGitProtectedBranchesInit,
   clearCommitSuccessfulState,
   setShowBranchPopupAction,
 } from "actions/gitSyncActions";
@@ -227,13 +226,6 @@ function* connectToGitSaga(action: ConnectToGitReduxAction) {
     if (isValidResponse) {
       // @ts-expect-error: response is of type unknown
       yield put(connectToGitSuccess(response?.data));
-      const defaultBranch = response?.data?.gitApplicationMetadata?.branchName;
-
-      yield put(
-        updateGitProtectedBranchesInit({
-          protectedBranches: defaultBranch ? [defaultBranch] : [],
-        }),
-      );
 
       yield put(fetchPage(currentPageId));
       if (action.onSuccessCallback) {

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -13214,7 +13214,7 @@ __metadata:
     d3-geo: ^3.1.0
     dayjs: ^1.10.6
     deep-diff: ^1.0.2
-    design-system: "npm:@appsmithorg/design-system@2.1.41"
+    design-system: "npm:@appsmithorg/design-system@2.1.42"
     design-system-old: "npm:@appsmithorg/design-system-old@1.1.17"
     diff: ^5.0.0
     dotenv: ^8.1.0
@@ -17270,9 +17270,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"design-system@npm:@appsmithorg/design-system@2.1.41":
-  version: 2.1.41
-  resolution: "@appsmithorg/design-system@npm:2.1.41"
+"design-system@npm:@appsmithorg/design-system@2.1.42":
+  version: 2.1.42
+  resolution: "@appsmithorg/design-system@npm:2.1.42"
   dependencies:
     "@radix-ui/react-dialog": ^1.0.2
     "@radix-ui/react-dropdown-menu": ^2.0.4
@@ -17304,7 +17304,7 @@ __metadata:
     react-dom: ^17.0.2
     react-router-dom: ^5.0.0
     styled-components: ^5.3.6
-  checksum: 43dd163bc993945b4376a96c04ab5c2a4752474fcc98dd4c911981d21f78a03742243d4f05fbc2e51c5e04639053972f6305f6078a3e0b452a5b206b9a8a5a72
+  checksum: 8857c67e9e1476c50c2b1cf3be5080ad9cbfeaccc709ed21c43e7a0756e93cdc4cfac23d53151bca7553d48238695986f2aa9fd735876f82a59e9dbf557e9cd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
1. Remove branch protection trigger from git connect saga
2. Updating test-cases and removed logic for removing branch protection after git connect


Fixes https://github.com/appsmithorg/appsmith/issues/34059

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9498573284>
> Commit: 6ef7f8bc0bfbe15880857fff1f6262c9e9b5ef4a
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9498573284&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->
















## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Git branch protection interactions in test scenarios.

- **New Features**
  - Enhanced Git connection success messages and actions.

- **Improvements**
  - Reordered import statements for better code organization.
  - Adjusted visibility of methods and refactored parameters in Git synchronization.

- **Dependencies**
  - Updated `design-system` dependency to version `2.1.42`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->