### PR TITLE
chore: Remove `findById` signature with `Optional`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
@@ -57,7 +57,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -141,16 +140,16 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
 
     @Override
     public Mono<Datasource> create(Datasource datasource) {
-        return createEx(datasource, Optional.of(workspacePermission.getDatasourceCreatePermission()));
+        return createEx(datasource, workspacePermission.getDatasourceCreatePermission());
     }
 
     // TODO: Check usage
     @Override
     public Mono<Datasource> createWithoutPermissions(Datasource datasource) {
-        return createEx(datasource, Optional.empty());
+        return createEx(datasource, null);
     }
 
-    private Mono<Datasource> createEx(@NotNull Datasource datasource, Optional<AclPermission> permission) {
+    private Mono<Datasource> createEx(@NotNull Datasource datasource, AclPermission permission) {
         // Validate incoming request
         String workspaceId = datasource.getWorkspaceId();
         if (!hasText(workspaceId)) {
@@ -263,7 +262,7 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
     }
 
     private Mono<Datasource> generateAndSetDatasourcePolicies(
-            Mono<User> userMono, Datasource datasource, Optional<AclPermission> permission) {
+            Mono<User> userMono, Datasource datasource, AclPermission permission) {
         return userMono.flatMap(user -> {
             Mono<Workspace> workspaceMono = workspaceService
                     .findById(datasource.getWorkspaceId(), permission)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
@@ -7,15 +7,11 @@ import com.appsmith.server.repositories.ce.params.QueryAllParams;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface AppsmithRepository<T extends BaseDomain> {
 
     Mono<T> findById(String id, AclPermission permission);
-
-    @Deprecated(forRemoval = true)
-    Mono<T> findById(String id, Optional<AclPermission> permission);
 
     Mono<T> updateById(String id, T resource, AclPermission permission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -115,14 +114,6 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
     public Mono<T> findById(String id, AclPermission permission) {
         return queryBuilder().byId(id).permission(permission).one();
-    }
-
-    /**
-     * @deprecated using `Optional` for function arguments is an anti-pattern.
-     */
-    @Deprecated(forRemoval = true)
-    public Mono<T> findById(String id, Optional<AclPermission> permission) {
-        return findById(id, permission.orElse(null));
     }
 
     public Mono<T> updateById(@NonNull String id, @NonNull T resource, AclPermission permission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
@@ -10,7 +10,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
@@ -24,8 +23,6 @@ public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
     Mono<Workspace> getById(String id);
 
     Mono<Workspace> findById(String id, AclPermission permission);
-
-    Mono<Workspace> findById(String id, Optional<AclPermission> permission);
 
     Mono<Workspace> save(Workspace workspace);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -446,11 +445,6 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
 
     @Override
     public Mono<Workspace> findById(String id, AclPermission permission) {
-        return repository.findById(id, permission);
-    }
-
-    @Override
-    public Mono<Workspace> findById(String id, Optional<AclPermission> permission) {
         return repository.findById(id, permission);
     }
 


### PR DESCRIPTION
Follow up to https://github.com/appsmithorg/appsmith/pull/34281.

The `.findById` method is now removed.

No conflicts, but needs extra changes in [this PR](https://github.com/appsmithorg/appsmith-ee/pull/4482) for build to pass on EE.

**/test sanity**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9563607766>
> Commit: 02f6031cec08a4e805f479b500be40b08a003142
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9563607766&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated methods to use direct values instead of `Optional` for permissions, simplifying method signatures and improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->