### PR TITLE
fix: learn more link in git connect success modal

### DIFF
--- a/app/client/src/constants/ThirdPartyConstants.tsx
+++ b/app/client/src/constants/ThirdPartyConstants.tsx
@@ -30,7 +30,7 @@ export const PROVISIONING_SETUP_DOC =
 export const DISCORD_URL = "https://discord.gg/rBTTVJp";
 export const ENTERPRISE_PRICING_PAGE = "https://www.appsmith.com/enterprise";
 export const DOCS_BRANCH_PROTECTION_URL =
-  "https://docs.appsmith.com/advanced-concepts/version-control-with-git/working-with-branches#branch-protection";
+  "https://docs.appsmith.com/advanced-concepts/version-control-with-git/reference/git-settings#branch-protection";
 export const DOCS_DEFAULT_BRANCH_URL =
   "https://docs.appsmith.com/advanced-concepts/version-control-with-git/working-with-branches#default-branch";
 export const PACKAGES_OVERVIEW_DOC =

--- a/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/ConnectionSuccess.tsx
@@ -98,8 +98,12 @@ function ConnectionSuccessBody() {
           {createMessage(GIT_CONNECT_SUCCESS_PROTECTION_MSG)}
         </Text>
       </div>
-      <LinkText isBold renderAs="p">
-        <Link href={DOCS_BRANCH_PROTECTION_URL}>
+      <LinkText className="inline-block" isBold renderAs="p">
+        <Link
+          data-testid="t--git-success-modal-learn-more-link"
+          target="_blank"
+          to={DOCS_BRANCH_PROTECTION_URL}
+        >
           {createMessage(GIT_CONNECT_SUCCESS_PROTECTION_DOC_CTA)}
         </Link>
       </LinkText>

--- a/app/client/src/pages/Editor/gitSync/Tabs/__tests__/ConnectionSuccess.test.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/__tests__/ConnectionSuccess.test.tsx
@@ -7,6 +7,7 @@ import { Provider } from "react-redux";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { GitSettingsTab } from "reducers/uiReducers/gitSyncReducer";
 import { BrowserRouter } from "react-router-dom";
+import { DOCS_BRANCH_PROTECTION_URL } from "constants/ThirdPartyConstants";
 
 const initialState = {
   ui: {
@@ -72,6 +73,20 @@ describe("Connection Success Modal", () => {
       type: ReduxActionTypes.GIT_SET_SETTINGS_MODAL_OPEN,
       payload: { open: true, tab: GitSettingsTab.BRANCH },
     });
+  });
+
+  it("'Learn more' link has proper URL", () => {
+    const { queryByTestId } = renderComponent();
+    expect(
+      queryByTestId("t--git-success-modal-learn-more-link")?.getAttribute(
+        "href",
+      ),
+    ).toBe(DOCS_BRANCH_PROTECTION_URL);
+    expect(
+      queryByTestId("t--git-success-modal-learn-more-link")?.getAttribute(
+        "target",
+      ),
+    ).toBe("_blank");
   });
 
   it("'Continue' cta button is working", () => {


### PR DESCRIPTION
## Description
Learn more link in Git connection success modal was not working properly. This PR fixes it

Fixes https://github.com/appsmithorg/appsmith/issues/34295

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9560201005>
> Commit: 3e282e06d3a26442a5f3acb0c8231b51ba13ee05
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9560201005&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation link for branch protection settings to the latest URL in the Git sync success modal.
- **Tests**
	- Added a test to verify the updated 'Learn more' link in the Git connection success modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->