### PR TITLE
chore: removed constraint on order of execution for consolidated apis

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImpl.java
@@ -216,6 +216,8 @@ public class GitAutoCommitHelperImpl extends GitAutoCommitHelperFallbackImpl imp
                 });
     }
 
+    @Override
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_git_autocommit_feature_enabled)
     public Mono<Boolean> publishAutoCommitEvent(
             AutoCommitTriggerDTO autoCommitTriggerDTO, String defaultApplicationId, String branchName) {
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConsolidatedAPIServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConsolidatedAPIServiceImpl.java
@@ -258,9 +258,8 @@ public class ConsolidatedAPIServiceImpl implements ConsolidatedAPIService {
 
         if (!isBlank(defaultPageId)) {
             /* Get current page */
-            fetches.add(pagesFromCurrentApplicationMonoCached
-                    .then(applicationPageService.getPageAndMigrateDslByBranchAndDefaultPageId(
-                            defaultPageId, branchName, isViewMode, true))
+            fetches.add(applicationPageService
+                    .getPageAndMigrateDslByBranchAndDefaultPageId(defaultPageId, branchName, isViewMode, true)
                     .as(this::toResponseDTO)
                     .doOnSuccess(consolidatedAPIResponseDTO::setPageWithMigratedDsl)
                     .name(getQualifiedSpanName(CURRENT_PAGE_SPAN, mode))


### PR DESCRIPTION
## Description
- In the last implementation of auto-commit we were comparing dslVersion of page dsl object with rts's latest version as a criteria to trigger auto-commit. This check was implemented in the page fetch section of `consolidated api call (page load)` itself. Since page dsls are migrated in the consolidated api, hence we required this check to be executed before the pages of application were migrated. Now that is not the case anymore. hence order of execution for home page load is not a constraint anymore. A removal is in order.

- Added a feature flag annotation with `release_git_autocommit_feature_enabled` to stop feature flag leaks on publisheAutocommitEvent method call.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9448324929>
> Commit: 7f7f88fcd8a761aa9deacdfcb1a93bdc6d5f9900
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9448324929&attempt=2" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
