### PR TITLE
chore: Strict API payloads for JSObjects and more

### DIFF
--- a/app/client/src/ce/api/JSActionAPI.tsx
+++ b/app/client/src/ce/api/JSActionAPI.tsx
@@ -95,8 +95,20 @@ class JSActionAPI extends API {
   static async updateJSCollection(
     jsConfig: JSCollection,
   ): Promise<AxiosPromise<JSCollectionCreateUpdateResponse>> {
-    const jsAction = Object.assign({}, jsConfig);
-    return API.put(`${JSActionAPI.url}/${jsAction.id}`, jsAction);
+    const payload = {
+      ...jsConfig,
+      actions:
+        jsConfig.actions?.map((action) => ({
+          ...action,
+          entityReferenceType: undefined,
+          datasource: (action as any).datasource && {
+            ...(action as any).datasource,
+            isValid: undefined,
+            new: undefined,
+          },
+        })) ?? undefined,
+    };
+    return API.put(`${JSActionAPI.url}/${jsConfig.id}`, payload);
   }
 
   static async deleteJSCollection(id: string) {
@@ -128,10 +140,25 @@ class JSActionAPI extends API {
   static async updateJSCollectionActionRefactor(
     updateJSCollectionActionName: UpdateCollectionActionNameRequest,
   ) {
-    return API.put(
-      JSActionAPI.url + "/refactorAction",
-      updateJSCollectionActionName,
-    );
+    const payload = {
+      ...updateJSCollectionActionName,
+      actionCollection: updateJSCollectionActionName.actionCollection && {
+        ...updateJSCollectionActionName.actionCollection,
+        actions:
+          updateJSCollectionActionName.actionCollection.actions?.map(
+            (action) => ({
+              ...action,
+              entityReferenceType: undefined,
+              datasource: (action as any).datasource && {
+                ...(action as any).datasource,
+                isValid: undefined,
+                new: undefined,
+              },
+            }),
+          ) ?? undefined,
+      },
+    };
+    return API.put(JSActionAPI.url + "/refactorAction", payload);
   }
 }
 

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -139,7 +139,6 @@ export function* fetchDynamicValuesSaga(
       formId,
       datasourceId,
       pluginId,
-      key,
     );
   }
 
@@ -159,7 +158,6 @@ function* fetchDynamicValueSaga(
   actionId: string,
   datasourceId: string,
   pluginId: string,
-  configProperty: string,
 ) {
   try {
     const { config, evaluatedConfig } =
@@ -247,9 +245,7 @@ function* fetchDynamicValueSaga(
       url,
       {
         actionId,
-        configProperty,
         datasourceId,
-        pluginId,
         ...evaluatedParams,
       },
     );


### PR DESCRIPTION
Part of #33724. Fixes for JSObject API calls and `EvaluatedValuePopUp_spec` test.

**/test sanity binding**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9665092474>
> Commit: d48cd19bfc2165bd06d605608ee632faa042a820
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9665092474&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Binding`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the structure of API request payloads for JS collections, ensuring more efficient data handling.
- **Bug Fixes**
  - Removed unnecessary parameters from dynamic value fetching functions, streamlining the process and reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->