### PR TITLE
test: updated js methods to refer ts locators for Git Tests

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/Merge_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/Merge_spec.js
@@ -35,7 +35,7 @@ describe(
 
       cy.get(gitSyncLocators.mergeButton).should("be.disabled");
       cy.wait(3000);
-      cy.get(gitSyncLocators.mergeBranchDropdownDestination).click();
+      cy.get(_.gitSync._mergeBranchDropdownDestination).click();
       cy.get(commonLocators.dropdownmenu).contains(mainBranch).click();
       _.agHelper.AssertElementAbsence(_.gitSync._checkMergeability, 30000);
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,10 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Git/GitSync/Merge_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitWithJSLibrary/GitwithCustomJSLibrary_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitSync/DeleteBranch_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitSync/MergeViaRemote_spec.ts
 cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitSync/GitBugs_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,10 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/Merge_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitWithJSLibrary/GitwithCustomJSLibrary_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/DeleteBranch_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/MergeViaRemote_spec.ts
+cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/GitBugs_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,10 @@
 # To run only limited tests - give the spec names in below format:
+cypress/e2e/Regression/ClientSide/Git/GitSync/Merge_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitWithJSLibrary/GitwithCustomJSLibrary_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/DeleteBranch_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/MergeViaRemote_spec.ts
 cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
+cypress/e2e/Regression/ClientSide/Git/GitSync/GitBugs_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,10 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Git/GitSync/Merge_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitWithJSLibrary/GitwithCustomJSLibrary_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitSync/DeleteBranch_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitSync/MergeViaRemote_spec.ts
-cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
-cypress/e2e/Regression/ClientSide/Git/GitSync/GitBugs_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/locators/gitSyncLocators.js
+++ b/app/client/cypress/locators/gitSyncLocators.js
@@ -20,7 +20,7 @@ export default {
   bottomBarCommitButton: ".t--bottom-bar-commit",
   bottomBarMergeButton: ".t--bottom-bar-merge",
   bottomBarPullButton: ".t--bottom-bar-pull",
-  mergeBranchDropdownDestination: ".t--merge-branch-dropdown-destination",
+  mergeBranchDropdownDestination: "[data-testid=t--merge-branch-dropdown-destination]",
   mergeCTA: "[data-testid=t--git-merge-button]",
   loaderQuickGitAction: ".t--loader-quick-git-action",
   connetStatusbar: ".t--connect-statusbar",

--- a/app/client/cypress/locators/gitSyncLocators.js
+++ b/app/client/cypress/locators/gitSyncLocators.js
@@ -20,7 +20,6 @@ export default {
   bottomBarCommitButton: ".t--bottom-bar-commit",
   bottomBarMergeButton: ".t--bottom-bar-merge",
   bottomBarPullButton: ".t--bottom-bar-pull",
-  mergeBranchDropdownDestination: "[data-testid=t--merge-branch-dropdown-destination]",
   mergeCTA: "[data-testid=t--git-merge-button]",
   loaderQuickGitAction: ".t--loader-quick-git-action",
   connetStatusbar: ".t--connect-statusbar",

--- a/app/client/cypress/support/gitSync.js
+++ b/app/client/cypress/support/gitSync.js
@@ -111,7 +111,7 @@ Cypress.Commands.add("merge", (destinationBranch) => {
   ); */
 
   agHelper.AssertElementEnabledDisabled(
-    gitSyncLocators.mergeBranchDropdownDestination,
+    gitSync._mergeBranchDropdownDestination,
     0,
     false,
   );
@@ -121,7 +121,7 @@ Cypress.Commands.add("merge", (destinationBranch) => {
       interceptions[0]?.response?.statusCode === 200 &&
       interceptions[1]?.response?.statusCode === 200
     ) {
-      cy.get(gitSyncLocators.mergeBranchDropdownDestination).click();
+      cy.get(gitSync._mergeBranchDropdownDestination).click();
       cy.get(commonLocators.dropdownmenu).contains(destinationBranch).click();
       agHelper.AssertElementAbsence(gitSync._checkMergeability, 35000);
       assertHelper.WaitForNetworkCall("mergeStatus");


### PR DESCRIPTION
RCA:
Locator was updated in the Ts helper and there was Js helper which was not updated

Solution:
Replaced js locator with ts locator
