### PR TITLE
fix: Comment shortcut adds JS Comment instead of HTML

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -394,6 +394,18 @@ class CodeEditor extends Component<Props, State> {
           saveAndAutoIndentCode(editor);
           AnalyticsUtil.logEvent("PRETTIFY_AND_SAVE_KEYBOARD_SHORTCUT");
         },
+        'Ctrl-/': function(cm) {
+          if (cm.getMode().name === 'htmlmixed') {
+            let selection = cm.getSelection();
+            if (selection.startsWith("<!--") && selection.endsWith("-->")) {
+              cm.replaceSelection(selection.slice(4, -3).trim());
+            } else {
+              cm.replaceSelection(`<!-- ${selection} -->`);
+            }
+          } else {
+            cm.toggleComment(); // Fallback to default behavior for other modes
+          }
+        },
         [getDeleteLineShortcut()]: () => {
           return;
         },


### PR DESCRIPTION
## Description

This update ensures that the comment shortcut now adds an HTML comment (`<!-- -->`) instead of a JavaScript comment (`//`).


Fixes #34310 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [X] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new keyboard shortcut (`Ctrl-/`) in the Code Editor to handle HTML comments and toggle comments in other modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->