### PR TITLE
fix:allow users to identify search is enabled in country dropdown

### DIFF
--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -32,6 +32,9 @@ const ErrorMessage = styled.div`
 class DropDownControl extends BaseControl<DropDownControlProps> {
   containerRef = React.createRef<HTMLDivElement>();
 
+  state = {
+    previousValue: this.props.propertyValue,
+  };
   componentDidMount() {
     this.containerRef.current?.addEventListener(
       DS_EVENT,
@@ -55,6 +58,24 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
         key: e.detail.meta.key,
       });
       e.stopPropagation();
+    }
+  };
+
+  handleOnClick = () => {
+    this.updateProperty(this.props.propertyName, "");
+  };
+
+  handleFocus = () => {
+    this.setState({ previousValue: this.props.propertyValue });
+    if (this.containerRef && this.containerRef.current) {
+      const activeElement = document.activeElement as HTMLElement;
+      activeElement.style.caretColor = "transparent";
+    }
+  };
+
+  handleBlur = () => {
+    if (!this.props.propertyValue) {
+      this.updateProperty(this.props.propertyName, this.state.previousValue);
     }
   };
 
@@ -123,6 +144,9 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
           isMultiSelect={this.props.isMultiSelect}
           isValid={!errors.length}
           onDeselect={this.onDeselect}
+          onFocus={this.handleFocus}
+          onClick={this.handleOnClick}
+          onBlur={this.handleBlur}
           onSelect={this.onSelect}
           optionFilterProp="label"
           optionLabelProp={this.props.hideSubText ? "label" : "children"}
@@ -201,6 +225,7 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
         selectedValue = value;
       }
       this.updateProperty(this.props.propertyName, selectedValue);
+      this.setState({ previousValue: selectedValue });
     }
   };
 

--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -67,7 +67,7 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
 
   handleFocus = () => {
     this.setState({ previousValue: this.props.propertyValue });
-    if (this.containerRef && this.containerRef.current) {
+    if (this.containerRef?.current) {
       const activeElement = document.activeElement as HTMLElement;
       activeElement.style.caretColor = "transparent";
     }


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No

### Description

### Bug : [Country dropdown bug](https://github.com/appsmithorg/appsmith/issues/34074)



I have raised this PR `In-order to allow user to know that , they can search for countries in the country dropdown in CurrencyInputWidget and PhoneInputWidget`

### Screenshots
 #### a small cursor is blinking before the selected value
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/ba9708f8-9045-4b07-bc3f-35d45b0c580a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced dropdown control with improved state management for focus and blur events.
  - Added new event handlers to better manage property updates and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->