### PR TITLE
fix: property pane height fix for animation

### DIFF
--- a/app/client/src/pages/Editor/IDE/index.tsx
+++ b/app/client/src/pages/Editor/IDE/index.tsx
@@ -42,7 +42,7 @@ function IDE() {
         <MainPane id="app-body" />
         <div
           className={classNames({
-            [`transition-transform transform duration-400 ${tailwindLayers.propertyPane}`]:
+            [`transition-transform transform duration-400 h-full ${tailwindLayers.propertyPane}`]:
               true,
             relative: !isCombinedPreviewMode,
             "translate-x-full fixed right-0": isCombinedPreviewMode,


### PR DESCRIPTION
## Description
This PR fixes the animation glitch which shrinks the property pane height when switching to preview mode.

https://github.com/appsmithorg/appsmith/assets/7565635/066cff0b-72b4-4645-bd4e-cccb53fc4e98



Fixes #34279 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.PropertyPane"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9561855587>
> Commit: c76260222a22281f90aaa86fa43dc40d8485d9a5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9561855587&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.PropertyPane`

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved transition behavior of an element by updating class name within the IDE page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->