### PR TITLE
ci: Update PR description with GitHub Script

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -171,22 +171,19 @@ jobs:
 
       # In case of a runnable command, update the PR with run details
       - name: Add test response with link to workflow run
-        uses: nefrob/pr-description@v1.1.2
+        uses: actions/github-script@v7
+        env:
+          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
+          BODY: |
+            > [!IMPORTANT]
+            > 🟣 🟣 🟣 Your tests are running.
+            > Tests running at: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+            > Commit: ${{ github.event.pull_request.head.sha }}
+            > Workflow: `${{ github.workflow }}`
+            > Tags: `${{ steps.checkAll.outputs.tags }}`
         with:
-            content: |
-              <!-- This is an auto-generated comment: Cypress test results  -->
-              > [!IMPORTANT]
-              > 🟣 🟣 🟣 Your tests are running.
-              > Tests running at: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
-              > Commit: ${{ github.event.pull_request.head.sha }}
-              > Workflow: `${{ github.workflow }}`
-              > Tags: `${{ steps.checkAll.outputs.tags }}`
-
-              <!-- end of auto-generated comment: Cypress test results  -->
-
-            regex: "<!-- This is an auto-generated comment: Cypress test results  -->.*?<!-- end of auto-generated comment: Cypress test results  -->"
-            regexFlags: ims
-            token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            require("write-cypress-comment.js")({core, context, github}, process.env.BODY))
 
   # Call the workflow to run Cypress tests
   perform-test:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -183,7 +183,7 @@ jobs:
             > Tags: `${{ steps.checkAll.outputs.tags }}`
         with:
           script: |
-            require("write-cypress-comment.js")({core, context, github}, process.env.BODY))
+            require("write-cypress-comment.js")({core, context, github}, process.env.BODY)
 
   # Call the workflow to run Cypress tests
   perform-test:

--- a/.github/workflows/scripts/write-cypress-comment.js
+++ b/.github/workflows/scripts/write-cypress-comment.js
@@ -1,0 +1,39 @@
+const HEADER = '<!-- This is an auto-generated comment: Cypress test results  -->';
+const FOOTER = '<!-- end of auto-generated comment: Cypress test results  -->';
+const PATTERN = new RegExp(HEADER + ".*?" + FOOTER, "ims");
+
+module.exports = async function({core, context, github}, note) {
+  const prNumber = context.payload.pull_request?.number;
+
+  if (!prNumber) {
+    core.setFailed(
+      `No open pull request found for ${context.eventName}, ${context.sha}`,
+    );
+    return;
+  }
+
+  const response = await github.rest.pulls.get({
+    ...context.repo,
+    pull_number: prNumber,
+  });
+
+  let body = response?.data?.body;
+  if (!body) {
+    core.setFailed(JSON.stringify(response, null, 2));
+    return;
+  }
+
+  note = [HEADER, note, FOOTER].join("\n");
+
+  if (body.match(PATTERN)) {
+    body = body.replace(PATTERN, note);
+  } else {
+    body += "\n\n" + note + "\n";
+  }
+
+  await github.rest.pulls.update({
+    ...context.repo,
+    pull_number: prNumber,
+    body,
+  });
+}


### PR DESCRIPTION
This PR switches the steps updating PR description to a local Javascript script, run using `actions/github-script`, instead of depending on an external third-party action.

Why? Besides reducing our dependency on third-party actions, which have been found to break with surprises, we need this to fix a bug with the `/test` command. The `/test` command, when is written with invalid tags, reports the error in the workflow run, but doesn't update the PR description. Because of how it's written in Javascript, we need a Javascript way to update the description to fix that. This will provide for that.

Further PRs will replace other uses of PR description update steps with this.

**/test sanity**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9556890596>
> Commit: 00d06858f6f7d14c6393cb16c894ddfd808b7cf8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9556890596&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to enhance pull request automation with Cypress test results.
  - Improved PR body updates with detailed test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->