### PR TITLE
chore: Fix Currency widget fails to display it's default value

### DIFF
--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
@@ -110,13 +110,13 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
   static getDerivedPropertiesMap() {
     return {
       isValid: `{{(()=>{${derivedProperties.isValid}})()}}`,
-      rawText: `{{(()=>{${derivedProperties.value}})()}}`,
     };
   }
 
   static getMetaPropertiesMap(): Record<string, any> {
     return _.merge(super.getMetaPropertiesMap(), {
-      text: undefined,
+      rawText: "",
+      parsedText: "",
       currencyCode: undefined,
     });
   }
@@ -124,6 +124,8 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
   static getDefaultPropertiesMap(): Record<string, string> {
     return _.merge(super.getDefaultPropertiesMap(), {
       currencyCode: "defaultCurrencyCode",
+      rawText: "defaultText",
+      parsedText: "defaultText",
     });
   }
 


### PR DESCRIPTION
Fixes #34056

/ok-to-test tags="@tag.Anvil"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the currency input widget to include `rawText` and `parsedText` properties for better data handling and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9460624233>
> Commit: 9957e7114a222231912174f00e5c61fd37c80aad
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9460624233&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->

