### PR TITLE
fix:updated css to align checkbox and label to center in checkbox-widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBox2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBox2_spec.js
@@ -13,13 +13,15 @@ describe(
     });
     it("Checkbox and it's label should be aligned in center", function () {
       cy.openPropertyPane("checkboxwidget");
-      cy.get(".sc-hINMOq").click({ force: true });
-      cy.get("#radix-61-trigger-style > .sc-bcXHqe").click({ force: true });
-
+      const checkboxLabel = ".sc-hINMOq";
+      const triggerStyle = "#radix-61-trigger-style > .sc-bcXHqe";
+      cy.get(checkboxLabel).click({ force: true });
+      cy.get(triggerStyle).click({ force: true });
       _.propPane.EnterJSContext("Font size", "");
       _.propPane.EnterJSContext("Font size", "4rem");
-
-      cy.get(".bp3-control").should("have.css", "align-items", "center");
+      const checkboxControl = ".bp3-control";
+      cy.get(checkboxControl).should("have.css", "align-items", "center");
+      cy.get(checkboxControl).should("exist");
     });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBox2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBox2_spec.js
@@ -1,0 +1,25 @@
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+
+describe(
+  "Checkbox Widget Functionality",
+  { tags: ["@tag.Widget", "@tag.Checkbox"] },
+  function () {
+    before(() => {
+      _.agHelper.AddDsl("emptyDSL");
+    });
+    it("Add new widget", () => {
+      cy.dragAndDropToCanvas("checkboxwidget", { x: 300, y: 300 });
+      cy.get(".t--widget-checkboxwidget").should("exist");
+    });
+    it("Checkbox and it's label should be aligned in center", function () {
+      cy.openPropertyPane("checkboxwidget");
+      cy.get(".sc-hINMOq").click({ force: true });
+      cy.get("#radix-61-trigger-style > .sc-bcXHqe").click({ force: true });
+
+      _.propPane.EnterJSContext("Font size", "");
+      _.propPane.EnterJSContext("Font size", "4rem");
+
+      cy.get(".bp3-control").should("have.css", "align-items", "center");
+    });
+  },
+);

--- a/app/client/src/widgets/CheckboxWidget/component/index.test.tsx
+++ b/app/client/src/widgets/CheckboxWidget/component/index.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "jest-styled-components";
+import CheckboxComponent from ".";
+import { Colors } from "constants/Colors";
+import { LabelPosition } from "components/constants";
+import { AlignWidgetTypes } from "WidgetProvider/constants";
+
+describe("CheckboxComponent", () => {
+  it("should render the StyledCheckbox with align-items set to center", () => {
+    const { container } = render(
+      <CheckboxComponent
+        widgetId="1"
+        isChecked={true}
+        isLoading={false}
+        label="Test Label"
+        onCheckChange={() => {}}
+        accentColor={Colors.GREEN_SOLID}
+        borderRadius="0"
+        labelPosition={LabelPosition.Left}
+        alignWidget={AlignWidgetTypes.LEFT}
+        isDynamicHeightEnabled={false}
+        isLabelInline={false}
+        isRequired={false}
+        isValid={true}
+        minHeight={50}
+        isFullWidth={true}
+        inputRef={() => {}}
+      />,
+    );
+    const styledCheckbox = container.querySelector(".bp3-checkbox");
+    expect(styledCheckbox).toHaveStyleRule("align-items", "center");
+  });
+});

--- a/app/client/src/widgets/CheckboxWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxWidget/component/index.tsx
@@ -76,6 +76,10 @@ export const CheckboxLabel = styled.div<{
 export const StyledCheckbox = styled(Checkbox)`
   &.bp3-control.bp3-align-right {
     padding-right: 0px;
+  };
+  align-items: center;
+  &.bp3-control.bp3-checkbox .bp3-control-indicator {
+    margin-top: -0.05rem;
   }
 `;
 


### PR DESCRIPTION

### [Issue](https://github.com/appsmithorg/appsmith/issues/15543)

### Description:

Updated the alignment of checkbox and its label to center when the size of label is increased.

#### Screenshots:

##### Before:
![image](https://github.com/user-attachments/assets/30204f29-ecc2-4804-920b-1f4cf471a763)

##### After:
![image](https://github.com/user-attachments/assets/120cd425-74bd-4e43-a3ce-a0ae3424d9e6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced end-to-end tests for the Checkbox widget to validate functionality and visual alignment.
	- Added unit tests for the CheckboxComponent to ensure correct rendering and style application.

- **Improvements**
	- Enhanced styling of the Checkbox widget for better visual presentation and alignment within the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->