### PR TITLE
chore: using Java Optional to prevent null return value

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
@@ -14,6 +14,8 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import lombok.Getter;
 
+import java.util.Optional;
+
 @Getter
 public enum AclPermission {
     /**
@@ -137,13 +139,13 @@ public enum AclPermission {
         this.entity = entity;
     }
 
-    public static AclPermission getPermissionByValue(String value, Class<? extends BaseDomain> entity) {
+    public static Optional<AclPermission> getPermissionByValue(String value, Class<? extends BaseDomain> entity) {
         for (AclPermission permission : values()) {
             if (permission.getValue().equals(value) && permission.getEntity().equals(entity)) {
-                return permission;
+                return Optional.of(permission);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     public static boolean isPermissionForEntity(AclPermission aclPermission, Class<?> clazz) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/ce/PolicyGeneratorCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/ce/PolicyGeneratorCE.java
@@ -13,14 +13,7 @@ import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DirectedAcyclicGraph;
 import org.jgrapht.traverse.DepthFirstIterator;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.APPLICATION_CREATE_PAGES;
@@ -280,12 +273,12 @@ public class PolicyGeneratorCE {
      * @return
      */
     public Set<Policy> getChildPolicies(
-            Policy policy, AclPermission aclPermission, Class<? extends BaseDomain> destinationEntity) {
+        Policy policy, Optional<AclPermission> aclPermission, Class<? extends BaseDomain> destinationEntity) {
 
         // In case the calling function could not translate the string value to AclPermission, return an empty set to
         // handle
         // erroneous cases
-        if (aclPermission == null) {
+        if (aclPermission.isEmpty()) {
             return Collections.emptySet();
         }
 
@@ -319,7 +312,7 @@ public class PolicyGeneratorCE {
             Class<? extends BaseDomain> destinationEntity) {
         Set<Policy> policies = policySet.stream()
                 .map(policy -> {
-                    AclPermission aclPermission =
+                    Optional<AclPermission> aclPermission =
                             AclPermission.getPermissionByValue(policy.getPermission(), sourceEntity);
                     // Get all the child policies for the given policy and aclPermission
                     return getChildPolicies(policy, aclPermission, destinationEntity);


### PR DESCRIPTION
## Description

Fixes #34911 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced robustness and alignment with modern Java best practices by using `Optional<AclPermission>` instead of returning `null` or `AclPermission` directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->