### PR TITLE
fix: workflow js func rename code split

### DIFF
--- a/app/client/src/ce/api/JSActionAPI.tsx
+++ b/app/client/src/ce/api/JSActionAPI.tsx
@@ -52,6 +52,7 @@ export interface RefactorAction {
   oldName: string;
   collectionName: string;
   moduleId?: string;
+  workflowId?: string;
   contextType?: ActionParentEntityTypeInterface;
 }
 export interface RefactorActionRequest extends RefactorAction {
@@ -74,39 +75,13 @@ class JSActionAPI extends API {
   static async createJSCollection(
     jsConfig: CreateJSCollectionRequest,
   ): Promise<AxiosPromise<JSCollectionCreateUpdateResponse>> {
-    const payload = {
-      ...jsConfig,
-      actions:
-        jsConfig.actions?.map((action) => ({
-          ...action,
-          entityReferenceType: undefined,
-          datasource: (action as any).datasource && {
-            ...(action as any).datasource,
-            isValid: undefined,
-            new: undefined,
-          },
-        })) ?? undefined,
-    };
-    return API.post(JSActionAPI.url, payload);
+    return API.post(JSActionAPI.url, jsConfig);
   }
 
   static async copyJSCollection(
     jsConfig: Partial<JSCollection>,
   ): Promise<AxiosPromise<JSCollectionCreateUpdateResponse>> {
-    const payload = {
-      ...jsConfig,
-      actions:
-        jsConfig.actions?.map((action) => ({
-          ...action,
-          entityReferenceType: undefined,
-          datasource: (action as any).datasource && {
-            ...(action as any).datasource,
-            isValid: undefined,
-            new: undefined,
-          },
-        })) ?? undefined,
-    };
-    return API.post(JSActionAPI.url, payload);
+    return API.post(JSActionAPI.url, jsConfig);
   }
 
   static async updateJSCollectionBody(

--- a/app/client/src/ce/api/JSActionAPI.tsx
+++ b/app/client/src/ce/api/JSActionAPI.tsx
@@ -75,13 +75,39 @@ class JSActionAPI extends API {
   static async createJSCollection(
     jsConfig: CreateJSCollectionRequest,
   ): Promise<AxiosPromise<JSCollectionCreateUpdateResponse>> {
-    return API.post(JSActionAPI.url, jsConfig);
+    const payload = {
+      ...jsConfig,
+      actions:
+        jsConfig.actions?.map((action) => ({
+          ...action,
+          entityReferenceType: undefined,
+          datasource: (action as any).datasource && {
+            ...(action as any).datasource,
+            isValid: undefined,
+            new: undefined,
+          },
+        })) ?? undefined,
+    };
+    return API.post(JSActionAPI.url, payload);
   }
 
   static async copyJSCollection(
     jsConfig: Partial<JSCollection>,
   ): Promise<AxiosPromise<JSCollectionCreateUpdateResponse>> {
-    return API.post(JSActionAPI.url, jsConfig);
+    const payload = {
+      ...jsConfig,
+      actions:
+        jsConfig.actions?.map((action) => ({
+          ...action,
+          entityReferenceType: undefined,
+          datasource: (action as any).datasource && {
+            ...(action as any).datasource,
+            isValid: undefined,
+            new: undefined,
+          },
+        })) ?? undefined,
+    };
+    return API.post(JSActionAPI.url, payload);
   }
 
   static async updateJSCollectionBody(

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -217,6 +217,7 @@ function* handleEachUpdateJSCollection(update: JSUpdate) {
                 collectionName: jsAction.name,
                 pageId: data.nameChangedActions[i].pageId || "",
                 moduleId: data.nameChangedActions[i].moduleId,
+                workflowId: data.nameChangedActions[i].workflowId,
                 oldName: data.nameChangedActions[i].oldName,
                 newName: data.nameChangedActions[i].newName,
               },

--- a/app/client/src/utils/JSPaneUtils.test.ts
+++ b/app/client/src/utils/JSPaneUtils.test.ts
@@ -299,6 +299,7 @@ const resultRenamedActions = {
       id: "fun1",
       collectionId: "1234",
       moduleId: undefined,
+      workflowId: undefined,
       oldName: "myFun1",
       newName: "myFun11",
       pageId: "page123",

--- a/app/client/src/utils/JSPaneUtils.tsx
+++ b/app/client/src/utils/JSPaneUtils.tsx
@@ -31,6 +31,7 @@ export interface JSCollectionDifference {
     newName: string;
     pageId: string;
     moduleId?: string;
+    workflowId?: string;
   }>;
   changedVariables: Variable[];
 }
@@ -104,6 +105,7 @@ export const getDifferenceInJSCollection = (
             newName: newActions[i].name,
             pageId: updateExisting.pageId,
             moduleId: updateExisting.moduleId,
+            workflowId: updateExisting.workflowId,
           });
           newActions.splice(i, 1);
           toBearchivedActions.splice(indexOfArchived, 1);


### PR DESCRIPTION
## Description
This is a code split PR for [EE change](https://github.com/appsmithorg/appsmith-ee/pull/4536) which fixes rename of functions inside of a js object.


Fixes [#34470](https://github.com/appsmithorg/appsmith/issues/34470)

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9690260557>
> Commit: 6da583fea14638c183a6b81d61c1870f7ea694f5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9690260557&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `workflowId` field to enhance the functionality of JavaScript actions and workflows.

- **Tests**
  - Updated tests to include the new `workflowId` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->