### PR TITLE
chore: Add baseId to app

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -17,6 +17,7 @@ import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.util.StringUtils;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -270,6 +271,15 @@ public class Application extends BaseDomain implements Artifact {
             applicationPage.setId(pageIdToNameMap.get(applicationPage.getId() + VIEW));
             applicationPage.setDefaultPageId(null);
         }
+    }
+
+    @Override
+    public String getBaseId() {
+        if (this.getGitArtifactMetadata() != null
+                && StringUtils.hasLength(this.getGitArtifactMetadata().getDefaultArtifactId())) {
+            return this.getGitArtifactMetadata().getDefaultArtifactId();
+        }
+        return Artifact.super.getBaseId();
     }
 
     @JsonView(Views.Internal.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ArtifactCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/ArtifactCE.java
@@ -1,14 +1,21 @@
 package com.appsmith.server.domains.ce;
 
 import com.appsmith.external.models.Policy;
+import com.appsmith.external.views.Views;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.domains.GitArtifactMetadata;
+import com.fasterxml.jackson.annotation.JsonView;
 
 import java.util.Set;
 
 public interface ArtifactCE {
 
     String getId();
+
+    @JsonView(Views.Internal.class)
+    default String getBaseId() {
+        return getId();
+    }
 
     String getName();
 


### PR DESCRIPTION
## Description
Adds a method that is not exposed externally yet to start to get baseId information in applications.

Carried from https://github.com/appsmithorg/appsmith-ee/pull/4408

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
