### PR TITLE
chore: Remove `deleted` boolean field

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -13,7 +13,6 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Transient;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -65,18 +64,6 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     @LastModifiedBy
     @JsonView(Views.Public.class)
     protected String modifiedBy;
-
-    /** @deprecated to rely only on `deletedAt` for all domain models.
-     * This field only exists here because its removal will cause a huge diff on all entities in git-connected
-     * applications. So, instead, we keep it, deprecated, query-transient (no corresponding field in Q* class),
-     * no getter/setter methods and only use it for reflection-powered services, like the git sync
-     * implementation. For all other practical purposes, this field doesn't exist.
-     */
-    @Deprecated(forRemoval = true)
-    @JsonView(Views.Internal.class)
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
-    protected transient Boolean deleted = false;
 
     @JsonView(Views.Public.class)
     protected Instant deletedAt = null;


### PR DESCRIPTION
Remove the `deleted` field since

1. it'll be removed from `release` branch soon.
2. we aren't creating the corresponding `deleted` column in database tables anyway.
