### PR TITLE
chore: Revert "Add dynamic property path for sourceData in SelectWidget (#34574)"

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
@@ -9,7 +9,6 @@ const {
   agHelper,
   assertHelper,
   dataSources,
-  propPane,
 } = require("../../../../../support/Objects/ObjectsCore");
 const {
   default: EditorNavigation,
@@ -92,7 +91,6 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
 
     cy.get("@dsName").then((dsName) => {
       EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
-      propPane.ToggleJSMode("sourcedata", false);
 
       oneClickBinding.ChooseAndAssertForm(
         `${dsName}`,

--- a/app/client/src/widgets/SelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/SelectWidget/widget/index.tsx
@@ -93,15 +93,11 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
       labelPosition: LabelPosition.Top,
       labelAlignment: Alignment.LEFT,
       labelWidth: 5,
-      sourceData: JSON.stringify(
-        [
-          { name: "Blue", code: "BLUE" },
-          { name: "Green", code: "GREEN" },
-          { name: "Red", code: "RED" },
-        ],
-        null,
-        2,
-      ),
+      sourceData: [
+        { name: "Blue", code: "BLUE" },
+        { name: "Green", code: "GREEN" },
+        { name: "Red", code: "RED" },
+      ],
       optionLabel: "name",
       optionValue: "code",
       serverSideFiltering: false,
@@ -115,7 +111,6 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
       labelTextSize: "0.875rem",
       responsiveBehavior: ResponsiveBehavior.Fill,
       minWidth: FILL_WIDGET_MIN_WIDTH,
-      dynamicPropertyPathList: [{ key: "sourceData" }],
     };
   }
 


### PR DESCRIPTION
**/test binding**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9754334718>
> Commit: 2c67d23abd75ce763c6e8eac2b1d9582bccca875
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9754334718&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Binding`

<!-- end of auto-generated comment: Cypress test results  -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal handling of `sourceData` within the Select widget for better performance and maintainability.

- **Tests**
  - Updated test cases for the Select widget to reflect the new handling of `sourceData`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->