### PR TITLE
fix: don't call modal onClose method in edit mode

### DIFF
--- a/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSModalWidget/widget/index.tsx
@@ -85,7 +85,7 @@ class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
   }
 
   onModalClose = () => {
-    if (this.props.onClose) {
+    if (!this.props.disableWidgetInteraction && this.props.onClose) {
       super.executeAction({
         triggerPropertyName: "onClose",
         dynamicString: this.props.onClose,


### PR DESCRIPTION
## Description
Fix modal onClose method in edit mode


Fixes #33861 

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9643445303>
> Commit: 179602e52dcc2cdcaeecc5f67af5bc4ac12ee431
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9643445303&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved modal widget behavior to ensure it checks for disableWidgetInteraction before closing, preventing unwanted closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->