### PR TITLE
fix: Disable custom widgets for airgapped environments

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetDefaultComponent_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetDefaultComponent_spec.ts
@@ -6,14 +6,13 @@ import {
   propPane,
 } from "../../../../../support/Objects/ObjectsCore";
 
-import { featureFlagIntercept } from "../../../../../support/Objects/FeatureFlags";
 import EditorNavigation, {
   EntityType,
 } from "../../../../../support/Pages/EditorNavigation";
 
 describe(
   "Custom widget Tests",
-  { tags: ["@tag.Widget", "@tag.Custom"] },
+  { tags: ["@tag.Widget", "@tag.excludeForAirgap"] },
   function () {
     before(() => {
       entityExplorer.DragDropWidgetNVerify("customwidget", 550, 100);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetEditorPropertyPane_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetEditorPropertyPane_spec.ts
@@ -7,7 +7,7 @@ import {
 
 describe(
   "Custom widget Tests",
-  { tags: ["@tag.Widget", "@tag.Custom"] },
+  { tags: ["@tag.Widget", "@tag.excludeForAirgap"] },
   function () {
     before(() => {
       agHelper.AddDsl("customWidget");

--- a/app/client/src/widgets/CustomWidget/widget/index.tsx
+++ b/app/client/src/widgets/CustomWidget/widget/index.tsx
@@ -34,6 +34,7 @@ import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { Colors } from "constants/Colors";
 import AnalyticsUtil from "@appsmith/utils/AnalyticsUtil";
 import { DynamicHeight, type WidgetFeatures } from "utils/WidgetFeatures";
+import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 
 const StyledLink = styled(Link)`
   display: inline-block;
@@ -55,6 +56,7 @@ class CustomWidget extends BaseWidget<CustomWidgetProps, WidgetState> {
       tags: [WIDGET_TAGS.DISPLAY],
       searchTags: ["external"],
       isSearchWildcard: true,
+      hideCard: isAirgapped(),
     };
   }
 


### PR DESCRIPTION
## Description
Since custom widgets rely on react delievered from `https://cdn.jsdelivr.net`, it can't work in airgapped edition.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9692258525>
> Commit: bf3b40a5c3c51a2271347967516a53655721f7a2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9692258525&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom widgets will now hide specific cards if the environment is air-gapped.

- **Tests**
  - Updated test tags for custom widgets to exclude tests in air-gapped environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->