### PR TITLE
chore: Introduce permissions via arguments for theme repository methods

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCE.java
@@ -9,11 +9,11 @@ import reactor.core.publisher.Mono;
 public interface CustomThemeRepositoryCE extends AppsmithRepository<Theme> {
     Flux<Theme> getApplicationThemes(String applicationId, AclPermission aclPermission);
 
-    Flux<Theme> getSystemThemes();
+    Flux<Theme> getSystemThemes(AclPermission permission);
 
-    Mono<Theme> getSystemThemeByName(String themeName);
+    Mono<Theme> getSystemThemeByName(String themeName, AclPermission permission);
 
-    Mono<Boolean> archiveByApplicationId(String applicationId);
+    Mono<Boolean> archiveByApplicationId(String applicationId, AclPermission permission);
 
-    Mono<Boolean> archiveDraftThemesById(String editModeThemeId, String publishedModeThemeId);
+    Mono<Boolean> archiveDraftThemesById(String editModeThemeId, String publishedModeThemeId, AclPermission permission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomThemeRepositoryCEImpl.java
@@ -27,39 +27,40 @@ public class CustomThemeRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Them
     }
 
     @Override
-    public Flux<Theme> getSystemThemes() {
+    public Flux<Theme> getSystemThemes(AclPermission permission) {
         return queryBuilder()
                 .criteria(Bridge.isTrue(Theme.Fields.isSystemTheme))
-                .permission(AclPermission.READ_THEMES)
+                .permission(permission)
                 .all();
     }
 
     @Override
-    public Mono<Theme> getSystemThemeByName(String themeName) {
+    public Mono<Theme> getSystemThemeByName(String themeName, AclPermission permission) {
         return queryBuilder()
                 .criteria(Bridge.equalIgnoreCase(Theme.Fields.name, themeName).isTrue(Theme.Fields.isSystemTheme))
-                .permission(AclPermission.READ_THEMES)
+                .permission(permission)
                 .one();
     }
 
-    private Mono<Boolean> archiveThemeByCriteria(BridgeQuery<Theme> criteria) {
+    private Mono<Boolean> archiveThemeByCriteria(BridgeQuery<Theme> criteria, AclPermission permission) {
         return queryBuilder()
                 .criteria(criteria)
-                .permission(AclPermission.MANAGE_THEMES)
+                .permission(permission)
                 .updateAll(Bridge.update().set(Theme.Fields.deletedAt, Instant.now()))
                 .map(count -> count > 0);
     }
 
     @Override
-    public Mono<Boolean> archiveByApplicationId(String applicationId) {
-        return archiveThemeByCriteria(Bridge.equal(Theme.Fields.applicationId, applicationId));
+    public Mono<Boolean> archiveByApplicationId(String applicationId, AclPermission permission) {
+        return archiveThemeByCriteria(Bridge.equal(Theme.Fields.applicationId, applicationId), permission);
     }
 
     @Override
-    public Mono<Boolean> archiveDraftThemesById(String editModeThemeId, String publishedModeThemeId) {
+    public Mono<Boolean> archiveDraftThemesById(
+            String editModeThemeId, String publishedModeThemeId, AclPermission permission) {
         BridgeQuery<Theme> criteria = Bridge.<Theme>in(
                         Theme.Fields.id, CollectionUtils.ofNonNulls(editModeThemeId, publishedModeThemeId))
                 .isFalse(Theme.Fields.isSystemTheme);
-        return archiveThemeByCriteria(criteria);
+        return archiveThemeByCriteria(criteria, permission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/base/ThemeServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/themes/base/ThemeServiceCEImpl.java
@@ -81,9 +81,9 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
                     if (StringUtils.hasLength(themeId)) {
                         return repository
                                 .findById(themeId, READ_THEMES)
-                                .switchIfEmpty(repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME));
+                                .switchIfEmpty(repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME, READ_THEMES));
                     } else { // theme id is not present, return default theme
-                        return repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME);
+                        return repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME, READ_THEMES);
                     }
                 });
     }
@@ -98,7 +98,7 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
 
     @Override
     public Flux<Theme> getSystemThemes() {
-        return repository.getSystemThemes();
+        return repository.getSystemThemes(READ_THEMES);
     }
 
     @Override
@@ -175,10 +175,12 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
     @Override
     public Mono<String> getDefaultThemeId() {
         if (StringUtils.isEmpty(defaultThemeId)) {
-            return repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME).map(theme -> {
-                defaultThemeId = theme.getId();
-                return theme.getId();
-            });
+            return repository
+                    .getSystemThemeByName(Theme.DEFAULT_THEME_NAME, READ_THEMES)
+                    .map(theme -> {
+                        defaultThemeId = theme.getId();
+                        return theme.getId();
+                    });
         }
         return Mono.just(defaultThemeId);
     }
