### PR TITLE
ci: Fix non used matrix parameter in build-client-server.yml

### DIFF
--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -131,7 +131,6 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
-      matrix: ${{needs.file-check.outputs.matrix_count}}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]


### PR DESCRIPTION
## Description
Fix non used matrix parameter in build-client-server.yml. It was removed from originated function parameter.

Fixes #`34418`  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/9640650543>
> Commit: acc2e4d8af13ae3c29a429c0e4db069976d69826
> Workflow: `PR Automation test suite`
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
