### PR TITLE
fix: Resolved incomplete error message for rating widget.

### DIFF
--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -81,7 +81,7 @@ function validateDefaultRate(value: unknown, props: any, _: any) {
         messages: [
           {
             name: "ValidationError",
-            message: `This value can be a decimal only if 'Allow half' is true`,
+            message: `This value can be a decimal only if 'Allow half stars' is true`,
           },
         ],
       };


### PR DESCRIPTION
## Description:
> When the Allow Half Stars property is turned off and the user enters a decimal value for the Default Rating, an incomplete error message is displayed.
I have raised this PR in order to replace the error message for rating widget.

## fixes: [[Bug]: Incomplete error message for Rating widget #17654](https://github.com/appsmithorg/appsmith/issues/17654)
### Screenshots
Before resolving bug:
![Screenshot from 2024-07-04 16-23-15](https://github.com/appsmithorg/appsmith/assets/136346053/83c161bd-f8af-4a38-8c74-60674e2ca4a6)


After resolving bug:
![Screenshot from 2024-07-04 16-32-03](https://github.com/appsmithorg/appsmith/assets/136346053/10a664ad-f72c-4c96-a814-7203db5ecc65)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated validation message in the `RateWidget` component from "Allow half" to "Allow half stars" for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->