### PR TITLE
fix: visually tag anvil application card

### DIFF
--- a/app/client/src/ce/pages/Applications/ResourceListLoader.tsx
+++ b/app/client/src/ce/pages/Applications/ResourceListLoader.tsx
@@ -35,6 +35,7 @@ function ResourceListLoader({ isMobile, resources }: ResourcesLoaderProps) {
               moreActionItems={[]}
               primaryAction={noop}
               setShowOverlay={noop}
+              showAnvilTag={false}
               showGitBadge={false}
               showOverlay={false}
               testId="t--package-card"

--- a/app/client/src/components/common/Card.tsx
+++ b/app/client/src/components/common/Card.tsx
@@ -28,6 +28,7 @@ type CardProps = PropsWithChildren<{
   titleTestId: string;
   isSelected?: boolean;
   hasEditPermission?: boolean;
+  showAnvilTag: boolean;
 }>;
 
 interface NameWrapperProps {
@@ -187,6 +188,7 @@ const Wrapper = styled(
       hasReadPermission?: boolean;
       backgroundColor: string;
       isMobile?: boolean;
+      $showAnvilTag: boolean;
     },
   ) => (
     <BlueprintCard
@@ -220,6 +222,26 @@ const Wrapper = styled(
     `
     width: 100% !important;
     height: 126px !important;
+  `}
+
+  ${({ $showAnvilTag }) =>
+    $showAnvilTag &&
+    `
+    &::after {
+      content: "New Layout System (BETA)";
+      background: teal;
+      position: absolute;
+      right: 0;
+      top: 0;
+      height: 22px;
+      border-radius: 4px 4px 0px 0px;
+      width: 100%;
+      color: white;
+      font-size: 14px;
+      font-weight: 600;
+      text-align: center;
+      
+    }
   `}
 `;
 
@@ -321,6 +343,7 @@ function Card({
   moreActionItems,
   primaryAction,
   setShowOverlay,
+  showAnvilTag,
   showGitBadge,
   showOverlay,
   testId,
@@ -345,6 +368,7 @@ function Card({
         testId={testId}
       >
         <Wrapper
+          $showAnvilTag={showAnvilTag}
           backgroundColor={backgroundColor}
           className={isFetching ? Classes.SKELETON : `${testId}-background`}
           hasReadPermission={hasReadPermission}

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -53,6 +53,7 @@ import { getCurrentUser } from "actions/authActions";
 import Card, { ContextMenuTrigger } from "components/common/Card";
 import { generateEditedByText } from "./helpers";
 import { noop } from "lodash";
+import { LayoutSystemTypes } from "layoutSystems/types";
 
 interface ApplicationCardProps {
   application: ApplicationPayload;
@@ -117,6 +118,10 @@ export function ApplicationCard(props: ApplicationCardProps) {
 
   const applicationId = props.application?.id;
   const showGitBadge = props.application?.gitApplicationMetadata?.branchName;
+
+  const hasAnvilLayout =
+    props.application.applicationDetail?.appPositioning?.type ===
+    LayoutSystemTypes.ANVIL;
 
   useEffect(() => {
     let colorCode;
@@ -464,6 +469,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
       moreActionItems={moreActionItems}
       primaryAction={props.isMobile ? launchMobileApp : noop}
       setShowOverlay={setShowOverlay}
+      showAnvilTag={hasAnvilLayout}
       showGitBadge={Boolean(showGitBadge)}
       showOverlay={showOverlay}
       testId={`t--application-card ${props.application.name}`}


### PR DESCRIPTION
## Description
Visually tag Anvil apps to differentiate them from non-anvil apps.
![Screenshot from 2024-06-12 16-43-58](https://github.com/appsmithorg/appsmith/assets/103687/7eaffa7c-fa60-41e3-a082-4ceaae7bd24f)




Fixes #34162 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
