### PR TITLE
chore: Don't rely on key order in objects

### DIFF
--- a/app/client/src/pages/Editor/ThemePropertyPane/controls/ThemeBorderRadiusControl.tsx
+++ b/app/client/src/pages/Editor/ThemePropertyPane/controls/ThemeBorderRadiusControl.tsx
@@ -2,7 +2,11 @@ import React, { useCallback } from "react";
 
 import type { AppTheme } from "entities/AppTheming";
 import { invertedBorderRadiusOptions } from "constants/ThemeConstants";
-import { SegmentedControl, Tooltip } from "design-system";
+import {
+  SegmentedControl,
+  type SegmentedControlOption,
+  Tooltip,
+} from "design-system";
 
 interface ThemeBorderRadiusControlProps {
   options: {
@@ -39,11 +43,11 @@ function ThemeBorderRadiusControl(props: ThemeBorderRadiusControlProps) {
     ? invertedBorderRadiusOptions[selectedOption]
     : "";
 
-    const buttonGroupOptions = [
-      makeButtonGroupOption("none", options.none),
-      makeButtonGroupOption("M", options.M),
-      makeButtonGroupOption("L", options.L),
-    ];
+  const buttonGroupOptions = [
+    makeButtonGroupOption("none", options.none),
+    makeButtonGroupOption("M", options.M),
+    makeButtonGroupOption("L", options.L),
+  ];
 
   return (
     <SegmentedControl
@@ -55,7 +59,10 @@ function ThemeBorderRadiusControl(props: ThemeBorderRadiusControlProps) {
   );
 }
 
-function makeButtonGroupOption(key: string, value: string): SegmentedControlOption {
+function makeButtonGroupOption(
+  key: string,
+  value: string,
+): SegmentedControlOption {
   return {
     label: (
       <Tooltip content={key} key={key}>
@@ -69,7 +76,7 @@ function makeButtonGroupOption(key: string, value: string): SegmentedControlOpti
       </Tooltip>
     ),
     value: key,
-  }
+  };
 }
 
 export default ThemeBorderRadiusControl;

--- a/app/client/src/pages/Editor/ThemePropertyPane/controls/ThemeBorderRadiusControl.tsx
+++ b/app/client/src/pages/Editor/ThemePropertyPane/controls/ThemeBorderRadiusControl.tsx
@@ -39,20 +39,11 @@ function ThemeBorderRadiusControl(props: ThemeBorderRadiusControlProps) {
     ? invertedBorderRadiusOptions[selectedOption]
     : "";
 
-  const buttonGroupOptions = Object.keys(options).map((optionKey) => ({
-    label: (
-      <Tooltip content={optionKey} key={optionKey}>
-        <div
-          className="w-5 h-5 t--theme-appBorderRadius border-t-2 border-l-2"
-          style={{
-            borderTopLeftRadius: options[optionKey],
-            borderColor: "var(--ads-v2-color-fg)",
-          }}
-        />
-      </Tooltip>
-    ),
-    value: optionKey,
-  }));
+    const buttonGroupOptions = [
+      makeButtonGroupOption("none", options.none),
+      makeButtonGroupOption("M", options.M),
+      makeButtonGroupOption("L", options.L),
+    ];
 
   return (
     <SegmentedControl
@@ -62,6 +53,23 @@ function ThemeBorderRadiusControl(props: ThemeBorderRadiusControlProps) {
       value={selectedOptionKey}
     />
   );
+}
+
+function makeButtonGroupOption(key: string, value: string): SegmentedControlOption {
+  return {
+    label: (
+      <Tooltip content={key} key={key}>
+        <div
+          className="w-5 h-5 t--theme-appBorderRadius border-t-2 border-l-2"
+          style={{
+            borderTopLeftRadius: value,
+            borderColor: "var(--ads-v2-color-fg)",
+          }}
+        />
+      </Tooltip>
+    ),
+    value: key,
+  }
 }
 
 export default ThemeBorderRadiusControl;


### PR DESCRIPTION
The way the border-radius selector in Theme settings is built, it relies on the `borderRadius` object to show up like this:

```js
{
  none: "",
  M: "",
  L: "",
}
```

And the order options is relying on that. So if we get back the following from the server:

```js
{
  L: "",
  M: "",
  none: "",
}
```

The options are reversed.

This may/may-not be a problem, but we're asserting in our tests (see below) that the first option be `none`, so clearly we want a predictable order here. This predictable ordering isn't available anymore with Postgres.

From [FilePickerV2_Widget_Reskinning_spec](https://github.com/appsmithorg/appsmith/blob/6f67dbd85e73f1115d04b5315d4b1efba5930781/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_Widget_Reskinning_spec.js#L19):
![shot-2024-06-27-02-50-26](https://github.com/appsmithorg/appsmith/assets/120119/882ea82d-b88d-4cd9-935a-09d0f92306e4)

from [Theme_FormWidget_spec](https://github.com/appsmithorg/appsmith/blob/6f67dbd85e73f1115d04b5315d4b1efba5930781/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/Theme_FormWidget_spec.js#L32):
![shot-2024-06-27-02-52-55](https://github.com/appsmithorg/appsmith/assets/120119/63f35bbd-5902-4dfd-a394-92af17cd94ea)

This PR "fixes" this by not relying a predictable order at all. We expect `none`, `M` and `L` only, and in that order, so that's exactly what we show in the UI. No shenanigans, no moving pieces.

I don't know if there's more places in the theme settings that suffer from this (likely there are), but I haven't seen anything else asserted in tests, so I don't know.

/test theme widget


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9690317817>
> Commit: 0fa1b528b17281c11be5b31630bbd53fc8e9813d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9690317817&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Theme, @tag.Widget`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the creation of button group options for the SegmentedControl component in the Theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->