### PR TITLE
fix: use isDryOps flag in customJsLIb import flow

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/MappedImportableResourcesCE_DTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/MappedImportableResourcesCE_DTO.java
@@ -55,7 +55,7 @@ public class MappedImportableResourcesCE_DTO {
 
     Map<DBOpsType, List<DatasourceStorage>> datasourceStorageDryRunQueries = new HashMap<>();
 
-    Map<String, List<CustomJSLib>> customJSLibsDryOps = new HashMap<>();
+    Map<DBOpsType, List<CustomJSLib>> customJSLibsDryOps = new HashMap<>();
 
     {
         for (DBOpsType dbOpsType : DBOpsType.values()) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/base/CustomJSLibServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/base/CustomJSLibServiceCE.java
@@ -3,6 +3,7 @@ package com.appsmith.server.jslibs.base;
 import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.server.domains.CustomJSLib;
 import com.appsmith.server.dtos.CustomJSLibContextDTO;
+import com.appsmith.server.dtos.DBOpsType;
 import com.appsmith.server.services.CrudService;
 import jakarta.validation.constraints.NotNull;
 import reactor.core.publisher.Flux;
@@ -36,7 +37,7 @@ public interface CustomJSLibServiceCE extends CrudService<CustomJSLib, String> {
     Mono<CustomJSLibContextDTO> persistCustomJSLibMetaDataIfDoesNotExistAndGetDTO(
             CustomJSLib jsLib,
             Boolean isForceInstall,
-            Map<String, List<CustomJSLib>> customJSLibsDryOps,
+            Map<DBOpsType, List<CustomJSLib>> customJSLibsDryOps,
             boolean isDryOps);
 
     Flux<CustomJSLib> getAllVisibleJSLibsInContext(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/base/CustomJSLibServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/base/CustomJSLibServiceCEImpl.java
@@ -83,7 +83,7 @@ public class CustomJSLibServiceCEImpl extends BaseService<CustomJSLibRepository,
     public Mono<CustomJSLibContextDTO> persistCustomJSLibMetaDataIfDoesNotExistAndGetDTO(
             CustomJSLib jsLib,
             Boolean isForceInstall,
-            Map<String, List<CustomJSLib>> customJSLibsDryOps,
+            Map<DBOpsType, List<CustomJSLib>> customJSLibsDryOps,
             boolean isDryOps) {
         return repository
                 .findUniqueCustomJsLib(jsLib)
@@ -92,7 +92,7 @@ public class CustomJSLibServiceCEImpl extends BaseService<CustomJSLibRepository,
                 .switchIfEmpty(Mono.defer(() -> {
                     if (isDryOps) {
                         jsLib.updateForBulkWriteOperation();
-                        addDryOpsForEntity(DBOpsType.SAVE.name(), customJSLibsDryOps, jsLib);
+                        addDryOpsForEntity(DBOpsType.SAVE, customJSLibsDryOps, jsLib);
                         return Mono.just(jsLib);
                     }
                     return repository.save(jsLib);
@@ -106,7 +106,7 @@ public class CustomJSLibServiceCEImpl extends BaseService<CustomJSLibRepository,
                     if ((jsLib.getDefs().length() > foundJSLib.getDefs().length()) || isForceInstall) {
                         jsLib.setId(foundJSLib.getId());
                         if (isDryOps) {
-                            addDryOpsForEntity(DBOpsType.SAVE.name(), customJSLibsDryOps, jsLib);
+                            addDryOpsForEntity(DBOpsType.SAVE, customJSLibsDryOps, jsLib);
                             return Mono.just(jsLib);
                         }
                         return repository.save(jsLib);
@@ -166,7 +166,7 @@ public class CustomJSLibServiceCEImpl extends BaseService<CustomJSLibRepository,
     }
 
     private void addDryOpsForEntity(
-            String queryType, Map<String, List<CustomJSLib>> dryRunOpsMap, CustomJSLib createdCustomJsLib) {
+            DBOpsType queryType, Map<DBOpsType, List<CustomJSLib>> dryRunOpsMap, CustomJSLib createdCustomJsLib) {
         if (dryRunOpsMap.containsKey(queryType)) {
             dryRunOpsMap.get(queryType).add(createdCustomJsLib);
         } else {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/importable/CustomJSLibImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/importable/CustomJSLibImportableServiceCEImpl.java
@@ -49,7 +49,8 @@ public class CustomJSLibImportableServiceCEImpl implements ImportableServiceCE<C
                     customJSLib.setId(null);
                     customJSLib.setCreatedAt(null);
                     customJSLib.setUpdatedAt(null);
-                    return customJSLibService.persistCustomJSLibMetaDataIfDoesNotExistAndGetDTO(customJSLib, false);
+                    return customJSLibService.persistCustomJSLibMetaDataIfDoesNotExistAndGetDTO(
+                            customJSLib, false, mappedImportableResourcesDTO.getCustomJSLibsDryOps(), true);
                 })
                 .collectList()
                 .doOnNext(mappedImportableResourcesDTO::setInstalledJsLibsList)


### PR DESCRIPTION
## Description
In the last PR, refactored the customJsLib persist method code to simulate the db ops by using the dryOps flag. But missed to use it in the import flow. This PR fixes this. 

## Automation

/ok-to-test tags="@tag.Templates, @tag.Git, @tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9868884786>
> Commit: 853614e378f156649e7b15fda7ec2cf75b03605b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9868884786&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Templates, @tag.Git, @tag.ImportExport`
> Spec:
> <hr>Wed, 10 Jul 2024 06:11:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced type safety and clarity in handling database operations for custom JavaScript libraries by updating parameter types across multiple methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->