### PR TITLE
fix: Update SelfReferenceRule to show entity's other property completion

### DIFF
--- a/app/client/src/utils/autocomplete/AutocompleteSortRules.ts
+++ b/app/client/src/utils/autocomplete/AutocompleteSortRules.ts
@@ -147,11 +147,11 @@ class NoSelfReferenceRule implements AutocompleteRule {
   static threshold = -Infinity;
   computeScore(completion: Completion<TernCompletionResult>): number {
     let score = 0;
-    const entityName = AutocompleteSorter.currentFieldInfo.entityName;
+    const { entityName, propertyPath } = AutocompleteSorter.currentFieldInfo;
     if (!entityName) return score;
     if (
       completion.text === entityName ||
-      completion.text.startsWith(`${entityName}.`)
+      completion.text === [entityName, propertyPath].join(".")
     )
       score = NoSelfReferenceRule.threshold;
     return score;

--- a/app/client/src/utils/autocomplete/__tests__/AutocompleteSortRules.test.ts
+++ b/app/client/src/utils/autocomplete/__tests__/AutocompleteSortRules.test.ts
@@ -187,4 +187,169 @@ describe("Autocomplete Ranking", () => {
       expect.arrayContaining(["showAlert(), APIQuery.clear(), APIQuery.run()"]),
     );
   });
+  it("Blocks self reference of entity", () => {
+    const completions: unknown[] = [
+      {
+        text: "appsmith",
+        displayText: "appsmith",
+        className:
+          "CodeMirror-Tern-completion CodeMirror-Tern-completion-object",
+        data: {
+          name: "appsmith",
+          type: "appsmith",
+          origin: "DATA_TREE",
+        },
+        origin: "DATA_TREE",
+        type: "OBJECT",
+        isHeader: false,
+      },
+      {
+        text: "Table1",
+        displayText: "Table1",
+        className:
+          "CodeMirror-Tern-completion CodeMirror-Tern-completion-object",
+        data: {
+          name: "Table1",
+          type: "Table1",
+          doc: "Table widget",
+          url: "https://docs.appsmith.com/reference/appsmith-framework/query-object",
+          origin: "DATA_TREE",
+        },
+        origin: "DATA_TREE",
+        type: "OBJECT",
+        isHeader: false,
+      },
+      {
+        text: "Table2.updatedRows",
+        displayText: "Table2.updatedRows",
+        className:
+          "CodeMirror-Tern-completion CodeMirror-Tern-completion-array",
+        data: {
+          name: "Table2.updatedRows",
+          type: "[?]",
+          origin: "DATA_TREE",
+        },
+        origin: "DATA_TREE",
+        type: "ARRAY",
+        isHeader: false,
+        recencyWeight: 2,
+        isEntityName: false,
+      },
+      {
+        text: "Table2.updatedRowIndices",
+        displayText: "Table2.updatedRowIndices",
+        className:
+          "CodeMirror-Tern-completion CodeMirror-Tern-completion-array",
+        data: {
+          name: "Table2.updatedRowIndices",
+          type: "[?]",
+          origin: "DATA_TREE",
+        },
+        origin: "DATA_TREE",
+        type: "ARRAY",
+        isHeader: false,
+        recencyWeight: 2,
+        isEntityName: false,
+      },
+      {
+        text: "Table2.updatedRow",
+        displayText: "Table2.updatedRow",
+        className:
+          "CodeMirror-Tern-completion CodeMirror-Tern-completion-object",
+        data: {
+          name: "Table2.updatedRow",
+          type: "Table2.updatedRow",
+          origin: "DATA_TREE",
+        },
+        origin: "DATA_TREE",
+        type: "OBJECT",
+        isHeader: false,
+        recencyWeight: 2,
+        isEntityName: false,
+      },
+      {
+        text: "Table2.tableData",
+        displayText: "Table2.tableData",
+        className:
+          "CodeMirror-Tern-completion CodeMirror-Tern-completion-array",
+        data: {
+          name: "Table2.tableData",
+          type: "[?]",
+          origin: "DATA_TREE",
+        },
+        origin: "DATA_TREE",
+        type: "ARRAY",
+        isHeader: false,
+        recencyWeight: 2,
+        isEntityName: false,
+      },
+    ];
+    const currentFieldInfo: unknown = {
+      expectedType: "ARRAY",
+      example: '[{ "name": "John" }]',
+      mode: "text-js",
+      entityName: "Table2",
+      entityType: "WIDGET",
+      entityId: "xy1ezsr0l5",
+      widgetType: "TABLE_WIDGET_V2",
+      propertyPath: "tableData",
+      token: {
+        start: 2,
+        end: 4,
+        string: "Ta",
+        type: "variable",
+        state: {
+          outer: true,
+          innerActive: {
+            open: "{{",
+            close: "}}",
+            delimStyle: "binding-brackets",
+            mode: {
+              electricInput: {},
+              blockCommentStart: null,
+              blockCommentEnd: null,
+              blockCommentContinue: null,
+              lineComment: null,
+              fold: "brace",
+              closeBrackets: "()[]{}''\"\"``",
+              helperType: "json",
+              jsonMode: true,
+              name: "javascript",
+            },
+          },
+          inner: {
+            lastType: "variable",
+            cc: [null],
+            lexical: {
+              indented: -2,
+              column: 0,
+              type: "block",
+              align: false,
+            },
+            indented: 0,
+          },
+          startingInner: false,
+        },
+      },
+    };
+    const entityInfo: DataTreeDefEntityInformation = {
+      type: ENTITY_TYPE.WIDGET,
+      subType: "TABLE_WIDGET_V2",
+    };
+    const sortedCompletionsText = AutocompleteSorter.sort(
+      completions as Completion<TernCompletionResult>[],
+      currentFieldInfo as FieldEntityInformation,
+      entityInfo,
+      true,
+    )
+      .filter((c) => !c.isHeader)
+      .map((c) => c.displayText);
+    expect(sortedCompletionsText).toEqual([
+      "Table2.updatedRowIndices",
+      "Table2.updatedRows",
+      "Table2.updatedRow",
+      "appsmith",
+      "Table1",
+    ]);
+  });
 });

--- a/app/client/src/utils/autocomplete/__tests__/TernServer.test.ts
+++ b/app/client/src/utils/autocomplete/__tests__/TernServer.test.ts
@@ -414,6 +414,7 @@ describe("Tern server sorting", () => {
       entityName: "sameEntity",
       entityType: ENTITY_TYPE.WIDGET,
       expectedType: AutocompleteDataType.STRING,
+      propertyPath: "tableData",
     };
     //completion that matches type and is present in dataTree.
     const scoredCompletion1 = new ScoredCompletion(


### PR DESCRIPTION
## Description

Update the selfReference autocomplete rule to show completion for the entity's other property when writing JS in one of its property.

Fixes https://github.com/appsmithorg/appsmith/issues/34684

## Automation

/test js

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9780079455>
> Commit: 03eb92fdda61a917829be20fb6f5d99562f162f3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9780079455&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of autocomplete suggestions by refining self-reference detection logic.

- **Tests**
  - Added new test cases to verify proper blocking of self-referencing completions.
  - Updated existing tests to include `propertyPath` in entity sorting validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->