### PR TITLE
Revert "chore: Introducing ReactorDebugAgent to improve the stack traces and make them easier to debug"

### DIFF
--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -438,14 +438,6 @@
             <version>2.14.2.Final</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- This dependency helps us print better & debuggable stack traces -->
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-tools</artifactId>
-            <version>${reactor-test.version}</version>
-        </dependency>
-
     </dependencies>
 
     <repositories>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
@@ -26,7 +26,6 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import reactor.tools.agent.ReactorDebugAgent;
 
 import java.time.Duration;
 
@@ -56,7 +55,6 @@ public class ServerApplication {
     }
 
     public static void main(String[] args) {
-        ReactorDebugAgent.init();
         new SpringApplicationBuilder(ServerApplication.class)
                 .bannerMode(Banner.Mode.OFF)
                 .run(args);

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.groupId>com.appsmith</project.groupId>
         <project.version>1.0-SNAPSHOT</project.version>
-        <reactor-test.version>3.6.7</reactor-test.version>
+        <reactor-test.version>3.5.1</reactor-test.version>
         <!-- By default skip the dockerization step. Only activate if necessary -->
         <skipDockerBuild>true</skipDockerBuild>
         <!-- We're forcing this version temporarily to fix CVE-2022-1471-->


### PR DESCRIPTION
Reverts appsmithorg/appsmith#34485 because this may be causing some delays in running the JUnit tests on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed unnecessary dependencies related to debug stack trace printing for cleaner and more efficient code. 
  - Downgraded `reactor-test` version to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->