### PR TITLE
fix: hide generate page button in DSFormHeader

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/hooks.ts
+++ b/app/client/src/pages/Editor/DataSourceEditor/hooks.ts
@@ -123,6 +123,10 @@ export const useShowPageGenerationOnHeader = (
 
   const isGoogleSheetPlugin = isGoogleSheetPluginDS(plugin?.packageName);
 
+  const releaseDragDropBuildingBlocks = useFeatureFlag(
+    FEATURE_FLAG.release_drag_drop_building_blocks_enabled,
+  );
+
   const isPluginAllowedToPreviewData =
     DATASOURCES_ALLOWED_FOR_PREVIEW_MODE.includes(plugin?.name || "") ||
     (plugin?.name === PluginName.MONGO &&
@@ -151,5 +155,9 @@ export const useShowPageGenerationOnHeader = (
     !isPluginAllowedToPreviewData &&
     !!generateCRUDSupportedPlugin[(datasource as Datasource).pluginId];
 
-  return supportTemplateGeneration && canGeneratePage;
+  return (
+    !releaseDragDropBuildingBlocks && // only show generate page button if dragging of building blocks is not enabled (product decision)
+    supportTemplateGeneration &&
+    canGeneratePage
+  );
 };

--- a/app/client/src/pages/Editor/DatasourceInfo/HideGeneratePageButton.test.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/HideGeneratePageButton.test.tsx
@@ -160,6 +160,36 @@ describe("GoogleSheetSchema Component", () => {
   });
 });
 
+describe("DSFormHeader Component", () => {
+  it("1. should not render the 'generate page' button when release_drag_drop_building_blocks_enabled is enabled", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue(true);
+    const mockHistoryPush = jest.fn();
+    const mockHistoryReplace = jest.fn();
+    const mockHistoryLocation = {
+      pathname: "/",
+      search: "",
+      hash: "",
+      state: {},
+    };
+
+    jest.spyOn(reactRouter, "useHistory").mockReturnValue({
+      push: mockHistoryPush,
+      replace: mockHistoryReplace,
+      location: mockHistoryLocation,
+    });
+
+    jest.spyOn(reactRouter, "useLocation").mockReturnValue(mockHistoryLocation);
+
+    renderDSFormHeader();
+
+    // Check that the "generate page" button is not rendered
+    const generatePageButton = screen.queryByText(
+      createMessage(DATASOURCE_GENERATE_PAGE_BUTTON),
+    );
+    expect(generatePageButton).not.toBeInTheDocument();
+  });
+});
+
 const mockDatasource: Datasource = {
   id: "667941878b418b52eb273895",
   userPermissions: [


### PR DESCRIPTION
## Description

In PR #34655, the "Generate Page" button was removed from the datasource preview page (Footer). However, the `DSFormHeader` for other datasource types still included this button, leading to inconsistencies across the application.

This PR addresses the issue by removing the "Generate Page" button from the DSFormHeader for all datasource types, ensuring uniformity in the datasource preview pages and aligning with the changes made in PR #34655.

Fixes #34771

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9836680996>
> Commit: bde150dd6010e110f32288a52e39657f96945704
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9836680996&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> <hr>Mon, 08 Jul 2024 09:44:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a feature flag to control the visibility of the "generate page" button in the DataSource Editor.
- **Tests**
  - Added a new test case to ensure the "generate page" button is hidden when the `release_drag_drop_building_blocks_enabled` feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->