### PR TITLE
perf: add react-hooks/exhaustive-deps rule

### DIFF
--- a/app/client/.eslintrc.base.json
+++ b/app/client/.eslintrc.base.json
@@ -13,7 +13,6 @@
     "react",
     "@typescript-eslint",
     "prettier",
-    "react-hooks",
     "sort-destructure-keys",
     "cypress",
     "testing-library",
@@ -26,7 +25,8 @@
     "plugin:testing-library/react",
     // Note: Please keep this as the last config to make sure that this (and by extension our .prettierrc file) overrides all configuration above it
     // https://www.npmjs.com/package/eslint-plugin-prettier#recommended-configuration
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 2020, // Allows for the parsing of modern ECMAScript features
@@ -54,8 +54,6 @@
     "jest/no-disabled-tests": "error",
     // enforce `import type` for all type-only imports so the bundler knows to erase them
     "@typescript-eslint/consistent-type-imports": "error",
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
     "react/jsx-boolean-value": "error",
     "react/self-closing-comp": "error",
     "react/jsx-sort-props": "error",

--- a/app/client/.eslintrc.base.json
+++ b/app/client/.eslintrc.base.json
@@ -23,10 +23,10 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:cypress/recommended",
     "plugin:testing-library/react",
+    "plugin:react-hooks/recommended",
     // Note: Please keep this as the last config to make sure that this (and by extension our .prettierrc file) overrides all configuration above it
     // https://www.npmjs.com/package/eslint-plugin-prettier#recommended-configuration
-    "plugin:prettier/recommended",
-    "plugin:react-hooks/recommended"
+    "plugin:prettier/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 2020, // Allows for the parsing of modern ECMAScript features

--- a/app/client/.eslintrc.base.json
+++ b/app/client/.eslintrc.base.json
@@ -55,6 +55,7 @@
     // enforce `import type` for all type-only imports so the bundler knows to erase them
     "@typescript-eslint/consistent-type-imports": "error",
     "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
     "react/jsx-boolean-value": "error",
     "react/self-closing-comp": "error",
     "react/jsx-sort-props": "error",


### PR DESCRIPTION
## Description
Adds ESLint rule `react-hooks/exhaustive-deps` with warn level. Context in the task below.

Fixes #34337 

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9584250724>
> Commit: daa705074504f398b80b1175440d00011b5d865d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9584250724&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: ``

<!-- end of auto-generated comment: Cypress test results  -->





## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added ESLint rule `react-hooks/exhaustive-deps` with a severity level of "warn" to enforce exhaustive dependencies in React hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->