### PR TITLE
chore: Remove redundant adding Postgres bin to `PATH`

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -4,9 +4,6 @@ set -e
 
 tlog "Running as: $(id)"
 
-# Temporary, remove after this change goes into `base.dockerfile`.
-export PATH="/usr/lib/postgresql/13/bin:${PATH}"
-
 stacks_path=/appsmith-stacks
 
 export SUPERVISORD_CONF_TARGET="$TMP/supervisor-conf.d/"  # export for use in supervisord.conf


### PR DESCRIPTION
This temporary change is no longer needed.

**/test sanity**


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9574310795>
> Commit: abad77fb024c61b595c529aa2ed024b8dcdf5dfb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9574310795&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the startup script by removing obsolete PATH modification for PostgreSQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->