### PR TITLE
chore: remove unevalTree

### DIFF
--- a/app/client/src/sagas/EvalWorkerActionSagas.ts
+++ b/app/client/src/sagas/EvalWorkerActionSagas.ts
@@ -19,7 +19,6 @@ import {
 import { handleStoreOperations } from "./ActionExecution/StoreActionSaga";
 import type { EvalTreeResponseData } from "workers/Evaluation/types";
 import isEmpty from "lodash/isEmpty";
-import type { UnEvalTree } from "entities/DataTree/dataTreeTypes";
 import { sortJSExecutionDataByCollectionId } from "workers/Evaluation/JSObject/utils";
 import type { LintTreeSagaRequestData } from "plugins/Linting/types";
 import { evalErrorHandler } from "./EvalErrorHandler";
@@ -27,7 +26,6 @@ import { getUnevaluatedDataTree } from "selectors/dataTreeSelectors";
 
 export interface UpdateDataTreeMessageData {
   workerResponse: EvalTreeResponseData;
-  unevalTree: UnEvalTree;
 }
 
 export function* handleEvalWorkerRequestSaga(listenerChannel: Channel<any>) {
@@ -141,12 +139,12 @@ export function* handleEvalWorkerMessage(message: TMessage<any>) {
       break;
     }
     case MAIN_THREAD_ACTION.UPDATE_DATATREE: {
-      const { unevalTree, workerResponse } = data as UpdateDataTreeMessageData;
+      const { workerResponse } = data as UpdateDataTreeMessageData;
       const unEvalAndConfigTree: ReturnType<typeof getUnevaluatedDataTree> =
         yield select(getUnevaluatedDataTree);
       yield call(updateDataTreeHandler, {
         evalTreeResponse: workerResponse as EvalTreeResponseData,
-        unevalTree,
+        unevalTree: unEvalAndConfigTree.unEvalTree || {},
         requiresLogging: false,
         configTree: unEvalAndConfigTree.configTree,
       });

--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.test.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.test.ts
@@ -190,7 +190,6 @@ describe("evaluateAndGenerateResponse", () => {
 
     expect(parsedUpdates).toEqual([]);
     expect(webworkerResponse).toEqual({
-      unevalTree: {},
       workerResponse: {
         dependencies: {},
         errors: [],
@@ -223,28 +222,6 @@ describe("evaluateAndGenerateResponse", () => {
     const parsedUpdates = getParsedUpdatesFromWebWorkerResp(webworkerResponse);
 
     expect(parsedUpdates).toEqual([]);
-  });
-  test("should send the new unevalTree in the web worker response", () => {
-    const updatedLabelUnevalTree = produce(unEvalTree, (draft: any) => {
-      if (draft.Text1?.text) {
-        draft.Text1.text = UPDATED_LABEL;
-      }
-    });
-    expect(evaluator.getOldUnevalTree()).toEqual(unEvalTree);
-    const updateTreeResponse = evaluator.setupUpdateTree(
-      updatedLabelUnevalTree,
-      configTree,
-    );
-    // the new unevalTree gets set in setupUpdateTree
-    expect(evaluator.getOldUnevalTree()).toEqual(updatedLabelUnevalTree);
-
-    const { unevalTree } = evalTreeWithChanges.evaluateAndGenerateResponse(
-      evaluator,
-      updateTreeResponse,
-      [],
-      [],
-    );
-    expect(unevalTree).toEqual(updatedLabelUnevalTree);
   });
 
   describe("updates", () => {

--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
@@ -106,7 +106,6 @@ export const evaluateAndGenerateResponse = (
     defaultResponse.evalMetaUpdates = [...(metaUpdates || [])];
     return {
       workerResponse: defaultResponse,
-      unevalTree: {},
     };
   }
 
@@ -134,7 +133,6 @@ export const evaluateAndGenerateResponse = (
   );
 
   defaultResponse.staleMetaIds = updateResponse.staleMetaIds;
-  const unevalTree = dataTreeEvaluator.getOldUnevalTree();
 
   // when additional paths are required to be added as updates, we extract the updates from the data tree using these paths.
   const additionalUpdates = getNewDataTreeUpdates(
@@ -159,7 +157,6 @@ export const evaluateAndGenerateResponse = (
 
   return {
     workerResponse: defaultResponse,
-    unevalTree,
   };
 };
 


### PR DESCRIPTION
## Description
evalTreeWithChanges is sending a redundant property unevalTree in the payload, we should remove this property to reduce the serialisation cost of including this property in the payload.

Fixes #34766

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9807127090>
> Commit: 73e226d70644bd0995e5c1c0b5b1d9c73e93e83a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9807127090&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/PartialImportExport/PartialExport_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Workspace/MemberRoles_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Workspace/ShareAppTests_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Fri, 05 Jul 2024 11:46:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->






## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of `unevalTree` by accessing it from `unEvalAndConfigTree` instead of directly from the message data in message handling logic.

- **Tests**
  - Updated tests to reflect the removal of the `unevalTree` property and related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->