### PR TITLE
fix:allow users to identify search is enabled in country dropdown

### DIFF
--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -32,6 +32,9 @@ const ErrorMessage = styled.div`
 class DropDownControl extends BaseControl<DropDownControlProps> {
   containerRef = React.createRef<HTMLDivElement>();
 
+  state = {
+    previousValue: this.props.propertyValue,
+  };
   componentDidMount() {
     this.containerRef.current?.addEventListener(
       DS_EVENT,
@@ -55,6 +58,24 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
         key: e.detail.meta.key,
       });
       e.stopPropagation();
+    }
+  };
+
+  handleOnClick = () => {
+    this.updateProperty(this.props.propertyName, "");
+  };
+
+  handleFocus = () => {
+    this.setState({ previousValue: this.props.propertyValue });
+    if (this.containerRef?.current) {
+      const activeElement = document.activeElement as HTMLElement;
+      activeElement.style.caretColor = "transparent";
+    }
+  };
+
+  handleBlur = () => {
+    if (!this.props.propertyValue) {
+      this.updateProperty(this.props.propertyName, this.state.previousValue);
     }
   };
 
@@ -123,6 +144,9 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
           isMultiSelect={this.props.isMultiSelect}
           isValid={!errors.length}
           onDeselect={this.onDeselect}
+          onFocus={this.handleFocus}
+          onClick={this.handleOnClick}
+          onBlur={this.handleBlur}
           onSelect={this.onSelect}
           optionFilterProp="label"
           optionLabelProp={this.props.hideSubText ? "label" : "children"}
@@ -201,6 +225,7 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
         selectedValue = value;
       }
       this.updateProperty(this.props.propertyName, selectedValue);
+      this.setState({ previousValue: selectedValue });
     }
   };
 


### PR DESCRIPTION
### Bug : [Country dropdown bug](https://github.com/appsmithorg/appsmith/issues/34074)



I have raised this PR `In-order to allow user to know that , they can search for countries in the country dropdown in CurrencyInputWidget and PhoneInputWidget`

### Screenshots
 #### a small cursor is blinking before the selected value
![image](https://github.com/zemoso-int/appsmith-from-the-business/assets/122865888/ba9708f8-9045-4b07-bc3f-35d45b0c580a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dropdown component with improved state management and interaction handling for a more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->