### PR TITLE
chore: Add CE Repository for `GitDeployKeys`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/GitDeployKeysRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/GitDeployKeysRepository.java
@@ -1,8 +1,5 @@
 package com.appsmith.server.repositories;
 
-import com.appsmith.server.domains.GitDeployKeys;
-import reactor.core.publisher.Mono;
+import com.appsmith.server.repositories.ce.GitDeployKeysRepositoryCE;
 
-public interface GitDeployKeysRepository extends BaseRepository<GitDeployKeys, String> {
-    Mono<GitDeployKeys> findByEmail(String email);
-}
+public interface GitDeployKeysRepository extends GitDeployKeysRepositoryCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/GitDeployKeysRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/GitDeployKeysRepositoryCE.java
@@ -1,0 +1,9 @@
+package com.appsmith.server.repositories.ce;
+
+import com.appsmith.server.domains.GitDeployKeys;
+import com.appsmith.server.repositories.BaseRepository;
+import reactor.core.publisher.Mono;
+
+public interface GitDeployKeysRepositoryCE extends BaseRepository<GitDeployKeys, String> {
+    Mono<GitDeployKeys> findByEmail(String email);
+}


### PR DESCRIPTION
The repository for `GitDeployKeys` domain doesn't have a corresponding CE class. This is breaking expectations on class hierarchy, and so complicating the `*Cake` class generation on `pg` branch. This PR fixes this inconsistency.


**/test sanity**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Unified functionality by refactoring `GitDeployKeysRepository` to extend `GitDeployKeysRepositoryCE`.
- **Bug Fixes**
	- Improved method organization for better maintainability and code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9674177862>
> Commit: bff6f7cf13486b9b9b017bea25d8e7d035a1f4a2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9674177862&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->

