### PR TITLE
fix: Update datasource deletion message for clarity

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/MySQL_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/MySQL_Spec.ts
@@ -91,7 +91,7 @@ describe(
     after("Verify Deletion of the datasource", () => {
       dataSources.DeleteDatasourceFromWithinDS(dsName, 409);
       agHelper.ValidateToastMessage(
-        "Cannot delete datasource since it has 1 action(s) using it.",
+        "Cannot delete datasource since it has 1 query using it.",
       ); //table is 1 action
     });
 

--- a/app/client/cypress/support/Pages/DataSources.ts
+++ b/app/client/cypress/support/Pages/DataSources.ts
@@ -897,7 +897,7 @@ export class DataSources {
         this.agHelper.AssertContains(
           responseStatus === 200
             ? "datasource deleted successfully"
-            : "action(s) using it",
+            : "Cannot delete datasource",
         );
       });
   }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
@@ -806,7 +806,9 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
                 .flatMap(objects -> {
                     final Long actionsCount = objects.getT2();
                     if (actionsCount > 0) {
-                        return Mono.error(new AppsmithException(AppsmithError.DATASOURCE_HAS_ACTIONS, actionsCount));
+                        String queryWord = actionsCount == 1 ? "query" : "queries";
+                        return Mono.error(
+                                new AppsmithException(AppsmithError.DATASOURCE_HAS_ACTIONS, actionsCount, queryWord));
                     }
                     return Mono.just(objects.getT1());
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -502,7 +502,7 @@ public enum AppsmithError {
     DATASOURCE_HAS_ACTIONS(
             409,
             AppsmithErrorCode.DATASOURCE_HAS_ACTIONS.getCode(),
-            "Cannot delete datasource since it has {0} action(s) using it.",
+            "Cannot delete datasource since it has {0} {1} using it.",
             AppsmithErrorAction.DEFAULT,
             "Datasource cannot be deleted",
             ErrorType.BAD_REQUEST,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -947,7 +947,8 @@ public class DatasourceServiceTest {
                 })
                 .flatMap(datasource -> datasourceService.archiveById(datasource.getId()));
 
-        StepVerifier.create(datasourceMono).verifyErrorMessage(AppsmithError.DATASOURCE_HAS_ACTIONS.getMessage("1"));
+        StepVerifier.create(datasourceMono)
+                .verifyErrorMessage(AppsmithError.DATASOURCE_HAS_ACTIONS.getMessage("1", "query"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #34604 

Hi @nidhi-nair , 

**Screenshots :**
**Earlier :**
![image](https://github.com/appsmithorg/appsmith/assets/124746204/0a02a9cb-b324-4844-9d7b-c5ee72439a45)
**After update the error message :**
![image](https://github.com/appsmithorg/appsmith/assets/124746204/26414136-98df-4df7-929d-f2556329d70d)
![image](https://github.com/appsmithorg/appsmith/assets/124746204/fc9faf36-65ef-4d72-9ce8-49514eb9f90e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error messages during datasource deletion to improve clarity: "Cannot delete datasource since it has 1 query using it."

- **Tests**
  - Adjusted test cases to reflect updated error messages and ensure accurate verification.

- **Documentation**
  - Improved error message documentation for better user understanding during datasource deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->