### PR TITLE
test: fix failing gitsync tests

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/GitSyncedApps_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/GitSyncedApps_spec.js
@@ -400,8 +400,7 @@ describe("Git sync apps", { tags: ["@tag.Git"] }, function () {
     cy.get(gitSyncLocators.commitCommentInput).type("Initial Commit");
     cy.get(gitSyncLocators.commitButton).click();
     cy.get(gitSyncLocators.closeGitSyncModal).click();
-    cy.merge(mainBranch);
-    agHelper.GetNClick(gitSyncLocators.closeGitSyncModal);
+    gitSync.MergeToMaster();
     cy.latestDeployPreview();
     // verify page is hidden on deploy mode
     agHelper.AssertContains("Child_Page Copy", "not.exist");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Git/GitSync/GitSyncedApps_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/GitSyncedApps_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/support/Pages/GitSync.ts
+++ b/app/client/cypress/support/Pages/GitSync.ts
@@ -37,6 +37,8 @@ export class GitSync {
   private mergeCTA = "[data-testid=t--git-merge-button]";
   public _mergeBranchDropdownDestination =
     ".t--merge-branch-dropdown-destination";
+  public _mergeBranchDropdownmenu =
+    ".t--merge-branch-dropdown-destination .rc-select-selection-search-input";
   public _dropdownmenu = ".rc-select-item-option-content";
   private _openRepoButton = "[data-testid=t--git-repo-button]";
   public _commitButton = ".t--commit-button";
@@ -380,11 +382,12 @@ export class GitSync {
   CheckMergeConflicts(destinationBranch: string) {
     this.agHelper.AssertElementExist(this._bottomBarPull);
     this.agHelper.GetNClick(this._bottomBarMergeButton);
-    cy.wait(2000);
-    this.agHelper.GetNClick(this._mergeBranchDropdownDestination);
-    // cy.get(commonLocators.dropdownmenu).contains(destinationBranch).click();
+    this.agHelper.WaitUntilEleAppear(this._mergeBranchDropdownmenu);
+    this.agHelper.WaitUntilEleDisappear(this._mergeLoader);
+    this.assertHelper.AssertNetworkStatus("@getBranch", 200);
+    this.agHelper.GetNClick(this._mergeBranchDropdownmenu, 0, true);
+    this.agHelper.WaitUntilEleAppear(this._dropdownmenu);
     this.agHelper.GetNClickByContains(this._dropdownmenu, destinationBranch);
-
     this.agHelper.AssertElementAbsence(this._checkMergeability, 35000);
   }
 


### PR DESCRIPTION
RCA:
Test was failing because of hard wait
Also the dropdown element which was being clicked was failing

Solution:
Removed hard waits and replaced with intercept
Updated locator and better method to fix tests

EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the method for merging changes to the master branch in Git sync tests for improved reliability.
  
- **Tests**
  - Revised Cypress test configurations and spec names for better organization and clarity.
  - Enhanced the `CheckMergeConflicts` method to improve test accuracy and reliability by including element visibility checks and network status assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->