### PR TITLE
fix: Supervisor buffer overflow errors

### DIFF
--- a/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
+++ b/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
@@ -8,33 +8,24 @@ Originally taken from https://github.com/coderanger/supervisor-stdout/blob/973ba
 import sys
 
 
-def write_stdout(s):
-    sys.stdout.write(s)
-    sys.stdout.flush()
-
-
-def write_stderr(s):
-    sys.stderr.write(s)
-    sys.stderr.flush()
-
-
 def main():
     while 1:
-        write_stdout("READY\n")  # transition from ACKNOWLEDGED to READY
+        print("READY", flush=True)  # transition from ACKNOWLEDGED to READY
         line = sys.stdin.readline()  # read header line from stdin
         headers = dict([x.split(":") for x in line.split()])
         data = sys.stdin.read(int(headers["len"]))  # read the event payload
-        write_stdout(
-            "RESULT %s\n%s" % (len(data.encode("utf-8")), data)
+        print(
+            "RESULT %s\n%s" % (len(data.encode("utf-8")), data),
+            end="",
+            flush=True,
         )  # transition from READY to ACKNOWLEDGED
 
 
 def event_handler(event, response):
-    line, data = response.rstrip().decode().split("\n", 1)
+    line, *lines = response.rstrip().decode().split("\n", 1)
     headers = dict(x.split(":", 1) for x in line.split())
-    lines = data.split("\n")
     prefix = "%s %s | " % (headers["processname"], headers["channel"])
-    print("\n".join(prefix + l for l in lines))
+    print(*(prefix + l for l in lines), sep="\n", file=sys.stderr, flush=True)
 
 
 if __name__ == "__main__":

--- a/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
+++ b/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
@@ -15,7 +15,7 @@ def main():
         headers = dict([x.split(":") for x in line.split()])
         data = sys.stdin.read(int(headers["len"]))  # read the event payload
         print(
-            "RESULT %s\n%s" % (len(data.encode("utf-8")), data),
+            f"RESULT {len(data.encode("utf-8"))}\n{data}",
             end="",
             flush=True,
         )  # transition from READY to ACKNOWLEDGED
@@ -24,7 +24,7 @@ def main():
 def event_handler(event, response):
     line, *lines = response.rstrip().decode().split("\n", 1)
     headers = dict(x.split(":", 1) for x in line.split())
-    prefix = "%s %s | " % (headers["processname"], headers["channel"])
+    prefix = f"{headers['processname']} {headers["channel"]} | "
     print(*(prefix + l for l in lines), sep="\n", file=sys.stderr, flush=True)
 
 

--- a/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
+++ b/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
@@ -24,7 +24,7 @@ def main():
 def event_handler(event, response):
     line, *lines = response.rstrip().decode().split("\n", 1)
     headers = dict(x.split(":", 1) for x in line.split())
-    prefix = f"{headers['processname']} {headers["channel"]} | "
+    prefix = f"{headers['processname']} {headers['channel']} | "
     print(*(prefix + l for l in lines), sep="\n", file=sys.stderr, flush=True)
 
 

--- a/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
+++ b/deploy/docker/fs/usr/lib/python3/dist-packages/supervisor/appsmith_supervisor_stdout.py
@@ -15,7 +15,7 @@ def main():
         headers = dict([x.split(":") for x in line.split()])
         data = sys.stdin.read(int(headers["len"]))  # read the event payload
         print(
-            f"RESULT {len(data.encode("utf-8"))}\n{data}",
+            f"RESULT {len(data.encode('utf-8'))}\n{data}",
             end="",
             flush=True,
         )  # transition from READY to ACKNOWLEDGED


### PR DESCRIPTION
Should fix the flood of buffer overflow errors we see from Supervisor.

The one "change" this PR has, is that all the logs from the Docker container will now be coming from `stderr`, not `stdout`. I don't expect it to cause any problems, but it _is_ a change in behaviour nonetheless.

Why do that? Because of the way Supervisor event listening works. This fix is based on the conversation at https://github.com/Supervisor/supervisor/issues/1417. Essentially that `stdout` should be reserved as a communication channel between Supervisord and the event-listener, and for logging, we should use `stderr`.

**/test sanity**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9592028116>
> Commit: 34a29eabc8dc82fb6a43b143e400d725d197a655
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9592028116&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved logging by switching to `print` statements with explicit flushing for more reliable output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->