### PR TITLE
fix: DB URL override fails in some cases

### DIFF
--- a/deploy/docker/fs/opt/appsmith/utils/bin/index.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/index.js
@@ -10,10 +10,16 @@ const mongo_shell_utils = require("./mongo_shell_utils.js");
 
 const APPLICATION_CONFIG_PATH = "/appsmith-stacks/configuration/docker.env";
 
+// Check if APPSMITH_DB_URL is set, if not set, fall back to APPSMITH_MONGODB_URI
+if (!process.env.APPSMITH_DB_URL) {
+  process.env.APPSMITH_DB_URL = process.env.APPSMITH_MONGODB_URI;
+  delete process.env.APPSMITH_MONGODB_URI;
+}
+
 // Loading latest application configuration
 require("dotenv").config({ path: APPLICATION_CONFIG_PATH });
 
-// Check if APPSMITH_DB_URL is set, if not set, fall back to APPSMITH_MONGODB_URI
+// AGAIN: Check if APPSMITH_DB_URL is set, if not set, fall back to APPSMITH_MONGODB_URI
 if (!process.env.APPSMITH_DB_URL) {
   process.env.APPSMITH_DB_URL = process.env.APPSMITH_MONGODB_URI;
 }

--- a/deploy/docker/fs/opt/appsmith/utils/bin/index.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/index.js
@@ -22,6 +22,7 @@ require("dotenv").config({ path: APPLICATION_CONFIG_PATH });
 // AGAIN: Check if APPSMITH_DB_URL is set, if not set, fall back to APPSMITH_MONGODB_URI
 if (!process.env.APPSMITH_DB_URL) {
   process.env.APPSMITH_DB_URL = process.env.APPSMITH_MONGODB_URI;
+  delete process.env.APPSMITH_MONGODB_URI;
 }
 
 const command = process.argv[2];


### PR DESCRIPTION
The current fallback implementation doesn't work in the below case:

> The `APPSMITH_MONGODB_URI` is set _outside_ the container, and `APPSMITH_DB_URL` is set in the `docker.env`.

This scenario will be showing up a lot more now that the `docker.env.sh` that generates new `docker.env` files has `APPSMITH_DB_URL` in it.

Problem is that since we load env variables from both outside and `docker.env` individually, we end up loading both `APPSMITH_MONGODB_URI` and `APPSMITH_DB_URL`. And in this case, the `APPSMITH_DB_URL` will be from the just-generated `docker.env`, so we'll end up with a localhost URL, even though `APPSMITH_MONGODB_URI` was set to an external endpoint outside the container.

This is the problem we were facing with our DPs recently.

This PR fixes this problem by doing the env name "rename" separately for outside env variables, and once for `docker.env` env variables.

**/test sanity**

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9481037167>
> Commit: c6ce2a8dda4a13d3aab64adf8c9af08abd1cea62
> Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9481037167&attempt=1" target="_blank">Click here!</a>

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved environment variable handling to ensure `APPSMITH_DB_URL` is correctly set, enhancing database connection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->