### PR TITLE
chore: Update Postgres port for TED in CI

### DIFF
--- a/.github/workflows/ci-debugging.yml
+++ b/.github/workflows/ci-debugging.yml
@@ -70,7 +70,7 @@ jobs:
           sudo /etc/init.d/ssh stop ;
           mkdir -p ~/git-server/keys
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
-            -p 5432:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
+            -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
             appsmith/test-event-driver:latest
           cd cicontainerlocal
           docker run -d --name appsmith -p 80:80 \

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -146,7 +146,7 @@ jobs:
           mkdir -p ~/git-server/keys
           ted_tag="${{inputs.ted_tag}}"
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
-            -p 5432:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
+            -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
             "appsmith/test-event-driver:${ted_tag:-latest}"
           docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \
             --privileged --pid=host --ipc=host --add-host=host.docker.internal:host-gateway\

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -152,7 +152,7 @@ jobs:
           sudo /etc/init.d/ssh stop ;
           mkdir -p ~/git-server/keys
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
-            -p 5432:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
+            -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
             appsmith/test-event-driver:latest
           docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \
             --privileged --pid=host --ipc=host --add-host=host.docker.internal:host-gateway\

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
@@ -36,6 +36,12 @@ describe(
           dataManager.dsValues[dataManager.defaultEnviorment].postgres_host,
         );
         agHelper.ClearNType(
+          dataSources._port,
+          dataManager.dsValues[
+            dataManager.defaultEnviorment
+          ].postgres_port.toString(),
+        );
+        agHelper.ClearNType(
           dataSources._databaseName,
           dataManager.dsValues[dataManager.defaultEnviorment]
             .postgres_databaseName,

--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -6,7 +6,7 @@
   "mongo-uri": "mongodb://host.docker.internal:28017/mongo_samples?retryWrites=true&w=majority",
 
   "postgres-host": "host.docker.internal",
-  "postgres-port": 5432,
+  "postgres-port": 5433,
   "postgres-databaseName": "fakeapi",
   "postgres-username": "docker",
   "postgres-password": "docker",

--- a/app/client/cypress/scripts/cypress-local-setup.js
+++ b/app/client/cypress/scripts/cypress-local-setup.js
@@ -36,7 +36,7 @@ function ensureTEDIsRunning() {
           );
           try {
             execSync(
-              "docker run --name ted --rm -d --pull always -p 2022:22 -p 5001:5001 -p 3306:3306 -p 28017:27017 -p 5432:5432 -p 25:25 -p 4200:4200 appsmith/test-event-driver",
+              "docker run --name ted --rm -d --pull always -p 2022:22 -p 5001:5001 -p 3306:3306 -p 28017:27017 -p 5433:5432 -p 25:25 -p 4200:4200 appsmith/test-event-driver",
               { stdio: "inherit" },
             );
             console.log(

--- a/app/client/cypress/support/Objects/DataManager.ts
+++ b/app/client/cypress/support/Objects/DataManager.ts
@@ -13,7 +13,7 @@ export class DataManager {
       mongo_databaseName: "mongo_prod",
 
       postgres_host: "host.docker.internal",
-      postgres_port: 5432,
+      postgres_port: 5433,
       postgres_databaseName: "fakeapi",
       postgres_username: "docker",
       postgres_password: "docker",
@@ -118,7 +118,7 @@ export class DataManager {
       mongo_databaseName: "mongo_staging",
 
       postgres_host: "host.docker.internal",
-      postgres_port: 5432,
+      postgres_port: 5433,
       postgres_databaseName: "stagingdb",
       postgres_username: "dockerstaging",
       postgres_password: "dockerstaging",


### PR DESCRIPTION
## Description
PR to update the Postgres posrt for TED container in CI.

/test all

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9646981763>
> Commit: d998c6fe77ac2acdb71888fe6b3d7603ddda508c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9646981763&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: ``

<!-- end of auto-generated comment: Cypress test results  -->








## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker port mapping from `5432` to `5433` across multiple CI workflow files to ensure consistency and avoid port conflicts.

- **Bug Fixes**
  - Adjusted PostgreSQL connection port from `5432` to `5433` in test fixtures and scripts to align with environment changes and prevent connection issues.

- **Tests**
  - Modified test scripts to handle new PostgreSQL port settings for improved reliability in testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->