### PR TITLE
feat: Add user context to permissions for repository methods

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
@@ -13,6 +13,7 @@ import com.appsmith.server.domains.Theme;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public enum AclPermission {
@@ -131,6 +132,9 @@ public enum AclPermission {
 
     private final String value;
     private final Class<? extends BaseDomain> entity;
+    // Field to store the user context against which the permission is being checked.
+    @Setter
+    private User user;
 
     AclPermission(String value, Class<? extends BaseDomain> entity) {
         this.value = value;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -16,6 +16,7 @@ import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.ActionCollectionViewDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.ReactiveContextUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.repositories.ActionCollectionRepository;
@@ -336,7 +337,8 @@ public class ActionCollectionServiceCEImpl
                     return dbActionCollection;
                 })
                 .flatMap(actionCollection -> this.update(id, actionCollection))
-                .flatMap(repository::setUserPermissionsInObject)
+                .zipWith(ReactiveContextUtils.getCurrentUser())
+                .flatMap(tuple -> repository.setUserPermissionsInObject(tuple.getT1(), tuple.getT2()))
                 .flatMap(actionCollection -> this.generateActionCollectionByViewMode(actionCollection, false)
                         .flatMap(actionCollectionDTO1 -> this.populateActionCollectionByViewMode(
                                 actionCollection.getUnpublishedCollection(), false))); // */
@@ -688,7 +690,8 @@ public class ActionCollectionServiceCEImpl
                                 }
                                 return Mono.just(savedActionCollection);
                             })
-                            .flatMap(repository::setUserPermissionsInObject)
+                            .zipWith(ReactiveContextUtils.getCurrentUser())
+                            .flatMap(tuple -> repository.setUserPermissionsInObject(tuple.getT1(), tuple.getT2()))
                             .cache();
 
                     return actionCollectionMono

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
@@ -28,6 +28,7 @@ import com.appsmith.server.helpers.GitDeployKeyGenerator;
 import com.appsmith.server.helpers.GitUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.helpers.TextUtils;
+import com.appsmith.server.helpers.UserPermissionUtils;
 import com.appsmith.server.migrations.ApplicationVersion;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.cakes.ApplicationRepositoryCake;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
@@ -40,7 +40,6 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.appsmith.server.helpers.DefaultResourcesUtils.createDefaultIdsOrUpdateWithGivenResourceIds;
 
