### PR TITLE
fix: If Anvil feature flag is enabled, disable fixed mode app editing

### DIFF
--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -131,6 +131,7 @@ import CreateNewAppFromTemplatesWrapper from "./CreateNewAppFromTemplateModal/Cr
 import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
 import { ASSETS_CDN_URL } from "constants/ThirdPartyConstants";
 import { LayoutSystemTypes } from "layoutSystems/types";
+import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 
 export const { cloudHosting } = getAppsmithConfigs();
 
@@ -498,6 +499,7 @@ export function ApplicationsSection(props: any) {
   const enableImportExport = true;
   const dispatch = useDispatch();
   const theme = useContext(ThemeContext);
+  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
   const isSavingWorkspaceInfo = useSelector(getIsSavingWorkspaceInfo);
   const isFetchingWorkspaces = useSelector(getIsFetchingWorkspaces);
   const isFetchingApplications = useSelector(getIsFetchingApplications);
@@ -750,7 +752,17 @@ export function ApplicationsSection(props: any) {
       ) {
         anvilApplications.push(application);
       } else {
-        nonAnvilApplications.push(application);
+        const _application = Object.assign({}, application);
+        // TODO(abhinav): Messing with permissions is obviously bad and not bullet proof.
+        // This is just a PoC and will likely need a new prop for ApplicationCard
+        // to handle this.
+        if (isAnvilEnabled) {
+          _application.userPermissions = [
+            "export:applications",
+            "read:applications",
+          ];
+        }
+        nonAnvilApplications.push(_application);
       }
     });
 
