### PR TITLE
ci: Accept spec input for Cypress run

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ""
+      spec:
+        description: "Spec files to run, one per line"
+        required: false
+        type: string
+        default: ""
       matrix:
         description: "Matrix jobs"
         required: false
@@ -350,6 +355,7 @@ jobs:
           browser: ${{ env.BROWSER_PATH }}
           install: false
           config-file: cypress_ci_custom.config.ts
+          spec: ${{ inputs.spec }}
           working-directory: app/client
           env: "NODE_ENV=development"
 

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -6,6 +6,9 @@ on:
       tags:
         required: true
         type: string
+      spec:
+        required: false
+        type: string
       matrix:
         required: true
         type: string
@@ -71,6 +74,7 @@ jobs:
     with:
       pr: ${{ github.event.number }}
       tags: ${{ inputs.tags }}
+      spec: ${{ inputs.spec }}
       matrix: ${{ inputs.matrix }}
 
   ci-test-result:


### PR DESCRIPTION
This PR doesn't have any real affect. It makes the `spec` parameter to the Cypress action, open to being set. In a following PR, we'll make this configurable via an extended `/test` command syntax, from `pr-automation.yml`, coming up.

The `spec` parameter to the Cypress action will be the empty string here, since we aren't setting it to anything anywhere. The action is coded to handle empty string here. As evident in this function: https://github.com/cypress-io/github-action/blob/1967c2d49b206850903322893068f989c23db474/index.js#L340.

This is what `ci-test-limited.yml` uses, but is not very convenient since we have to make another commit to revert the changes in the file after we're done. Instead, we want to extend the `/test` command's syntax to be able to inline the spec list in the PR description itself. 🤞

**/test rating**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9797382840>
> Commit: 701bd3b70a25f3554aac143fdbd4cf1b44d258b9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9797382840&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Rating`
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to allow specifying spec files for Cypress tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->