### PR TITLE
fix: add regex check on phone number change

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInput_Part2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInput_Part2_spec.ts
@@ -292,6 +292,9 @@ describe(
 
       agHelper.ClearNType(locators._input, "100");
       agHelper.ValidateToastMessage("Value Changed");
+      agHelper.WaitUntilToastDisappear("Value Changed");
+      agHelper.ClearNType(locators._input, "a");
+      cy.get(locators._toastMsg).should("not.exist");
 
       // onFocus
       propPane.SelectPlatformFunction("onFocus", "Show alert");

--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -423,6 +423,18 @@ class PhoneInputWidget extends BaseInputWidget<
       },
     });
 
+    // This regular expression validates that the input:
+    // - Does not start with a whitespace character
+    // - Contains only digits, spaces, parentheses, plus, and minus symbols
+    if (/^(?!\s)[\d\s()+-]*$/.test(value)) {
+      this.props.updateWidgetMetaProperty("text", formattedValue, {
+        triggerPropertyName: "onTextChanged",
+        dynamicString: this.props.onTextChanged,
+        event: {
+          type: EventType.ON_TEXT_CHANGE,
+        },
+      });
+    }
     if (!this.props.isDirty) {
       this.props.updateWidgetMetaProperty("isDirty", true);
     }


### PR DESCRIPTION
Fixes - [25911](https://github.com/appsmithorg/appsmith/issues/25911)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for phone input to ensure only numeric values are accepted.
  
- **Tests**
  - Enhanced test scenario to validate the lifecycle of the toast message after user input, ensuring it disappears appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->