### PR TITLE
ci: Write Cypress status with the GitHub Script

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -60,23 +60,16 @@ jobs:
       # In case of missing tags, guides towards correct usage in test response
       - name: Add test response with tags documentation link
         if: steps.parseTags.outputs.outcome != 'success'
-        uses: nefrob/pr-description@v1.1.2
+        uses: actions/github-script@v7
+        env:
+          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
+          BODY: |
+            The provided command lacks proper tags. Please modify PR body, specifying the tags you want to include or use `/ok-to-test tags="@tag.All"` to run all specs.
+            Explore the [tags documentation](https://www.notion.so/appsmith/Ok-to-test-With-Tags-7c0fc64d4efb4afebf53348cd6252918).
         with:
-            content: |
-              <!-- This is an auto-generated comment: Cypress test results  -->
-              > [!WARNING]
-              > The provided command lacks proper tags. Please modify PR body, specifying the tags you want to include or use `/ok-to-test tags="@tag.All"` to run all specs.
-              > Explore the tags documentation [here](https://www.notion.so/appsmith/Ok-to-test-With-Tags-7c0fc64d4efb4afebf53348cd6252918)
-
-              <!-- end of auto-generated comment: Cypress test results  -->
-            regex: "<!-- This is an auto-generated comment: Cypress test results  -->.*?<!-- end of auto-generated comment: Cypress test results  -->"
-            regexFlags: ims
-            token: ${{ secrets.GITHUB_TOKEN }}
-
-      # In case of missing tags, exit the workflow with failure
-      - name: Stop the workflow run if tags are not present
-        if: steps.parseTags.outputs.outcome != 'success'
-        run: exit 1
+          script: |
+            require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
+            setFailed()
 
       - name: Check Tags
         env:
@@ -95,23 +88,16 @@ jobs:
       # In case of incorrect tags, guides towards correct tags
       - name: Add test response with tags list link
         if: steps.checkTags.outputs.outcome == 'failure'
-        uses: nefrob/pr-description@v1.1.2
+        uses: actions/github-script@v7
+        env:
+          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
+          BODY: |
+            The provided command contains incorrect tags. Please modify PR body, specifying the tags you want to include or use `/ok-to-test tags="@tag.All"` to run all specs.
+            Please find [complete list of tags](https://github.com/appsmithorg/appsmith/blob/release/app/client/cypress/tags.js).
         with:
-            content: |
-              <!-- This is an auto-generated comment: Cypress test results  -->
-              > [!WARNING]
-              > The provided command contains incorrect tags. Please modify PR body, specifying the tags you want to include or use `/ok-to-test tags="@tag.All"` to run all specs.
-              > Please find complete list of tags [here](https://github.com/appsmithorg/appsmith/blob/release/app/client/cypress/tags.js)
-
-              <!-- end of auto-generated comment: Cypress test results  -->
-            regex: "<!-- This is an auto-generated comment: Cypress test results  -->.*?<!-- end of auto-generated comment: Cypress test results  -->"
-            regexFlags: ims
-            token: ${{ secrets.GITHUB_TOKEN }}
-
-      # In case of incorrect tags, exit the workflow with failure
-      - name: Stop the workflow run if tags are incorrect
-        if: steps.checkTags.outputs.outcome == 'failure'
-        run: exit 1
+          script: |
+            require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
+            setFailed()
 
       # In case of a run with all test cases, allocate a larger matrix
       - name: Check if @tag.All is present in tags
@@ -131,24 +117,16 @@ jobs:
       # In case of incorrect usage for all test cases, inform the PR author of correct usage
       - name: Add test response to use correct @tag.All format
         if: steps.checkAll.outputs.invalid_tags_all != ''
-        uses: nefrob/pr-description@v1.1.2
+        uses: actions/github-script@v7
+        env:
+          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
+          BODY: |
+            Please use `/ok-to-test tags="@tag.All"` to run all specs.
+            Explore the [tags documentation](https://www.notion.so/appsmith/Ok-to-test-With-Tags-7c0fc64d4efb4afebf53348cd6252918).
         with:
-            content: |
-              <!-- This is an auto-generated comment: Cypress test results  -->
-              > [!WARNING]
-              > Please use `/ok-to-test tags="@tag.All"` to run all specs.
-              > Explore the tags documentation [here](https://www.notion.so/appsmith/Ok-to-test-With-Tags-7c0fc64d4efb4afebf53348cd6252918)
-
-              <!-- end of auto-generated comment: Cypress test results  -->
-
-            regex: "<!-- This is an auto-generated comment: Cypress test results  -->.*?<!-- end of auto-generated comment: Cypress test results  -->"
-            regexFlags: ims
-            token: ${{ secrets.GITHUB_TOKEN }}
-
-      # In case of incorrect usage for all test cases, exit the workflow with failure
-      - name: Stop the workflow run if given @tag.All format is wrong
-        if: steps.checkAll.outputs.invalid_tags_all != ''
-        run: exit 1
+          script: |
+            require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
+            core.setFailed()
 
       # In case of a runnable command, update the PR with run details
       - name: Add test response with link to workflow run
@@ -156,15 +134,14 @@ jobs:
         env:
           NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
           BODY: |
-            > [!IMPORTANT]
-            > 🟣 🟣 🟣 Your tests are running.
-            > Tests running at: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
-            > Commit: ${{ github.event.pull_request.head.sha }}
-            > Workflow: `${{ github.workflow }}`
-            > Tags: `${{ steps.checkAll.outputs.tags }}`
+            Your tests are running.
+            Tests running at: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+            Commit: ${{ github.event.pull_request.head.sha }}
+            Workflow: `${{ github.workflow }}`
+            Tags: `${{ steps.checkAll.outputs.tags }}`
         with:
           script: |
-            require("write-cypress-comment.js")({core, context, github}, process.env.BODY)
+            require("write-cypress-status.js")({core, context, github}, "important", process.env.BODY)
 
   # Call the workflow to run Cypress tests
   perform-test:

--- a/.github/workflows/scripts/write-cypress-status.js
+++ b/.github/workflows/scripts/write-cypress-status.js
@@ -2,7 +2,18 @@ const HEADER = '<!-- This is an auto-generated comment: Cypress test results  --
 const FOOTER = '<!-- end of auto-generated comment: Cypress test results  -->';
 const PATTERN = new RegExp(HEADER + ".*?" + FOOTER, "ims");
 
-module.exports = async function({core, context, github}, note) {
+// Ref: https://github.com/orgs/community/discussions/16925
+const VALID_ALERT_TYPES = ["note", "tip", "important", "warning", "caution"]
+
+const ALERT_PREFIXES = {
+  important: "🟣 🟣 🟣 ",
+}
+
+module.exports = async function({core, context, github}, alertType, note) {
+  if (!VALID_ALERT_TYPES.includes(alertType)) {
+    core.setFailed("Invalid alert type: '" + alertType + "'. Allowed: " + VALID_ALERT_TYPES.join(", ") + ".");
+  }
+
   const prNumber = context.payload.pull_request?.number;
 
   if (!prNumber) {
@@ -23,7 +34,12 @@ module.exports = async function({core, context, github}, note) {
     return;
   }
 
-  note = [HEADER, note, FOOTER].join("\n");
+  note = [
+    HEADER,
+    `> [!${alertType.toUpperCase()}]`,
+    ((ALERT_PREFIXES[alertType] ?? "") + note.trim()).replaceAll(/^/gm, "> "),
+    FOOTER,
+  ].join("\n");
 
   if (body.match(PATTERN)) {
     body = body.replace(PATTERN, note);


### PR DESCRIPTION
Replacing more of `nefrob/pr-description@v1.1.2` with our GitHub Script. This is moving towards Javascript CI, and hopefully an unit-testable CI.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Replaced `nefrob/pr-description` action with `actions/github-script` for handling test responses in PR automation.
  - Improved guidance on modifying PR body for correct tag usage and linked to relevant documentation.
  - Enhanced script content to handle warnings and failures more effectively in PR workflow automation.

- **New Features**
  - Updated the `write-cypress-status` script to support different alert types and prefixes, ensuring better validation and formatting of alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->