### PR TITLE
fix: set eval version for workflows artefact 

### DIFF
--- a/app/client/src/ce/api/ApplicationApi.tsx
+++ b/app/client/src/ce/api/ApplicationApi.tsx
@@ -14,8 +14,7 @@ import type {
   LayoutSystemTypes,
 } from "layoutSystems/types";
 import type { BaseAction } from "entities/Action";
-
-export type EvaluationVersion = number;
+import type { EvaluationVersion } from "constants/EvalConstants";
 
 export interface PublishApplicationRequest {
   applicationId: string;

--- a/app/client/src/ce/constants/ReduxActionConstants.tsx
+++ b/app/client/src/ce/constants/ReduxActionConstants.tsx
@@ -3,7 +3,6 @@ import type { Workspace } from "@appsmith/constants/workspaceConstants";
 import type {
   AppEmbedSetting,
   ApplicationPagePayload,
-  EvaluationVersion,
   GitApplicationMetadata,
 } from "@appsmith/api/ApplicationApi";
 import type { ApplicationVersion } from "@appsmith/actions/applicationActions";
@@ -17,6 +16,7 @@ import type { AppLayoutConfig } from "reducers/entityReducers/pageListReducer";
 import type { DSLWidget } from "WidgetProvider/constants";
 import type { LayoutSystemTypeConfig } from "layoutSystems/types";
 import type { AffectedJSObjects } from "sagas/EvaluationsSagaUtils";
+import type { EvaluationVersion } from "constants/EvalConstants";
 
 export const ReduxSagaChannels = {
   WEBSOCKET_APP_LEVEL_WRITE_CHANNEL: "WEBSOCKET_APP_LEVEL_WRITE_CHANNEL",

--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -18,7 +18,7 @@ export interface Workflow {
   tokenGenerated: boolean;
   // Evaluation version of the application. Used to ensure the escape characters are properly evaluated.
   // PR for reference: https://github.com/appsmithorg/appsmith/pull/8796
-  evaluationVersion?: EvaluationVersion;
+  evaluationVersion: EvaluationVersion;
   token?: string;
 }
 

--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -1,4 +1,4 @@
-import type { EvaluationVersion } from "@appsmith/api/ApplicationApi";
+import type { EvaluationVersion } from "constants/EvalConstants";
 
 type ID = string;
 

--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -16,6 +16,8 @@ export interface Workflow {
   slug: string; // Slug of the workflow (Not in use currently).
   mainJsObjectId: string; // ID of the main JS object.
   tokenGenerated: boolean;
+  // Evaluation version of the application. Used to ensure the escape characters are properly evaluated.
+  // PR for reference: https://github.com/appsmithorg/appsmith/pull/8796
   evaluationVersion?: EvaluationVersion;
   token?: string;
 }

--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -1,3 +1,5 @@
+import type { EvaluationVersion } from "@appsmith/api/ApplicationApi";
+
 type ID = string;
 
 // Type for the workflow object.
@@ -14,6 +16,7 @@ export interface Workflow {
   slug: string; // Slug of the workflow (Not in use currently).
   mainJsObjectId: string; // ID of the main JS object.
   tokenGenerated: boolean;
+  evaluationVersion?: EvaluationVersion;
   token?: string;
 }
 

--- a/app/client/src/ce/selectors/applicationSelectors.tsx
+++ b/app/client/src/ce/selectors/applicationSelectors.tsx
@@ -178,7 +178,7 @@ export const getIsDeletingNavigationLogo = (state: AppState) => {
   return state.ui.applications.isDeletingNavigationLogo;
 };
 
-const DEFAULT_EVALUATION_VERSION = 2;
+export const DEFAULT_EVALUATION_VERSION = 2;
 
 export const selectEvaluationVersion = (state: AppState) =>
   state.ui.applications.currentApplication?.evaluationVersion ||

--- a/app/client/src/ce/selectors/applicationSelectors.tsx
+++ b/app/client/src/ce/selectors/applicationSelectors.tsx
@@ -15,6 +15,7 @@ import {
   type ThemeSetting,
   defaultThemeSetting,
 } from "constants/AppConstants";
+import { DEFAULT_EVALUATION_VERSION } from "constants/EvalConstants";
 
 const fuzzySearchOptions = {
   keys: ["applications.name", "workspace.name", "packages.name"],
@@ -177,8 +178,6 @@ export const getIsUploadingNavigationLogo = (state: AppState) => {
 export const getIsDeletingNavigationLogo = (state: AppState) => {
   return state.ui.applications.isDeletingNavigationLogo;
 };
-
-export const DEFAULT_EVALUATION_VERSION = 2;
 
 export const selectEvaluationVersion = (state: AppState) =>
   state.ui.applications.currentApplication?.evaluationVersion ||

--- a/app/client/src/ce/workers/Evaluation/Actions.ts
+++ b/app/client/src/ce/workers/Evaluation/Actions.ts
@@ -8,7 +8,7 @@ import type {
   DataTreeEntity,
 } from "entities/DataTree/dataTreeTypes";
 import type { EvalContext } from "workers/Evaluation/evaluate";
-import type { EvaluationVersion } from "@appsmith/api/ApplicationApi";
+import type { EvaluationVersion } from "constants/EvalConstants";
 import { addFn } from "workers/Evaluation/fns/utils/fnGuard";
 import {
   getEntityFunctions,

--- a/app/client/src/constants/EvalConstants.ts
+++ b/app/client/src/constants/EvalConstants.ts
@@ -1,0 +1,2 @@
+export type EvaluationVersion = number;
+export const DEFAULT_EVALUATION_VERSION: EvaluationVersion = 2;

--- a/app/client/src/ee/configs/index.ts
+++ b/app/client/src/ee/configs/index.ts
@@ -1,5 +1,5 @@
 export * from "ce/configs/index";
-import type { EvaluationVersion } from "@appsmith/api/ApplicationApi";
+import type { EvaluationVersion } from "constants/EvalConstants";
 import type { INJECTED_CONFIGS } from "ce/configs/index";
 
 declare global {

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -70,7 +70,7 @@ import {
 } from "constants/AppsmithActionConstants/ActionConstants";
 import { validate } from "workers/Evaluation/validations";
 import { REPLAY_DELAY } from "entities/Replay/replayUtils";
-import type { EvaluationVersion } from "@appsmith/api/ApplicationApi";
+import type { EvaluationVersion } from "constants/EvalConstants";
 
 import type { LogObject } from "entities/AppsmithConsole";
 import { ENTITY_TYPE } from "@appsmith/entities/AppsmithConsole/utils";


### PR DESCRIPTION
## Description
Eval version 2 is used to properly handle the escape characters like `\n` etc in the eval flow. If not set, it is defaulting to behaviour for eval version 1. This PR introduces the type fixes to allow for eval version to be set via the API. The main change is in the EE PR and this PR is to update the type. 


Fixes #34171 

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9478023950>
> Commit: c5edfb33f93802d2a025a064ddaa4593ea7932a4
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9478023950&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Consolidated `EvaluationVersion` type imports to a single source for improved maintainability.
  - Promoted `DEFAULT_EVALUATION_VERSION` to be exportable for broader use across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->