### PR TITLE
chore: Buffer first eval action to fix race condition in packages

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -646,6 +646,7 @@ function* evalAndLintingHandler(
 }
 
 function* evaluationChangeListenerSaga(): any {
+  const firstEvalActionChannel = yield actionChannel(FIRST_EVAL_REDUX_ACTIONS);
   // Explicitly shutdown old worker if present
   yield all([call(evalWorker.shutdown), call(lintWorker.shutdown)]);
   const [evalWorkerListenerChannel] = yield all([
@@ -669,8 +670,9 @@ function* evaluationChangeListenerSaga(): any {
   yield spawn(handleEvalWorkerRequestSaga, evalWorkerListenerChannel);
 
   const initAction: EvaluationReduxAction<unknown> = yield take(
-    FIRST_EVAL_REDUX_ACTIONS,
+    firstEvalActionChannel,
   );
+  firstEvalActionChannel.close();
 
   // Wait for widget config build to complete before starting evaluation only if the current editor is not a workflow
   const isCurrentEditorWorkflowType = yield select(


### PR DESCRIPTION
## Description
Check the issue description for the actual problem.

Solution:
To mitigate the race condition; instead of using `take` post setup worker an `actionChannel` is used to create a queue to detect any first eval action dispatched while the code path completes the worker setup. This queue is then picked by and the action is processed and the `actionChannel` is closed.

The baseline theory of the solution is to create a queue of any first eval action dispatch throughout the lifecycle of the setup process but act only when the setup is complete

Fixes https://github.com/appsmithorg/appsmith/issues/34890

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
