### PR TITLE
fix: Retain existing flags even if CS API fails

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/FeatureFlagMigrationHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/FeatureFlagMigrationHelperCEImpl.java
@@ -96,7 +96,10 @@ public class FeatureFlagMigrationHelperCEImpl implements FeatureFlagMigrationHel
                     if (CollectionUtils.isNullOrEmpty(features.getFeatures())) {
                         // In case the retrieval of the latest flags from CS encounters an error, the previous flags
                         // will serve as a fallback value.
-                        return cacheableFeatureFlagHelper.updateCachedTenantFeatures(tenantId, existingCachedFeatures);
+                        return cacheableFeatureFlagHelper
+                                .evictCachedTenantFeatures(tenantId)
+                                .then(cacheableFeatureFlagHelper.updateCachedTenantFeatures(
+                                        tenantId, existingCachedFeatures));
                     }
                     return Mono.just(features);
                 });


### PR DESCRIPTION
## Description
PR to fix refreshing feature flags when instance fails to fetch flags from CS.  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9563924054>
> Commit: 9278bb30d62f7fbb7656e39448be6df611cd9514
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9563924054&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved feature flag updates by ensuring cached tenant features are evicted before updating, preventing potential stale data issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->