### PR TITLE
chore: filtering the autocomplete options to be single level from input query

### DIFF
--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -551,9 +551,14 @@ class CodeMirrorTernService {
     const isCursorInsideBindingOrJSObject =
       checkIfCursorInsideBinding(cm) || checkIfCursorInsideJSObject(cm);
 
+    const dotOperatorCountInputQuery =
+      inputQuery.replace(parentPath, "").match(/\./g)?.length || 0;
     for (let i = 0; i < data.completions.length; ++i) {
       const completion = data.completions[i];
       if (typeof completion === "string") continue;
+      const dotOperatorCountCompletion =
+        completion.name.match(/\./g)?.length || 0;
+      if (dotOperatorCountInputQuery !== dotOperatorCountCompletion) continue;
       const isKeyword = isCustomKeywordType(completion);
       const className = typeToIcon(completion.type as string, isKeyword);
       const dataType = getDataType(completion.type as string);


### PR DESCRIPTION
## Description
Added a check to filter the autocomplete options only for a single level i.e. if we have `{{}}` then list options like `Query1`, `Table1` etc, if we have `{{Query1}}` then list `Query1.data`, `Query1.clear` etc.

Fixes #35128
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
