### PR TITLE
chore: Remove unused ACL fields on `User` entity

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
@@ -69,18 +69,6 @@ public class User extends BaseDomain implements UserDetails, OidcUser {
     @JsonView(Views.Public.class)
     private String examplesWorkspaceId;
 
-    // There is a many-to-many relationship with groups. If this value is modified, please also modify the list of
-    // users in that particular group document as well.
-    @JsonView(Views.Public.class)
-    private Set<String> groupIds = new HashSet<>();
-
-    // These permissions are in addition to the privileges provided by the groupIds. We can assign individual
-    // permissions
-    // to users instead of creating a group for them. To be used only for one-off permissions.
-    // During evaluation a union of the group permissions and user-specific permissions will take effect.
-    @JsonView(Views.Public.class)
-    private Set<String> permissions = new HashSet<>();
-
     // This field is used when a user is invited to appsmith. This inviteToken is used to confirm the identity in verify
     // token flow.
     @JsonView(Views.Internal.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
@@ -20,7 +20,6 @@ import org.springframework.util.StringUtils;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -92,10 +92,8 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
             }
             usagePulse.setUser(hashedEmail);
             updateUser.setLastActiveAt(Instant.now());
-            // Avoid updating the ACL fields
-            updateUser.setGroupIds(null);
+            // Avoid updating policies
             updateUser.setPolicies(null);
-            updateUser.setPermissions(null);
 
             return userService.updateWithoutPermission(user.getId(), updateUser).then(save(usagePulse));
         });


### PR DESCRIPTION
/test sanity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified user data structure by removing unused `groupIds` and `permissions` fields, improving efficiency in user-group relationships and permissions handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9759459682>
> Commit: 9d42126d64430423543800fd4b9837f0c92aa614
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9759459682&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
<!-- end of auto-generated comment: Cypress test results  -->
