### PR TITLE
chore: add notification prop to js object

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
@@ -322,6 +322,10 @@ const StyledTabPanel = styled(TabPanel)`
   padding: 0 var(--ads-v2-spaces-7);
 `;
 
+const StyledNotificationWrapper = styled.div`
+  padding-top: var(--ads-v2-spaces-5);
+`;
+
 function ImportedKeyValue(props: {
   datas: { key: string; value: string; isInvalid?: boolean }[];
   keyValueName: string;
@@ -608,7 +612,11 @@ function CommonEditorForm(props: CommonFormPropsWithExtraParams) {
               </Button>
             </ActionButtons>
           </FormRow>
-          {notification}
+          {notification && (
+            <StyledNotificationWrapper>
+              {notification}
+            </StyledNotificationWrapper>
+          )}
           <FormRow className="api-info-row">
             <div>
               {/* eslint-disable-next-line */}

--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -81,6 +81,7 @@ interface JSFormProps {
   backLink?: React.ReactNode;
   hideContextMenuOnEditor?: boolean;
   hideEditIconOnEditor?: boolean;
+  notification?: React.ReactNode;
 }
 
 type Props = JSFormProps;
@@ -105,12 +106,18 @@ const SecondaryWrapper = styled.div`
   }
 `;
 
+const StyledNotificationWrapper = styled.div`
+  padding: 0 var(--ads-v2-spaces-7) var(--ads-v2-spaces-3)
+    var(--ads-v2-spaces-7);
+`;
+
 function JSEditorForm({
   backLink,
   contextMenu,
   hideContextMenuOnEditor = false,
   hideEditIconOnEditor = false,
   jsCollectionData,
+  notification,
   onUpdateSettings,
   saveJSObjectName,
   showSettings = true,
@@ -356,6 +363,11 @@ function JSEditorForm({
               />
             </ActionButtons>
           </StyledFormRow>
+          {notification && (
+            <StyledNotificationWrapper>
+              {notification}
+            </StyledNotificationWrapper>
+          )}
           <Wrapper>
             <div className="flex flex-1">
               <SecondaryWrapper>

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -139,6 +139,11 @@ export const SegmentedControlContainer = styled.div`
   overflow-x: scroll;
 `;
 
+const StyledNotificationWrapper = styled.div`
+  padding: 0 var(--ads-v2-spaces-7) var(--ads-v2-spaces-3)
+    var(--ads-v2-spaces-7);
+`;
+
 interface QueryFormProps {
   onDeleteClick: () => void;
   onRunClick: () => void;
@@ -307,7 +312,9 @@ export function EditorJSONtoForm(props: Props) {
           onRunClick={onRunClick}
           plugin={plugin}
         />
-        {notification}
+        {notification && (
+          <StyledNotificationWrapper>{notification}</StyledNotificationWrapper>
+        )}
         <Wrapper>
           <div className="flex flex-1 w-full">
             <SecondaryWrapper>


### PR DESCRIPTION
## Description
The PR adds a new prop to be passed to the JSObject editor to show a banner or notification. This also adds uniform styling to the other editors

PR for https://github.com/appsmithorg/appsmith-ee/pull/4485

## Automation

/ok-to-test tags="@tag.Datasource, @tag.IDE, @tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9759655417>
> Commit: 8bc7746531e2ad1f4c84d81cc3092a3042b55a95
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9759655417&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.IDE, @tag.JS`
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced styled notification components across various editor forms to enhance user alerts and notifications.
	
- **UI Enhancements**
	- Improved the visual presentation of notifications within the Editor by wrapping them in a new styled notification wrapper.

- **Bug Fixes**
	- Ensured that notifications are conditionally displayed, improving the clarity and user experience in the Editor forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->