### PR TITLE
fix: adding encrypted icon to passphrase and updated label

### DIFF
--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/form.json
@@ -124,10 +124,11 @@
           }
         },
         {
-          "label": "Private key passphrase",
+          "label": "Passphrase",
           "configProperty": "datasourceConfiguration.authentication.passphrase",
           "controlType": "INPUT_TEXT",
           "placeholderText": "private key passphrase",
+          "encrypted": true,
           "hidden": {
             "conditionType": "OR",
             "conditions": [

--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/form.json
@@ -126,8 +126,9 @@
         {
           "label": "Passphrase",
           "configProperty": "datasourceConfiguration.authentication.passphrase",
+          "dataType": "PASSWORD",
           "controlType": "INPUT_TEXT",
-          "placeholderText": "private key passphrase",
+          "placeholderText": "Private key passphrase",
           "encrypted": true,
           "hidden": {
             "conditionType": "OR",


### PR DESCRIPTION
## Description
This PR addresses the issues related to passphrase key for snowflake datasource in case the authentication type is key pair :
- The label has been changed from `Private key passphrase` to `Passphrase`
- The passphrase label shows that the value is encrypted as well.


Fixes #34647 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9773928050>
> Commit: ce95381ec803a07d06b8c4cc2183387cf7a8f31a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9773928050&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Renamed the label "Private key passphrase" to "Passphrase" for better clarity.
	- Enhanced security by adding encryption for passphrase input in form configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->