### PR TITLE
chore: added logs for connection pool in mysql

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -374,7 +374,7 @@ public class MySqlPlugin extends BasePlugin {
                                 Optional<PoolMetrics> poolMetricsOptional = connectionPool.getMetrics();
                                 if (poolMetricsOptional.isPresent()) {
                                     PoolMetrics poolMetrics = poolMetricsOptional.get();
-                                    log.debug(
+                                    log.info(
                                             "Execute query: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}, Max allocations: {}, Max pending acquire: {}",
                                             poolMetrics.acquiredSize(),
                                             poolMetrics.pendingAcquireSize(),
@@ -734,7 +734,7 @@ public class MySqlPlugin extends BasePlugin {
                                         Optional<PoolMetrics> poolMetricsOptional = connectionPool.getMetrics();
                                         if (poolMetricsOptional.isPresent()) {
                                             PoolMetrics poolMetrics = poolMetricsOptional.get();
-                                            log.debug(
+                                            log.info(
                                                     "Get structure: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}, Max allocations: {}, Max pending acquire: {}",
                                                     poolMetrics.acquiredSize(),
                                                     poolMetrics.pendingAcquireSize(),

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -375,11 +375,13 @@ public class MySqlPlugin extends BasePlugin {
                                 if (poolMetricsOptional.isPresent()) {
                                     PoolMetrics poolMetrics = poolMetricsOptional.get();
                                     log.debug(
-                                            "Execute query: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}: ",
+                                            "Execute query: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}, Max allocations: {}, Max pending acquire: {}",
                                             poolMetrics.acquiredSize(),
                                             poolMetrics.pendingAcquireSize(),
                                             poolMetrics.allocatedSize(),
-                                            poolMetrics.idleSize());
+                                            poolMetrics.idleSize(),
+                                            poolMetrics.getMaxAllocatedSize(),
+                                            poolMetrics.getMaxPendingAcquireSize());
                                 }
 
                                 return resultMono
@@ -733,11 +735,13 @@ public class MySqlPlugin extends BasePlugin {
                                         if (poolMetricsOptional.isPresent()) {
                                             PoolMetrics poolMetrics = poolMetricsOptional.get();
                                             log.debug(
-                                                    "Get structure: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}: ",
+                                                    "Get structure: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}, Max allocations: {}, Max pending acquire: {}",
                                                     poolMetrics.acquiredSize(),
                                                     poolMetrics.pendingAcquireSize(),
                                                     poolMetrics.allocatedSize(),
-                                                    poolMetrics.idleSize());
+                                                    poolMetrics.idleSize(),
+                                                    poolMetrics.getMaxAllocatedSize(),
+                                                    poolMetrics.getMaxPendingAcquireSize());
                                         }
                                         if (isValid) {
                                             return connection


### PR DESCRIPTION
## Description

This PR adds logs around connection pool metrics in order to debug memory leak issue https://github.com/appsmithorg/appsmith/issues/34028

Following metrics are logged for Get strcuture and Excute query calls:
- Acquired  - It indicates number of connections acquired from pool
- Idle - Number of connections sitting idle in the connection pool
- Allocated - Number of connections active / idle in the pool
- Pending - Number of connections pending to be acquired.

This information can help us understand if connections are not being released from the pool leading to memory leak.

Fixes #35158  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10148654649>
> Commit: 2588f79ed0203bd6943408e421f37159dbdfbc48
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10148654649&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Mon, 29 Jul 2024 17:38:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced logging capabilities for the MySqlPlugin connection pool metrics, improving observability during database operations.

- **Bug Fixes**
  - Improved monitoring tools to help identify potential memory leak issues related to connection pool usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->