### PR TITLE
chore: hide form settings in button widget

### DIFF
--- a/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
@@ -118,32 +118,4 @@ export const propertyPaneContentConfig = [
       },
     ],
   },
-  // TODO: refactor widgetParentProps implementation when we address #10659
-  {
-    sectionName: "Form settings",
-    children: [
-      {
-        helpText:
-          "Disabled if the form is invalid, if this widget exists directly within a Form widget.",
-        propertyName: "disabledWhenInvalid",
-        label: "Disabled invalid forms",
-        controlType: "SWITCH",
-        isJSConvertible: true,
-        isBindProperty: true,
-        isTriggerProperty: false,
-        validation: { type: ValidationTypes.BOOLEAN },
-      },
-      {
-        helpText:
-          "Resets the fields of the form, on click, if this widget exists directly within a Form widget.",
-        propertyName: "resetFormOnClick",
-        label: "Reset form on success",
-        controlType: "SWITCH",
-        isJSConvertible: true,
-        isBindProperty: true,
-        isTriggerProperty: false,
-        validation: { type: ValidationTypes.BOOLEAN },
-      },
-    ],
-  },
 ];

--- a/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
@@ -118,35 +118,4 @@ export const propertyPaneContentConfig = [
       },
     ],
   },
-  // TODO: refactor widgetParentProps implementation when we address #10659
-  {
-    sectionName: "Form settings",
-    hidden: () => {
-      return true;
-    },
-    children: [
-      {
-        helpText:
-          "Disabled if the form is invalid, if this widget exists directly within a Form widget.",
-        propertyName: "disabledWhenInvalid",
-        label: "Disabled invalid forms",
-        controlType: "SWITCH",
-        isJSConvertible: true,
-        isBindProperty: true,
-        isTriggerProperty: false,
-        validation: { type: ValidationTypes.BOOLEAN },
-      },
-      {
-        helpText:
-          "Resets the fields of the form, on click, if this widget exists directly within a Form widget.",
-        propertyName: "resetFormOnClick",
-        label: "Reset form on success",
-        controlType: "SWITCH",
-        isJSConvertible: true,
-        isBindProperty: true,
-        isTriggerProperty: false,
-        validation: { type: ValidationTypes.BOOLEAN },
-      },
-    ],
-  },
 ];

--- a/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
@@ -118,4 +118,35 @@ export const propertyPaneContentConfig = [
       },
     ],
   },
+  // TODO: refactor widgetParentProps implementation when we address #10659
+  {
+    sectionName: "Form settings",
+    hidden: () => {
+      return true;
+    },
+    children: [
+      {
+        helpText:
+          "Disabled if the form is invalid, if this widget exists directly within a Form widget.",
+        propertyName: "disabledWhenInvalid",
+        label: "Disabled invalid forms",
+        controlType: "SWITCH",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: { type: ValidationTypes.BOOLEAN },
+      },
+      {
+        helpText:
+          "Resets the fields of the form, on click, if this widget exists directly within a Form widget.",
+        propertyName: "resetFormOnClick",
+        label: "Reset form on success",
+        controlType: "SWITCH",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: { type: ValidationTypes.BOOLEAN },
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Fixes #33935

/ok-to-test tags="@tag.Anvil"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed form settings section from the property pane configuration to streamline settings management.

<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9460604238>
> Commit: f75662e62726b06e8627ba4f5c5f43da8ee89419
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9460604238&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

