### PR TITLE
fix: Update email regex to allow longer domain names

### DIFF
--- a/app/client/src/widgets/InputWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.js
@@ -72,7 +72,7 @@ export default {
          *  https://stackoverflow.com/questions/15017052/understanding-email-validation-using-javascript
          * */
         const emailRegex = new RegExp(
-          /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+$/,
+          /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,6})+$/,
         );
         if (!emailRegex.test(value)) {
           /* email should conform to generic email regex */

--- a/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
@@ -172,6 +172,19 @@ describe("Derived property - ", () => {
         _,
       );
 
+      expect(isValid).toBeFalsy();
+
+      //Email input with required true and valid value
+      isValid = derivedProperty.isValid(
+        {
+          inputType: InputTypes.EMAIL,
+          inputText: "test@test.school",
+          isRequired: true,
+        },
+        null,
+        _,
+      );
+
       expect(isValid).toBeTruthy();
 
       //Password input with required false and empty value


### PR DESCRIPTION

Fixes #<issue_number>

## Description
The email regex in the InputWidgetV2 component was updated to allow domain names with up to 6 characters. This change ensures that valid email addresses with longer domain names are accepted.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Input, @tag.Sanity, @tag.Binding"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9872927695>
> Commit: e2e99648eee0c0c71e05e8f3879124b2be17023f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9872927695&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Input, @tag.Sanity, @tag.Binding`
> Spec:
> <hr>Wed, 10 Jul 2024 11:29:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated email validation to support domains with 2 to 6 characters.

- **Tests**
	- Added tests for email input validation to ensure correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->