### PR TITLE
chore: Add newrelic tracking spans to AppViewer engine and AppEditor engine

### DIFF
--- a/app/client/src/UITelemetry/generateTraces.ts
+++ b/app/client/src/UITelemetry/generateTraces.ts
@@ -76,15 +76,15 @@ export function startNestedSpan(
   return generatorTrace.startSpan(spanName, spanOptions, parentContext);
 }
 
-export function endSpan(span: Span) {
-  span.end();
+export function endSpan(span?: Span) {
+  span?.end();
 }
 
 export function setAttributesToSpan(
-  span: Span,
-  spanAttributes: SpanAttributes,
+  span?: Span,
+  spanAttributes: SpanAttributes = {},
 ) {
-  span.setAttributes(spanAttributes);
+  span?.setAttributes(spanAttributes);
 }
 
 export function wrapFnWithParentTraceContext(parentSpan: Span, fn: () => any) {

--- a/app/client/src/entities/Engine/AppViewerEngine.ts
+++ b/app/client/src/entities/Engine/AppViewerEngine.ts
@@ -34,7 +34,8 @@ import {
   fetchAppThemesAction,
   fetchSelectedAppThemeAction,
 } from "actions/appThemingActions";
-
+import type { Span } from "@opentelemetry/api";
+import { endSpan, startNestedSpan } from "UITelemetry/generateTraces";
 export default class AppViewerEngine extends AppEngine {
   constructor(mode: APP_MODE) {
     super(mode);
@@ -50,16 +51,30 @@ export default class AppViewerEngine extends AppEngine {
     return;
   }
 
-  *completeChore() {
+  *completeChore(rootSpan: Span) {
+    const completeChoreSpan = startNestedSpan(
+      "AppViewerEngine.completeChore",
+      rootSpan,
+    );
+
     yield call(waitForWidgetConfigBuild);
     yield put({
       type: ReduxActionTypes.INITIALIZE_PAGE_VIEWER_SUCCESS,
     });
     yield spawn(reportSWStatus);
+
+    endSpan(completeChoreSpan);
   }
 
-  *setupEngine(payload: AppEnginePayload) {
-    yield call(super.setupEngine.bind(this), payload);
+  *setupEngine(payload: AppEnginePayload, rootSpan: Span) {
+    const viewerSetupSpan = startNestedSpan(
+      "AppViewerEngine.setupEngine",
+      rootSpan,
+    );
+
+    yield call(super.setupEngine.bind(this), payload, rootSpan);
+
+    endSpan(viewerSetupSpan);
   }
 
   startPerformanceTracking() {
@@ -78,7 +93,13 @@ export default class AppViewerEngine extends AppEngine {
     toLoadPageId: string,
     applicationId: string,
     allResponses: DeployConsolidatedApi,
+    rootSpan: Span,
   ): any {
+    const loadAppEntitiesSpan = startNestedSpan(
+      "AppViewerEngine.loadAppEntities",
+      rootSpan,
+    );
+
     const {
       currentTheme,
       customJSLibraries,
@@ -128,9 +149,29 @@ export default class AppViewerEngine extends AppEngine {
         `Unable to fetch actions for the application: ${applicationId}`,
       );
 
+    const waitForUserSpan = startNestedSpan(
+      "AppViewerEngine.waitForFetchUserSuccess",
+      rootSpan,
+    );
     yield call(waitForFetchUserSuccess);
+    endSpan(waitForUserSpan);
+
+    const waitForSegmentSpan = startNestedSpan(
+      "AppViewerEngine.waitForSegmentInit",
+      rootSpan,
+    );
     yield call(waitForSegmentInit, true);
+    endSpan(waitForSegmentSpan);
+
+    const waitForEnvironmentsSpan = startNestedSpan(
+      "AppViewerEngine.waitForFetchEnvironments",
+      rootSpan,
+    );
     yield call(waitForFetchEnvironments);
+    endSpan(waitForEnvironmentsSpan);
+
     yield put(fetchAllPageEntityCompletion([executePageLoadActions()]));
+
+    endSpan(loadAppEntitiesSpan);
   }
 }

--- a/app/client/src/entities/Engine/index.ts
+++ b/app/client/src/entities/Engine/index.ts
@@ -139,9 +139,9 @@ export default abstract class AppEngine {
     rootSpan: Span;
   }) {
     try {
-      const loadAppUrlSpan = startNestedSpan("AppEngine.loadAppURL", rootSpan);
-
       if (!this._urlRedirect) return;
+
+      const loadAppUrlSpan = startNestedSpan("AppEngine.loadAppURL", rootSpan);
       const newURL: string = yield call(
         this._urlRedirect.generateRedirectURL.bind(this),
         pageId,

--- a/app/client/src/entities/Engine/index.ts
+++ b/app/client/src/entities/Engine/index.ts
@@ -129,7 +129,15 @@ export default abstract class AppEngine {
     endSpan(setupEngineSpan);
   }
 
-  *loadAppURL(pageId: string, pageIdInUrl: string = "", rootSpan: Span) {
+  *loadAppURL({
+    pageId,
+    pageIdInUrl,
+    rootSpan,
+  }: {
+    pageId: string;
+    pageIdInUrl?: string;
+    rootSpan: Span;
+  }) {
     try {
       const loadAppUrlSpan = startNestedSpan("AppEngine.loadAppURL", rootSpan);
 

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -540,10 +540,11 @@ export default function* executePluginActionTriggerSaga(
     },
     actionId,
   );
-  span &&
-    setAttributesToSpan(span, {
-      actionId: actionId,
-    });
+
+  setAttributesToSpan(span, {
+    actionId: actionId,
+  });
+
   const action = shouldBeDefined<Action>(
     yield select(getAction, actionId),
     `Action not found for id - ${actionId}`,
@@ -1286,7 +1287,7 @@ function* executePageLoadActionsSaga(
       getLayoutOnLoadIssues,
     );
     const actionCount = flatten(pageActions).length;
-    span && setAttributesToSpan(span, { numActions: actionCount });
+    setAttributesToSpan(span, { numActions: actionCount });
     // when cyclical depedency issue is there,
     // none of the page load actions would be executed
     PerformanceTracker.startAsyncTracking(
@@ -1343,11 +1344,12 @@ function* executePluginActionSaga(
 ) {
   const actionId = pluginAction.id;
   const pluginActionNameToDisplay = getPluginActionNameToDisplay(pluginAction);
-  parentSpan &&
-    setAttributesToSpan(parentSpan, {
-      actionId,
-      pluginName: pluginActionNameToDisplay,
-    });
+
+  setAttributesToSpan(parentSpan, {
+    actionId,
+    pluginName: pluginActionNameToDisplay,
+  });
+
   if (pluginAction.confirmBeforeExecute) {
     const modalPayload = {
       name: pluginActionNameToDisplay,

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -338,8 +338,8 @@ export function* startAppEngine(action: ReduxAction<AppEnginePayload>) {
       allResponses,
       rootSpan,
     );
-    yield call(engine.loadGit, applicationId, rootSpan); // Separate methods
-    yield call(engine.completeChore, rootSpan); // Separate methods
+    yield call(engine.loadGit, applicationId, rootSpan);
+    yield call(engine.completeChore, rootSpan);
     yield put(generateAutoHeightLayoutTreeAction(true, false));
     engine.stopPerformanceTracking();
   } catch (e) {

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -324,12 +324,11 @@ export function* startAppEngine(action: ReduxAction<AppEnginePayload>) {
       rootSpan,
     );
 
-    yield call(
-      engine.loadAppURL,
-      toLoadPageId,
-      action.payload.pageId,
+    yield call(engine.loadAppURL, {
+      pageId: toLoadPageId,
+      pageIdInUrl: action.payload.pageId,
       rootSpan,
-    );
+    });
 
     yield call(
       engine.loadAppEntities,

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -85,6 +85,11 @@ import type { Datasource } from "entities/Datasource";
 import type { Plugin, PluginFormPayload } from "api/PluginApi";
 import ConsolidatedPageLoadApi from "api/ConsolidatedPageLoadApi";
 import { axiosConnectionAbortedCode } from "@appsmith/api/ApiUtils";
+import {
+  endSpan,
+  startNestedSpan,
+  startRootSpan,
+} from "UITelemetry/generateTraces";
 
 export const URL_CHANGE_ACTIONS = [
   ReduxActionTypes.CURRENT_APPLICATION_NAME_UPDATE,
@@ -284,32 +289,57 @@ export function* getInitResponses({
 }
 
 export function* startAppEngine(action: ReduxAction<AppEnginePayload>) {
+  const rootSpan = startRootSpan("startAppEngine", {
+    mode: action.payload.mode,
+    pageId: action.payload.pageId,
+    applicationId: action.payload.applicationId,
+    branch: action.payload.branch,
+  });
+
   try {
     const engine: AppEngine = AppEngineFactory.create(
       action.payload.mode,
       action.payload.mode,
     );
     engine.startPerformanceTracking();
-    yield call(engine.setupEngine, action.payload);
+    yield call(engine.setupEngine, action.payload, rootSpan);
+
+    const getInitResponsesSpan = startNestedSpan(
+      "getInitResponsesSpan",
+      rootSpan,
+    );
+
     const allResponses: InitConsolidatedApi = yield call(getInitResponses, {
       ...action.payload,
     });
+
+    endSpan(getInitResponsesSpan);
+
     yield put({ type: ReduxActionTypes.LINT_SETUP });
+
     const { applicationId, toLoadPageId } = yield call(
       engine.loadAppData,
       action.payload,
       allResponses,
+      rootSpan,
     );
-    yield call(engine.loadAppURL, toLoadPageId, action.payload.pageId);
+
+    yield call(
+      engine.loadAppURL,
+      toLoadPageId,
+      action.payload.pageId,
+      rootSpan,
+    );
 
     yield call(
       engine.loadAppEntities,
       toLoadPageId,
       applicationId,
       allResponses,
+      rootSpan,
     );
-    yield call(engine.loadGit, applicationId);
-    yield call(engine.completeChore);
+    yield call(engine.loadGit, applicationId, rootSpan); // Separate methods
+    yield call(engine.completeChore, rootSpan); // Separate methods
     yield put(generateAutoHeightLayoutTreeAction(true, false));
     engine.stopPerformanceTracking();
   } catch (e) {
@@ -317,6 +347,8 @@ export function* startAppEngine(action: ReduxAction<AppEnginePayload>) {
     if (e instanceof AppEngineApiError) return;
     Sentry.captureException(e);
     yield put(safeCrashAppRequest());
+  } finally {
+    endSpan(rootSpan);
   }
 }
 


### PR DESCRIPTION
## Description
Add new relic tracking spans to all fn calls in Appviewer and AppEditor engine.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9868467158>
> Commit: 9267930a1501b1a6eaab985c714c04a4f2a5da52
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9868467158&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 10 Jul 2024 05:32:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced app performance tracking with added telemetry spans for key functions.

- **Tests**
  - Updated test cases to include telemetry span tracking, ensuring better performance monitoring and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->