### PR TITLE
fix: display label instead of value in select column of table widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select3_spec.ts
@@ -1,0 +1,228 @@
+import {
+  entityExplorer,
+  propPane,
+  agHelper,
+  draggableWidgets,
+  table,
+  locators,
+} from "../../../../../../support/Objects/ObjectsCore";
+import {
+  getWidgetSelector,
+  WIDGET,
+} from "../../../../../../locators/WidgetLocators";
+
+const tableData = `[
+    {
+      "id": 2,
+      "name": "saicharan",
+      "gender": "M"
+    },
+    {
+      "id": 3,
+      "name": "Raju",
+      "gender": "M"
+    },
+    {
+      "id": 4,
+      "name": "Rajesh",
+      "gender": "M"
+    },
+    {
+      "id": 5,
+      "name": "Lahari",
+      "gender": "F"
+    },
+    {
+      "id": 6,
+      "name": "Sneha",
+      "gender": "F"
+    },
+    {
+      "id": 7,
+      "name": "Varshini",
+      "gender": "F"
+    },
+    {
+      "id": 8,
+      "name": "Vidmahi",
+      "gender": "F"
+    },
+    {
+      "id": 9,
+      "name": "nikhil",
+      "gender": "M"
+    }
+  ]`;
+const updatedTableData = `[
+    {
+      "id": 2,
+      "name": "saicharan",
+      "gender": "27"
+    },
+    {
+      "id": 3,
+      "name": "Raju",
+      "gender": "M"
+    },
+    {
+      "id": 4,
+      "name": "Rajesh",
+      "gender": "M"
+    },
+    {
+      "id": 5,
+      "name": "Lahari",
+      "gender": "F"
+    },
+    {
+      "id": 6,
+      "name": "Sneha",
+      "gender": "F"
+    },
+    {
+      "id": 7,
+      "name": "Varshini",
+      "gender": "F"
+    },
+    {
+      "id": 8,
+      "name": "Vidmahi",
+      "gender": "F"
+    },
+    {
+      "id": 9,
+      "name": "nikhil",
+      "gender": "M"
+    }
+  ]`;
+
+describe(
+  "Table widget v2: select column displayAs property test",
+  { tags: ["@tag.Widget", "@tag.Table"] },
+  () => {
+    before(() => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 300, 300);
+      propPane.EnterJSContext("Table data", tableData);
+    });
+
+    it("Check if property displayAs, helperText are visible", function () {
+      table.ChangeColumnType("gender", "Select", "v2");
+      table.EditColumn("gender", "v2");
+      agHelper.GetNAssertContains(
+        locators._helperText,
+        "Each computed value here represents default value/display value",
+      );
+      agHelper.AssertElementExist(propPane._propertyControl("displayas"));
+    });
+    it("Check that select options value and label are being present on table when displayAs = value or label", function () {
+      propPane.UpdatePropertyFieldValue(
+        "Options",
+        `[
+            {
+            "label":"female",
+            "value":"F"
+            },
+            {
+            "label":"male",
+            "value":"M"
+            }
+          ]`,
+      );
+      propPane.SelectPropertiesDropDown("Display as", "Value");
+      table.ReadTableRowColumnData(0, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("M");
+      });
+      table.ReadTableRowColumnData(4, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("F");
+      });
+
+      propPane.SelectPropertiesDropDown("Display as", "Label");
+
+      table.ReadTableRowColumnData(0, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("male");
+      });
+      table.ReadTableRowColumnData(4, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("female");
+      });
+    });
+    it("Check computed value appearance in table and validation error in select options", function () {
+      let propPaneBack = "[data-testid='t--property-pane-back-btn']";
+
+      agHelper.SelectDropdownList("Column type", "Plain text");
+      propPane.TogglePropertyState("Editable", "On");
+      table.EditTableCell(0, 2, "27");
+      // Click on the save button
+      agHelper.GetNClickByContains(
+        table._tableRowColumnData(0, 3, "v2"),
+        "Save",
+      );
+      cy.get(propPaneBack).click({ force: true });
+      propPane.EnterJSContext("Table data", updatedTableData);
+      table.ChangeColumnTypeWithoutNavigatingBackToPropertyPane(
+        "gender",
+        "Select",
+        "v2",
+      );
+
+      table.ReadTableRowColumnData(0, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("");
+      });
+
+      propPane.SelectPropertiesDropDown("Display as", "Value");
+
+      table.ReadTableRowColumnData(0, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("27");
+      });
+
+      agHelper
+        .GetElement(`${propPane._propertyControl("options")}`)
+        .then(($elem: any) => {
+          agHelper.TypeIntoTextArea($elem, " ");
+        });
+
+      agHelper.VerifyEvaluatedErrorMessage(
+        "Computed Value at row: [1] is not present in the select options.",
+      );
+    });
+    it("Check that while editing cell's value is changed to label or value of select options based on displayAs property", () => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 300, 600);
+      propPane.TypeTextIntoField(
+        "Text",
+        "{{Table1.primaryColumns.gender.computedValue}}",
+      );
+
+      // Click on edit icon of select cell
+      agHelper.HoverElement(table._tableRow(1, 2, "v2"));
+      agHelper.GetNClick(
+        table._tableRow(1, 2, "v2") + " " + table._editCellIconDiv,
+        0,
+        true,
+      );
+
+      agHelper.ContainsNClick("male", 0);
+      table.ReadTableRowColumnData(1, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("M");
+      });
+      agHelper.GetText(getWidgetSelector(WIDGET.TEXT)).then((value) => {
+        expect(value).to.equal(
+          '[  "27",  "M",  "M",  "F",  "F",  "F",  "F",  "M"]',
+        );
+      });
+
+      // open table property pane:
+      agHelper.GetNClick(getWidgetSelector(WIDGET.TABLE), 0, true);
+      propPane.SelectPropertiesDropDown("Display as", "Label");
+
+      agHelper.HoverElement(table._tableRow(1, 2, "v2"));
+      agHelper.GetNClick(
+        table._tableRow(1, 2, "v2") + " " + table._editCellIconDiv,
+        0,
+        true,
+      );
+      agHelper.ContainsNClick("male", 0);
+      table.ReadTableRowColumnData(1, 2, "v2").then(($cellData) => {
+        expect($cellData).to.eq("male");
+      });
+    });
+  },
+);

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -330,4 +330,5 @@ export class CommonLocators {
   _menuItem = ".bp3-menu-item";
   _slashCommandHintText = ".slash-command-hint-text";
   _selectionItem = ".rc-select-selection-item";
+  _helperText = ".t--property-control-helperText";
 }

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -609,10 +609,10 @@ export class AggregateHelper {
     this.Sleep(); //for selected value to reflect!
   }
 
