### PR TITLE
chore: add widget id prefix

### DIFF
--- a/app/client/src/layoutSystems/anvil/utils/layouts/update/sectionUtils.ts
+++ b/app/client/src/layoutSystems/anvil/utils/layouts/update/sectionUtils.ts
@@ -25,7 +25,9 @@ export function* createSectionAndAddWidget(
   /**
    * Step 1: Create Section widget.
    */
-  const widgetId: string = generateReactKey();
+  const widgetId: string = generateReactKey({
+    prefix: "section-",
+  });
   const updatedWidgets: CanvasWidgetsReduxState = yield addNewAnvilWidgetToDSL(
     allWidgets,
     {

--- a/app/client/src/layoutSystems/anvil/utils/layouts/update/zoneUtils.ts
+++ b/app/client/src/layoutSystems/anvil/utils/layouts/update/zoneUtils.ts
@@ -34,7 +34,7 @@ export function* createZoneAndAddWidgets(
   /**
    * Create Zone widget.
    */
-  const widgetId: string = generateReactKey();
+  const widgetId: string = generateReactKey({ prefix: "zone-" });
   const updatedWidgets: CanvasWidgetsReduxState = yield addNewAnvilWidgetToDSL(
     allWidgets,
     {

--- a/app/client/src/layoutSystems/anvil/utils/sectionOperationUtils.ts
+++ b/app/client/src/layoutSystems/anvil/utils/sectionOperationUtils.ts
@@ -167,7 +167,7 @@ export function* addNewZonesToSection(
   do {
     const sectionWidget: FlattenedWidgetProps = updatedWidgets[sectionWidgetId];
     const newWidget: any = {
-      newWidgetId: generateReactKey(),
+      newWidgetId: generateReactKey({ prefix: "zone-" }),
       parentId: sectionWidget.widgetId,
       type: anvilWidgets.ZONE_WIDGET,
     };

--- a/app/client/src/pages/Editor/widgetSidebar/WidgetCard.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/WidgetCard.tsx
@@ -128,10 +128,13 @@ function WidgetCard(props: CardProps) {
         widgetName: props.details.displayName,
       });
     }
+
     setDraggingNewWidget &&
       setDraggingNewWidget(true, {
         ...props.details,
-        widgetId: generateReactKey(),
+        widgetId: generateReactKey({
+          prefix: props.details.type === "ZONE_WIDGET" ? "zone-" : "component-",
+        }),
       });
   };
 


### PR DESCRIPTION
## Description
Add widget type to id in order to simplify debugging. For example `3jgf4p6owp` => `section-3jgf4p6owp`

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10158529399>
> Commit: 053f81ff4f5a92120b2b289ccb18125eb04380d8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10158529399&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 30 Jul 2024 08:58:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced organization of widgets with unique prefixes for `widgetId` generation, allowing for better identification of section and zone widgets.
	- Improved logic in the WidgetCard for differentiating widget types through structured `widgetId` prefixes.

- **Bug Fixes**
	- Addressed issues related to widget ID uniqueness, ensuring consistent and organized widget management within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->