### PR TITLE
fix: Avoid collapsing widget tags when in Anvil

### DIFF
--- a/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
@@ -21,7 +21,7 @@ import UIEntityTagGroup from "./UIEntityTagGroup";
 import { useUIExplorerItems } from "./hooks";
 import { useSelector } from "react-redux";
 import { widgetsExistCurrentPage } from "@appsmith/selectors/entitiesSelector";
-import { getIsAnvilLayout } from "../../../layoutSystems/anvil/integrations/selectors";
+import { getIsAnvilLayout } from "layoutSystems/anvil/integrations/selectors";
 
 function UIEntitySidebar({
   focusSearchInput,

--- a/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
@@ -21,6 +21,7 @@ import UIEntityTagGroup from "./UIEntityTagGroup";
 import { useUIExplorerItems } from "./hooks";
 import { useSelector } from "react-redux";
 import { widgetsExistCurrentPage } from "@appsmith/selectors/entitiesSelector";
+import { getIsAnvilLayout } from "../../../layoutSystems/anvil/integrations/selectors";
 
 function UIEntitySidebar({
   focusSearchInput,
@@ -38,6 +39,7 @@ function UIEntitySidebar({
   const isDragDropBuildingBlocksEnabled = useFeatureFlag(
     FEATURE_FLAG.release_drag_drop_building_blocks_enabled,
   );
+  const isAnvil = useSelector(getIsAnvilLayout);
   const hasWidgets = useSelector(widgetsExistCurrentPage);
   const hideSuggestedWidgets = useMemo(
     () =>
@@ -152,8 +154,10 @@ function UIEntitySidebar({
             // Do not expand all the widget tags when the user does not have any
             // widgets yet.
             // Only show Suggested or Building Blocks
+            // This behavior should not be used if Anvil layout is active
             let isInitiallyOpen = false;
             if (
+              isAnvil ||
               hasWidgets ||
               [
                 WIDGET_TAGS.SUGGESTED_WIDGETS as string,


### PR DESCRIPTION
## Description

Based on [this discussion](https://theappsmith.slack.com/archives/C02JT9CSE6L/p1720083186027799) we are changing [this](https://github.com/appsmithorg/appsmith/issues/34386) behaviour to not apply on Anvil Layouts


## Automation

/ok-to-test tags="@tag.Anvil, @tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9792153185>
> Commit: edbeed28513b7902bfbc2be5fa6fc220cdd96941
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9792153185&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil, @tag.Widget`
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved logic for widget tags based on the new `isAnvil` layout flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->