### PR TITLE
feat: Add dynamic property path for sourceData in SelectWidget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
@@ -92,6 +92,7 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
 
     cy.get("@dsName").then((dsName) => {
       EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
+      propPane.ToggleJSMode("sourcedata", false);
 
       oneClickBinding.ChooseAndAssertForm(
         `${dsName}`,
@@ -103,7 +104,6 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
         },
       );
     });
-    propPane.ToggleJSMode("sourcedata", false);
 
     agHelper.GetNClick(OneClickBindingLocator.connectData);
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
@@ -9,6 +9,7 @@ const {
   agHelper,
   assertHelper,
   dataSources,
+  propPane
 } = require("../../../../../support/Objects/ObjectsCore");
 const {
   default: EditorNavigation,
@@ -86,7 +87,7 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
       .should("not.be.empty");
   });
 
-  it("5. Select widget selection is not cleared when the widget is server side filtered", () => {
+  it.only("5. Select widget selection is not cleared when the widget is server side filtered", () => {
     dataSources.CreateDataSource("Postgres");
 
     cy.get("@dsName").then((dsName) => {
@@ -102,6 +103,7 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
         },
       );
     });
+    propPane.ToggleJSMode("sourcedata", false);
 
     agHelper.GetNClick(OneClickBindingLocator.connectData);
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
@@ -9,7 +9,7 @@ const {
   agHelper,
   assertHelper,
   dataSources,
-  propPane
+  propPane,
 } = require("../../../../../support/Objects/ObjectsCore");
 const {
   default: EditorNavigation,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
@@ -87,7 +87,7 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
       .should("not.be.empty");
   });
 
-  it.only("5. Select widget selection is not cleared when the widget is server side filtered", () => {
+  it("5. Select widget selection is not cleared when the widget is server side filtered", () => {
     dataSources.CreateDataSource("Postgres");
 
     cy.get("@dsName").then((dsName) => {

--- a/app/client/src/widgets/SelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/SelectWidget/widget/index.tsx
@@ -111,6 +111,7 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
       labelTextSize: "0.875rem",
       responsiveBehavior: ResponsiveBehavior.Fill,
       minWidth: FILL_WIDGET_MIN_WIDTH,
+      dynamicPropertyPathList: [{ key: "sourceData" }],
     };
   }
 

--- a/app/client/src/widgets/SelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/SelectWidget/widget/index.tsx
@@ -93,11 +93,15 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
       labelPosition: LabelPosition.Top,
       labelAlignment: Alignment.LEFT,
       labelWidth: 5,
-      sourceData: [
-        { name: "Blue", code: "BLUE" },
-        { name: "Green", code: "GREEN" },
-        { name: "Red", code: "RED" },
-      ],
+      sourceData: JSON.stringify(
+        [
+          { name: "Blue", code: "BLUE" },
+          { name: "Green", code: "GREEN" },
+          { name: "Red", code: "RED" },
+        ],
+        null,
+        2,
+      ),
       optionLabel: "name",
       optionValue: "code",
       serverSideFiltering: false,


### PR DESCRIPTION
## Description
Add dynamic property path for sourceData in SelectWidget.

Fixes #34568
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9712372976>
> Commit: c5521e46382d448715183862aededc142136db0a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9712372976&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`

<!-- end of auto-generated comment: Cypress test results  -->









## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the Select Widget with a new property to support dynamic property paths.
- **Tests**
	- Added new tests to validate the dynamic property paths functionality in the Select Widget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->