### PR TITLE
chore: Remove `current` symlink to Postgres

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -28,8 +28,6 @@ RUN set -o xtrace \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 postgresql-14 \
-  # Create a symlink to the current version of PostgreSQL
-  && ln -s /usr/lib/postgresql/13 /usr/lib/postgresql/current \
   && apt-get clean
 
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"


### PR DESCRIPTION
Reason for this previously documented at https://github.com/appsmithorg/appsmith/pull/34265#issue-2356259090.

Cypress tests don' make sense since the only diff is on `base.dockerfile`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile to streamline PostgreSQL setup. Removed creation of a symlink to the current version of PostgreSQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->