### PR TITLE
ci: Do case-insensitive tag matches

### DIFF
--- a/.github/workflows/scripts/test-tag-parser.js
+++ b/.github/workflows/scripts/test-tag-parser.js
@@ -39,7 +39,7 @@ function parseTags({core, context}) {
     // More smart matchers?
 
     // No match, fail.
-    core.setFailed("\tNo match found for tag:", rawTag);
+    core.setFailed("\tNo match found for tag: " + rawTag);
 
     // We still process the rest, so we report all invalid tags in the input in a single run.
   }

--- a/.github/workflows/scripts/test-tag-parser.js
+++ b/.github/workflows/scripts/test-tag-parser.js
@@ -18,9 +18,10 @@ function parseTags({core, context}) {
 
   for (const [rawTag] of config.matchAll(/\w+/g)) {
     console.log("Given: '" + rawTag + "'");
+    const rawTagLowerAndPrefixed = "@tag." + rawTag.toLowerCase();
 
     // See if there is exact case-insensitive match.
-    const exactTagMatch = allTags.find(t => t.toLowerCase() === "@tag." + rawTag);
+    const exactTagMatch = allTags.find(t => t.toLowerCase() === rawTagLowerAndPrefixed);
     if (exactTagMatch) {
       console.log("\tMatch found:", exactTagMatch);
       concreteTags.push(exactTagMatch);
@@ -28,7 +29,7 @@ function parseTags({core, context}) {
     }
 
     // See if there is a singular/plural match (very rudimentary language skills).
-    const countedMatch = allTags.find(t => t.toLowerCase().replace(/s$/, "") === "@tag." + rawTag.replace(/s$/, ""));
+    const countedMatch = allTags.find(t => t.toLowerCase().replace(/s$/, "") === rawTagLowerAndPrefixed.replace(/s$/, ""));
     if (countedMatch) {
       console.log("\tMatch found:", countedMatch);
       concreteTags.push(countedMatch);


### PR DESCRIPTION
Specifying the `/test` command like this:

```
/test IDE
```

Doesn't pick up the `@tag.IDE` tag, but using `/test ide` does. This is because of incorrect case-matching logic. This PR fixes this.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced case-insensitivity for tag matching to reduce errors.
  - Improved error messaging for unmatched tags to provide clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->