### PR TITLE
fix: form input truncated on submit

### DIFF
--- a/app/client/src/widgets/FormWidget/widget/index.tsx
+++ b/app/client/src/widgets/FormWidget/widget/index.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import _, { get, some } from "lodash";
+import _, { get, some, debounce } from "lodash";
 import equal from "fast-deep-equal/es6";
 import type { WidgetProps } from "../../BaseWidget";
 import type { ContainerWidgetProps } from "widgets/ContainerWidget/widget";
@@ -330,6 +330,11 @@ class FormWidget extends ContainerWidget {
     super.resetChildrenMetaProperty(this.props.widgetId);
   };
 
+  /* Before this fix,  the input fields within form were truncated if the user clicks on submit instantly. To resolve this
+  added debounce to handleResetInputs so that form data is captured correctly on submit*/
+
+  debouncedHandleResetInputs = debounce(this.handleResetInputs, 300);
+
   componentDidMount() {
     super.componentDidMount();
     this.updateFormData();
@@ -408,7 +413,7 @@ class FormWidget extends ContainerWidget {
           const grandChild = { ...child };
           if (isInvalid) grandChild.isFormValid = false;
           // Add submit and reset handlers
-          grandChild.onReset = this.handleResetInputs;
+          grandChild.onReset = this.debouncedHandleResetInputs;
           return grandChild;
         },
       );


### PR DESCRIPTION
## Description

Fixes [#34674 ](https://github.com/appsmithorg/appsmith/issues/34674) 

- Adds debounce to the handleResetInput method in form widget 
- ensures that the form submission logic waits for the latest state updates, preventing issues with truncated input values.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form input handling with a new method that delays the reset of input fields during rapid submissions, improving data capture.
  
- **Bug Fixes**
	- Resolved issues with premature truncation of input fields when the form is submitted quickly, enhancing overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->