### PR TITLE
chore: Use `RequiredArgsConstructor` when possible

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CacheableRepositoryHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CacheableRepositoryHelperCEImpl.java
@@ -15,6 +15,7 @@ import com.appsmith.server.helpers.InMemoryCacheableRepositoryHelper;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
@@ -35,19 +36,11 @@ import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.n
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class CacheableRepositoryHelperCEImpl implements CacheableRepositoryHelperCE {
     private final ReactiveMongoOperations mongoOperations;
     private final InMemoryCacheableRepositoryHelper inMemoryCacheableRepositoryHelper;
     private final ObservationRegistry observationRegistry;
-
-    public CacheableRepositoryHelperCEImpl(
-            ReactiveMongoOperations mongoOperations,
-            InMemoryCacheableRepositoryHelper inMemoryCacheableRepositoryHelper,
-            ObservationRegistry observationRegistry) {
-        this.mongoOperations = mongoOperations;
-        this.inMemoryCacheableRepositoryHelper = inMemoryCacheableRepositoryHelper;
-        this.observationRegistry = observationRegistry;
-    }
 
     @Cache(cacheName = "permissionGroupsForUser", key = "{#user.email + #user.tenantId}")
     @Override
@@ -188,7 +181,7 @@ public class CacheableRepositoryHelperCEImpl implements CacheableRepositoryHelpe
         BridgeQuery<Tenant> andCriteria = Bridge.and(defaultTenantCriteria, notDeletedCriteria);
         Query query = new Query();
         query.addCriteria(andCriteria);
-        log.info("FETCHING TENANT FROM DATABASE AS NOT PRESENT IN CACHE!");
+        log.info("Fetching tenant from database as it couldn't be found in the cache!");
         return mongoOperations
                 .findOne(query, Tenant.class)
                 .map(tenant -> {


### PR DESCRIPTION
This class injects `mongoOperations`, which isn't available on Postgres, so there we inject `entityManager`. So when constructor params change in this class, we get an unnecessary conflict. Using `@RequiredArgsConstructor` makes this conflict go away.

And a minor case-fix in a log message.

/test sanity
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9547442599>
> Commit: 2e51a781238d58c8af95b50d4f388a508bc3de41
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9547442599&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved codebase maintainability by simplifying constructor initialization with `@RequiredArgsConstructor` annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->