### PR TITLE
fix: Parsing issue with S3 settings

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/setting.json
@@ -28,7 +28,7 @@
           "subtitle": "Maximum time after which the query will return",
           "configProperty": "actionConfiguration.timeoutInMillisecond",
           "controlType": "INPUT_TEXT",
-          "dataType": "NUMBER"
+          "dataType": "NUMBER",
           "width": "270px"
         }
       ]


### PR DESCRIPTION
## Description
Broken setting JSON was making it so that the S3 settings pane was defaulting to DB form. This disallowed users to edit JSON substitution configuration that is specific to this plugin.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected configuration settings for Amazon S3 plugin to ensure proper processing and validation of numeric input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->