### PR TITLE
chore: Don't include `new` in responses

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -4,6 +4,7 @@ import com.appsmith.external.helpers.Identifiable;
 import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Git;
 import com.appsmith.external.views.Views;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AccessLevel;
@@ -78,7 +79,7 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     protected Set<Policy> policies = new HashSet<>();
 
     @Override
-    @JsonView(Views.Public.class)
+    @JsonIgnore
     public boolean isNew() {
         return this.getId() == null;
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
@@ -28,6 +28,6 @@ public class CommonConfigTest {
         userData.setUserPermissions(null);
 
         String value = objectMapper.writeValueAsString(userData);
-        JSONAssert.assertEquals("{\"proficiency\":\"abcd\",\"role\":\"new_role\",\"new\":true}", value, true);
+        JSONAssert.assertEquals("{\"proficiency\":\"abcd\",\"role\":\"new_role\"}", value, true);
     }
 }


### PR DESCRIPTION
This field isn't used on client and so shouldn't be sent across.

/test sanity

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9756721589>
> Commit: ea117610d61253afe4e0ead3b80f9e21adc22235
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9756721589&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`

<!-- end of auto-generated comment: Cypress test results  -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data handling by modifying visibility annotations, enhancing security and data privacy.

- **Tests**
  - Updated tests to align with changes in data visibility, ensuring accurate validation of JSON responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->