### PR TITLE
chore: added snapshots to artifacts

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -396,6 +396,14 @@ jobs:
           path: ~/results
           overwrite: true
 
+      - name: Upload cypress snapshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots-${{github.run_attempt}}
+          path: ${{ github.workspace }}/app/client/cypress/snapshots
+          overwrite: true
+
       # Set status = failedtest
       - name: Set fail if there are test failures
         if: failure()


### PR DESCRIPTION
## Description
Snapshots are added to understand why snapshot comparing tests have been failing on CI.
Conversation link - https://theappsmith.slack.com/archives/C0134BAVDB4/p1719481924157319

Tried here- https://github.com/appsmithorg/appsmith/actions/runs/9776708332


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9777496574>
> Commit: 23e22d0a71afe415e76d19115c59629c539332f0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9777496574&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to upload Cypress snapshots in case of test failures, improving debugging capabilities for test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->