### PR TITLE
chore: Remove unused methods in `NewPageServiceCE`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
@@ -89,8 +89,6 @@ public interface NewPageServiceCE extends CrudService<NewPage, String> {
     Mono<NewPage> findByGitSyncIdAndDefaultApplicationId(
             String defaultApplicationId, String gitSyncId, Optional<AclPermission> permission);
 
-    Flux<NewPage> findPageSlugsByApplicationIds(List<String> applicationIds, AclPermission aclPermission);
-
     Mono<Void> publishPages(Collection<String> pageIds, AclPermission permission);
 
     ApplicationPagesDTO getApplicationPagesDTO(Application application, List<NewPage> newPages, boolean viewMode);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
@@ -627,11 +627,6 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
         return repository.findByGitSyncIdAndDefaultApplicationId(defaultApplicationId, gitSyncId, permission);
     }
 
-    @Override
-    public Flux<NewPage> findPageSlugsByApplicationIds(List<String> applicationIds, AclPermission aclPermission) {
-        return repository.findSlugsByApplicationIds(applicationIds, aclPermission);
-    }
-
     /**
      * Returns a list of pages of an Application.
      * If Application ID is present, it'll fetch all pages of that application in the provided mode.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
@@ -32,8 +32,6 @@ public interface CustomNewPageRepositoryCE extends AppsmithRepository<NewPage> {
     Mono<NewPage> findPageByBranchNameAndDefaultPageId(
             String branchName, String defaultPageId, AclPermission permission);
 
-    Flux<NewPage> findSlugsByApplicationIds(List<String> applicationIds, AclPermission aclPermission);
-
     Mono<NewPage> findByGitSyncIdAndDefaultApplicationId(
             String defaultApplicationId, String gitSyncId, AclPermission permission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -8,6 +8,7 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.helpers.ce.bridge.BridgeUpdate;
+import com.appsmith.server.projections.IdOnly;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -171,23 +172,8 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         return queryBuilder()
                 .criteria(q)
                 .permission(permission)
-                .fields("id")
-                .one()
-                .map(NewPage::getId);
-    }
-
-    @Override
-    public Flux<NewPage> findSlugsByApplicationIds(List<String> applicationIds, AclPermission aclPermission) {
-        return queryBuilder()
-                .criteria(Bridge.in(NewPage.Fields.applicationId, applicationIds))
-                .fields(
-                        NewPage.Fields.unpublishedPage_slug,
-                        NewPage.Fields.unpublishedPage_customSlug,
-                        NewPage.Fields.publishedPage_slug,
-                        NewPage.Fields.publishedPage_customSlug,
-                        NewPage.Fields.applicationId)
-                .permission(aclPermission)
-                .all();
+                .one(IdOnly.class)
+                .map(IdOnly::id);
     }
 
     @Override


### PR DESCRIPTION
Unused on EE as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal logic by updating methods to use projections instead of fetching specific fields.
  
- **Chores**
  - Removed deprecated methods related to fetching page slugs by application IDs to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->