### PR TITLE
chore: trigger linting actions in any non published mode

### DIFF
--- a/app/client/src/ce/actions/evaluationActionsList.ts
+++ b/app/client/src/ce/actions/evaluationActionsList.ts
@@ -123,7 +123,8 @@ export const EVAL_AND_LINT_REDUX_ACTIONS = union(
 export function getRequiresLinting(action: ReduxAction<unknown>) {
   const appMode: ReturnType<typeof getAppMode> = getAppMode(store.getState());
 
+  // for any case apart from published mode of an app, we should trigger linting
   const requiresLinting =
-    appMode === APP_MODE.EDIT && shouldTriggerLinting(action);
+    appMode !== APP_MODE.PUBLISHED && shouldTriggerLinting(action);
   return requiresLinting;
 }


### PR DESCRIPTION
## Description
The CE's selector implementation has been changed to lint actions for all non published app modes. 

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9906233665>
> Commit: 6b50ea5ef919b3b79e53642f63c7a9e981d8b307
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9906233665&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 12 Jul 2024 11:06:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted linting trigger conditions to ensure linting is activated for all modes except the published mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->