### PR TITLE
fix:ButtonGroupWidget shows warn when there is a duplicate label.

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/ButtonGroup_DuplicateLabel_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/ButtonGroup_DuplicateLabel_spec.ts
@@ -1,0 +1,30 @@
+import {
+  agHelper,
+  draggableWidgets,
+  entityExplorer,
+  propPane,
+} from "../../../../../support/Objects/ObjectsCore";
+
+import { buttongroupwidgetlocators } from "../../../../../locators/WidgetLocators";
+
+describe(
+  "tests for the button group when the button and menu items had dupliacte labels",
+  { tags: ["@tag.Widget", "@tag.Button"] },
+  () => {
+    before("Login to the app and navigate to the workspace", function () {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.BUTTON_GROUP);
+    });
+    it("change the 2nd button label to the same as the first button and verify the duplicate label error", () => {
+      agHelper.GetNClick(buttongroupwidgetlocators.buttongroup);
+      agHelper.GetNClick(propPane._tableEditColumnButton, 1);
+      propPane.UpdatePropertyFieldValue("Text", "Favorite");
+      agHelper.GetNClick(propPane._goBackToProperty);
+      const inputField = agHelper.GetElement(
+        ".has-duplicate-label input[type='text']",
+        "noVerify",
+      );
+      cy.wait(1000);
+      inputField.should("have.css", "border-color", "rgb(255, 180, 180)");
+    });
+  },
+);

--- a/app/client/src/components/propertyControls/InputTextControl.tsx
+++ b/app/client/src/components/propertyControls/InputTextControl.tsx
@@ -17,6 +17,8 @@ import LazyCodeEditor from "../editorComponents/LazyCodeEditor";
 import type { AdditionalDynamicDataTree } from "utils/autocomplete/customTreeTypeDefCreator";
 import { bindingHintHelper } from "components/editorComponents/CodeEditor/hintHelpers";
 import { slashCommandHintHelper } from "components/editorComponents/CodeEditor/commandsHelper";
