### PR TITLE
fix: Prefetch apis: Include only branchname header in request key

### DIFF
--- a/app/client/src/ce/utils/serviceWorkerUtils.test.ts
+++ b/app/client/src/ce/utils/serviceWorkerUtils.test.ts
@@ -442,6 +442,17 @@ describe("serviceWorkerUtils", () => {
         const key = prefetchApiService.getRequestKey(request);
         expect(key).toBe("GET:https://app.appsmith.com/:branchname:main");
       });
+
+      it("should only append branchname header in request key", () => {
+        const request = new Request("https://app.appsmith.com", {
+          method: "GET",
+        });
+        request.headers.append("branchname", "main");
+        request.headers.append("another-header-key", "another-header-value");
+        request.headers.append("Content-Type", "application/json");
+        const key = prefetchApiService.getRequestKey(request);
+        expect(key).toBe("GET:https://app.appsmith.com/:branchname:main");
+      });
     });
 
     describe("aqcuireFetchMutex", () => {

--- a/app/client/src/ce/utils/serviceWorkerUtils.ts
+++ b/app/client/src/ce/utils/serviceWorkerUtils.ts
@@ -157,15 +157,23 @@ export class PrefetchApiService {
   cacheMaxAge = 2 * 60 * 1000; // 2 minutes in milliseconds
   // Mutex to lock the fetch and cache operation
   prefetchFetchMutexMap = new Map<string, Mutex>();
+  // Header keys used to create the unique request key
+  headerKeys = ["branchname"];
 
   constructor() {}
 
   // Function to get the request key
   getRequestKey = (request: Request) => {
-    const headersKey = Array.from(request.headers.entries())
-      .map(([key, value]) => `${key}:${value}`)
-      .join(",");
-    return `${request.method}:${request.url}:${headersKey}`;
+    let requestKey = `${request.method}:${request.url}`;
+
+    this.headerKeys.forEach((headerKey) => {
+      const headerValue = request.headers.get(headerKey);
+      if (headerValue) {
+        requestKey += `:${headerKey}:${headerValue}`;
+      }
+    });
+
+    return requestKey;
   };
 
   // Function to acquire the fetch mutex for a request


### PR DESCRIPTION
## Description
The request key used to store the mutex for prefetch request was including all header keys. The prefetch request created by the service worker only had one key (branchname) but the request initiated by the client had more headers. Because of this mismatch in keys the request was missing the cache.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9615050979>
> Commit: e9c4a982eddded5dce31005365978b4729dadba2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9615050979&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved request key generation by including specific headers, enhancing cache performance.

- **Tests**
  - Added a test case to verify the new request key generation logic based on headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->