### PR TITLE
fix: commit icon of github on airgapped, the app crashes. #33812

### DIFF
--- a/app/client/src/pages/Editor/gitSync/components/ReconnectSSHError.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/ReconnectSSHError.tsx
@@ -56,7 +56,7 @@ function ReconnectSSHError() {
 
   if (
     errorData &&
-    errorData.response.responseMeta.error.code === "AE-GIT-4044"
+    errorData?.response?.responseMeta?.error?.code === "AE-GIT-4044"
   ) {
     return (
       <StyledCallout


### PR DESCRIPTION
Screenshot after Solving the app crash.
![image](https://github.com/appsmithorg/appsmith/assets/165656044/5c6f3c9a-4fc6-4404-aa99-2a87293b2963)

**Bug Fixes:**
Page crashes happened because of null pointer exception from front-end code, fixed that one.

Fixes : #33812 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the `ReconnectSSHError` component to prevent crashes due to undefined nested properties using optional chaining.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->