### PR TITLE
fix:inconsistent behavior of widget color across widgets

### DIFF
--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.test.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.test.tsx
@@ -1,6 +1,9 @@
 // eslint-disable-next-line
 // @ts-nocheck
-import { defaultSelectedValuesValidation } from "./";
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import CheckboxGroupWidget, { defaultSelectedValuesValidation } from "./";
 
 describe("<CheckboxGroup />", () => {
   test("should return empty parsed array on null options", async () => {
@@ -77,5 +80,30 @@ describe("<CheckboxGroup />", () => {
     });
 
     expect(result).toStrictEqual({ isValid: true, parsed: [] });
+  });
+
+  test("should sets accent color to default color when accentColor prop is empty", () => {
+    const DEFAULT_BACKGROUND_COLOR = "#50AF6C";
+    const labels = [
+      { label: "Blue", value: "BLUE" },
+      { label: "Green", value: "GREEN" },
+      { label: "Red", value: "RED" },
+    ];
+    const updateWidgetMetaProperty = jest.fn();
+
+    render(
+      <CheckboxGroupWidget
+        accentColor=""
+        options={labels}
+        updateWidgetMetaProperty={updateWidgetMetaProperty}
+        selectedValues={["BLUE"]}
+      />,
+    );
+
+    const checkboxOne = document.querySelectorAll(".bp3-control-indicator")[0];
+    expect(checkboxOne).toBeInTheDocument();
+    expect(checkboxOne).toHaveStyle(
+      `background-color: ${DEFAULT_BACKGROUND_COLOR}`,
+    );
   });
 });

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -32,6 +32,9 @@ import IconSVG from "../icon.svg";
 import ThumbnailSVG from "../thumbnail.svg";
 import { WIDGET_TAGS } from "constants/WidgetConstants";
 import { FlexVerticalAlignment } from "layoutSystems/common/utils/constants";
+import { Colors } from "constants/Colors";
+
+const DEFAULT_BACKGROUND_COLOR = Colors.GREEN_SOLID;
 
 export function defaultSelectedValuesValidation(
   value: unknown,
@@ -676,7 +679,7 @@ class CheckboxGroupWidget extends BaseWidget<
 
     return (
       <CheckboxGroupComponent
-        accentColor={this.props.accentColor}
+        accentColor={this.props.accentColor || DEFAULT_BACKGROUND_COLOR}
         borderRadius={this.props.borderRadius}
         compactMode={isCompactMode(componentHeight)}
         isDisabled={this.props.isDisabled}


### PR DESCRIPTION
[Issue - 24621](https://github.com/appsmithorg/appsmith/issues/24621)

#### Description
- updated default color of CheckboxGroup to match all other widgets
- added jest unit test cases for the same

#### Screenshots
![image](https://github.com/user-attachments/assets/24d96676-6aae-4403-b7d7-e8e45ab76f27)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default background color for the `CheckboxGroupWidget` when the `accentColor` prop is not specified, enhancing visual consistency.
  
- **Tests**
	- Added a new test case to verify the default behavior of the `accentColor` prop in the `CheckboxGroupWidget`, ensuring correct rendering under specified conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->