### PR TITLE
chore: Fix regexes for APIs needing environment

### DIFF
--- a/app/client/src/ce/api/ApiUtils.ts
+++ b/app/client/src/ce/api/ApiUtils.ts
@@ -28,6 +28,7 @@ import { CONTENT_TYPE_HEADER_KEY } from "constants/ApiEditorConstants/CommonApiC
 import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 import { getCurrentEnvironmentId } from "@appsmith/selectors/environmentSelectors";
 import { UNUSED_ENV_ID } from "constants/EnvironmentContants";
+import { ID_EXTRACTION_REGEX } from "@appsmith/constants/routes/appRoutes";
 
 const executeActionRegex = /actions\/execute/;
 const timeoutErrorRegex = /timeout of (\d+)ms exceeded/;
@@ -49,8 +50,8 @@ export const BLOCKED_ROUTES_REGEX = new RegExp(
 );
 
 export const ENV_ENABLED_ROUTES = [
-  "v1/datasources/[a-z0-9]+/structure",
-  "/v1/datasources/[a-z0-9]+/trigger",
+  `v1/datasources/${ID_EXTRACTION_REGEX}/structure`,
+  `/v1/datasources/${ID_EXTRACTION_REGEX}/trigger`,
   "v1/actions/execute",
   "v1/saas",
 ];

--- a/app/client/src/ce/constants/routes/appRoutes.ts
+++ b/app/client/src/ce/constants/routes/appRoutes.ts
@@ -13,7 +13,7 @@ const { match } = require("path-to-regexp");
 const MONGO_OBJECT_ID_REGEX = "[0-9a-f]{24}";
 const UUID_REGEX =
   "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
-const ID_EXTRACTION_REGEX = `(${MONGO_OBJECT_ID_REGEX}|${UUID_REGEX})`;
+export const ID_EXTRACTION_REGEX = `(${MONGO_OBJECT_ID_REGEX}|${UUID_REGEX})`;
 
 export const BUILDER_BASE_PATH_DEPRECATED = "/applications";
 export const BUILDER_VIEWER_PATH_PREFIX = "/app/";


### PR DESCRIPTION
The regex used to identify if an API needs environment information, doesn't support UUIDs. This PR adds that.

Ideally, we should pass this information from where we're calling `Api.get()`, not via an interceptor that matches certain very specific API paths. Especially since the regex isn't matching generic paths. Add to that, headers is the wrong place for things like this, because this is essentially a "query param", it's a parameter to the query in the GET API call, on equal footing with `datasourceId`. The generic Axios interceptors being aware of the concept called environments, itself is an abstraction leak, in my opinion. Problem for another day though.

/test sanity


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9850313501>
> Commit: e6348e0685c1cc79d8932b5fcaa35d67e635186b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9850313501&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 09 Jul 2024 03:33:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced dynamic route matching for data source structures and triggers, making the application more flexible and robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->