### PR TITLE
chore: Use `id` argument to find action collections

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -397,7 +397,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
 
         // First collect all valid action ids from before, and diff against incoming action ids
         Mono<List<ActionDTO>> deleteNonExistingActionMono = newActionService
-                .findByCollectionIdAndViewMode(actionCollectionDTO.getId(), false, actionPermission.getEditPermission())
+                .findByCollectionIdAndViewMode(id, false, actionPermission.getEditPermission())
                 .filter(newAction -> !defaultActionIds.contains(
                         newAction.getDefaultResources().getActionId()))
                 .flatMap(x -> newActionService


### PR DESCRIPTION
This is causing a test failure in `pg` because we're trying to extract the `id` out of a DTO that was originally passed to `.save()`, which doesn't work with Hibernate. This failure in `pg` got introduced by the test class changes in appsmithorg/appsmith#34535.


/test sanity


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9732360344>
> Commit: a29cf611a6f4dd8d6bd7a2da894252168cac56cf
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9732360344&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the method call to ensure the correct parameter is used for updating unpublished action collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->