### PR TITLE
revert: change value to label in onItemSelect inside SelectCell of table widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -174,39 +174,7 @@ describe(
       cy.discardTableRow(4, 0);
     });
 
-    it("6. should check that on option select uses label as value in select cell (#34743)", () => {
-      cy.updateCodeInput(
-        ".t--property-control-options",
-        `
-      [
-        {
-          "label": "#1label",
-          "value": "#1value"
-        },
-        {
-          "label": "#2label",
-          "value": "#2value"
-        },
-        {
-          "label": "#3label",
-          "value": "#3value"
-        }
-      ]
-    `,
-      );
-      cy.editTableSelectCell(0, 0);
-      cy.get(".menu-item-link").contains("#3label").click();
-
-      _.agHelper.ValidateToastMessage("#3label");
-
-      cy.get(".menu-virtual-list").should("not.exist");
-      cy.readTableV2data(0, 0).then((val) => {
-        expect(val).to.equal("#3label");
-      });
-      cy.discardTableRow(4, 0);
-    });
-
-    it("7. should check that currentRow is accessible in the select options", () => {
+    it("6. should check that currentRow is accessible in the select options", () => {
       cy.updateCodeInput(
         ".t--property-control-options",
         `
@@ -231,7 +199,7 @@ describe(
       cy.get(".menu-item-text").contains("#1").should("not.exist");
     });
 
-    it("8. should check that 'same select option in new row' property is working", () => {
+    it("7. should check that 'same select option in new row' property is working", () => {
       _.propPane.NavigateBackToPropertyPane();
 
       const checkSameOptionsInNewRowWhileEditing = () => {
@@ -297,7 +265,7 @@ describe(
       checkSameOptionsWhileAddingNewRow();
     });
 
-    it("9. should check that 'new row select options' is working", () => {
+    it("8. should check that 'new row select options' is working", () => {
       const checkNewRowOptions = () => {
         // New row select options should be visible when "Same options in new row" is turned off
         _.propPane.TogglePropertyState("Same options in new row", "Off");
@@ -362,7 +330,7 @@ describe(
       checkNoOptionState();
     });
 
-    it("10. should check that server side filering is working", () => {
+    it("9. should check that server side filering is working", () => {
       _.dataSources.CreateDataSource("Postgres");
       _.dataSources.CreateQueryAfterDSSaved(
         "SELECT * FROM public.astronauts {{this.params.filterText ? `WHERE name LIKE '%${this.params.filterText}%'` : ''}} LIMIT 10;",

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
@@ -149,7 +149,7 @@ export const SelectCell = (props: SelectProps) => {
   const onSelect = useCallback(
     (option: DropdownOption) => {
       onItemSelect(
-        option.label || "",
+        option.value || "",
         rowIndex,
         alias,
         onOptionSelectActionString,


### PR DESCRIPTION
Reverts appsmithorg/appsmith#34743

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9888593641>
> Commit: eec317589c3e8ec7fa68a85811f0fb4e7e632582
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9888593641&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Thu, 11 Jul 2024 09:38:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved test cases for select options in the table widget for better clarity and organization.
  - Updated `SelectCell` component to use option values instead of labels for item selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->