### PR TITLE
chore: Fix `.equals` on subclasses of `AuthenticationDTO`

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,6 +21,7 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @DocumentType(Authentication.API_KEY)
 public class ApiKeyAuth extends AuthenticationDTO {
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BasicAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BasicAuth.java
@@ -7,6 +7,7 @@ import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +18,7 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @DocumentType(Authentication.BASIC)
 public class BasicAuth extends AuthenticationDTO {
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BearerTokenAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BearerTokenAuth.java
@@ -7,6 +7,7 @@ import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +18,7 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @DocumentType(Authentication.BEARER_TOKEN)
 public class BearerTokenAuth extends AuthenticationDTO {
     @Encrypted @JsonView({Views.Internal.class, FromRequest.class})

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DBAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DBAuth.java
@@ -7,6 +7,7 @@ import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +18,7 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @DocumentType(Authentication.DB_AUTH)
 public class DBAuth extends AuthenticationDTO {
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -10,6 +10,7 @@ import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @DocumentType(Authentication.OAUTH2)
 public class OAuth2 extends AuthenticationDTO {
 


### PR DESCRIPTION
**/test sanity datasource**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9657231521>
> Commit: a88e9b94b4263f20c43a8da9154822182d62855c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9657231521&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Datasource`
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/9657231521" target="_blank">workflow here</a>.

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved equality and hashing behavior for various authentication classes, enhancing data integrity and consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->