### PR TITLE
fix: Disable Git and CRUD Page generation when Anvil feature flag is enabled

### DIFF
--- a/app/client/src/ce/hooks/datasourceEditorHooks.tsx
+++ b/app/client/src/ce/hooks/datasourceEditorHooks.tsx
@@ -29,7 +29,7 @@ import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { ActionParentEntityType } from "@appsmith/entities/Engine/actionHelpers";
 import { isEnabledForPreviewData } from "utils/editorContextUtils";
 import { getPlugin } from "@appsmith/selectors/entitiesSelector";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
+import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
 
 export interface HeaderActionProps {
   datasource: Datasource | ApiDatasourceForm | undefined;
@@ -58,7 +58,7 @@ export const useHeaderActions = (
   const showGenerateButton = useShowPageGenerationOnHeader(
     datasource as Datasource,
   );
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
+  const isAnvilEnabled = useSelector(getIsAnvilEnabledInCurrentApplication);
 
   const plugin = useSelector((state: AppState) =>
     getPlugin(state, datasource?.pluginId || ""),

--- a/app/client/src/ce/hooks/datasourceEditorHooks.tsx
+++ b/app/client/src/ce/hooks/datasourceEditorHooks.tsx
@@ -29,6 +29,7 @@ import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { ActionParentEntityType } from "@appsmith/entities/Engine/actionHelpers";
 import { isEnabledForPreviewData } from "utils/editorContextUtils";
 import { getPlugin } from "@appsmith/selectors/entitiesSelector";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 export interface HeaderActionProps {
   datasource: Datasource | ApiDatasourceForm | undefined;
@@ -57,6 +58,7 @@ export const useHeaderActions = (
   const showGenerateButton = useShowPageGenerationOnHeader(
     datasource as Datasource,
   );
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
 
   const plugin = useSelector((state: AppState) =>
     getPlugin(state, datasource?.pluginId || ""),
@@ -105,7 +107,7 @@ export const useHeaderActions = (
     );
 
     const generatePageButton =
-      showGenerateButton && !showReconnectButton ? (
+      showGenerateButton && !showReconnectButton && !isAnvilEnabled ? (
         <Button
           className={"t--generate-template"}
           isDisabled={!canGeneratePage}

--- a/app/client/src/components/BottomBar/index.tsx
+++ b/app/client/src/components/BottomBar/index.tsx
@@ -11,12 +11,12 @@ import { getCurrentApplicationId } from "selectors/editorSelectors";
 import { useDispatch } from "react-redux";
 import { softRefreshActions } from "actions/pluginActionActions";
 import { START_SWITCH_ENVIRONMENT } from "@appsmith/constants/messages";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
+import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
 
 export default function BottomBar({ viewMode }: { viewMode: boolean }) {
   const appId = useSelector(getCurrentApplicationId) || "";
   const dispatch = useDispatch();
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
+  const isAnvilEnabled = useSelector(getIsAnvilEnabledInCurrentApplication);
 
   const onChangeEnv = () => {
     dispatch(softRefreshActions());

--- a/app/client/src/components/BottomBar/index.tsx
+++ b/app/client/src/components/BottomBar/index.tsx
@@ -11,10 +11,12 @@ import { getCurrentApplicationId } from "selectors/editorSelectors";
 import { useDispatch } from "react-redux";
 import { softRefreshActions } from "actions/pluginActionActions";
 import { START_SWITCH_ENVIRONMENT } from "@appsmith/constants/messages";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 export default function BottomBar({ viewMode }: { viewMode: boolean }) {
   const appId = useSelector(getCurrentApplicationId) || "";
   const dispatch = useDispatch();
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
 
   const onChangeEnv = () => {
     dispatch(softRefreshActions());
@@ -31,7 +33,7 @@ export default function BottomBar({ viewMode }: { viewMode: boolean }) {
             viewMode={viewMode}
           />
         )}
-        {!viewMode && <QuickGitActions />}
+        {!viewMode && !isAnvilEnabled && <QuickGitActions />}
       </Wrapper>
       {!viewMode && (
         <Wrapper>

--- a/app/client/src/components/designSystems/appsmith/header/DeployLinkButton.tsx
+++ b/app/client/src/components/designSystems/appsmith/header/DeployLinkButton.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "design-system";
 import { KBEditorMenuItem } from "@appsmith/pages/Editor/KnowledgeBase/KBEditorMenuItem";
 import { useHasConnectToGitPermission } from "pages/Editor/gitSync/hooks/gitPermissionHooks";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
+import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
 
 interface Props {
   trigger: ReactNode;
@@ -24,7 +24,7 @@ export const DeployLinkButton = (props: Props) => {
   const dispatch = useDispatch();
   const isGitConnected = useSelector(getIsGitConnected);
   const isConnectToGitPermitted = useHasConnectToGitPermission();
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
+  const isAnvilEnabled = useSelector(getIsAnvilEnabledInCurrentApplication);
 
   const goToGitConnectionPopup = () => {
     AnalyticsUtil.logEvent("GS_CONNECT_GIT_CLICK", {

--- a/app/client/src/components/designSystems/appsmith/header/DeployLinkButton.tsx
+++ b/app/client/src/components/designSystems/appsmith/header/DeployLinkButton.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "design-system";
 import { KBEditorMenuItem } from "@appsmith/pages/Editor/KnowledgeBase/KBEditorMenuItem";
 import { useHasConnectToGitPermission } from "pages/Editor/gitSync/hooks/gitPermissionHooks";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 interface Props {
   trigger: ReactNode;
@@ -23,6 +24,7 @@ export const DeployLinkButton = (props: Props) => {
   const dispatch = useDispatch();
   const isGitConnected = useSelector(getIsGitConnected);
   const isConnectToGitPermitted = useHasConnectToGitPermission();
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
 
   const goToGitConnectionPopup = () => {
     AnalyticsUtil.logEvent("GS_CONNECT_GIT_CLICK", {
@@ -48,7 +50,7 @@ export const DeployLinkButton = (props: Props) => {
         />
       </MenuTrigger>
       <MenuContent>
-        {!isGitConnected && isConnectToGitPermitted && (
+        {!isGitConnected && isConnectToGitPermitted && !isAnvilEnabled && (
           <MenuItem
             className="t--connect-to-git-btn"
             onClick={goToGitConnectionPopup}

--- a/app/client/src/layoutSystems/anvil/integrations/selectors.ts
+++ b/app/client/src/layoutSystems/anvil/integrations/selectors.ts
@@ -4,10 +4,18 @@ import { selectFeatureFlagCheck } from "@appsmith/selectors/featureFlagsSelector
 import { FEATURE_FLAG } from "@appsmith/entities/FeatureFlag";
 import { LayoutSystemTypes } from "layoutSystems/types";
 import { getLayoutSystemType } from "selectors/layoutSystemSelectors";
+import { createSelector } from "reselect";
 
 export const getIsAnvilLayoutEnabled = (state: AppState) => {
   return selectFeatureFlagCheck(state, FEATURE_FLAG.release_anvil_enabled);
 };
+
+export const getIsAnvilEnabledInCurrentApplication = createSelector(
+  getLayoutSystemType,
+  (layoutSystemType: LayoutSystemTypes) => {
+    return layoutSystemType === LayoutSystemTypes.ANVIL;
+  },
+);
 
 export const getIsAnvilLayout = (state: AppState) => {
   const layoutSystemType = getLayoutSystemType(state);

--- a/app/client/src/pages/Editor/DatasourceInfo/DatasourceViewModeSchema.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/DatasourceViewModeSchema.tsx
@@ -52,7 +52,7 @@ import { useEditorType } from "@appsmith/hooks";
 import history from "utils/history";
 import { getIsGeneratingTemplatePage } from "selectors/pageListSelectors";
 import { setDatasourcePreviewSelectedTableName } from "actions/datasourceActions";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
+import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
 
 interface Props {
   datasource: Datasource;
@@ -78,7 +78,7 @@ const DatasourceViewModeSchema = (props: Props) => {
   );
 
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
+  const isAnvilEnabled = useSelector(getIsAnvilEnabledInCurrentApplication);
 
   const editorType = useEditorType(history.location.pathname);
 

--- a/app/client/src/pages/Editor/DatasourceInfo/DatasourceViewModeSchema.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/DatasourceViewModeSchema.tsx
@@ -52,6 +52,7 @@ import { useEditorType } from "@appsmith/hooks";
 import history from "utils/history";
 import { getIsGeneratingTemplatePage } from "selectors/pageListSelectors";
 import { setDatasourcePreviewSelectedTableName } from "actions/datasourceActions";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 interface Props {
   datasource: Datasource;
@@ -77,6 +78,7 @@ const DatasourceViewModeSchema = (props: Props) => {
   );
 
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
 
   const editorType = useEditorType(history.location.pathname);
 
@@ -236,7 +238,8 @@ const DatasourceViewModeSchema = (props: Props) => {
     !failedFetchingPreviewData &&
     tableName &&
     canCreateDatasourceActions &&
-    canCreatePages;
+    canCreatePages &&
+    !isAnvilEnabled;
 
   return (
     <ViewModeSchemaContainer>

--- a/app/client/src/pages/Editor/DatasourceInfo/GoogleSheetSchema.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/GoogleSheetSchema.tsx
@@ -51,7 +51,7 @@ import ItemLoadingIndicator from "./ItemLoadingIndicator";
 import { useEditorType } from "@appsmith/hooks";
 import history from "utils/history";
 import { getIsGeneratingTemplatePage } from "selectors/pageListSelectors";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
+import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
 
 interface Props {
   datasourceId: string;
@@ -79,7 +79,7 @@ function GoogleSheetSchema(props: Props) {
     setSelectedDatasourceIsInvalid,
   });
 
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
+  const isAnvilEnabled = useSelector(getIsAnvilEnabledInCurrentApplication);
 
   const toggleOnUnmountRefObject = useRef<{
     selectedSheet?: string;

--- a/app/client/src/pages/Editor/DatasourceInfo/GoogleSheetSchema.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/GoogleSheetSchema.tsx
@@ -51,6 +51,7 @@ import ItemLoadingIndicator from "./ItemLoadingIndicator";
 import { useEditorType } from "@appsmith/hooks";
 import history from "utils/history";
 import { getIsGeneratingTemplatePage } from "selectors/pageListSelectors";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 interface Props {
   datasourceId: string;
@@ -77,6 +78,8 @@ function GoogleSheetSchema(props: Props) {
     setSelectedDatasourceTableOptions: setSpreadsheetOptions,
     setSelectedDatasourceIsInvalid,
   });
+
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
 
   const toggleOnUnmountRefObject = useRef<{
     selectedSheet?: string;
@@ -376,7 +379,8 @@ function GoogleSheetSchema(props: Props) {
     !isError &&
     sheetData?.length &&
     canCreateDatasourceActions &&
-    canCreatePages;
+    canCreatePages &&
+    !isAnvilEnabled;
 
   const filteredSpreadsheets = spreadsheetOptions.filter((option) =>
     (option.label || "").toLowerCase()?.includes(searchString),

--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -56,7 +56,7 @@ import {
   hasCreateDSActionPermissionInApp,
 } from "@appsmith/utils/BusinessFeatures/permissionPageHelpers";
 import { useEditorType } from "@appsmith/hooks";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
+import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
 
 const Wrapper = styled.div`
   padding: 15px;
@@ -173,7 +173,7 @@ function DatasourceCard(props: DatasourceCardProps) {
   );
 
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
+  const isAnvilEnabled = useSelector(getIsAnvilEnabledInCurrentApplication);
 
   const editorType = useEditorType(history.location.pathname);
 

--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -56,6 +56,7 @@ import {
   hasCreateDSActionPermissionInApp,
 } from "@appsmith/utils/BusinessFeatures/permissionPageHelpers";
 import { useEditorType } from "@appsmith/hooks";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 const Wrapper = styled.div`
   padding: 15px;
@@ -172,6 +173,7 @@ function DatasourceCard(props: DatasourceCardProps) {
   );
 
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
 
   const editorType = useEditorType(history.location.pathname);
 
@@ -322,21 +324,23 @@ function DatasourceCard(props: DatasourceCardProps) {
             </Queries>
           </div>
           <ButtonsWrapper className="action-wrapper">
-            {supportTemplateGeneration && !showReconnectButton && (
-              <Button
-                className={"t--generate-template"}
-                isDisabled={!canGeneratePage}
-                kind="secondary"
-                onClick={(e: any) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  routeToGeneratePage();
-                }}
-                size="md"
-              >
-                {createMessage(GENERATE_NEW_PAGE_BUTTON_TEXT)}
-              </Button>
-            )}
+            {supportTemplateGeneration &&
+              !showReconnectButton &&
+              !isAnvilEnabled && (
+                <Button
+                  className={"t--generate-template"}
+                  isDisabled={!canGeneratePage}
+                  kind="secondary"
+                  onClick={(e: any) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    routeToGeneratePage();
+                  }}
+                  size="md"
+                >
+                  {createMessage(GENERATE_NEW_PAGE_BUTTON_TEXT)}
+                </Button>
+              )}
             {showReconnectButton && (
               <Button
                 className={"t--reconnect-btn"}

--- a/app/client/src/pages/common/ImportModal.tsx
+++ b/app/client/src/pages/common/ImportModal.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import React, { useCallback, useEffect } from "react";
 import styled, { useTheme, css } from "styled-components";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { setWorkspaceIdForImport } from "@appsmith/actions/applicationActions";
 import {
   createMessage,
@@ -21,6 +21,7 @@ import type { Theme } from "constants/DefaultTheme";
 import { Icon, Modal, ModalContent, ModalHeader, Text } from "design-system";
 import useMessages from "@appsmith/hooks/importModal/useMessages";
 import useMethods from "@appsmith/hooks/importModal/useMethods";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 const TextWrapper = styled.div`
   padding: 0;
@@ -201,6 +202,8 @@ function ImportModal(props: ImportModalProps) {
     resetAppFileToBeUploaded,
     uploadingText,
   } = useMethods({ editorId, workspaceId });
+
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
   const dispatch = useDispatch();
   const onGitImport = useCallback(() => {
     onClose && onClose();
@@ -277,7 +280,9 @@ function ImportModal(props: ImportModalProps) {
                 uploadIcon="file-line"
               />
             </FileImportCard>
-            {!toEditor && <GitImportCard handler={onGitImport} />}
+            {!toEditor && !isAnvilEnabled && (
+              <GitImportCard handler={onGitImport} />
+            )}
           </Row>
         )}
         {isImporting && (


### PR DESCRIPTION
## Description
- This PR removes all avenues that allow users to connect apps to Git when Anvil's feature flag is enabled (only in Anvil applications)
- This PR removes all avenues that allow users to generate a CRUD page when Anvil's feature flag is enabled (only in Anvil applications)
- Import app via Git is disabled globally when Anvil feature flag is enabled.

Fixes #34161 
Fixes #34163 


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
