### PR TITLE
Fix:/widget name validation

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBoxGroupTestWithInvalidName.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBoxGroupTestWithInvalidName.ts
@@ -1,0 +1,33 @@
+import { entityExplorer } from "../../../../../support/Objects/ObjectsCore";
+import EditorNavigation, {
+  EntityType,
+} from "../../../../../support/Pages/EditorNavigation";
+
+describe("Checkbox Tests", { tags: ["@tag.Widget", "@tag.Checkbox"] }, () => {
+  before(() => {
+    entityExplorer.DragDropWidgetNVerify("checkboxgroupwidget", 550, 100);
+  });
+  it("CheckboxGroup renamed with the name which start with a digit", () => {
+    EditorNavigation.SelectEntityByName("CheckboxGroup1", EntityType.Widget);
+    const title = cy.get(".t--property-pane-title");
+    title.should("exist");
+    title.dblclick();
+    title.type("1CheckboxGroup{enter}");
+    title.should("have.text", "1CheckboxGroup");
+    const warn = cy.get(".Toastify__toast-body");
+    warn.should("exist");
+  });
+  it("CheckboxGroup renamed with valid name", () => {
+    EditorNavigation.SelectEntityByName("CheckboxGroup1", EntityType.Widget);
+    const newTitle = cy.get(".t--property-pane-title");
+    newTitle.should("exist");
+    newTitle.dblclick();
+    newTitle.type("CheckboxGroup{enter}");
+    newTitle.should("have.text", "CheckboxGroup");
+    cy.wait(3000);
+    EditorNavigation.SelectEntityByName("CheckboxGroup", EntityType.Widget);
+    const newTitle1 = cy.get(".t--property-pane-title");
+    newTitle1.should("exist");
+    newTitle1.should("have.text", "CheckboxGroup");
+  });
+});

--- a/app/client/src/ce/sagas/PageSagas.tsx
+++ b/app/client/src/ce/sagas/PageSagas.tsx
@@ -994,9 +994,20 @@ export function* updateWidgetNameSaga(
       // Send a update saying that we've successfully updated the name
       yield put(updateWidgetNameSuccess());
     } else {
-      // check if name is not conflicting with any
+      const numPattern = /^\d/i;
+      //check if the name starts with a number
+      if (numPattern.test(action.payload.newName)) {
+        yield put({
+          type: ReduxActionErrorTypes.UPDATE_WIDGET_NAME_ERROR,
+          payload: {
+            error: {
+              message: `Entity name: ${action.payload.newName} cannot start with a number.`,
+            },
+          },
+        });
+      } // check if name is not conflicting with any
       // existing entity/api/queries/reserved words
-      if (isNameValid(action.payload.newName, getUsedNames)) {
+      else if (isNameValid(action.payload.newName, getUsedNames)) {
         const request: UpdateWidgetNameRequest = {
           newName: action.payload.newName,
           oldName: widgetName,


### PR DESCRIPTION
issue: [22259](https://github.com/appsmithorg/appsmith/issues/22259)

added the validation to check if the widget name start with a number

when the widget name starts with a digit then this error is thrown:
![checkbox invalid name](https://github.com/user-attachments/assets/ebffe976-21c5-4b60-91cc-11ba1e4ca4f5)

and when the error is thrown the name of the widget is not updated.
 if the widget name is valid:
![checkbox valid name](https://github.com/user-attachments/assets/09c1cf0a-9815-49c4-8d5c-04a8e60e163e)

similarly this condition is checked while updating any widget name.

cypress test video:

https://github.com/user-attachments/assets/05b853f8-483a-4326-9d66-1d515e4d672a





