### PR TITLE
ci: Run prepare script for adaptable image, if available

### DIFF
--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -170,6 +170,12 @@ jobs:
             scripts/generate_info_json.sh
           fi
 
+      - name: Place server artifacts-es
+        run: |
+          if [[ -f scripts/prepare_server_artifacts.sh ]]; then
+            scripts/prepare_server_artifacts.sh
+          fi
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
This is so DPs on `pg` branch continue to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a workflow step to check and execute server artifact preparation script during the on-demand build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->