### PR TITLE
chore: Only send `uidString` to remove a JSLib

### DIFF
--- a/app/client/src/api/LibraryAPI.tsx
+++ b/app/client/src/api/LibraryAPI.tsx
@@ -21,7 +21,7 @@ export default class LibraryApi extends Api {
     library: Partial<JSLibrary>,
   ) {
     const url = LibraryApi.getUpdateLibraryBaseURL(applicationId) + "/remove";
-    return Api.patch(url, { uidString: (library as any).uidString });
+    return Api.patch(url, { accessor: library.accessor, url: library.url });
   }
 
   static async getLibraries(applicationId: string, mode: APP_MODE) {

--- a/app/client/src/api/LibraryAPI.tsx
+++ b/app/client/src/api/LibraryAPI.tsx
@@ -21,7 +21,7 @@ export default class LibraryApi extends Api {
     library: Partial<JSLibrary>,
   ) {
     const url = LibraryApi.getUpdateLibraryBaseURL(applicationId) + "/remove";
-    return Api.patch(url, library);
+    return Api.patch(url, { uidString: (library as any).uidString });
   }
 
   static async getLibraries(applicationId: string, mode: APP_MODE) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/CustomJSLibControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/CustomJSLibControllerCE.java
@@ -61,9 +61,8 @@ public class CustomJSLibControllerCE {
             @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName,
             @RequestHeader(name = FieldName.IS_FORCE_REMOVE, defaultValue = "false") Boolean isForceRemove) {
         log.debug(
-                "Going to remove JS lib: {}_{} from {}: {}, on branch:{}",
-                customJSLib.getName(),
-                customJSLib.getVersion(),
+                "Going to remove JS lib: {} from {}: {}, on branch:{}",
+                customJSLib.getUidString(),
                 contextType.name().toLowerCase(),
                 applicationId,
                 branchName);


### PR DESCRIPTION
Part of #33724. The server uses only `uidString` for this API endpoint, which is all we should be sending. The server accepts a few other fields as well today, but doesn't use them. That'll also be fixed in the future, to only accept strictly what's needed.

/test sanity js



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9672660446>
> Commit: a61fa21404ab4ab7fd450f2db9f256dfe86f2f4d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9672660446&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.JS`

<!-- end of auto-generated comment: Cypress test results  -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `updateLibrary` method to send specific payload data, enhancing API reliability.

- **Logging Improvements**
  - Updated log messages in the `removeJSLibFromApplication` method to exclude version information for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->