### PR TITLE
feat: support supabase storage

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/pom.xml
+++ b/app/server/appsmith-plugins/amazons3Plugin/pom.xml
@@ -39,6 +39,12 @@
             </exclusions>
         </dependency>
 
+         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.17.174</version>
+        </dependency>
+        
         <!-- Test Dependencies -->
 
     </dependencies>

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/S3PluginConstants.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/S3PluginConstants.java
@@ -4,6 +4,8 @@ public class S3PluginConstants {
     public static final String S3_DRIVER = "com.amazonaws.services.s3.AmazonS3";
     public static final int S3_SERVICE_PROVIDER_PROPERTY_INDEX = 1;
     public static final int CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX = 2;
+
+    public static final int DEFAULT_BUCKET_PROPERTY_INDEX = 3;
     public static final int CUSTOM_ENDPOINT_INDEX = 0;
     public static final String DEFAULT_URL_EXPIRY_IN_MINUTES = "5"; // max 7 days is possible
     public static final String YES = "YES";
@@ -12,4 +14,7 @@ public class S3PluginConstants {
     public static final String AWS_S3_SERVICE_PROVIDER = "amazon-s3";
     public static String DEFAULT_FILE_NAME = "MyFile.txt";
     public static final String ACCESS_DENIED_ERROR_CODE = "AccessDenied";
+    public static final String GOOGLE_CLOUD_SERVICE_PROVIDER = "google-cloud-storage";
+    public static final String SUPABASE_S3_SERVICE_PROVIDER = "supabase";
+    public static final String AUTO = "auto";
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
@@ -44,6 +44,14 @@
               "value": "minio"
             },
             {
+              "label": "Google Cloud Storage",
+              "value": "google-cloud-storage"
+            },
+            {
+              "label": "Supabase",
+              "value": "supabase"
+            },
+            {
               "label": "Other",
               "value": "other"
             }
@@ -103,8 +111,26 @@
                 "path": "datasourceConfiguration.properties[1].value",
                 "comparison": "NOT_EQUALS",
                 "value": "minio"
+              },
+              {
+                "path": "datasourceConfiguration.properties[1].value",
+                "comparison": "NOT_EQUALS",
+                "value": "supabase"
               }
             ]
+          }
+        },
+        {
+          "label": "Default Bucket",
+          "configProperty": "datasourceConfiguration.properties[3].value",
+          "controlType": "INPUT_TEXT",
+          "initialValue": "",
+          "placeholderText": "Enter default bucket name",
+          "isRequired": true,
+          "hidden": {
+            "path": "datasourceConfiguration.properties[1].value",
+            "comparison": "NOT_EQUALS",
+            "value": "google-cloud-storage"
           }
         }
       ]


### PR DESCRIPTION
Fixes #34728 

**What's in this pr :**
- Added new aws-sdk version 2 dependency which support supabase s3 storage.
- Added methods to establish connection with supabase.
- Added some print statements to know the control flow.
- Modified listFilesInBucket method for supports both amazon s3 and supabase s3.
- Added one constant for Supabase S3 storage.

**Issue :**

The dependency we have for the Amazon S3 plugin is v1 of the aws-sdk, which does not support Supabase S3. To address this, we need to use aws-sdk v2, which uses different APIs. I managed to connect with Supabase S3, but I'm unable to perform queries because the existing code relies on the v1 dependency. This causes conflicts related to method types and leads to complexity.

**Screenshots :**
![image](https://github.com/user-attachments/assets/7722be00-46b2-4ca3-995d-29633b0f45ba)
![image](https://github.com/user-attachments/assets/5fbba4b5-c4ea-4444-85fe-7b82fea0ce16)

In the terminal, we got the output of Supabase results:

From testSupabaseStorage method :
![image](https://github.com/user-attachments/assets/4184ff09-db6d-4161-b80c-16ff7780c012)

From listFilesInBucket method :
![image](https://github.com/user-attachments/assets/8f1a3da4-f6de-42cd-8cb6-17a847bdd25a)


