### PR TITLE
fix: Hide params in a toggle for action selector queries

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/Field/FieldConfig.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/Field/FieldConfig.ts
@@ -141,6 +141,7 @@ export const FIELD_CONFIG: AppsmithFunctionConfigType = {
       return objectSetter(value, currentValue, 1);
     },
     view: ViewTypes.TEXT_VIEW,
+    isDefaultOpen: false,
   },
   [FieldType.NAVIGATION_TARGET_FIELD]: {
     label: () => "Target",

--- a/app/client/src/components/editorComponents/ActionCreator/Field/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Field/index.tsx
@@ -54,6 +54,7 @@ export function Field(props: FieldProps) {
   const options = FIELD_CONFIG[fieldType].options(props);
   const toolTip = FIELD_CONFIG[fieldType].toolTip;
   const exampleText = FIELD_CONFIG[fieldType].exampleText;
+  const isDefaultOpen = FIELD_CONFIG[fieldType].isDefaultOpen;
 
   switch (fieldType) {
     case FieldType.ACTION_SELECTOR_FIELD:
@@ -218,6 +219,7 @@ export function Field(props: FieldProps) {
         value: value,
         additionalAutoComplete: props.additionalAutoComplete,
         dataTreePath: props.dataTreePath,
+        isDefaultOpen: isDefaultOpen,
       });
       break;
     case FieldType.CALLBACK_FUNCTION_API_AND_QUERY:

--- a/app/client/src/components/editorComponents/ActionCreator/types.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/types.ts
@@ -57,6 +57,7 @@ export type TextViewProps = ViewProps & {
   additionalAutoComplete?: AdditionalDynamicDataTree;
   toolTip?: string;
   dataTreePath?: string | undefined;
+  isDefaultOpen?: boolean;
 };
 
 export type TabViewProps = Omit<ViewProps, "get" | "set"> & SwitcherProps;
@@ -153,6 +154,7 @@ export interface AppsmithFunctionConfigValues {
   view: ViewType;
   exampleText: string;
   toolTip?: string;
+  isDefaultOpen?: boolean;
 }
 
 export interface AppsmithFunctionConfigType {

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/TextView/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/TextView/index.tsx
@@ -15,6 +15,11 @@ import {
   evaluateActionSelectorField,
 } from "actions/actionSelectorActions";
 import { isFunctionPresent } from "@shared/ast";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleHeader,
+} from "design-system";
 
 export function TextView(props: TextViewProps) {
   const id = useMemo(() => generateReactKey(), []);
@@ -51,8 +56,8 @@ export function TextView(props: TextViewProps) {
   const value = evaluatedCodeValue?.value || codeWithoutMoustache;
 
   return (
-    <FieldWrapper className="text-view">
-      <ControlWrapper isAction key={props.label}>
+    <Collapsible isOpen={props.isDefaultOpen} key={props.label}>
+      <CollapsibleHeader>
         {props.label && (
           <label
             className="!text-gray-600 !text-xs"
@@ -62,28 +67,34 @@ export function TextView(props: TextViewProps) {
             {props.label}
           </label>
         )}
-        <InputText
-          additionalAutocomplete={props.additionalAutoComplete}
-          dataTreePath={props.dataTreePath}
-          enableAI={false}
-          evaluatedValue={value}
-          expected={{
-            type: "string",
-            example: props.exampleText,
-            autocompleteDataType: AutocompleteDataType.STRING,
-            openExampleTextByDefault: true,
-          }}
-          label={props.label}
-          onChange={(event: any) => {
-            if (event.target) {
-              props.set(event.target.value, true);
-            } else {
-              props.set(event, true);
-            }
-          }}
-          value={textValue}
-        />
-      </ControlWrapper>
-    </FieldWrapper>
+      </CollapsibleHeader>
+      <CollapsibleContent>
+        <FieldWrapper className="text-view">
+          <ControlWrapper isAction key={props.label}>
+            <InputText
+              additionalAutocomplete={props.additionalAutoComplete}
+              dataTreePath={props.dataTreePath}
+              enableAI={false}
+              evaluatedValue={value}
+              expected={{
+                type: "string",
+                example: props.exampleText,
+                autocompleteDataType: AutocompleteDataType.STRING,
+                openExampleTextByDefault: true,
+              }}
+              label={props.label}
+              onChange={(event: any) => {
+                if (event.target) {
+                  props.set(event.target.value, true);
+                } else {
+                  props.set(event, true);
+                }
+              }}
+              value={textValue}
+            />
+          </ControlWrapper>
+        </FieldWrapper>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }


### PR DESCRIPTION
## Description
 
**Problem statement:**
The params section has been a source of confusion as seen in user tests, repeatedly. For an optional field and one that is not at all used -- it occupies prominent space in the action selector. We could address this by hiding this section by default when there are no params configured. (This should be in-line with the behaviour of a JS function which does not have any params configured)

https://pasteboard.co/SzHNaENv54iU.png

**Solution:**
This PR solves this problem by collapsing the params section whenever we select a query to execute using action selector, this way we are not confusing new users by providing lots of options in the beginning and users can eventually discover this feature as when they require it.

Before:

https://github.com/appsmithorg/appsmith/assets/30018882/795e26ac-28d0-442c-85f0-93bd661d04b6


After:

https://github.com/appsmithorg/appsmith/assets/30018882/f80a786f-61c5-4635-b6b2-9e036866ead7

Fixes #32872 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS, @tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9477080478>
> Commit: 9ceb88ec1770be4e9a0bb82e4ce23af871565c1d
> Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9477080478&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/ActionExecution/ActionSelector_JsToNonJSMode_2_spec.ts
> <li>cypress/e2e/Regression/ClientSide/ActionExecution/FieldEvaluation_spec.ts
> <li>cypress/e2e/Regression/ClientSide/ActionExecution/NavigateTo_spec.ts
> <li>cypress/e2e/Regression/ClientSide/ActionExecution/PostWindowMessage_spec.ts
> <li>cypress/e2e/Regression/ClientSide/ActionExecution/setInterval_spec.js
> <li>cypress/e2e/Regression/ClientSide/ActionExecution/uiToCode_spec.ts </ol>
> To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
