### PR TITLE
fix: Add & list tabs padding fixes

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/JS/Add.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/JS/Add.tsx
@@ -63,10 +63,6 @@ const AddJS = ({ containerProps, innerContainerProps }: AddProps) => {
         />
 
         <GroupedList
-          flexProps={{
-            pr: "spaces-2",
-            px: "spaces-3",
-          }}
           groups={groupedJsOperations.map((op) => ({
             groupTitle: op.title,
             className: op.className,

--- a/app/client/src/pages/Editor/IDE/EditorPane/JS/List.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/JS/List.tsx
@@ -60,6 +60,7 @@ const ListJSObjects = () => {
       flexDirection="column"
       gap="spaces-3"
       overflow="hidden"
+      px="spaces-3"
       py="spaces-3"
     >
       {files && files.length > 0 ? (
@@ -80,13 +81,12 @@ const ListJSObjects = () => {
           flexDirection="column"
           gap="spaces-4"
           overflowY="auto"
-          px="spaces-3"
         >
           {localFiles.map(({ group, items }) => {
             return (
               <Flex flexDirection={"column"} key={group}>
                 {group !== "NA" ? (
-                  <Flex px="spaces-3" py="spaces-1">
+                  <Flex py="spaces-1">
                     <Text
                       className="overflow-hidden overflow-ellipsis whitespace-nowrap"
                       kind="body-s"

--- a/app/client/src/pages/Editor/IDE/EditorPane/Query/Add.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/Query/Add.tsx
@@ -36,10 +36,6 @@ const AddQuery = ({ containerProps, innerContainerProps }: AddProps) => {
           titleMessage={EDITOR_PANE_TEXTS.query_create_tab_title}
         />
         <GroupedList
-          flexProps={{
-            pr: "spaces-2",
-            px: "spaces-3",
-          }}
           groups={groupedActionOperations.map((group) => ({
             groupTitle: group.title,
             className: group.className,

--- a/app/client/src/pages/Editor/IDE/EditorPane/Query/List.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/Query/List.tsx
@@ -47,6 +47,7 @@ const ListQuery = () => {
       flexDirection="column"
       gap="spaces-3"
       overflow="hidden"
+      px="spaces-3"
       py="spaces-3"
     >
       {files.length > 0 ? (
@@ -56,16 +57,11 @@ const ListQuery = () => {
           onSearch={setSearchTerm}
         />
       ) : null}
-      <Flex
-        flexDirection={"column"}
-        gap="spaces-4"
-        overflowY="auto"
-        px="spaces-3"
-      >
+      <Flex flexDirection={"column"} gap="spaces-4" overflowY="auto">
         {localFiles.map(({ group, items }) => {
           return (
             <Flex flexDirection={"column"} key={group}>
-              <Flex px="spaces-3" py="spaces-1">
+              <Flex py="spaces-1">
                 <Text
                   className="overflow-hidden overflow-ellipsis whitespace-nowrap"
                   kind="body-s"

--- a/app/client/src/pages/Editor/IDE/EditorPane/components/AddAndSearchbar.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/components/AddAndSearchbar.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const AddAndSearchbar = ({ hasAddPermission, onAddClick, onSearch }: Props) => {
   return (
-    <Flex alignItems="center" flexDirection="row" gap="spaces-3" px="spaces-3">
+    <Flex alignItems="center" flexDirection="row" gap="spaces-3">
       <SearchInput onChange={onSearch} size="sm" />
       {hasAddPermission ? (
         <Button

--- a/app/client/src/pages/Editor/IDE/EditorPane/components/GroupedList.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/components/GroupedList.tsx
@@ -32,7 +32,7 @@ const GroupedList = (props: Props) => {
         <Flex flexDirection="column" key={group.groupTitle}>
           {group.groupTitle ? (
             <Text
-              className="px-[var(--ads-v2-spaces-3)] py-[var(--ads-v2-spaces-1)]"
+              className="px-0 py-[var(--ads-v2-spaces-1)]"
               color="var(--ads-v2-color-fg-muted)"
               kind="body-s"
             >

--- a/app/client/src/pages/Editor/IDE/EditorPane/components/SegmentAddHeader.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/components/SegmentAddHeader.tsx
@@ -20,8 +20,6 @@ const SegmentAddHeader = (props: Props) => {
           : "var(--ads-v2-color-gray-50)"
       }
       justifyContent="space-between"
-      pl="spaces-4"
-      pr="spaces-2"
       py="spaces-2"
     >
       <Text color="var(--ads-v2-color-fg)" kind="heading-xs">


### PR DESCRIPTION
## Description

Fixed padding for add and list view of tab as per design.


Fixes #34529

## Automation

/ok-to-test tags="@tag.IDE, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
