### PR TITLE
fix: added backwards compatibility for older snowflake datasources

### DIFF
--- a/app/client/src/api/DatasourcesApi.ts
+++ b/app/client/src/api/DatasourcesApi.ts
@@ -178,6 +178,9 @@ class DatasourcesApi extends API {
       toastMessage: undefined,
       datasourceConfiguration: datasourceStorage.datasourceConfiguration && {
         ...datasourceStorage.datasourceConfiguration,
+        authentication: DatasourcesApi.cleanAuthenticationObject(
+          datasourceStorage.datasourceConfiguration.authentication,
+        ),
         connection: datasourceStorage.datasourceConfiguration.connection && {
           ...datasourceStorage.datasourceConfiguration.connection,
           ssl: {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DBAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DBAuth.java
@@ -26,6 +26,7 @@ public class DBAuth extends AuthenticationDTO {
         SCRAM_SHA_1,
         SCRAM_SHA_256,
         MONGODB_CR,
+        USERNAME_PASSWORD
     }
 
     @JsonView({Views.Public.class, FromRequest.class})

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DBAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DBAuth.java
@@ -26,8 +26,6 @@ public class DBAuth extends AuthenticationDTO {
         SCRAM_SHA_1,
         SCRAM_SHA_256,
         MONGODB_CR,
-        USERNAME_PASSWORD,
-        KEY_PAIR
     }
 
     @JsonView({Views.Public.class, FromRequest.class})

--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/java/com/external/plugins/SnowflakePlugin.java
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/java/com/external/plugins/SnowflakePlugin.java
@@ -204,13 +204,9 @@ public class SnowflakePlugin extends BasePlugin {
                 DatasourceConfiguration datasourceConfiguration, Properties properties) {
             // Only for username password auth, we need to set these properties, for others
             // like key-pair auth, authentication specific properties need to be set on config itself
-            // check for authenticationType == null is added to provide backwards compatibility
             AuthenticationDTO authentication = datasourceConfiguration.getAuthentication();
-            String authenticationType =
-                    datasourceConfiguration.getAuthentication().getAuthenticationType();
-            Boolean isDBAuth =
-                    (authenticationType != null && DB_AUTH.equals(authenticationType)) || authenticationType == null;
-            if (isDBAuth) {
+            String authenticationType = getAuthenticationType(authentication);
+            if (DB_AUTH.equals(authenticationType)) {
                 DBAuth dbAuth = (DBAuth) authentication;
                 properties.setProperty("user", dbAuth.getUsername());
                 properties.setProperty("password", dbAuth.getPassword());
@@ -288,7 +284,7 @@ public class SnowflakePlugin extends BasePlugin {
                 invalids.add(SnowflakeErrorMessages.DS_MISSING_AUTHENTICATION_DETAILS_ERROR_MSG);
             } else {
                 if (SNOWFLAKE_KEY_PAIR_AUTH.equals(
-                        datasourceConfiguration.getAuthentication().getAuthenticationType())) {
+                        getAuthenticationType(datasourceConfiguration.getAuthentication()))) {
                     KeyPairAuth authentication = (KeyPairAuth) datasourceConfiguration.getAuthentication();
                     if (StringUtils.isEmpty(authentication.getUsername())) {
                         invalids.add(SnowflakeErrorMessages.DS_MISSING_USERNAME_ERROR_MSG);
@@ -467,8 +463,7 @@ public class SnowflakePlugin extends BasePlugin {
             HikariConfig commonConfig = getCommonHikariConfig(properties);
             Mono<HikariConfig> configMono = Mono.empty();
 
-            String authenticationType =
-                    datasourceConfiguration.getAuthentication().getAuthenticationType();
+            String authenticationType = getAuthenticationType(datasourceConfiguration.getAuthentication());
             if (authenticationType != null) {
                 switch (authenticationType) {
                     case DB_AUTH:
@@ -480,10 +475,6 @@ public class SnowflakePlugin extends BasePlugin {
                     default:
                         break;
                 }
-            } else {
-                // Else cases added for older datasources, they would not have authenticationType in their config object
-                // As this is newly introduced
-                configMono = getBasicAuthConfig(commonConfig, datasourceConfiguration);
             }
             return configMono;
         }
@@ -571,6 +562,16 @@ public class SnowflakePlugin extends BasePlugin {
             StringBuilder urlBuilder =
                     new StringBuilder("jdbc:snowflake://" + dsConfig.getUrl() + ".snowflakecomputing.com?");
             return urlBuilder.toString();
+        }
+
+        private String getAuthenticationType(AuthenticationDTO authentication) {
+            String authenticationType = authentication.getAuthenticationType();
+            if (authenticationType == null) {
+                // This is required to provide backwards compatibility for older snowflake datasources
+                // Where authenticationType property is null, in that case it should default to DB_AUTH
+                authentication.setAuthenticationType(DB_AUTH);
+            }
+            return authentication.getAuthenticationType();
         }
     }
 }

--- a/app/server/appsmith-plugins/snowflakePlugin/src/test/java/com/external/plugins/SnowflakePluginTest.java
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/test/java/com/external/plugins/SnowflakePluginTest.java
@@ -102,7 +102,6 @@ public class SnowflakePluginTest {
         DBAuth auth = new DBAuth();
         auth.setUsername("test");
         auth.setPassword("test");
-        auth.setAuthenticationType("dbAuth");
         datasourceConfiguration.setAuthentication(auth);
         List<Property> properties = new ArrayList<>();
         properties.add(new Property("warehouse", "warehouse"));


### PR DESCRIPTION
## Description
This PR adds backwards compatibility for older snowflake datasources so that we wont need migration. 

With new updates on snowflake plugin for key pair authentication, we have introduced a new field in authentication object called authenticationType, this field is responsible for telling us whether it's a basic authentication or key pair authentication. For older datasources, this field wont be there, so in order to ensure that those datasource continue to work smoothly, we have added a fallback mechanism, where if any datasource does not have authentication field, it will be considered as basic auth and we will set its properties accordingly. This PR adds that support


### Steps to test:
1. Create a snowflake datasource along with queries on app.appsmith.com
2. Attach these queries to table widget so they run on page load
3. Export this app and get json
4. Import this json on the DP of this PR, the queries should work


Fixes #34627
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9759249212>
> Commit: f68972710918b450d989c1d28a9286a397fc08bd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9759249212&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
<!-- end of auto-generated comment: Cypress test results  -->



## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced backward compatibility for Snowflake plugins by handling cases where `authenticationType` is not present in older datasources.

- **New Features**
  - Improved datasource configuration by cleaning the authentication object in the `DatasourcesApi`.

- **Refactor**
  - Simplified authentication type handling by removing unused `USERNAME_PASSWORD` and `KEY_PAIR` enums in `DBAuth`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->