### PR TITLE
chore: Remove `updateAndFind`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -129,10 +129,9 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         // Set policies to null in the update object
         resource.setPolicies(null);
 
-        return queryBuilder()
-                .byId(id)
-                .permission(permission)
-                .updateFirstAndFind(buildUpdateFromSparseResource(resource));
+        final QueryAllParams<T> q = queryBuilder().byId(id).permission(permission);
+
+        return q.updateFirst(buildUpdateFromSparseResource(resource)).then(Mono.defer(q::one));
     }
 
     public Mono<Integer> updateByIdWithoutPermissionCheck(@NonNull String id, BridgeUpdate update) {
@@ -354,19 +353,6 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
                 return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "scope"));
             }
         }));
-    }
-
-    public Mono<T> updateExecuteAndFind(@NonNull QueryAllParams<T> params, @NonNull UpdateDefinition update) {
-        if (QueryAllParams.Scope.ALL.equals(params.getScope())) {
-            // Not implemented yet, since not needed yet.
-            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "scope"));
-
-        } else if (QueryAllParams.Scope.FIRST.equals(params.getScope())) {
-            return updateExecute(params, update).then(Mono.defer(() -> queryOneExecute(params)));
-
-        } else {
-            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "scope"));
-        }
     }
 
     public BridgeUpdate buildUpdateFromSparseResource(T resource) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/params/QueryAllParams.java
@@ -87,11 +87,6 @@ public class QueryAllParams<T extends BaseDomain> {
         return repo.updateExecute(this, update);
     }
 
-    public Mono<T> updateFirstAndFind(@NonNull UpdateDefinition update) {
-        scope = Scope.FIRST;
-        return repo.updateExecuteAndFind(this, update);
-    }
-
     public QueryAllParams<T> criteria(Criteria c) {
         if (c == null) {
             return this;


### PR DESCRIPTION
This method is only partially implemented (see the `updateExecuteAndFind`), is only used in one place, and isn't implemented at all in `pg` branch. Removing this method reduces the diff, and avoids more usages of this method that's missing on `pg`.

**/test sanity**

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9482954144>
> Commit: b4d3023e8e8275a3ea7e5e7e3b91d91c116e6bb8
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9482954144&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal structure of the update method for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->