### PR TITLE
chore: added one more step for limited-tests to contributor guidelines

### DIFF
--- a/contributions/CodeContributionsGuidelines.md
+++ b/contributions/CodeContributionsGuidelines.md
@@ -24,12 +24,13 @@ We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so
 1. Fork the repo and create a new branch from the `release` branch.
 2. Branches are named as `fix/fix-name` or `feature/feature-name`
 3. Please add tests for your changes. Client-side changes require Cypress/Jest tests while server-side changes require JUnit tests.
-4. Once you are confident in your code changes, create a pull request in your fork to the release branch in the appsmithorg/appsmith base repository.
-5. If you've changed any APIs, please call this out in the pull request and ensure backward compatibility.
-6. Link the issue of the base repository in your Pull request description. [Guide](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-7. When you raise a pull request, tag the maintainer you are collaborating with to start the build process.
-8. If changes are requested, work on them, commit them back, and tag the reviewer again. 
-9. Once all changes have been approved by the reviewer and the CI has run successfully, your PR will be merged into the base branch. Congratulations! 
+4. If you are adding new cypress tests, add test path to `limited-tests.txt`
+5. Once you are confident in your code changes, create a pull request in your fork to the release branch in the appsmithorg/appsmith base repository.
+6. If you've changed any APIs, please call this out in the pull request and ensure backward compatibility.
+7. Link the issue of the base repository in your Pull request description. [Guide](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
+8. When you raise a pull request, tag the maintainer you are collaborating with to start the build process.
+9. If changes are requested, work on them, commit them back, and tag the reviewer again. 
+10. Once all changes have been approved by the reviewer and the CI has run successfully, your PR will be merged into the base branch. Congratulations! 
 
 ### 🏡 Setup for local development
 


### PR DESCRIPTION
## Description

 As we are have been seeing contributors are adding new cypress tests we want to execute it using `ci-test-limit`. We need to always make a change to limited-tests file to run new test now we will trigger `ci-test-limit` directly to save efforts. 
 
 Fyi: we need to revert `limited-tests.txt` after everything looks good on PR. this step to reduce one step effort from our side


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9804245011>
> Commit: 8384096f415124619b17aac586b4a98ccd3717a5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9804245011&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> <hr>Fri, 05 Jul 2024 07:03:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
