### PR TITLE
chore: Fix missing changes in revert #34313

### DIFF
--- a/app/client/src/pages/Editor/EditorName/index.tsx
+++ b/app/client/src/pages/Editor/EditorName/index.tsx
@@ -9,12 +9,14 @@ import { SavingState } from "design-system-old";
 import EditableName from "./EditableName";
 import { NavigationMenu } from "./NavigationMenu";
 import { Menu, toast, MenuTrigger } from "design-system";
+import type { Theme } from "constants/DefaultTheme";
 import ForkApplicationModal from "pages/Applications/ForkApplicationModal";
 import { Container, StyledIcon } from "./components";
 import { useSelector } from "react-redux";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
 import type { NavigationMenuDataProps } from "./useNavigationMenuData";
 import type { MenuItemData } from "./NavigationMenuItem";
+import { useTheme } from "styled-components";
 
 type EditorNameProps = CommonComponentProps & {
   applicationId?: string | undefined;
@@ -48,6 +50,8 @@ export function EditorName(props: EditorNameProps) {
     isPopoverOpen,
     setIsPopoverOpen,
   } = props;
+
+  const theme = useTheme() as Theme;
 
   const [isEditingDefault, setIsEditingDefault] = useState(isNewEditor);
   const [isEditing, setIsEditing] = useState(!!isEditingDefault);
@@ -100,6 +104,7 @@ export function EditorName(props: EditorNameProps) {
 
   const navigationMenuData = getNavigationMenu({
     editMode,
+    theme,
     setForkApplicationModalOpen,
   });
 

--- a/app/client/src/pages/Editor/EditorName/useNavigationMenuData.ts
+++ b/app/client/src/pages/Editor/EditorName/useNavigationMenuData.ts
@@ -19,6 +19,7 @@ import {
 import { getCurrentApplication } from "@appsmith/selectors/applicationSelectors";
 import { Colors } from "constants/Colors";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
+import type { ThemeProp } from "WidgetProvider/constants";
 import { toast } from "design-system";
 import { DOCS_BASE_URL } from "constants/ThirdPartyConstants";
 import { getAppsmithConfigs } from "@appsmith/configs";
@@ -26,7 +27,7 @@ import { getCurrentUser } from "selectors/usersSelectors";
 
 const { cloudHosting, intercomAppID } = getAppsmithConfigs();
 
-export interface NavigationMenuDataProps {
+export interface NavigationMenuDataProps extends ThemeProp {
   editMode: typeof noop;
   setForkApplicationModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }


### PR DESCRIPTION
## Description
Reverted missed out code in https://github.com/appsmithorg/appsmith/pull/34367

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9608916182>
> Commit: a2525661414e7bb571914ede981383778e9c4d56
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9608916182&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
