### PR TITLE
fix: datepicker doesnt close on first selection of date on month change

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.js
@@ -1,0 +1,42 @@
+import {
+  draggableWidgets,
+  entityExplorer,
+  agHelper,
+} from "../../../../../support/Objects/ObjectsCore";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+import { datePickerlocators } from "../../../../../locators/WidgetLocators";
+
+describe(
+  "DatePicker Widget Property pane tests with js bindings",
+  { tags: ["@tag.Widget", "@tag.Datepicker"] },
+  function () {
+    before(() => {
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.DATEPICKER);
+    });
+
+    function navigateAndSelectRandomDate(direction) {
+      const buttonClass =
+        direction === "prev"
+          ? ".DayPicker-NavButton--prev"
+          : ".DayPicker-NavButton--next";
+      agHelper.AssertElementVisibility(buttonClass, true, 0);
+      agHelper.GetNClick(buttonClass);
+      cy.get(".DayPicker-Month")
+        .first()
+        .find(".DayPicker-Day")
+        .then(($days) => {
+          const randomIndex = Math.floor(Math.random() * $days.length);
+          cy.wrap($days[randomIndex]).click();
+        });
+    }
+
+    it("1.should close datepicker on single click when month is changed", function () {
+      agHelper.GetNClick(datePickerlocators.input);
+      navigateAndSelectRandomDate("prev");
+      agHelper.GetNClick(datePickerlocators.input);
+      navigateAndSelectRandomDate("prev");
+      agHelper.GetNClick(datePickerlocators.input);
+      navigateAndSelectRandomDate("next");
+    });
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker4_spec.ts
@@ -14,7 +14,7 @@ describe(
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.DATEPICKER);
     });
 
-    function navigateAndSelectRandomDate(direction) {
+    const navigateAndSelectRandomDate = (direction: string) => {
       const buttonClass =
         direction === "prev"
           ? ".DayPicker-NavButton--prev"
@@ -28,7 +28,7 @@ describe(
           const randomIndex = Math.floor(Math.random() * $days.length);
           cy.wrap($days[randomIndex]).click();
         });
-    }
+    };
 
     it("1.should close datepicker on single click when month is changed", function () {
       agHelper.GetNClick(datePickerlocators.input);

--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -377,7 +377,7 @@ class DatePickerComponent extends React.Component<
               }}
               maxDate={maxDate}
               minDate={minDate}
-              onChange={this.onDateSelected}
+              onChange={this.handleDateChange}
               parseDate={this.parseDate}
               placeholder={"Select Date"}
               popoverProps={{
@@ -480,6 +480,14 @@ class DatePickerComponent extends React.Component<
       });
       onDateSelected(date);
     }
+  };
+  handleDateChange = (selectedDate: Date | null) => {
+    const formattedDate = selectedDate
+      ? moment(selectedDate).format(ISO_DATE_FORMAT)
+      : "";
+    this.setState({ selectedDate: formattedDate }, () => {
+      this.props.onDateSelected(formattedDate);
+    });
   };
 }
 


### PR DESCRIPTION
/ok-to-test tags="@tag.Widget"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated tests for the DatePicker widget to ensure proper functionality and user interaction.
  
- **Improvements**
  - Updated the date selection handling in the DatePicker component for better state management and consistent date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10034258508>
> Commit: 166d42d04245ade67d72d980a2c57a32a466daea
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10034258508&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Mon, 22 Jul 2024 04:39:40 UTC
<!-- end of auto-generated comment: Cypress test results  -->
