### PR TITLE
fix: fixed git config route protection using fetchGlobalGitConfigInit…

### DIFF
--- a/app/client/src/pages/UserProfile/General.tsx
+++ b/app/client/src/pages/UserProfile/General.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Button, Input, toast, Text } from "design-system";
 import { useDispatch, useSelector } from "react-redux";
 import { getCurrentUser } from "selectors/usersSelectors";
@@ -19,7 +19,6 @@ import { ALL_LANGUAGE_CHARACTERS_REGEX } from "constants/Regex";
 import { createMessage } from "design-system-old/build/constants/messages";
 import { notEmptyValidator } from "design-system-old";
 import { getIsFormLoginEnabled } from "@appsmith/selectors/tenantSelectors";
-import { fetchGlobalGitConfigInit } from "actions/gitSyncActions";
 
 const nameValidator = (
   value: string,
@@ -70,11 +69,6 @@ function General() {
         }),
       );
   };
-
-  useEffect(() => {
-    // onMount Fetch Global config
-    dispatch(fetchGlobalGitConfigInit());
-  }, []);
 
   if (user?.email === ANONYMOUS_USERNAME) return null;
 

--- a/app/client/src/pages/UserProfile/General.tsx
+++ b/app/client/src/pages/UserProfile/General.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button, Input, toast, Text } from "design-system";
 import { useDispatch, useSelector } from "react-redux";
 import { getCurrentUser } from "selectors/usersSelectors";
@@ -19,6 +19,7 @@ import { ALL_LANGUAGE_CHARACTERS_REGEX } from "constants/Regex";
 import { createMessage } from "design-system-old/build/constants/messages";
 import { notEmptyValidator } from "design-system-old";
 import { getIsFormLoginEnabled } from "@appsmith/selectors/tenantSelectors";
+import { fetchGlobalGitConfigInit } from "actions/gitSyncActions";
 
 const nameValidator = (
   value: string,
@@ -69,6 +70,11 @@ function General() {
         }),
       );
   };
+
+  useEffect(() => {
+    // onMount Fetch Global config
+    dispatch(fetchGlobalGitConfigInit());
+  }, []);
 
   if (user?.email === ANONYMOUS_USERNAME) return null;
 

--- a/app/client/src/pages/UserProfile/GitConfig.tsx
+++ b/app/client/src/pages/UserProfile/GitConfig.tsx
@@ -13,10 +13,7 @@ import {
   getGlobalGitConfig,
   getIsFetchingGlobalGitConfig,
 } from "selectors/gitSyncSelectors";
-import {
-  fetchGlobalGitConfigInit,
-  updateGlobalGitConfigInit,
-} from "actions/gitSyncActions";
+import { updateGlobalGitConfigInit } from "actions/gitSyncActions";
 import { emailValidator } from "design-system-old";
 
 export default function GitConfig() {
@@ -59,11 +56,6 @@ export default function GitConfig() {
       toast.show("Please enter valid user details");
     }
   };
