### PR TITLE
fix/Added error message when label and value are empty in radio group …

### DIFF
--- a/app/client/src/components/propertyControls/KeyValueComponent.tsx
+++ b/app/client/src/components/propertyControls/KeyValueComponent.tsx
@@ -38,6 +38,15 @@ function updateOptionValue<T>(
     };
   });
 }
+const FlexBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ErrorMessageBox = styled.div`
+  color: red;
+`;
 
 const StyledBox = styled.div`
   width: 10px;
@@ -69,6 +78,7 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
     SegmentedControlOptionWithKey[]
   >([]);
   const [typing, setTyping] = useState<boolean>(false);
+  const [errorMessages, setErrorMessages] = useState<string[]>([]);
   const { pairs } = props;
   useEffect(() => {
     let { pairs } = props;
@@ -84,6 +94,7 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
     );
 
     pairs.length !== 0 && !typing && setRenderPairs(newRenderPairs);
+    validatePairs(newRenderPairs);
   }, [props, pairs.length, renderPairs.length]);
 
   const debouncedUpdatePairs = useCallback(
@@ -105,6 +116,7 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
 
     setRenderPairs(updatedRenderPairs);
     debouncedUpdatePairs(updatedPairs);
+    validatePairs(updatedRenderPairs);
   }
 
   function updateValue(index: number, updatedValue: string) {
@@ -119,6 +131,17 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
 
     setRenderPairs(updatedRenderPairs);
     debouncedUpdatePairs(updatedPairs);
+    validatePairs(updatedRenderPairs);
+  }
+
+  function validatePairs(pairs: SegmentedControlOptionWithKey[]) {
+    const newErrorMessages = pairs.map((pair) => {
+      if (!pair.label && !pair.value) {
+        return "Both Name and Value can't be empty";
+      }
+      return "";
+    });
+    setErrorMessages(newErrorMessages);
   }
 
   function deletePair(index: number, isUpdatedViaKeyboard = false) {
@@ -129,6 +152,7 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
     const newRenderPairs = renderPairs.filter((o, i) => i !== index);
 
     setRenderPairs(newRenderPairs);
+    validatePairs(newRenderPairs);
     props.updatePairs(newPairs, isUpdatedViaKeyboard);
   }
 
@@ -162,6 +186,7 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
     });
 
     setRenderPairs(updatedRenderPairs);
+    validatePairs(updatedRenderPairs);
     props.updatePairs(pairs, e.detail === 0);
   }
 
@@ -177,40 +202,47 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
     <>
       {renderPairs.map((pair: SegmentedControlOptionWithKey, index) => {
         return (
-          <ControlWrapper key={pair.key} orientation={"HORIZONTAL"}>
-            <StyledInputGroup
-              dataType={"text"}
-              onBlur={onInputBlur}
-              onChange={(value: string) => {
-                updateKey(index, value);
-              }}
-              onFocus={onInputFocus}
-              placeholder={"Name"}
-              value={pair.label}
-            />
-            <StyledBox />
-            <StyledInputGroup
-              dataType={"text"}
-              onBlur={onInputBlur}
-              onChange={(value: string) => {
-                updateValue(index, value);
-              }}
-              onFocus={onInputFocus}
-              placeholder={"Value"}
-              value={pair.value}
-            />
-            <StyledBox />
-            <Button
-              isIconButton
-              kind="tertiary"
-              onClick={(e: React.MouseEvent) => {
-                deletePair(index, e.detail === 0);
-              }}
-              size="sm"
-              startIcon="delete-bin-line"
-              style={{ width: "50px" }}
-            />
-          </ControlWrapper>
+          <FlexBox>
+            <ControlWrapper key={pair.key} orientation={"HORIZONTAL"}>
+              <StyledInputGroup
+                dataType={"text"}
+                onBlur={onInputBlur}
+                onChange={(value: string) => {
+                  updateKey(index, value);
+                }}
+                onFocus={onInputFocus}
+                placeholder={"Name"}
+                value={pair.label}
+              />
+              <StyledBox />
+              <StyledInputGroup
+                dataType={"text"}
+                onBlur={onInputBlur}
+                onChange={(value: string) => {
+                  updateValue(index, value);
+                }}
+                onFocus={onInputFocus}
+                placeholder={"Value"}
+                value={pair.value}
+              />
+              <StyledBox />
+              <Button
+                isIconButton
+                kind="tertiary"
+                onClick={(e: React.MouseEvent) => {
+                  deletePair(index, e.detail === 0);
+                }}
+                size="sm"
+                startIcon="delete-bin-line"
+                style={{ width: "50px" }}
+              />
+            </ControlWrapper>
+            {errorMessages[index] && (
+              <ErrorMessageBox>
+                {errorMessages[index]}
+              </ErrorMessageBox>
+            )}
+          </FlexBox>
         );
       })}
 

--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -70,6 +70,16 @@ export function optionsCustomValidation(
         break;
       }
 
+      if (!label && !value) {
+        _isValid = false;
+        message = {
+          name: "ValidationError",
+          message:
+            "Both Name and Value can't be empty",
+        };
+        break;
+      }
+
       //Check if the required field "label" is present:
       if (!label) {
         _isValid = false;


### PR DESCRIPTION

### **User description**

## Description:
In Radio button widget->In property pane->if the options section(label or value) is kept empty the required error message should be displayed.

### Bug: [In Radio button widget->In property pane->if the options section(label or value) is kept empty the required error message should be displayed](https://github.com/appsmithorg/appsmith/issues/4653)
## Before:
![Screenshot from 2024-06-10 16-47-22](https://github.com/zemoso-int/appsmith-from-the-business/assets/136346053/bfb7cc95-1bd0-4240-bde2-c028bbf7e2d0)


## After resolving bug:

![Screenshot from 2024-06-12 09-44-43](https://github.com/zemoso-int/appsmith-from-the-business/assets/136346053/bd626167-0413-4b59-9d6f-41f41385555a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added error message handling for empty name and value fields in the key-value component.
  - Introduced custom validation tests for the RadioGroup widget with checks for selected values and validation messages.
  - Enhanced validation logic in the RadioGroup widget to display an error message when both label and value are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added error message handling for empty name and value fields in key-value pairs in the `KeyValueComponent`.
- Introduced `ErrorMessageBox` styled component for displaying error messages.
- Implemented `validatePairs` function to validate key-value pairs and set appropriate error messages.
- Updated the component structure to include error message display below each key-value pair.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KeyValueComponent.tsx</strong><dd><code>Add validation and error messages for empty key-value pairs</code></dd></summary>
<hr>

app/client/src/components/propertyControls/KeyValueComponent.tsx
<li>Added <code>ErrorMessageBox</code> styled component for error display.<br> <li> Introduced <code>validatePairs</code> function to validate key-value pairs.<br> <li> Updated component to display error messages for empty name or value <br>fields.<br> <li> Modified component structure to include error message display.<br>


</details>
    

  </td>
  <td><a href="https://github.com/zemoso-int/appsmith-from-the-business/pull/65/files#diff-13c5e25bba9b70961fe4ac51d939339a538a336bb26a175a969ae850c430b16b">+66/-34</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

