### PR TITLE
test: adjust widget sidebar cypress tests to account for custom widget removal from Airgapped

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -196,11 +196,10 @@ describe(
       agHelper.TypeText(entityExplorer._widgetSearchInput, "p");
       agHelper.AssertElementLength(entityExplorer._widgetCards, 2);
 
+      agHelper.ClearNType(entityExplorer._widgetSearchInput, "cypress");
       if (Cypress.env("AIRGAPPED")) {
-        agHelper.ClearNType(entityExplorer._widgetSearchInput, "cypress");
         agHelper.AssertElementLength(entityExplorer._widgetCards, 0);
       } else {
-        agHelper.ClearNType(entityExplorer._widgetSearchInput, "cypress");
         agHelper.AssertElementLength(entityExplorer._widgetCards, 1);
         agHelper.AssertElementExist(".t--widget-card-draggable-customwidget");
       }

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -71,15 +71,12 @@ describe(
 
     if (Cypress.env("AIRGAPPED")) {
       // Remove map and custom widget in case of airgap
-      WIDGETS_CATALOG.Content = ["Progress", "Rating", "Text"];
-      WIDGETS_CATALOG.Display = [
-        "Chart",
-        "Iframe",
-        "List",
-        "Map Chart",
-        "Stats Box",
-        "Table",
-      ];
+      WIDGETS_CATALOG.Content = WIDGETS_CATALOG.Display.filter(
+        (widget) => widget !== "Map",
+      );
+      WIDGETS_CATALOG.Display = WIDGETS_CATALOG.Display.filter(
+        (widget) => widget !== "Custom",
+      );
     }
 
     const getTotalNumberOfWidgets = () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -199,7 +199,10 @@ describe(
       agHelper.TypeText(entityExplorer._widgetSearchInput, "p");
       agHelper.AssertElementLength(entityExplorer._widgetCards, 2);
 
-      if (!Cypress.env("AIRGAPPED")) {
+      if (Cypress.env("AIRGAPPED")) {
+        agHelper.ClearNType(entityExplorer._widgetSearchInput, "cypress");
+        agHelper.AssertElementLength(entityExplorer._widgetCards, 0);
+      } else {
         agHelper.ClearNType(entityExplorer._widgetSearchInput, "cypress");
         agHelper.AssertElementLength(entityExplorer._widgetCards, 1);
         agHelper.AssertElementExist(".t--widget-card-draggable-customwidget");

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -6,7 +6,7 @@ import {
 
 describe(
   "Entity explorer tests related to widgets and validation",
-  { tags: ["@tag.IDE", "@tag.Widget", "@tag.excludeForAirgap"] },
+  { tags: ["@tag.IDE", "@tag.Widget"] },
   function () {
     // Taken from here appsmith/app/client/src/constants/WidgetConstants.tsx
     const WIDGET_TAGS: Record<string, string> = {
@@ -70,8 +70,16 @@ describe(
     };
 
     if (Cypress.env("AIRGAPPED")) {
-      // Remove map widget in case of airgap
+      // Remove map and custom widget in case of airgap
       WIDGETS_CATALOG.Content = ["Progress", "Rating", "Text"];
+      WIDGETS_CATALOG.Display = [
+        "Chart",
+        "Iframe",
+        "List",
+        "Map Chart",
+        "Stats Box",
+        "Table",
+      ];
     }
 
     const getTotalNumberOfWidgets = () => {
@@ -191,9 +199,11 @@ describe(
       agHelper.TypeText(entityExplorer._widgetSearchInput, "p");
       agHelper.AssertElementLength(entityExplorer._widgetCards, 2);
 
-      agHelper.ClearNType(entityExplorer._widgetSearchInput, "cypress");
-      agHelper.AssertElementLength(entityExplorer._widgetCards, 1);
-      agHelper.AssertElementExist(".t--widget-card-draggable-customwidget");
+      if (!Cypress.env("AIRGAPPED")) {
+        agHelper.ClearNType(entityExplorer._widgetSearchInput, "cypress");
+        agHelper.AssertElementLength(entityExplorer._widgetCards, 1);
+        agHelper.AssertElementExist(".t--widget-card-draggable-customwidget");
+      }
 
       agHelper.ClearTextField(entityExplorer._widgetSearchInput);
       // click to show all building blocks

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -6,7 +6,7 @@ import {
 
 describe(
   "Entity explorer tests related to widgets and validation",
-  { tags: ["@tag.IDE", "@tag.Widget"] },
+  { tags: ["@tag.IDE", "@tag.Widget", "@tag.excludeForAirgap"] },
   function () {
     // Taken from here appsmith/app/client/src/constants/WidgetConstants.tsx
     const WIDGET_TAGS: Record<string, string> = {


### PR DESCRIPTION
## Description
This [PR](https://github.com/appsmithorg/appsmith/pull/34540) removed custom widgets from Airgapped versions and this caused the widget sidebar tests to fail. This PR updated the required tests to account for this change.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9757281541>
> Commit: bd1e5ed15428623a92065d5ed2ea52b0b09a9db4
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9757281541&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
<!-- end of auto-generated comment: Cypress test results  -->




## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated widgets catalog to display different widgets based on the airgapped environment.
  - Adjusted widget search behavior to align with the airgapped environment, enhancing search accuracy and display.

- **Bug Fixes**
  - Fixed widget card display consistency when the `AIRGAPPED` environment variable is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->