@@ -267,7 +266,7 @@ public class GitApplicationHelperCEImpl implements GitArtifactHelperCE<Applicati
 
         Flux<NewAction> newActionFlux = newPageFlux.flatMap(newPage -> {
             return newActionService
-                    .findByPageId(newPage.getId(), Optional.empty())
+                    .findByPageId(newPage.getId())
                     .map(newAction -> {
                         newAction.setDefaultResources(null);
                         if (newAction.getUnpublishedAction() != null) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/PermissionAspect.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/PermissionAspect.java
@@ -1,0 +1,78 @@
+package com.appsmith.server.aspect;
+
+import com.appsmith.server.acl.AclPermission;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.appsmith.server.helpers.UserPermissionUtils.updateAclWithUserContext;
+
+@Aspect
+@Slf4j
+@Component
+public class PermissionAspect {
+
+    @Around("execution(* com.appsmith.server.repositories..*(..))")
+    public Object handlePermission(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        Class<?> returnType =
+                ((MethodSignature) joinPoint.getSignature()).getMethod().getReturnType();
+        if (!Mono.class.isAssignableFrom(returnType) && !Flux.class.isAssignableFrom(returnType)) {
+            return joinPoint.proceed(joinPoint.getArgs());
+        }
+
+        AclPermission permissionWithoutUserContext = Arrays.stream(joinPoint.getArgs())
+                .filter(arg -> arg instanceof AclPermission
+                        // TODO (Abhijeet): This is a temporary fix to avoid Optional<AclPermission> in the repository
+                        // methods.
+                        || (arg instanceof Optional && ((Optional<?>) arg).orElse(null) instanceof AclPermission))
+                .map(arg -> {
+                    if (arg instanceof AclPermission) {
+                        return (AclPermission) arg;
+                    }
+                    return (AclPermission) ((Optional<?>) arg).orElse(null);
+                })
+                // We expect only one permission object to be passed to the repository methods.
+                .findFirst()
+                .orElse(null);
+        if (permissionWithoutUserContext == null) {
+            return joinPoint.proceed(joinPoint.getArgs());
+        }
+
+        Mono<AclPermission> permissionMono = updateAclWithUserContext(permissionWithoutUserContext);
+        if (Mono.class.isAssignableFrom(returnType)) {
+            return permissionMono.then(Mono.defer(() -> {
+                try {
+                    return (Mono<?>) joinPoint.proceed(joinPoint.getArgs());
+                } catch (Throwable e) {
+                    log.error(
+                            "Error occurred while adding the user context to the permission object when invoking function {}",
+                            joinPoint.getSignature().getName(),
+                            e);
+                    return Mono.error(e);
+                }
+            }));
+        } else if (Flux.class.isAssignableFrom(returnType)) {
+            return permissionMono.thenMany(Flux.defer(() -> {
+                try {
+                    return (Flux<?>) joinPoint.proceed(joinPoint.getArgs());
+                } catch (Throwable e) {
+                    log.error(
+                            "Error occurred while adding the user context to the permission object when invoking function {}",
+                            joinPoint.getSignature().getName(),
+                            e);
+                    return Flux.error(e);
+                }
+            }));
+        }
+        return joinPoint.proceed(joinPoint.getArgs());
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
@@ -22,6 +22,7 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.helpers.ReactiveContextUtils;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.ratelimiting.RateLimitService;
 import com.appsmith.server.repositories.DatasourceRepository;
@@ -194,7 +195,7 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
                     })
                     .flatMap(datasource1 -> {
                         Mono<User> userMono = sessionUserService.getCurrentUser();
-                        return generateAndSetDatasourcePolicies(userMono, datasource1, permission);
+                        return generateAndSetDatasourcePolicies(userMono, datasource1, permission.orElse(null));
                     })
                     .flatMap(this::validateAndSaveDatasourceToRepository)
                     .flatMap(savedDatasource ->
@@ -265,7 +266,7 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
     }
 
     private Mono<Datasource> generateAndSetDatasourcePolicies(
-            Mono<User> userMono, Datasource datasource, Optional<AclPermission> permission) {
+            Mono<User> userMono, Datasource datasource, AclPermission permission) {
         return userMono.flatMap(user -> {
             Mono<Workspace> workspaceMono = workspaceService
                     .findById(datasource.getWorkspaceId(), permission)
@@ -381,7 +382,8 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
         return Mono.just(datasource)
                 .flatMap(this::validateDatasource)
                 .flatMap(repository::save)
-                .flatMap(repository::setUserPermissionsInObject);
+                .zipWith(ReactiveContextUtils.getCurrentUser())
+                .flatMap(tuple -> repository.setUserPermissionsInObject(tuple.getT1(), tuple.getT2()));
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/fork/internal/ApplicationForkingServiceCEImpl.java
@@ -29,6 +29,7 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.fork.forkable.ForkableService;
+import com.appsmith.server.helpers.ReactiveContextUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.helpers.UserPermissionUtils;
 import com.appsmith.server.imports.internal.ImportService;
@@ -193,7 +194,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
                     return createForkedPageMono.flatMap(savedPage -> {
                         clonedPages.add(savedPage);
                         Flux<NewAction> sourceActionFlux = newActionService
-                                .findByPageIdsForExport(List.of(templatePageId), Optional.empty())
+                                .findByPageIdsForExport(List.of(templatePageId), null)
                                 .cache();
 
                         forkingSourceToForkableActionsFluxMap.put(sourceMetaForPage, sourceActionFlux);
@@ -599,6 +600,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
                             AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, srcApplicationId)))
                     .cache();
 
+            Mono<User> currentUserMono = ReactiveContextUtils.getCurrentUser();
             // Normal Application forking with developer/edit access
             Flux<BaseDomain> pageFlux = applicationMono.flatMapMany(application -> newPageRepository
                     .findIdsAndPoliciesByApplicationIdIn(List.of(application.getId()))
@@ -608,7 +610,8 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
                         newPage.setPolicies(idPoliciesOnly.getPolicies());
                         return newPage;
                     })
-                    .flatMap(newPageRepository::setUserPermissionsInObject));
+                    .zipWith(currentUserMono)
+                    .flatMap(tuple -> newPageRepository.setUserPermissionsInObject(tuple.getT1(), tuple.getT2())));
 
             Flux<BaseDomain> actionFlux = applicationMono.flatMapMany(application -> newActionRepository
                     .findIdsAndPoliciesByApplicationIdIn(List.of(application.getId()))
@@ -618,16 +621,20 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
                         newAction.setPolicies(idPoliciesOnly.getPolicies());
                         return newAction;
                     })
-                    .flatMap(newActionRepository::setUserPermissionsInObject));
+                    .zipWith(currentUserMono)
+                    .flatMap(tuple -> newActionRepository.setUserPermissionsInObject(tuple.getT1(), tuple.getT2())));
 
             Flux<BaseDomain> actionCollectionFlux =
                     applicationMono.flatMapMany(application -> actionCollectionRepository
                             .findByApplicationId(application.getId(), Optional.empty(), Optional.empty())
-                            .flatMap(actionCollectionRepository::setUserPermissionsInObject));
+                            .zipWith(currentUserMono)
+                            .flatMap(tuple -> actionCollectionRepository.setUserPermissionsInObject(
+                                    tuple.getT1(), tuple.getT2())));
 
             Flux<BaseDomain> workspaceFlux = Flux.from(workspaceRepository
                     .findById(targetWorkspaceId)
-                    .flatMap(workspaceRepository::setUserPermissionsInObject));
+                    .zipWith(currentUserMono)
+                    .flatMap(tuple -> workspaceRepository.setUserPermissionsInObject(tuple.getT1(), tuple.getT2())));
 
             Mono<Set<String>> permissionGroupIdsMono =
                     permissionGroupService.getSessionUserPermissionGroupIds().cache();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ReactiveContextUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ReactiveContextUtils.java
