### PR TITLE
fix: expose isVisible field in JSONFom widget autocomplete

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Bugs_AC_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Bugs_AC_Spec.ts
@@ -160,4 +160,17 @@ describe("Autocomplete bug fixes", { tags: ["@tag.JS"] }, function () {
       "console.log('hello')",
     );
   });
+
+  it("11. Bug #31114 Verify Object Properties in Autocomplete List for isVisible Field in JSONForm Widget", function () {
+    entityExplorer.DragDropWidgetNVerify(draggableWidgets.JSONFORM, 400, 800);
+    EditorNavigation.SelectEntityByName("Text1", EntityType.Widget);
+    propPane.EnterJSContext("Visible", "");
+    propPane.TypeTextIntoField("Visible", "{{JSONForm1.isVis");
+    agHelper.AssertElementExist(locators._hints);
+    agHelper.GetNAssertElementText(
+      locators._hints,
+      "isVisible",
+      "contain.text",
+    );
+  });
 });

--- a/app/client/src/widgets/JSONFormWidget/widget/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/widget/index.tsx
@@ -31,7 +31,10 @@ import type {
   Stylesheet,
 } from "entities/AppTheming";
 import type { BatchPropertyUpdatePayload } from "actions/controlActions";
-import { isAutoHeightEnabledForWidget } from "widgets/WidgetUtils";
+import {
+  isAutoHeightEnabledForWidget,
+  DefaultAutocompleteDefinitions,
+} from "widgets/WidgetUtils";
 import { generateTypeDef } from "utils/autocomplete/defCreatorUtils";
 import type {
   AnvilConfig,
@@ -461,6 +464,7 @@ class JSONFormWidget extends BaseWidget<
         sourceData: generateTypeDef(widget.sourceData),
         fieldState: generateTypeDef(widget.fieldState),
         isValid: "bool",
+        isVisible: DefaultAutocompleteDefinitions.isVisible,
       };
 
       return definitions;


### PR DESCRIPTION
Fixes [#31114](https://github.com/appsmithorg/appsmith/issues/31114)
Added missing field isVisible in getAutocompleteDefinition fn
Added cypress test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced autocomplete functionality in the JSONForm Widget to include the `isVisible` property.

- **Tests**
	- Added a new test case to verify object properties in the autocomplete list for the `isVisible` field in the JSONForm Widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->