### PR TITLE
fix: jest ci script

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -29,7 +29,7 @@
     "cytest": "REACT_APP_TESTING=TESTING REACT_APP_ENVIRONMENT=DEVELOPMENT craco start & ./node_modules/.bin/cypress open",
     "test:unit": "yarn g:jest --coverage --collectCoverage=true --coverageDirectory='../../' --coverageReporters='json-summary'",
     "test:jest": "jest --watch",
-    "g:jest": "cd $INIT_CWD && jest -b --colors --no-cache --silent --maxWorkers=50%",
+    "g:jest": "cd $INIT_CWD && jest --colors --no-cache --silent --maxWorkers=50%",
     "test:unit:ci": "yarn workspaces foreach -tv run test:unit",
     "generate:widget": "plop --plopfile generators/index.js",
     "postinstall": "node cypress/apply-patches.js && yarn init-husky",


### PR DESCRIPTION
## Description
Now, all unit tests will continue to be run in the CI pipeline, even if they fail.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test script in `package.json` to improve test execution environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->