### PR TITLE
test: Use `deep.eq` for comparing objects

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Date_column_editing_1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Date_column_editing_1_spec.ts
@@ -60,20 +60,28 @@ describe(
       );
       agHelper.AssertElementAbsence(table._dateInputPopover);
       agHelper.AssertElementAbsence(table._editCellEditor);
-      agHelper
-        .GetText(locators._textWidget, "text", 0)
-        .then(($textData) =>
-          expect($textData).to.eq(
-            `{"revenue":42600000,"imdb_id":"tt3228774","release_date":"2021-05-17"}`,
-          ),
-        );
-      agHelper
-        .GetText(locators._textWidget, "text", 1)
-        .then(($textData) =>
-          expect($textData).to.eq(
-            `[{"index":0,"updatedFields":{"release_date":"2021-05-17"},"allFields":{"revenue":42600000,"imdb_id":"tt3228774","release_date":"2021-05-17"}}]`,
-          ),
-        );
+      agHelper.GetText(locators._textWidget, "text", 0).then(($textData) =>
+        expect(JSON.parse($textData as string)).to.deep.eq({
+          revenue: 42600000,
+          imdb_id: "tt3228774",
+          release_date: "2021-05-17",
+        }),
+      );
+      agHelper.GetText(locators._textWidget, "text", 1).then(($textData) =>
+        expect(JSON.parse($textData as string)).to.deep.eq([
+          {
+            index: 0,
+            updatedFields: {
+              release_date: "2021-05-17",
+            },
+            allFields: {
+              revenue: 42600000,
+              imdb_id: "tt3228774",
+              release_date: "2021-05-17",
+            },
+          },
+        ]),
+      );
       agHelper
         .GetText(locators._textWidget, "text", 2)
         .then(($textData) => expect($textData).to.eq("[0]"));


### PR DESCRIPTION
The JSON string comparison is flaky because it depends on the order of keys in serialized objects. We actually don't care for the order the keys are serialized, just that the keys and values are as we want.

This PR should fix that.

[Slack conversation](https://theappsmith.slack.com/archives/C0134BAVDB4/p1719409620659339).

/test table


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9681276909>
> Commit: 3fa1746c580d700a3084d94166850acd18432d09
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9681276909&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved accuracy of text data retrieval and comparison in table widget tests by updating assertions to correctly parse and compare JSON objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->