### PR TITLE
chore: Remove duplicate default field in JSON

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationPage.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationPage.java
@@ -2,6 +2,7 @@ package com.appsmith.server.domains;
 
 import com.appsmith.external.views.Git;
 import com.appsmith.external.views.Views;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,7 +36,7 @@ public class ApplicationPage {
     @JsonView(Views.Internal.class)
     String defaultPageId;
 
-    @JsonView({Views.Public.class, Views.Export.class})
+    @JsonIgnore
     public boolean isDefault() {
         return Boolean.TRUE.equals(isDefault);
     }


### PR DESCRIPTION
The default boolean is showing up twice when these objects are serialized by Jackson. So today, it shows up twice in JSON HTTP responses:
![shot-2024-06-12-01-10-29@2x](https://github.com/appsmithorg/appsmith/assets/120119/48f6a862-3fe0-4a6a-b13a-5b1d2b82b7da)

But with this PR, we only see one:
![shot-2024-06-12-01-33-04@2x](https://github.com/appsmithorg/appsmith/assets/120119/b5c80f7b-15ea-4927-804b-7b49b5e6ab6c)

On Postgres, since we use Jackson to serialize into database as well, this means that we're saving redundant default field into the database as well. This should fix that as well.

**/test all**

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9476619780>
> Commit: c746454ebd85b5b601e7cbfbb199c7e1efd276a6
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9476619780&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated data handling for application pages to improve performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->