### PR TITLE
chore: add code split for identifying invalid actions during import flow

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
@@ -89,9 +89,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                         Set<String> invalidActionIds = new HashSet<>();
                         if (Boolean.FALSE.equals(importingMetaDTO.getIsPartialImport())) {
                             for (NewAction action : importActionResultDTO.getExistingActions()) {
-                                if (!importActionResultDTO
-                                        .getImportedActionIds()
-                                        .contains(action.getId())) {
+                                if (isExistingActionInvalid(importActionResultDTO, action)) {
                                     invalidActionIds.add(action.getId());
                                 }
                             }
@@ -116,6 +114,30 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                     return Mono.error(throwable);
                 })
                 .then();
+    }
+
+    /**
+     * Checks if the given action is invalid based on the import results.
+     *
+     * @param importActionResultDTO The import result containing information about imported action IDs.
+     * @param action The action to check for validity.
+     * @return {@code true} if the action is invalid (i.e., its ID is not present in the imported action IDs),
+     *         {@code false} otherwise.
+     */
+    protected boolean isExistingActionInvalid(ImportActionResultDTO importActionResultDTO, NewAction action) {
+        return !importActionResultDTO.getImportedActionIds().contains(action.getId());
+    }
+
+    /**
+     * Checks if the given actionCollection is invalid based on the import results.
+     *
+     * @param savedCollectionIds The list of already saved Ids of the actionCollections.
+     * @param collection The actionCollection to check for validity.
+     * @return {@code true} if the actionCollection is invalid (i.e., its ID is not present in the savedCollectionIds),
+     *         {@code false} otherwise.
+     */
+    protected boolean isExistingActionCollectionInvalid(List<String> savedCollectionIds, ActionCollection collection) {
+        return !savedCollectionIds.contains(collection.getId());
     }
 
     protected Mono<List<NewAction>> getImportableEntities(ArtifactExchangeJson artifactExchangeJson) {
@@ -157,7 +179,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                         Set<String> invalidCollectionIds = new HashSet<>();
                         for (ActionCollection collection :
                                 importActionCollectionResultDTO.getExistingActionCollections()) {
-                            if (!savedCollectionIds.contains(collection.getId())) {
+                            if (isExistingActionCollectionInvalid(savedCollectionIds, collection)) {
                                 invalidCollectionIds.add(collection.getId());
                             }
                         }
@@ -261,7 +283,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
 
             Mono<Map<String, NewAction>> actionsInCurrentArtifactMono = artifactBasedImportableService
                     .getExistingResourcesInCurrentArtifactFlux(artifact)
-                    .filter(collection -> collection.getGitSyncId() != null)
+                    .filter(newAction -> newAction.getGitSyncId() != null)
                     .collectMap(NewAction::getGitSyncId);
 
             // find existing actions in all the branches of this artifact and put them in a map


### PR DESCRIPTION
## Description
EE counterpart PR: https://github.com/appsmithorg/appsmith-ee/pull/4623


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git, @tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9855809156>
> Commit: 2c7be98dbec1f9792b6510403a3d7375ded5767e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9855809156&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git, @tag.ImportExport`
> Spec:
> <hr>Tue, 09 Jul 2024 11:21:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code readability and maintainability by abstracting validation logic into new methods for checking the validity of imported actions and action collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->