### PR TITLE
chore: set the view mode when fetching actions for action collection

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -255,7 +255,7 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
         actionCollectionViewDTO.setDefaultResources(defaults);
         return newActionService
                 .findByCollectionIdAndViewMode(actionCollection.getId(), viewMode, aclPermission)
-                .map(action -> newActionService.generateActionByViewMode(action, false))
+                .map(action -> newActionService.generateActionByViewMode(action, viewMode))
                 .collectList()
                 .map(actionDTOList -> {
                     actionCollectionViewDTO.setActions(actionDTOList);


### PR DESCRIPTION
## Description
> Fetch the correct actions for action collection based on view mode.


Fixes [[Bug]: When triggering a workflow, unpublished js object is being used instead of a published one.](https://github.com/appsmithorg/appsmith/issues/34520)

## Automation

/ok-to-test tags="@tag.JS,@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9691919440>
> Commit: f3b7bdd5a23ffcc891fffb51aaed39266f8d2dad
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9691919440&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS,@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of action collections in view mode for better accuracy.

- **Tests**
  - Enhanced tests for action collections, ensuring better validation of collection IDs and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->