### PR TITLE
Revert "chore: Don't include `new` in responses (#34617)"

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -4,7 +4,6 @@ import com.appsmith.external.helpers.Identifiable;
 import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Git;
 import com.appsmith.external.views.Views;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.AccessLevel;
@@ -79,7 +78,7 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     protected Set<Policy> policies = new HashSet<>();
 
     @Override
-    @JsonIgnore
+    @JsonView(Views.Public.class)
     public boolean isNew() {
         return this.getId() == null;
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
@@ -28,6 +28,6 @@ public class CommonConfigTest {
         userData.setUserPermissions(null);
 
         String value = objectMapper.writeValueAsString(userData);
-        JSONAssert.assertEquals("{\"proficiency\":\"abcd\",\"role\":\"new_role\"}", value, true);
+        JSONAssert.assertEquals("{\"proficiency\":\"abcd\",\"role\":\"new_role\",\"new\":true}", value, true);
     }
 }


### PR DESCRIPTION
**/test ImportExport git**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9761964432>
> Commit: 44fd1e67988bee13cbb8a3353825f04304daaf93
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9761964432&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.ImportExport, @tag.Git
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Git/GitSync/GitSyncedApps_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
<!-- end of auto-generated comment: Cypress test results  -->
