### PR TITLE
chore: reverted server version number

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaMigration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaMigration.java
@@ -124,9 +124,6 @@ public class JsonSchemaMigration {
             case 6:
                 MigrationHelperMethods.ensureXmlParserPresenceInCustomJsLibList(applicationJson);
                 applicationJson.setServerSchemaVersion(7);
-            case 7:
-                applicationJson.setServerSchemaVersion(8);
-
             default:
                 // Unable to detect the serverSchema
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaVersions.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaVersions.java
@@ -12,6 +12,6 @@ import lombok.Getter;
  */
 @Getter
 public class JsonSchemaVersions {
-    public static final Integer serverVersion = 8;
+    public static final Integer serverVersion = 7;
     public static final Integer clientVersion = 1;
 }


### PR DESCRIPTION
## Description
 - Reverting server version number from 8 to 7, this would mean that even if the feature flag is on, the server won't see any autocommits.

- Following this Pr, after promotion is complete we would go ahead create feature flagging implementation for handling json schema version numbers.

Fixes https://github.com/appsmithorg/appsmith/issues/34157
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9460989464>
> Commit: d6b05f2437c5810d1aa32ad4fb1950a84897e977
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9460989464&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated server schema version from 8 to 7 for improved compatibility.
  - Adjusted migration logic to handle server schema version detection more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->