### PR TITLE
fix: Queries do not fetch any data when datasources are configured while importing an app

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
@@ -321,7 +321,7 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
                             // Check if the action has datasource is present and contains pluginId
                             Datasource datasource =
                                     newAction.getUnpublishedAction().getDatasource();
-                            if (datasource != null && datasource.getPluginId() == null) {
+                            if (datasource != null) {
                                 // Since the datasource are not yet saved to db, if we don't update the action with
                                 // correct datasource,
                                 // the action ave will fail due to validation


### PR DESCRIPTION
## Description
The null check for adding datasource information to an action was invalid. And all the actions get the datasource from the existing datasource object. Hence all the actions were failing with missing workspaceId. 

Fixes https://github.com/appsmithorg/appsmith/issues/34772

## Automation

/ok-to-test tags="@tag.Git, @tag.ImportExport, @tag.Templates"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9839296466>
> Commit: 8854a2701d4aebf7601efba7643acfe3d44d712d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9839296466&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git, @tag.ImportExport, @tag.Templates`
> <hr>Mon, 08 Jul 2024 12:31:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified conditional checks in the backend to improve code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->