-
-  useEffect(() => {
-    // onMount Fetch Global config
-    dispatch(fetchGlobalGitConfigInit());
-  }, []);
 
   return (
     <Wrapper>

--- a/app/client/src/pages/UserProfile/index.test.tsx
+++ b/app/client/src/pages/UserProfile/index.test.tsx
@@ -1,0 +1,138 @@
+import "@testing-library/jest-dom/extend-expect";
+import React from "react";
+import { render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { lightTheme } from "selectors/themeSelectors";
+import { ThemeProvider } from "styled-components";
+import { BrowserRouter as Router } from "react-router-dom";
+import { unitTestBaseMockStore } from "layoutSystems/common/dropTarget/unitTestUtils";
+import UserProfile from ".";
+import {
+  ReduxActionErrorTypes,
+  ReduxActionTypes,
+} from "@appsmith/constants/ReduxActionConstants";
+import { fetchGlobalGitConfigInit } from "actions/gitSyncActions";
+import Login from "pages/UserAuth/Login";
+
+const defaultStoreState = {
+  ...unitTestBaseMockStore,
+  tenant: {
+    tenantConfiguration: {},
+  },
+  entities: {
+    ...unitTestBaseMockStore.entities,
+    plugins: {
+      list: [],
+    },
+    datasources: {
+      list: [],
+      mockDatasourceList: [],
+    },
+  },
+  ui: {
+    ...unitTestBaseMockStore.ui,
+    selectedWorkspace: {
+      ...unitTestBaseMockStore.ui.selectedWorkspace,
+      applications: [unitTestBaseMockStore.ui.applications.currentApplication],
+    },
+    debugger: {
+      isOpen: false,
+    },
+    editor: {
+      loadingStates: {},
+      isProtectedMode: true,
+      zoomLevel: 1,
+    },
+    gitSync: {
+      globalGitConfig: {},
+      branches: [],
+      localGitConfig: {},
+      disconnectingGitApp: {},
+    },
+    users: {
+      loadingStates: {},
+      list: [],
+      users: [],
+      error: "",
+      currentUser: {
+        name: "mockUser",
+        email: "mockUser@gmail.com",
+      },
+      featureFlag: {
+        data: {},
+        isFetched: true,
+        overriddenFlags: {},
+      },
+      productAlert: {
+        config: {},
+      },
+    },
+    apiPane: {
+      isCreating: false,
+      isRunning: {},
+      isSaving: {},
+      isDeleting: {},
+      isDirty: {},
+      extraformData: {},
+      selectedConfigTabIndex: 0,
+      debugger: {
+        open: false,
+      },
+    },
+  },
+};
+
+jest.mock("design-system-old/build/constants/messages", () => ({
+  ...jest.requireActual("design-system-old/build/constants/messages"),
+  createMessage: () => "",
+}));
+
+jest.mock("actions/gitSyncActions", () => ({
+  fetchGlobalGitConfigInit: jest.fn(),
+}));
+
+const mockStore = configureStore([]);
+describe("Git config ", () => {
+  let store: any;
+  it("Should render UserProfile component for logged in user", () => {
+    store = mockStore(defaultStoreState);
+    (fetchGlobalGitConfigInit as jest.Mock).mockReturnValue({
+      type: ReduxActionTypes.FETCH_GLOBAL_GIT_CONFIG_INIT,
+    });
+    const { getAllByText, getByTestId } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <Router>
+            <UserProfile />
+          </Router>
+        </ThemeProvider>
+      </Provider>,
+    );
+    expect(getAllByText("Upload display picture")).toBeInTheDocument;
+    const input = getByTestId("t--display-name");
+    expect(input.getAttribute("value")).toBe("mockUser");
+  });
+
+  it("Should render Login Page for non logged in User", () => {
+    store = mockStore(defaultStoreState);
+    (fetchGlobalGitConfigInit as jest.Mock).mockReturnValue({
+      type: ReduxActionErrorTypes.FETCH_GLOBAL_GIT_CONFIG_ERROR,
+    });
+    const { getAllByText } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <Router>
+            <Login />
+          </Router>
+        </ThemeProvider>
+      </Provider>,
+    );
+    expect(getAllByText("Sign in to your account")).toBeInTheDocument;
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+    store.clearActions();
+  });
+});

--- a/app/client/src/pages/UserProfile/index.tsx
+++ b/app/client/src/pages/UserProfile/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PageWrapper from "pages/common/PageWrapper";
 import styled from "styled-components";
 import { Tabs, Tab, TabsList, TabPanel } from "design-system";
@@ -7,6 +7,8 @@ import GitConfig from "./GitConfig";
 import { useLocation } from "react-router";
 import { GIT_PROFILE_ROUTE } from "constants/routes";
 import { BackButton } from "components/utils/helperComponents";
+import { useDispatch } from "react-redux";
+import { fetchGlobalGitConfigInit } from "actions/gitSyncActions";
 
 const ProfileWrapper = styled.div`
   width: 978px;
@@ -22,6 +24,7 @@ const ProfileWrapper = styled.div`
 
 function UserProfile() {
   const location = useLocation();
+  const dispatch = useDispatch();
 
   let initialTab = "general";
   const tabs = [
@@ -44,6 +47,11 @@ function UserProfile() {
   }
 
   const [selectedTab, setSelectedTab] = useState(initialTab);
+
+  useEffect(() => {
+    // onMount Fetch Global config
+    dispatch(fetchGlobalGitConfigInit());
+  }, []);
 
   return (
     <PageWrapper displayName={"Profile"}>


### PR DESCRIPTION
## Description:
In this PR I have fixed the GitConfig route `dev.appsmtih.com/profile` with the help of `fetchGlobalGitConfigInit` method.
Now  If an unauthorized user try to access this URL , it will redirects to the login page.

## Issue video
[Screencast from 11-07-24 02:37:08 PM IST.webm](https://github.com/appsmithorg/appsmith/assets/127818049/1c851c90-c0d0-47d7-8b1e-8c5df74b6f28)

## Solution video
[Screencast from 11-07-24 02:36:02 PM IST.webm](https://github.com/appsmithorg/appsmith/assets/127818049/7f7840e7-d00c-4deb-93f0-ad7c3bc74bf5)


> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #34603  
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic fetching of global Git configuration when visiting the UserProfile page.
  
- **Refactor**
  - Simplified imports and component logic in the UserProfile and GitConfig components for better maintainability.

- **Bug Fixes**
  - Improved initialization behavior of the GitConfig component by removing redundant fetch operations.

- **Tests**
  - Introduced unit tests for the UserProfile component to verify rendering behavior based on user authentication states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->