### PR TITLE
chore: Fix `PATH` getting reset by `su`

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -430,7 +430,7 @@ init_postgres() {
 
     if [[ ! -e "$POSTGRES_DB_PATH/PG_VERSION" ]]; then
       tlog "Initializing local Postgres data folder"
-      su postgres -c "initdb -D $POSTGRES_DB_PATH"
+      su postgres -c "env PATH='$PATH' initdb -D $POSTGRES_DB_PATH"
     fi
   else
     runEmbeddedPostgres=0


### PR DESCRIPTION
The `PATH` env variable gets reset to it's original value by `su`, because its a "secure" env variable, and is _never_ preserved across user-switches.

Because of this, the Postgres commands like `initdb` are not found on the `PATH`. This PR fixes this by setting the `PATH` in the command passed to `su` itself, so that `initdb` can now be found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the initialization process for local Postgres data folder to ensure compatibility with environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->