### PR TITLE
chore: Refactor cleanup methods for tests

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/extensions/AfterAllCleanUpExtension.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/extensions/AfterAllCleanUpExtension.java
@@ -1,12 +1,14 @@
 package com.appsmith.server.extensions;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.List;
+import static com.appsmith.server.testhelpers.cleanup.DBCleanup.deleteAllRoutines;
+import static com.appsmith.server.testhelpers.cleanup.DBCleanup.deleteAllTables;
 
 /**
  * This SpringExtension is used to clean up the database after all tests have run. It drops all tables and routines.
@@ -22,7 +24,7 @@ import java.util.List;
  * <br>
  */
 @Slf4j
-public class AfterAllCleanUpExtension extends SpringExtension {
+public class AfterAllCleanUpExtension implements AfterAllCallback {
     @Override
     public void afterAll(ExtensionContext context) {
         Class<?> testClass = context.getRequiredTestClass();
@@ -32,26 +34,5 @@ public class AfterAllCleanUpExtension extends SpringExtension {
         log.debug("Cleaning up after all tests for {}", testClass.getName());
         deleteAllTables(jdbcTemplate);
         deleteAllRoutines(jdbcTemplate);
-    }
-
-    public void deleteAllTables(JdbcTemplate jdbcTemplate) {
-        List<String> tableNames =
-                jdbcTemplate.queryForList("SELECT tablename FROM pg_tables WHERE schemaname = 'public'", String.class);
-
-        for (String tableName : tableNames) {
-            if (tableName.equals("user")) {
-                tableName = "\"user\"";
-            }
-            jdbcTemplate.execute("DROP TABLE IF EXISTS " + tableName + " CASCADE");
-        }
-    }
-
-    public void deleteAllRoutines(JdbcTemplate jdbcTemplate) {
-        List<String> routineNames = jdbcTemplate.queryForList(
-                "SELECT routine_name FROM information_schema.routines WHERE specific_schema = 'public'", String.class);
-
-        for (String routineName : routineNames) {
-            jdbcTemplate.execute("DROP FUNCTION IF EXISTS public." + routineName + " CASCADE");
-        }
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/GitExecutorTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/GitExecutorTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 @Import({GitExecutorImpl.class})
 @ExtendWith(AfterAllCleanUpExtension.class)
-@DirtiesContext
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @SpringBootTest
 public class GitExecutorTest {
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/testhelpers/cleanup/DBCleanup.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/testhelpers/cleanup/DBCleanup.java
@@ -1,0 +1,28 @@
+package com.appsmith.server.testhelpers.cleanup;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+public class DBCleanup {
+    public static void deleteAllTables(JdbcTemplate jdbcTemplate) {
+        List<String> tableNames =
+                jdbcTemplate.queryForList("SELECT tablename FROM pg_tables WHERE schemaname = 'public'", String.class);
+
+        for (String tableName : tableNames) {
+            if (tableName.equals("user")) {
+                tableName = "\"user\"";
+            }
+            jdbcTemplate.execute("DROP TABLE IF EXISTS " + tableName + " CASCADE");
+        }
+    }
+
+    public static void deleteAllRoutines(JdbcTemplate jdbcTemplate) {
+        List<String> routineNames = jdbcTemplate.queryForList(
+                "SELECT routine_name FROM information_schema.routines WHERE specific_schema = 'public'", String.class);
+
+        for (String routineName : routineNames) {
+            jdbcTemplate.execute("DROP FUNCTION IF EXISTS public." + routineName + " CASCADE");
+        }
+    }
+}


### PR DESCRIPTION
## Description
PR to create separate helper class for adding the cleanup stage. This also makes sure `AfterAllCleanUpExtension` only implements the `AfterAllCallback` to achieve the isolation.