### PR TITLE
fix: Update BuildingBlockSagas to handle nested object value replacement in queries

### DIFF
--- a/app/client/src/sagas/BuildingBlockSagas/index.ts
+++ b/app/client/src/sagas/BuildingBlockSagas/index.ts
@@ -12,6 +12,7 @@ import type { CopiedWidgetData } from "layoutSystems/anvil/utils/paste/types";
 import { getWidgetHierarchy } from "layoutSystems/anvil/utils/paste/utils";
 import { all, call, put, select } from "redux-saga/effects";
 import { apiCallToSaveAction } from "sagas/ActionSagas";
+import { accessNestedObjectValue } from "sagas/PasteWidgetUtils";
 import { saveCopiedWidgets } from "utils/storage";
 
 export function* saveBuildingBlockWidgetsToStore(
@@ -73,11 +74,17 @@ export function updateWidgetsNameInNewQueries(
   return queries
     .filter((query) => !!query)
     .map((query) => {
-      if (!query.actionConfiguration.body || !query.jsonPathKeys) {
+      if (!query.actionConfiguration && !query.jsonPathKeys) {
         return query;
       }
-      query.actionConfiguration.body =
-        query.actionConfiguration.body.replaceAll(oldWidgetName, newWidgetName);
+      query?.dynamicBindingPathList?.forEach((path: { key: string }) => {
+        accessNestedObjectValue(
+          query.actionConfiguration,
+          path.key,
+          oldWidgetName,
+          newWidgetName,
+        );
+      });
       query.jsonPathKeys = query.jsonPathKeys.map((path: string) =>
         path.replaceAll(oldWidgetName, newWidgetName),
       );

--- a/app/client/src/sagas/PasteWidgetUtils/PasteWidgetUtils.test.ts
+++ b/app/client/src/sagas/PasteWidgetUtils/PasteWidgetUtils.test.ts
@@ -64,6 +64,22 @@ describe("accessNestedObjectValue", () => {
 
     expect(result).toBeUndefined();
   });
+
+  it("4. should work for null/undefined object", () => {
+    const obj = null;
+
+    const oldValue = "oldValue";
+    const newValue = "newValue";
+
+    const result = accessNestedObjectValue(
+      obj,
+      "foo.bar.qux",
+      oldValue,
+      newValue,
+    );
+
+    expect(result).toBeUndefined();
+  });
 });
 
 describe("handleJSONFormPropertiesListedInDynamicBindingPath", () => {


### PR DESCRIPTION
## Description
This pull request updates the BuildingBlockSagas module to handle nested object value replacement in queries. 

Previously, the module only replaced values at the top level of the object, but now it correctly handles nested values as well. This improves the accuracy and reliability of the queries.

The changes include adding a new utility function, `accessNestedObjectValue`, which is used to access and update nested values in the `actionConfiguration` object. 
Additionally, the `updateWidgetsNameInNewQueries` function has been modified to use this utility function when replacing widget names in queries. 

Overall, these changes enhance the functionality of the BuildingBlockSagas module and ensure that queries are properly updated with the new widget names."


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9698473149>
> Commit: 6e82692e4cbf8d2e9630499006aa2e0f8adbfdd3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9698473149&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`

<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal logic for updating nested object values in widget names.

- **Tests**
  - Added new test case for handling `null` or `undefined` inputs in utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->