### PR TITLE
chore: Update ci files for utilising base image on pg branch

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -82,11 +82,9 @@ jobs:
 
       - name: Set base image tag
         id: set_base_tag
-        env:
-          IS_PG_BUILD: ${{ inputs.is-pg-build }}
         run: |
           if [[ "${{ inputs.pr }}" != 0 || "${{ github.ref_name }}" != master ]]; then
-            if [[ $IS_PG_BUILD == 'true' || "${{ github.ref_name }}" == pg ]]; then
+            if [[ ${{ inputs.is-pg-build }} == 'true' || "${{ github.ref_name }}" == pg ]]; then
               base_tag=pg
             else
               base_tag=release

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -9,6 +9,11 @@ on:
         description: "This is the PR number in case the workflow is being called in a pull request"
         required: false
         type: number
+      is-pg-build:
+        description: "This is a boolean value in case the workflow is being called for a PG build"
+        required: false
+        type: string
+        default: "false"
 
 jobs:
   build-docker:
@@ -75,6 +80,23 @@ jobs:
             scripts/generate_info_json.sh
           fi
 
+      - name: Set base image tag
+        id: set_base_tag
+        env:
+          IS_PG_BUILD: ${{ inputs.is-pg-build }}
+        run: |
+          if [[ "${{ inputs.pr }}" != 0 || "${{ github.ref_name }}" != master ]]; then
+            if [[ $IS_PG_BUILD == 'true' || "${{ github.ref_name }}" == pg ]]; then
+              base_tag=pg
+            else
+              base_tag=release
+            fi
+          else
+            base_tag=nightly
+          fi
+          echo "base_tag=$base_tag" >> $GITHUB_OUTPUT
+
+
       # We don't use Depot Docker builds because it's faster for local Docker images to be built locally.
       # It's slower and more expensive to build these Docker images on Depot and download it back to the CI node.
       - name: Build docker image
@@ -83,11 +105,9 @@ jobs:
         run: |
           set -o xtrace
           declare -a args
-          if [[ "${{ inputs.pr }}" != 0 || "${{ github.ref_name }}" != master ]]; then
+          base_tag=${{ steps.set_base_tag.outputs.base_tag }}
+          if [[ base_tag != 'nightly' ]]; then
             args+=(--build-arg "APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com")
-            base_tag=release
-          else
-            base_tag=nightly
           fi
           args+=(--build-arg "BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:$base_tag")
           docker build -t cicontainer "${args[@]}" .

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -30,6 +30,7 @@ jobs:
     with:
       pr: ${{ github.event.client_payload.pull_request.number }}
       skip-tests: ${{ github.event.client_payload.slash_command.args.named.skip-tests }}
+      is-pg-build: ${{ github.event.client_payload.pull_request.base.ref == 'pg' }}
 
   client-build:
     name: client-build
@@ -175,6 +176,16 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Set base image tag
+        id: set_base_tag
+        run: |
+          if [[ ${{ github.event.client_payload.pull_request.base.ref }} == 'pg' ]]; then
+            base_tag=pg
+          else
+            base_tag=release
+          fi
+          echo "base_tag=$base_tag" >> $GITHUB_OUTPUT
+
       - name: Push to Docker Hub
         uses: docker/build-push-action@v4
         with:
@@ -186,7 +197,7 @@ jobs:
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp:${{ vars.EDITION }}-${{ github.event.client_payload.pull_request.number }}
           build-args: |
             APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com
-            BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:release
+            BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:${{ steps.set_base_tag.outputs.base_tag }}
 
     outputs:
       imageHash: ${{ vars.EDITION }}-${{ github.event.client_payload.pull_request.number }}

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -197,3 +197,4 @@ jobs:
     with:
       tags: ${{ needs.parse-tags.outputs.tags}}
       matrix: ${{ needs.parse-tags.outputs.matrix}}
+      is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' }}

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -9,6 +9,11 @@ on:
       matrix:
         required: true
         type: string
+      is-pg-build:
+        description: "This is a boolean value in case the workflow is being called for a PG build"
+        required: false
+        type: string
+        default: "false"
 
 jobs:
   server-build:
@@ -19,6 +24,7 @@ jobs:
     with:
       pr: ${{ github.event.number }}
       skip-tests: true
+      is-pg-build: ${{ inputs.is-pg-build }}
 
   client-build:
     if: success()
@@ -53,6 +59,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{ github.event.number }}
+      is-pg-build: ${{ inputs.is-pg-build }}
 
   ci-test:
     needs: [build-docker-image]

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -141,6 +141,7 @@ jobs:
       - name: Conditionally start PostgreSQL
         run: |
           if [[ inputs.is-pg-build == 'true' ]]; then
+            echo "Requesting PostgreSQL container to be started for pg specific build."
             docker run --name appsmith-pg -p 5432:5432 -d -e POSTGRES_PASSWORD=password postgres:alpine postgres -N 1500
           fi
 

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Conditionally start PostgreSQL
         run: |
-          if [[ inputs.is-pg-build == 'true' ]]; then
+          if [[ ${{ inputs.is-pg-build }} == 'true' ]]; then
             echo "Requesting PostgreSQL container to be started for pg specific build."
             docker run --name appsmith-pg -p 5432:5432 -d -e POSTGRES_PASSWORD=password postgres:alpine postgres -N 1500
           fi


### PR DESCRIPTION
## Description
Temporary arrangement to consume different base image for `pg` vs `release`, until we upgrade Postgres to v15 on release.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9479342636>
> Commit: 69d29d1657d606d78c5f85aa130cf773eb693d27
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9479342636&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->











## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new input parameter `is-pg-build` to several workflows for better customization of PostgreSQL builds.
  - Enhanced Docker image build processes with dynamic base image tagging based on pull request conditions.

- **Chores**
  - Updated GitHub Actions workflows to improve build automation and conditional logic handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->