### PR TITLE
chore: diffing unevalTrees using microdiff to improve performance

### DIFF
--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -77,7 +77,7 @@ import {
 } from "lodash";
 
 import type { Diff } from "deep-diff";
-import { applyChange, diff } from "deep-diff";
+import { applyChange } from "deep-diff";
 import {
   EXECUTION_PARAM_KEY,
   EXECUTION_PARAM_REFERENCE_REGEX,
@@ -625,9 +625,11 @@ export default class DataTreeEvaluator {
       undefined,
       webworkerTelemetry,
       () =>
-        diff(
-          oldUnEvalTreeWithStringifiedJSFunctions,
-          unEvalTreeWithStringifiedJSFunctions,
+        convertMicroDiffToDeepDiff(
+          microDiff(
+            oldUnEvalTreeWithStringifiedJSFunctions,
+            unEvalTreeWithStringifiedJSFunctions,
+          ),
         ) || [],
     );
     // Since eval tree is listening to possible events that don't cause differences

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -644,7 +644,7 @@ export default class DataTreeEvaluator {
       };
     }
 
-    DataStore.update(differences);
+    DataStore.update(differences as Diff<DataTree, DataTree>[]);
 
     //find all differences which can lead to updating of dependency map
     const translatedDiffs = flatten(


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9700619925>
> Commit: e0a8913ddf6f0edc15595ec7f20039c759f220c1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9700619925&attempt=5&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: ``
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/AutoDimension_2_spec.ts
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/AutoHeight_Container_spec.ts
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/AutoHeight_Form_spec.ts
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/AutoHeight_Modal_spec.ts
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/AutoHeight_Tabs_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column_query_change_spec.js </ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.

<!-- end of auto-generated comment: Cypress test results  -->










## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of data difference computation to enhance performance and reliability when handling changes in the data tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->