### PR TITLE
fix: datepicker doesnt close on first selection of date on month change

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.js
@@ -1,0 +1,42 @@
+import {
+  draggableWidgets,
+  entityExplorer,
+  agHelper,
+} from "../../../../../support/Objects/ObjectsCore";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+import { datePickerlocators } from "../../../../../locators/WidgetLocators";
+
+describe(
+  "DatePicker Widget Property pane tests with js bindings",
+  { tags: ["@tag.Widget", "@tag.Datepicker"] },
+  function () {
+    before(() => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.DATEPICKER);
+    });
+
+    function navigateAndSelectRandomDate(direction) {
+      const buttonClass =
+        direction === "prev"
+          ? ".DayPicker-NavButton--prev"
+          : ".DayPicker-NavButton--next";
+      agHelper.AssertElementVisibility(buttonClass, true, 0);
+      agHelper.GetNClick(buttonClass);
+      cy.get(".DayPicker-Month")
+        .first()
+        .find(".DayPicker-Day")
+        .then(($days) => {
+          const randomIndex = Math.floor(Math.random() * $days.length);
+          cy.wrap($days[randomIndex]).click();
+        });
+    }
+
+    it("1.should close datepicker on single click when month is changed", function () {
+      agHelper.GetNClick(datePickerlocators.input);
+      navigateAndSelectRandomDate("prev");
+      agHelper.GetNClick(datePickerlocators.input);
+      navigateAndSelectRandomDate("prev");
+      agHelper.GetNClick(datePickerlocators.input);
+      navigateAndSelectRandomDate("next");
+    });
+  },
+);

--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -377,7 +377,7 @@ class DatePickerComponent extends React.Component<
               }}
               maxDate={maxDate}
               minDate={minDate}
-              onChange={this.onDateSelected}
+              onChange={this.handleDateChange}
               parseDate={this.parseDate}
               placeholder={"Select Date"}
               popoverProps={{
@@ -480,6 +480,14 @@ class DatePickerComponent extends React.Component<
       });
       onDateSelected(date);
     }
+  };
+  handleDateChange = (selectedDate: Date | null) => {
+    const formattedDate = selectedDate
+      ? moment(selectedDate).format(ISO_DATE_FORMAT)
+      : "";
+    this.setState({ selectedDate: formattedDate }, () => {
+      this.props.onDateSelected(formattedDate);
+    });
   };
 }
 


### PR DESCRIPTION
/ok-to-test tags="@tag.Widget"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9968639762>
> Commit: d94581ab086489904a7fab5fa579b90b0bf6ec65
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9968639762&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Widget
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/9968639762" target="_blank">workflow here</a>.
> <hr>Wed, 17 Jul 2024 05:25:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new tests for the DatePicker Widget to ensure proper functionality and behavior.
  
- **Bug Fixes**
  - Improved date formatting and state updates in the DatePicker component, ensuring more accurate date selection and display.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->