### PR TITLE
chore: Remove Postgres v13 from base image

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -27,7 +27,7 @@ RUN set -o xtrace \
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
-  && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-13 postgresql-14 \
+  && apt-get install --no-install-recommends --yes mongodb-org redis postgresql-14 \
   && apt-get clean
 
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"


### PR DESCRIPTION
1. This was kept for a short grace period, to be removed once we're confident of upgrading to v14.
2. The `pg-upgrade.sh` script is capable of handling this. It will install v13 when upgrading to v14, if it's not already available. See: https://github.com/appsmithorg/appsmith/blob/2adb12d57bef55de353ba25dd7123be7ae370598/deploy/docker/fs/opt/appsmith/pg-upgrade.sh#L53-L54


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated PostgreSQL version in Docker setup from 13 to 14 for improved performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->