### PR TITLE
chore: Logs and potential fix for CI startup flakiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN <<END
 
   # Ensure all *.sh scripts are executable.
   find . -name node_modules -prune -or -type f -name '*.sh' -print -exec chmod +x '{}' ';'
+
+  # Ensure all custom command-scripts have executable permission
+  chmod +x /opt/bin/*
 END
 
 #Add the jar to the container

--- a/app/client/cypress/setup-test-ci.sh
+++ b/app/client/cypress/setup-test-ci.sh
@@ -39,6 +39,7 @@ echo "status code: $status_code"
 
 if [ "$status_code" -eq "502" ]; then
   echo "Unable to connect to server"
+  docker logs appsmith
   exit 1
 fi
 


### PR DESCRIPTION
The `tlog` command isn't predictably getting the executable permission, so we're explicitly setting that up in `Dockerfile` here.

As well as in the setup script for Cypress, if we get a 502 even after 90 seconds, we print the logs of the `appsmith` container, so we're not guessing the causes. This should provide us more information next time we see such flakiness.

**/test sanity**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9658565348>
> Commit: 96c777dd9a1bd8c28477bf1dcd1d4748ced0022e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9658565348&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile to ensure custom command-scripts in `/opt/bin/` have executable permissions.
  - Enhanced `setup-test-ci.sh` script to output `appsmith` logs when the server connection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->