### PR TITLE
chore: added classes for ce and ee spans

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ActionSpan.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ActionSpan.java
@@ -1,23 +1,9 @@
 package com.appsmith.external.constants.spans;
 
-import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+import com.appsmith.external.constants.spans.ce.ActionSpanCE;
 
 /**
  * Please make sure that all span names start with `appsmith.` because span with any other naming format would get
  * dropped / ignored as defined in TracingConfig.java
  */
-public final class ActionSpan {
-
-    // Action execution spans
-    public static final String ACTION_EXECUTION_REQUEST_PARSING = APPSMITH_SPAN_PREFIX + "request.parsing";
-    public static final String ACTION_EXECUTION_CACHED_DATASOURCE = APPSMITH_SPAN_PREFIX + "get.datasource.cached";
-    public static final String ACTION_EXECUTION_DATASOURCE_CONTEXT = APPSMITH_SPAN_PREFIX + "get.datasource.context";
-    public static final String ACTION_EXECUTION_EDITOR_CONFIG = APPSMITH_SPAN_PREFIX + "get.editorConfig.cached";
-    public static final String ACTION_EXECUTION_PLUGIN_EXECUTION = APPSMITH_SPAN_PREFIX + "total.plugin.execution";
-    public static final String ACTION_EXECUTION_SERVER_EXECUTION = APPSMITH_SPAN_PREFIX + "total.server.execution";
-
-    // Getter spans
-    public static final String GET_UNPUBLISHED_ACTION = APPSMITH_SPAN_PREFIX + "get.action.unpublished";
-    public static final String GET_VIEW_MODE_ACTION = APPSMITH_SPAN_PREFIX + "get.action.viewmode";
-    public static final String GET_ACTION_REPOSITORY_CALL = APPSMITH_SPAN_PREFIX + "get.action.repository.call";
-}
+public final class ActionSpan extends ActionSpanCE {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/DatasourceSpan.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/DatasourceSpan.java
@@ -1,9 +1,5 @@
 package com.appsmith.external.constants.spans;
 
-import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+import com.appsmith.external.constants.spans.ce.DatasourceSpanCE;
 
-public class DatasourceSpan {
-    public static final String FETCH_ALL_DATASOURCES_WITH_STORAGES =
-            APPSMITH_SPAN_PREFIX + "get_all_datasource_storage";
-    public static final String FETCH_ALL_PLUGINS_IN_WORKSPACE = APPSMITH_SPAN_PREFIX + "get_all_plugins_in_workspace";
-}
+public class DatasourceSpan extends DatasourceSpanCE {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/TenantSpan.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/TenantSpan.java
@@ -1,10 +1,5 @@
 package com.appsmith.external.constants.spans;
 
-import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+import com.appsmith.external.constants.spans.ce.TenantSpanCE;
 
-public class TenantSpan {
-    public static final String FETCH_DEFAULT_TENANT_SPAN = APPSMITH_SPAN_PREFIX + "fetch_default_tenant";
-    public static final String FETCH_TENANT_CACHE_POST_DESERIALIZATION_ERROR_SPAN =
-            APPSMITH_SPAN_PREFIX + "fetch_tenant_cache_post_deserialization_error";
-    public static final String FETCH_TENANT_FROM_DB_SPAN = APPSMITH_SPAN_PREFIX + "fetch_tenant_from_db";
-}
+public class TenantSpan extends TenantSpanCE {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/ActionSpanCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/ActionSpanCE.java
@@ -1,0 +1,22 @@
+package com.appsmith.external.constants.spans.ce;
+
+import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+
+/**
+ * Please make sure that all span names start with `appsmith.` because span with any other naming format would get
+ * dropped / ignored as defined in TracingConfig.java
+ */
+public class ActionSpanCE {
+    // Action execution spans
+    public static final String ACTION_EXECUTION_REQUEST_PARSING = APPSMITH_SPAN_PREFIX + "request.parsing";
+    public static final String ACTION_EXECUTION_CACHED_DATASOURCE = APPSMITH_SPAN_PREFIX + "get.datasource.cached";
+    public static final String ACTION_EXECUTION_DATASOURCE_CONTEXT = APPSMITH_SPAN_PREFIX + "get.datasource.context";
+    public static final String ACTION_EXECUTION_EDITOR_CONFIG = APPSMITH_SPAN_PREFIX + "get.editorConfig.cached";
+    public static final String ACTION_EXECUTION_PLUGIN_EXECUTION = APPSMITH_SPAN_PREFIX + "total.plugin.execution";
+    public static final String ACTION_EXECUTION_SERVER_EXECUTION = APPSMITH_SPAN_PREFIX + "total.server.execution";
+
+    // Getter spans
+    public static final String GET_UNPUBLISHED_ACTION = APPSMITH_SPAN_PREFIX + "get.action.unpublished";
+    public static final String GET_VIEW_MODE_ACTION = APPSMITH_SPAN_PREFIX + "get.action.viewmode";
+    public static final String GET_ACTION_REPOSITORY_CALL = APPSMITH_SPAN_PREFIX + "get.action.repository.call";
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/DatasourceSpanCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/DatasourceSpanCE.java
@@ -1,0 +1,9 @@
+package com.appsmith.external.constants.spans.ce;
+
+import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+
+public class DatasourceSpanCE {
+    public static final String FETCH_ALL_DATASOURCES_WITH_STORAGES =
+            APPSMITH_SPAN_PREFIX + "get_all_datasource_storage";
+    public static final String FETCH_ALL_PLUGINS_IN_WORKSPACE = APPSMITH_SPAN_PREFIX + "get_all_plugins_in_workspace";
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/TenantSpanCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/TenantSpanCE.java
@@ -1,0 +1,10 @@
+package com.appsmith.external.constants.spans.ce;
+
+import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+
+public class TenantSpanCE {
+    public static final String FETCH_DEFAULT_TENANT_SPAN = APPSMITH_SPAN_PREFIX + "fetch_default_tenant";
+    public static final String FETCH_TENANT_CACHE_POST_DESERIALIZATION_ERROR_SPAN =
+            APPSMITH_SPAN_PREFIX + "fetch_tenant_cache_post_deserialization_error";
+    public static final String FETCH_TENANT_FROM_DB_SPAN = APPSMITH_SPAN_PREFIX + "fetch_tenant_from_db";
+}


### PR DESCRIPTION
## Description
The spans directory currently did not have a way to add EE-specific spans. 
<img width="340" alt="SCR-20240626-j4l" src="https://github.com/appsmithorg/appsmith/assets/25542733/610dd7d4-2309-4fed-8dce-7faf1c02b6a7">


**This PR fixes the span directory to add ce and ee spans support.**



Fixes #34483  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9676199406>
> Commit: 45830b0d45a1b4b78e13b0174e48e5361f9336a5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9676199406&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code structure by extending specialized classes (`ActionSpanCE`, `DatasourceSpanCE`, `TenantSpanCE`) for `ActionSpan`, `DatasourceSpan`, and `TenantSpan`.
  
- **New Features**
  - Introduced new constants for tracing various action executions and data fetching related to datasources and tenants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->