### PR TITLE
test: Fix extracing pageId from app page URL

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/OnLoadActions_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/OnLoadActions_Spec.ts
@@ -30,7 +30,7 @@ describe(
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
       cy.url().then((url) => {
         const pageid = agHelper.extractPageIdFromUrl(url);
-        assert(pageid != null);
+        expect(pageid).to.not.be.null;
         cy.log(pageid + "page id");
         cy.request("GET", "api/v1/pages/" + pageid).then((response) => {
           const respBody = JSON.stringify(response.body);

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/OnLoadActions_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/OnLoadActions_Spec.ts
@@ -29,7 +29,8 @@ describe(
       agHelper.AddDsl("onPageLoadActionsDsl");
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
       cy.url().then((url) => {
-        const pageid = url.split("/")[5]?.split("-").pop();
+        const pageid = agHelper.extractPageIdFromUrl(url);
+        assert(pageid != null);
         cy.log(pageid + "page id");
         cy.request("GET", "api/v1/pages/" + pageid).then((response) => {
           const respBody = JSON.stringify(response.body);

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -142,7 +142,11 @@ export class AggregateHelper {
     }
 
     // Extract the page ID, either as an ObjectID or as a UUID.
-    return parts[5]?.match(/[0-9a-f]{24}$|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)?.[0] ?? null;
+    return (
+      parts[5]?.match(
+        /[0-9a-f]{24}$|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      )?.[0] ?? null
+    );
   }
 
   public AddDsl(

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -133,15 +133,28 @@ export class AggregateHelper {
     });
   }
 
+  public extractPageIdFromUrl(url: string): null | string {
+    const parts = url.split("/");
+
+    if (parts[3] !== "app") {
+      // Not a app URL.
+      return null;
+    }
+
+    // Can handle both ObjectID and UUID. Not a very strict pattern, but that's not the purpose here.
+    return parts[5]?.match(/[a-f0-9]+((-[a-f0-9]+){4})?$/)?.[0] ?? null;
+  }
+
   public AddDsl(
     dslFile: string,
     elementToCheckPresenceaftDslLoad: string | "" = "", //    reloadWithoutCache = true,
   ) {
-    let pageid: string, layoutId;
+    let layoutId;
     let appId: string | null;
     cy.fixture(dslFile).then((val) => {
       cy.url().then((url) => {
-        pageid = url.split("/")[5]?.split("-").pop() as string;
+        const pageid = this.extractPageIdFromUrl(url);
+        assert(pageid != null);
         //Fetch the layout id
         cy.request("GET", "api/v1/pages/" + pageid).then((response: any) => {
           const respBody = JSON.stringify(response.body);

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -154,7 +154,7 @@ export class AggregateHelper {
     cy.fixture(dslFile).then((val) => {
       cy.url().then((url) => {
         const pageid = this.extractPageIdFromUrl(url);
-        assert(pageid != null);
+        expect(pageid).to.not.be.null;
         //Fetch the layout id
         cy.request("GET", "api/v1/pages/" + pageid).then((response: any) => {
           const respBody = JSON.stringify(response.body);

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -141,8 +141,8 @@ export class AggregateHelper {
       return null;
     }
 
-    // Can handle both ObjectID and UUID. Not a very strict pattern, but that's not the purpose here.
-    return parts[5]?.match(/[a-f0-9]+((-[a-f0-9]+){4})?$/)?.[0] ?? null;
+    // Extract the page ID, either as an ObjectID or as a UUID.
+    return parts[5]?.match(/[0-9a-f]{24}$|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)?.[0] ?? null;
   }
 
   public AddDsl(

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -371,7 +371,8 @@ Cypress.Commands.add("addDsl", (dsl) => {
     if (RapidMode.config.enabled && RapidMode.config.usesDSL) {
       pageid = RapidMode.config.pageID;
     } else {
-      pageid = url.split("/")[5]?.split("-").pop();
+      pageid = agHelper.extractPageIdFromUrl(url);
+      assert(pageid != null);
     }
 
     //Fetch the layout id

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -372,7 +372,7 @@ Cypress.Commands.add("addDsl", (dsl) => {
       pageid = RapidMode.config.pageID;
     } else {
       pageid = agHelper.extractPageIdFromUrl(url);
-      assert(pageid != null);
+      expect(pageid).to.not.be.null;
     }
 
     //Fetch the layout id


### PR DESCRIPTION
Over on `pg`, we use UUIDs for page IDs, not Object IDs, so the way we extract page ID should account for this. This PR supports page IDs as both ObjectId and UUID. So the same code should work on both `release` and `pg`.

**/test sanity**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9625470562>
> Commit: e21db70964e824cbbb82a76182f46fe08a259f90
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9625470562&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved URL parsing logic for extracting `pageid` using a new method to enhance robustness.
  - Added assertions to ensure `pageid` is not null before proceeding with further actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->