### PR TITLE
ci: Add UTC time to Cypress messages

### DIFF
--- a/.github/workflows/scripts/write-cypress-status.js
+++ b/.github/workflows/scripts/write-cypress-status.js
@@ -40,6 +40,7 @@ module.exports = async function({core, context, github}, alertType, note) {
     HEADER,
     `> [!${alertType.toUpperCase()}]`,
     ((ALERT_PREFIXES[alertType] ?? "") + note.trim()).replaceAll(/^/gm, "> "),
+    "> <hr>" + new Date().toUTCString().replace("GMT", "UTC"),
     FOOTER,
   ].join("\n");
 


### PR DESCRIPTION
**/test rating**

![shot-2024-07-04-14-56-26](https://github.com/appsmithorg/appsmith/assets/120119/485c06c7-4adb-419d-b4da-3e999b87f3e8)




<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9796447291>
> Commit: 456128bd61a357ada1b3e2cd3937a0ff47d89c26
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9796447291&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Rating`
> <hr>Thu, 04 Jul 2024 15:11:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added the current date and time in UTC to the status messages generated by the Cypress script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->