### PR TITLE
ci: Clean up disk usage before saving container to disk

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -113,6 +113,10 @@ jobs:
       # Saving the docker image to tar file
       - name: Save Docker image to tar file
         run: |
+          docker image ls --all --no-trunc --format '{{.Repository}},{{.ID}}' \
+            | grep -v cicontainer \
+            | cut -d, -f2 \
+            | xargs docker rmi
           docker save cicontainer -o cicontainer.tar
           gzip cicontainer.tar
 


### PR DESCRIPTION
Saving the Docker image to disk is failing on EE `pg` because of lack of disk space. So we clean up all the unused Docker images just before doing this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to remove a specific Docker image before saving a new one, improving Docker image management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->