### PR TITLE
chore: add default name prop to js object debugger logs

### DIFF
--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -88,11 +88,13 @@ type Props = ReduxStateProps &
     isLoading: boolean;
     onButtonClick: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     jsCollectionData: JSCollectionData | undefined;
+    debuggerLogsDefaultName?: string;
   };
 
 function JSResponseView(props: Props) {
   const {
     currentFunction,
+    debuggerLogsDefaultName,
     disabled,
     errorCount,
     errors,
@@ -270,7 +272,9 @@ function JSResponseView(props: Props) {
     {
       key: DEBUGGER_TAB_KEYS.LOGS_TAB,
       title: createMessage(DEBUGGER_LOGS),
-      panelComponent: <DebuggerLogs searchQuery={jsObject?.name} />,
+      panelComponent: (
+        <DebuggerLogs searchQuery={debuggerLogsDefaultName || jsObject?.name} />
+      ),
     },
   ];
 


### PR DESCRIPTION
## Description
Adding a prop to JSResponse View component to accept the default search text for the logs tab

PR for https://github.com/appsmithorg/appsmith-ee/pull/4695
## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9961504301>
> Commit: d6faf1945320bf0e662c4fffdd99258ea66364d5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9961504301&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Tue, 16 Jul 2024 18:08:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Debugger Logs: Users can now see a default name in the debugger logs if provided, improving clarity and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->