### PR TITLE
chore: Removed two extra machines for ci-test-limit

### DIFF
--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -14,11 +14,6 @@ on:
         required: false
         type: number
         default: 0
-      matrix:
-        description: "Matrix jobs"
-        required: false
-        type: string
-        default: "[0]"
   workflow_call:
     inputs:
       pr:
@@ -30,11 +25,6 @@ on:
         required: false
         type: number
         default: 0
-      matrix:
-        description: "This is the matrix job number"
-        required: false
-        type: string
-        default: "[0]"
 
 jobs:
   ci-test-limited:
@@ -48,10 +38,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        job: ${{ fromJson(inputs.matrix) }}
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -100,9 +86,9 @@ jobs:
         with:
           path: |
             ~/run_result
-          key: ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+          key: ${{ github.run_id }}-${{ github.job }}
           restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+            ${{ github.run_id }}-${{ github.job }}
 
       - name: Get the previous run result
         if: steps.cache-appsmith.outputs.cache-hit == 'true'
@@ -382,7 +368,7 @@ jobs:
         working-directory: "."
         run: |
           mkdir -p  ~/dockerlogs
-          docker logs appsmith 2>&1 > ~/dockerlogs/dockerlogs-${{ matrix.job }}.txt
+          docker logs appsmith 2>&1 > ~/dockerlogs/dockerlogs-log.txt
 
       # Upload docker logs
       - name: Upload failed test list artifact
@@ -397,7 +383,7 @@ jobs:
         if: failure()
         run: |
           mkdir -p ~/results
-          mv ${{ github.workspace }}/app/client/results ~/results/${{ matrix.job }}
+          mv ${{ github.workspace }}/app/client/results ~/results
 
       - name: Upload cypress report
         if: failure()
@@ -420,14 +406,14 @@ jobs:
         with:
           path: |
             ~/run_result
-          key: ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+          key: ${{ github.run_id }}-${{ github.job }}
 
       # Upload the log artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server logs bundle on failure
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: server-logs-${{ matrix.job }}
+          name: server-logs
           path: app/server/server-logs.log
           overwrite: true
 

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -18,7 +18,7 @@ on:
         description: "Matrix jobs"
         required: false
         type: string
-        default: "[0, 1, 2]"
+        default: "[0]"
   workflow_call:
     inputs:
       pr:
@@ -34,7 +34,7 @@ on:
         description: "This is the matrix job number"
         required: false
         type: string
-        default: "[0, 1, 2]"
+        default: "[0]"
 
 jobs:
   ci-test-limited:

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
ci-test-limit runs 3 machines by default and this is wastage of our resource, in most of our use cases we end up using only one machine soremoving extra unnecessary two.

run - https://github.com/appsmithorg/appsmith/actions/runs/9593828953/job/26455099156

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9594698568>
> Commit: 18d2ab3a9f292c6e3ca8ed7c803bbabde75cb1ab
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9594698568&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test workflow configuration for more efficient CI runs.
  
- **Tests**
  - Switched limited test spec file to improve test coverage and relevance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->