### PR TITLE
chore: Remove `updateAndReturn` and start to rely on `updateById`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/AppsmithRepository.java
@@ -23,8 +23,6 @@ public interface AppsmithRepository<T extends BaseDomain> {
 
     Mono<T> setUserPermissionsInObject(T obj);
 
-    Mono<T> updateAndReturn(String id, BridgeUpdate updateObj, AclPermission permission);
-
     /**
      * This method uses the mongodb bulk operation to save a list of new actions. When calling this method, please note
      * the following points:

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -20,7 +20,6 @@ import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.data.annotation.Transient;
-import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -478,36 +477,6 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
     protected Mono<Set<String>> getAnonymousUserPermissionGroups() {
         return cacheableRepositoryHelper.getPermissionGroupsOfAnonymousUser();
-    }
-
-    /**
-     * Updates a document in the database that matches the provided query and returns the modified document.
-     * This method performs a find-and-modify operation internally to atomically update a document in the database.
-     *
-     * @param id The unique identifier of the document to be updated.
-     * @param updateObj The update object specifying the modifications to be applied to the document.
-     * @param permission An optional permission parameter for access control.
-     * @return A Mono emitting the updated document after modification.
-     *
-     * @implNote
-     * The `findAndModify` method operates at the database level and does not automatically handle encryption or decryption of fields. If the document contains encrypted fields, it is the responsibility of the caller to handle encryption and decryption both before and after using this method.
-     *
-     * @see FindAndModifyOptions
-     */
-    public Mono<T> updateAndReturn(String id, BridgeUpdate updateObj, AclPermission permission) {
-        Query query = new Query(Criteria.where("id").is(id));
-
-        FindAndModifyOptions findAndModifyOptions =
-                FindAndModifyOptions.options().returnNew(Boolean.TRUE);
-
-        if (permission == null) {
-            return mongoOperations.findAndModify(query, updateObj, findAndModifyOptions, this.genericDomain);
-        }
-
-        return getCurrentUserPermissionGroupsIfRequired(permission, true).flatMap(permissionGroups -> {
-            query.addCriteria(new Criteria().andOperator(notDeleted(), userAcl(permissionGroups, permission)));
-            return mongoOperations.findAndModify(query, updateObj, findAndModifyOptions, this.genericDomain);
-        });
     }
 
     public Mono<Void> bulkInsert(List<T> domainList) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/TenantServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/TenantServiceCETest.java
@@ -9,7 +9,6 @@ import com.appsmith.server.domains.TenantConfiguration;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.FeatureFlagMigrationHelper;
 import com.appsmith.server.helpers.UserUtils;
-import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.appsmith.server.repositories.TenantRepository;
 import com.appsmith.server.repositories.UserRepository;
@@ -88,9 +87,9 @@ class TenantServiceCETest {
         assert tenant != null;
         originalTenantConfiguration = tenant.getTenantConfiguration();
 
-        tenantRepository
-                .updateAndReturn(tenant.getId(), Bridge.update().set(Tenant.Fields.tenantConfiguration, null), null)
-                .block();
+        Tenant update = new Tenant();
+        update.setTenantConfiguration(null);
+        tenantRepository.updateById(tenant.getId(), update, null).block();
 
         // Make api_user super-user to test tenant admin functionality
         // Todo change this to tenant admin once we introduce multitenancy


### PR DESCRIPTION
## Description
PR to remove `updateAndReturn` and instead start relying on `updateById` repository method. Both of these method is doing the similar op, hence the cleanup. Also on pg branch `updateAndReturn` needs to be fixed if we want to keep supporting both the methods hence the cleanup approach is taken.  

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced `updateAndReturn` method with `updateById` for updating tenant configuration.

- **Bug Fixes**
  - Improved the way tenant configurations are updated to enhance reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->