### PR TITLE
chore: Fix Connect data button is active on preview mode and triggers property pane pop-up

### DIFF
--- a/app/client/src/widgets/wds/WDSTableWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSTableWidget/widget/index.tsx
@@ -961,7 +961,8 @@ export class WDSTableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           showConnectDataOverlay={
             primaryColumns &&
             !Object.keys(primaryColumns).length &&
-            this.props.renderMode === RenderModes.CANVAS
+            this.props.renderMode === RenderModes.CANVAS &&
+            !Boolean(this.props.isPreviewMode)
           }
           sortTableColumn={this.handleColumnSorting}
           tableData={finalTableData}


### PR DESCRIPTION
Fixes #33719

/ok-to-test tags="@tag.Anvil"<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9461238496>
> Commit: a5a79c94a8ce1d5c312c9b87d484974295e5eab2
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9461238496&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the conditional logic for displaying the connect data overlay in the table widget, ensuring it does not show in preview mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->