### PR TITLE
ci: removed matrix for ci-test-limit

### DIFF
--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -142,7 +142,6 @@ jobs:
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
       previous-workflow-run-id: ${{ fromJson(needs.file-check.outputs.runId) }}
-      matrix: ${{ needs.file-check.outputs.matrix_count }}
 
   ci-test-limited-result:
     needs: [file-check, ci-test-limited]


### PR DESCRIPTION
## Description
removed matrix for ci-test-limit

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflows to streamline the `ci-test-limited` job by removing the `matrix` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->