### PR TITLE
chore: fix Read only widget incorrectly triggers configured actions that are hidden because of the toggle

### DIFF
--- a/app/client/src/widgets/wds/WDSInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSInputWidget/widget/index.tsx
@@ -83,6 +83,8 @@ class WDSInputWidget extends WDSBaseInputWidget<InputWidgetProps, WidgetState> {
   }
 
   onFocusChange = (focusState: boolean) => {
+    if (this.props.isReadOnly) return;
+
     if (focusState) {
       this.props.updateWidgetMetaProperty("isFocused", focusState, {
         triggerPropertyName: "onFocus",


### PR DESCRIPTION
Fixes #34000

/ok-to-test tags="@tag.Anvil"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9460620209>
> Commit: fd17eacb6f9edee8905fb5cf1054b56822f2c3cd
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9460620209&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

