### PR TITLE
fix:ensure onDateselcted triggers only on valid dates

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -158,6 +158,7 @@ class DatePickerComponent extends React.Component<
     super(props);
     this.state = {
       selectedDate: props.selectedDate,
+      isPopoverOpen: false,
     };
   }
 
@@ -186,7 +187,7 @@ class DatePickerComponent extends React.Component<
         isOpen: props.isPopoverOpen,
       };
     }
-    return {};
+    return { isOpen: this.state.isPopoverOpen };
   };
 
   render() {
@@ -373,11 +374,15 @@ class DatePickerComponent extends React.Component<
               inputProps={{
                 inputRef: this.props.inputRef,
                 onFocus: () => this.props.onFocus?.(),
-                onBlur: () => this.props.onBlur?.(),
+                onBlur: () => {
+                  this.setState({ isPopoverOpen: false });
+                  this.props.onBlur?.();
+                },
+                onClick: () => this.setState({ isPopoverOpen: true }),
               }}
               maxDate={maxDate}
               minDate={minDate}
-              onChange={this.onDateSelected}
+              onChange={this.handleDateChange}
               parseDate={this.parseDate}
               placeholder={"Select Date"}
               popoverProps={{
@@ -444,6 +449,7 @@ class DatePickerComponent extends React.Component<
     if (!isValid && this.props?.onDateOutOfRange) {
       this.props.onDateOutOfRange();
     }
+
     return isValid;
   };
 
@@ -463,22 +469,19 @@ class DatePickerComponent extends React.Component<
     }
   };
 
-  /**
-   * checks if selelectedDate is null or not,
-   * sets state and calls props onDateSelected
-   * if its null, don't call onDateSelected
-   * update internal state while changing month/year to update calender
-   *
-   * @param selectedDate
-   */
-  onDateSelected = (selectedDate: Date | null, isUserChange: boolean) => {
-    if (isUserChange) {
-      const { onDateSelected } = this.props;
-      const date = selectedDate ? selectedDate.toISOString() : "";
-      this.setState({
-        selectedDate: date,
-      });
-      onDateSelected(date);
+  handleDateChange = (selectedDate: Date | null) => {
+    if (selectedDate === null) {
+      this.setState({ selectedDate: "" });
+    } else {
+      const formattedDate = moment(selectedDate).format(ISO_DATE_FORMAT);
+      if (this.isValidDate(selectedDate)) {
+        this.setState({ selectedDate: formattedDate }, () => {
+          this.props.onDateSelected(formattedDate);
+          this.setState({ isPopoverOpen: false });
+        });
+      } else {
+        this.setState({ selectedDate: "" });
+      }
     }
   };
 }
@@ -522,6 +525,7 @@ interface DatePickerComponentProps extends ComponentProps {
 
 interface DatePickerComponentState {
   selectedDate?: string;
+  isPopoverOpen: boolean;
 }
 
 export default DatePickerComponent;

--- a/app/client/src/widgets/DatePickerWidget2/component/utils.ts
+++ b/app/client/src/widgets/DatePickerWidget2/component/utils.ts
@@ -1,7 +1,7 @@
 import moment from "moment";
 
-export const parseDate = (dateStr: string, dateFormat: string): Date => {
+export const parseDate = (dateStr: string, dateFormat: string): Date | null=> {
   const date = moment(dateStr, dateFormat);
   if (date.isValid()) return date.toDate();
-  else return moment().toDate();
+  else return null;
 };


### PR DESCRIPTION
### Description

### Fixes : [#32683](https://github.com/appsmithorg/appsmith/issues/32683) 

#### I have raised this draft PR In-order to trigger onDateSelected in triggered only on valid dates and not for every character entered in date input and followed similar pattern like [ant-design date-picker model](https://ant.design/components/date-picker)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced date picker functionality with improved visibility control for the popover.
  - Introduced a new date selection handler that closes the popover after a date is selected.

- **Bug Fixes**
  - Updated date parsing to return `null` for invalid inputs, improving clarity on date validation.

- **Documentation**
  - Updated method names and state interfaces for better understanding and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->