### PR TITLE
fix: Focus retention issue after delete datasource

### DIFF
--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -428,8 +428,8 @@ export function* deleteDatasourceSaga(
 
     if (isValidResponse) {
       const currentUrl = `${window.location.pathname}`;
-      yield call(FocusRetention.handleRemoveFocusHistory, currentUrl);
       yield call(handleDatasourceDeleteRedirect, id);
+      yield call(FocusRetention.handleRemoveFocusHistory, currentUrl);
 
       toast.show(createMessage(DATASOURCE_DELETE, response.data.name), {
         kind: "success",


### PR DESCRIPTION
## Description

This PR fix the invalid URL issue after deleting the last datasource. This is caused by the focus retention delete order. Whenever a focus history is being deleted, it should be done after redirection to the new URL.

Fixes #33994   

## Automation

/ok-to-test tags="@tag.IDE, @tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9657584656>
> Commit: 010092ee7e177a8244912b45962cb79ff210ec29
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9657584656&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE, @tag.Datasource`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the deletion process of data sources to ensure proper handling of focus history and redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->