### PR TITLE
fix: JSObject function is not defined error

### DIFF
--- a/app/client/src/ce/sagas/InferAffectedJSObjects.ts
+++ b/app/client/src/ce/sagas/InferAffectedJSObjects.ts
@@ -13,14 +13,20 @@ import type { JSCollection } from "entities/JSCollection";
 export function getAffectedJSObjectIdsFromJSAction(
   action: ReduxAction<unknown> | BufferedReduxAction<unknown>,
 ): AffectedJSObjects {
+  if (action.type === ReduxActionTypes.FETCH_ALL_PAGE_ENTITY_COMPLETION) {
+    return {
+      ids: [],
+      isAllAffected: true,
+    };
+  }
+
   if (!JS_ACTIONS.includes(action.type)) {
     return {
       ids: [],
       isAllAffected: false,
     };
   }
-  // only JS actions here
-  action as ReduxAction<unknown>;
+
   // When fetching JSActions fails, we need to diff all JSObjects because the reducer updates it
   // to empty collection
   if (


### PR DESCRIPTION
## Description

- Add the initial fetch all entity completion to the affectedJSObject logic to make sure the JSObjects are defined on page change

Fixes #34681 
Fixed #34933 
## Automation

/test js

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/9998917287>
> Commit: 88f6c636e89de881883e6d4f5d648104257977b9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=9998917287&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Thu, 18 Jul 2024 22:05:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of specific action types to ensure correct identification of affected objects.
  - Enhanced logic to address cases where action types are not included in the predefined set, providing more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->