### PR TITLE
chore: Fix datasource creation throwing 400

### DIFF
--- a/app/client/src/api/DatasourcesApi.ts
+++ b/app/client/src/api/DatasourcesApi.ts
@@ -76,10 +76,10 @@ class DatasourcesApi extends API {
     }
 
     const clean: any = {
-      authenticationType: authentication.authenticationType,
+      authenticationType: authentication.authenticationType ?? "dbAuth",
     };
 
-    switch (authentication.authenticationType) {
+    switch (clean.authenticationType) {
       case "dbAuth":
         clean.authType = authentication.authType;
         clean.username = authentication.username;

--- a/app/client/src/api/DatasourcesApi.ts
+++ b/app/client/src/api/DatasourcesApi.ts
@@ -50,7 +50,7 @@ class DatasourcesApi extends API {
             datasourceConfiguration: {
               ...storage.datasourceConfiguration,
               isValid: undefined,
-              authentication: this.cleanAuthenticationObject(
+              authentication: DatasourcesApi.cleanAuthenticationObject(
                 storage.datasourceConfiguration.authentication,
               ),
               connection: storage.datasourceConfiguration.connection && {

--- a/app/client/src/api/DatasourcesApi.ts
+++ b/app/client/src/api/DatasourcesApi.ts
@@ -50,6 +50,9 @@ class DatasourcesApi extends API {
             datasourceConfiguration: {
               ...storage.datasourceConfiguration,
               isValid: undefined,
+              authentication: this.cleanupAuthenticationObject(
+                storage.datasourceConfiguration.authentication,
+              ),
               connection: storage.datasourceConfiguration.connection && {
                 ...storage.datasourceConfiguration.connection,
                 ssl: {
@@ -65,6 +68,64 @@ class DatasourcesApi extends API {
     }
 
     return API.post(DatasourcesApi.url, datasourceConfig);
+  }
+
+  static cleanupAuthenticationObject(authentication: any): any {
+    if (!authentication) {
+      return undefined;
+    }
+    const common: any = {
+      authenticationType: authentication.authenticationType,
+    };
+
+    switch (authentication.authenticationType) {
+      case "dbAuth":
+        common.authType = authentication.authType;
+        common.username = authentication.username;
+        common.password = authentication.password;
+        common.databaseName = authentication.databaseName;
+        break;
+      case "oAuth2":
+        common.grantType = authentication.grantType;
+        common.isTokenHeader = authentication.isTokenHeader;
+        common.isAuthorizationHeader = authentication.isAuthorizationHeader;
+        common.clientId = authentication.clientId;
+        common.clientSecret = authentication.clientSecret;
+        common.authorizationUrl = authentication.authorizationUrl;
+        common.expiresIn = authentication.expiresIn;
+        common.accessTokenUrl = authentication.accessTokenUrl;
+        common.scopeString = authentication.scopeString;
+        common.scope = authentication.scope;
+        common.sendScopeWithRefreshToken =
+          authentication.sendScopeWithRefreshToken;
+        common.refreshTokenClientCredentialsLocation =
+          authentication.refreshTokenClientCredentialsLocation;
+        common.headerPrefix = authentication.headerPrefix;
+        common.customTokenParameters = authentication.customTokenParameters;
+        common.audience = authentication.audience;
+        common.resource = authentication.resource;
+        common.useSelfSignedCert = authentication.useSelfSignedCert;
+        break;
+      case "basic":
+        common.username = authentication.username;
+        common.password = authentication.password;
+        break;
+      case "apiKey":
+        common.addTo = authentication.addTo;
+        common.label = authentication.label;
+        common.headerPrefix = authentication.headerPrefix;
+        common.value = authentication.value;
+        break;
+      case "bearerToken":
+        common.bearerToken = authentication.bearerToken;
+        break;
+      case "snowflakeKeyPairAuth":
+        common.username = authentication.username;
+        common.privateKey = authentication.privateKey;
+        common.passphrase = authentication.passphrase;
+    }
+
+    return common;
   }
 
   // Api to test current environment datasource

--- a/app/client/src/api/DatasourcesApi.ts
+++ b/app/client/src/api/DatasourcesApi.ts
@@ -50,7 +50,7 @@ class DatasourcesApi extends API {
             datasourceConfiguration: {
               ...storage.datasourceConfiguration,
               isValid: undefined,
-              authentication: this.cleanupAuthenticationObject(
+              authentication: this.cleanAuthenticationObject(
                 storage.datasourceConfiguration.authentication,
               ),
               connection: storage.datasourceConfiguration.connection && {
@@ -70,62 +70,63 @@ class DatasourcesApi extends API {
     return API.post(DatasourcesApi.url, datasourceConfig);
   }
 
-  static cleanupAuthenticationObject(authentication: any): any {
+  static cleanAuthenticationObject(authentication: any): any {
     if (!authentication) {
       return undefined;
     }
-    const common: any = {
+
+    const auth: any = {
       authenticationType: authentication.authenticationType,
     };
 
     switch (authentication.authenticationType) {
       case "dbAuth":
-        common.authType = authentication.authType;
-        common.username = authentication.username;
-        common.password = authentication.password;
-        common.databaseName = authentication.databaseName;
+        auth.authType = authentication.authType;
+        auth.username = authentication.username;
+        auth.password = authentication.password;
+        auth.databaseName = authentication.databaseName;
         break;
       case "oAuth2":
-        common.grantType = authentication.grantType;
-        common.isTokenHeader = authentication.isTokenHeader;
-        common.isAuthorizationHeader = authentication.isAuthorizationHeader;
-        common.clientId = authentication.clientId;
-        common.clientSecret = authentication.clientSecret;
-        common.authorizationUrl = authentication.authorizationUrl;
-        common.expiresIn = authentication.expiresIn;
-        common.accessTokenUrl = authentication.accessTokenUrl;
-        common.scopeString = authentication.scopeString;
-        common.scope = authentication.scope;
-        common.sendScopeWithRefreshToken =
+        auth.grantType = authentication.grantType;
+        auth.isTokenHeader = authentication.isTokenHeader;
+        auth.isAuthorizationHeader = authentication.isAuthorizationHeader;
+        auth.clientId = authentication.clientId;
+        auth.clientSecret = authentication.clientSecret;
+        auth.authorizationUrl = authentication.authorizationUrl;
+        auth.expiresIn = authentication.expiresIn;
+        auth.accessTokenUrl = authentication.accessTokenUrl;
+        auth.scopeString = authentication.scopeString;
+        auth.scope = authentication.scope;
+        auth.sendScopeWithRefreshToken =
           authentication.sendScopeWithRefreshToken;
-        common.refreshTokenClientCredentialsLocation =
+        auth.refreshTokenClientCredentialsLocation =
           authentication.refreshTokenClientCredentialsLocation;
-        common.headerPrefix = authentication.headerPrefix;
-        common.customTokenParameters = authentication.customTokenParameters;
-        common.audience = authentication.audience;
-        common.resource = authentication.resource;
-        common.useSelfSignedCert = authentication.useSelfSignedCert;
+        auth.headerPrefix = authentication.headerPrefix;
+        auth.customTokenParameters = authentication.customTokenParameters;
+        auth.audience = authentication.audience;
+        auth.resource = authentication.resource;
+        auth.useSelfSignedCert = authentication.useSelfSignedCert;
         break;
       case "basic":
-        common.username = authentication.username;
-        common.password = authentication.password;
+        auth.username = authentication.username;
+        auth.password = authentication.password;
         break;
       case "apiKey":
-        common.addTo = authentication.addTo;
-        common.label = authentication.label;
-        common.headerPrefix = authentication.headerPrefix;
-        common.value = authentication.value;
+        auth.addTo = authentication.addTo;
+        auth.label = authentication.label;
+        auth.headerPrefix = authentication.headerPrefix;
+        auth.value = authentication.value;
         break;
       case "bearerToken":
-        common.bearerToken = authentication.bearerToken;
+        auth.bearerToken = authentication.bearerToken;
         break;
       case "snowflakeKeyPairAuth":
-        common.username = authentication.username;
-        common.privateKey = authentication.privateKey;
-        common.passphrase = authentication.passphrase;
+        auth.username = authentication.username;
+        auth.privateKey = authentication.privateKey;
+        auth.passphrase = authentication.passphrase;
     }
 
-    return common;
+    return auth;
   }
 
   // Api to test current environment datasource

--- a/app/client/src/api/DatasourcesApi.ts
+++ b/app/client/src/api/DatasourcesApi.ts
@@ -75,58 +75,58 @@ class DatasourcesApi extends API {
       return undefined;
     }
 
-    const auth: any = {
+    const clean: any = {
       authenticationType: authentication.authenticationType,
     };
 
     switch (authentication.authenticationType) {
       case "dbAuth":
-        auth.authType = authentication.authType;
-        auth.username = authentication.username;
-        auth.password = authentication.password;
-        auth.databaseName = authentication.databaseName;
+        clean.authType = authentication.authType;
+        clean.username = authentication.username;
+        clean.password = authentication.password;
+        clean.databaseName = authentication.databaseName;
         break;
       case "oAuth2":
-        auth.grantType = authentication.grantType;
-        auth.isTokenHeader = authentication.isTokenHeader;
-        auth.isAuthorizationHeader = authentication.isAuthorizationHeader;
-        auth.clientId = authentication.clientId;
-        auth.clientSecret = authentication.clientSecret;
-        auth.authorizationUrl = authentication.authorizationUrl;
-        auth.expiresIn = authentication.expiresIn;
-        auth.accessTokenUrl = authentication.accessTokenUrl;
-        auth.scopeString = authentication.scopeString;
-        auth.scope = authentication.scope;
-        auth.sendScopeWithRefreshToken =
+        clean.grantType = authentication.grantType;
+        clean.isTokenHeader = authentication.isTokenHeader;
+        clean.isAuthorizationHeader = authentication.isAuthorizationHeader;
+        clean.clientId = authentication.clientId;
+        clean.clientSecret = authentication.clientSecret;
+        clean.authorizationUrl = authentication.authorizationUrl;
+        clean.expiresIn = authentication.expiresIn;
+        clean.accessTokenUrl = authentication.accessTokenUrl;
+        clean.scopeString = authentication.scopeString;
+        clean.scope = authentication.scope;
+        clean.sendScopeWithRefreshToken =
           authentication.sendScopeWithRefreshToken;
-        auth.refreshTokenClientCredentialsLocation =
+        clean.refreshTokenClientCredentialsLocation =
           authentication.refreshTokenClientCredentialsLocation;
-        auth.headerPrefix = authentication.headerPrefix;
-        auth.customTokenParameters = authentication.customTokenParameters;
-        auth.audience = authentication.audience;
-        auth.resource = authentication.resource;
-        auth.useSelfSignedCert = authentication.useSelfSignedCert;
+        clean.headerPrefix = authentication.headerPrefix;
+        clean.customTokenParameters = authentication.customTokenParameters;
+        clean.audience = authentication.audience;
+        clean.resource = authentication.resource;
+        clean.useSelfSignedCert = authentication.useSelfSignedCert;
         break;
       case "basic":
-        auth.username = authentication.username;
-        auth.password = authentication.password;
+        clean.username = authentication.username;
+        clean.password = authentication.password;
         break;
       case "apiKey":
-        auth.addTo = authentication.addTo;
-        auth.label = authentication.label;
-        auth.headerPrefix = authentication.headerPrefix;
-        auth.value = authentication.value;
+        clean.addTo = authentication.addTo;
+        clean.label = authentication.label;
+        clean.headerPrefix = authentication.headerPrefix;
+        clean.value = authentication.value;
         break;
       case "bearerToken":
-        auth.bearerToken = authentication.bearerToken;
+        clean.bearerToken = authentication.bearerToken;
         break;
       case "snowflakeKeyPairAuth":
-        auth.username = authentication.username;
-        auth.privateKey = authentication.privateKey;
-        auth.passphrase = authentication.passphrase;
+        clean.username = authentication.username;
+        clean.privateKey = authentication.privateKey;
+        clean.passphrase = authentication.passphrase;
     }
 
-    return auth;
+    return clean;
   }
 
   // Api to test current environment datasource


### PR DESCRIPTION
The recent changes to deny any requests that have unrecognized fields in the body, is making the datasource creation API fail. This is because we are sending extra fields that shouldn't be sent.

[Slack conversation](https://theappsmith.slack.com/archives/CPQNLFHTN/p1719577339838649?thread_ts=1719466294.012589&cid=CPQNLFHTN).


**/test sanity datasource**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9714799545>
> Commit: 85495fbcf6ec641162c7c30ea8f758dcaee380e3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9714799545&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Datasource`
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/9714799545" target="_blank">workflow here</a>.

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced data security by adding a method to sanitize and retain only necessary authentication information for various authentication types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->