-  // public SelectDropdownList(ddName: string, dropdownOption: string) {
-  //   this.GetNClick(this.locator._existingFieldTextByName(ddName));
-  //   cy.get(this.locator._dropdownText).contains(dropdownOption).click();
-  // }
+  public SelectDropdownList(ddName: string, dropdownOption: string) {
+    this.GetNClick(this.locator._existingFieldTextByName(ddName));
+    cy.get(this.locator._dropdownText).contains(dropdownOption).click();
+  }
 
   public SelectFromMultiSelect(
     options: string[],

--- a/app/client/cypress/support/Pages/Table.ts
+++ b/app/client/cypress/support/Pages/Table.ts
@@ -554,6 +554,16 @@ export class Table {
     if (tableVersion == "v2") this.propPane.NavigateBackToPropertyPane();
   }
 
+  public ChangeColumnTypeWithoutNavigatingBackToPropertyPane(
+    columnName: string,
+    newDataType: columnTypeValues,
+    tableVersion: "v1" | "v2" = "v1",
+  ) {
+    this.EditColumn(columnName, tableVersion);
+    this.propPane.SelectPropertiesDropDown("Column type", newDataType);
+    this.assertHelper.AssertNetworkStatus("@updateLayout");
+  }
+
   public AssertURLColumnNavigation(
     row: number,
     col: number,

--- a/app/client/src/constants/PropertyControlConstants.tsx
+++ b/app/client/src/constants/PropertyControlConstants.tsx
@@ -55,7 +55,9 @@ export interface PropertyPaneControlConfig {
   // Serves in the tooltip
   helpText?: string;
   //Dynamic text serves below the property pane inputs
-  helperText?: ((props: any) => React.ReactNode) | React.ReactNode;
+  helperText?:
+    | ((props: any, propertyName?: string) => React.ReactNode)
+    | React.ReactNode;
   isJSConvertible?: boolean;
   customJSControl?: string;
   controlType: ControlType;

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -719,7 +719,7 @@ const PropertyControl = memo((props: Props) => {
       : props.label;
 
     const helperText = isFunction(props.helperText)
-      ? props.helperText(widgetProperties)
+      ? props.helperText(widgetProperties, propertyName)
       : props.helperText;
 
     dataTreePath =

--- a/app/client/src/widgets/TableWidgetV2/component/Constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/component/Constants.ts
@@ -183,6 +183,7 @@ export interface SelectCellProperties {
   placeholderText?: string;
   resetFilterTextOnClose?: boolean;
   selectOptions?: DropdownOption[];
+  selectDisplayAs?: string;
 }
 
 export interface ImageCellProperties {
@@ -385,6 +386,7 @@ export interface ColumnProperties
   menuItemsSource?: MenuItemsSource;
   configureMenuItems?: ConfigureMenuItems;
   sourceData?: Array<Record<string, unknown>>;
+  selectDisplayAs?: SelectCellProperties["selectDisplayAs"];
 }
 
 export const ConditionFunctions: {
@@ -571,3 +573,8 @@ export const noOfItemsToDisplay = 4;
 
 // 12px for the (noOfItemsToDisplay+ 1) item to let the user know there are more items to scroll
 export const extraSpace = 12;
+
+export enum SelectOptionAccessor {
+  LABEL = "label",
+  VALUE = "value",
+}

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
@@ -8,6 +8,7 @@ import { CellWrapper } from "../TableStyledWrappers";
 import type { EditableCellActions } from "widgets/TableWidgetV2/constants";
 import { BasicCell } from "./BasicCell";
 import { useCallback } from "react";
+import { SelectOptionAccessor } from "../Constants";
 
 const StyledSelectComponent = styled(SelectComponent)<{
   accentColor: string;
@@ -100,6 +101,7 @@ type SelectProps = BaseCellComponentProps & {
   onFilterChangeActionString?: string;
   disabledEditIconMessage: string;
   isNewRow: boolean;
+  selectDisplayAs: string;
 };
 
 /*
@@ -137,6 +139,7 @@ export const SelectCell = (props: SelectProps) => {
     placeholderText,
     resetFilterTextOnClose,
     rowIndex,
+    selectDisplayAs = SelectOptionAccessor.LABEL,
     serverSideFiltering = false,
     tableWidth,
     textColor,
@@ -149,7 +152,7 @@ export const SelectCell = (props: SelectProps) => {
   const onSelect = useCallback(
     (option: DropdownOption) => {
       onItemSelect(
-        option.value || "",
+        option?.value ?? "",
         rowIndex,
         alias,
         onOptionSelectActionString,
@@ -189,6 +192,18 @@ export const SelectCell = (props: SelectProps) => {
     .map((d: DropdownOption) => d.value)
     .indexOf(value);
 
+  let cellValue: string | number | undefined | null = value;
+
+  if (selectDisplayAs === SelectOptionAccessor.LABEL) {
+    const selectedOption = options.find(
+      (item) => item[SelectOptionAccessor.VALUE] === value,
+    );
+
+    cellValue = selectedOption
+      ? selectedOption[SelectOptionAccessor.LABEL]
+      : "";
+  }
+
   if (isEditable && isCellEditable && isCellEditMode) {
     return (
       <StyledCellWrapper
@@ -227,7 +242,7 @@ export const SelectCell = (props: SelectProps) => {
           resetFilterTextOnClose={resetFilterTextOnClose}
           selectedIndex={selectedIndex}
           serverSideFiltering={serverSideFiltering}
-          value={value}
+          value={cellValue}
           widgetId={""}
           width={width}
         />
@@ -257,7 +272,7 @@ export const SelectCell = (props: SelectProps) => {
         tableWidth={tableWidth}
         textColor={textColor}
         textSize={textSize}
-        value={value}
+        value={cellValue}
         verticalAlignment={verticalAlignment}
       />
     );

--- a/app/client/src/widgets/TableWidgetV2/constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/constants.ts
@@ -230,3 +230,5 @@ export const DEFAULT_COLUMN_NAME = "Table Column";
 
 export const ALLOW_TABLE_WIDGET_SERVER_SIDE_FILTERING =
   FEATURE_FLAG["release_table_serverside_filtering_enabled"];
+export const COMPUTED_VALUE_SELECT_HELPER_TEXT =
+  "Each computed value here represents default value/display value";

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -41,6 +41,7 @@ import {
   SORT_ORDER,
   SortOrderTypes,
   StickyType,
+  SelectOptionAccessor,
 } from "../component/Constants";
 import type {
   EditableCell,
@@ -2130,6 +2131,9 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
             placeholderText={cellProperties.placeholderText}
             resetFilterTextOnClose={cellProperties.resetFilterTextOnClose}
             rowIndex={rowIndex}
+            selectDisplayAs={
+              cellProperties.selectDisplayAs ?? SelectOptionAccessor.VALUE
+            }
             serverSideFiltering={cellProperties.serverSideFiltering}
             tableWidth={this.props.componentWidth}
             textColor={cellProperties.textColor}

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Data.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Data.ts
@@ -1,6 +1,10 @@
 import { ValidationTypes } from "constants/WidgetValidation";
 import type { TableWidgetProps } from "widgets/TableWidgetV2/constants";
-import { ColumnTypes, DateInputFormat } from "widgets/TableWidgetV2/constants";
+import {
+  ColumnTypes,
+  DateInputFormat,
+  COMPUTED_VALUE_SELECT_HELPER_TEXT,
+} from "widgets/TableWidgetV2/constants";
 import { get } from "lodash";
 import {
   getBasePropertyPath,
@@ -9,12 +13,14 @@ import {
   uniqueColumnAliasValidation,
   updateCurrencyDefaultValues,
   updateMenuItemsSource,
+  updateSelectColumnDisplayAsValue,
   updateNumberColumnTypeTextAlignment,
   updateThemeStylesheetsInColumns,
 } from "../../propertyUtils";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
 import { composePropertyUpdateHook } from "widgets/WidgetUtils";
 import { CurrencyDropdownOptions } from "widgets/CurrencyInputWidget/component/CurrencyCodeDropdown";
+import type { WidgetProps } from "widgets/BaseWidget";
 
 export default {
   sectionName: "Data",
@@ -84,6 +90,7 @@ export default {
         updateThemeStylesheetsInColumns,
         updateMenuItemsSource,
         updateCurrencyDefaultValues,
+        updateSelectColumnDisplayAsValue,
       ]),
       dependencies: ["primaryColumns", "columnOrder", "childStylesheet"],
       isBindProperty: false,
@@ -155,6 +162,13 @@ export default {
       helpText:
         "The value computed & shown in each cell. Use {{currentRow}} to reference each row in the table. This property is not accessible outside the column settings.",
       propertyName: "computedValue",
+      helperText: (props: WidgetProps, propertyPath: string) => {
+        const basePropertyPath = getBasePropertyPath(propertyPath);
+        const columnType = get(props, `${basePropertyPath}.columnType`);
+        return columnType === ColumnTypes.SELECT
+          ? COMPUTED_VALUE_SELECT_HELPER_TEXT
+          : "";
+      },
       label: "Computed value",
       controlType: "TABLE_COMPUTE_VALUE",
       additionalControlData: {

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Select.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Select.ts
@@ -1,6 +1,7 @@
 import { ValidationTypes } from "constants/WidgetValidation";
 import { get } from "lodash";
 import type { TableWidgetProps } from "widgets/TableWidgetV2/constants";
+import { SelectOptionAccessor } from "widgets/TableWidgetV2/component/Constants";
 import { ColumnTypes } from "widgets/TableWidgetV2/constants";
 import {
   getBasePropertyPath,
@@ -30,6 +31,7 @@ export default {
           },
           fnString: selectColumnOptionsValidation.toString(),
         },
+        dependentPaths: ["primaryColumns"],
       },
       isTriggerProperty: false,
       dependencies: ["primaryColumns"],
@@ -93,6 +95,32 @@ export default {
             return true;
           }
         }
+      },
+    },
+    {
+      propertyName: "selectDisplayAs",
+      defaultValue: "label",
+      helpText: "Allows to display an option's label or value in the cell",
+      label: "Display as",
+      controlType: "DROP_DOWN",
+      isBindProperty: true,
+      isJSConvertible: true,
+      isTriggerProperty: false,
+      options: [
+        {
+          label: "Label",
+          value: SelectOptionAccessor.LABEL,
+        },
+        {
+          label: "Value",
+          value: SelectOptionAccessor.VALUE,
+        },
+      ],
+      validation: {
+        type: ValidationTypes.TEXT,
+        params: {
+          allowedValues: ["label", "value"],
+        },
       },
     },
     {

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.test.ts
@@ -9,10 +9,12 @@ import {
   updateCustomColumnAliasOnLabelChange,
   selectColumnOptionsValidation,
   allowedFirstDayOfWeekRange,
+  updateSelectColumnDisplayAsValue,
 } from "./propertyUtils";
 import _ from "lodash";
 import type { ColumnTypes, TableWidgetProps } from "../constants";
 import { StickyType } from "../component/Constants";
+import { ColumnTypes as ColumnTypesType } from "../constants";
 
 describe("PropertyUtils - ", () => {
   it("totalRecordsCountValidation - should test with all possible values", () => {
@@ -1014,5 +1016,70 @@ describe("allowedFirstDayOfWeekRange", () => {
       parsed: 0,
       messages: ["Number should be between 0-6."],
     });
+  });
+});
+describe("updateSelectColumnDisplayAsValue", () => {
+  it(`Should return an updates array when the column type is "select" and the selectDisplayAs value is not present.`, () => {
+    const tableProps = {
+      primaryColumns: {
+        gender: {
+          computedValue: ["male", "female"],
+        },
+        columnType: ColumnTypesType.SELECT,
+      },
+    };
+
+    expect(
+      updateSelectColumnDisplayAsValue(
+        tableProps as unknown as TableWidgetProps,
+        "primaryColumns.gender.computedValue",
+        "select",
+      ),
+    ).toEqual([
+      {
+        propertyPath: "primaryColumns.gender.selectDisplayAs",
+        propertyValue: "label",
+      },
+    ]);
+  });
+
+  it(`should return an undefined when column type is not "select" and selectDisplayAs value is present`, () => {
+    const tableProps = {
+      primaryColumns: {
+        gender: {
+          computedValue: ["male", "female"],
+          selectDisplayAs: "label",
+        },
+        columnType: ColumnTypesType.TEXT,
+      },
+    };
+
+    expect(
+      updateSelectColumnDisplayAsValue(
+        tableProps as unknown as TableWidgetProps,
+        "primaryColumns.gender.computedValue",
+        "select",
+      ),
+    ).toEqual(undefined);
+  });
+
+  it(`should return an undefined when column type is "select" and selectDisplayAs value is present`, () => {
+    const tableProps = {
+      primaryColumns: {
+        gender: {
+          computedValue: ["male", "female"],
+          selectDisplayAs: "label",
+        },
+        columnType: ColumnTypesType.SELECT,
+      },
+    };
+
+    expect(
+      updateSelectColumnDisplayAsValue(
+        tableProps as unknown as TableWidgetProps,
+        "primaryColumns.gender.computedValue",
+        "select",
+      ),
+    ).toEqual(undefined);
   });
 });

--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
@@ -517,6 +517,11 @@ export const getCellProperties = (
         rowIndex,
         true,
       ),
+      selectDisplayAs: getPropertyValue(
+        columnProperties.selectDisplayAs,
+        rowIndex,
+        true,
+      ),
       decimals: columnProperties.decimals,
       thousandSeparator: getBooleanPropertyValue(
         columnProperties.thousandSeparator,


### PR DESCRIPTION
Fixed issue [26188](https://github.com/appsmithorg/appsmith/issues/26188)

This pull request adds a new feature called "Display as" for the select column type in the table widget.
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/4a17133c-d71a-4c91-9ad5-15fdd64a1a9c)


- Whenever a column is set to select, by default we show labels and not values.
- ![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/2fc889cd-a0b9-4bee-a1f3-c3a8bc9d7b33)
- For existing tables, since we have created this problem we ensure we don't break their apps. We will give an option called "Display As" as suggested in the original issue and for new select columns, it will be Label and for existing columns, it will be Value.
- ![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/4662b15e-8bbb-4480-88e0-bdc9d88c4895)
- We make it clear that the computed value here refers to the default value/display value. Displaying this as the helper text below the computed value property only for select column type.
- Added a helper text below the computed value field that indicates that the computed value here is a default value/display value
- ![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/b2339499-e61c-4c3a-a505-7170520b4f0b)
- Validation:When computed value is not present in the select option then we throw an error in select option. This is irrespective of displayAs property.
- ![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/70485706-957f-40e1-9ca4-e232fd28583d)
-For new row select options, there is no validation of computed value. Since are adding new data into the table and it has to adhere to the select options that we provide.
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/61e54149-af7e-4df2-859e-89034a8d755e)

- For displaying value in cell,
       When display as is set to label, we show empty values for missing labels in the widget
       ![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/341dd402-1511-4ecb-a9cb-d5034e090fe2)
       When display as is set to value, we show the computed value as it is even if labels are missing
       ![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/fda89da8-3046-41e1-b7cf-4946f26b77b9)


- When computed value is not present in the select options, we still make the select options available. We do this because its not the select options that has issue but its computed value.
- 
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/119920490/f90d46c1-2470-4ff5-bee4-90f5b9bbbb71)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced table widget with new `selectDisplayAs` property to display options as label or value.
  - Updated `PropertyControl` component to support enhanced `helperText` functionality.

- **Improvements**
  - Added helper text `COMPUTED_VALUE_SELECT_HELPER_TEXT` for clearer display of computed values in the table widget.

- **Bug Fixes**
  - Fixed dropdown selection functionality in the `AggregateHelper` class.

- **Tests**
  - Introduced comprehensive tests for new `selectDisplayAs` property and related functionalities in the table widget.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->