### PR TITLE
fix: no queries to bind cta added in autocomplete

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
@@ -66,6 +66,7 @@ export interface FieldEntityInformation {
   mode?: TEditorModes;
   token?: CodeMirror.Token;
   widgetType?: WidgetType;
+  currentPageId?: string;
 }
 
 export type HintHelper = (

--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
@@ -40,6 +40,7 @@ export const bindingHintHelper: HintHelper = (editor: CodeMirror.Editor) => {
         CodemirrorTernService.setEntityInformation(editor, {
           ...entityInformation,
           blockCompletions: additionalData.blockCompletions,
+          currentPageId: additionalData.currentPageId,
         });
       } else {
         CodemirrorTernService.setEntityInformation(editor, entityInformation);

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -161,6 +161,7 @@ import {
 } from "actions/activeFieldActions";
 import CodeMirrorTernService from "utils/autocomplete/CodemirrorTernService";
 import { getEachEntityInformation } from "@appsmith/utils/autocomplete/EntityDefinitions";
+import { getCurrentPageId } from "selectors/editorSelectors";
 
 type ReduxStateProps = ReturnType<typeof mapStateToProps>;
 type ReduxDispatchProps = ReturnType<typeof mapDispatchToProps>;
@@ -688,6 +689,7 @@ class CodeEditor extends Component<Props, State> {
           focusEditor: this.focusEditor,
           executeCommand: this.props.executeCommand,
           isJsEditor: this.props.mode === EditorModes.JAVASCRIPT,
+          currentPageId: this.props.pageId,
         });
         if (hinterOpen) break;
       }
@@ -1387,6 +1389,7 @@ class CodeEditor extends Component<Props, State> {
         focusEditor: this.focusEditor,
         executeCommand: this.props.executeCommand,
         isJsEditor: this.props.mode === EditorModes.JAVASCRIPT,
+        currentPageId: this.props.pageId,
       });
       if (hinterOpen) break;
     }
@@ -1805,6 +1808,7 @@ const mapStateToProps = (state: AppState, props: EditorProps) => ({
   datasourceTableKeys: getAllDatasourceTableKeys(state, props.dataTreePath),
   installedLibraries: selectInstalledLibraries(state),
   focusedProperty: getFocusablePropertyPaneField(state),
+  pageId: getCurrentPageId(state),
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/app/client/src/utils/autocomplete/AutocompleteSortRules.ts
+++ b/app/client/src/utils/autocomplete/AutocompleteSortRules.ts
@@ -9,9 +9,13 @@ import type {
   DataTreeDefEntityInformation,
   TernCompletionResult,
 } from "./CodemirrorTernService";
-import { createCompletionHeader } from "./CodemirrorTernService";
+import {
+  createCompletionHeader,
+  createNoQueriesCTACompletion,
+} from "./CodemirrorTernService";
 import { AutocompleteDataType } from "./AutocompleteDataType";
 import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
+import { queryAddURL } from "@appsmith/RouteBuilder";
 
 interface AutocompleteRule {
   computeScore(
@@ -465,6 +469,18 @@ export class AutocompleteSorter {
       },
     );
 
+    // No actions present, add a CTA for create query
+    if (actionCompletionsList.length === 0) {
+      actionCompletionsList.push(createCompletionHeader("Queries"));
+      actionCompletionsList.push(
+        createNoQueriesCTACompletion(
+          "No queries to bind. Create a new query",
+          queryAddURL({
+            pageId: AutocompleteSorter.currentFieldInfo?.currentPageId,
+          }),
+        ),
+      );
+    }
     return [
       ...actionCompletionsList,
       ...jsObjectCompletionsList,

--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -25,6 +25,7 @@ import {
   checkIfCursorInsideBinding,
   checkIfCursorInsideJSObject,
 } from "components/editorComponents/CodeEditor/codeEditorUtils";
+import history from "utils/history";
 
 const bigDoc = 250;
 const cls = "CodeMirror-Tern-";
@@ -1328,6 +1329,21 @@ export const createCompletionHeader = (name: string): Completion<any> => ({
   origin: "",
   type: AutocompleteDataType.UNKNOWN,
   isHeader: true,
+});
+
+export const createNoQueriesCTACompletion = (
+  name: string,
+  pathToRedirectTo: string,
+): Completion<any> => ({
+  text: name,
+  displayText: name,
+  className: "CodeMirror-Tern-completion",
+  data: { doc: "" },
+  origin: "",
+  type: AutocompleteDataType.UNKNOWN,
+  hint: () => {
+    history.push(pathToRedirectTo);
+  },
 });
 
 export default new CodeMirrorTernService({


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #34920  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
