### PR TITLE
fix:several components have label display issues (#34433)

### DIFF
--- a/app/client/src/widgets/ButtonWidget/component/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/component/index.tsx
@@ -43,7 +43,7 @@ const RecaptchaWrapper = styled.div`
   }
 `;
 
-const ToolTipWrapper = styled.div`
+export const ToolTipWrapper = styled.div`
   height: 100%;
   && .bp3-popover2-target {
     height: 100%;
@@ -54,7 +54,7 @@ const ToolTipWrapper = styled.div`
   }
 `;
 
-const TooltipStyles = createGlobalStyle`
+export const TooltipStyles = createGlobalStyle`
   .btnTooltipContainer {
     .bp3-popover2-content {
       max-width: 350px;
@@ -482,7 +482,9 @@ function ButtonComponent(props: ButtonComponentProps & RecaptchaProps) {
         <TooltipStyles />
         <Popover2
           autoFocus={false}
-          content={<Interweave content={props.tooltip} />}
+          content={
+            <Interweave content={props.tooltip ? props.tooltip : props.text} />
+          }
           hoverOpenDelay={200}
           interactionKind="hover"
           portalClassName="btnTooltipContainer"

--- a/app/client/src/widgets/FilePickerWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/component/index.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import type { ComponentProps } from "widgets/BaseComponent";
-import { BaseButton } from "widgets/ButtonWidget/component";
+import {
+  BaseButton,
+  ToolTipWrapper,
+  TooltipStyles,
+} from "widgets/ButtonWidget/component";
 import { Colors } from "constants/Colors";
+import { Popover2 } from "@blueprintjs/popover2";
+import { Position } from "@blueprintjs/core";
 
 function FilePickerComponent(props: FilePickerComponentProps) {
   let computedLabel = props.label;
@@ -11,19 +17,30 @@ function FilePickerComponent(props: FilePickerComponentProps) {
   }
 
   return (
-    <BaseButton
-      borderRadius={props.borderRadius}
-      boxShadow={props.boxShadow}
-      buttonColor={props.buttonColor}
-      disabled={props.isDisabled}
-      loading={props.isLoading}
-      maxWidth={props.maxWidth}
-      minHeight={props.minHeight}
-      minWidth={props.minWidth}
-      onClick={props.openModal}
-      shouldFitContent={props.shouldFitContent}
-      text={computedLabel}
-    />
+    <ToolTipWrapper>
+      <TooltipStyles />
+      <Popover2
+        content={computedLabel}
+        hoverOpenDelay={200}
+        interactionKind="hover"
+        portalClassName="btnTooltipContainer"
+        position={Position.TOP}
+      >
+        <BaseButton
+          borderRadius={props.borderRadius}
+          boxShadow={props.boxShadow}
+          buttonColor={props.buttonColor}
+          disabled={props.isDisabled}
+          loading={props.isLoading}
+          maxWidth={props.maxWidth}
+          minHeight={props.minHeight}
+          minWidth={props.minWidth}
+          onClick={props.openModal}
+          shouldFitContent={props.shouldFitContent}
+          text={computedLabel}
+        />
+      </Popover2>
+    </ToolTipWrapper>
   );
 }
 export interface FilePickerComponentProps extends ComponentProps {

--- a/app/client/src/widgets/JSONFormWidget/component/Form.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/Form.tsx
@@ -4,17 +4,22 @@ import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { debounce, isEmpty } from "lodash";
 import { FormProvider, useForm } from "react-hook-form";
-import { Text } from "@blueprintjs/core";
+import { Position, Text } from "@blueprintjs/core";
 import { klona } from "klona";
 
 import useFixedFooter from "./useFixedFooter";
 import type { ButtonStyleProps } from "widgets/ButtonWidget/component";
-import { BaseButton as Button } from "widgets/ButtonWidget/component";
+import {
+  BaseButton as Button,
+  ToolTipWrapper,
+  TooltipStyles,
+} from "widgets/ButtonWidget/component";
 import { Colors } from "constants/Colors";
 import { FORM_PADDING_Y, FORM_PADDING_X } from "./styleConstants";
 import type { Schema } from "../constants";
 import { ROOT_SCHEMA_KEY } from "../constants";
 import { convertSchemaItemToFormData, schemaItemDefaultValue } from "../helper";
+import { Popover2 } from "@blueprintjs/popover2";
 
 export type FormProps<TValues = any> = PropsWithChildren<{
   backgroundColor?: string;
@@ -285,25 +290,47 @@ function Form<TValues = any>(
             ref={footerRef}
           >
             {showReset && (
-              <StyledResetButtonWrapper>
-                <Button
-                  {...resetButtonStyles}
-                  className="t--jsonform-reset-btn"
-                  onClick={(e) => onReset(schema, e)}
-                  text={resetButtonLabel}
-                  type="reset"
-                />
-              </StyledResetButtonWrapper>
+              <ToolTipWrapper>
+                <TooltipStyles />
+                <Popover2
+                  content={resetButtonLabel}
+                  hoverOpenDelay={200}
+                  interactionKind="hover"
+                  portalClassName="btnTooltipContainer"
+                  position={Position.TOP}
+                >
+                  <StyledResetButtonWrapper>
+                    <Button
+                      {...resetButtonStyles}
+                      className="t--jsonform-reset-btn"
+                      onClick={(e) => onReset(schema, e)}
+                      text={resetButtonLabel}
+                      type="reset"
+                    />
+                  </StyledResetButtonWrapper>
+                </Popover2>
+              </ToolTipWrapper>
             )}
-            <Button
-              {...submitButtonStyles}
-              className="t--jsonform-submit-btn"
-              disabled={disabledWhenInvalid && isFormInValid}
-              loading={isSubmitting}
-              onClick={onSubmit}
-              text={submitButtonLabel}
-              type="submit"
-            />
+            <ToolTipWrapper>
+              <TooltipStyles />
+              <Popover2
+                content={submitButtonLabel}
+                hoverOpenDelay={200}
+                interactionKind="hover"
+                portalClassName="btnTooltipContainer"
+                position={Position.TOP}
+              >
+                <Button
+                  {...submitButtonStyles}
+                  className="t--jsonform-submit-btn"
+                  disabled={disabledWhenInvalid && isFormInValid}
+                  loading={isSubmitting}
+                  onClick={onSubmit}
+                  text={submitButtonLabel}
+                  type="submit"
+                />
+              </Popover2>
+            </ToolTipWrapper>
           </StyledFormFooter>
         )}
       </StyledForm>

--- a/app/client/src/widgets/MenuButtonWidget/component/index.tsx
+++ b/app/client/src/widgets/MenuButtonWidget/component/index.tsx
@@ -7,6 +7,7 @@ import {
   Menu,
   MenuItem as BlueprintMenuItem,
   Classes as BlueprintClasses,
+  Position,
 } from "@blueprintjs/core";
 import { Classes, Popover2 } from "@blueprintjs/popover2";
 import type { IconName } from "@blueprintjs/icons";
@@ -34,6 +35,7 @@ import type {
   PopoverContentProps,
 } from "../constants";
 import type { ThemeProp } from "WidgetProvider/constants";
+import { ToolTipWrapper, TooltipStyles } from "widgets/ButtonWidget/component";
 
 const PopoverStyles = createGlobalStyle<{
   parentWidth: number;
@@ -325,30 +327,41 @@ function PopoverTargetButton(props: PopoverTargetButtonProps) {
   const isRightAlign = iconAlign === Alignment.RIGHT;
 
   return (
-    <DragContainer
-      buttonColor={buttonColor}
-      buttonVariant={buttonVariant}
-      disabled={isDisabled}
-      maxWidth={maxWidth}
-      minHeight={minHeight}
-      minWidth={minWidth}
-      renderMode={renderMode}
-      shouldFitContent={shouldFitContent}
-    >
-      <BaseButton
-        alignText={getAlignText(isRightAlign, iconName)}
-        borderRadius={borderRadius}
-        boxShadow={boxShadow}
-        buttonColor={buttonColor}
-        buttonVariant={buttonVariant}
-        disabled={isDisabled}
-        fill
-        icon={!isRightAlign && iconName ? iconName : null}
-        placement={placement}
-        rightIcon={isRightAlign && iconName ? iconName : null}
-        text={label}
-      />
-    </DragContainer>
+    <ToolTipWrapper>
+      <TooltipStyles />
+      <Popover2
+        content={label}
+        hoverOpenDelay={200}
+        interactionKind="hover"
+        portalClassName="btnTooltipContainer"
+        position={Position.TOP}
+      >
+        <DragContainer
+          buttonColor={buttonColor}
+          buttonVariant={buttonVariant}
+          disabled={isDisabled}
+          maxWidth={maxWidth}
+          minHeight={minHeight}
+          minWidth={minWidth}
+          renderMode={renderMode}
+          shouldFitContent={shouldFitContent}
+        >
+          <BaseButton
+            alignText={getAlignText(isRightAlign, iconName)}
+            borderRadius={borderRadius}
+            boxShadow={boxShadow}
+            buttonColor={buttonColor}
+            buttonVariant={buttonVariant}
+            disabled={isDisabled}
+            fill
+            icon={!isRightAlign && iconName ? iconName : null}
+            placement={placement}
+            rightIcon={isRightAlign && iconName ? iconName : null}
+            text={label}
+          />
+        </DragContainer>
+      </Popover2>
+    </ToolTipWrapper>
   );
 }
 


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`34433`  
_or_  
Fixes `https://github.com/appsmithorg/appsmith/issues/34433`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No

SCREENSHOTS AFTER FIXING THE ISSUE 
FilePicker widget
![Screenshot from 2024-06-28 15-55-26](https://github.com/zemoso-int/appsmith-from-the-business/assets/119922265/f50157c8-63bd-4896-935a-38cd6d7b0657)

JSONFORM Widget
![Screenshot from 2024-06-28 15-55-06](https://github.com/zemoso-int/appsmith-from-the-business/assets/119922265/11784f75-463f-4a42-afa4-0c457c0f7da0)
![Screenshot from 2024-06-28 15-55-04](https://github.com/zemoso-int/appsmith-from-the-business/assets/119922265/7bfb97c1-16f1-4d47-8061-f2450320a488)

MenuButton WIdget
![Screenshot from 2024-06-28 15-54-18](https://github.com/zemoso-int/appsmith-from-the-business/assets/119922265/56a19e94-9e56-4683-bc9f-2fe573f4859b)

ButtonWidget
![Screenshot from 2024-06-28 15-53-54](https://github.com/zemoso-int/appsmith-from-the-business/assets/119922265/480c3d97-358a-4560-83e6-93ecc9dfc673)

There were two other widgets, the MapChart and the Chart component, that had similar issues. However, due to the limitations of the tooltip for the title in ECharts, I wasn't able to implement a solution. I tried targeting it using CSS selectors, but it didn't accept the styles provided in that format. I hope the team can review this and suggest an alternative approach for these two widgets and even request you to review the other for the widgets for which I could solve issue and if the approach followed is correct or not   ,So that I can proceed with the cypress testing for this widgets .
Thank you 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
  - Enhanced the `FilePickerWidget` with tooltips for better user guidance.
  - Added tooltips to the `JSONFormWidget` reset and submit buttons for improved usability.
  - Introduced tooltips in the `MenuButtonWidget` for better interactivity.

- **Improvements**
  - Updated `ButtonWidget` to conditionally render tooltips based on user interaction.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->