### PR TITLE
test: Remove pause from code

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/FormLogin/EmailVerfication_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/FormLogin/EmailVerfication_spec.ts
@@ -58,7 +58,6 @@ describe("Email verification", () => {
     cy.wait("@getEnvVariables");
     cy.get(adminsSettings.authenticationTab).click();
     cy.get(adminsSettings.formloginButton).click();
-    //cy.pause();
     // Assert verification is disabled
     cy.get(adminsSettings.enableEmailVerificationInput).should("be.disabled");
     // Assert callout

--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitWithTheming/GitWithTheming_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitWithTheming/GitWithTheming_spec.js
@@ -109,7 +109,6 @@ describe("Git with Theming:", { tags: ["@tag.Git"] }, function () {
       "background-color",
       backgroudColorMaster,
     );
-    cy.pause();
     // delete tempBranch
     cy.get(gitSyncLocators.branchButton).click();
     cy.get(gitSyncLocators.branchListItem)

--- a/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/UUID_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/UUID_Spec.ts
@@ -96,7 +96,6 @@ describe("UUID Datatype tests", { tags: ["@tag.Datasource"] }, function () {
 
     agHelper.ClickButton("Generate UUID's");
     agHelper.AssertContains("All UUIDs generated & available");
-    cy.pause();
     agHelper.ClickButton("Insert");
     agHelper.AssertElementAbsence(locators._specificToast("failed to execute")); //Assert that Insert did not fail
     agHelper.AssertElementVisibility(locators._buttonByText("Run InsertQuery"));


### PR DESCRIPTION
## Description
Removed the cy.pause() which is not needed in running test cases. Locally developer can use but it should never be pushed as part of PR.

Fixes #`@tag.sanity`  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9856177524>
> Commit: 5bb8ade1caf74ea952e327bb33488a13885fb85d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9856177524&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 09 Jul 2024 11:54:30 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Removed pause commands in multiple test files, ensuring smoother and uninterrupted test executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->