### PR TITLE
chore: log the client authorisation request for debugging purposes

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/CustomServerOAuth2AuthorizationRequestResolverCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/CustomServerOAuth2AuthorizationRequestResolverCE.java
@@ -7,6 +7,8 @@ import com.appsmith.server.constants.Security;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.RedirectHelper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -81,6 +83,8 @@ public class CustomServerOAuth2AuthorizationRequestResolverCE implements ServerO
 
     private final CustomOauth2ClientRepositoryManager ouath2ClientManager;
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     /**
      * Creates a new instance
      *
@@ -134,7 +138,19 @@ public class CustomServerOAuth2AuthorizationRequestResolverCE implements ServerO
                 .map(ServerWebExchangeMatcher.MatchResult::getVariables)
                 .map(variables -> variables.get(DEFAULT_REGISTRATION_ID_URI_VARIABLE_NAME))
                 .cast(String.class)
-                .flatMap(clientRegistrationId -> resolve(exchange, clientRegistrationId));
+                .flatMap(clientRegistrationId -> resolve(exchange, clientRegistrationId))
+                .map(request -> {
+                    // TODO: Remove this log statement post client debugging.
+                    // @author: nsarupr (nilesh@appsmith.com)
+                    // We are ignoring the exception here because we are only logging for debugging purposes.
+                    try {
+                        log.debug("This log statement is for debugging purposes only. "
+                                + "Please remove this post client debugging.");
+                        log.debug("Resolved OAuth2AuthorizationRequest : {}", objectMapper.writeValueAsString(request));
+                    } catch (JsonProcessingException ignored) {
+                    }
+                    return request;
+                });
     }
 
     @Override


### PR DESCRIPTION
## Description
> Adding a debug log to log the Client's Authorisation request. 
> For a certain user, the OIDC authentication isn't working 100%, and this flaky behaviour is happening because the authorisation request is not being saved in the redis `spring:session:sessions:<session-id>`. This ends up giving an authentication error. A snippet of the error is shown below.
> ```
> In the login failure handler. Cause: [authorization_request_not_found] 
> org.springframework.security.oauth2.core.OAuth2AuthenticationException: [authorization_request_not_found]
> ```
> Here's another ticket to track when we need to remove this logging.


Fixes 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