@@ -214,7 +216,7 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
                     Mono<Theme> editModeThemeMono;
                     if (!StringUtils.hasLength(
                             application.getEditModeThemeId())) { // theme id is empty, use the default theme
-                        editModeThemeMono = repository.getSystemThemeByName(Theme.LEGACY_THEME_NAME);
+                        editModeThemeMono = repository.getSystemThemeByName(Theme.LEGACY_THEME_NAME, READ_THEMES);
                     } else { // theme id is not empty, fetch it by id
                         editModeThemeMono = repository.findById(application.getEditModeThemeId(), READ_THEMES);
                     }
@@ -401,7 +403,7 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
 
     @Override
     public Mono<Theme> getSystemTheme(String themeName) {
-        return repository.getSystemThemeByName(themeName);
+        return repository.getSystemThemeByName(themeName, READ_THEMES);
     }
 
     @Override
@@ -434,11 +436,11 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
     @Override
     public Mono<Theme> getOrSaveTheme(Theme theme, Application destApplication) {
         if (theme == null) { // this application was exported without theme, assign the legacy theme to it
-            return repository.getSystemThemeByName(Theme.LEGACY_THEME_NAME); // return the default theme
+            return repository.getSystemThemeByName(Theme.LEGACY_THEME_NAME, READ_THEMES); // return the default theme
         } else if (theme.isSystemTheme()) {
             return repository
-                    .getSystemThemeByName(theme.getName())
-                    .switchIfEmpty(repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME));
+                    .getSystemThemeByName(theme.getName(), READ_THEMES)
+                    .switchIfEmpty(repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME, READ_THEMES));
         } else {
             // create a new theme
             Theme newTheme = new Theme();
@@ -464,9 +466,9 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepository, Theme, Stri
     @Override
     public Mono<Application> archiveApplicationThemes(Application application) {
         return repository
-                .archiveByApplicationId(application.getId())
+                .archiveByApplicationId(application.getId(), MANAGE_THEMES)
                 .then(repository.archiveDraftThemesById(
-                        application.getEditModeThemeId(), application.getPublishedModeThemeId()))
+                        application.getEditModeThemeId(), application.getPublishedModeThemeId(), MANAGE_THEMES))
                 .thenReturn(application);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ThemeServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ThemeServiceTest.java
@@ -658,7 +658,7 @@ public class ThemeServiceTest {
         Application publishedApp =
                 applicationPageService.publish(savedApplication.getId(), TRUE).block();
 
-        Mono<Theme> classicThemeMono = themeRepository.getSystemThemeByName(Theme.LEGACY_THEME_NAME);
+        Mono<Theme> classicThemeMono = themeRepository.getSystemThemeByName(Theme.LEGACY_THEME_NAME, READ_THEMES);
 
         Mono<Tuple2<Application, Theme>> appAndThemeTuple =
                 Mono.just(publishedApp).zipWith(classicThemeMono);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ThemeImportableServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ThemeImportableServiceCETest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
+import static com.appsmith.server.acl.AclPermission.READ_THEMES;
 import static com.appsmith.server.constants.FieldName.ADMINISTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -191,8 +192,9 @@ public class ThemeImportableServiceCETest {
     @WithUserDetails("api_user")
     @Test
     public void importThemesToApplication_ApplicationThemeNotFound_DefaultThemeImported() {
-        Theme defaultTheme =
-                themeRepository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME).block();
+        Theme defaultTheme = themeRepository
+                .getSystemThemeByName(Theme.DEFAULT_THEME_NAME, READ_THEMES)
+                .block();
 
         // create the theme information present in the application JSON
         Theme themeInJson = new Theme();


### PR DESCRIPTION
## Description
PR to add permissions via repo method arguments for CustomThemeRepository. This is required because on pg branch we are looking for the AclPermission argument and are attaching the user context in the repository method, which then is used for evaluating if the user has the required permissions. This is again because the JDBC driver is non-reactive in nature and if we add the blocking statements in reactive chani user context gets lost. 

## Automation

/ok-to-test tags="@tag.Git, @tag.Theme"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
