### PR TITLE
chore: Cleanup unused method

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCE.java
@@ -10,7 +10,6 @@ import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
 import java.util.Set;
 
 public interface DatasourceServiceCE {
@@ -58,8 +57,6 @@ public interface DatasourceServiceCE {
      * @return
      */
     Flux<Datasource> getAllByWorkspaceIdWithStorages(String workspaceId, AclPermission permission);
-
-    Flux<Datasource> saveAll(List<Datasource> datasourceList);
 
     Mono<Datasource> create(Datasource datasource);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
@@ -801,15 +801,6 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
     }
 
     @Override
-    public Flux<Datasource> saveAll(List<Datasource> datasourceList) {
-        datasourceList.stream()
-                .filter(datasource -> datasource.getGitSyncId() == null)
-                .forEach(datasource -> datasource.setGitSyncId(
-                        datasource.getWorkspaceId() + "_" + Instant.now().toString()));
-        return repository.saveAll(datasourceList);
-    }
-
-    @Override
     public Mono<Datasource> archiveById(String id) {
         return repository
                 .findById(id, datasourcePermission.getDeletePermission())


### PR DESCRIPTION
## Description
PR to remove unused method `saveAll` from DatasourceServiceCE. I have checked this is not being used on EE repo as well.

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9641535499>
> Commit: 6dd6abdcf7879ce5fb4eefa02279375db74ea02e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9641535499&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed bulk save functionality for datasources to streamline and simplify data management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->