### PR TITLE
fix:Incorrect font color for titles in T&C page

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/FormLogin/TermsAndConditions.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/FormLogin/TermsAndConditions.ts
@@ -1,7 +1,7 @@
 describe("Terms-And-Conditions", () => {
     it("1. Should check the color of titles is #202939", () => {
-        cy.visit("terms-and-conditions.html");
-        cy.wait(1000);
+        const termsAndConditionsUrl = "terms-and-conditions.html";
+        cy.visit(termsAndConditionsUrl);
         cy.get("h1, h2, h3, h4, h5, h6").each(($el) => {
             cy.wrap($el).should("have.css", "color", "rgb(32, 41, 57)");
         });

--- a/app/client/cypress/e2e/Regression/ClientSide/FormLogin/TermsAndConditions.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/FormLogin/TermsAndConditions.ts
@@ -1,0 +1,9 @@
+describe("Terms-And-Conditions", () => {
+    it("1. Should check the color of titles is #202939", () => {
+        cy.visit("terms-and-conditions.html");
+        cy.wait(1000);
+        cy.get("h1, h2, h3, h4, h5, h6").each(($el) => {
+            cy.wrap($el).should("have.css", "color", "rgb(32, 41, 57)");
+        });
+    });
+});

--- a/app/client/public/terms-and-conditions.html
+++ b/app/client/public/terms-and-conditions.html
@@ -53,6 +53,7 @@
         h6 {
             margin: 0 0 18px;
             font-weight: 400;
+            color: #202939
         }
 
         p {


### PR DESCRIPTION
### description
I have raise this pr `inorder to fix Incorrect font color for titles in T&C page`

### screenshots
### before
![image](https://github.com/user-attachments/assets/7f3934be-66fb-4a91-92c0-0d1b19bee31a)


### after
![image](https://github.com/user-attachments/assets/1c66f3a4-4157-43b6-9837-a721ce1ac3e1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new test suite for validating the color of heading elements on the "Terms and Conditions" page, ensuring adherence to design specifications.

- **Style**
	- Updated the text color of `<h6>` elements in the "Terms and Conditions" page to a dark blue shade for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->