### PR TITLE
chore: capturing allPaths and unevalTree diffs computation latency

### DIFF
--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -583,11 +583,16 @@ export default class DataTreeEvaluator {
       stringifiedLocalUnEvalTreeJSCollection,
     );
 
-    const differences: Diff<DataTree, DataTree>[] =
-      diff(
-        oldUnEvalTreeWithStringifiedJSFunctions,
-        localUnEvalTreeWithStringifiedJSFunctions,
-      ) || [];
+    const differences: Diff<DataTree, DataTree>[] = profileFn(
+      "unEvalTreeWithStringifiedJSFunctionsDiff",
+      undefined,
+      webworkerTelemetry,
+      () =>
+        diff(
+          oldUnEvalTreeWithStringifiedJSFunctions,
+          localUnEvalTreeWithStringifiedJSFunctions,
+        ) || [],
+    );
     // Since eval tree is listening to possible events that don't cause differences
     // We want to check if no diffs are present and bail out early
     if (differences.length === 0) {
@@ -628,7 +633,10 @@ export default class DataTreeEvaluator {
 
     const updateDependencyStartTime = performance.now();
     // TODO => Optimize using dataTree diff
-    this.allKeys = getAllPaths(localUnEvalTreeWithStringifiedJSFunctions);
+
+    this.allKeys = profileFn("getAllPaths", undefined, webworkerTelemetry, () =>
+      getAllPaths(localUnEvalTreeWithStringifiedJSFunctions),
+    );
     // Find all the paths that have changed as part of the difference and update the
     // global dependency map if an existing dynamic binding has now become legal
     const {


### PR DESCRIPTION
## Description
Capturing the telemetry of webworker's allPaths and unEvalTreeWithStringifiedJSFunctionsDiff computation.

#34397 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/9613641914>
> Commit: b3d679a8a079fc5c3febf7b4855916f32c982512
> Workflow: `PR Automation test suite`
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced profiling for key operations to monitor performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->