### PR TITLE
Bug (Fix): Fixes duplicate workspace name issue on client side

### DIFF
--- a/app/client/src/ce/pages/Applications/WorkspaceMenu.tsx
+++ b/app/client/src/ce/pages/Applications/WorkspaceMenu.tsx
@@ -33,6 +33,8 @@ interface WorkspaceMenuProps {
   workspace: Workspace;
   workspaceNameChange: (newName: string, workspaceId: string) => void;
   workspaceToOpenMenu: string | null;
+  allWorkSpaces: Workspace[];
+  activeWorkspaceId: string;
 }
 
 const WorkspaceRename = styled(EditableText)`
@@ -76,7 +78,17 @@ function WorkspaceMenu({
   workspace,
   workspaceNameChange,
   workspaceToOpenMenu,
+  allWorkSpaces,
+  activeWorkspaceId,
 }: WorkspaceMenuProps) {
+  const isWorkspaceNameTaken = (newName: string, workspaces: Workspace[]) => {
+    return workspaces
+      .filter((workspace) => workspace.id !== activeWorkspaceId)
+      .some(
+        (workspace) =>
+          workspace.name.toLowerCase().trim() === newName.toLowerCase().trim(),
+      );
+  };
   return (
     <Menu
       className="t--workspace-name"
@@ -121,10 +133,14 @@ function WorkspaceMenu({
                 hideEditIcon={false}
                 isEditingDefault={false}
                 isInvalid={(value: string) => {
-                  return notEmptyValidator(value).message;
+                  const isTaken = isWorkspaceNameTaken(value, allWorkSpaces);
+                  return isTaken
+                    ? "A workspace with this name already exists"
+                    : notEmptyValidator(value).message;
                 }}
                 onBlur={(value: string) => {
-                  workspaceNameChange(value, workspace.id);
+                  !isWorkspaceNameTaken(value, allWorkSpaces) &&
+                    workspaceNameChange(value, workspace.id);
                 }}
                 placeholder="Workspace name"
                 savingState={

--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -68,7 +68,11 @@ import MediaQuery from "react-responsive";
 import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import { getCurrentUser } from "selectors/usersSelectors";
 import styled, { ThemeContext } from "styled-components";
-import { getNextEntityName, getRandomPaletteColor } from "utils/AppsmithUtils";
+import {
+  getNextEntityName,
+  getNextWorkspaceNameWithRandomString,
+  getRandomPaletteColor,
+} from "utils/AppsmithUtils";
 import PerformanceTracker, {
   PerformanceTransactionName,
 } from "utils/PerformanceTracker";
@@ -263,6 +267,7 @@ export function LeftPaneSection(props: {
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
   const tenantPermissions = useSelector(getTenantPermissions);
   const fetchedWorkspaces = useSelector(getFetchedWorkspaces);
+  const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(false);
 
   const canCreateWorkspace = getHasCreateWorkspacePermission(
     isFeatureEnabled,
@@ -270,9 +275,10 @@ export function LeftPaneSection(props: {
   );
 
   const createNewWorkspace = async () => {
+    setIsButtonDisabled(true);
     await submitCreateWorkspaceForm(
       {
-        name: getNextEntityName(
+        name: getNextWorkspaceNameWithRandomString(
           "Untitled workspace ",
           fetchedWorkspaces.map((el: any) => el.name),
         ),
@@ -280,6 +286,10 @@ export function LeftPaneSection(props: {
       dispatch,
     );
     dispatch(fetchAllWorkspaces());
+
+    setTimeout(() => {
+      setIsButtonDisabled(false);
+    }, 100);
   };
 
   return (
@@ -293,7 +303,7 @@ export function LeftPaneSection(props: {
           >
             <Button
               data-testid="t--workspace-new-workspace-auto-create"
-              isDisabled={props.isFetchingWorkspaces}
+              isDisabled={props.isFetchingWorkspaces || isButtonDisabled}
               kind="tertiary"
               onClick={createNewWorkspace}
               startIcon="add-line"
@@ -816,6 +826,8 @@ export function ApplicationsSection(props: any) {
                       workspace={activeWorkspace}
                       workspaceNameChange={workspaceNameChange}
                       workspaceToOpenMenu={workspaceToOpenMenu}
+                      allWorkSpaces={workspaces}
+                      activeWorkspaceId={activeWorkspaceId}
                     />
                   )}
               </WorkspaceShareUsers>

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -517,3 +517,32 @@ function extractSentryException(event: Sentry.Event) {
   const value = event.exception.values ? event.exception.values[0] : null;
   return value;
 }
+
+export const getNextWorkspaceNameWithRandomString = (
+  basePrefix: string,
+  existingNames: string[],
+) => {
+  const regex = new RegExp(`^${basePrefix} (\\d+)-[a-z]{3}$`);
+
+  const usedIndices: number[] = existingNames.map((name) => {
+    if (name && regex.test(name)) {
+      const matches = name.match(regex);
+      const ind =
+        matches && Array.isArray(matches) ? parseInt(matches[1], 10) : 0;
+      return Number.isNaN(ind) ? 0 : ind;
+    }
+    return 0;
+  }) as number[];
+
+  const lastIndex = Math.max(...usedIndices, 0);
+  const nextIndex = lastIndex + 1;
+
+  const characters = "abcdefghijklmnopqrstuvwxyz";
+  let randomString = "";
+  for (let i = 0; i < 3; i++) {
+    const randomIndex = Math.floor(Math.random() * characters.length);
+    randomString += characters[randomIndex];
+  }
+
+  return `${basePrefix} ${nextIndex}-${randomString}`;
+};


### PR DESCRIPTION
In this pr, we have fixed the issue of having same name for the workspaces from the client side. This gives better experience for the user.
-> We have used debounce Technique  in-order to achieve this and also appended a string at the end which helps us to uniquely identify even when any 2 users try to create the workspace at same time.
![image](https://github.com/appsmithorg/appsmith/assets/91499264/f73edffc-a93e-42c5-b3ff-8f1e4e201a0e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to check if a workspace name is already taken when renaming a workspace.
  - Enhanced workspace creation to automatically generate unique names by appending a random string.

- **Improvements**
  - Introduced state management to disable the "Create Workspace" button while a new workspace is being created, preventing duplicate submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->