### PR TITLE
chore: Deprecate `.findById` signature with `Optional` parameter

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
@@ -14,7 +14,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ActionCollectionServiceCE extends CrudService<ActionCollection, String> {
 
@@ -47,10 +46,8 @@ public interface ActionCollectionServiceCE extends CrudService<ActionCollection,
 
     Mono<ActionCollectionDTO> deleteUnpublishedActionCollection(String id);
 
-    Mono<ActionCollectionDTO> deleteUnpublishedActionCollectionWithOptionalPermission(
-            String id,
-            Optional<AclPermission> deleteCollectionPermission,
-            Optional<AclPermission> deleteActionPermission);
+    Mono<ActionCollectionDTO> deleteUnpublishedActionCollection(
+            String id, AclPermission deleteCollectionPermission, AclPermission deleteActionPermission);
 
     Mono<ActionCollectionDTO> deleteWithoutPermissionUnpublishedActionCollection(String id);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -42,7 +42,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -343,28 +342,18 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
 
     @Override
     public Mono<ActionCollectionDTO> deleteWithoutPermissionUnpublishedActionCollection(String id) {
-        return deleteUnpublishedActionCollectionEx(
-                id, Optional.empty(), Optional.of(actionPermission.getDeletePermission()));
+        return deleteUnpublishedActionCollection(id, null, actionPermission.getDeletePermission());
     }
 
     @Override
     public Mono<ActionCollectionDTO> deleteUnpublishedActionCollection(String id) {
-        return deleteUnpublishedActionCollectionEx(
-                id,
-                Optional.of(actionPermission.getDeletePermission()),
-                Optional.of(actionPermission.getDeletePermission()));
+        return deleteUnpublishedActionCollection(
+                id, actionPermission.getDeletePermission(), actionPermission.getDeletePermission());
     }
 
     @Override
-    public Mono<ActionCollectionDTO> deleteUnpublishedActionCollectionWithOptionalPermission(
-            String id,
-            Optional<AclPermission> deleteCollectionPermission,
-            Optional<AclPermission> deleteActionPermission) {
-        return deleteUnpublishedActionCollectionEx(id, deleteCollectionPermission, deleteActionPermission);
-    }
-
-    public Mono<ActionCollectionDTO> deleteUnpublishedActionCollectionEx(
-            String id, Optional<AclPermission> permission, Optional<AclPermission> deleteActionPermission) {
+    public Mono<ActionCollectionDTO> deleteUnpublishedActionCollection(
+            String id, AclPermission permission, AclPermission deleteActionPermission) {
         Mono<ActionCollection> actionCollectionMono = repository
                 .findById(id, permission)
                 .switchIfEmpty(Mono.error(
@@ -377,7 +366,7 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
                             && toDelete.getPublishedCollection().getName() != null) {
                         toDelete.getUnpublishedCollection().setDeletedAt(Instant.now());
                         modifiedActionCollectionMono = newActionService
-                                .findByCollectionIdAndViewMode(id, false, deleteActionPermission.orElse(null))
+                                .findByCollectionIdAndViewMode(id, false, deleteActionPermission)
                                 .flatMap(newAction -> newActionService
                                         .deleteGivenNewAction(newAction)
                                         // return an empty action so that the filter can remove it from the list

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
@@ -256,7 +256,7 @@ public class GitApplicationHelperCEImpl implements GitArtifactHelperCE<Applicati
         // Update all the resources to replace defaultResource Ids with the resource Ids as branchName
         // will be deleted
         Flux<NewPage> newPageFlux = Flux.fromIterable(defaultApplication.getPages())
-                .flatMap(page -> newPageService.findById(page.getId(), Optional.empty()))
+                .flatMap(page -> newPageService.findById(page.getId(), null))
                 .map(newPage -> {
                     newPage.setDefaultResources(null);
                     return createDefaultIdsOrUpdateWithGivenResourceIds(newPage, null);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
@@ -58,7 +58,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -375,7 +374,7 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
             ApplicationJson applicationJson,
             MappedImportableResourcesDTO mappedImportableResourcesDTO) {
         return branchedPageIdMono.flatMap(
-                pageId -> newPageService.findById(pageId, Optional.empty()).flatMap(newPage -> {
+                pageId -> newPageService.findById(pageId, null).flatMap(newPage -> {
                     String pageName = newPage.getUnpublishedPage().getName();
                     // update page name reference with newPage
                     Map<String, NewPage> pageNameMap = new HashMap<>();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -48,7 +48,7 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
     Mono<ActionDTO> updateUnpublishedAction(String id, ActionDTO action);
 
     Mono<Tuple2<ActionDTO, NewAction>> updateUnpublishedActionWithoutAnalytics(
-            String id, ActionDTO action, Optional<AclPermission> permission);
+            String id, ActionDTO action, AclPermission permission);
 
     Mono<ActionDTO> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission permission);
 
@@ -84,8 +84,7 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
 
     Mono<ActionDTO> deleteUnpublishedAction(String id);
 
-    Mono<ActionDTO> deleteUnpublishedActionWithOptionalPermission(
-            String id, Optional<AclPermission> newActionDeletePermission);
+    Mono<ActionDTO> deleteUnpublishedAction(String id, AclPermission newActionDeletePermission);
 
     Flux<ActionDTO> getUnpublishedActions(MultiValueMap<String, String> params, Boolean includeJsActions);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -579,7 +579,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 action != null ? action.getId() : null,
                 id);
 
-        return updateUnpublishedActionWithoutAnalytics(id, action, Optional.of(actionPermission.getEditPermission()))
+        return updateUnpublishedActionWithoutAnalytics(id, action, actionPermission.getEditPermission())
                 .zipWhen(zippedActions -> {
                     ActionDTO updatedActionDTO = zippedActions.getT1();
                     if (updatedActionDTO.getDatasource() != null
@@ -626,7 +626,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
      */
     @Override
     public Mono<Tuple2<ActionDTO, NewAction>> updateUnpublishedActionWithoutAnalytics(
-            String id, ActionDTO action, Optional<AclPermission> permission) {
+            String id, ActionDTO action, AclPermission permission) {
         log.debug(
                 "Updating unpublished action without analytics with action id: {} ",
                 action != null ? action.getId() : null);
@@ -848,12 +848,11 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
 
     @Override
     public Mono<ActionDTO> deleteUnpublishedAction(String id) {
-        return deleteUnpublishedActionWithOptionalPermission(id, Optional.of(actionPermission.getDeletePermission()));
+        return deleteUnpublishedAction(id, actionPermission.getDeletePermission());
     }
 
     @Override
-    public Mono<ActionDTO> deleteUnpublishedActionWithOptionalPermission(
-            String id, Optional<AclPermission> newActionDeletePermission) {
+    public Mono<ActionDTO> deleteUnpublishedAction(String id, AclPermission newActionDeletePermission) {
         Mono<NewAction> actionMono = repository
                 .findById(id, newActionDeletePermission)
                 .switchIfEmpty(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
@@ -99,7 +98,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                         log.info("Deleting {} actions which are no more used", invalidActionIds.size());
                         return Flux.fromIterable(invalidActionIds)
                                 .flatMap(actionId -> newActionService
-                                        .deleteUnpublishedActionWithOptionalPermission(actionId, Optional.empty())
+                                        .deleteUnpublishedAction(actionId, null)
                                         // return an empty action so that the filter can remove it from the list
                                         .onErrorResume(throwable -> {
                                             log.debug("Failed to delete action with id {} during import", actionId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
@@ -23,8 +23,6 @@ public interface NewPageServiceCE extends CrudService<NewPage, String> {
 
     Mono<NewPage> findById(String pageId, AclPermission aclPermission);
 
-    Mono<NewPage> findById(String pageId, Optional<AclPermission> aclPermission);
-
     Mono<PageDTO> findPageById(String pageId, AclPermission aclPermission, Boolean view);
 
     Flux<PageDTO> findByApplicationId(String applicationId, AclPermission permission, Boolean view);
@@ -73,7 +71,7 @@ public interface NewPageServiceCE extends CrudService<NewPage, String> {
 
     Mono<Boolean> archiveByIds(Collection<String> idList);
 
-    Mono<NewPage> archiveWithoutPermissionById(String id);
+    Mono<NewPage> archiveByIdWithoutPermission(String id);
 
     Flux<NewPage> saveAll(List<NewPage> pages);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
@@ -124,11 +124,6 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     }
 
     @Override
-    public Mono<NewPage> findById(String pageId, Optional<AclPermission> aclPermission) {
-        return repository.findById(pageId, aclPermission);
-    }
-
-    @Override
     public Flux<PageDTO> findByApplicationId(String applicationId, AclPermission permission, Boolean view) {
         return findNewPagesByApplicationId(applicationId, permission).flatMap(page -> getPageByViewMode(page, view));
     }
@@ -521,13 +516,13 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     }
 
     @Override
-    public Mono<NewPage> archiveWithoutPermissionById(String id) {
-        return archiveByIdEx(id, Optional.empty());
+    public Mono<NewPage> archiveByIdWithoutPermission(String id) {
+        return archiveByIdEx(id, null);
     }
 
     @Override
     public Mono<NewPage> archiveById(String id) {
-        return archiveByIdEx(id, Optional.of(pagePermission.getDeletePermission()));
+        return archiveByIdEx(id, pagePermission.getDeletePermission());
     }
 
     @Override
@@ -535,8 +530,8 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
         return repository.archiveAllById(idList);
     }
 
-    public Mono<NewPage> archiveByIdEx(String id, Optional<AclPermission> permission) {
-        Mono<NewPage> pageMono = this.findById(id, permission)
+    private Mono<NewPage> archiveByIdEx(String id, AclPermission permission) {
+        Mono<NewPage> pageMono = findById(id, permission)
                 .switchIfEmpty(
                         Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.PAGE_ID, id)))
                 .cache();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
@@ -359,15 +359,10 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
                         // This does not apply to the traditional import via file approach
                         return Flux.fromIterable(invalidPageIds)
                                 .flatMap(pageId -> {
-                                    return applicationPageService.deleteUnpublishedPageWithOptionalPermission(
-                                            pageId,
-                                            Optional.empty(),
-                                            Optional.empty(),
-                                            Optional.empty(),
-                                            Optional.empty());
+                                    return applicationPageService.deleteUnpublishedPage(pageId, null, null, null, null);
                                 })
                                 .flatMap(page -> newPageService
-                                        .archiveWithoutPermissionById(page.getId())
+                                        .archiveByIdWithoutPermission(page.getId())
                                         .onErrorResume(e -> {
                                             log.debug(
                                                     "Unable to archive page {} with error {}",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
@@ -14,6 +14,7 @@ public interface AppsmithRepository<T extends BaseDomain> {
 
     Mono<T> findById(String id, AclPermission permission);
 
+    @Deprecated(forRemoval = true)
     Mono<T> findById(String id, Optional<AclPermission> permission);
 
     Mono<T> updateById(String id, T resource, AclPermission permission);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -120,7 +120,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
     /**
      * @deprecated using `Optional` for function arguments is an anti-pattern.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public Mono<T> findById(String id, Optional<AclPermission> permission) {
         return findById(id, permission.orElse(null));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCE.java
@@ -11,7 +11,6 @@ import com.appsmith.server.dtos.PageDTO;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ApplicationPageServiceCE {
 
@@ -50,12 +49,12 @@ public interface ApplicationPageServiceCE {
 
     Mono<PageDTO> deleteUnpublishedPageByBranchAndDefaultPageId(String defaultPageId, String branchName);
 
-    Mono<PageDTO> deleteUnpublishedPageWithOptionalPermission(
+    Mono<PageDTO> deleteUnpublishedPage(
             String id,
-            Optional<AclPermission> deletePagePermission,
-            Optional<AclPermission> readApplicationPermission,
-            Optional<AclPermission> deleteCollectionPermission,
-            Optional<AclPermission> deleteActionPermission);
+            AclPermission deletePagePermission,
+            AclPermission readApplicationPermission,
+            AclPermission deleteCollectionPermission,
+            AclPermission deleteActionPermission);
 
     Mono<PageDTO> deleteUnpublishedPage(String id);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -127,7 +126,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
     protected Mono<ActionDTO> associateContextIdToActionDTO(
             ActionDTO actionDTO, CreatorContextType contextType, String contextId) {
         actionDTO.setPageId(contextId);
-        return newPageService.findById(contextId, Optional.empty()).map(newPage -> {
+        return newPageService.findById(contextId, null).map(newPage -> {
             // Set git related resource IDs
             actionDTO.setDefaultResources(newPage.getDefaultResources());
             return actionDTO;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -48,7 +48,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -484,7 +483,7 @@ public class ActionCollectionServiceImplTest {
 
     @Test
     public void testDeleteUnpublishedActionCollection_withInvalidId_throwsError() {
-        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<Optional<AclPermission>>any()))
+        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.empty());
 
         final Mono<ActionCollectionDTO> actionCollectionMono =
@@ -514,7 +513,7 @@ public class ActionCollectionServiceImplTest {
 
         Instant deletedAt = Instant.now();
 
-        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<Optional<AclPermission>>any()))
+        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(actionCollection));
 
         Mockito.when(newActionService.findByCollectionIdAndViewMode(
@@ -556,7 +555,7 @@ public class ActionCollectionServiceImplTest {
         unpublishedCollection.setDefaultResources(setDefaultResources(unpublishedCollection));
         Instant deletedAt = Instant.now();
 
-        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<Optional<AclPermission>>any()))
+        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(actionCollection));
 
         ActionDTO actionDTO =
@@ -607,7 +606,7 @@ public class ActionCollectionServiceImplTest {
                 .getUnpublishedCollection()
                 .setDefaultResources(setDefaultResources(actionCollection.getUnpublishedCollection()));
 
-        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<Optional<AclPermission>>any()))
+        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(actionCollection));
 
         ActionDTO actionDTO =
@@ -655,7 +654,7 @@ public class ActionCollectionServiceImplTest {
                 .getUnpublishedCollection()
                 .setDefaultResources(setDefaultResources(actionCollection.getUnpublishedCollection()));
 
-        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<Optional<AclPermission>>any()))
+        Mockito.when(actionCollectionRepository.findById(Mockito.any(), Mockito.<AclPermission>any()))
                 .thenReturn(Mono.just(actionCollection));
 
         ActionDTO actionDTO =

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/NewPageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/NewPageServiceTest.java
@@ -36,7 +36,6 @@ import reactor.test.StepVerifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -431,7 +430,7 @@ public class NewPageServiceTest {
                     dependencyMap.put("key3", List.of("val1", "val2"));
                     return newPageService
                             .updateDependencyMap(pageDTO.getId(), dependencyMap, null)
-                            .then(newPageService.findById(pageDTO.getId(), Optional.empty()));
+                            .then(newPageService.findById(pageDTO.getId(), null));
                 });
 
         StepVerifier.create(newPageMono)
@@ -468,7 +467,7 @@ public class NewPageServiceTest {
                     return newPageService
                             .updateDependencyMap(pageDTO.getId(), dependencyMap, null)
                             .flatMap(page -> applicationPageService.publish(application.getId(), null, false))
-                            .then(newPageService.findById(pageDTO.getId(), Optional.empty()));
+                            .then(newPageService.findById(pageDTO.getId(), null));
                 });
 
         StepVerifier.create(newPageMono)
@@ -504,7 +503,7 @@ public class NewPageServiceTest {
                 })
                 .flatMap(pageDTO -> newPageService
                         .updateDependencyMap(pageDTO.getId(), null, null)
-                        .then(newPageService.findById(pageDTO.getId(), Optional.empty())));
+                        .then(newPageService.findById(pageDTO.getId(), null)));
 
         StepVerifier.create(newPageMono)
                 .assertNext(newPage -> {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
@@ -282,7 +282,7 @@ public class PartialImportServiceTest {
                 .block();
 
         String pageId = newPageService
-                .findById(testApplication.getPages().get(0).getId(), Optional.empty())
+                .findById(testApplication.getPages().get(0).getId(), null)
                 .block()
                 .getId();
 
@@ -400,7 +400,7 @@ public class PartialImportServiceTest {
                 .block();
 
         String pageId = newPageService
-                .findById(testApplication.getPages().get(0).getId(), Optional.empty())
+                .findById(testApplication.getPages().get(0).getId(), null)
                 .block()
                 .getId();
 
@@ -481,7 +481,7 @@ public class PartialImportServiceTest {
                 .block();
 
         String pageId = newPageService
-                .findById(testApplication.getPages().get(0).getId(), Optional.empty())
+                .findById(testApplication.getPages().get(0).getId(), null)
                 .block()
                 .getId();
         BuildingBlockDTO buildingBlockDTO = new BuildingBlockDTO();


### PR DESCRIPTION
This is work on getting to remove the `.findById` signature with `Optional<>` arguments. This signature doesn't add any value, encourages confusing multi-signature service methods (check the diff here), and is causing unnecessary problems in `pg` branch with generating `*Cake` classes.

This PR doesn't get rid of this entirely, just one part. A follow-up PR will be opened after this is merged.

Nothing new, nothing fixed. Only a refactor.

No conflicts to EE, but needs extra changes, in [this PR](https://github.com/appsmithorg/appsmith-ee/pull/3714) to be merged for the build to pass.

**/test sanity**

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9549476417>
> Commit: c1e45f2fe50530b7ec8436d9722310537d125166
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9549476417&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified method signatures by removing the use of `Optional` for permission parameters across various services. Permissions are now passed directly.
  - Deprecated `findById` method that uses `Optional<AclPermission>` to improve code clarity and maintainability.

- **Chores**
  - Updated test cases to remove the use of `Optional.empty()` and replaced with `null` in method calls.
  - Removed unnecessary imports of `Optional` in multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->