### PR TITLE
refactor: move apps link out of menu & refactor nav menu data

### DIFF
--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -75,7 +75,6 @@ import { Omnibar } from "./commons/Omnibar";
 import { EditorShareButton } from "./EditorShareButton";
 import { HelperBarInHeader } from "./HelpBarInHeader";
 import { AppsmithLink } from "./AppsmithLink";
-import { GetNavigationMenuData } from "./EditorName/NavigationMenuData";
 
 const { cloudHosting } = getAppsmithConfigs();
 
@@ -208,7 +207,6 @@ export function EditorHeader() {
                 editInteractionKind={EditInteractionKind.SINGLE}
                 editorName="Application"
                 fill
-                getNavigationMenu={GetNavigationMenuData}
                 isError={isErroredSavingName}
                 isNewEditor={
                   applicationList.filter((el) => el.id === applicationId)

--- a/app/client/src/pages/Editor/EditorName/index.tsx
+++ b/app/client/src/pages/Editor/EditorName/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from "react";
 
-import { useTheme } from "styled-components";
 import type { noop } from "lodash";
 import type {
   CommonComponentProps,
@@ -9,14 +8,12 @@ import type {
 import { SavingState } from "design-system-old";
 import EditableName from "./EditableName";
 import { NavigationMenu } from "./NavigationMenu";
-import type { Theme } from "constants/DefaultTheme";
 import { Menu, toast, MenuTrigger } from "design-system";
 import ForkApplicationModal from "pages/Applications/ForkApplicationModal";
 import { Container, StyledIcon } from "./components";
 import { useSelector } from "react-redux";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
-import type { MenuItemData } from "./NavigationMenuItem";
-import type { NavigationMenuDataProps } from "./NavigationMenuData";
+import { useNavigationMenuData } from "./useNavigationMenuData";
 
 type EditorNameProps = CommonComponentProps & {
   applicationId?: string | undefined;
@@ -34,10 +31,6 @@ type EditorNameProps = CommonComponentProps & {
   isPopoverOpen: boolean;
   setIsPopoverOpen: typeof noop;
   editorName: string;
-  getNavigationMenu: ({
-    editMode,
-    setForkApplicationModalOpen,
-  }: NavigationMenuDataProps) => MenuItemData[];
 };
 
 export function EditorName(props: EditorNameProps) {
@@ -45,13 +38,10 @@ export function EditorName(props: EditorNameProps) {
     defaultSavingState,
     defaultValue,
     editorName,
-    getNavigationMenu,
     isNewEditor,
     isPopoverOpen,
     setIsPopoverOpen,
   } = props;
-
-  const theme = useTheme() as Theme;
 
   const [isEditingDefault, setIsEditingDefault] = useState(isNewEditor);
   const [isEditing, setIsEditing] = useState(!!isEditingDefault);
@@ -102,9 +92,8 @@ export function EditorName(props: EditorNameProps) {
     }
   }, []);
 
-  const NavigationMenuData = getNavigationMenu({
+  const navigationMenuData = useNavigationMenuData({
     editMode,
-    theme,
     setForkApplicationModalOpen,
   });
 
@@ -145,7 +134,7 @@ export function EditorName(props: EditorNameProps) {
           </Container>
         </MenuTrigger>
         <NavigationMenu
-          menuItems={NavigationMenuData}
+          menuItems={navigationMenuData}
           setIsPopoverOpen={setIsPopoverOpen}
         />
       </Menu>

--- a/app/client/src/pages/Editor/IDE/Header/index.tsx
+++ b/app/client/src/pages/Editor/IDE/Header/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from "react";
 import {
   Flex,
   Tooltip,
-  Text,
   Divider,
   Modal,
   ModalContent,
@@ -13,6 +12,7 @@ import {
   Tab,
   TabPanel,
   Button,
+  Link,
 } from "design-system";
 import { useDispatch, useSelector } from "react-redux";
 import { EditInteractionKind, SavingState } from "design-system-old";
@@ -29,7 +29,6 @@ import {
   HEADER_TITLES,
 } from "@appsmith/constants/messages";
 import EditorName from "pages/Editor/EditorName";
-import { GetNavigationMenuData } from "pages/Editor/EditorName/NavigationMenuData";
 import {
   getCurrentApplicationId,
   getCurrentPageId,
@@ -76,6 +75,7 @@ import { EditorState } from "@appsmith/entities/IDE/constants";
 import { EditorSaveIndicator } from "pages/Editor/EditorSaveIndicator";
 import type { Page } from "@appsmith/constants/ReduxActionConstants";
 import { IDEHeader, IDEHeaderTitle } from "IDE";
+import { APPLICATIONS_URL } from "constants/routes";
 
 const StyledDivider = styled(Divider)`
   height: 50%;
@@ -166,7 +166,7 @@ const Header = () => {
     dispatch(updateApplication(id, data));
   };
 
-  const handlePublish = () => {
+  const handlePublish = useCallback(() => {
     if (applicationId) {
       dispatch(publishApplication(applicationId));
 
@@ -201,23 +201,18 @@ const Header = () => {
         templateTitle: currentApplication?.forkedFromTemplateTitle,
       });
     }
-  };
+  }, [applicationId, currentApplication, dispatch]);
 
-  const handleClickDeploy = useCallback(
-    (fromDeploy?: boolean) => {
-      if (isGitConnected) {
-        dispatch(showConnectGitModal());
-        AnalyticsUtil.logEvent("GS_DEPLOY_GIT_CLICK", {
-          source: fromDeploy
-            ? "Deploy button"
-            : "Application name menu (top left)",
-        });
-      } else {
-        handlePublish();
-      }
-    },
-    [dispatch, handlePublish],
-  );
+  const handleClickDeploy = useCallback(() => {
+    if (isGitConnected) {
+      dispatch(showConnectGitModal());
+      AnalyticsUtil.logEvent("GS_DEPLOY_GIT_CLICK", {
+        source: "Deploy button",
+      });
+    } else {
+      handlePublish();
+    }
+  }, [dispatch, handlePublish, isGitConnected]);
 
   return (
     <>
@@ -230,12 +225,10 @@ const Header = () => {
           <Flex alignItems={"center"}>
             {currentWorkspace.name && (
               <>
-                <Text
-                  color={"var(--ads-v2-colors-content-label-inactive-fg)"}
-                  kind="body-m"
-                >
-                  {currentWorkspace.name + " / "}
-                </Text>
+                <Link className="mr-1.5" to={APPLICATIONS_URL}>
+                  {currentWorkspace.name}
+                </Link>
+                {"/"}
                 <EditorName
                   applicationId={applicationId}
                   className="t--application-name editable-application-name max-w-48"
@@ -246,7 +239,6 @@ const Header = () => {
                   editInteractionKind={EditInteractionKind.SINGLE}
                   editorName="Application"
                   fill
-                  getNavigationMenu={GetNavigationMenuData}
                   isError={isErroredSavingName}
                   isNewEditor={
                     applicationList.filter((el) => el.id === applicationId)
@@ -343,7 +335,7 @@ const Header = () => {
                 isDisabled={isProtectedMode}
                 isLoading={isPublishing}
                 kind="tertiary"
-                onClick={() => handleClickDeploy(true)}
+                onClick={handleClickDeploy}
                 size="md"
                 startIcon={"rocket"}
               >


### PR DESCRIPTION
## Description
Moved `Back to all apps` from  dropdown menu directly to header.

Additionally renamed `NavigationMenuData.ts` to `useNavigationMenuData.ts` and fixed dependency related memoization issues.

<img width="267" alt="image" src="https://github.com/appsmithorg/appsmith/assets/173164/020abfe3-1359-43ff-aa99-972a45f270bd">

Fixes #32982

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9567752111>
> Commit: 824b2fe1231de1d073a1b19054507643b325400f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9567752111&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed `getNavigationMenu` prop from `EditorHeader` for streamlined navigation menu data retrieval.
  - Updated `EditorName` to use `useNavigationMenuData` for navigation menu items.
  - Refactored `useNavigationMenuData` to use `useCallback` and `useMemo` for enhanced performance.
  - Adjusted imports and event handling functions in `IDE/Header` to use `useCallback` for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->