### PR TITLE
chore: Add script to upgrade Postgres 13 data to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,14 @@ RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd 
   && chmod ugo+w /etc /appsmith-stacks \
   && chmod -R ugo+w /var/run /.mongodb /etc/ssl /usr/local/share
 
+# Temporary, until we can change Postgres version in `base.dockerfile`.
+RUN <<END
+  apt update
+  apt install --yes postgresql-14
+  apt clean
+END
+ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
+
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,14 +43,6 @@ RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd 
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh
 
-# Temporary, until we can change Postgres version in `base.dockerfile`.
-RUN <<END
-  apt update
-  apt install --yes postgresql-14
-  apt clean
-END
-ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
-
 EXPOSE 80
 EXPOSE 443
 ENTRYPOINT [ "/opt/appsmith/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,6 @@ RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd 
   && chmod ugo+w /etc /appsmith-stacks \
   && chmod -R ugo+w /var/run /.mongodb /etc/ssl /usr/local/share
 
-# Temporary, until we can change Postgres version in `base.dockerfile`.
-RUN <<END
-  apt update
-  apt install --yes postgresql-14
-  apt clean
-END
-ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
-
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd 
   && chmod ugo+w /etc /appsmith-stacks \
   && chmod -R ugo+w /var/run /.mongodb /etc/ssl /usr/local/share
 
+LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
+LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh
+
 # Temporary, until we can change Postgres version in `base.dockerfile`.
 RUN <<END
   apt update
@@ -47,9 +50,6 @@ RUN <<END
   apt clean
 END
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
-
-LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
-LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh
 
 EXPOSE 80
 EXPOSE 443

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -27,12 +27,12 @@ RUN set -o xtrace \
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
-  && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 \
+  && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 postgresql-14 \
   # Create a symlink to the current version of PostgreSQL
   && ln -s /usr/lib/postgresql/13 /usr/lib/postgresql/current \
   && apt-get clean
 
-ENV PATH="/usr/lib/postgresql/13/bin:${PATH}"
+ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 
 # Install Java
 RUN set -o xtrace \

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -418,18 +418,18 @@ init_postgres() {
   # Initialize embedded postgres by default; set APPSMITH_ENABLE_EMBEDDED_DB to 0, to use existing cloud postgres mockdb instance
   if [[ ${APPSMITH_ENABLE_EMBEDDED_DB: -1} != 0 ]]; then
     tlog "Checking initialized local postgres"
-    local postgres_db_path="$stacks_path/data/postgres/main"
+    POSTGRES_DB_PATH="$stacks_path/data/postgres/main"
 
-    mkdir -p "$postgres_db_path" "$TMP/pg-runtime"
+    mkdir -p "$POSTGRES_DB_PATH" "$TMP/pg-runtime"
 
     # Postgres does not allow it's server to be run with super user access, we use user postgres and the file system owner also needs to be the same user postgres
-    chown -R postgres:postgres "$postgres_db_path" "$TMP/pg-runtime"
+    chown -R postgres:postgres "$POSTGRES_DB_PATH" "$TMP/pg-runtime"
 
-    if [[ -e "$postgres_db_path/PG_VERSION" ]]; then
+    if [[ -e "$POSTGRES_DB_PATH/PG_VERSION" ]]; then
       /opt/appsmith/pg-upgrade.sh
     else
       tlog "Initializing local Postgres data folder"
-      su postgres -c "env PATH='$PATH' initdb -D $postgres_db_path"
+      su postgres -c "env PATH='$PATH' initdb -D $POSTGRES_DB_PATH"
     fi
   else
     runEmbeddedPostgres=0

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -4,9 +4,6 @@ set -e
 
 tlog "Running as: $(id)"
 
-# Temporary, remove after this change goes into `base.dockerfile`.
-export PATH="/usr/lib/postgresql/13/bin:${PATH}"
-
 stacks_path=/appsmith-stacks
 
 export SUPERVISORD_CONF_TARGET="$TMP/supervisor-conf.d/"  # export for use in supervisord.conf
@@ -421,16 +418,18 @@ init_postgres() {
   # Initialize embedded postgres by default; set APPSMITH_ENABLE_EMBEDDED_DB to 0, to use existing cloud postgres mockdb instance
   if [[ ${APPSMITH_ENABLE_EMBEDDED_DB: -1} != 0 ]]; then
     tlog "Checking initialized local postgres"
-    POSTGRES_DB_PATH="$stacks_path/data/postgres/main"
+    local postgres_db_path="$stacks_path/data/postgres/main"
 
-    mkdir -p "$POSTGRES_DB_PATH" "$TMP/pg-runtime"
+    mkdir -p "$postgres_db_path" "$TMP/pg-runtime"
 
     # Postgres does not allow it's server to be run with super user access, we use user postgres and the file system owner also needs to be the same user postgres
-    chown -R postgres:postgres "$POSTGRES_DB_PATH" "$TMP/pg-runtime"
+    chown -R postgres:postgres "$postgres_db_path" "$TMP/pg-runtime"
 
-    if [[ ! -e "$POSTGRES_DB_PATH/PG_VERSION" ]]; then
+    if [[ -e "$postgres_db_path/PG_VERSION" ]]; then
+      /opt/appsmith/pg-upgrade.sh
+    else
       tlog "Initializing local Postgres data folder"
-      su postgres -c "env PATH='$PATH' initdb -D $POSTGRES_DB_PATH"
+      su postgres -c "env PATH='$PATH' initdb -D $postgres_db_path"
     fi
   else
     runEmbeddedPostgres=0

--- a/deploy/docker/fs/opt/appsmith/pg-upgrade.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-upgrade.sh
@@ -38,11 +38,13 @@ if [[ -f "$pg_data_dir/postmaster.pid" ]]; then
 	exit 1
 fi
 
+top_available_version="$(postgres --version | grep -o '[[:digit:]]\+' | head -1)"
+
 declare -a to_uninstall
 to_uninstall=()
 
 # 13 to 14
-if [[ "$old_version" == 13 ]]; then
+if [[ "$old_version" == 13 && "$top_available_version" > "$old_version" ]]; then
 	if [[ ! -e "$postgres_path/$old_version" ]]; then
 		apt-get update
 		apt-get install --yes "postgresql-$old_version"

--- a/deploy/docker/fs/opt/appsmith/pg-upgrade.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-upgrade.sh
@@ -17,7 +17,11 @@ set -o nounset
 #   4. When we can't proceed due to any exceptional scenarios, communicate clearly.
 #   5. Mark old/stale/deprecated data with a date, so it can be deleted with confidence later.
 
-# TODO: Verify that no Postgres server is running.
+# Check if any Postgres server is running
+if pgrep -x "postgres" > /dev/null; then
+  echo "Error: A Postgres server is currently running. Please stop it before proceeding with the upgrade."
+  exit 1
+fi
 
 postgres_path=/usr/lib/postgresql
 

--- a/deploy/docker/fs/opt/appsmith/pg-upgrade.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-upgrade.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+# This script will upgrade Postgres to the "current" version of Postgres, if needed.
+
+# Assumptions:
+#   1. Postgres is currently not running. The caller of this script ensures that _no_ version of Postgres server is currently running.
+#   2. The newest version of Postgres we want to use, is already installed.
+#   3. Postgres is installed via apt package manager only.
+
+# Contract:
+#   1. Don't install old version of Postgres, if it's already installed.
+#   2. Use absolute paths to all Postgres executables, don't rely on any of them to be coming from "\$PATH".
+#   3. Be idempotent across versions.
+#   4. When we can't proceed due to any exceptional scenarios, communicate clearly.
+#   5. Mark old/stale/deprecated data with a date, so it can be deleted with confidence later.
+
+# TODO: Verify that no Postgres server is running.
+
+postgres_path=/usr/lib/postgresql
+
+pg_data_dir=/appsmith-stacks/data/postgres/main
+
+old_version=""
+if [[ -f "$pg_data_dir/PG_VERSION" ]]; then
+	old_version="$(cat "$pg_data_dir/PG_VERSION")"
+fi
+
+if [[ -z "$old_version" ]]; then
+	tlog "No existing Postgres data found, not upgrading anything." >&2
+	exit
+fi
+
+if [[ -f "$pg_data_dir/postmaster.pid" ]]; then
+	tlog "Previous Postgres was not shutdown cleanly. Please start and stop Postgres $old_version properly with 'supervisorctl' only." >&2
+	exit 1
+fi
+
+declare -a to_uninstall
+to_uninstall=()
+
+# 13 to 14
+if [[ "$old_version" == 13 ]]; then
+	if [[ ! -e "$postgres_path/$old_version" ]]; then
+		apt-get update
+		apt-get install --yes "postgresql-$old_version"
+		to_uninstall+=("postgresql-$old_version")
+	fi
+
+  new_version="$((old_version + 1))"
+  new_data_dir="$pg_data_dir-$new_version"
+
+  # `pg_upgrade` writes log to current folder. So change to a temp folder first.
+  rm -rf "$TMP/pg_upgrade" "$new_data_dir"
+  mkdir -p "$TMP/pg_upgrade" "$new_data_dir"
+  chown -R postgres "$TMP/pg_upgrade" "$new_data_dir"
+  cd "$TMP/pg_upgrade"
+
+	# Required by the temporary Postgres server started by `pg_upgrade`.
+	chown postgres /etc/ssl/private/ssl-cert-snakeoil.key
+	chmod 0600 /etc/ssl/private/ssl-cert-snakeoil.key
+
+	su postgres --command "
+		set -o errexit
+		set -o xtrace
+		'$postgres_path/$new_version/bin/initdb' --pgdata='$new_data_dir'
+		'$postgres_path/$new_version/bin/pg_upgrade' \
+			--old-datadir='$pg_data_dir' \
+			--new-datadir='$new_data_dir' \
+			--old-bindir='$postgres_path/$old_version/bin' \
+			--new-bindir='$postgres_path/$new_version/bin'
+	"
+
+	date -u '+%FT%T.%3NZ' > "$pg_data_dir/deprecated-on.txt"
+	mv -v "$pg_data_dir" "$pg_data_dir-$old_version"
+	mv -v "$new_data_dir" "$pg_data_dir"
+
+	# Dangerous generated script that deletes the now updated data folder.
+	rm -fv "$TMP/pg_upgrade/delete_old_cluster.sh"
+fi
+
+if [[ -n "${#to_uninstall[@]}" ]]; then
+	apt-get purge "${to_uninstall[@]}"
+	apt-get clean
+fi
+
+echo "== Fin =="

--- a/deploy/docker/tests/pg-upgrade/run.sh
+++ b/deploy/docker/tests/pg-upgrade/run.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# A script to test Postgres upgrades. WIP.
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+from_tag=release
+to_tag=local
+
+container_name=appsmith-pg-upgrade-test
+port=20080
+
+docker rm -f "$container_name"
+docker volume rm --force "$container_name"
+
+# TODO: Add `--pull always` for images that have a manifest?
+
+docker volume create "$container_name"
+docker run \
+  --name "$container_name" \
+  --detach \
+  --publish "$port":80 \
+  --volume "$container_name":/appsmith-stacks \
+  appsmith/appsmith-ce:"$from_tag"
+
+wait-for-supervisor() {
+  while ! docker exec "$container_name" test -e /tmp/appsmith/supervisor.sock; do
+    sleep 1
+  done
+  sleep 2
+}
+
+wait-for-supervisor
+
+docker exec "$container_name" bash -exc '
+supervisorctl status \
+  | awk '\''$1 != "postgres" && $1 != "stdout" {print $1}'\'' \
+  | xargs supervisorctl stop
+
+# Insert some sample data
+su postgres -c "psql -h 127.0.0.1 -c \"
+create table t (id serial, name text);
+insert into t values (1, '\''one'\'');
+insert into t values (2, '\''two'\'');
+insert into t values (3, '\''three'\'');
+\""
+
+supervisorctl stop postgres
+
+cat /appsmith-stacks/data/postgres/main/PG_VERSION
+'
+
+docker rm -f "$container_name"
+
+docker run \
+  --name "$container_name" \
+  --detach \
+  --publish "$port":80 \
+  --volume "$container_name":/appsmith-stacks \
+  appsmith/appsmith-ce:"$to_tag"
+
+wait-for-supervisor
+
+status=0
+
+if [[ 14 != "$(docker exec "$container_name" cat /appsmith-stacks/data/postgres/main/PG_VERSION)" ]]; then
+  echo "Version isn't 14"
+  status=1
+fi
+
+docker exec -it "$container_name" bash
+
+docker rm --force "$container_name"
+docker volume rm --force "$container_name"
+
+exit "$status"

--- a/deploy/docker/tests/pg-upgrade/run.sh
+++ b/deploy/docker/tests/pg-upgrade/run.sh
@@ -77,15 +77,12 @@ else
   3 | three
 (3 rows)'
   if ! diff <(echo "$expected_contents") <(su postgres -c 'psql -h 127.0.0.1 -c "select * from t"'); then
+    status=1
     echo "Table contents mismatch. Found this:"
     su postgres -c 'psql -h 127.0.0.1 -c "select * from t"'
     echo "Instead of this:"
     echo "$expected_contents"
   fi
-fi
-
-if [[ $status == 0 && su postgres -c 'psql -h 127.0.0.1 -c "select * from t"' ]]; then
-
 fi
 
 docker exec -it "$container_name" bash


### PR DESCRIPTION
We're upgrading embedded Postgres from 13 to 14, and this PR includes a script to perform the upgrade of the data folder from v13 schema to v14 schema. This script temporarily installs Postgres 13, if not available, for the upgrade process, so will continue to work when and if we choose to remove `postgresql-13` from the base image.

Tested this manually as well, running an Appsmith with Postgres 13, executing some workflows via webhook, getting some run data generated, then upgrading Postgres with the script in this PR, and ensuring that the workflow run history is still there and visible on the UI exactly the same. It is.

No conflicts or additional changes needed on EE. [All server and Cypress tests pass on EE](https://github.com/appsmithorg/appsmith-ee/pull/4493).

![shot-2024-06-20-02-13-26](https://github.com/appsmithorg/appsmith/assets/120119/9bb60e3a-6cc9-4df9-9064-caead78729a6)


**/test sanity**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9590240540>
> Commit: 9c75da53f871ffb912015c18a7504327cba88f2c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9590240540&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automation script for upgrading PostgreSQL to the latest version.
  - Introduced testing script for PostgreSQL upgrades in Docker environments.

- **Improvements**
  - Upgraded PostgreSQL from version 13 to 14 in Docker setup, ensuring compatibility and performance enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->