### PR TITLE
fix: added min-width to the label component, it will be in it's posit…

### DIFF
--- a/app/client/src/widgets/components/LabelWithTooltip.test.tsx
+++ b/app/client/src/widgets/components/LabelWithTooltip.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import '@testing-library/jest-dom/extend-expect';
+import LabelWithTooltip, {  LabelWithTooltipProps } from "./LabelWithTooltip";
+import { ThemeProvider } from "styled-components";
+export const mockTheme = {
+    fontSizes: {
+      6: 14,  
+    },
+    colors: {
+      mirage: "#1E2A38",
+      grey8: "#B0BEC5",
+      propertyPane: {
+        jsIconBg: "#F0F0F0",  
+      },
+    },
+  };
+
+describe("<LabelWithTooltip/>", () => {
+  const defaultProps: LabelWithTooltipProps = {
+    compact: false,
+    text: "Label", 
+  };
+
+  const renderComponent = (props: Partial<LabelWithTooltipProps> = {}) => {
+    return render(<ThemeProvider theme={mockTheme}><LabelWithTooltip {...defaultProps} {...props} /></ThemeProvider>);
+  };
+
+  it("should renders the label with text", () => {
+    renderComponent();
+    const label = screen.getByText("Label");
+    expect(label).toBeInTheDocument();
+  });
+
+  it("should displays help icon when helpText is provided", () => {
+    renderComponent({ helpText: "Help Text" });
+    const helpIcon = screen.getByTestId("label-container");
+    expect(helpIcon).toBeInTheDocument();
+  });
+
+});

--- a/app/client/src/widgets/components/LabelWithTooltip.tsx
+++ b/app/client/src/widgets/components/LabelWithTooltip.tsx
@@ -135,7 +135,7 @@ export const LabelContainer = styled.div<LabelContainerProps>`
     isDynamicHeightEnabled ? "&& { word-break: break-all; }" : ""};
 
   ${({ alignment, compact, inline, optionCount, position, width }) => `
-    ${width && `width: ${width}px`};
+    ${width && `width: ${width}px; min-width:60px`};
     ${
       position !== LabelPosition.Top &&
       (position === LabelPosition.Left || compact)


### PR DESCRIPTION
**Description:**
-Added the min with to the label component ,so that it adjust properly. when we increase the width of radio button.

fix: [26549](https://github.com/appsmithorg/appsmith/issues/26549)
 

**Changes in PR:**
1.added the min-width in the labelwithtooltip component , so that the label adjusts properly.
2.added test cases for the changes  in code .

**snap shots:**
before:
![Screenshot from 2024-07-19 16-46-01](https://github.com/user-attachments/assets/943fdde8-c5cf-43c2-ac4a-94aaab940dd6)
After
![Screenshot from 2024-07-21 09-54-53](https://github.com/user-attachments/assets/b2350108-9376-4b86-b7f8-7d4cbc2cdf8b)

test cases output:
![Screenshot from 2024-07-26 21-02-12](https://github.com/user-attachments/assets/54804c91-fd15-4673-a64d-a514f88227e5)



Hii @ghost  @pranavkanade  @Nikhil-Nandagopal , Please review this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced unit tests for the `LabelWithTooltip` component, improving test coverage and validation of its functionality.
  
- **Improvements**
	- Enhanced styling logic for the `LabelWithTooltip` component by enforcing a minimum width of 60 pixels, ensuring better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->