@@ -1,0 +1,14 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.domains.User;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import reactor.core.publisher.Mono;
+
+public class ReactiveContextUtils {
+    public static Mono<User> getCurrentUser() {
+        return ReactiveSecurityContextHolder.getContext()
+                .map(SecurityContext::getAuthentication)
+                .map(auth -> (User) auth.getPrincipal());
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportServiceCEImpl.java
@@ -21,6 +21,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ImportArtifactPermissionProvider;
 import com.appsmith.server.helpers.ImportExportUtils;
+import com.appsmith.server.helpers.ReactiveContextUtils;
 import com.appsmith.server.imports.importable.ImportableService;
 import com.appsmith.server.imports.internal.artifactbased.ArtifactBasedImportService;
 import com.appsmith.server.migrations.JsonSchemaMigration;
@@ -174,8 +175,8 @@ public class ImportServiceCEImpl implements ImportServiceCE {
 
         ArtifactBasedImportService<?, ?, ?> contextBasedImportService =
                 getArtifactBasedImportService(artifactExchangeJson);
-        return permissionGroupRepository
-                .getCurrentUserPermissionGroups()
+        return ReactiveContextUtils.getCurrentUser()
+                .flatMap(permissionGroupRepository::getPermissionGroupsForUser)
                 .zipWhen(userPermissionGroup -> {
                     return Mono.just(contextBasedImportService.getImportArtifactPermissionProviderForImportingArtifact(
                             userPermissionGroup));
@@ -224,8 +225,8 @@ public class ImportServiceCEImpl implements ImportServiceCE {
                         AppsmithError.UNSUPPORTED_IMPORT_OPERATION_FOR_GIT_CONNECTED_APPLICATION));
             } else {
                 contextBasedImportService.setJsonArtifactNameToNullBeforeUpdate(artifactId, artifactExchangeJson);
-                return permissionGroupRepository
-                        .getCurrentUserPermissionGroups()
+                return ReactiveContextUtils.getCurrentUser()
+                        .flatMap(permissionGroupRepository::getPermissionGroupsForUser)
                         .zipWhen(userPermissionGroup -> {
                             return Mono.just(
                                     contextBasedImportService.getImportArtifactPermissionProviderForUpdatingArtifact(
@@ -272,8 +273,8 @@ public class ImportServiceCEImpl implements ImportServiceCE {
 
         ArtifactBasedImportService<?, ?, ?> artifactBasedImportService =
                 getArtifactBasedImportService(artifactExchangeJson);
-        return permissionGroupRepository
-                .getCurrentUserPermissionGroups()
+        return ReactiveContextUtils.getCurrentUser()
+                .flatMap(permissionGroupRepository::getPermissionGroupsForUser)
                 .zipWhen(userPermissionGroups -> {
                     return Mono.just(artifactBasedImportService.getImportArtifactPermissionProviderForConnectingToGit(
                             userPermissionGroups));
@@ -302,8 +303,8 @@ public class ImportServiceCEImpl implements ImportServiceCE {
          */
         ArtifactBasedImportService<?, ?, ?> contextBasedImportService =
                 getArtifactBasedImportService(artifactExchangeJson);
-        return permissionGroupRepository
-                .getCurrentUserPermissionGroups()
+        return ReactiveContextUtils.getCurrentUser()
+                .flatMap(permissionGroupRepository::getPermissionGroupsForUser)
                 .zipWhen(userPermissionGroups -> {
                     return Mono.just(contextBasedImportService.getImportArtifactPermissionProviderForRestoringSnapshot(
                             userPermissionGroups));
@@ -347,8 +348,8 @@ public class ImportServiceCEImpl implements ImportServiceCE {
                 getArtifactBasedImportService(artifactExchangeJson);
         contextBasedImportService.updateArtifactExchangeJsonWithEntitiesToBeConsumed(
                 artifactExchangeJson, entitiesToImport);
-        return permissionGroupRepository
-                .getCurrentUserPermissionGroups()
+        return ReactiveContextUtils.getCurrentUser()
+                .flatMap(permissionGroupRepository::getPermissionGroupsForUser)
                 .zipWhen(userPermissionGroups -> {
                     return Mono.just(
                             contextBasedImportService.getImportArtifactPermissionProviderForMergingJsonWithArtifact(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -67,8 +67,6 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
 
     Flux<NewAction> findByPageId(String pageId, AclPermission permission);
 
-    Flux<NewAction> findByPageId(String pageId, Optional<AclPermission> permission);
-
     Flux<NewAction> findByPageIdAndViewMode(String pageId, Boolean viewMode, AclPermission permission);
 
     Flux<NewAction> findAllByApplicationIdAndViewMode(
@@ -150,9 +148,9 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
 
     Flux<PluginTypeAndCountDTO> countActionsByPluginType(String applicationId);
 
-    Flux<NewAction> findByPageIds(List<String> unpublishedPages, Optional<AclPermission> optionalPermission);
+    Flux<NewAction> findByPageIds(List<String> unpublishedPages, AclPermission permission);
 
-    Flux<NewAction> findByPageIdsForExport(List<String> unpublishedPages, Optional<AclPermission> optionalPermission);
+    Flux<NewAction> findByPageIdsForExport(List<String> unpublishedPages, AclPermission permission);
 
     Flux<NewAction> findAllActionsByContextIdAndContextTypeAndViewMode(
             String contextId,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exportable/applications/NewActionApplicationExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/exportable/applications/NewActionApplicationExportableServiceCEImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -26,7 +25,7 @@ public class NewActionApplicationExportableServiceCEImpl extends ApplicationExpo
 
     @Override
     public Flux<NewAction> findByContextIdsForExport(List<String> contextIds, AclPermission permission) {
-        return newActionService.findByPageIdsForExport(contextIds, Optional.ofNullable(permission));
+        return newActionService.findByPageIdsForExport(contextIds, null);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
@@ -25,7 +25,6 @@ import reactor.core.publisher.Flux;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -58,13 +57,13 @@ public class NewActionApplicationImportableServiceCEImpl
 
     @Override
     public Flux<NewAction> getExistingResourcesInCurrentArtifactFlux(Artifact artifact) {
-        return repository.findByApplicationId(artifact.getId(), Optional.empty(), Optional.empty());
+        return repository.findByApplicationId(artifact.getId());
     }
 
     @Override
     public Flux<NewAction> getExistingResourcesInOtherBranchesFlux(String defaultArtifactId, String currentArtifactId) {
         return repository
-                .findByDefaultApplicationId(defaultArtifactId, Optional.empty())
+                .findByDefaultApplicationId(defaultArtifactId, null)
                 .filter(newAction -> !Objects.equals(newAction.getApplicationId(), currentArtifactId));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
@@ -2,6 +2,7 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.BridgeUpdate;
 import com.appsmith.server.repositories.ce.params.QueryAllParams;
 
@@ -13,9 +14,6 @@ public interface AppsmithRepository<T extends BaseDomain> {
 
     Optional<T> findById(String id, AclPermission permission);
 
-    @Deprecated(forRemoval = true)
-    Optional<T> findById(String id, Optional<AclPermission> permission);
-
     Optional<T> findById(String id, List<String> projectionFieldNames, AclPermission permission);
 
     Optional<T> updateById(String id, T resource, AclPermission permission);
@@ -25,6 +23,8 @@ public interface AppsmithRepository<T extends BaseDomain> {
     /*no-cake*/ QueryAllParams<T> queryBuilder();
 
     T setUserPermissionsInObject(T obj, Collection<String> permissionGroups);
+
+    T setUserPermissionsInObject(T obj, User user);
 
     T setUserPermissionsInObject(T obj);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
@@ -18,8 +18,6 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
 
     List<NewAction> findByPageId(String pageId, AclPermission aclPermission);
 
-    List<NewAction> findByPageId(String pageId, Optional<AclPermission> aclPermission);
-
     List<NewAction> findByPageId(String pageId);
 
     List<NewAction> findByPageIdAndViewMode(String pageId, Boolean viewMode, AclPermission aclPermission);
@@ -34,8 +32,7 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
 
     List<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission, Sort sort);
 
-    List<NewAction> findByApplicationId(
-            String applicationId, Optional<AclPermission> aclPermission, Optional<Sort> sort);
+    List<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission, Optional<Sort> sort);
 
     List<NewAction> findByApplicationIdAndViewMode(String applicationId, Boolean viewMode, AclPermission aclPermission);
 
@@ -44,14 +41,12 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
     Optional<NewAction> findByBranchNameAndDefaultActionId(
             String branchName, String defaultActionId, Boolean viewMode, AclPermission permission);
 
-    List<NewAction> findByDefaultApplicationId(String defaultApplicationId, Optional<AclPermission> permission);
+    List<NewAction> findByDefaultApplicationId(String defaultApplicationId, AclPermission permission);
 
     List<NewAction> findByPageIds(List<String> pageIds, AclPermission permission);
 
-    List<NewAction> findByPageIds(List<String> pageIds, Optional<AclPermission> permission);
-
     List<NewAction> findNonJsActionsByApplicationIdAndViewMode(
-            String applicationId, Boolean viewMode, AclPermission aclPermission);
+        String applicationId, Boolean viewMode, AclPermission aclPermission);
 
     List<NewAction> findAllNonJsActionsByNameAndPageIdsAndViewMode(
             String name, List<String> pageIds, Boolean viewMode, AclPermission aclPermission, Sort sort);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -33,12 +33,11 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     }
 
     @Override
-    public List<NewAction> findByApplicationId(
-            String applicationId, Optional<AclPermission> aclPermission, Optional<Sort> sort) {
+    public List<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission, Optional<Sort> sort) {
         return queryBuilder()
                 .criteria(getCriterionForFindByApplicationId(applicationId)
                         .isNull(NewAction.Fields.unpublishedAction_deletedAt))
-                .permission(aclPermission.orElse(null))
+                .permission(aclPermission)
                 .sort(sort.orElse(null))
                 .all();
     }
@@ -65,13 +64,8 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     }
 
     @Override
-    public List<NewAction> findByPageId(String pageId, Optional<AclPermission> aclPermission) {
-        return findByPageId(pageId, aclPermission.orElse(null));
-    }
-
-    @Override
     public List<NewAction> findByPageId(String pageId) {
-        return this.findByPageId(pageId, Optional.empty());
+        return this.findByPageId(pageId, null);
     }
 
     @Override
@@ -237,12 +231,6 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     }
 
     @Override
-    @Deprecated
-    public List<NewAction> findByPageIds(List<String> pageIds, Optional<AclPermission> permission) {
-        return findByPageIds(pageIds, permission.orElse(null));
-    }
-
-    @Override
     public List<NewAction> findNonJsActionsByApplicationIdAndViewMode(
             String applicationId, Boolean viewMode, AclPermission aclPermission) {
         return queryBuilder()
@@ -311,12 +299,12 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     }
 
     @Override
-    public List<NewAction> findByDefaultApplicationId(String defaultApplicationId, Optional<AclPermission> permission) {
+    public List<NewAction> findByDefaultApplicationId(String defaultApplicationId, AclPermission permission) {
         final String defaultResources = BranchAwareDomain.Fields.defaultResources;
         return queryBuilder()
                 .criteria(Bridge.equal(NewAction.Fields.defaultResources_applicationId, defaultApplicationId)
                         .isNull(NewAction.Fields.unpublishedAction_deletedAt))
-                .permission(permission.orElse(null))
+                .permission(permission)
                 .all();
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCE.java
@@ -30,7 +30,7 @@ public interface CustomPermissionGroupRepositoryCE extends AppsmithRepository<Pe
     List<PermissionGroup> findAllByAssignedToUserIn(
             Set<String> userIds, Optional<List<String>> includeFields, Optional<AclPermission> permission);
 
-    Set<String> getCurrentUserPermissionGroups();
+    Mono<Set<String>> getPermissionGroupsForUser(User user);
 
     Set<String> getAllPermissionGroupsIdsForUser(User user);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomPermissionGroupRepositoryCEImpl.java
@@ -83,8 +83,8 @@ public class CustomPermissionGroupRepositoryCEImpl extends BaseAppsmithRepositor
     }
 
     @Override
-    public Set<String> getCurrentUserPermissionGroups() {
-        return super.getCurrentUserPermissionGroups();
+    public Set<String> getPermissionGroupsForUser(User user) {
+        return super.getPermissionGroupsForUser(user);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -3,6 +3,7 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Theme;
 import com.appsmith.server.helpers.CollectionUtils;
+import com.appsmith.server.helpers.UserPermissionUtils;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -13,6 +13,7 @@ import com.appsmith.server.dtos.ActionCollectionMoveDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ContextTypeUtils;
+import com.appsmith.server.helpers.ReactiveContextUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeUpdate;
@@ -430,7 +431,8 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
                     });
                 })
                 .flatMap(actionCollection -> actionCollectionService.update(actionCollection.getId(), actionCollection))
-                .flatMap(actionCollectionRepository::setUserPermissionsInObject)
+                .zipWith(ReactiveContextUtils.getCurrentUser())
+                .flatMap(tuple -> actionCollectionRepository.setUserPermissionsInObject(tuple.getT1(), tuple.getT2()))
                 .flatMap(savedActionCollection ->
                         updateLayoutBasedOnContext(savedActionCollection).thenReturn(savedActionCollection))
                 .flatMap(savedActionCollection -> analyticsService.sendUpdateEvent(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
@@ -10,7 +10,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
@@ -24,8 +23,6 @@ public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
     Mono<Workspace> getById(String id);
 
     Mono<Workspace> findById(String id, AclPermission permission);
-
-    Mono<Workspace> findById(String id, Optional<AclPermission> permission);
 
     Mono<Workspace> save(Workspace workspace);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -47,7 +47,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -189,8 +188,7 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
                             .thenReturn(createdWorkspace);
                 })
                 .flatMap(this::createWorkspaceDependents)
-                .flatMap(analyticsService::sendCreateEvent)
-                .map(x -> x);
+                .flatMap(analyticsService::sendCreateEvent);
     }
 
     protected void prepareWorkspaceToCreate(Workspace workspace, User user) {
@@ -452,11 +450,6 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
     @Override
     public Mono<Workspace> findById(String id, AclPermission permission) {
         return repository.findById(id, permission);
-    }
-
-    @Override
-    public Mono<Workspace> findById(String id, Optional<AclPermission> permission) {
-        return findById(id, permission.orElse(null));
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -14,9 +14,11 @@ import com.appsmith.server.defaultresources.DefaultResourcesService;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
+import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.ReactiveContextUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.layouts.UpdateLayoutService;
 import com.appsmith.server.newactions.base.NewActionService;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -299,7 +302,7 @@ public class ActionCollectionServiceImplTest {
             argument.setId("testActionCollectionId");
             return Mono.just(argument);
         });
-        Mockito.when(actionCollectionRepository.setUserPermissionsInObject(Mockito.any()))
+        Mockito.when(actionCollectionRepository.setUserPermissionsInObject(Mockito.any(), Mockito.any(User.class)))
                 .thenAnswer(invocation -> {
                     final ActionCollection argument =
                             (ActionCollection) invocation.getArguments()[0];
@@ -316,15 +319,19 @@ public class ActionCollectionServiceImplTest {
                     return argument;
                 });
 
-        final Mono<ActionCollectionDTO> actionCollectionDTOMono =
-                layoutCollectionService.createCollection(actionCollectionDTO, null);
+        try (MockedStatic<ReactiveContextUtils> mockedStatic = Mockito.mockStatic(ReactiveContextUtils.class)) {
+            // Define the behavior of the static method
+            mockedStatic.when(ReactiveContextUtils::getCurrentUser).thenReturn(Mono.just(new User()));
+            final Mono<ActionCollectionDTO> actionCollectionDTOMono =
+                    layoutCollectionService.createCollection(actionCollectionDTO, null);
 
-        StepVerifier.create(actionCollectionDTOMono)
-                .assertNext(actionCollectionDTO1 -> {
-                    assertTrue(actionCollectionDTO1.getActions().isEmpty());
-                    assertThat(actionCollectionDTO1.getUserPermissions()).hasSize(2);
-                })
-                .verifyComplete();
+            StepVerifier.create(actionCollectionDTOMono)
+                    .assertNext(actionCollectionDTO1 -> {
+                        assertTrue(actionCollectionDTO1.getActions().isEmpty());
+                        assertThat(actionCollectionDTO1.getUserPermissions()).hasSize(2);
+                    })
+                    .verifyComplete();
+        }
     }
 
     @Test
@@ -400,7 +407,7 @@ public class ActionCollectionServiceImplTest {
                     return Mono.just(argument);
                 });
 
-        Mockito.when(actionCollectionRepository.setUserPermissionsInObject(Mockito.any()))
+        Mockito.when(actionCollectionRepository.setUserPermissionsInObject(Mockito.any(), Mockito.any(User.class)))
                 .thenAnswer(invocation -> {
                     final ActionCollection argument =
                             (ActionCollection) invocation.getArguments()[0];
@@ -417,24 +424,28 @@ public class ActionCollectionServiceImplTest {
                     return argument;
                 });
 
-        final Mono<ActionCollectionDTO> actionCollectionDTOMono =
-                layoutCollectionService.createCollection(actionCollectionDTO, null);
+        try (MockedStatic<ReactiveContextUtils> mockedStatic = Mockito.mockStatic(ReactiveContextUtils.class)) {
+            // Define the behavior of the static method
+            mockedStatic.when(ReactiveContextUtils::getCurrentUser).thenReturn(Mono.just(new User()));
+            final Mono<ActionCollectionDTO> actionCollectionDTOMono =
+                    layoutCollectionService.createCollection(actionCollectionDTO, null);
 
-        StepVerifier.create(actionCollectionDTOMono)
-                .assertNext(actionCollectionDTO1 -> {
-                    assertEquals(1, actionCollectionDTO1.getActions().size());
-                    assertThat(actionCollectionDTO1.getUserPermissions()).hasSize(2);
-                    final ActionDTO actionDTO =
-                            actionCollectionDTO1.getActions().get(0);
-                    assertEquals("testAction", actionDTO.getName());
-                    assertEquals("testActionId", actionDTO.getId());
-                    assertEquals("testCollection.testAction", actionDTO.getFullyQualifiedName());
-                    assertEquals(
-                            "testActionCollectionId",
-                            actionDTO.getDefaultResources().getCollectionId());
-                    assertTrue(actionDTO.getClientSideExecution());
-                })
-                .verifyComplete();
+            StepVerifier.create(actionCollectionDTOMono)
+                    .assertNext(actionCollectionDTO1 -> {
+                        assertEquals(1, actionCollectionDTO1.getActions().size());
+                        assertThat(actionCollectionDTO1.getUserPermissions()).hasSize(2);
+                        final ActionDTO actionDTO =
+                                actionCollectionDTO1.getActions().get(0);
+                        assertEquals("testAction", actionDTO.getName());
+                        assertEquals("testActionId", actionDTO.getId());
+                        assertEquals("testCollection.testAction", actionDTO.getFullyQualifiedName());
+                        assertEquals(
+                                "testActionCollectionId",
+                                actionDTO.getDefaultResources().getCollectionId());
+                        assertTrue(actionDTO.getClientSideExecution());
+                    })
+                    .verifyComplete();
+        }
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -65,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -192,10 +193,10 @@ public class DatasourceContextServiceTest {
 
         doReturn(Mono.just(datasource))
                 .when(datasourceRepository)
-                .findById("id1", datasourcePermission.getDeletePermission());
+                .findById(eq("id1"), eq(datasourcePermission.getDeletePermission()));
         doReturn(Mono.just(datasource))
                 .when(datasourceRepository)
-                .findById("id1", datasourcePermission.getExecutePermission());
+                .findById(eq("id1"), eq(datasourcePermission.getExecutePermission()));
         doReturn(Mono.just(new Plugin())).when(pluginService).findById("mockPlugin");
         doReturn(Mono.just(0L)).when(newActionRepository).countByDatasourceId("id1");
         doReturn(Mono.just(datasource)).when(datasourceRepository).archiveById("id1");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
@@ -66,7 +66,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -293,9 +292,8 @@ public class PartialImportServiceTest {
         Mono<Tuple3<Application, List<NewAction>, List<ActionCollection>>> result = partialImportService
                 .importResourceInPage(workspaceId, testApplication.getId(), pageId, null, filePart)
                 .flatMap(application -> {
-                    Mono<List<NewAction>> actionList = newActionService
-                            .findByPageId(pageId, Optional.empty())
-                            .collectList();
+                    Mono<List<NewAction>> actionList =
+                            newActionService.findByPageId(pageId).collectList();
                     Mono<List<ActionCollection>> actionCollectionList =
                             actionCollectionService.findByPageId(pageId).collectList();
 
@@ -352,7 +350,7 @@ public class PartialImportServiceTest {
                 .importResourceInPage(workspaceId, application.getId(), savedPage.getId(), "master", filePart)
                 .flatMap(application1 -> {
                     Mono<List<NewAction>> actionList = newActionService
-                            .findByPageId(finalSavedPage.getId(), Optional.empty())
+                            .findByPageId(finalSavedPage.getId())
                             .collectList();
                     Mono<List<ActionCollection>> actionCollectionList = actionCollectionService
                             .findByPageId(finalSavedPage.getId())
@@ -413,9 +411,8 @@ public class PartialImportServiceTest {
                 .then(partialImportService.importResourceInPage(
                         workspaceId, testApplication.getId(), pageId, null, filePart))
                 .flatMap(application -> {
-                    Mono<List<NewAction>> actionList = newActionService
-                            .findByPageId(pageId, Optional.empty())
-                            .collectList();
+                    Mono<List<NewAction>> actionList =
+                            newActionService.findByPageId(pageId).collectList();
                     Mono<List<ActionCollection>> actionCollectionList =
                             actionCollectionService.findByPageId(pageId).collectList();
 
@@ -505,9 +502,7 @@ public class PartialImportServiceTest {
                     return Mono.zip(
                             Mono.just(buildingBlockResponseDTO),
                             actionCollectionService.findByPageId(pageId).collectList(),
-                            newActionService
-                                    .findByPageId(pageId, Optional.empty())
-                                    .collectList());
+                            newActionService.findByPageId(pageId).collectList());
                 });
 
         StepVerifier.create(result)


### PR DESCRIPTION
## Description
We are using non-reactive driver (JDBC) for Postgres which makes the DB calls synchronous in nature. This is forcing us to add blocking calls to fetch the permission groups for the user. As a part of this call we are fetching the current user from the ReactiveSecurityContext, but with blocking call this results in null value. To fix this we are going ahead with adding the user object in the AclPermission in the reactive chain itself to avoid the dependency of ReactiveSecurityContext in the synchronous call.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
