### PR TITLE
fix: fixing unprotect logic in callout

### DIFF
--- a/app/client/src/pages/Editor/IDE/ProtectedCallout.tsx
+++ b/app/client/src/pages/Editor/IDE/ProtectedCallout.tsx
@@ -6,7 +6,11 @@ import {
   setShowBranchPopupAction,
   updateGitProtectedBranchesInit,
 } from "actions/gitSyncActions";
-import { getIsUpdateProtectedBranchesLoading } from "selectors/gitSyncSelectors";
+import {
+  getCurrentGitBranch,
+  getIsUpdateProtectedBranchesLoading,
+  getProtectedBranchesSelector,
+} from "selectors/gitSyncSelectors";
 import {
   BRANCH_PROTECTION_CALLOUT_CREATE_BRANCH,
   BRANCH_PROTECTION_CALLOUT_MSG,
@@ -23,15 +27,20 @@ const StyledCallout = styled(Callout)`
 function ProtectedCallout() {
   const dispatch = useDispatch();
   const isLoading = useSelector(getIsUpdateProtectedBranchesLoading);
+  const currentBranch = useSelector(getCurrentGitBranch);
+  const protectedBranches = useSelector(getProtectedBranchesSelector);
 
   const handleClickOnNewBranch = () => {
     dispatch(setShowBranchPopupAction(true));
   };
 
   const handleClickOnUnprotect = () => {
+    const remainingBranches = protectedBranches.filter(
+      (protectedBranch) => protectedBranch !== currentBranch,
+    );
     dispatch(
       updateGitProtectedBranchesInit({
-        protectedBranches: [],
+        protectedBranches: remainingBranches,
       }),
     );
   };
@@ -44,11 +53,13 @@ function ProtectedCallout() {
       links={[
         {
           key: "create-branch",
+          "data-testid": "t--git-protected-create-branch-cta",
           children: createMessage(BRANCH_PROTECTION_CALLOUT_CREATE_BRANCH),
           onClick: handleClickOnNewBranch,
         },
         {
           key: "unprotect",
+          "data-testid": "t--git-protected-unprotect-branch-cta",
           children: isLoading
             ? createMessage(BRANCH_PROTECTION_CALLOUT_UNPROTECT_LOADING)
             : createMessage(BRANCH_PROTECTION_CALLOUT_UNPROTECT),


### PR DESCRIPTION
## Description
Clicking "Unprotect branch" in the branch protection callout was making all the branches as unprotected. This PR fixes that and only allows the current branch to be unprotected


Fixes #33310  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
