### PR TITLE
feat: Updated the @Transient from the jakarta dependency.

### DIFF
--- a/app/server/appsmith-interfaces/pom.xml
+++ b/app/server/appsmith-interfaces/pom.xml
@@ -250,7 +250,12 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing</artifactId>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/jakarta.persistence/jakarta.persistence-api -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.2.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.http.HttpMethod;
 import reactor.netty.http.HttpProtocol;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationResponse.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.time.Instant;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -17,7 +17,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.mongodb.core.index.Indexed;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Datasource.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Datasource.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.util.CollectionUtils;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Executable.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Executable.java
@@ -3,7 +3,7 @@ package com.appsmith.external.models;
 import com.appsmith.external.dtos.DslExecutableDTO;
 import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.time.Instant;
 import java.util.List;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.logging.log4j.util.Strings;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.time.Instant;
 import java.util.HashSet;

--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -438,6 +438,12 @@
             <version>2.14.2.Final</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/jakarta.persistence/jakarta.persistence-api -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.2.0</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.io.Serializable;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationPage.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationPage.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 @Getter
 @Setter

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitArtifactMetadata.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitArtifactMetadata.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Data;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.util.StringUtils;
 
 import java.time.Instant;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitAuth.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitAuth.java
@@ -5,7 +5,7 @@ import com.appsmith.external.models.AppsmithDomain;
 import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Data;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.time.Instant;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Layout.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Layout.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 import net.minidev.json.JSONObject;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Plugin.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Plugin.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Tenant.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Tenant.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 import org.checkerframework.common.aliasing.qual.Unique;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/LayoutDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/LayoutDTO.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import net.minidev.json.JSONObject;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.util.List;
 import java.util.Set;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.time.Instant;
 import java.util.HashSet;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/ActionCollectionCE_DTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/ActionCollectionCE_DTO.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.springframework.data.annotation.Transient;
+import jakarta.persistence.Transient;
 
 import java.time.Instant;
 import java.util.HashSet;


### PR DESCRIPTION
**Description**

This is the PR for the [TASK](#33572 )

**Changes in PR:**
- Added the Jakarta dependency in pom.xml of appsmith-server and appsmith-interfaces.
- Replaced the @Trasient from the jakarta by removing from springframework.

Difference between **org.springframework.data.annotation.Transient** and **jakarta.persistence.Transient**
@org.springframework.data.annotation.Transient specifically states to the spring framework that the Object Mapper you are using should not include this value when converting from Java Object to JSON.

Also note if you attempted to persist the above entity into the database, it would still save it to the database because @org.springframework.data.annotation.Transient only applys to Object mapping frameworks not JPA.

**fixes**- #33572 

Please review this PR- @sharat87 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to use `jakarta.persistence-api` version `3.2.0`.
  - Refactored annotations from `org.springframework.data.annotation.Transient` to `jakarta.persistence.Transient` for multiple models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->