### PR TITLE
fix: datepicker doesn't close on first selection of date on month change

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.js
@@ -1,0 +1,43 @@
+import {
+  draggableWidgets,
+  entityExplorer,
+} from "../../../../../support/Objects/ObjectsCore";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+
+describe(
+  "DatePicker Widget Property pane tests with js bindings",
+  { tags: ["@tag.Widget", "@tag.Datepicker"] },
+  function () {
+    before(() => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.DATEPICKER);
+    });
+
+    function navigateAndSelectRandomDate(direction) {
+      const buttonClass =
+        direction === "prev"
+          ? ".DayPicker-NavButton--prev"
+          : ".DayPicker-NavButton--next";
+      cy.get(buttonClass).should("be.visible").click();
+      cy.get(".DayPicker").should("be.visible");
+      cy.get(".DayPicker-Month")
+        .first()
+        .find(".DayPicker-Day")
+        .then(($days) => {
+          const randomIndex = Math.floor(Math.random() * $days.length);
+          cy.wrap($days[randomIndex]).click();
+        });
+    }
+
+    it("1.should close datepicker on single click when month is changed", function () {
+      cy.openPropertyPane("datepickerwidget2");
+      cy.get(".t--widget-datepickerwidget2 input").click();
+      cy.get(".DayPicker").should("be.visible");
+
+      navigateAndSelectRandomDate("prev");
+      cy.get(".t--widget-datepickerwidget2 input").click();
+      navigateAndSelectRandomDate("prev");
+      cy.get(".t--widget-datepickerwidget2 input").click();
+      navigateAndSelectRandomDate("next");
+    });
+  },
+);

--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -377,7 +377,7 @@ class DatePickerComponent extends React.Component<
               }}
               maxDate={maxDate}
               minDate={minDate}
-              onChange={this.onDateSelected}
+              onChange={this.handleDateChange}
               parseDate={this.parseDate}
               placeholder={"Select Date"}
               popoverProps={{
@@ -479,6 +479,18 @@ class DatePickerComponent extends React.Component<
         selectedDate: date,
       });
       onDateSelected(date);
+    }
+  };
+
+  handleDateChange = (selectedDate: Date | null) => {
+    if (selectedDate === null) {
+      this.setState({ selectedDate: "" });
+      this.props.onDateSelected("");
+    } else {
+      const formattedDate = moment(selectedDate).format(ISO_DATE_FORMAT);
+      this.setState({ selectedDate: formattedDate }, () => {
+        this.props.onDateSelected(formattedDate);
+      });
     }
   };
 }


### PR DESCRIPTION
Fixes issue #30701 

Added cypress test for the fix

https://github.com/appsmithorg/appsmith/assets/119920490/d8e92377-6d27-49f9-8839-e18b8b6aae65



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new tests to the DatePicker widget ensuring functionality and reliability.
- **Bug Fixes**
	- Improved date selection logic to handle null values and formatted dates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->