### PR TITLE
ci: Run server tests on `pg` branch

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -45,7 +45,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{ github.event.pull_request.number }}
-      is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' }}
+      is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' || github.event.pull_request.head.ref == 'pg' }}
 
   client-build:
     name: client-build

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -139,11 +139,10 @@ jobs:
           java-version: "17"
 
       - name: Conditionally start PostgreSQL
+        if: |
+          inputs.is-pg-build == 'true' && inputs.skip-tests != 'true'
         run: |
-          if [[ ${{ inputs.is-pg-build }} == 'true' ]]; then
-            echo "Requesting PostgreSQL container to be started for pg specific build."
-            docker run --name appsmith-pg -p 5432:5432 -d -e POSTGRES_PASSWORD=password postgres:alpine postgres -N 1500
-          fi
+          docker run --name appsmith-pg -p 5432:5432 -d -e POSTGRES_PASSWORD=password postgres:alpine postgres -N 1500
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow conditions to ensure PostgreSQL build is triggered when the pull request head reference is 'pg'.
  - Simplified logic to unconditionally start the PostgreSQL container in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->