### PR TITLE
fix: update widget sidebar for airgapped environment

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -71,15 +71,12 @@ describe(
 
     if (Cypress.env("AIRGAPPED")) {
       // Remove map and custom widget in case of airgap
-      WIDGETS_CATALOG.Content = ["Progress", "Rating", "Text"];
-      WIDGETS_CATALOG.Display = [
-        "Chart",
-        "Iframe",
-        "List",
-        "Map Chart",
-        "Stats Box",
-        "Table",
-      ];
+      WIDGETS_CATALOG.Content = WIDGETS_CATALOG.Content.filter(
+        (widget) => widget !== "Map",
+      );
+      WIDGETS_CATALOG.Display = WIDGETS_CATALOG.Display.filter(
+        (widget) => widget !== "Custom",
+      );
     }
 
     const getTotalNumberOfWidgets = () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -71,12 +71,15 @@ describe(
 
     if (Cypress.env("AIRGAPPED")) {
       // Remove map and custom widget in case of airgap
-      WIDGETS_CATALOG.Content = WIDGETS_CATALOG.Display.filter(
-        (widget) => widget !== "Map",
-      );
-      WIDGETS_CATALOG.Display = WIDGETS_CATALOG.Display.filter(
-        (widget) => widget !== "Custom",
-      );
+      WIDGETS_CATALOG.Content = ["Progress", "Rating", "Text"];
+      WIDGETS_CATALOG.Display = [
+        "Chart",
+        "Iframe",
+        "List",
+        "Map Chart",
+        "Stats Box",
+        "Table",
+      ];
     }
 
     const getTotalNumberOfWidgets = () => {


### PR DESCRIPTION
## Description
The widget sidebar has been updated to display a different set of widgets when running in an airgapped environment. This change ensures that the widget sidebar remains consistent and functional in both regular and airgapped environments.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9773967679>
> Commit: a10dfa6e1b45371f972f38a13155826363329fa5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9773967679&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved widget handling in airgapped environments by applying a direct filter to the widget catalog instead of filtering out specific widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->