### PR TITLE
fix:25741-audio recorder complete action twice called fixed

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/AudioRecorder1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/AudioRecorder1_spec.ts
@@ -152,5 +152,27 @@ describe(
         0,
       );
     });
+
+    it("5. Verify onRecordingComplete called once after stopping", () => {
+      // Select the AudioRecorder1 widget
+      EditorNavigation.SelectEntityByName("AudioRecorder1", EntityType.Widget);
+      propPane.TogglePropertyState("Disabled", "Off");
+      // Set up the onRecordingStart action to show an alert with the message "Recording Started"
+      propPane.SelectPlatformFunction("onRecordingStart", "Show alert");
+      agHelper.EnterActionValue("Message", "Recording Started");
+      // Set up the onRecordingComplete action to show an alert with the message "Recording Completed"
+      propPane.SelectPlatformFunction("onRecordingComplete", "Show alert");
+      agHelper.EnterActionValue("Message", "Recording Completed");
+      agHelper.GetNClick(widgetLocators.recorderPrompt);
+      agHelper.GetNClick(widgetLocators.recorderStart);
+
+      // Validate that the toast message "Recording Started" is displayed
+      agHelper.validateToastMessageNTimes("Recording Started", 1);
+      agHelper.WaitUntilAllToastsDisappear();
+      agHelper.GetNClick(widgetLocators.recorderStop);
+
+      // Validate that there is exactly one toast message with "Recording Completed"
+      agHelper.validateToastMessageNTimes("Recording Completed", 1);
+    });
   },
 );

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -1515,7 +1515,14 @@ export class AggregateHelper {
       .invoke("height")
       .should("be.closeTo", height, 1);
   }
-
+  
+  public validateToastMessageNTimes(texts: string, length = 1) {
+    this.GetElement(this.locator._toastMsg, "noVerify").should(
+      "have.length",
+      length,
+    );
+  }
+  
   public AssertText(
     selector: ElementType,
     textOrValue: "text" | "val" = "text",

--- a/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
+++ b/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
@@ -288,10 +288,6 @@ class AudioRecorderWidget extends BaseWidget<
 
       this.props.updateWidgetMetaProperty("dataURL", blobIdForBase64, {
         triggerPropertyName: "onRecordingComplete",
-        dynamicString: this.props.onRecordingComplete,
-        event: {
-          type: EventType.ON_RECORDING_COMPLETE,
-        },
       });
       this.props.updateWidgetMetaProperty("rawBinary", blobIdForRaw, {
         triggerPropertyName: "onRecordingComplete",


### PR DESCRIPTION
### PR Description: 
- [ Issue 25741](https://github.com/appsmithorg/appsmith/issues/25741)
- Fixed audio recorder complete action twice called fixed
- Added cypress test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new test case to verify the functionality of the AudioRecorder1 widget, ensuring correct toast messages upon starting and stopping recordings.
	- Added a method for validating the presence of toast messages in tests, enhancing testing capabilities.

- **Bug Fixes**
	- Streamlined event handling in the AudioRecorderWidget by removing unnecessary parameters related to the onRecordingComplete event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->