### PR TITLE
fix:onTextChanged action gets triggered on typing numbers after 2 dec…

### DIFF
--- a/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
@@ -498,8 +498,13 @@ class CurrencyInputWidget extends BaseInputWidget<
   onValueChange = (value: string) => {
     let formattedValue = "";
     const decimalSeperator = getLocaleDecimalSeperator();
+    const decimals = this.props.decimals ?? 0;
     try {
       if (value && value.includes(decimalSeperator)) {
+        const [integerPart, fractionalPart] = value.split(decimalSeperator);
+            if (fractionalPart && fractionalPart.length > decimals) {
+                return;
+            }
         formattedValue = limitDecimalValue(this.props.decimals, value);
       } else {
         formattedValue = value;


### PR DESCRIPTION
## Description: 
> In the Currency Input widget if we allow 2 decimal places and set a onTextChanged action, then on typing numbers after the 2nd decimal place the action gets triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `CurrencyInputWidget` to correctly handle fractional part lengths, ensuring it respects the specified decimal places.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

___

### **PR Type**
Bug fix


___

### **Description**
- Implemented a fix to prevent the `onTextChanged` action from being triggered when typing numbers after the allowed decimal places in the Currency Input widget.
- Added logic to split the input value and validate the length of the fractional part against the specified decimal places.


___





> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

