### PR TITLE
chore: Remove unused `regexMatchIgnoreCase`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/Bridge.java
@@ -79,11 +79,6 @@ public final class Bridge {
         return Bridge.<T>query().equal(key, value);
     }
 
-    @Deprecated
-    public static <T extends BaseDomain> BridgeQuery<T> regexMatchIgnoreCase(@NonNull String key, String regexPattern) {
-        return Bridge.<T>query().regexMatchIgnoreCase(key, regexPattern);
-    }
-
     public static <T extends BaseDomain> BridgeQuery<T> searchIgnoreCase(@NonNull String key, @NonNull String needle) {
         return Bridge.<T>query().searchIgnoreCase(key, needle);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/bridge/BridgeQuery.java
@@ -22,7 +22,7 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
         return this;
     }
 
-    public BridgeQuery<T> equal(@NonNull String key, @NonNull int value) {
+    public BridgeQuery<T> equal(@NonNull String key, int value) {
         checks.add(Criteria.where(key).is(value));
         return this;
     }
@@ -55,11 +55,6 @@ public final class BridgeQuery<T extends BaseDomain> extends Criteria {
      */
     public BridgeQuery<T> equal(@NonNull String key, boolean value) {
         checks.add(Criteria.where(key).is(value));
-        return this;
-    }
-
-    public BridgeQuery<T> regexMatchIgnoreCase(@NonNull String key, @NonNull String regexPattern) {
-        checks.add(Criteria.where(key).regex(regexPattern, "i"));
         return this;
     }
 


### PR DESCRIPTION
This method isn't used anywhere, EE included, and we don't want it to be used either. There's specialized methods for things this was used in the past, `searchIgnoreCase` and `inIgnoresCase`, and should be preferred instead of this. If a new need comes up that needs regex, we'll come up with a specialized query method again.

**/test sanity**



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9858374518>
> Commit: 7b4eef3f04e81ec96c4f88b8c3e354dae95e92b3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9858374518&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 09 Jul 2024 14:13:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed deprecated `regexMatchIgnoreCase` method for cleaner and more maintainable code.
  - Updated `equal` method to improve flexibility by accepting `int` values without the `@NonNull` annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->