### PR TITLE
chore: Add tests for copy paste for anvil widgets.

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
@@ -21,7 +21,7 @@ describe(
       );
       agHelper.GetNClick(anvilLocators.anvilWidgetNameSelector("Button1"));
       // when we select a widget, the URL is updated with widget ID, storing the URL to assert later
-      const widgetSelectURLBeforeCopy = cy.url();
+      cy.url().as("widgetSelectURLBeforeCopy");
       cy.get("body").type(`{${modifierKey}}c`);
 
       // paste into canvas
@@ -41,10 +41,9 @@ describe(
         2,
       );
 
-      const widgetSelectURLAfterCopy = cy.url();
       // after the pasting, the new Widget is selected and the URL is updated with the new widget ID
       // so the URL should be different from the URL before copy
-      expect(widgetSelectURLBeforeCopy).not.to.equal(widgetSelectURLAfterCopy);
+      cy.get("@widgetSelectURLBeforeCopy").should("not.eq", cy.url());
 
       // paste into section
       agHelper.GetNClick(

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
@@ -10,7 +10,7 @@ describe(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Paste functionality`,
   { tags: ["@tag.Anvil"] },
   () => {
-    it("1. Checks if the non-model widget is pasted into the mai canvas, zone and section", () => {
+    it("1. Checks if the non-modal widget is pasted into the mai canvas, zone and section", () => {
       anvilLayout.dnd.DragDropNewAnvilWidgetNVerify(
         anvilLocators.WDSBUTTON,
         10,
@@ -149,6 +149,34 @@ describe(
       cy.get(anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON))
         .last()
         .should("have.attr", "data-widget-name", "Button1Copy3");
+    });
+
+    it("4. Checks if the widget can be pasted in Modal Widget", () => {
+      // copy the button widget
+      agHelper.GetNClick(anvilLocators.anvilWidgetNameSelector("Button1"));
+      cy.get("body").type(`{${modifierKey}}c`);
+
+      // drop a modal widget
+      anvilLayout.dnd.DragDropNewAnvilWidgetNVerify(
+        anvilLocators.WDSMODAL,
+        10,
+        10,
+        {
+          skipWidgetSearch: true,
+          dropTargetDetails: {
+            dropModal: true,
+          },
+        },
+      );
+
+      // paste the button widget
+      cy.get("body").type(`{${modifierKey}}v`);
+
+      // since the modal is open, the button should be pasted inside the modal
+      agHelper.AssertElementLength(
+        `${anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSMODAL)} ${anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON)}`,
+        1,
+      );
     });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
@@ -1,0 +1,144 @@
+import { anvilLocators } from "../../../../support/Pages/Anvil/Locators";
+import { agHelper, anvilLayout, entityExplorer } from "../../../../support/Objects/ObjectsCore";
+import { ANVIL_EDITOR_TEST, modifierKey } from "../../../../support/Constants";
+
+describe(`${ANVIL_EDITOR_TEST}: Anvil tests for Paste functionality`,
+  { tags: ["@tag.Anvil"] }, () => {
+    it("1. Checks if the non-model widget is pasted into the mai canvas, zone and section", () => {
+      anvilLayout.dnd.DragDropNewAnvilWidgetNVerify(
+        anvilLocators.WDSBUTTON,
+        10,
+        10,
+        {
+          skipWidgetSearch: true,
+        },
+      );
+      agHelper.GetNClick(anvilLocators.anvilWidgetNameSelector("Button1"));
+      // when we select a widget, the URL is updated with widget ID, storing the URL to assert later
+      const widgetSelectURLBeforeCopy = cy.url();
+      cy.get("body").type(`{${modifierKey}}c`);
+
+      // paste into canvas
+      agHelper.GetNClick(anvilLocators.mainCanvasSelector);
+      cy.get("body").type(`{${modifierKey}}v`);
+      // since we pasted in canvas, a new zone and section, and a new copied button should be created
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.ZONE),
+        2,
+      );
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.SECTION),
+        2,
+      );
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON),
+        2,
+      );
+
+      const widgetSelectURLAfterCopy = cy.url();
+      // after the pasting, the new Widget is selected and the URL is updated with the new widget ID
+      // so the URL should be different from the URL before copy
+      expect(widgetSelectURLBeforeCopy).not.to.equal(widgetSelectURLAfterCopy);
+
+      // paste into section
+      agHelper.GetNClick(anvilLocators.anvilWidgetNameSelectorFromEntityExplorer("Section1"));
+      cy.get("body").type(`{${modifierKey}}v`);
+      // since we pasted in section, a new zone and a new copied button should be created
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.ZONE),
+        3,
+      );
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON),
+        3,
+      );
+      // and no new section should be created and space redistribution should be [6, 6]
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.SECTION),
+        2,
+      );
+      anvilLayout.sections.verifySectionDistribution("Section1", [6, 6]);
+
+      // paste into zone
+      agHelper.GetNClick(anvilLocators.anvilWidgetNameSelector("Zone1"));
+      cy.get("body").type(`{${modifierKey}}v`);
+      // since we pasted in zone, a new copied button should be created, no new zone or section should be created
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON),
+        4,
+      );
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.ZONE),
+        3,
+      );
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.SECTION),
+        2,
+      );
+    });
+
+    it("2. Checks if the modal widget is pasted into the main canvas", () => {
+      // drop a modal widget
+      anvilLayout.dnd.DragDropNewAnvilWidgetNVerify(
+        anvilLocators.WDSMODAL,
+        10,
+        10,
+        {
+          skipWidgetSearch: true,
+          dropTargetDetails: {
+            dropModal: true,
+          },
+        },
+      );
+
+      // copy the modal widget
+      cy.get("body").type(`{${modifierKey}}c`);
+
+      // press escape to close the modal
+      agHelper.PressEscape();
+
+      // select the canvas and paste into canvas
+      agHelper.GetNClick(anvilLocators.mainCanvasSelector);
+      cy.get("body").type(`{${modifierKey}}v`);
+      // since we pasted in canvas, a new copied modal should be created
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetNameSelectorFromEntityExplorer("Modal1Copy"),
+        1,
+      );
+
+      // close the modal
+      agHelper.PressEscape();
+    });
+
+    it("3. Checks if no widget is selected, the main canvas is the destined parent", () => {
+      // copy the button widget
+      agHelper.GetNClick(anvilLocators.anvilWidgetNameSelector("Button1"));
+      cy.get("body").type(`{${modifierKey}}c`);
+
+      // deselect widgets by clicking on the canvas
+      cy.get(`${anvilLocators.mainCanvasSelector} > div`).click();
+
+      // paste the button widget
+      cy.get("body").type(`{${modifierKey}}v`);
+
+      // since no widget is selected, the main canvas is the destined parent, so new section
+      // and zone should be created and the button should be the last element in the main canvas
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON),
+        5,
+      );
+
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.SECTION),
+        3,
+      );
+
+      agHelper.AssertElementLength(
+        anvilLocators.anvilWidgetTypeSelector(anvilLocators.ZONE),
+        4,
+      );
+
+      // the new button should be the last element in the main canvas
+      cy.get(anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON)).last().should("have.attr", "data-widget-name", "Button1Copy3");
+    });
+  });

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
@@ -1,9 +1,15 @@
 import { anvilLocators } from "../../../../support/Pages/Anvil/Locators";
-import { agHelper, anvilLayout, entityExplorer } from "../../../../support/Objects/ObjectsCore";
+import {
+  agHelper,
+  anvilLayout,
+  entityExplorer,
+} from "../../../../support/Objects/ObjectsCore";
 import { ANVIL_EDITOR_TEST, modifierKey } from "../../../../support/Constants";
 
-describe(`${ANVIL_EDITOR_TEST}: Anvil tests for Paste functionality`,
-  { tags: ["@tag.Anvil"] }, () => {
+describe(
+  `${ANVIL_EDITOR_TEST}: Anvil tests for Paste functionality`,
+  { tags: ["@tag.Anvil"] },
+  () => {
     it("1. Checks if the non-model widget is pasted into the mai canvas, zone and section", () => {
       anvilLayout.dnd.DragDropNewAnvilWidgetNVerify(
         anvilLocators.WDSBUTTON,
@@ -41,7 +47,9 @@ describe(`${ANVIL_EDITOR_TEST}: Anvil tests for Paste functionality`,
       expect(widgetSelectURLBeforeCopy).not.to.equal(widgetSelectURLAfterCopy);
 
       // paste into section
-      agHelper.GetNClick(anvilLocators.anvilWidgetNameSelectorFromEntityExplorer("Section1"));
+      agHelper.GetNClick(
+        anvilLocators.anvilWidgetNameSelectorFromEntityExplorer("Section1"),
+      );
       cy.get("body").type(`{${modifierKey}}v`);
       // since we pasted in section, a new zone and a new copied button should be created
       agHelper.AssertElementLength(
@@ -139,6 +147,9 @@ describe(`${ANVIL_EDITOR_TEST}: Anvil tests for Paste functionality`,
       );
 
       // the new button should be the last element in the main canvas
-      cy.get(anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON)).last().should("have.attr", "data-widget-name", "Button1Copy3");
+      cy.get(anvilLocators.anvilWidgetTypeSelector(anvilLocators.WDSBUTTON))
+        .last()
+        .should("have.attr", "data-widget-name", "Button1Copy3");
     });
-  });
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilCopyPaste_spec.ts
@@ -123,7 +123,7 @@ describe(
       cy.get("body").type(`{${modifierKey}}c`);
 
       // deselect widgets by clicking on the canvas
-      cy.get(`${anvilLocators.mainCanvasSelector} > div`).click();
+      cy.get(`${anvilLocators.mainCanvasSelector}`).click();
 
       // paste the button widget
       cy.get("body").type(`{${modifierKey}}v`);

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -53,8 +53,9 @@ export class AggregateHelper {
   public get isMac() {
     return Cypress.platform === "darwin";
   }
-  private selectLine = `${this.isMac ? "{cmd}{shift}{leftArrow}" : "{shift}{home}"
-    }`;
+  private selectLine = `${
+    this.isMac ? "{cmd}{shift}{leftArrow}" : "{shift}{home}"
+  }`;
   public get removeLine() {
     return "{backspace}";
   }
@@ -307,11 +308,11 @@ export class AggregateHelper {
       locator =
         selector.startsWith("//") || selector.startsWith("(//")
           ? cy.xpath(selector, {
-            timeout,
-          })
+              timeout,
+            })
           : cy.get(selector, {
-            timeout,
-          });
+              timeout,
+            });
     } else locator = cy.wrap(selector);
     return exists === "noVerify"
       ? locator // Return the locator without verification if exists is "noVerify"
@@ -391,16 +392,16 @@ export class AggregateHelper {
           if (
             $body.find(
               this.locator._toastContainer +
-              " span:contains(" +
-              toolTipOrToasttext +
-              ")",
+                " span:contains(" +
+                toolTipOrToasttext +
+                ")",
             ).length > 0
           ) {
             this.GetElement(
               this.locator._toastContainer +
-              ":has(:contains('" +
-              toolTipOrToasttext +
-              "'))",
+                ":has(:contains('" +
+                toolTipOrToasttext +
+                "'))",
             ).then(($toastContainer) => {
               $toastContainer.remove();
             });
@@ -415,12 +416,12 @@ export class AggregateHelper {
     indexOrOptions:
       | number
       | Partial<{
-        index: number;
-        force: boolean;
-        waitAfterClick: boolean;
-        sleepTime: number;
-        type?: "click" | "invoke";
-      }> = 0,
+          index: number;
+          force: boolean;
+          waitAfterClick: boolean;
+          sleepTime: number;
+          type?: "click" | "invoke";
+        }> = 0,
   ) {
     const button = this.locator._buttonByText(btnVisibleText);
     let index: number,
@@ -936,11 +937,11 @@ export class AggregateHelper {
     indexOrOptions:
       | number
       | Partial<{
-        index: number;
-        parseSpecialCharSeq: boolean;
-        shouldFocus: boolean;
-        delay: number;
-      }> = 0,
+          index: number;
+          parseSpecialCharSeq: boolean;
+          shouldFocus: boolean;
+          delay: number;
+        }> = 0,
   ) {
     let index: number;
     let shouldFocus = true;
@@ -1293,7 +1294,7 @@ export class AggregateHelper {
     // but until we’ve upgraded to v12, we can’t rely on that and have to fit everything into a single query.
     const codeMirrorSelector = isXPathSelector
       ? selector +
-      "//*[contains(concat(' ', normalize-space(@class), ' '), ' CodeMirror ')]"
+        "//*[contains(concat(' ', normalize-space(@class), ' '), ' CodeMirror ')]"
       : selector + " .CodeMirror";
     this.GetElement(codeMirrorSelector)
       .find("textarea")

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -53,9 +53,8 @@ export class AggregateHelper {
   public get isMac() {
     return Cypress.platform === "darwin";
   }
-  private selectLine = `${
-    this.isMac ? "{cmd}{shift}{leftArrow}" : "{shift}{home}"
-  }`;
+  private selectLine = `${this.isMac ? "{cmd}{shift}{leftArrow}" : "{shift}{home}"
+    }`;
   public get removeLine() {
     return "{backspace}";
   }
@@ -308,11 +307,11 @@ export class AggregateHelper {
       locator =
         selector.startsWith("//") || selector.startsWith("(//")
           ? cy.xpath(selector, {
-              timeout,
-            })
+            timeout,
+          })
           : cy.get(selector, {
-              timeout,
-            });
+            timeout,
+          });
     } else locator = cy.wrap(selector);
     return exists === "noVerify"
       ? locator // Return the locator without verification if exists is "noVerify"
@@ -392,16 +391,16 @@ export class AggregateHelper {
           if (
             $body.find(
               this.locator._toastContainer +
-                " span:contains(" +
-                toolTipOrToasttext +
-                ")",
+              " span:contains(" +
+              toolTipOrToasttext +
+              ")",
             ).length > 0
           ) {
             this.GetElement(
               this.locator._toastContainer +
-                ":has(:contains('" +
-                toolTipOrToasttext +
-                "'))",
+              ":has(:contains('" +
+              toolTipOrToasttext +
+              "'))",
             ).then(($toastContainer) => {
               $toastContainer.remove();
             });
@@ -416,12 +415,12 @@ export class AggregateHelper {
     indexOrOptions:
       | number
       | Partial<{
-          index: number;
-          force: boolean;
-          waitAfterClick: boolean;
-          sleepTime: number;
-          type?: "click" | "invoke";
-        }> = 0,
+        index: number;
+        force: boolean;
+        waitAfterClick: boolean;
+        sleepTime: number;
+        type?: "click" | "invoke";
+      }> = 0,
   ) {
     const button = this.locator._buttonByText(btnVisibleText);
     let index: number,
@@ -937,11 +936,11 @@ export class AggregateHelper {
     indexOrOptions:
       | number
       | Partial<{
-          index: number;
-          parseSpecialCharSeq: boolean;
-          shouldFocus: boolean;
-          delay: number;
-        }> = 0,
+        index: number;
+        parseSpecialCharSeq: boolean;
+        shouldFocus: boolean;
+        delay: number;
+      }> = 0,
   ) {
     let index: number;
     let shouldFocus = true;
@@ -1294,7 +1293,7 @@ export class AggregateHelper {
     // but until we’ve upgraded to v12, we can’t rely on that and have to fit everything into a single query.
     const codeMirrorSelector = isXPathSelector
       ? selector +
-        "//*[contains(concat(' ', normalize-space(@class), ' '), ' CodeMirror ')]"
+      "//*[contains(concat(' ', normalize-space(@class), ' '), ' CodeMirror ')]"
       : selector + " .CodeMirror";
     this.GetElement(codeMirrorSelector)
       .find("textarea")

--- a/app/client/cypress/support/Pages/Anvil/Locators/index.ts
+++ b/app/client/cypress/support/Pages/Anvil/Locators/index.ts
@@ -16,7 +16,7 @@ const anvilWidgetBasedSelectors = {
   },
   anvilWidgetNameSelectorFromEntityExplorer: (widgetName: string) => {
     return `[data-testid=t--entity-item-${widgetName}]`;
-  }
+  },
 };
 
 const anvilModalWidgetSelectors = {

--- a/app/client/cypress/support/Pages/Anvil/Locators/index.ts
+++ b/app/client/cypress/support/Pages/Anvil/Locators/index.ts
@@ -14,6 +14,9 @@ const anvilWidgetBasedSelectors = {
   anvilWidgetTypeSelector: (widgetType: string) => {
     return `.t--widget-${widgetType}`;
   },
+  anvilWidgetNameSelectorFromEntityExplorer: (widgetName: string) => {
+    return `[data-testid=t--entity-item-${widgetName}]`;
+  }
 };
 
 const anvilModalWidgetSelectors = {

--- a/app/client/src/layoutSystems/anvil/integrations/sagas/pasteSagas/index.ts
+++ b/app/client/src/layoutSystems/anvil/integrations/sagas/pasteSagas/index.ts
@@ -57,6 +57,9 @@ export function* pasteWidgetSagas() {
     }: {
       widgets: CopiedWidgetData[];
     } = yield getCopiedWidgets();
+
+    if (!copiedWidgets.length) return;
+
     const modalWidgets = copiedWidgets.filter(
       (widget) => widget.hierarchy === widgetHierarchy.WDS_MODAL_WIDGET,
     );
@@ -64,8 +67,6 @@ export function* pasteWidgetSagas() {
       (widget) => widget.hierarchy !== widgetHierarchy.WDS_MODAL_WIDGET,
     );
     const originalWidgets: CopiedWidgetData[] = [...nonModalWidgets];
-
-    if (!originalWidgets.length) return;
 
     const selectedWidget: FlattenedWidgetProps =
       yield getSelectedWidgetWhenPasting();


### PR DESCRIPTION
Fixes #33982 

/ok-to-test tags="@tag.Anvil"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9952206667>
> Commit: d70ec63edc6cbc9a760c0c1471f9f4249557ee2f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9952206667&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`
> Spec:
> <hr>Tue, 16 Jul 2024 07:23:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced tests for paste functionality in the Anvil editor, covering various scenarios to ensure correct behavior when pasting widgets.

- **Improvement**
  - Enhanced the paste function in Anvil editor to skip processing when no copied widgets are present.

- **Tests**
  - Added comprehensive test cases to verify the paste functionality, including drag-and-drop, keyboard shortcuts, and validation of widget placement and attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->