### PR TITLE
chore: remove execution time calculation from logs

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
@@ -437,10 +437,7 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
         Mono<String> branchedPageIdMono =
                 newPageService.findBranchedPageId(branchName, buildingBlockDTO.getPageId(), AclPermission.MANAGE_PAGES);
 
-        Stopwatch processStopwatch = new Stopwatch("Download Content from Cloud service");
         return applicationJsonMono.flatMap(applicationJson -> {
-            processStopwatch.stopAndLogTimeInMillis();
-            Stopwatch processStopwatch1 = new Stopwatch("Importing resource in db ");
             return this.importResourceInPage(
                             buildingBlockDTO.getWorkspaceId(),
                             buildingBlockDTO.getApplicationId(),
@@ -451,7 +448,6 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
                     .flatMap(tuple -> {
                         BuildingBlockImportDTO buildingBlockImportDTO = tuple.getT1();
                         String branchedPageId = tuple.getT2();
-                        processStopwatch1.stopAndLogTimeInMillis();
                         // Fetch layout and get new onPageLoadActions
                         // This data is not present in a client, since these are created
                         // after importing the block


### PR DESCRIPTION
## Description
Remove the execution time calculation via stopwatch. This was used for profiling earlier but not required anymore and pollutes the logs. 

## Automation

/ok-to-test tags="@tag.Templates"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10088622540>
> Commit: acfae67521a442d3d786099c0b46fc04f8ffda33
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10088622540&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Templates`
> Spec:
> <hr>Thu, 25 Jul 2024 05:37:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed stopwatch logging for performance monitoring during the import process to simplify code.
  
The overall functionality of importing resources remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->