### PR TITLE
chore: removed git annotation from dependency map variable

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
@@ -78,8 +78,7 @@ public class PageDTO {
     @JsonView(Views.Public.class)
     DefaultResources defaultResources;
 
-    // TODO: get this clarified for GIT annotation
-    @JsonView({Views.Public.class, Git.class})
+    @JsonView(Views.Public.class)
     Map<String, List<String>> dependencyMap;
 
     public void sanitiseToExportDBObject() {


### PR DESCRIPTION
## Description
- One Git.class annotation was added to PageDTO's dependency Map, On further research It is found that this field is only relevant for view mode and it's calculated only when we publish the application. Since git only serialises the unpublished pageDTO, then
- dependency map wouldn't be calculated at the time of serialisation.
- dependency map is not required for unpublishedPageDTO
- dependency map can be safely removed.

### This Ideally shouldn't require a ci run.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9639806966>
> Commit: 38b6ce1f2920189ae30165809bdccee69347c7ca
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9639806966&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code maintainability by refining the `@JsonView` annotation for the `dependencyMap` field in the PageDTO class, removing unnecessary views.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->