### PR TITLE
fix: revert to passing hook as a prop for EE compatibility

### DIFF
--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -46,6 +46,7 @@ import RealtimeAppEditors from "./RealtimeAppEditors";
 import { EditorSaveIndicator } from "./EditorSaveIndicator";
 import { selectFeatureFlags } from "@appsmith/selectors/featureFlagsSelectors";
 import { fetchUsersForWorkspace } from "@appsmith/actions/workspaceActions";
+import { useNavigationMenuData } from "./EditorName/useNavigationMenuData";
 
 import {
   getIsGitConnected,
@@ -207,6 +208,7 @@ export function EditorHeader() {
                 editInteractionKind={EditInteractionKind.SINGLE}
                 editorName="Application"
                 fill
+                getNavigationMenu={useNavigationMenuData}
                 isError={isErroredSavingName}
                 isNewEditor={
                   applicationList.filter((el) => el.id === applicationId)

--- a/app/client/src/pages/Editor/EditorName/index.tsx
+++ b/app/client/src/pages/Editor/EditorName/index.tsx
@@ -13,7 +13,8 @@ import ForkApplicationModal from "pages/Applications/ForkApplicationModal";
 import { Container, StyledIcon } from "./components";
 import { useSelector } from "react-redux";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
-import { useNavigationMenuData } from "./useNavigationMenuData";
+import type { NavigationMenuDataProps } from "./useNavigationMenuData";
+import type { MenuItemData } from "./NavigationMenuItem";
 
 type EditorNameProps = CommonComponentProps & {
   applicationId?: string | undefined;
@@ -31,6 +32,10 @@ type EditorNameProps = CommonComponentProps & {
   isPopoverOpen: boolean;
   setIsPopoverOpen: typeof noop;
   editorName: string;
+  getNavigationMenu: ({
+    editMode,
+    setForkApplicationModalOpen,
+  }: NavigationMenuDataProps) => MenuItemData[];
 };
 
 export function EditorName(props: EditorNameProps) {
@@ -38,6 +43,7 @@ export function EditorName(props: EditorNameProps) {
     defaultSavingState,
     defaultValue,
     editorName,
+    getNavigationMenu,
     isNewEditor,
     isPopoverOpen,
     setIsPopoverOpen,
@@ -92,7 +98,7 @@ export function EditorName(props: EditorNameProps) {
     }
   }, []);
 
-  const navigationMenuData = useNavigationMenuData({
+  const navigationMenuData = getNavigationMenu({
     editMode,
     setForkApplicationModalOpen,
   });

--- a/app/client/src/pages/Editor/IDE/Header/index.tsx
+++ b/app/client/src/pages/Editor/IDE/Header/index.tsx
@@ -76,6 +76,7 @@ import { EditorSaveIndicator } from "pages/Editor/EditorSaveIndicator";
 import type { Page } from "@appsmith/constants/ReduxActionConstants";
 import { IDEHeader, IDEHeaderTitle } from "IDE";
 import { APPLICATIONS_URL } from "constants/routes";
+import { useNavigationMenuData } from "../../EditorName/useNavigationMenuData";
 
 const StyledDivider = styled(Divider)`
   height: 50%;
@@ -239,6 +240,7 @@ const Header = () => {
                   editInteractionKind={EditInteractionKind.SINGLE}
                   editorName="Application"
                   fill
+                  getNavigationMenu={useNavigationMenuData}
                   isError={isErroredSavingName}
                   isNewEditor={
                     applicationList.filter((el) => el.id === applicationId)


### PR DESCRIPTION
## Description
Revert to passing hook as a prop for EE compatibility.

Fixes #32982

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9600106265>
> Commit: 042f94586b64efc1b8224059ceebddb0a4a9f0e6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9600106265&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced navigation menu generation in the editor with improved data management.

- **Refactor**
  - Updated the navigation menu logic to use a new function, improving code maintainability and data handling.

- **Bug Fixes**
  - Fixed inconsistencies in the navigation menu across different components in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->