+import store from "store";
+import { onUpdatedlabel } from "components/utils/getWidgetIdsWithDuplicateLabel";
 
 export function InputText(props: {
   label: string;
@@ -139,6 +141,20 @@ class InputTextControl extends BaseControl<InputControlProps> {
     let value = event;
     if (typeof event !== "string") {
       value = event.target.value;
+    }
+    const updateIsDuplicateLabel = (property: string, isDuplicate: boolean) => {
+      this.updateProperty(property, isDuplicate);
+    };
+    if (this.props.widgetProperties.type === "BUTTON_GROUP_WIDGET") {
+      const state = store.getState();
+      onUpdatedlabel(
+        this.props.widgetProperties.widgetId,
+        state,
+        this.props.widgetProperties.groupButtons,
+        this.props.propertyName,
+        value as string,
+        updateIsDuplicateLabel,
+      );
     }
     this.updateProperty(this.props.propertyName, value, true);
   };

--- a/app/client/src/components/propertyControls/InputTextControl.tsx
+++ b/app/client/src/components/propertyControls/InputTextControl.tsx
@@ -18,7 +18,11 @@ import type { AdditionalDynamicDataTree } from "utils/autocomplete/customTreeTyp
 import { bindingHintHelper } from "components/editorComponents/CodeEditor/hintHelpers";
 import { slashCommandHintHelper } from "components/editorComponents/CodeEditor/commandsHelper";
 import store from "store";
-import { onUpdatedlabel } from "components/utils/getWidgetIdsWithDuplicateLabel";
+import {
+  onUpdatedlabel,
+  onUpdatedMenulabel,
+} from "components/utils/getWidgetIdsWithDuplicateLabel";
+import { debounce } from "lodash";
 
 export function InputText(props: {
   label: string;
@@ -85,6 +89,9 @@ export function InputText(props: {
   );
 }
 
+const debouncedOnUpdateLabel = debounce(onUpdatedlabel, 500);
+const debounceOnMenuLabelUpdate = debounce(onUpdatedMenulabel, 500);
+
 class InputTextControl extends BaseControl<InputControlProps> {
   static contextType = CollapseContext;
   context!: React.ContextType<typeof CollapseContext>;
@@ -147,7 +154,7 @@ class InputTextControl extends BaseControl<InputControlProps> {
     };
     if (this.props.widgetProperties.type === "BUTTON_GROUP_WIDGET") {
       const state = store.getState();
-      onUpdatedlabel(
+      debouncedOnUpdateLabel(
         this.props.widgetProperties.widgetId,
         state,
         this.props.widgetProperties.groupButtons,
@@ -155,7 +162,21 @@ class InputTextControl extends BaseControl<InputControlProps> {
         value as string,
         updateIsDuplicateLabel,
       );
+    } else if (
+      this.props.widgetProperties.type === "MENU_BUTTON_WIDGET" &&
+      this.props.widgetProperties.menuItems !== undefined
+    ) {
+      const state = store.getState();
+      debounceOnMenuLabelUpdate(
+        this.props.widgetProperties.widgetId,
+        state,
+        this.props.widgetProperties.menuItems,
+        this.props.propertyName,
+        value as string,
+        updateIsDuplicateLabel,
+      );
     }
+    
     this.updateProperty(this.props.propertyName, value, true);
   };
 

--- a/app/client/src/components/propertyControls/MenuItemsControl.tsx
+++ b/app/client/src/components/propertyControls/MenuItemsControl.tsx
@@ -12,6 +12,7 @@ import { map, includes } from "lodash";
 import {
   getduplicateLabelWidgetIds,
   getWidgetIdsWithDuplicateLabelWhenUpdated,
+  onDeleteGetDuplicateIds,
 } from "components/utils/getWidgetIdsWithDuplicateLabel";
 
 interface State {
@@ -142,6 +143,7 @@ class MenuItemsControl extends BaseControl<ControlProps, State> {
     const updatedArray = menuItemsArray.filter((eachItem: any, i: number) => {
       return i !== index;
     });
+    const labels = map(updatedArray, "label");
     const updatedObj = updatedArray.reduce(
       (obj: any, each: any, index: number) => {
         obj[each.id] = {
@@ -152,7 +154,18 @@ class MenuItemsControl extends BaseControl<ControlProps, State> {
       },
       {},
     );
-    const duplicateIds = getduplicateLabelWidgetIds(updatedObj);
+    const updateMenuProperty = (widgetId: string, isDuplicate = false) => {
+      this.updateProperty(
+        `${this.props.propertyName}.${widgetId}.isDuplicateLabel`,
+        isDuplicate,
+      );
+    };
+    const duplicateIds = onDeleteGetDuplicateIds(
+      updatedArray,
+      this.state.duplicateMenuIds,
+      labels,
+      updateMenuProperty,
+    );
     this.setState({ duplicateMenuIds: duplicateIds });
     this.updateProperty(this.props.propertyName, updatedObj);
   };
@@ -189,7 +202,7 @@ class MenuItemsControl extends BaseControl<ControlProps, State> {
     let menuItems = this.props.propertyValue || [];
     const menuItemsArray = this.getMenuItems();
     const newMenuItemId = generateReactKey({ prefix: "menuItem" });
-
+    const menuNames = map(menuItemsArray, "label");
     menuItems = {
       ...menuItems,
       [newMenuItemId]: {
@@ -202,7 +215,9 @@ class MenuItemsControl extends BaseControl<ControlProps, State> {
         isDuplicateLabel: false,
       },
     };
-
+    if(includes(menuNames, "Menu Item")){ this.setState({
+          duplicateMenuIds: [...this.state.duplicateMenuIds, newMenuItemId],
+        })}
     this.updateProperty(this.props.propertyName, menuItems);
   };
 

--- a/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.test.ts
+++ b/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.test.ts
@@ -1,0 +1,312 @@
+import {
+  getWidgetIdsWithDuplicateLabelWhenUpdated,
+  onDeleteGetDuplicateIds,
+  onUpdatedMenulabel,
+  onUpdatedlabel,
+  getduplicateLabelWidgetIds,
+} from "./getWidgetIdsWithDuplicateLabel";
+import "@testing-library/jest-dom";
+import "@testing-library/react";
+
+const items = [
+  {
+    id: "button1",
+    label: "add",
+    isDisabled: false,
+    isVisible: true,
+    widgetId: "button1",
+    itemType: "BUTTON",
+    isDuplicateLabel: false,
+  },
+  {
+    id: "button2",
+    label: "add",
+    isDisabled: false,
+    isVisible: true,
+    widgetId: "button2",
+    itemType: "BUTTON",
+    isDuplicateLabel: true,
+  },
+  {
+    id: "button3",
+    label: "add",
+    isDisabled: false,
+    isVisible: true,
+    widgetId: "button3",
+    itemType: "BUTTON",
+    isDuplicateLabel: true,
+  },
+  {
+    id: "button4",
+    label: "add1",
+    isDisabled: false,
+    isVisible: true,
+    widgetId: "button4",
+    itemType: "BUTTON",
+    isDuplicateLabel: false,
+  },
+];
+
+const buttonGroupButtons = {
+  widgetId: "buttonGroup1",
+  type: "BUTTON_GROUP_WIDGET",
+  groupButtons: {
+    button1: {
+      id: "button1",
+      widgetId: "button1",
+      isDisabled: false,
+      isVisible: true,
+      label: "add",
+      isDuplicateLabel: false,
+      menuItems: {},
+    },
+    button2: {
+      id: "button2",
+      widgetId: "button2",
+      isDisabled: false,
+      isVisible: true,
+      label: "favriote",
+      isDuplicateLabel: false,
+      menuItems: {},
+    },
+    button3: {
+      id: "button3",
+      widgetId: "button3",
+      isDisabled: false,
+      isVisible: true,
+      label: "more",
+      isDuplicateLabel: false,
+      menuItems: {
+        menuItem1: {
+          id: "menuItem1",
+          widgetId: "",
+          label: "First Menu Item",
+          isVisible: true,
+          isDisabled: false,
+          isDuplicateLabel: false,
+        },
+        menuItem2: {
+          id: "menuItem2",
+          widgetId: "",
+          label: "Second Menu Item",
+          isVisible: true,
+          isDisabled: false,
+          isDuplicateLabel: false,
+        },
+        menuItem3: {
+          id: "menuItem3",
+          widgetId: "",
+          label: "First Menu Item",
+          isVisible: true,
+          isDisabled: false,
+          isDuplicateLabel: true,
+        },
+      },
+    },
+    button4: {
+      id: "button4",
+      widgetId: "",
+      label: "add",
+      isVisible: true,
+      isDisabled: false,
+      isDuplicateLabel: true,
+      menuItems: {},
+    },
+  },
+};
+const menuButton = {
+  widgetId: "menuButton1",
+  type: "MENU_BUTTON_WIDGET",
+  widgetName: "MenuButton1",
+  menuItems: {
+    menuItem1: {
+      id: "menuItem1",
+      widgetId: "",
+      label: "add",
+      isVisible: true,
+      isDisabled: false,
+      isDuplicateLabel: false,
+    },
+    menuItem2: {
+      id: "menuItem2",
+      widgetId: "",
+      label: "favriote",
+      isVisible: true,
+      isDisabled: false,
+      isDuplicateLabel: false,
+    },
+    menuItem3: {
+      id: "menuItem3",
+      widgetId: "",
+      label: "add",
+      isVisible: true,
+      isDisabled: false,
+      isDuplicateLabel: true,
+    },
+  },
+};
+const state = {
+  entities: {
+    canvasWidgets: {
+      buttonGroup1: buttonGroupButtons,
+      menuButton1: menuButton,
+    },
+  },
+};
+
+describe("test cases for checking the functionality for geting and updating the duplicate labels", () => {
+  it("test to get the duplicate ids from the items", () => {
+    const duplicateIds = getduplicateLabelWidgetIds(items);
+    expect(duplicateIds.length).toBe(2);
+    expect(duplicateIds).toEqual(["button2", "button3"]);
+  });
+  it("test to get duplicateIds when a new button or menu button is deleted", () => {
+    const duplicateIds = ["button2", "button3"];
+    let updatedItems = items.filter((item) => item.id !== "button2");
+    const mockUpdateFun = jest.fn();
+    const newDuplicateIds = onDeleteGetDuplicateIds(
+      updatedItems,
+      duplicateIds,
+      ["add", "add", "add1"],
+      mockUpdateFun,
+    );
+    expect(newDuplicateIds.length).toBe(1);
+    expect(mockUpdateFun).toBeCalled();
+    updatedItems = updatedItems.filter((item) => item.id !== "button1");
+    const newDuplicateIds2 = onDeleteGetDuplicateIds(
+      updatedItems,
+      ["button3"],
+      ["add", "add1"],
+      mockUpdateFun,
+    );
+    expect(newDuplicateIds2.length).toBe(0);
+    expect(mockUpdateFun).toBeCalledTimes(2);
+  });
+  it("test to update the duplicate ids when a new label is updated", () => {
+    const duplicateIds = ["button2", "button3"];
+    const mockUpdateFun = jest.fn();
+    const labels = ["add", "add", "add", "add1"];
+    const newDuplicateIds = getWidgetIdsWithDuplicateLabelWhenUpdated(
+      duplicateIds,
+      labels,
+      "favriote",
+      "button2",
+      1,
+      mockUpdateFun,
+      items,
+    );
+    expect(newDuplicateIds.length).toBe(1);
+    expect(mockUpdateFun).toBeCalled();
+    expect(newDuplicateIds).toEqual(["button3"]);
+    duplicateIds.shift();
+    const newMockFun = jest.fn();
+    const newItems = [...items];
+    newItems[1].label = "favriote";
+    const newDuplicateIds2 = getWidgetIdsWithDuplicateLabelWhenUpdated(
+      duplicateIds,
+      ["add", "favriote", "add", "add1"],
+      "favriote",
+      "button1",
+      0,
+      newMockFun,
+      newItems,
+    );
+    expect(newDuplicateIds2.length).toBe(1);
+    expect(newDuplicateIds2).toEqual(["button1"]);
+    expect(newMockFun).toBeCalledTimes(2);
+  });
+  it("test to check the duplicate ids when the button group is updated with input control", () => {
+    const mockUpdateFun = jest.fn();
+    onUpdatedlabel(
+      "buttonGroup1",
+      state,
+      { button4: { label: "add" } },
+      "buttonGroup1.groupButtons.button4.label",
+      "add10",
+      mockUpdateFun,
+    );
+    expect(mockUpdateFun).toBeCalled();
+    const newMockFunction1 = jest.fn();
+    onUpdatedlabel(
+      "buttonGroup1",
+      state,
+      { button1: { label: "add" } },
+      "buttonGroup1.groupButtons.button1.label",
+      "favriote",
+      newMockFunction1,
+    );
+    expect(newMockFunction1).toBeCalledTimes(2);
+    const newMockFunction2 = jest.fn();
+    onUpdatedlabel(
+      "buttonGroup1",
+      state,
+      { button3: { menuItems: { menuItem3: { label: "First Menu Item" } } } },
+      "buttonGroup1.groupButtons.button3.menuItems.menuItem3.label",
+      "add10",
+      newMockFunction2,
+    );
+    expect(newMockFunction2).toBeCalled();
+    const newMockFunction3 = jest.fn();
+    onUpdatedlabel(
+      "buttonGroup1",
+      state,
+      { button3: { menuItems: { menuItem1: { label: "First Menu Item" } } } },
+      "buttonGroup1.groupButtons.button3.menuItems.menuItem1.label",
+      "Second Menu Item",
+      newMockFunction3,
+    );
+    expect(newMockFunction3).toBeCalledTimes(2);
+    const newMockFunction4 = jest.fn();
+    onUpdatedlabel(
+      "buttonGroup1",
+      state,
+      { button3: { menuItems: { menuItem2: { label: "Second Menu Item" } } } },
+      "buttonGroup1.groupButtons.button3.menuItems.menuItem2.label",
+      "Menu Item",
+      newMockFunction4,
+    );
+    expect(newMockFunction4).toBeCalledTimes(0);
+    const newMockFunction5 = jest.fn();
+    onUpdatedlabel(
+      "buttonGroup1",
+      state,
+      { button2: { label: "favriote" } },
+      "buttonGroup1.groupButtons.button2.label",
+      "favriote10",
+      newMockFunction5,
+    );
+    expect(newMockFunction5).toBeCalledTimes(0);
+  });
+  it("test to check the updatation of duplicate Ids when we update the label of a  menu item in menu button using input field", () => {
+    const mockFun1 = jest.fn();
+    onUpdatedMenulabel(
+      "menuButton1",
+      state,
+      { menuItem3: { label: "add" } },
+      "menuItems.menuItem3.label",
+      "add10",
+      mockFun1,
+    );
+    expect(mockFun1).toBeCalled();
+    const mockFun2 = jest.fn();
+    onUpdatedMenulabel(
+      "menuButton1",
+      state,
+      { menuItem1: { label: "add" } },
+      "menuItems.menuItem1.label",
+      "favriote",
+      mockFun2,
+    );
+    expect(mockFun2).toBeCalledTimes(2);
+    const mockFun3 = jest.fn();
+    onUpdatedMenulabel(
+      "menuButton1",
+      state,
+      { menuItem2: { label: "favriote" } },
+      "menuItems.menuItem2.label",
+      "add10",
+      mockFun3,
+    );
+    expect(mockFun3).not.toBeCalled();
+  });
+});

--- a/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.tsx
+++ b/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.tsx
@@ -1,0 +1,152 @@
+import type { ControlProps } from "../propertyControls/BaseControl";
+import includes from "lodash/includes";
+import type { MenuItem } from "../propertyControls/MenuItemsControl";
+import type { MenuItem as ButtonMenuItem } from "../propertyControls/ButtonListControl";
+
+//This function is used to get the widget ids with duplicate labels
+export const getduplicateLabelWidgetIds = (
+  propertyValue: ControlProps["propertyValue"],
+) => {
+  const duplicateLabelWidgetIds = [];
+  const widgetIds = Object.keys(propertyValue);
+  for (let index = 0; index < widgetIds.length; index++) {
+    if (propertyValue[widgetIds[index]].isDuplicateLabel) {
+      duplicateLabelWidgetIds.push(propertyValue[widgetIds[index]].id);
+    }
+  }
+  return duplicateLabelWidgetIds;
+};
+//This function is used to get the widget ids with duplicate labels when updated and update the isDuplicateLabel property
+export const getWidgetIdsWithDuplicateLabelWhenUpdated = (
+  duplicateIds: string[],
+  labels: string[],
+  updatedLabel: string,
+  widgetId: string,
+  index: number,
+  updateMenuProperty: (widgetId: string, isDuplicate?: boolean) => void,
+  items: (MenuItem | ButtonMenuItem)[],
+) => {
+  let duplicateMenuButtonIds = [...duplicateIds];
+  if (includes(labels, updatedLabel)) {
+    duplicateMenuButtonIds.push(widgetId);
+    updateMenuProperty(widgetId, true);
+  } else {
+    duplicateMenuButtonIds = duplicateMenuButtonIds.filter(
+      (id) => id !== widgetId,
+    );
+    updateMenuProperty(widgetId);
+  }
+  const widgetIdToLabelMap = new Map<string, string>();
+  items.forEach((item) => {
+    widgetIdToLabelMap.set(item.id, item.label);
+  });
+  labels[index] = updatedLabel;
+  widgetIdToLabelMap.set(widgetId, updatedLabel);
+  const DuplicateId: string[] = [];
+  duplicateMenuButtonIds.forEach((id: string) => {
+    let count = 0;
+    labels.forEach((label) => {
+      if (label === widgetIdToLabelMap.get(id)) {
+        count++;
+      }
+    });
+    if (count > 1) {
+      DuplicateId.push(id);
+    } else {
+      updateMenuProperty(id);
+    }
+  });
+  return DuplicateId;
+};
+
+//This function is used to update the isDuplicateLabel property of the button and menu items when it is edited from input text control.
+export const onUpdatedlabel = (
+  widgetId: string,
+  state: any,
+  groupButtons: any,
+  propertyName: string,
+  updatedLabel: string,
+  updateProperty: (
+    propertyName: string,
+    value: any,
+    isDynamicTrigger?: boolean,
+  ) => void,
+) => {
+  const widget = state.entities.canvasWidgets[widgetId];
+  const buttonId = Object.keys(groupButtons)[0];
+  if (Object.keys(groupButtons[buttonId]).includes("label")) {
+    const buttonStructure = propertyName.split(".");
+    buttonStructure.pop();
+    const buttonStructureString = buttonStructure.join(".");
+    const buttonIds = Object.keys(widget.groupButtons);
+    const buttonNames = buttonIds.map(
+      (buttonId) => widget.groupButtons[buttonId].label,
+    );
+    //Check if the updated label is already present in the button labels
+    if (buttonNames.includes(updatedLabel)) {
+      updateProperty(`${buttonStructureString}.isDuplicateLabel`, true);
+    } else if (widget.groupButtons[buttonId].isDuplicateLabel) {
+      //Check if the isDuplicateLabel property is true for the button and the updated label is not present in the button labels
+      updateProperty(
+        `${buttonStructure[0]}.${buttonId}.isDuplicateLabel`,
+        false,
+      );
+    }
+    const index = buttonIds.indexOf(buttonId);
+    buttonNames[index] = updatedLabel;
+    const duplicateIds = buttonIds.filter(
+      (buttonId) => widget.groupButtons[buttonId].isDuplicateLabel,
+    );
+    //remove the isDuplicateLabel property if the label is not duplicate due to the edit
+    duplicateIds.forEach((id: string) => {
+      let count = 0;
+      buttonNames.forEach((label) => {
+        if (label === widget.groupButtons[id].label) {
+          count++;
+        }
+      });
+      if (count == 1) {
+        updateProperty(`${buttonStructure[0]}.${id}.isDuplicateLabel`, false);
+      }
+    });
+  } else {
+    const menuStructure = propertyName.split(".");
+    menuStructure.pop();
+    const menuId = menuStructure.pop()!;
+    const menuStructureString = menuStructure.join(".");
+    const menuIds = Object.keys(widget.groupButtons[buttonId].menuItems);
+    const menuNames = menuIds.map(
+      (id) => widget.groupButtons[buttonId].menuItems[id].label,
+    );
+    //Check if the updated label is already present in the menu labels
+    if (menuNames.includes(updatedLabel)) {
+      updateProperty(`${menuStructureString}.${menuId}.isDuplicateLabel`, true);
+    } else if (
+      widget.groupButtons[buttonId].menuItems[menuId].isDuplicateLabel
+    ) {
+      //Check if the isDuplicateLabel property is true for the menu item and the updated label is not present in the menu labels
+      updateProperty(
+        `${menuStructureString}.${menuId}.isDuplicateLabel`,
+        false,
+      );
+    }
+    const index = menuIds.indexOf(menuId);
+    menuNames[index] = updatedLabel;
+    const duplicateIds = menuIds.filter(
+      (menuId) =>
+        widget.groupButtons[buttonId].menuItems[menuId].isDuplicateLabel,
+    );
+    //remove the isDuplicateLabel property if the label is not duplicate due to the edit
+    duplicateIds.forEach((id: string) => {
+      let count = 0;
+      menuNames.forEach((label) => {
+        if (label === widget.groupButtons[buttonId].menuItems[id].label) {
+          count++;
+        }
+      });
+      if (count === 1) {
+        updateProperty(`${menuStructureString}.${id}.isDuplicateLabel`, false);
+      }
+    });
+  }
+};

--- a/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.tsx
+++ b/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.tsx
@@ -59,6 +59,35 @@ export const getWidgetIdsWithDuplicateLabelWhenUpdated = (
   return DuplicateId;
 };
 
+export const onDeleteGetDuplicateIds = (
+  updatedobj: (ButtonMenuItem | MenuItem)[],
+  duplicateIds: string[],
+  labels: string[],
+  updateMenuProperty: (widgetId: string, isDuplicate?: boolean) => void,
+) => {
+  const duplicateMenuButtonIds = [...duplicateIds];
+  const widgetIdToLabelMap = new Map<string, string>();
+  updatedobj.forEach((item) => {
+    widgetIdToLabelMap.set(item.id, item.label);
+  });
+  const DuplicateId: string[] = [];
+  duplicateMenuButtonIds.forEach((id: string) => {
+    let count = 0;
+    labels.forEach((label) => {
+      if (label === widgetIdToLabelMap.get(id)) {
+        count++;
+      }
+    });
+    if (count > 1) {
+      DuplicateId.push(id);
+    } else {
+      updateMenuProperty(id);
+    }
+  });
+  return DuplicateId;
+};
+
+
 //This function is used to update the isDuplicateLabel property of the button and menu items when it is edited from input text control.
 export const onUpdatedlabel = (
   widgetId: string,

--- a/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.tsx
+++ b/app/client/src/components/utils/getWidgetIdsWithDuplicateLabel.tsx
@@ -87,7 +87,6 @@ export const onDeleteGetDuplicateIds = (
   return DuplicateId;
 };
 
-
 //This function is used to update the isDuplicateLabel property of the button and menu items when it is edited from input text control.
 export const onUpdatedlabel = (
   widgetId: string,
@@ -175,6 +174,53 @@ export const onUpdatedlabel = (
       });
       if (count === 1) {
         updateProperty(`${menuStructureString}.${id}.isDuplicateLabel`, false);
+      }
+    });
+  }
+};
+
+export const onUpdatedMenulabel = (
+  widgetId: string,
+  state: any,
+  menuItems: any,
+  propertyName: string,
+  updatedLabel: string,
+  updateProperty: (
+    propertyName: string,
+    value: any,
+    isDynamicTrigger?: boolean,
+  ) => void,
+) => {
+  const widget = state.entities.canvasWidgets[widgetId];
+  const menuId = Object.keys(menuItems)[0];
+  if (Object.keys(menuItems[menuId]).includes("label")) {
+    const menuStructure = propertyName.split(".");
+    menuStructure.pop();
+    const menuStructureString = menuStructure.join(".");
+    const menuIds = Object.keys(widget.menuItems);
+    const menuNames = menuIds.map((id) => widget.menuItems[id].label);
+    //Check if the updated label is already present in the button labels
+    if (menuNames.includes(updatedLabel)) {
+      updateProperty(`${menuStructureString}.isDuplicateLabel`, true);
+    } else if (widget.menuItems[menuId].isDuplicateLabel) {
+      //Check if the isDuplicateLabel property is true for the button and the updated label is not present in the button labels
+      updateProperty(`${menuStructure[0]}.${menuId}.isDuplicateLabel`, false);
+    }
+    const index = menuIds.indexOf(menuId);
+    menuNames[index] = updatedLabel;
+    const duplicateIds = menuIds.filter(
+      (id) => widget.menuItems[id].isDuplicateLabel,
+    );
+    //remove the isDuplicateLabel property if the label is not duplicate due to the edit
+    duplicateIds.forEach((id: string) => {
+      let count = 0;
+      menuNames.forEach((label) => {
+        if (label === widget.menuItems[id].label) {
+          count++;
+        }
+      });
+      if (count == 1) {
+        updateProperty(`${menuStructure[0]}.${id}.isDuplicateLabel`, false);
       }
     });
   }

--- a/app/client/src/widgets/ButtonGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/ButtonGroupWidget/widget/index.tsx
@@ -67,6 +67,7 @@ class ButtonGroupWidget extends BaseWidget<
           isDisabled: false,
           index: 0,
           menuItems: {},
+          isDuplicateLabel: false,
         },
         groupButton2: {
           label: "Add",
@@ -79,6 +80,7 @@ class ButtonGroupWidget extends BaseWidget<
           isDisabled: false,
           index: 1,
           menuItems: {},
+          isDuplicateLabel: false,
         },
         groupButton3: {
           label: "More",
@@ -90,6 +92,7 @@ class ButtonGroupWidget extends BaseWidget<
           isVisible: true,
           isDisabled: false,
           index: 2,
+          isDuplicateLabel: false,
           menuItems: {
             menuItem1: {
               label: "First Option",
@@ -100,6 +103,7 @@ class ButtonGroupWidget extends BaseWidget<
               isVisible: true,
               isDisabled: false,
               index: 0,
+              isDuplicateLabel: false,
             },
             menuItem2: {
               label: "Second Option",
@@ -110,6 +114,7 @@ class ButtonGroupWidget extends BaseWidget<
               isVisible: true,
               isDisabled: false,
               index: 1,
+              isDuplicateLabel: false,
             },
             menuItem3: {
               label: "Delete",
@@ -124,6 +129,7 @@ class ButtonGroupWidget extends BaseWidget<
               isVisible: true,
               isDisabled: false,
               index: 2,
+              isDuplicateLabel: false,
             },
           },
         },

--- a/app/client/src/widgets/MenuButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/MenuButtonWidget/widget/index.tsx
@@ -51,6 +51,7 @@ class MenuButtonWidget extends BaseWidget<MenuButtonWidgetProps, WidgetState> {
           isVisible: true,
           isDisabled: false,
           index: 0,
+          isDuplicateLabel: false,
         },
         menuItem2: {
           label: "Second Menu Item",
@@ -59,6 +60,7 @@ class MenuButtonWidget extends BaseWidget<MenuButtonWidgetProps, WidgetState> {
           isVisible: true,
           isDisabled: false,
           index: 1,
+          isDuplicateLabel: false,
         },
         menuItem3: {
           label: "Third Menu Item",
@@ -67,6 +69,7 @@ class MenuButtonWidget extends BaseWidget<MenuButtonWidgetProps, WidgetState> {
           isVisible: true,
           isDisabled: false,
           index: 2,
+          isDuplicateLabel: false,
         },
       },
       rows: 4,


### PR DESCRIPTION
fixed the bug and showing the warning to user when there is a duplicate button label in button group widget
issue: [issue](https://github.com/appsmithorg/appsmith/issues/11317)
I have implemented the code to show the duplicate button label.
when there is a duplicate:
![image](https://github.com/appsmithorg/appsmith/assets/115529190/9b688980-aa05-4038-810c-0b66a0f8e9d2)
multiple duplicates:
![image](https://github.com/appsmithorg/appsmith/assets/115529190/1e269a19-0ed1-4557-8ba9-297730497304)
when there is a duplicate is menu item:
![image](https://github.com/appsmithorg/appsmith/assets/115529190/20cfd46a-ff9d-48ae-b28e-179863c9fc3a)

video: [link](https://drive.google.com/file/d/1dT6uL8ptZH-vQXmbuWfaRr4Dx5DbKmvc/view?usp=sharing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functionality to manage and identify duplicate labels within button and menu item controls.
  - Introduced new methods to efficiently handle duplicate labels for improved user interaction.

- **Improvements**
  - Enhanced label management to prevent duplicate button and menu item labels.
  - Improved UI component behavior by updating properties based on label changes, leading to a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->