### PR TITLE
fix: snowflake imports issue fixed

### DIFF
--- a/app/client/src/components/formControls/BaseControl.tsx
+++ b/app/client/src/components/formControls/BaseControl.tsx
@@ -21,7 +21,8 @@ export type ComparisonOperations =
   | "IN"
   | "NOT_IN"
   | "FEATURE_FLAG"
-  | "VIEW_MODE";
+  | "VIEW_MODE"
+  | "DEFINED_AND_NOT_EQUALS";
 
 export enum ComparisonOperationsEnum {
   VIEW_MODE = "VIEW_MODE",

--- a/app/client/src/components/formControls/utils.ts
+++ b/app/client/src/components/formControls/utils.ts
@@ -255,6 +255,8 @@ export const caculateIsHidden = (
       case "VIEW_MODE":
         // This can be used to decide which form controls to show in view mode or edit mode depending on the value.
         return viewMode === value;
+      case "DEFINED_AND_NOT_EQUALS":
+        return !!valueAtPath && valueAtPath !== value;
       default:
         return true;
     }

--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/form.json
@@ -95,7 +95,7 @@
               },
               {
                 "path": "datasourceConfiguration.authentication.authenticationType",
-                "comparison": "NOT_EQUALS",
+                "comparison": "DEFINED_AND_NOT_EQUALS",
                 "value": "dbAuth"
               }
             ]


### PR DESCRIPTION
## Description


This PR fixes the intermittent issue in snowflake, where if we import the app containing snowflake and if we open the datasource it in edit mode, password field was not there. 

Root cause:
When we are on slow 3g and when we don’t wait for datasources to load in reconnect dialog and quickly go to application, the authentication object does not get set, which causes snowflake password conditions to break and it does not show up.
We tried by simulating slow 3g on all environments and were able to reproduce it

Steps to test:
- We can try importing following app json and simulating slow 3g in network tab
- Once app is imported, when we see reconnect modal, quickly click on go to application before the datasources are loaded in the modal
[Snow issue_aparna.json](https://github.com/user-attachments/files/16107584/Snow.issue_aparna.json)



Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9805844586>
> Commit: 9868be55568774565f9c675d8cec92b12eb55d70
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9805844586&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> <hr>Fri, 05 Jul 2024 09:38:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new comparison operation `DEFINED_AND_NOT_EQUALS` for form controls.
  
- **Bug Fixes**
  - Updated the Snowflake plugin to use `DEFINED_AND_NOT_EQUALS` for better validation of authentication type configurations.

- **Improvements**
  - Enhanced form control logic to support more precise comparison checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->