### PR TITLE
fix: Remove collapsed widget tags

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -86,7 +86,7 @@ describe(
       );
     };
 
-    it("1. All widget tags should be visible but only Suggested tag is open.", () => {
+    it("1. All widget tags should be visible and open by default.", () => {
       agHelper.AssertElementLength(
         entityExplorer._widgetTagsList,
         Object.keys(WIDGET_TAGS).length,

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Widgets_Sidebar.ts
@@ -86,11 +86,6 @@ describe(
       );
     };
 
-    before(() => {
-      entityExplorer.DragDropWidgetNVerify(draggableWidgets.INPUT_V2);
-      PageLeftPane.switchToAddNew();
-    });
-
     it("1. All widget tags should be visible but only Suggested tag is open.", () => {
       agHelper.AssertElementLength(
         entityExplorer._widgetTagsList,

--- a/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
@@ -159,6 +159,7 @@ function UIEntitySidebar({
             if (
               isAnvil ||
               hasWidgets ||
+              isSearching ||
               [
                 WIDGET_TAGS.SUGGESTED_WIDGETS as string,
                 WIDGET_TAGS.BUILDING_BLOCKS as string,

--- a/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
@@ -19,9 +19,6 @@ import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { groupWidgetCardsByTags } from "../utils";
 import UIEntityTagGroup from "./UIEntityTagGroup";
 import { useUIExplorerItems } from "./hooks";
-import { useSelector } from "react-redux";
-import { widgetsExistCurrentPage } from "@appsmith/selectors/entitiesSelector";
-import { getIsAnvilLayout } from "layoutSystems/anvil/integrations/selectors";
 
 function UIEntitySidebar({
   focusSearchInput,
@@ -39,8 +36,6 @@ function UIEntitySidebar({
   const isDragDropBuildingBlocksEnabled = useFeatureFlag(
     FEATURE_FLAG.release_drag_drop_building_blocks_enabled,
   );
-  const isAnvil = useSelector(getIsAnvilLayout);
-  const hasWidgets = useSelector(widgetsExistCurrentPage);
   const hideSuggestedWidgets = useMemo(
     () =>
       (isSearching && !areSearchResultsEmpty) ||
@@ -151,27 +146,9 @@ function UIEntitySidebar({
               return null;
             }
 
-            // Do not expand all the widget tags when the user does not have any
-            // widgets yet.
-            // Only show Suggested or Building Blocks
-            // This behavior should not be used if Anvil layout is active
-            let isInitiallyOpen = false;
-            if (
-              isAnvil ||
-              hasWidgets ||
-              isSearching ||
-              [
-                WIDGET_TAGS.SUGGESTED_WIDGETS as string,
-                WIDGET_TAGS.BUILDING_BLOCKS as string,
-              ].includes(tag)
-            ) {
-              isInitiallyOpen = true;
-            }
-
             return (
               <UIEntityTagGroup
                 cards={cardsForThisTag}
-                isInitiallyOpen={isInitiallyOpen}
                 isLoading={!!entityLoading[tag as WidgetTags]}
                 key={tag}
                 tag={tag}

--- a/app/client/src/pages/Editor/widgetSidebar/UIEntityTagGroup.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntityTagGroup.tsx
@@ -34,14 +34,12 @@ const LoadingContainer = styled.div`
 `;
 
 interface Props {
-  isInitiallyOpen: boolean;
   tag: string;
   cards: WidgetCardProps[];
   isLoading: boolean;
 }
 
 const UIEntityTagGroup = (props: Props) => {
-  const [isOpen, setIsOpen] = React.useState(props.isInitiallyOpen);
   const [showFullItems, setShowFullItems] = React.useState(false);
   const toggleShowFullItems = () => {
     setShowFullItems(!showFullItems);
@@ -82,9 +80,7 @@ const UIEntityTagGroup = (props: Props) => {
       className={`pb-2 widget-tag-collapsible widget-tag-collapsible-${props.tag
         .toLowerCase()
         .replace(/ /g, "-")}`}
-      isOpen={isOpen}
       key={props.tag}
-      onOpenChange={setIsOpen}
     >
       <CollapsibleHeader arrowPosition="start">
         <Text
@@ -98,7 +94,6 @@ const UIEntityTagGroup = (props: Props) => {
       <CollapsibleContent>
         <div
           className="grid items-stretch grid-cols-3 gap-x-1 gap-y-1 justify-items-stretch"
-          data-collapsed={!isOpen}
           data-testid="ui-entity-tag-group"
         >
           {props.tag === WIDGET_TAGS.SUGGESTED_WIDGETS

--- a/app/client/src/pages/Editor/widgetSidebar/UIEntityTagGroup.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntityTagGroup.tsx
@@ -80,6 +80,7 @@ const UIEntityTagGroup = (props: Props) => {
       className={`pb-2 widget-tag-collapsible widget-tag-collapsible-${props.tag
         .toLowerCase()
         .replace(/ /g, "-")}`}
+      isOpen
       key={props.tag}
     >
       <CollapsibleHeader arrowPosition="start">

--- a/app/client/src/pages/Editor/widgetSidebar/tests/UIEntitySidebar.test.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/tests/UIEntitySidebar.test.tsx
@@ -127,21 +127,4 @@ describe("UIEntitySidebar", () => {
     const { queryByText } = renderUIEntitySidebar(true, true);
     expect(queryByText(WIDGET_TAGS.SUGGESTED_WIDGETS)).toBeNull();
   });
-
-  it("6. should have `Building Blocks` section open when no widgets exist", () => {
-    mockUIExplorerItems();
-    const { getAllByTestId, getByText } = renderUIEntitySidebar(true, true);
-    expect(getByText(WIDGET_TAGS.BUILDING_BLOCKS)).not.toBeNull();
-    const groups = getAllByTestId("ui-entity-tag-group");
-    for (const group of groups) {
-      if (
-        group.getElementsByClassName("t--widget-card-draggable-buildingblock")
-          .length
-      ) {
-        expect(group.getAttribute("data-collapsed")).toBe("false");
-      } else {
-        expect(group.getAttribute("data-collapsed")).toBe("true");
-      }
-    }
-  });
 });


### PR DESCRIPTION
## Description

Reverses the collapsible widget tags introduced in #34644 

## Automation

/ok-to-test tags="@tag.IDE, @tag.Anvil, @tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10053206890>
> Commit: c63a67699537528b7e4f7b721607f08628aa6a38
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10053206890&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE, @tag.Anvil, @tag.Widget`
> Spec:
> <hr>Tue, 23 Jul 2024 06:29:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the behavior of the widget sidebar for improved user interaction.

- **Bug Fixes**
  - Removed automated test setup that could affect the initial state of the sidebar during testing.

- **Refactor**
  - Simplified the logic for determining the initial expansion state of widget tags in the sidebar.
  - Adjusted the `UIEntityTagGroup` component to manage its visibility behavior statically instead of dynamically.

- **Tests**
  - Updated the test suite for the `UIEntitySidebar` component to reflect changes in behavior regarding the "Building Blocks" section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->