### PR TITLE
fix: pass correct widgetId for reflow of building blocks

### DIFF
--- a/app/client/src/sagas/BuildingBlockSagas/BuildingBlockAdditionSagas.ts
+++ b/app/client/src/sagas/BuildingBlockSagas/BuildingBlockAdditionSagas.ts
@@ -381,7 +381,10 @@ export function* addAndMoveBuildingBlockToCanvasSaga(
   );
   yield call(
     loadBuildingBlocksIntoApplication,
-    actionPayload.payload.newWidget,
+    {
+      ...actionPayload.payload.newWidget,
+      widgetId: actionPayload.payload.canvasId,
+    },
     skeletonWidget.widgetId,
   );
 }


### PR DESCRIPTION
## Description
**Problem**
When dragging a dropping a building block on the canvas with reflow (i.e when other widgets are moved) the process fails. The building block does not show, the skeleton loader does not go away and an error message is shown.

**Why**
The flow for adding building blocks with reflow does not contain a widgetId in the newWidget object, instead, the payload carries a canvasId parameter.

**Solution**
I have added a check to add the correct value for the widgetId in the flow for dropping building blocks on canvas with reflow.


Fixes #34139 

## Automation

/ok-to-test tags="@tag.Templates"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9448541112>
> Commit: fc8cfe04c784888514f119b0b51b67ea60014910
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9448541112&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the stability of the widget loading process by ensuring the correct widget ID is assigned when adding and moving building blocks to the canvas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->