### PR TITLE
fix: Ensured no errors pops up when a space is given infront of export default

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/JSObject/JSObject_Editor_spec2.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/JSObject/JSObject_Editor_spec2.js
@@ -1,0 +1,26 @@
+import { jsEditor } from "../../../../support/Objects/ObjectsCore";
+
+describe("JS Editor cypress test case", { tags: ["@tag.JS"] }, () => {
+  it("1. Bug : should accept spaces before export default", () => {
+    jsEditor.CreateJSObject(
+      `  export default {
+  myFun1: () => {
+    function hi(a,b) {
+      console.log(a,b);
+    }
+    hi(1,2);
+  },
+  myFun2: async () => {
+    //use async-await or promises
+  }
+}`,
+      {
+        completeReplace: true,
+        toRun: false,
+        prettify: false,
+      },
+    );
+
+    jsEditor.AssertSelectedFunction("myFun1");
+  });
+});

--- a/app/client/src/workers/Evaluation/JSObject/index.ts
+++ b/app/client/src/workers/Evaluation/JSObject/index.ts
@@ -63,7 +63,7 @@ export const getUpdatedLocalUnEvalTreeAfterJSUpdates = (
   return localUnEvalTree;
 };
 
-export const validJSBodyRegex = new RegExp(/^export default[\s]*?({[\s\S]*?})/);
+export const validJSBodyRegex = new RegExp(/^\s*export default[\s]*?({[\s\S]*?})/);
 
 /**
  * Here we parse the JSObject and then determine


### PR DESCRIPTION
## Description
> Currently, when creating a JS object, adding a space before export default {} throws an error. This behavior restricts developers from formatting their code according to their preferences. Allowing spaces before export default {} will enable more flexible and readable code formatting.
## Fixes: [[Bug]: Allow space before 'export default{}' #33984](https://github.com/appsmithorg/appsmith/issues/33984)

## Cypress video:
https://github.com/zemoso-int/appsmith-from-the-business/assets/136346053/e7fda5dc-6f8e-43a6-9a74-86190b3af33c


## Screenshots:
### Before resolving bug:
![Screenshot from 2024-07-01 08-57-49](https://github.com/zemoso-int/appsmith-from-the-business/assets/136346053/212feb41-4491-4c93-bb35-7bcbb51d2851)

### After resolving bug:
![Screenshot from 2024-07-02 10-49-57](https://github.com/zemoso-int/appsmith-from-the-business/assets/136346053/41982ac0-aa77-42e2-b299-e46d8544a77d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JavaScript editor to accept leading spaces before the `export default` statement, enhancing code flexibility and reducing errors.

- **Tests**
  - Added a new Cypress test to verify the functionality of the JavaScript editor with the updated regex pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the regular expression pattern in `index.ts` to allow spaces before `export default` statements.
- This change enables more flexible and readable code formatting by not throwing errors when spaces are present before `export default`.
