### PR TITLE
fix: Cherrypick/revert-34872

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -174,39 +174,7 @@ describe(
       cy.discardTableRow(4, 0);
     });
 
-    it("6. should check that on option select uses label as value in select cell (#34743)", () => {
-      cy.updateCodeInput(
-        ".t--property-control-options",
-        `
-      [
-        {
-          "label": "#1label",
-          "value": "#1value"
-        },
-        {
-          "label": "#2label",
-          "value": "#2value"
-        },
-        {
-          "label": "#3label",
-          "value": "#3value"
-        }
-      ]
-    `,
-      );
-      cy.editTableSelectCell(0, 0);
-      cy.get(".menu-item-link").contains("#3label").click();
-
-      _.agHelper.ValidateToastMessage("#3label");
-
-      cy.get(".menu-virtual-list").should("not.exist");
-      cy.readTableV2data(0, 0).then((val) => {
-        expect(val).to.equal("#3label");
-      });
-      cy.discardTableRow(4, 0);
-    });
-
-    it("7. should check that currentRow is accessible in the select options", () => {
+    it("6. should check that currentRow is accessible in the select options", () => {
       cy.updateCodeInput(
         ".t--property-control-options",
         `
@@ -231,7 +199,7 @@ describe(
       cy.get(".menu-item-text").contains("#1").should("not.exist");
     });
 
-    it("8. should check that 'same select option in new row' property is working", () => {
+    it("7. should check that 'same select option in new row' property is working", () => {
       _.propPane.NavigateBackToPropertyPane();
 
       const checkSameOptionsInNewRowWhileEditing = () => {
@@ -297,7 +265,7 @@ describe(
       checkSameOptionsWhileAddingNewRow();
     });
 
-    it("9. should check that 'new row select options' is working", () => {
+    it("8. should check that 'new row select options' is working", () => {
       const checkNewRowOptions = () => {
         // New row select options should be visible when "Same options in new row" is turned off
         _.propPane.TogglePropertyState("Same options in new row", "Off");
@@ -362,7 +330,7 @@ describe(
       checkNoOptionState();
     });
 
-    it("10. should check that server side filering is working", () => {
+    it("9. should check that server side filering is working", () => {
       _.dataSources.CreateDataSource("Postgres");
       _.dataSources.CreateQueryAfterDSSaved(
         "SELECT * FROM public.astronauts {{this.params.filterText ? `WHERE name LIKE '%${this.params.filterText}%'` : ''}} LIMIT 10;",

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
@@ -149,7 +149,7 @@ export const SelectCell = (props: SelectProps) => {
   const onSelect = useCallback(
     (option: DropdownOption) => {
       onItemSelect(
-        option.label || "",
+        option.value || "",
         rowIndex,
         alias,
         onOptionSelectActionString,


### PR DESCRIPTION

## Description
Reverts appsmithorg/appsmith#34743

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