@@ -856,21 +868,23 @@ export function ApplicationsSection(props: any) {
                 updateApplicationDispatch={updateApplicationDispatch}
                 workspaceId={activeWorkspace.id}
               />
-              <ApplicationCardList
-                applications={anvilApplications}
-                canInviteToWorkspace={canInviteToWorkspace}
-                deleteApplication={deleteApplication}
-                enableImportExport={enableImportExport}
-                hasCreateNewApplicationPermission={
-                  hasCreateNewApplicationPermission
-                }
-                hasManageWorkspacePermissions={hasManageWorkspacePermissions}
-                isMobile={isMobile}
-                onClickAddNewButton={onClickAddNewAppButton}
-                title={createMessage(ANVIL_APPLICATIONS)}
-                updateApplicationDispatch={updateApplicationDispatch}
-                workspaceId={activeWorkspace.id}
-              />
+              {isAnvilEnabled && (
+                <ApplicationCardList
+                  applications={anvilApplications}
+                  canInviteToWorkspace={canInviteToWorkspace}
+                  deleteApplication={deleteApplication}
+                  enableImportExport={enableImportExport}
+                  hasCreateNewApplicationPermission={
+                    hasCreateNewApplicationPermission
+                  }
+                  hasManageWorkspacePermissions={hasManageWorkspacePermissions}
+                  isMobile={isMobile}
+                  onClickAddNewButton={onClickAddNewAppButton}
+                  title={createMessage(ANVIL_APPLICATIONS)}
+                  updateApplicationDispatch={updateApplicationDispatch}
+                  workspaceId={activeWorkspace.id}
+                />
+              )}
               <PackageCardList
                 isMobile={isMobile}
                 packages={packages}

--- a/app/client/src/layoutSystems/anvil/integrations/selectors.ts
+++ b/app/client/src/layoutSystems/anvil/integrations/selectors.ts
@@ -22,6 +22,17 @@ export const getIsAnvilLayout = (state: AppState) => {
   return layoutSystemType === LayoutSystemTypes.ANVIL;
 };
 
+export const getIsEditingAllowedBasedOnLayoutSystem = (state: AppState) => {
+  const isAnvilEnabled = selectFeatureFlagCheck(
+    state,
+    FEATURE_FLAG.release_anvil_enabled,
+  );
+  if (!isAnvilEnabled) return true;
+  const isAnvilLayout = getIsAnvilLayout(state);
+  if (isAnvilLayout) return true;
+  return false;
+};
+
 // ToDo: This is a placeholder implementation this is bound to change
 export function getDropTargetLayoutId(state: AppState, canvasId: string) {
   const layout: LayoutProps[] = state.entities.canvasWidgets[canvasId].layout;

--- a/app/client/src/pages/AppViewer/Navigation/Sidebar.tsx
+++ b/app/client/src/pages/AppViewer/Navigation/Sidebar.tsx
@@ -37,6 +37,7 @@ import { getIsAppSettingsPaneWithNavigationTabOpen } from "selectors/appSettings
 import NavigationLogo from "@appsmith/pages/AppViewer/NavigationLogo";
 import MenuItemContainer from "./components/MenuItemContainer";
 import BackToAppsButton from "./components/BackToAppsButton";
+import { getIsEditingAllowedBasedOnLayoutSystem } from "layoutSystems/anvil/integrations/selectors";
 
 interface SidebarProps {
   currentApplicationDetails?: ApplicationPayload;
@@ -87,6 +88,7 @@ export function Sidebar(props: SidebarProps) {
   const isAppSettingsPaneWithNavigationTabOpen = useSelector(
     getIsAppSettingsPaneWithNavigationTabOpen,
   );
+  const shouldAllowEdit = useSelector(getIsEditingAllowedBasedOnLayoutSystem);
 
   useEffect(() => {
     setQuery(window.location.search);
@@ -222,14 +224,16 @@ export function Sidebar(props: SidebarProps) {
                 isMinimal={isMinimal}
               />
 
-              <PrimaryCTA
-                className="t--back-to-editor"
-                insideSidebar
-                isMinimal={isMinimal}
-                navColorStyle={navColorStyle}
-                primaryColor={primaryColor}
-                url={editorURL}
-              />
+              {shouldAllowEdit && (
+                <PrimaryCTA
+                  className="t--back-to-editor"
+                  insideSidebar
+                  isMinimal={isMinimal}
+                  navColorStyle={navColorStyle}
+                  primaryColor={primaryColor}
+                  url={editorURL}
+                />
+              )}
 
               <BackToAppsButton
                 currentApplicationDetails={currentApplicationDetails}

--- a/app/client/src/pages/AppViewer/Navigation/components/TopHeader.tsx
+++ b/app/client/src/pages/AppViewer/Navigation/components/TopHeader.tsx
@@ -23,6 +23,7 @@ import { HeaderRow, StyledNav } from "./TopHeader.styled";
 import TopInline from "../TopInline";
 import NavigationLogo from "@appsmith/pages/AppViewer/NavigationLogo";
 import BackToAppsButton from "./BackToAppsButton";
+import { getIsEditingAllowedBasedOnLayoutSystem } from "layoutSystems/anvil/integrations/selectors";
 
 interface TopHeaderProps {
   currentApplicationDetails?: ApplicationPayload;
@@ -61,6 +62,8 @@ const TopHeader = (props: TopHeaderProps) => {
   );
   const pageId = useSelector(getCurrentPageId);
   const editorURL = useHref(builderURL, { pageId });
+
+  const shouldAllowEdit = useSelector(getIsEditingAllowedBasedOnLayoutSystem);
 
   return (
     <StyledNav
@@ -119,12 +122,14 @@ const TopHeader = (props: TopHeaderProps) => {
                 />
 
                 <HeaderRightItemContainer>
-                  <PrimaryCTA
-                    className="t--back-to-editor"
-                    navColorStyle={navColorStyle}
-                    primaryColor={primaryColor}
-                    url={editorURL}
-                  />
+                  {shouldAllowEdit && (
+                    <PrimaryCTA
+                      className="t--back-to-editor"
+                      navColorStyle={navColorStyle}
+                      primaryColor={primaryColor}
+                      url={editorURL}
+                    />
+                  )}
 
                   <BackToAppsButton
                     currentApplicationDetails={currentApplicationDetails}

--- a/app/client/src/pages/AppViewer/PageMenu.tsx
+++ b/app/client/src/pages/AppViewer/PageMenu.tsx
@@ -24,6 +24,7 @@ import { StyledCtaContainer } from "./Navigation/Sidebar.styled";
 import ShareButton from "./Navigation/components/ShareButton";
 import BackToAppsButton from "./Navigation/components/BackToAppsButton";
 import { getHideWatermark } from "@appsmith/selectors/tenantSelectors";
+import { getIsEditingAllowedBasedOnLayoutSystem } from "layoutSystems/anvil/integrations/selectors";
 
 interface NavigationProps {
   isOpen?: boolean;
@@ -41,7 +42,9 @@ export function PageMenu(props: NavigationProps) {
   const workspaceID = useSelector(getCurrentWorkspaceId);
   const headerHeight = useSelector(getAppViewHeaderHeight);
   const [query, setQuery] = useState("");
-  const hideWatermark = useSelector(getHideWatermark);
+  const hideWatermark: boolean = useSelector(getHideWatermark);
+  const shouldAllowEdit = useSelector(getIsEditingAllowedBasedOnLayoutSystem);
+
   const navColorStyle =
     application?.applicationDetail?.navigationSetting?.colorStyle ||
     NAVIGATION_SETTINGS.COLOR_STYLE.LIGHT;
@@ -130,7 +133,7 @@ export function PageMenu(props: NavigationProps) {
                 insideSidebar
               />
 
-              {isOpen && (
+              {isOpen && shouldAllowEdit && (
                 <PrimaryCTA
                   className="t--back-to-editor--mobile"
                   insideSidebar

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -164,6 +164,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
 
   const appIcon = (props.application?.icon ||
     getApplicationIcon(applicationId)) as AppIconName;
+
   const hasEditPermission = isPermitted(
     props.application?.userPermissions ?? [],
     PERMISSION_TYPE.MANAGE_APPLICATION,

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -47,6 +47,8 @@ import ReconfigureCDKeyModal from "@appsmith/components/gitComponents/Reconfigur
 import DisableCDModal from "@appsmith/components/gitComponents/DisableCDModal";
 import { PartialExportModal } from "components/editorComponents/PartialImportExport/PartialExportModal";
 import { PartialImportModal } from "components/editorComponents/PartialImportExport/PartialImportModal";
+import { getIsEditingAllowedBasedOnLayoutSystem } from "layoutSystems/anvil/integrations/selectors";
+import history from "utils/history";
 
 interface EditorProps {
   currentApplicationId?: string;
@@ -68,6 +70,7 @@ interface EditorProps {
   pageLevelSocketRoomId: string;
   isMultiPane: boolean;
   widgetConfigBuildSuccess: () => void;
+  shouldAllowEditBasedOnLayoutSystem: boolean;
 }
 
 type Props = EditorProps & RouteComponentProps<BuilderRouteParams>;
@@ -141,6 +144,12 @@ class Editor extends Component<Props> {
         urlBuilder.setCurrentPageId(pageId);
       }
     }
+
+    const viewerURL = urlBuilder.build(
+      { pageId, params: {} },
+      APP_MODE.PUBLISHED,
+    );
+    if (!this.props.shouldAllowEditBasedOnLayoutSystem) history.push(viewerURL);
   }
 
   componentWillUnmount() {
@@ -201,6 +210,8 @@ const mapStateToProps = (state: AppState) => ({
   user: getCurrentUser(state),
   currentApplicationName: state.ui.applications.currentApplication?.name,
   currentPageId: getCurrentPageId(state),
+  shouldAllowEditBasedOnLayoutSystem:
+    getIsEditingAllowedBasedOnLayoutSystem(state),
 });
 
 const mapDispatchToProps = (dispatch: any) => {


### PR DESCRIPTION
## Description
- When Anvil feature flag is enabled, disable editing of fixed mode apps
- When Anvil feature flag is disabled, prevent the listing of anvil apps


Fixes #34170 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
