### PR TITLE
Feat: Delete redundant zones

### DIFF
--- a/app/client/src/layoutSystems/anvil/utils/layouts/update/zoneUtils.test.ts
+++ b/app/client/src/layoutSystems/anvil/utils/layouts/update/zoneUtils.test.ts
@@ -1,0 +1,216 @@
+import { RenderModes } from "../../../../../constants/WidgetConstants";
+import { mockButtonProps } from "../../../../../mocks/widgetProps/button";
+import { isRedundantZoneWidget, isZoneWidget } from "./zoneUtils";
+
+describe("isZoneWidget", () => {
+  it("should return true if the widget is a zone widget", () => {
+    // TODO: Use factory to generate widget
+    const widget = {
+      type: "ZONE_WIDGET",
+      widgetId: "123",
+      widgetName: "Button1",
+      renderMode: RenderModes.CANVAS,
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    expect(isZoneWidget(widget)).toBe(true);
+  });
+
+  it("should return false if the widget is not a zone widget", () => {
+    const widget = mockButtonProps();
+
+    expect(isZoneWidget(widget)).toBe(false);
+  });
+});
+
+describe("isRedundantZoneWidget", () => {
+  it("should return true if the widget is a redundant zone widget", () => {
+    const widget = {
+      type: "ZONE_WIDGET",
+      widgetId: "123",
+      widgetName: "Zone1",
+      renderMode: RenderModes.CANVAS,
+      children: [],
+      dynamicPropertyPathList: [],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    const parentWidget = {
+      type: "SECTION_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123"],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    expect(isRedundantZoneWidget(widget, parentWidget)).toBe(true);
+  });
+
+  it("should return false if the widget is not empty", () => {
+    const widget = {
+      type: "ZONE_WIDGET",
+      widgetId: "123",
+      widgetName: "Zone1",
+      renderMode: RenderModes.CANVAS,
+      children: ["000"],
+      dynamicPropertyPathList: [],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    const parentWidget = {
+      type: "SECTION_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123"],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    expect(isRedundantZoneWidget(widget, parentWidget)).toBe(false);
+  });
+
+  it("should return false if the widget is not zone", () => {
+    const widget = {
+      type: "SECTION_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123"],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    const parentWidget = {
+      type: "SECTION_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123"],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    expect(isRedundantZoneWidget(widget, parentWidget)).toBe(false);
+  });
+
+  it("should return false if the widget is not the only child", () => {
+    const widget = {
+      type: "ZONE_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123"],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    const parentWidget = {
+      type: "SECTION_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123", "877"],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    expect(isRedundantZoneWidget(widget, parentWidget)).toBe(false);
+  });
+
+  it("should return false if the widget has JS props enabled", () => {
+    const widget = {
+      type: "ZONE_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123"],
+      dynamicPropertyPathList: [{ key: "isVisible" }],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    const parentWidget = {
+      type: "SECTION_WIDGET",
+      widgetId: "567",
+      widgetName: "Section1",
+      renderMode: RenderModes.CANVAS,
+      children: ["123"],
+      version: 1,
+      isLoading: false,
+      parentColumnSpace: 10,
+      parentRowSpace: 10,
+      leftColumn: 0,
+      rightColumn: 10,
+      topRow: 0,
+      bottomRow: 4,
+    };
+
+    expect(isRedundantZoneWidget(widget, parentWidget)).toBe(false);
+  });
+});

--- a/app/client/src/layoutSystems/anvil/utils/layouts/update/zoneUtils.ts
+++ b/app/client/src/layoutSystems/anvil/utils/layouts/update/zoneUtils.ts
@@ -22,6 +22,11 @@ import {
   transformMovedWidgets,
 } from "./moveUtils";
 import type { WidgetProps } from "widgets/BaseWidget";
+import {
+  hasWidgetJsPropertiesEnabled,
+  isEmptyWidget,
+  widgetChildren,
+} from "../widgetUtils";
 
 export function* createZoneAndAddWidgets(
   allWidgets: CanvasWidgetsReduxState,
@@ -242,3 +247,15 @@ export function* moveWidgetsToZone(
     return updatedWidgets;
   }
 }
+
+export const isZoneWidget = (widget: FlattenedWidgetProps): boolean =>
+  widget.type === anvilWidgets.ZONE_WIDGET;
+
+export const isRedundantZoneWidget = (
+  widget: FlattenedWidgetProps,
+  parentSection: FlattenedWidgetProps,
+): boolean =>
+  isZoneWidget(widget) &&
+  isEmptyWidget(widget) &&
+  widgetChildren(parentSection).length === 1 &&
+  !hasWidgetJsPropertiesEnabled(widget);

--- a/app/client/src/layoutSystems/anvil/utils/layouts/widgetUtils.test.ts
+++ b/app/client/src/layoutSystems/anvil/utils/layouts/widgetUtils.test.ts
@@ -1,0 +1,82 @@
+import { mockButtonProps } from "../../../../mocks/widgetProps/button";
+import {
+  hasWidgetJsPropertiesEnabled,
+  isEmptyWidget,
+  widgetChildren,
+} from "./widgetUtils";
+
+describe("isEmptyWidget", () => {
+  it("should return true if the widget is empty", () => {
+    const widget = {
+      ...mockButtonProps(),
+      children: [],
+    };
+
+    expect(isEmptyWidget(widget)).toBe(true);
+  });
+
+  it("should return true if children are undefined", () => {
+    const widget = {
+      ...mockButtonProps(),
+      children: undefined,
+    };
+
+    expect(isEmptyWidget(widget)).toBe(true);
+  });
+
+  it("should return false if the widget is not empty", () => {
+    const widget = {
+      ...mockButtonProps(),
+      children: ["1"],
+    };
+
+    expect(isEmptyWidget(widget)).toBe(false);
+  });
+});
+
+describe("widgetChildren", () => {
+  it("should return children of the widget", () => {
+    const widget = {
+      ...mockButtonProps(),
+      children: ["1", "2"],
+    };
+
+    expect(widgetChildren(widget)).toEqual(["1", "2"]);
+  });
+
+  it("should return an empty array if children are undefined", () => {
+    const widget = {
+      ...mockButtonProps(),
+      children: undefined,
+    };
+
+    expect(widgetChildren(widget)).toEqual([]);
+  });
+});
+
+describe("hasWidgetJsPropertiesEnabled", () => {
+  it("should return true if the widget has enabled widget JS properties", () => {
+    const widget = {
+      ...mockButtonProps(),
+      dynamicPropertyPathList: [{ key: "isVisible" }],
+    };
+
+    expect(hasWidgetJsPropertiesEnabled(widget)).toBe(true);
+  });
+
+  it("should return false if the widget does not have enabled widget JS properties", () => {
+    const widget = {
+      ...mockButtonProps(),
+      dynamicPropertyPathList: [],
+    };
+    expect(hasWidgetJsPropertiesEnabled(widget)).toBe(false);
+  });
+
+  it("should return false if the widget has undefined dynamicPropertyPathList", () => {
+    const widget = {
+      ...mockButtonProps(),
+      dynamicPropertyPathList: undefined,
+    };
+    expect(hasWidgetJsPropertiesEnabled(widget)).toBe(false);
+  });
+});

--- a/app/client/src/layoutSystems/anvil/utils/layouts/widgetUtils.ts
+++ b/app/client/src/layoutSystems/anvil/utils/layouts/widgetUtils.ts
@@ -2,6 +2,7 @@ import WidgetFactory from "WidgetProvider/factory";
 import type { WidgetType } from "constants/WidgetConstants";
 import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
 import type { WidgetLayoutProps } from "../anvilTypes";
+import type { FlattenedWidgetProps } from "../../../../WidgetProvider/constants";
 
 /**
  * Check from widget configuration if the widget is a Fill widget.
@@ -27,3 +28,13 @@ export function isFillWidgetPresentInList(
     (child: WidgetLayoutProps) => child && isFillWidgetType(child.widgetType),
   );
 }
+
+export const isEmptyWidget = (widget: FlattenedWidgetProps): boolean =>
+  !widget.children || widget.children.length === 0;
+
+export const hasWidgetJsPropertiesEnabled = (
+  widget: FlattenedWidgetProps,
+): boolean => (widget.dynamicPropertyPathList || []).length > 0;
+
+export const widgetChildren = (widget: FlattenedWidgetProps): string[] =>
+  widget.children || [];


### PR DESCRIPTION
## Description
Delete redundant zones when drag last widget out or remove it.

https://www.notion.so/appsmith/Removing-redundant-zones-8a2cf907c97246adb618664940e298b0

Fixes #34854 

## Automation

/ok-to-test tags="@tag.anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
