### PR TITLE
fix:ensure save row button is disabled when date column is required

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow_Date_validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow_Date_validation_spec.js
@@ -1,0 +1,87 @@
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+
+const tableData = `[
+    {
+        "id": 1,
+        "date": "2023-06-01T12:00:00-06:30",
+        "email": "saiprabhu@gmail.com",
+        "userName": "Saiprabhu",
+        "department": "Sales"
+      },
+      {
+        "id": 2,
+        "date": "2023-06-02T12:00:00-06:30",
+        "email": "saicharan@gmail.com",
+        "userName": "Saicharan",
+        "department": "Marketing"
+      },
+      {
+        "id": 3,
+        "date": "2023-06-03T12:00:00-06:30",
+        "email": "varaprasad@gmail.com",
+        "userName": "Varaprasad",
+        "department": "HR"
+      },
+      {
+        "id": 4,
+        "date": "2023-06-04T12:00:00-06:30",
+        "email": "shivamkumar@gmail.com",
+        "userName": "Shivamkumar",
+        "department": "Finance"
+      },
+      {
+        "id": 5,
+        "date": "2023-06-05T12:00:00-06:30",
+        "email": "madhurendra@gmail.com",
+        "userName": "Madhurendra",
+        "department": "IT"
+      },
+      {
+        "id": 6,
+        "email": "vamshi@gmail.com",
+        "userName": "Vamshi",
+        "date": "2023-06-06T12:00:00-06:30",
+        "department": "Engineering"
+      },
+      {
+        "id": 7,
+        "date": "2023-06-07T12:00:00-06:30",
+        "email": "yogesh@gmail.com",
+        "userName": "Yogesh",
+        "department": "Customer Service"
+      }
+  ]`;
+
+describe("Table row Validation flow", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
+  it("1. Saverow button should be disabled when date column is set to required and has no value", () => {
+    _.entityExplorer.DragDropWidgetNVerify("tablewidgetv2");
+    cy.viewport(1700, 800)
+    cy.openPropertyPane("tablewidgetv2");
+    _.propPane.EnterJSContext("Table data", tableData);
+    _.propPane.TogglePropertyState("Allow adding a row", "On");
+    cy.get(".t--add-new-row").click();
+    cy.makeColumnEditable("email");
+    cy.get('[data-rbd-draggable-id="email"] > :nth-child(1) > .sc-ibVIrx > .sc-jShKGg > .t--edit-column-btn > .sc-hHTYSt')
+    .should('be.visible')
+    .click();
+    _.propPane.TogglePropertyState("Required", "On");
+    cy.get('[data-testid="t--property-pane-back-btn"] > .sc-hHTYSt')
+    .should('be.visible')
+    .click();
+    cy.makeColumnEditable("date");
+    cy.get('[data-rbd-draggable-id="date"] > :nth-child(1) > .sc-ibVIrx > .sc-jShKGg > .t--edit-column-btn > .sc-hHTYSt')
+    .should('be.visible')
+    .click();
+    _.propPane.TogglePropertyState("Required", "On");
+     cy.get('[data-testid="t--property-pane-back-btn"] > .sc-hHTYSt')
+    .should('be.visible')
+    .click();
+    cy.get('[data-colindex="2"] > .sc-JmZxe > .sc-bEzTyZ > [data-testid="input-container"] > .sc-cTVMo > .sc-jeToga > .bp3-popover-wrapper > .bp3-popover-target > .bp3-input-group > .bp3-input')
+    .should('be.visible')
+    .type('v@gmail.com');
+    cy.get('[data-colindex="1"] > .sc-JmZxe > .sc-bEzTyZ > [data-testid="input-container"] > .sc-cTVMo > .sc-jeToga > .bp3-popover-wrapper > .bp3-popover-target > .bp3-input-group > .bp3-input')
+    .should('be.visible')
+    .type('2024-06-24T12:00:00-06:30');
+  });
+
+});

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/DateCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/DateCell.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { VerticalAlignment } from "../Constants";
 import {
   ALIGN_ITEMS,
@@ -196,6 +196,14 @@ export const DateCell = (props: DateComponentProps) => {
   const [showRequiredError, setShowRequiredError] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    if (isRequired && !value) {
+      setIsValid(false);
+    } else {
+      setIsValid(true);
+    }
+  }, [value, isRequired]);
+  
   const valueInISOFormat = useMemo(() => {
     if (typeof value !== "string") return "";
 
@@ -213,8 +221,9 @@ export const DateCell = (props: DateComponentProps) => {
   }, [value, props.outputFormat]);
 
   const onDateSelected = (date: string) => {
+    const formattedDate = date ? moment(date).format(inputFormat) : "";
     if (isNewRow) {
-      updateNewRowValues(alias, date, date);
+      updateNewRowValues(alias, date, formattedDate);
       return;
     }
 
@@ -227,7 +236,7 @@ export const DateCell = (props: DateComponentProps) => {
     setShowRequiredError(false);
     setHasFocus(false);
 
-    const formattedDate = date ? moment(date).format(inputFormat) : "";
+    
     onDateSave(rowIndex, alias, formattedDate, onDateSelectedString);
   };
 
@@ -241,8 +250,9 @@ export const DateCell = (props: DateComponentProps) => {
   };
 
   const onPopoverClosed = () => {
+    const isValidValue = value !== undefined && value !== null;
     setHasFocus(false);
-    setIsValid(true);
+    setIsValid(isValidValue);
     toggleCellEditMode(
       false,
       rowIndex,

--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -187,9 +187,7 @@ export default {
         tableSizes.COLUMN_HEADER_HEIGHT) /
       tableSizes.ROW_HEIGHT;
 
-    return pageSize % 1 > 0.3 && props.tableData.length > pageSize
-      ? Math.ceil(pageSize)
-      : Math.floor(pageSize);
+    return pageSize % 1 > 0.3 ? Math.ceil(pageSize) : Math.floor(pageSize);
   },
   //
   getProcessedTableData: (props, moment, _) => {
@@ -787,7 +785,7 @@ export default {
     };
 
     let editableColumns = [];
-    const validatableColumns = ["text", "number", "currency"];
+    const validatableColumns = ["text","number", "currency","date"];
 
     if (props.isAddRowInProgress) {
       Object.values(props.primaryColumns)
@@ -839,6 +837,7 @@ export default {
         switch (editedColumn.columnType) {
           case "number":
           case "currency":
+          case "date":
             if (
               !_.isNil(validation.min) &&
               validation.min !== "" &&


### PR DESCRIPTION
### Description


I have raised this PR `In-order to ensure that the save row button is disabled when the date column is set to required`

###  📸 Screenshot
 ### when department and doj are set to required save row is disabled
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/f982ca52-258c-49b4-8106-af9b59576449)

### when department has value and doj doesn't have , still the save row button is enabled
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/6a908bed-50a1-434a-b106-073ecd07b3d7)

### when department and doj are set to required save row button is disabled and doj column indicating error
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/07c0cd79-d483-4d8e-8cc7-b77e1c434be0)

### when department has value and doj doesn't have , still the save row button is disabled
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/7acb7ced-c52f-4bed-b2db-916757fe4174)

### when both the fieilds have values save row button is enabled
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/ce147156-754e-4ef7-a8c6-cbfee11a2147)

###  📸 Cypress Testing Video

https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/ba74fb1d-bd31-4549-a15a-6efdc01ed909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to disable the "Save row" button in tables when a required date column has no value.

- **Bug Fixes**
  - Corrected date formatting in the table's date cell to ensure consistency.

- **Tests**
  - Introduced a new test scenario to validate the disabled state of the "Save row" button for date columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->