### PR TITLE
chore: added spans for super user check and fetch user permissions

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/UserSpan.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/UserSpan.java
@@ -1,0 +1,5 @@
+package com.appsmith.external.constants.spans;
+
+import com.appsmith.external.constants.spans.ce.UserSpanCE;
+
+public class UserSpan extends UserSpanCE {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/TenantSpanCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/TenantSpanCE.java
@@ -3,8 +3,9 @@ package com.appsmith.external.constants.spans.ce;
 import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
 
 public class TenantSpanCE {
-    public static final String FETCH_DEFAULT_TENANT_SPAN = APPSMITH_SPAN_PREFIX + "fetch_default_tenant";
+    public static final String TENANT_SPAN = APPSMITH_SPAN_PREFIX + "tenant.";
+    public static final String FETCH_DEFAULT_TENANT_SPAN = TENANT_SPAN + "fetch_default_tenant";
     public static final String FETCH_TENANT_CACHE_POST_DESERIALIZATION_ERROR_SPAN =
-            APPSMITH_SPAN_PREFIX + "fetch_tenant_cache_post_deserialization_error";
-    public static final String FETCH_TENANT_FROM_DB_SPAN = APPSMITH_SPAN_PREFIX + "fetch_tenant_from_db";
+            TENANT_SPAN + "fetch_tenant_cache_post_deserialization_error";
+    public static final String FETCH_TENANT_FROM_DB_SPAN = TENANT_SPAN + "fetch_tenant_from_db";
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/UserSpanCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/UserSpanCE.java
@@ -1,0 +1,9 @@
+package com.appsmith.external.constants.spans.ce;
+
+import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+
+public class UserSpanCE {
+    public static final String CHECK_SUPER_USER_SPAN = APPSMITH_SPAN_PREFIX + "check_super_user";
+    public static final String FETCH_ALL_PERMISSION_GROUPS_OF_USER_SPAN =
+            APPSMITH_SPAN_PREFIX + "fetch_all_permission_groups_of_user";
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/UserSpanCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/UserSpanCE.java
@@ -3,7 +3,8 @@ package com.appsmith.external.constants.spans.ce;
 import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
 
 public class UserSpanCE {
-    public static final String CHECK_SUPER_USER_SPAN = APPSMITH_SPAN_PREFIX + "check_super_user";
+    public static final String USER_SPAN = APPSMITH_SPAN_PREFIX + "user.";
+    public static final String CHECK_SUPER_USER_SPAN = USER_SPAN + "check_super_user";
     public static final String FETCH_ALL_PERMISSION_GROUPS_OF_USER_SPAN =
-            APPSMITH_SPAN_PREFIX + "fetch_all_permission_groups_of_user";
+            USER_SPAN + "fetch_all_permission_groups_of_user";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/UserUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/UserUtils.java
@@ -5,6 +5,7 @@ import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.repositories.ConfigRepository;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.solutions.PermissionGroupPermission;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,8 +14,14 @@ public class UserUtils extends UserUtilsCE {
             ConfigRepository configRepository,
             PermissionGroupRepository permissionGroupRepository,
             CacheableRepositoryHelper cacheableRepositoryHelper,
-            PermissionGroupPermission permissionGroupPermission) {
+            PermissionGroupPermission permissionGroupPermission,
+            ObservationRegistry observationRegistry) {
 
-        super(configRepository, permissionGroupRepository, cacheableRepositoryHelper, permissionGroupPermission);
+        super(
+                configRepository,
+                permissionGroupRepository,
+                cacheableRepositoryHelper,
+                permissionGroupPermission,
+                observationRegistry);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
@@ -13,7 +13,9 @@ import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.repositories.ConfigRepository;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.solutions.PermissionGroupPermission;
+import io.micrometer.observation.ObservationRegistry;
 import net.minidev.json.JSONObject;
+import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.appsmith.external.constants.spans.UserSpan.CHECK_SUPER_USER_SPAN;
 import static com.appsmith.server.acl.AclPermission.ASSIGN_PERMISSION_GROUPS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_INSTANCE_CONFIGURATION;
 import static com.appsmith.server.acl.AclPermission.READ_INSTANCE_CONFIGURATION;
@@ -39,15 +42,18 @@ public class UserUtilsCE {
     private final PermissionGroupRepository permissionGroupRepository;
 
     private final PermissionGroupPermission permissionGroupPermission;
+    private final ObservationRegistry observationRegistry;
 
     public UserUtilsCE(
             ConfigRepository configRepository,
             PermissionGroupRepository permissionGroupRepository,
             CacheableRepositoryHelper cacheableRepositoryHelper,
-            PermissionGroupPermission permissionGroupPermission) {
+            PermissionGroupPermission permissionGroupPermission,
+            ObservationRegistry observationRegistry) {
         this.configRepository = configRepository;
         this.permissionGroupRepository = permissionGroupRepository;
         this.permissionGroupPermission = permissionGroupPermission;
+        this.observationRegistry = observationRegistry;
     }
 
     public Mono<Boolean> isSuperUser(User user) {
@@ -61,7 +67,9 @@ public class UserUtilsCE {
         return configRepository
                 .findByName(INSTANCE_CONFIG, AclPermission.MANAGE_INSTANCE_CONFIGURATION)
                 .map(config -> Boolean.TRUE)
-                .switchIfEmpty(Mono.just(Boolean.FALSE));
+                .switchIfEmpty(Mono.just(Boolean.FALSE))
+                .name(CHECK_SUPER_USER_SPAN)
+                .tap(Micrometer.observation(observationRegistry));
     }
 
     public Mono<Boolean> makeSuperUser(List<User> users) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
@@ -60,16 +60,16 @@ public class UserUtilsCE {
         return configRepository
                 .findByNameAsUser(INSTANCE_CONFIG, user, AclPermission.MANAGE_INSTANCE_CONFIGURATION)
                 .map(config -> Boolean.TRUE)
-                .switchIfEmpty(Mono.just(Boolean.FALSE));
+                .switchIfEmpty(Mono.just(Boolean.FALSE))
+                .name(CHECK_SUPER_USER_SPAN)
+                .tap(Micrometer.observation(observationRegistry));
     }
 
     public Mono<Boolean> isCurrentUserSuperUser() {
         return configRepository
                 .findByName(INSTANCE_CONFIG, AclPermission.MANAGE_INSTANCE_CONFIGURATION)
                 .map(config -> Boolean.TRUE)
-                .switchIfEmpty(Mono.just(Boolean.FALSE))
-                .name(CHECK_SUPER_USER_SPAN)
-                .tap(Micrometer.observation(observationRegistry));
+                .switchIfEmpty(Mono.just(Boolean.FALSE));
     }
 
     public Mono<Boolean> makeSuperUser(List<User> users) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomConfigRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomConfigRepositoryImpl.java
@@ -1,7 +1,15 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomConfigRepositoryCEImpl;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CustomConfigRepositoryImpl extends CustomConfigRepositoryCEImpl implements CustomConfigRepository {}
+public class CustomConfigRepositoryImpl extends CustomConfigRepositoryCEImpl implements CustomConfigRepository {
+    private final ObservationRegistry observationRegistry;
+
+    public CustomConfigRepositoryImpl(ObservationRegistry observationRegistry) {
+        super(observationRegistry);
+        this.observationRegistry = observationRegistry;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomConfigRepositoryCEImpl.java
@@ -6,10 +6,20 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
+import io.micrometer.observation.ObservationRegistry;
+import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Mono;
+
+import static com.appsmith.external.constants.spans.UserSpan.FETCH_ALL_PERMISSION_GROUPS_OF_USER_SPAN;
 
 public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Config>
         implements CustomConfigRepositoryCE {
+
+    private final ObservationRegistry observationRegistry;
+
+    public CustomConfigRepositoryCEImpl(ObservationRegistry observationRegistry) {
+        this.observationRegistry = observationRegistry;
+    }
 
     @Override
     public Mono<Config> findByName(String name, AclPermission permission) {
@@ -19,10 +29,13 @@ public class CustomConfigRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Con
 
     @Override
     public Mono<Config> findByNameAsUser(String name, User user, AclPermission permission) {
-        return getAllPermissionGroupsForUser(user).flatMap(permissionGroups -> queryBuilder()
-                .criteria(Bridge.equal(Config.Fields.name, name))
-                .permission(permission)
-                .permissionGroups(permissionGroups)
-                .one());
+        return getAllPermissionGroupsForUser(user)
+                .name(FETCH_ALL_PERMISSION_GROUPS_OF_USER_SPAN)
+                .tap(Micrometer.observation(observationRegistry))
+                .flatMap(permissionGroups -> queryBuilder()
+                        .criteria(Bridge.equal(Config.Fields.name, name))
+                        .permission(permission)
+                        .permissionGroups(permissionGroups)
+                        .one());
     }
 }


### PR DESCRIPTION
## Description
> This PR adds the spans for tracking /tenants/current API. 
Corresponding EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4539

Fixes #34480 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9692811833>
> Commit: 0f1059ad4870ae83d6188b6fbff07ab90d058d97
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9692811833&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced user span control flow constants for improved monitoring and performance tracking.
  
- **Refactor**
  - Renamed tenant-related span constants for consistency and clarity.
  
- **Enhancements**
  - Improved super user checks with added telemetry using Micrometer for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->