### PR TITLE
fixed: Wrong evaluated value after binding checkbox group widget with…

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/SwitchGroup1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/SwitchGroup1_spec.ts
@@ -217,7 +217,7 @@ describe(
       agHelper.TypeText(widgetsLoc.RadioInput, "{{BLUE}}", 1);
       propPane.ToggleJSMode("Options", true);
       agHelper.AssertElementAbsence(locators._toastMsg);
-      agHelper.GetNAssertElementText(widgets.textWidget, "RED");
+      agHelper.GetNAssertElementText(widgets.textWidget, "");
     });
 
     it("4. Set Label, Tooltip, Inline and check switch group", () => {
@@ -278,7 +278,7 @@ describe(
         0,
         true,
       );
-      agHelper.AssertElementVisibility(locators._visibleTextSpan("RED"));
+      agHelper.AssertElementVisibility(locators._visibleTextSpan("BLUE"));
     });
   },
 );

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.test.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.test.tsx
@@ -61,4 +61,21 @@ describe("<CheckboxGroup />", () => {
 
     expect(result).toStrictEqual({ isValid: true, parsed: ["blue"] });
   });
+
+  test("should return empty array when default value is not in options", async () => {
+    const result = defaultSelectedValuesValidation(`["blue"]`, {
+      options: [
+        {
+          label: "Apple",
+          value: "1",
+        },
+        {
+          label: "Orange",
+          value: "2",
+        },
+      ],
+    });
+
+    expect(result).toStrictEqual({ isValid: true, parsed: [] });
+  });
 });

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -35,12 +35,18 @@ import { FlexVerticalAlignment } from "layoutSystems/common/utils/constants";
 
 export function defaultSelectedValuesValidation(
   value: unknown,
+  props: any,
 ): ValidationResponse {
   let values: string[] = [];
+  const options: OptionProps[] = props.options || [];
 
   if (typeof value === "string") {
     try {
       values = JSON.parse(value);
+      values = values.filter((value: string) =>
+        options.some((option: OptionProps) => option.value === value),
+      );
+
       if (!Array.isArray(values)) {
         throw new Error();
       }
@@ -614,7 +620,6 @@ class CheckboxGroupWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: CheckboxGroupWidgetProps) {
-    //search props.selectedValues in the options if not found set selectedValues to []
     const validSelectedValues = prevProps.selectedValues.filter(
       (value: string) =>
         prevProps.options.some((option) => option.value === value),

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -160,6 +160,12 @@ class CheckboxGroupWidget extends BaseWidget<
     };
   }
 
+  static getDependencyMap(): Record<string, string[]> {
+    return {
+      defaultSelectedValues: ["options"],
+    };
+  }
+
   static getAutocompleteDefinitions(): AutocompletionDefinitions {
     return {
       "!doc":

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -9,7 +9,7 @@ import type { ValidationResponse } from "constants/WidgetValidation";
 import { ValidationTypes } from "constants/WidgetValidation";
 import type { SetterConfig, Stylesheet } from "entities/AppTheming";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
-import { compact, xor, findIndex } from "lodash";
+import { compact, xor } from "lodash";
 import { default as React } from "react";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
 import type { DerivedPropertiesMap } from "WidgetProvider/factory";
@@ -615,23 +615,15 @@ class CheckboxGroupWidget extends BaseWidget<
 
   componentDidUpdate(prevProps: CheckboxGroupWidgetProps) {
     //search props.selectedValues in the options if not found set selectedValues to []
-    if (
-      prevProps.selectedValues &&
-      prevProps.selectedValues.length > 0 &&
-      prevProps.options &&
-      prevProps.options.length > 0
-    ) {
-      for (const i of prevProps.selectedValues) {
-        if (
-          findIndex(
-            prevProps.options,
-            (option: OptionProps) => option.value === i,
-          ) === -1
-        ) {
-          this.props.updateWidgetMetaProperty("selectedValues", []);
-          break;
-        }
-      }
+    const validSelectedValues = prevProps.selectedValues.filter(
+      (value: string) =>
+        prevProps.options.some((option) => option.value === value),
+    );
+    if (validSelectedValues.length !== prevProps.selectedValues.length) {
+      this.props.updateWidgetMetaProperty(
+        "selectedValues",
+        validSelectedValues,
+      );
     }
 
     // Reset isDirty to false whenever defaultSelectedValues changes

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -32,6 +32,7 @@ import IconSVG from "../icon.svg";
 import ThumbnailSVG from "../thumbnail.svg";
 import { WIDGET_TAGS } from "constants/WidgetConstants";
 import { FlexVerticalAlignment } from "layoutSystems/common/utils/constants";
+import _ from "lodash";
 
 export function defaultSelectedValuesValidation(
   value: unknown,
@@ -614,6 +615,26 @@ class CheckboxGroupWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: CheckboxGroupWidgetProps) {
+    //search props.selectedValues in the options if not found set selectedValues to []
+    if (
+      prevProps.selectedValues &&
+      prevProps.selectedValues.length > 0 &&
+      prevProps.options &&
+      prevProps.options.length > 0
+    ) {
+      for (const i of prevProps.selectedValues) {
+        if (
+          _.findIndex(
+            prevProps.options,
+            (option: OptionProps) => option.value === i,
+          ) === -1
+        ) {
+          this.props.updateWidgetMetaProperty("selectedValues", []);
+          break;
+        }
+      }
+    }
+
     // Reset isDirty to false whenever defaultSelectedValues changes
     if (
       xor(this.props.defaultSelectedValues, prevProps.defaultSelectedValues)

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -9,7 +9,7 @@ import type { ValidationResponse } from "constants/WidgetValidation";
 import { ValidationTypes } from "constants/WidgetValidation";
 import type { SetterConfig, Stylesheet } from "entities/AppTheming";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
-import { compact, xor } from "lodash";
+import { compact, xor, findIndex } from "lodash";
 import { default as React } from "react";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
 import type { DerivedPropertiesMap } from "WidgetProvider/factory";
@@ -32,7 +32,6 @@ import IconSVG from "../icon.svg";
 import ThumbnailSVG from "../thumbnail.svg";
 import { WIDGET_TAGS } from "constants/WidgetConstants";
 import { FlexVerticalAlignment } from "layoutSystems/common/utils/constants";
-import _ from "lodash";
 
 export function defaultSelectedValuesValidation(
   value: unknown,
@@ -624,7 +623,7 @@ class CheckboxGroupWidget extends BaseWidget<
     ) {
       for (const i of prevProps.selectedValues) {
         if (
-          _.findIndex(
+          findIndex(
             prevProps.options,
             (option: OptionProps) => option.value === i,
           ) === -1


### PR DESCRIPTION
/ok-to-test tags="@tag.Widget"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9904430121>
> Commit: bf57c2223fc720e076139edfcfeda6f0e0bbb004
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9904430121&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Fri, 12 Jul 2024 08:54:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->
