### PR TITLE
test: Add missing `.block()` on reactive calls

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/ce/RefactoringServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/ce/RefactoringServiceCETest.java
@@ -156,7 +156,7 @@ class RefactoringServiceCETest {
 
     @BeforeEach
     public void setup() {
-        newPageService.deleteAll();
+        newPageService.deleteAll().block();
         User currentUser = sessionUserService.getCurrentUser().block();
         Workspace toCreate = new Workspace();
         toCreate.setName("LayoutActionServiceTest");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/ce/RefactoringServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/refactors/ce/RefactoringServiceTest.java
@@ -135,7 +135,7 @@ public class RefactoringServiceTest {
 
     @BeforeEach
     public void setup() {
-        newPageService.deleteAll();
+        newPageService.deleteAll().block();
         User apiUser = userService.findByEmail("api_user").block();
         Workspace toCreate = new Workspace();
         toCreate.setName("LayoutActionServiceTest");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -162,7 +162,7 @@ public class LayoutActionServiceTest {
 
     @BeforeEach
     public void setup() {
-        newPageService.deleteAll();
+        newPageService.deleteAll().block();
         User apiUser = userService.findByEmail("api_user").block();
         Workspace toCreate = new Workspace();
         toCreate.setName("LayoutActionServiceTest");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -1239,6 +1239,6 @@ public class PageServiceTest {
 
     @AfterEach
     public void purgeAllPages() {
-        newPageService.deleteAll();
+        newPageService.deleteAll().block();
     }
 }


### PR DESCRIPTION
**/test sanity**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved consistency and reliability of test setups by ensuring asynchronous operations complete before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->