### PR TITLE
feat: add custom message for empty list widget

### DIFF
--- a/app/client/packages/dsl/src/migrate/helpers/widget-configs.json
+++ b/app/client/packages/dsl/src/migrate/helpers/widget-configs.json
@@ -54297,6 +54297,18 @@
             "validation": {
               "type": "BOOLEAN"
             }
+          },
+          {
+            "propertyName": "emptyMessage",
+            "helpText": "Sets the message for when the list is empty",
+            "placeholderText": "No data to display",
+            "label": "Empty Message",
+            "controlType": "INPUT_TEXT",
+            "isBindProperty": true,
+            "isTriggerProperty": false,
+            "validation": {
+              "type": "TEXT"
+            }
           }
         ]
       }

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
@@ -40,6 +40,7 @@ const DEFAULT_OPTIONS = {
   containerWidgetId: simpleListInput.mainContainerId,
   currTemplateWidgets: simpleListInput.templateWidgets,
   data,
+  emptyMessage: "No data to display",
   itemSpacing: 8,
   infiniteScroll: false,
   levelData: undefined,
@@ -90,7 +91,7 @@ const levelData: LevelData = {
       },
       List6: {
         entityDefinition:
-          "backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,triggeredItem: List6.triggeredItem,selectedItemView: List6.selectedItemView,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize",
+          "backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,emptyMessage: List6.emptyMessage,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,triggeredItem: List6.triggeredItem,selectedItemView: List6.selectedItemView,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize",
         rowIndex: 0,
         metaWidgetId: "fs2d2lqjgd",
         metaWidgetName: "List6",
@@ -741,7 +742,7 @@ describe("#generate", () => {
           },
           List6: {
             entityDefinition:
-              "backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItem: List6.triggeredItem,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize,currentItemsView: List6.currentItemsView",
+              "backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,emptyMessage: List6.emptyMessage,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItem: List6.triggeredItem,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize,currentItemsView: List6.currentItemsView",
             rowIndex: 0,
             metaWidgetId: "fs2d2lqjgd",
             metaWidgetName: "List6",
@@ -891,7 +892,7 @@ describe("#generate", () => {
     const expectedLevel_1 = {
       currentView: {
         List6:
-          "{{{backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,triggeredItem: List6.triggeredItem,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize}}}",
+          "{{{backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,emptyMessage: List6.emptyMessage,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,triggeredItem: List6.triggeredItem,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize}}}",
       },
     };
 
@@ -965,7 +966,7 @@ describe("#generate", () => {
     });
 
     const expectedDataBinding =
-      "{{\n      {\n        \n          Image1: { image: Image1.image,isVisible: Image1.isVisible }\n        ,\n          Text1: { isVisible: Text1.isVisible,text: Text1.text }\n        ,\n          Text2: { isVisible: Text2.isVisible,text: Text2.text }\n        ,\n          List6: { backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItemView: List6.triggeredItemView,items: List6.items,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize,selectedItemIndex: List6.selectedItemIndex,triggeredItemIndex: List6.triggeredItemIndex }\n        \n      }\n    }}";
+      "{{\n      {\n        \n          Image1: { image: Image1.image,isVisible: Image1.isVisible }\n        ,\n          Text1: { isVisible: Text1.isVisible,text: Text1.text }\n        ,\n          Text2: { isVisible: Text2.isVisible,text: Text2.text }\n        ,\n          List6: { backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,emptyMessage: List6.emptyMessage,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItemView: List6.triggeredItemView,items: List6.items,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize,selectedItemIndex: List6.selectedItemIndex,triggeredItemIndex: List6.triggeredItemIndex }\n        \n      }\n    }}";
 
     Object.values(initialResult.metaWidgets).forEach((widget) => {
       if (widget.type === "CONTAINER_WIDGET") {
@@ -1007,7 +1008,7 @@ describe("#generate", () => {
     };
 
     const expectedDataBinding =
-      "{{\n      {\n        \n          Image1: { image: Image1.image,isVisible: Image1.isVisible }\n        ,\n          Text1: { isVisible: Text1.isVisible,text: Text1.text }\n        ,\n          Text2: { isVisible: Text2.isVisible,text: Text2.text }\n        ,\n          List6: { backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItem: List6.triggeredItem,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize,currentItemsView: List6.currentItemsView }\n        \n      }\n    }}";
+      "{{\n      {\n        \n          Image1: { image: Image1.image,isVisible: Image1.isVisible }\n        ,\n          Text1: { isVisible: Text1.isVisible,text: Text1.text }\n        ,\n          Text2: { isVisible: Text2.isVisible,text: Text2.text }\n        ,\n          List6: { backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,emptyMessage: List6.emptyMessage,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItem: List6.triggeredItem,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize,currentItemsView: List6.currentItemsView }\n        \n      }\n    }}";
 
     const count = Object.keys(metaWidgets).length;
     expect(count).toEqual(18);

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -80,6 +80,7 @@ export interface GeneratorOptions {
   prevTemplateWidgets?: TemplateWidgets;
   data: Record<string, unknown>[];
   hooks?: Hooks;
+  emptyMessage?: string;
   itemSpacing: number;
   infiniteScroll: ConstructorProps["infiniteScroll"];
   level?: number;
@@ -223,6 +224,7 @@ class MetaWidgetGenerator {
   private getWidgetCache: ConstructorProps["getWidgetCache"];
   private getWidgetReferenceCache: ConstructorProps["getWidgetReferenceCache"];
   private hooks?: GeneratorOptions["hooks"];
+  private emptyMessage: GeneratorOptions["emptyMessage"];
   private itemSpacing: GeneratorOptions["itemSpacing"];
   private infiniteScroll: ConstructorProps["infiniteScroll"];
   private isListCloned: ConstructorProps["isListCloned"];
@@ -265,6 +267,7 @@ class MetaWidgetGenerator {
     this.data = [];
     this.getWidgetCache = props.getWidgetCache;
     this.getWidgetReferenceCache = props.getWidgetReferenceCache;
+    this.emptyMessage = "";
     this.itemSpacing = 0;
     this.infiniteScroll = props.infiniteScroll;
     this.isListCloned = props.isListCloned;
@@ -302,6 +305,7 @@ class MetaWidgetGenerator {
     this.containerParentId = options.containerParentId;
     this.containerWidgetId = options.containerWidgetId;
     this.data = options.data;
+    this.emptyMessage = options.emptyMessage;
     this.itemSpacing = options.itemSpacing;
     this.infiniteScroll = options.infiniteScroll;
     this.levelData = options.levelData;

--- a/app/client/src/widgets/ListWidgetV2/widget/defaultProps.ts
+++ b/app/client/src/widgets/ListWidgetV2/widget/defaultProps.ts
@@ -85,6 +85,7 @@ export default {
       },
     },
   },
+  emptyMessage: "No data to display",
   itemSpacing: 8,
   templateHeight: 160,
   listData: DEFAULT_LIST_DATA,

--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -247,6 +247,7 @@ class ListWidget extends BaseWidget<
             "https://docs.appsmith.com/widget-reference/how-to-use-widgets",
         },
         isVisible: DefaultAutocompleteDefinitions.isVisible,
+        emptyMessage: DefaultAutocompleteDefinitions.emptyMessage,
         itemSpacing: "number",
         selectedItem: generateTypeDef(widget.selectedItem, extraDefsToDefine),
         selectedItemView: generateTypeDef(
@@ -1391,7 +1392,7 @@ class ListWidget extends BaseWidget<
     ) {
       return (
         <>
-          <ListComponentEmpty>No data to display</ListComponentEmpty>
+          <ListComponentEmpty>{this.props.emptyMessage}</ListComponentEmpty>
           {this.renderPaginationUI()}
         </>
       );
@@ -1443,6 +1444,7 @@ export interface ListWidgetProps<T extends WidgetProps = WidgetProps>
   children?: T[];
   currentItemStructure?: Record<string, string>;
   itemSpacing?: number;
+  emptyMessage?: string;
   infiniteScroll?: boolean;
   level?: number;
   levelData?: LevelData;

--- a/app/client/src/widgets/ListWidgetV2/widget/propertyConfig.test.ts
+++ b/app/client/src/widgets/ListWidgetV2/widget/propertyConfig.test.ts
@@ -3,6 +3,7 @@ import _ from "lodash";
 import {
   defaultSelectedItemValidation,
   primaryColumnValidation,
+  PropertyPaneContentConfig
 } from "./propertyConfig";
 import type { ListWidgetProps } from ".";
 import type { ValidationResponse } from "constants/WidgetValidation";
@@ -311,6 +312,21 @@ describe(".defaultSelectedItemValidation", () => {
       );
 
       expect(output).toEqual(expected(value));
+    }
+  });
+});
+
+describe('.propertyConfig', () => {
+  it('should include emptyMessage property', () => {
+    const config = PropertyPaneContentConfig as Array<{ sectionName: string; children: any[] }>;
+
+    const allChildren = config.flatMap(section => section.children);
+
+    const emptyMessageConfig = allChildren.find((prop: any) => prop.propertyName === 'emptyMessage');
+
+    expect(emptyMessageConfig).toBeDefined();
+    if (emptyMessageConfig) {
+      expect(emptyMessageConfig.controlType).toBe('INPUT_TEXT');
     }
   });
 });

--- a/app/client/src/widgets/ListWidgetV2/widget/propertyConfig.ts
+++ b/app/client/src/widgets/ListWidgetV2/widget/propertyConfig.ts
@@ -413,6 +413,18 @@ export const PropertyPaneContentConfig = [
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
       },
+      {
+        propertyName: "emptyMessage",
+        helpText: "Sets the message for when the list is empty",
+        placeholderText: "No data to display",
+        label: "Empty Message",
+        controlType: "INPUT_TEXT",
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: {
+          type: ValidationTypes.TEXT,
+        },
+      },
     ],
   },
 ];

--- a/app/client/src/widgets/WidgetUtils.ts
+++ b/app/client/src/widgets/WidgetUtils.ts
@@ -76,6 +76,10 @@ export const DefaultAutocompleteDefinitions = {
     "!type": "bool",
     "!doc": "Boolean value indicating if the widget is in visible state",
   },
+  emptyMessage: {
+    "!type": "string",
+    "!doc": "String to display if widget is empty",
+  },
 };
 
 export const hexToRgb = (


### PR DESCRIPTION
## Description
Makes the message that appears when a list is empty customisable.

Fixes: #31293 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `emptyMessage` property to the ListWidgetV2 component to display a message when there is no data.
  
- **Tests**
  - Updated test cases to include the new `emptyMessage` property in the ListWidgetV2 component.

- **Documentation**
  - Added documentation for the `emptyMessage` property in the widget configuration and utility files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->