### PR TITLE
fix: Added wrap for overflowing editor content

### DIFF
--- a/app/client/src/IDE/Components/Sidebar/Sidebar.tsx
+++ b/app/client/src/IDE/Components/Sidebar/Sidebar.tsx
@@ -21,6 +21,7 @@ export interface IDESidebarButton
   extends Omit<SidebarButtonProps, "onClick" | "selected"> {
   state: EditorState;
   urlSuffix: string;
+  count?: number;
 }
 
 interface IDESidebarProps {
@@ -39,6 +40,7 @@ function IDESidebar(props: IDESidebarProps) {
       <div>
         {topButtons.map((button) => (
           <SidebarButton
+            count={button.count}
             icon={button.icon}
             key={button.state}
             onClick={onClick}
@@ -52,6 +54,7 @@ function IDESidebar(props: IDESidebarProps) {
       <div>
         {bottomButtons.map((button) => (
           <SidebarButton
+            count={button.count}
             icon={button.icon}
             key={button.state}
             onClick={onClick}

--- a/app/client/src/IDE/Components/Sidebar/SidebarButton/SidebarButton.tsx
+++ b/app/client/src/IDE/Components/Sidebar/SidebarButton/SidebarButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Flex, Icon, Text, Tooltip } from "design-system";
+import { Flex, Icon, Tag, Text, Tooltip } from "design-system";
 import styled from "styled-components";
 
 import { Condition } from "../../../enums";
@@ -22,6 +22,7 @@ export interface SidebarButtonProps {
   urlSuffix: string;
   tooltip?: string;
   condition?: Condition;
+  count?: number;
 }
 
 const Container = styled(Flex)`
@@ -67,8 +68,17 @@ const ConditionIcon = styled(Icon)`
 `;
 
 function SidebarButton(props: SidebarButtonProps) {
-  const { condition, icon, onClick, selected, title, tooltip, urlSuffix } =
-    props;
+  const {
+    condition,
+    count,
+    icon,
+    onClick,
+    selected,
+    title,
+    tooltip,
+    urlSuffix,
+  } = props;
+
   const handleOnClick = useCallback(() => {
     if (!selected) {
       onClick(urlSuffix);
@@ -88,7 +98,15 @@ function SidebarButton(props: SidebarButtonProps) {
           role="button"
           selected={selected}
         >
-          <Icon name={icon} size="lg" />
+          <Icon className="mix-blend-luminosity" name={icon} size="lg" />
+          {count && count > 0 ? (
+            <Tag
+              className="absolute right-[-4px] top-[-6px] !border-[var(--ads-v2-color-border)]"
+              isClosable={false}
+            >
+              {count > 9 ? "9+" : count}
+            </Tag>
+          ) : null}
           {condition && (
             <ConditionIcon
               className={`t--sidebar-${condition}-condition-icon`}

--- a/app/client/src/ce/entities/IDE/constants.ts
+++ b/app/client/src/ce/entities/IDE/constants.ts
@@ -33,9 +33,9 @@ export enum EditorState {
 }
 
 export const SidebarTopButtonTitles = {
-  DATA: "Data",
+  DATA: "Queries",
   UI: "UI",
-  LOGIC: "Logic",
+  LOGIC: "JS",
 };
 
 export const SidebarBottomButtonTitles = {

--- a/app/client/src/ce/entities/IDE/constants.ts
+++ b/app/client/src/ce/entities/IDE/constants.ts
@@ -25,17 +25,21 @@ import type { IDESidebarButton } from "IDE";
 
 export enum EditorState {
   DATA = "DATA",
-  EDITOR = "EDITOR",
+  UI = "UI",
+  LOGIC = "LOGIC",
+  DATASOURCES = "DATASOURCES",
   SETTINGS = "SETTINGS",
   LIBRARIES = "LIBRARIES",
 }
 
 export const SidebarTopButtonTitles = {
   DATA: "Data",
-  EDITOR: "Editor",
+  UI: "UI",
+  LOGIC: "Logic",
 };
 
 export const SidebarBottomButtonTitles = {
+  DATASOURCES: "Datasources",
   SETTINGS: "Settings",
   LIBRARIES: "Libraries",
 };
@@ -59,20 +63,32 @@ export enum EditorViewMode {
 
 export const TopButtons: IDESidebarButton[] = [
   {
-    state: EditorState.EDITOR,
+    state: EditorState.DATA,
+    icon: "queries-v3",
+    title: SidebarTopButtonTitles.DATA,
+    urlSuffix: "queries",
+  },
+  {
+    state: EditorState.UI,
     icon: "editor-v3",
-    title: SidebarTopButtonTitles.EDITOR,
+    title: SidebarTopButtonTitles.UI,
     urlSuffix: "",
   },
   {
-    state: EditorState.DATA,
-    icon: "datasource-v3",
-    title: SidebarTopButtonTitles.DATA,
-    urlSuffix: "datasource",
+    state: EditorState.LOGIC,
+    icon: "snippet",
+    title: SidebarTopButtonTitles.LOGIC,
+    urlSuffix: "jsObjects",
   },
 ];
 
 export const BottomButtons: IDESidebarButton[] = [
+  {
+    state: EditorState.DATASOURCES,
+    icon: "datasource-v3",
+    urlSuffix: "datasource",
+    tooltip: SidebarBottomButtonTitles.DATASOURCES,
+  },
   {
     state: EditorState.LIBRARIES,
     icon: "packages-v3",

--- a/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
+++ b/app/client/src/ce/navigation/FocusStrategy/AppIDEFocusStrategy.ts
@@ -87,7 +87,7 @@ export const createEditorFocusInfo = (pageId: string, branch?: string) => ({
   key: createEditorFocusInfoKey(pageId, branch),
   entityInfo: {
     id: `EDITOR.${pageId}`,
-    appState: EditorState.EDITOR,
+    appState: EditorState.UI,
     entity: FocusEntity.EDITOR,
     params: {},
   },
@@ -156,7 +156,7 @@ export const AppIDEFocusStrategy: FocusStrategy = {
     // Store editor state if previous url was in editor.
     // Does not matter if still in editor or not
     if (
-      prevFocusEntityInfo.appState === EditorState.EDITOR &&
+      prevFocusEntityInfo.appState === EditorState.UI &&
       prevFocusEntityInfo.entity !== FocusEntity.NONE &&
       (prevFocusEntityInfo.entity !== currentFocusEntityInfo.entity ||
         prevFocusEntityInfo.params.pageId !==
@@ -166,7 +166,7 @@ export const AppIDEFocusStrategy: FocusStrategy = {
         entityInfo: {
           entity: FocusEntity.EDITOR,
           id: `EDITOR.${prevFocusEntityInfo.params.pageId}`,
-          appState: EditorState.EDITOR,
+          appState: EditorState.UI,
           params: prevFocusEntityInfo.params,
         },
         key: `EDITOR_STATE.${prevFocusEntityInfo.params.pageId}#${branch}`,

--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/JS/utils.test.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/JS/utils.test.ts
@@ -29,7 +29,7 @@ describe("getJSUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.JS_OBJECT,
       id: "abc",
-      appState: EditorState.EDITOR,
+      appState: EditorState.LOGIC,
       params: {},
     };
     const url = getJSUrl(focusEntity, false);
@@ -47,7 +47,7 @@ describe("getJSUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.JS_OBJECT_ADD,
       id: "abc",
-      appState: EditorState.EDITOR,
+      appState: EditorState.LOGIC,
       params: {},
     };
     const url = getJSUrl(focusEntity, false);
@@ -60,7 +60,7 @@ describe("getJSUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.QUERY,
       id: "abc",
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: {
         queryId: "abc",
         pageId: "0123456789abcdef00000000",

--- a/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/utils.test.ts
+++ b/app/client/src/ce/pages/Editor/IDE/EditorPane/Query/utils.test.ts
@@ -35,7 +35,7 @@ describe("getQueryUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.QUERY,
       id: "abc",
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: {
         pluginPackageName: PluginPackageName.GOOGLE_SHEETS,
         apiId: "abc",
@@ -57,7 +57,7 @@ describe("getQueryUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.QUERY,
       id: "abc",
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: {
         apiId: "abc",
       },
@@ -78,7 +78,7 @@ describe("getQueryUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.QUERY,
       id: "abc",
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: {
         queryId: "abc",
       },
@@ -99,7 +99,7 @@ describe("getQueryUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.QUERY,
       id: "add",
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: {
         queryId: "add",
       },
@@ -115,7 +115,7 @@ describe("getQueryUrl", () => {
     const focusEntity: FocusEntityInfo = {
       entity: FocusEntity.JS_OBJECT,
       id: "abc",
-      appState: EditorState.EDITOR,
+      appState: EditorState.LOGIC,
       params: {
         collectionId: "abc",
       },

--- a/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/OnBoarding/OnBoarding.test.tsx
@@ -15,7 +15,7 @@ import Onboarding from ".";
 import { unitTestBaseMockStore } from "../unitTestUtils";
 
 jest.mock("pages/Editor/IDE/hooks", () => ({
-  useCurrentAppState: jest.fn().mockReturnValue(EditorState.EDITOR),
+  useCurrentAppState: jest.fn().mockReturnValue(EditorState.UI),
   useCurrentEditorState: jest.fn(),
 }));
 

--- a/app/client/src/layoutSystems/common/dropTarget/OnBoarding/index.tsx
+++ b/app/client/src/layoutSystems/common/dropTarget/OnBoarding/index.tsx
@@ -28,7 +28,10 @@ function Onboarding() {
     FEATURE_FLAG.release_drag_drop_building_blocks_enabled,
   );
 
-  const isEditorState = appState === IDEAppState.EDITOR;
+  const isEditorState =
+    appState === IDEAppState.UI ||
+    appState === IDEAppState.LOGIC ||
+    appState === IDEAppState.DATA;
   const isUISegment = segment === EditorEntityTab.UI;
 
   const shouldShowBuildingBlocksDropTarget = useMemo(

--- a/app/client/src/navigation/FocusEntity.test.ts
+++ b/app/client/src/navigation/FocusEntity.test.ts
@@ -17,7 +17,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.CANVAS,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.UI,
         params: {
           applicationId,
           pageId,
@@ -29,7 +29,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.PROPERTY_PANE,
         id: "ryvc8i7oja",
-        appState: EditorState.EDITOR,
+        appState: EditorState.UI,
         params: {
           applicationId,
           pageId,
@@ -42,7 +42,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY_LIST,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           applicationId,
           entity: "queries",
@@ -55,7 +55,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY,
         id: "myApiId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           apiId: "myApiId",
           applicationId,
@@ -68,7 +68,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY,
         id: "myQueryId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           queryId: "myQueryId",
           applicationId,
@@ -81,7 +81,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.JS_OBJECT_LIST,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.LOGIC,
         params: {
           applicationId,
           entity: "jsObjects",
@@ -94,7 +94,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.JS_OBJECT,
         id: "myJSId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.LOGIC,
         params: {
           applicationId,
           collectionId: "myJSId",
@@ -107,7 +107,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.DATASOURCE_LIST,
         id: "",
-        appState: EditorState.DATA,
+        appState: EditorState.DATASOURCES,
         params: {
           applicationId,
           entity: "datasource",
@@ -120,7 +120,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.DATASOURCE,
         id: "myDatasourceId",
-        appState: EditorState.DATA,
+        appState: EditorState.DATASOURCES,
         params: {
           applicationId,
           datasourceId: "myDatasourceId",
@@ -135,7 +135,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.CANVAS,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.UI,
         params: {
           applicationSlug: "eval",
           pageId,
@@ -148,7 +148,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.PROPERTY_PANE,
         id: "ryvc8i7oja",
-        appState: EditorState.EDITOR,
+        appState: EditorState.UI,
         params: {
           applicationSlug: "app-slug",
           pageId,
@@ -162,7 +162,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY_LIST,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           applicationSlug: "eval",
           entity: "queries",
@@ -176,7 +176,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY,
         id: "myApiId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           apiId: "myApiId",
           applicationSlug: "eval",
@@ -190,7 +190,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY,
         id: "myQueryId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           applicationSlug: "eval",
           pageId,
@@ -204,7 +204,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.JS_OBJECT_LIST,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.LOGIC,
         params: {
           applicationSlug: "eval",
           entity: "jsObjects",
@@ -218,7 +218,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.JS_OBJECT,
         id: "myJSId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.LOGIC,
         params: {
           applicationSlug: "eval",
           collectionId: "myJSId",
@@ -262,7 +262,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.CANVAS,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.UI,
         params: {
           pageId,
           customSlug: "myCustomSlug-",
@@ -274,7 +274,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.PROPERTY_PANE,
         id: "ryvc8i7oja",
-        appState: EditorState.EDITOR,
+        appState: EditorState.UI,
         params: {
           pageId,
           customSlug: "myCustomSlug-",
@@ -287,7 +287,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY_LIST,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           pageId,
           customSlug: "myCustomSlug-",
@@ -300,7 +300,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY,
         id: "myApiId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           pageId,
           customSlug: "myCustomSlug-",
@@ -313,7 +313,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.QUERY,
         id: "myQueryId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: {
           pageId,
           customSlug: "myCustomSlug-",
@@ -326,7 +326,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.JS_OBJECT_LIST,
         id: "",
-        appState: EditorState.EDITOR,
+        appState: EditorState.LOGIC,
         params: {
           pageId,
           entity: "jsObjects",
@@ -339,7 +339,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.JS_OBJECT,
         id: "myJSId",
-        appState: EditorState.EDITOR,
+        appState: EditorState.LOGIC,
         params: {
           collectionId: "myJSId",
           pageId,
@@ -352,7 +352,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.DATASOURCE_LIST,
         id: "",
-        appState: EditorState.DATA,
+        appState: EditorState.DATASOURCES,
         params: {
           entity: "datasource",
           pageId,
@@ -365,7 +365,7 @@ describe("identifyEntityFromPath", () => {
       expected: {
         entity: FocusEntity.DATASOURCE,
         id: "myDatasourceId",
-        appState: EditorState.DATA,
+        appState: EditorState.DATASOURCES,
         params: {
           pageId,
           customSlug: "myCustomSlug-",

--- a/app/client/src/navigation/FocusEntity.ts
+++ b/app/client/src/navigation/FocusEntity.ts
@@ -96,7 +96,7 @@ const getQueryAddPathObj = (match: match<MatchEntityFromPath>) => {
   return {
     entity: FocusEntity.QUERY_ADD,
     id: "",
-    appState: EditorState.EDITOR,
+    appState: EditorState.DATA,
     params: match.params,
   };
 };
@@ -105,7 +105,7 @@ const getJSAddPathObj = (match: match<MatchEntityFromPath>) => {
   return {
     entity: FocusEntity.JS_OBJECT_ADD,
     id: "",
-    appState: EditorState.EDITOR,
+    appState: EditorState.LOGIC,
     params: match.params,
   };
 };
@@ -116,7 +116,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.NONE,
       id: "",
-      appState: EditorState.EDITOR,
+      appState: EditorState.UI,
       params: {},
     };
   }
@@ -128,7 +128,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
       return {
         entity: FocusEntity.QUERY,
         id: match.params.apiId,
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: match.params,
       };
     }
@@ -138,7 +138,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.QUERY,
       id: match.params.apiId,
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: match.params,
     };
   }
@@ -147,14 +147,14 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
       return {
         entity: FocusEntity.NONE,
         id: match.params.datasourceId,
-        appState: EditorState.DATA,
+        appState: EditorState.DATASOURCES,
         params: match.params,
       };
     } else {
       return {
         entity: FocusEntity.DATASOURCE,
         id: match.params.datasourceId,
-        appState: EditorState.DATA,
+        appState: EditorState.DATASOURCES,
         params: match.params,
       };
     }
@@ -163,7 +163,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.DATASOURCE_CREATE,
       id: match.params.selectedTab,
-      appState: EditorState.DATA,
+      appState: EditorState.DATASOURCES,
       params: match.params,
     };
   }
@@ -171,7 +171,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.DATASOURCE_LIST,
       id: "",
-      appState: EditorState.DATA,
+      appState: EditorState.DATASOURCES,
       params: match.params,
     };
   }
@@ -182,7 +182,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.QUERY,
       id: match.params.queryId,
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: match.params,
     };
   }
@@ -194,7 +194,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
       return {
         entity: FocusEntity.QUERY_MODULE_INSTANCE,
         id: match.params.moduleInstanceId,
-        appState: EditorState.EDITOR,
+        appState: EditorState.DATA,
         params: match.params,
       };
     }
@@ -205,7 +205,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
       return {
         entity: FocusEntity.JS_MODULE_INSTANCE,
         id: match.params.moduleInstanceId,
-        appState: EditorState.EDITOR,
+        appState: EditorState.LOGIC,
         params: match.params,
       };
     }
@@ -217,7 +217,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.JS_OBJECT,
       id: match.params.collectionId,
-      appState: EditorState.EDITOR,
+      appState: EditorState.LOGIC,
       params: match.params,
     };
   }
@@ -225,7 +225,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.PROPERTY_PANE,
       id: match.params.widgetIds,
-      appState: EditorState.EDITOR,
+      appState: EditorState.UI,
       params: match.params,
     };
   }
@@ -233,7 +233,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.WIDGET_LIST,
       id: "",
-      appState: EditorState.EDITOR,
+      appState: EditorState.UI,
       params: match.params,
     };
   }
@@ -241,7 +241,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.QUERY_LIST,
       id: "",
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: match.params,
     };
   }
@@ -249,7 +249,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
     return {
       entity: FocusEntity.JS_OBJECT_LIST,
       id: "",
-      appState: EditorState.EDITOR,
+      appState: EditorState.LOGIC,
       params: match.params,
     };
   }
@@ -274,7 +274,7 @@ export function identifyEntityFromPath(path: string): FocusEntityInfo {
   return {
     entity: FocusEntity.CANVAS,
     id: "",
-    appState: EditorState.EDITOR,
+    appState: EditorState.UI,
     params: match.params,
   };
 }

--- a/app/client/src/pages/Editor/IDE/EditorPane/EditorPaneSegments.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/EditorPaneSegments.tsx
@@ -5,7 +5,7 @@ import { SentryRoute } from "@appsmith/AppRouter";
 import QueriesSegment from "./Query";
 import WidgetsSegment from "./UI";
 import JSSegment from "./JS";
-import SegmentedHeader from "./components/SegmentedHeader";
+// import SegmentedHeader from "./components/SegmentedHeader";
 import EditorTabs from "../EditorTabs";
 import {
   jsSegmentRoutes,
@@ -32,7 +32,7 @@ const EditorPaneSegments = () => {
       height="100%"
       overflow="hidden"
     >
-      <SegmentedHeader />
+      {/* <SegmentedHeader /> */}
       {ideViewMode === EditorViewMode.SplitScreen ? <EditorTabs /> : null}
       <Flex
         className="ide-editor-left-pane__content"

--- a/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.test.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/FileTabs.test.tsx
@@ -19,7 +19,7 @@ describe("FileTabs", () => {
   const activeEntity = {
     entity: FocusEntity.API,
     id: "File 1",
-    appState: EditorState.EDITOR,
+    appState: EditorState.DATA,
     params: {},
   };
 

--- a/app/client/src/pages/Editor/IDE/EditorTabs/List.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/List.tsx
@@ -24,9 +24,9 @@ export const List = () => {
   return (
     <ListContainer
       bg="var(--ads-v2-color-bg)"
-      className="absolute top-[78px]"
+      className="absolute top-[32px]"
       data-testid="t--editorpane-list-view"
-      h="calc(100% - 78px)"
+      h="calc(100% - 32px)"
       w="100%"
       zIndex="10"
     >

--- a/app/client/src/pages/Editor/IDE/Header/index.tsx
+++ b/app/client/src/pages/Editor/IDE/Header/index.tsx
@@ -93,14 +93,16 @@ interface HeaderTitleProps {
 
 const HeaderTitleComponent = ({ appState, currentPage }: HeaderTitleProps) => {
   switch (appState) {
-    case EditorState.DATA:
+    case EditorState.DATASOURCES:
       return (
         <IDEHeaderTitle
           key={appState}
           title={createMessage(HEADER_TITLES.DATA)}
         />
       );
-    case EditorState.EDITOR:
+    case EditorState.UI:
+    case EditorState.DATA:
+    case EditorState.LOGIC:
       return <EditorTitle key={appState} title={currentPage?.pageName || ""} />;
     case EditorState.SETTINGS:
       return (

--- a/app/client/src/pages/Editor/IDE/Sidebar.tsx
+++ b/app/client/src/pages/Editor/IDE/Sidebar.tsx
@@ -26,12 +26,12 @@ function Sidebar() {
   const datasources = useSelector(getDatasources);
   const datasourcesExist = datasources.length > 0;
 
-  // Updates the top button config based on datasource existence
-  const topButtons = React.useMemo(() => {
+  // Updates the bottom button config based on datasource existence
+  const bottomButtons = React.useMemo(() => {
     return datasourcesExist
-      ? TopButtons
-      : TopButtons.map((button) => {
-          if (button.state === EditorState.DATA) {
+      ? BottomButtons
+      : BottomButtons.map((button) => {
+          if (button.state === EditorState.DATASOURCES) {
             return {
               ...button,
               condition: Condition.Warn,
@@ -63,11 +63,11 @@ function Sidebar() {
 
   return (
     <IDESidebar
-      bottomButtons={BottomButtons}
+      bottomButtons={bottomButtons}
       editorState={appState}
       id={"t--app-sidebar"}
       onClick={onClick}
-      topButtons={topButtons}
+      topButtons={TopButtons}
     />
   );
 }

--- a/app/client/src/pages/Editor/IDE/Sidebar.tsx
+++ b/app/client/src/pages/Editor/IDE/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   createMessage,
   EMPTY_DATASOURCE_TOOLTIP_SIDEBUTTON,
 } from "@appsmith/constants/messages";
+import { getActionsCount, getJsActionsCount } from "selectors/ideSelectors";
 
 function Sidebar() {
   const dispatch = useDispatch();
@@ -25,6 +26,26 @@ function Sidebar() {
   const currentWorkspaceId = useSelector(getCurrentWorkspaceId);
   const datasources = useSelector(getDatasources);
   const datasourcesExist = datasources.length > 0;
+  const actionsCount = useSelector(getActionsCount);
+  const jsObjectCount = useSelector(getJsActionsCount);
+
+  const topButtons = React.useMemo(() => {
+    return TopButtons.map((button) => {
+      if (button.state === EditorState.DATA) {
+        return {
+          ...button,
+          count: actionsCount,
+        };
+      }
+      if (button.state === EditorState.LOGIC) {
+        return {
+          ...button,
+          count: jsObjectCount,
+        };
+      }
+      return button;
+    });
+  }, [actionsCount, jsObjectCount]);
 
   // Updates the bottom button config based on datasource existence
   const bottomButtons = React.useMemo(() => {
@@ -67,7 +88,7 @@ function Sidebar() {
       editorState={appState}
       id={"t--app-sidebar"}
       onClick={onClick}
-      topButtons={TopButtons}
+      topButtons={topButtons}
     />
   );
 }

--- a/app/client/src/pages/Editor/IDE/hooks.ts
+++ b/app/client/src/pages/Editor/IDE/hooks.ts
@@ -37,7 +37,7 @@ import { closeQueryActionTab } from "actions/pluginActionActions";
 import { getCurrentEntityInfo } from "../utils";
 
 export const useCurrentAppState = () => {
-  const [appState, setAppState] = useState(EditorState.EDITOR);
+  const [appState, setAppState] = useState(EditorState.UI);
   const { pathname } = useLocation();
   const entityInfo = identifyEntityFromPath(pathname);
   useEffect(() => {

--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -369,7 +369,7 @@ function JSEditorForm({
             </StyledNotificationWrapper>
           )}
           <Wrapper>
-            <div className="flex flex-1">
+            <div className="flex flex-1 w-full">
               <SecondaryWrapper>
                 <TabbedViewContainer isExecuting={isExecutingCurrentJSAction}>
                   <Tabs

--- a/app/client/src/pages/Editor/WidgetsEditor/components/CodeModeTooltip.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/components/CodeModeTooltip.tsx
@@ -33,7 +33,12 @@ const CodeModeTooltip = (props: { children: React.ReactElement }) => {
       });
   }, [isWidgetSelectionBlock]);
   if (!isWidgetSelectionBlock) return props.children;
-  if (editorState !== EditorState.EDITOR) return props.children;
+  if (
+    editorState !== EditorState.UI &&
+    editorState !== EditorState.DATA &&
+    editorState !== EditorState.LOGIC
+  )
+    return props.children;
   return (
     <Tooltip
       content={createMessage(CANVAS_VIEW_MODE_TOOLTIP, `${modText()}`)}

--- a/app/client/src/pages/Editor/utils.tsx
+++ b/app/client/src/pages/Editor/utils.tsx
@@ -498,7 +498,9 @@ export function isInSideBySideEditor({
 }) {
   return (
     viewMode === EditorViewMode.SplitScreen &&
-    appState === EditorState.EDITOR &&
+    (appState === EditorState.UI ||
+      appState === EditorState.LOGIC ||
+      appState === EditorState.DATA) &&
     segment !== EditorEntityTab.UI
   );
 }

--- a/app/client/src/sagas/getNextEntityAfterRemove.test.ts
+++ b/app/client/src/sagas/getNextEntityAfterRemove.test.ts
@@ -25,7 +25,7 @@ describe("getNextEntityAfterRemove function", () => {
     .mockImplementation(() => ({
       entity: FocusEntity.QUERY,
       id: "2",
-      appState: EditorState.EDITOR,
+      appState: EditorState.DATA,
       params: {},
     }));
 

--- a/app/client/src/selectors/ideSelectors.tsx
+++ b/app/client/src/selectors/ideSelectors.tsx
@@ -1,7 +1,6 @@
 import { createSelector } from "reselect";
 import { selectFeatureFlags } from "@appsmith/selectors/featureFlagsSelectors";
 import type { AppState } from "@appsmith/reducers";
-import { getPageActions } from "@appsmith/selectors/entitiesSelector";
 import {
   EditorEntityTab,
   EditorViewMode,
@@ -28,14 +27,21 @@ export const getIDEViewMode = createSelector(
   },
 );
 
-export const getActionsCount = (pageId: string) =>
-  createSelector(getPageActions(pageId), (actions) => {
-    return actions.length || 0;
-  });
+export const getActionsCount = createSelector(
+  getCurrentPageId,
+  (state: AppState) => state.entities.actions,
+  (pageId, actions) => {
+    return actions.filter((v) => v.config.pageId === pageId).length || 0;
+  },
+);
 
-export const getJsActionsCount = (state: AppState, pageId: string) =>
-  state.entities.jsActions.filter((v) => v.config.pageId === pageId).length ||
-  0;
+export const getJsActionsCount = createSelector(
+  getCurrentPageId,
+  (state) => state.entities.jsActions,
+  (pageId, jsActions) => {
+    return jsActions.filter((v) => v.config.pageId === pageId).length || 0;
+  },
+);
 
 export const getWidgetsCount = (state: AppState, pageId: string) =>
   Object.values(state.ui.pageWidgets[pageId].dsl).filter(

--- a/app/client/src/utils/hooks/useHoverToFocusWidget.ts
+++ b/app/client/src/utils/hooks/useHoverToFocusWidget.ts
@@ -21,7 +21,10 @@ export const useHoverToFocusWidget = (
   // This state tells the current IDE state
   const ideState = useCurrentAppState();
   // Check if in the editor state
-  const isEditor = ideState === EditorState.EDITOR;
+  const isEditor =
+    ideState === EditorState.UI ||
+    ideState === EditorState.LOGIC ||
+    ideState === EditorState.DATA;
 
   // This state tells us whether a `ResizableComponent` is resizing
   const isResizing = useSelector(


### PR DESCRIPTION
## Description

Horizontal scroll was not enabled in JS object side by side view. To fix the content overflowing issue, this PR added word wrap by limiting the width of the editor.

Fixes #35240

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/10142901890>
> Commit: cffb593e9e0716fc2a31b7b70c16a42178f07c46
> Workflow: `PR Automation test suite`
> Tags: `@tag.All`
> Spec: ``
> <hr>Mon, 29 Jul 2024 10:52:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced optional count property for sidebar buttons, enhancing interactivity with numeric indicators.
	- Updated sidebar button configurations to better reflect application states, including newly defined states and titles.
	- Enhanced sidebar functionality with dynamic action counts displayed on buttons based on the current state.

- **Bug Fixes**
	- Adjusted application state checks to include additional states, improving the control flow and overall logic.

- **Style**
	- Improved layout and styling of components for better user interface and experience.

- **Tests**
	- Updated test cases to reflect changes in application state management, ensuring accuracy in test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->