### PR TITLE
fix: Removed switch for overflow list when there are no files

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorTabs/Editortabs.test.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/Editortabs.test.tsx
@@ -39,7 +39,6 @@ describe("EditorTabs render checks", () => {
       `/app/applicationSlug/pageSlug-${page.pageId}/edit`,
       state,
     );
-    // check toggle is active
     expect(container.firstChild).toBeNull();
   });
 
@@ -48,11 +47,6 @@ describe("EditorTabs render checks", () => {
     const { getByTestId, queryByTestId } = renderComponent(
       `/app/applicationSlug/pageSlug-${page.pageId}/edit/queries`,
       state,
-    );
-    // check toggle is active
-    expect(getByTestId("t--list-toggle")).toHaveAttribute(
-      "data-selected",
-      "true",
     );
     // check tabs is empty
     const tabsContainer = getByTestId("t--tabs-container");
@@ -74,7 +68,7 @@ describe("EditorTabs render checks", () => {
       `/app/applicationSlug/pageSlug-${page.pageId}/edit/queries`,
       state,
     );
-    // check toggle is active
+    // check toggle
     expect(queryByTestId("t--list-toggle")).toBeNull();
 
     // check tabs is empty
@@ -143,7 +137,7 @@ describe("EditorTabs render checks", () => {
       state,
     );
 
-    // check toggle is not active
+    // check toggle
     expect(queryByTestId("t--list-toggle")).toBeNull();
 
     // check tabs is not empty

--- a/app/client/src/pages/Editor/IDE/EditorTabs/index.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/index.tsx
@@ -86,7 +86,7 @@ const EditorTabs = () => {
   return (
     <>
       <Container>
-        {ideViewMode === EditorViewMode.SplitScreen && (
+        {ideViewMode === EditorViewMode.SplitScreen && files.length > 0 ? (
           <ToggleButton
             data-testid="t--list-toggle"
             icon="hamburger"
@@ -94,7 +94,7 @@ const EditorTabs = () => {
             onClick={handleHamburgerClick}
             size="md"
           />
-        )}
+        ) : null}
         <ScrollArea
           className="h-[32px] top-[0.5px]"
           data-testid="t--editor-tabs"


### PR DESCRIPTION
## Description

Tabs overflow switch was staying active when no tabs is selected. This was confusing users and was grabing attention towards it. This PR removed the list button when there are no tabs.

Fixes #34624

## Automation

/ok-to-test tags="@tag.Sanity, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9970645051>
> Commit: 00ca00327095807d91964f191e898e0fee36be54
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9970645051&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.IDE`
> Spec:
> <hr>Wed, 17 Jul 2024 08:44:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the conditional rendering of the `ToggleButton` in the `EditorTabs` based on `ideViewMode` and file presence for a more intuitive user experience.

- **Tests**
  - Simplified and generalized the test cases for `EditorTabs` to ensure more reliable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->