### PR TITLE
test: openPropertyPane js helper update with new TS helper

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/DatePicker_Text_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/DatePicker_Text_spec.js
@@ -18,13 +18,13 @@ describe(
       /**
        * Bind DatePicker1 to Text for "selectedDate"
        */
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{DatePicker1.selectedDate}}");
 
       /**
        * Set the Calender for today's date in DatePicker1
        */
-      cy.openPropertyPane("datepickerwidget");
+      _.propPane.openPropertyPane("datepickerwidget");
       cy.get(formWidgetsPage.defaultDate).click();
       cy.ClearDateFooter();
       cy.SetDateToToday();
@@ -52,7 +52,7 @@ describe(
     });
 
     it.skip("2. DatePicker1-text: Change the date in DatePicker1 and Validate the same in text widget", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
 
       /**
        * Bind the datepicker1 to text widget
@@ -73,7 +73,7 @@ describe(
       /**
        * Changing date on datepicker1 to current date +1
        */
-      cy.openPropertyPane("datepickerwidget");
+      _.propPane.openPropertyPane("datepickerwidget");
       cy.get(formWidgetsPage.defaultDate).click();
       cy.ClearDateFooter();
       cy.setDate(1, "ddd MMM DD YYYY");
@@ -107,7 +107,7 @@ describe(
       /**
        * Bind the DatePicker1 and DatePicker2 along with hard coded text to Text widget
        */
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext(
         "text",
         "{{DatePicker1.isDisabled}} DatePicker {{DatePicker2.isDisabled}}",
@@ -128,7 +128,7 @@ describe(
       /**
        * bind datepicker to show a message "Hello" on date selected
        */
-      cy.openPropertyPane("datepickerwidget");
+      _.propPane.openPropertyPane("datepickerwidget");
       cy.getAlert("onDateSelected");
 
       /**

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
@@ -117,7 +117,7 @@ Object.entries(widgetsToTest).forEach(([widgetSelector, testConfig], index) => {
       it("2. StoreValue should have complete input value", () => {
         // if default input widget type is changed from text to any other type then uncomment below code.
         // if (widgetSelector === draggableWidgets.INPUT_V2) {
-        //   cy.openPropertyPane(widgetSelector);
+        //   _.propPane.openPropertyPane(widgetSelector);
         //   cy.selectDropdownValue(".t--property-control-datatype", "Text");
         //   cy.get(".t--property-control-required label")
         //     .last()

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
@@ -117,7 +117,7 @@ Object.entries(widgetsToTest).forEach(([widgetSelector, testConfig], index) => {
       it("2. StoreValue should have complete input value", () => {
         // if default input widget type is changed from text to any other type then uncomment below code.
         // if (widgetSelector === draggableWidgets.INPUT_V2) {
-        //   _.propPane.openPropertyPane(widgetSelector);
+        //   propPane.openPropertyPane(widgetSelector);
         //   cy.selectDropdownValue(".t--property-control-datatype", "Text");
         //   cy.get(".t--property-control-required label")
         //     .last()

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -1,6 +1,7 @@
 import EditorNavigation, {
   EntityType,
 } from "../../../../support/Pages/EditorNavigation";
+import * as _ from "../../../../support/Objects/ObjectsCore";
 
 const commonlocators = require("../../../../locators/commonlocators.json");
 import {

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Page_Load_Spec.js
@@ -32,7 +32,7 @@ describe("Page Load tests", { tags: ["@tag.IDE"] }, () => {
     //add page within page
     agHelper.AddDsl("PageLoadDsl");
     // Update the text to be asserted later
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.testCodeMirror("This is Page 2");
     // Publish
     deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Tab_rename_Delete_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Tab_rename_Delete_spec.ts
@@ -8,6 +8,7 @@ import EditorNavigation, {
   EntityType,
   PageLeftPane,
 } from "../../../../support/Pages/EditorNavigation";
+import * as _ from "../../../../support/Objects/ObjectsCore";
 
 describe("Tab widget test", { tags: ["@tag.IDE"] }, function () {
   const tabname = "UpdatedTab";

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Tab_rename_Delete_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Tab_rename_Delete_spec.ts
@@ -53,7 +53,7 @@ describe("Tab widget test", { tags: ["@tag.IDE"] }, function () {
 
     it("Tab Widget Functionality To Unchecked Visible Widget", function() {
 deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("tabswidget");
+      _.propPane.openPropertyPane("tabswidget");
       cy.closePropertyPane();
       cy.get(Layoutpage.tabWidget)
         .contains("Tab 2")

--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Bug_Fixes.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Bug_Fixes.js
@@ -3,7 +3,7 @@ import * as _ from "../../../../support/Objects/ObjectsCore";
 describe("Canvas context Property Pane", { tags: ["@tag.IDE"] }, function () {
   it("1. Bug 18191: Unable to delete checkbox child when it is inside list widget #18191", () => {
     _.agHelper.AddDsl("Bugs/CheckboxGroupInListWidgetDsl");
-    cy.openPropertyPane("checkboxgroupwidget");
+    _.propPane.openPropertyPane("checkboxgroupwidget");
     //check number of options
     cy.get(
       `.t--property-control-options > div:nth-child(2) > div[orientation="HORIZONTAL"]`,

--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_AutoLayout_Validation_BasicSpec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_AutoLayout_Validation_BasicSpec.js
@@ -13,7 +13,7 @@ describe(
   function () {
     it("1. Validate basic conversion algorithm usecases", function () {
       _.agHelper.AddDsl("conversionFrAutoLayoutDsl");
-      //cy.openPropertyPane("containerwidget");
+      //_.propPane.openPropertyPane("containerwidget");
       cy.get("@getConsolidatedData").then((httpResponse) => {
         const data = httpResponse.response.body.data.pageWithMigratedDsl.data;
         testHeight = data.layouts[0].dsl.bottomRow;

--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_FixedLayout_Mobile_Validation_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_FixedLayout_Mobile_Validation_Spec.js
@@ -1,5 +1,7 @@
 import { agHelper, autoLayout } from "../../../../support/Objects/ObjectsCore";
+import * as _ from "../../../../support/Objects/ObjectsCore";
 let testHeight;
+
 
 describe(
   "Auto conversion algorithm usecases for fixed Layout",

--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_FixedLayout_Mobile_Validation_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_FixedLayout_Mobile_Validation_Spec.js
@@ -7,7 +7,7 @@ describe(
   function () {
     it("1. Validate basic conversion algorithm usecases fixed layout usecase Mobile", function () {
       agHelper.AddDsl("conversionFrAutoLayoutDsl");
-      //cy.openPropertyPane("containerwidget");
+      //_.propPane.openPropertyPane("containerwidget");
       cy.get("@getConsolidatedData").then((httpResponse) => {
         const data = httpResponse.response.body.data.pageWithMigratedDsl.data;
         testHeight = data.layouts[0].dsl.bottomRow;

--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_FixedLayout_Validation_Desktop.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionAlgorithm_FixedLayout_Validation_Desktop.js
@@ -7,7 +7,7 @@ describe(
   function () {
     it("1. Validate basic conversion algorithm usecases fixed layout Desktop", function () {
       _.agHelper.AddDsl("conversionFrAutoLayoutDsl");
-      //cy.openPropertyPane("containerwidget");
+      //_.propPane.openPropertyPane("containerwidget");
       cy.get("@getConsolidatedData").then((httpResponse) => {
         const data = httpResponse.response.body.data.pageWithMigratedDsl.data;
         testHeight = data.layouts[0].dsl.bottomRow;

--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ValidateAutoFillContainerWidgets_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ValidateAutoFillContainerWidgets_spec.js
@@ -9,7 +9,7 @@ describe(
   function () {
     it("1. Validate change with height width for widgets", function () {
       _.agHelper.AddDsl("AutolayoutWidgetsDsl");
-      //cy.openPropertyPane("containerwidget");
+      //_.propPane.openPropertyPane("containerwidget");
       EditorNavigation.SelectEntityByName("Container1", EntityType.Widget);
       cy.get(".t--widget-containerwidget")
         .first()

--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ValidateAutoFillContainerWithInput_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ValidateAutoFillContainerWithInput_spec.js
@@ -9,7 +9,7 @@ describe(
   function () {
     it("1. Validate change with height width for widgets", function () {
       _.agHelper.AddDsl("autoLayoutContainerWidgetDsl");
-      //cy.openPropertyPane("containerwidget");
+      //_.propPane.openPropertyPane("containerwidget");
       EditorNavigation.SelectEntityByName("Container1", EntityType.Widget);
       cy.get(".t--widget-containerwidget")
         .first()

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Inspect_Element_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Inspect_Element_spec.js
@@ -5,7 +5,7 @@ describe("Inspect Entity", function () {
     _.agHelper.AddDsl("debuggerDependencyDsl");
   });
   it("1. Check whether depedencies and references are shown correctly", function () {
-    cy.openPropertyPane("inputwidgetv2");
+    _.propPane.openPropertyPane("inputwidgetv2");
     cy.testJsontext("defaultvalue", "{{Button1.text}}");
     _.agHelper.GetNClick(".t--debugger-count");
     cy.contains(".ads-v2-tabs__list-tab", "Inspect entity").click();

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/PreviewMode_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/PreviewMode_spec.js
@@ -29,7 +29,7 @@ describe("Preview mode functionality", { tags: ["@tag.IDE"] }, function () {
 
   it("2. Check invisible widget should not show in proview mode and should show in edit mode", function () {
     _.agHelper.GetNClick(_.locators._previewModeToggle("preview"));
-    cy.openPropertyPane("buttonwidget");
+    _.propPane.openPropertyPane("buttonwidget");
     cy.UncheckWidgetProperties(commonlocators.visibleCheckbox);
 
     // button should not show in preview mode

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_spec.js
@@ -80,7 +80,7 @@ describe("Undo/Redo functionality", function () {
   // });
 
   it("2. checks undo/redo for toggle control in property pane", function () {
-    cy.openPropertyPane("checkboxwidget");
+    _.propPane.openPropertyPane("checkboxwidget");
     cy.CheckWidgetProperties(commonlocators.disableCheckbox);
 
     cy.get("body").type(`{${modifierKey}}z`);

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Replay_spec.js
@@ -80,7 +80,7 @@ describe("Undo/Redo functionality", function () {
   // });
 
   it("2. checks undo/redo for toggle control in property pane", function () {
-    _.propPane.openPropertyPane("checkboxwidget");
+    propPane.openPropertyPane("checkboxwidget");
     cy.CheckWidgetProperties(commonlocators.disableCheckbox);
 
     cy.get("body").type(`{${modifierKey}}z`);

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Resize_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Resize_spec.js
@@ -8,7 +8,7 @@ describe("Canvas Resize", function () {
   it("1. Deleting bottom widget should resize canvas", function () {
     const InitHeight = "2950px";
     cy.get(commonlocators.dropTarget).should("have.css", "height", InitHeight);
-    //cy.openPropertyPane("textwidget");
+    //_.propPane.openPropertyPane("textwidget");
     cy.intercept("PUT", "/api/v1/layouts/*/pages/*").as("deleteUpdate");
     propPane.DeleteWidgetFromPropertyPane("Text2");
     cy.wait("@deleteUpdate").then((response) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/TriggerErrors_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/TriggerErrors_spec.js
@@ -5,7 +5,7 @@ describe("Trigger errors in the debugger", function () {
     _.agHelper.AddDsl("debuggerTableDsl");
   });
   it("1. Trigger errors need to be shown in the errors tab", function () {
-    cy.openPropertyPane("tablewidget");
+    _.propPane.openPropertyPane("tablewidget");
     cy.testJsontext("tabledata", `[{"name": 1}, {"name": 2}]`);
     cy.focused().blur();
     cy.get(".t--property-control-onrowselected").find(".t--js-toggle").click();

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Unique_key_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Unique_key_spec.js
@@ -19,7 +19,7 @@ describe("Unique react keys", function () {
     cy.dragAndDropToCanvas("selectwidget", { x: 200, y: 600 });
     cy.dragAndDropToCanvas("selectwidget", { x: 200, y: 700 });
 
-    cy.openPropertyPane("chartwidget");
+    _.propPane.openPropertyPane("chartwidget");
     cy.deleteWidget(widgetsPage.chartWidget);
 
     cy.get(widgetsPage.selectwidget).should("have.length", 2);
@@ -30,7 +30,7 @@ describe("Unique react keys", function () {
     cy.dragAndDropToCanvas("chartwidget", { x: 200, y: 200 });
     cy.dragAndDropToCanvas("selectwidget", { x: 200, y: 600 });
     //copy and paste
-    cy.openPropertyPane("selectwidget");
+    _.propPane.openPropertyPane("selectwidget");
     cy.get("body").type(`{${modifierKey}}c`);
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500);
@@ -44,7 +44,7 @@ describe("Unique react keys", function () {
 
     cy.get(widgetsPage.selectwidget).should("have.length", 2);
 
-    cy.openPropertyPane("chartwidget");
+    _.propPane.openPropertyPane("chartwidget");
     cy.deleteWidget(widgetsPage.chartWidget);
 
     cy.get(widgetsPage.selectwidget).should("have.length", 2);

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Widget_Error_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Widget_Error_spec.js
@@ -14,7 +14,7 @@ describe("Widget error state", function () {
   });
 
   it("1. Check widget error state", function () {
-    cy.openPropertyPane("buttonwidget");
+    _.propPane.openPropertyPane("buttonwidget");
 
     cy.get(".t--property-control-visible").find(".t--js-toggle").click();
     cy.EnableAllCodeEditors();

--- a/app/client/cypress/e2e/Regression/ClientSide/PropertyPane/PropertyPaneCTA_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/PropertyPane/PropertyPaneCTA_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("1. Check if CTA is shown when there is no action", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.get(".t--propertypane-connect-cta")
         .scrollIntoView()
         .should("be.visible");

--- a/app/client/cypress/e2e/Regression/ClientSide/PropertyPane/PropertyPane_Connections_Error_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/PropertyPane/PropertyPane_Connections_Error_spec.js
@@ -9,11 +9,11 @@ describe(
     });
 
     it("1. Check if the connection shows an error state when a connection has an error", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       cy.testJsontext("tabledata", "{{error}}");
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{Table1.searchText}}");
 
       // Find class which indicates an error

--- a/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/ThemeReset_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/ThemeReset_spec.js
@@ -11,7 +11,7 @@ describe("Theme validation usecases", { tags: ["@tag.Theme"] }, function () {
     cy.get(".t--widget-buttonwidget").should("exist");
 
     // open property pane
-    cy.openPropertyPane("buttonwidget");
+    _.propPane.openPropertyPane("buttonwidget");
     cy.moveToStyleTab();
     // change color to red
     cy.get(widgetsPage.buttonColor).click({ force: true }).clear().type("red");

--- a/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/ThemeReset_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/ThemeReset_spec.js
@@ -1,6 +1,7 @@
 const widgetsPage = require("../../../../locators/Widgets.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
-import { ObjectsRegistry, propPane } from "../../../../support/Objects/Registry";
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+import * as _ from "../../../../support/Objects/ObjectsCore";
 
 const appSettings = ObjectsRegistry.AppSettings;
 
@@ -11,7 +12,7 @@ describe("Theme validation usecases", { tags: ["@tag.Theme"] }, function () {
     cy.get(".t--widget-buttonwidget").should("exist");
 
     // open property pane
-    propPane.openPropertyPane("buttonwidget");
+    _.propPane.openPropertyPane("buttonwidget");
     cy.moveToStyleTab();
     // change color to red
     cy.get(widgetsPage.buttonColor).click({ force: true }).clear().type("red");

--- a/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/ThemeReset_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ThemingTests/ThemeReset_spec.js
@@ -1,6 +1,6 @@
 const widgetsPage = require("../../../../locators/Widgets.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
-import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+import { ObjectsRegistry, propPane } from "../../../../support/Objects/Registry";
 
 const appSettings = ObjectsRegistry.AppSettings;
 
@@ -11,7 +11,7 @@ describe("Theme validation usecases", { tags: ["@tag.Theme"] }, function () {
     cy.get(".t--widget-buttonwidget").should("exist");
 
     // open property pane
-    _.propPane.openPropertyPane("buttonwidget");
+    propPane.openPropertyPane("buttonwidget");
     cy.moveToStyleTab();
     // change color to red
     cy.get(widgetsPage.buttonColor).click({ force: true }).clear().type("red");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/AudioRecorder_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/AudioRecorder_spec.js
@@ -1,3 +1,4 @@
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 const widgetName = "audiorecorderwidget";
 
 describe(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/AudioRecorder_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/AudioRecorder_spec.js
@@ -8,7 +8,7 @@ describe(
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 300 });
       cy.get(`.t--widget-${widgetName}`).should("exist");
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{AudioRecorder1.isDirty}}`,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/audio_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Audio/audio_spec.js
@@ -11,7 +11,7 @@ describe(
     });
 
     it("1. Audio Widget play functionality validation", function () {
-      cy.openPropertyPane("audiowidget");
+      _.propPane.openPropertyPane("audiowidget");
       cy.widgetText(
         "Audio1",
         widgetsPage.audioWidget,
@@ -53,7 +53,7 @@ describe(
 
     it("3. Checks if audio widget is reset on button click", function () {
       cy.dragAndDropToCanvas("buttonwidget", { x: 300, y: 300 });
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.widgetText(
         "Button1",
         widgetsPage.buttonWidget,
@@ -63,10 +63,10 @@ describe(
       cy.selectWidgetForReset("Audio1");
 
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(".t--property-control-text", `{{Audio1.playState}}`);
 
-      cy.openPropertyPane("audiowidget");
+      _.propPane.openPropertyPane("audiowidget");
       cy.get(widgetsPage.autoPlay).click({ force: true });
       // Wait time added, allowing a second to pass between playing and pausing the widget, before it is reset to zero
       cy.wait(1000);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/ButtonLintErrorValidation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/ButtonLintErrorValidation_spec.js
@@ -9,7 +9,7 @@ describe(
       _.agHelper.AddDsl("buttonLintErrorDsl");
     });
     it("Linting Error validation on mouseover and errorlog tab", function () {
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       /**
        * @param{Text} Random Text
        * @param{CheckboxWidget}Mouseover

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/Button_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Button/Button_spec.js
@@ -19,7 +19,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
     });
 
     it("1. Icon alignment should not change when changing the icon", () => {
@@ -70,7 +70,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
       // Button default variant validation", function () {
       // Checks whether the default variant is PRIMARY or not
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.get(widgetsPage.widgetBtn).should(
         "have.attr",
         "data-test-variant",
@@ -120,7 +120,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //Uncheck the disabled checkbox and validate
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.UncheckWidgetProperties(commonlocators.disableCheckbox);
       cy.validateEnableWidget(
         widgetsPage.buttonWidget,
@@ -150,7 +150,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //Uncheck the disabled checkbox and validate
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.testJsontext("disabled", "false");
       cy.validateEnableWidget(
         widgetsPage.buttonWidget,
@@ -172,7 +172,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //Check the disableed checkbox and Validate
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.CheckWidgetProperties(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();
       cy.get(publishPage.buttonWidget).should("be.visible");
@@ -188,7 +188,7 @@ describe(
       cy.get(publishPage.buttonWidget).should("not.exist");
       _.deployMode.NavigateBacktoEditor();
       //Check the disabled checkbox using JS and Validate
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.EnableAllCodeEditors();
       cy.testJsontext("visible", "true");
       _.deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Chart/Custom_Chart_Data_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Chart/Custom_Chart_Data_spec.js
@@ -10,7 +10,7 @@ describe(
 
     it("1. change chart type to custom chart", function () {
       const value1 = 40;
-      cy.openPropertyPane("chartwidget");
+      _.propPane.openPropertyPane("chartwidget");
       cy.UpdateChartType("Custom Fusion Charts (deprecated)");
       //change chart value via input widget and validate
       enterAndTest("inputwidgetv2", value1, value1);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Chart/Custom_Chart_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Chart/Custom_Chart_spec.js
@@ -15,7 +15,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.openPropertyPane("chartwidget");
+      _.propPane.openPropertyPane("chartwidget");
     });
 
     it("1. Fill the Chart Widget Properties.", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBoxLintErrorMultipleRowValidation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBoxLintErrorMultipleRowValidation_spec.js
@@ -9,7 +9,7 @@ describe(
       _.agHelper.AddDsl("snippetDsl");
     });
     it("Linting warning validation", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       /**
        * @param{Text} Random Text
        * @param{CheckboxWidget}Mouseover

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBoxMultipleLintError_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBoxMultipleLintError_spec.js
@@ -9,7 +9,7 @@ describe(
       _.agHelper.AddDsl("snippetErrordsl");
     });
     it("Linting warning validation", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       /**
        * @param{Text} Random Text
        * @param{CheckboxWidget}Mouseover

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBox_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckBox_spec.js
@@ -12,7 +12,7 @@ describe(
       _.agHelper.AddDsl("newFormDsl");
     });
     it("Checkbox Widget Functionality", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       /**
        * @param{Text} Random Text
        * @param{CheckboxWidget}Mouseover
@@ -44,32 +44,32 @@ describe(
       );
     });
     it("Checkbox Functionality To Check Disabled Widget", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       _.agHelper.CheckUncheck(commonlocators.Disablejs + " " + "input");
       _.deployMode.DeployApp();
       cy.get(publish.checkboxWidget + " " + "input").should("be.disabled");
     });
     it("Checkbox Functionality To Check Enabled Widget", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       _.agHelper.CheckUncheck(commonlocators.Disablejs + " " + "input", false);
       _.deployMode.DeployApp();
       cy.get(publish.checkboxWidget + " " + "input").should("be.enabled");
     });
     it("Checkbox Functionality To Unchecked Visible Widget", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
       _.deployMode.DeployApp();
       cy.get(publish.checkboxWidget + " " + "input").should("not.exist");
     });
     it("Checkbox Functionality To Check Visible Widget", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();
       cy.get(publish.checkboxWidget + " " + "input").should("be.checked");
     });
 
     it("Check isDirty meta property", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(".t--property-control-text", `{{checker.isDirty}}`);
       // Check if initial value of isDirty is false
       cy.get(".t--widget-textwidget").should("contain", "false");
@@ -78,7 +78,7 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").should("contain", "true");
       // Change defaultCheckedState property
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       cy.get(".t--property-control-defaultstate label").last().click();
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget").should("contain", "false");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup1_spec.js
@@ -14,7 +14,7 @@ describe(
     });
 
     it("should check that prefilled option is added and empty value is allowed in options", () => {
-      cy.openPropertyPane("checkboxgroupwidget");
+      _.propPane.openPropertyPane("checkboxgroupwidget");
       cy.get(".t--property-control-options-add").click({ force: true });
       cy.get(".t--property-control-options")
         .find(".t--js-toggle")
@@ -42,7 +42,7 @@ describe(
     });
 
     it("should check that more thatn empty value is not allowed in options", () => {
-      cy.openPropertyPane("checkboxgroupwidget");
+      _.propPane.openPropertyPane("checkboxgroupwidget");
       cy.updateCodeInput(
         ".t--property-control-options",
         `[

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
@@ -1,5 +1,6 @@
 const formWidgetsPage = require("../../../../../locators/FormWidgets.json");
 const publish = require("../../../../../locators/publishWidgetspage.json");
+
 import {
   agHelper,
   propPane,
@@ -61,7 +62,7 @@ describe(
       cy.get(publish.checkboxGroupWidget + " " + "input").should("not.exist");
       deployMode.NavigateBacktoEditor();
       //Checkbox Group Functionality To Check Visible Widget
-      _.propPane.openPropertyPane("checkboxgroupwidget");
+      propPane.openPropertyPane("checkboxgroupwidget");
       propPane.TogglePropertyState("Visible", "On");
       deployMode.DeployApp();
       cy.wait(500);
@@ -90,7 +91,7 @@ describe(
     });
 
     it("4. Checkbox Group Functionality To alignment options", function () {
-      _.propPane.openPropertyPane("checkboxgroupwidget");
+      propPane.openPropertyPane("checkboxgroupwidget");
       cy.moveToStyleTab();
       // check default value
       cy.get(".t--property-control-alignment").should("exist");
@@ -117,10 +118,10 @@ describe(
 
     it("5. Check isDirty meta property", function () {
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       propPane.UpdatePropertyFieldValue("Text", "{{CBGTest.isDirty}}");
       // Change defaultSelectedValues
-      _.propPane.openPropertyPane("checkboxgroupwidget");
+      propPane.openPropertyPane("checkboxgroupwidget");
       cy.moveToContentTab();
       propPane.UpdatePropertyFieldValue("Default selected values", "GREEN");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
@@ -61,7 +61,7 @@ describe(
       cy.get(publish.checkboxGroupWidget + " " + "input").should("not.exist");
       deployMode.NavigateBacktoEditor();
       //Checkbox Group Functionality To Check Visible Widget
-      cy.openPropertyPane("checkboxgroupwidget");
+      _.propPane.openPropertyPane("checkboxgroupwidget");
       propPane.TogglePropertyState("Visible", "On");
       deployMode.DeployApp();
       cy.wait(500);
@@ -90,7 +90,7 @@ describe(
     });
 
     it("4. Checkbox Group Functionality To alignment options", function () {
-      cy.openPropertyPane("checkboxgroupwidget");
+      _.propPane.openPropertyPane("checkboxgroupwidget");
       cy.moveToStyleTab();
       // check default value
       cy.get(".t--property-control-alignment").should("exist");
@@ -117,10 +117,10 @@ describe(
 
     it("5. Check isDirty meta property", function () {
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       propPane.UpdatePropertyFieldValue("Text", "{{CBGTest.isDirty}}");
       // Change defaultSelectedValues
-      cy.openPropertyPane("checkboxgroupwidget");
+      _.propPane.openPropertyPane("checkboxgroupwidget");
       cy.moveToContentTab();
       propPane.UpdatePropertyFieldValue("Default selected values", "GREEN");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup_withQuery_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup_withQuery_spec.js
@@ -33,7 +33,7 @@ describe(
 
       // add checkbox group widget
       cy.dragAndDropToCanvas("checkboxgroupwidget", { x: 300, y: 300 });
-      _.propPane.openPropertyPane("checkboxgroupwidget");
+      cy.openPropertyPane("checkboxgroupwidget");
 
       // bind options to query data
       cy.get(".t--property-control-options")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup_withQuery_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup_withQuery_spec.js
@@ -33,7 +33,7 @@ describe(
 
       // add checkbox group widget
       cy.dragAndDropToCanvas("checkboxgroupwidget", { x: 300, y: 300 });
-      cy.openPropertyPane("checkboxgroupwidget");
+      _.propPane.openPropertyPane("checkboxgroupwidget");
 
       // bind options to query data
       cy.get(".t--property-control-options")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/CodeScanner/CodeScanner1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/CodeScanner/CodeScanner1_spec.ts
@@ -21,7 +21,7 @@ describe(
     it("2 => Check if the default scanner layout is ALWAYS_ON", () => {
       // Drop a text widget to test the code scanner value binding
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 600 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.moveToContentTab();
       cy.updateCodeInput(
         ".t--property-control-text",
@@ -47,7 +47,7 @@ describe(
               { tags: ["@tag.Widget", "@tag.Scanner"] },
               () => {
                 it("3.1.1.1 => Disabled icon should be visible", () => {
-                  cy.openPropertyPane(widgetName);
+                  _.propPane.openPropertyPane(widgetName);
                   cy.moveToContentTab();
 
                   // Disable and publish
@@ -75,7 +75,7 @@ describe(
               { tags: ["@tag.Widget", "@tag.Scanner"] },
               () => {
                 it("3.1.2.1 => Disabled icon should not be visible", () => {
-                  cy.openPropertyPane(widgetName);
+                  _.propPane.openPropertyPane(widgetName);
                   cy.moveToContentTab();
 
                   // Enable and publish
@@ -108,7 +108,7 @@ describe(
           { tags: ["@tag.Widget", "@tag.Scanner"] },
           () => {
             it("3.2.1 => Widget should be invisible on the canvas", () => {
-              cy.openPropertyPane(widgetName);
+              _.propPane.openPropertyPane(widgetName);
               cy.moveToContentTab();
 
               // Visibilty OFF and publish
@@ -123,7 +123,7 @@ describe(
             });
 
             it("3.2.2 => Widget should be visible on the canvas", () => {
-              cy.openPropertyPane(widgetName);
+              _.propPane.openPropertyPane(widgetName);
               cy.moveToContentTab();
 
               // Visibilty ON and publish
@@ -146,7 +146,7 @@ describe(
       { tags: ["@tag.Widget", "@tag.Scanner"] },
       () => {
         it("4.1 => Check if scanner layout can be changed from Always On to Click to Scan", () => {
-          cy.openPropertyPane(widgetName);
+          _.propPane.openPropertyPane(widgetName);
           cy.moveToContentTab();
 
           // Select scanner layout as CLICK_TO_SCAN
@@ -188,7 +188,7 @@ describe(
           { tags: ["@tag.Widget", "@tag.Scanner"] },
           () => {
             it("4.2.1 => Button on the canvas should be disabled", () => {
-              cy.openPropertyPane(widgetName);
+              _.propPane.openPropertyPane(widgetName);
               cy.moveToContentTab();
 
               // Disable and publish
@@ -205,7 +205,7 @@ describe(
             });
 
             it("4.2.2 => Button on the canvas should be enabled again", () => {
-              cy.openPropertyPane(widgetName);
+              _.propPane.openPropertyPane(widgetName);
               cy.moveToContentTab();
 
               // Enable and publish
@@ -228,7 +228,7 @@ describe(
           { tags: ["@tag.Widget", "@tag.Scanner"] },
           () => {
             it("4.3.1 => Button on the canvas should be invisible", () => {
-              cy.openPropertyPane(widgetName);
+              _.propPane.openPropertyPane(widgetName);
               cy.moveToContentTab();
 
               // Visibilty OFF and publish
@@ -245,7 +245,7 @@ describe(
             });
 
             it("4.3.2 => Button on the canvas should be visible again", () => {
-              cy.openPropertyPane(widgetName);
+              _.propPane.openPropertyPane(widgetName);
               cy.moveToContentTab();
 
               // Visibilty ON and publish

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Container_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Container_spec.js
@@ -18,7 +18,7 @@ describe(
     });
 
     it("Container Widget Functionality", function () {
-      cy.openPropertyPane("containerwidget");
+      _.propPane.openPropertyPane("containerwidget");
       /**
        * @param{Text} Random Text
        * @param{ContainerWidget}Mouseover
@@ -80,7 +80,7 @@ describe(
 
     it("Test border width and verity", function () {
       _.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("containerwidget");
+      _.propPane.openPropertyPane("containerwidget");
       cy.moveToStyleTab();
       cy.testJsontext("borderwidth", "10");
       cy.get(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInputDynamicCurrencyCode_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInputDynamicCurrencyCode_spec.js
@@ -11,7 +11,7 @@ describe(
     });
 
     it("1. Should show empty dropdown for a typo", () => {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
 
       // Turn on allowCurrencyChange
       cy.get(".t--property-control-allowcurrencychange label")
@@ -44,7 +44,7 @@ describe(
     });
 
     it("2. should check that widget can be used with dynamic default currency code", () => {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.get(".t--property-control-currency .CodeMirror-code").should(
         "contain",
         "{{appsmith.store.test}}",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInput_ShowStepArrows_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInput_ShowStepArrows_spec.js
@@ -9,7 +9,7 @@ describe(
   function () {
     it("1. Validate that For new currency input widgets being dragged, the value for showStepArrows should be set to false", () => {
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 400 });
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
 
       cy.get(widgetsPage.showStepArrowsToggleCheckBox).should("not.be.checked");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInput_ShowStepArrows_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInput_ShowStepArrows_spec.js
@@ -1,5 +1,5 @@
 const widgetsPage = require("../../../../../locators/Widgets.json");
-const { agHelper } = require("../../../../../support/Objects/ObjectsCore");
+const { agHelper, propPane } = require("../../../../../support/Objects/ObjectsCore");
 
 const widgetName = "currencyinputwidget";
 
@@ -9,7 +9,7 @@ describe(
   function () {
     it("1. Validate that For new currency input widgets being dragged, the value for showStepArrows should be set to false", () => {
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 400 });
-      _.propPane.openPropertyPane(widgetName);
+      propPane.openPropertyPane(widgetName);
 
       cy.get(widgetsPage.showStepArrowsToggleCheckBox).should("not.be.checked");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInput_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInput_spec.js
@@ -18,7 +18,7 @@ describe(
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 300 });
       cy.get(`.t--widget-${widgetName}`).should("exist");
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{CurrencyInput1.text}}:{{CurrencyInput1.value}}:{{CurrencyInput1.isValid}}:{{typeof CurrencyInput1.text}}:{{typeof CurrencyInput1.value}}:{{CurrencyInput1.countryCode}}:{{CurrencyInput1.currencyCode}}`,
@@ -26,7 +26,7 @@ describe(
     });
 
     it("2. should check for type of value and widget", () => {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.get(".t--property-control-currency").click();
       cy.get(".t--property-control-currency").type("usd");
       cy.selectDropdownValue(
@@ -39,7 +39,7 @@ describe(
         if (text) {
           cy.get(widgetInput).type(text);
         }
-        cy.openPropertyPane("textwidget");
+        _.propPane.openPropertyPane("textwidget");
         cy.get(".t--widget-textwidget").should("contain", expected);
       }
       [
@@ -52,7 +52,7 @@ describe(
         enterAndTest(d[0], d[1]);
       });
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "1");
 
       [
@@ -65,7 +65,7 @@ describe(
         enterAndTest(d[0], d[1]);
       });
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "2");
 
       [
@@ -79,7 +79,7 @@ describe(
       });
       cy.get(".currency-change-dropdown-trigger").should("contain", "$");
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.get(".t--property-control-currency").click();
       cy.get(".t--property-control-currency").type("ind");
       cy.selectDropdownValue(
@@ -89,7 +89,7 @@ describe(
       enterAndTest("100.22", "100.22:100.22:true:string:number:IN:INR");
       cy.get(".currency-change-dropdown-trigger").should("contain", "₹");
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.get(".t--property-control-allowcurrencychange input")
         .last()
         .click({ force: true });
@@ -104,11 +104,11 @@ describe(
     });
 
     it("3. should accept 0 decimal option", () => {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "0");
       cy.closePropertyPane();
       cy.wait(500);
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.get(".t--property-control-decimalsallowed span span").should(
         "have.text",
         "0",
@@ -116,7 +116,7 @@ describe(
     });
 
     it("4. should check that widget input resets on submit", () => {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.getAlert("onSubmit", "Submitted!!");
 
       cy.get(widgetInput).clear();
@@ -133,15 +133,15 @@ describe(
         if (text) {
           cy.get(widgetInput).type(text);
         }
-        cy.openPropertyPane("textwidget");
+        _.propPane.openPropertyPane("textwidget");
         cy.get(".t--widget-textwidget").should("contain", expected);
       }
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{CurrencyInput1.text}}:{{CurrencyInput1.value}}`,
       );
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "0");
 
       [
@@ -156,7 +156,7 @@ describe(
         enterAndTest(d[0], d[1]);
       });
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "1");
       [
         //[input, {{CurrencyInput1.text}}:{{CurrencyInput1.value}}]
@@ -170,7 +170,7 @@ describe(
         enterAndTest(d[0], d[1]);
       });
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "2");
       [
         //[input, {{CurrencyInput1.text}}:{{CurrencyInput1.value}}]
@@ -189,11 +189,11 @@ describe(
       cy.get(widgetInput).clear();
       cy.wait(300);
       cy.get(widgetInput).type("1000.90");
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.get(widgetInput).should("contain.value", "1,000.90");
       cy.get(widgetInput).focus({ force: true });
       cy.get(widgetInput).should("contain.value", "1000.90");
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.get(widgetInput).should("contain.value", "1,000.90");
     });
 
@@ -204,7 +204,7 @@ describe(
         cy.get(widgetInput).should("contain.value", expected);
       }
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "0");
 
       [
@@ -220,7 +220,7 @@ describe(
         enterAndTest(d[0], d[1]);
       });
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "1");
       [
         //[input, expected]
@@ -237,7 +237,7 @@ describe(
         enterAndTest(d[0], d[1]);
       });
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(".t--property-control-decimalsallowed input", "2");
       [
         //[input, expected]
@@ -261,13 +261,13 @@ describe(
     });
 
     it("7. Check isDirty meta property", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{CurrencyInput1.isDirty}}`,
       );
       // Init isDirty
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.updateCodeInput(".t--property-control-defaultvalue", "1");
       cy.closePropertyPane();
       // Check if initial value of isDirty is false
@@ -278,7 +278,7 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").should("contain", "true");
       // Change defaultText
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.updateCodeInput(".t--property-control-defaultvalue", "5");
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget").should("contain", "false");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker1_spec.js
@@ -14,7 +14,7 @@ describe(
     });
 
     it("1. Datepicker default date validation with js binding and default date", function () {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.get(".t--property-control-defaultdate input").clear();
       cy.get(formWidgetsPage.toggleJsDefaultDate).click();
       cy.EnableAllCodeEditors();
@@ -26,7 +26,7 @@ describe(
 
     it("2. Datepicker default time picker validation by Time precision", function () {
       // default value in property pane
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.get(
         ".t--property-control-timeprecision .rc-select-selection-item",
       ).should("have.text", "Minute");
@@ -45,7 +45,7 @@ describe(
 
     it("3. Hide Time picker from Datepicker", function () {
       // default value in property pane
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.get(".t--property-control-timeprecision .rc-select-selection-item")
         .last()
         .click({ force: true });
@@ -66,7 +66,7 @@ describe(
 
     it("4. set second field in time picker for Datepicker", function () {
       // default value in property pane
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
 
       cy.get(".t--property-control-timeprecision .rc-select-selection-item")
         .last()
@@ -99,7 +99,7 @@ describe(
     });
 
     it("6. Text widgets binding with datepicker", function () {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.selectDateFormat("DD/MM/YYYY");
       cy.assertDateFormat();
       cy.closePropertyPane();
@@ -107,7 +107,7 @@ describe(
     });
 
     it("7. Datepicker default date validation with js binding and default date with moment object", function () {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       //cy.testJsontext("defaultdate", "");
       cy.clearPropertyValue(0);
       cy.get(formWidgetsPage.toggleJsDefaultDate).click().wait(1000); //disable

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
@@ -14,7 +14,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.openPropertyPane("datepickerwidget");
+      _.propPane.openPropertyPane("datepickerwidget");
     });
 
     // ADS changes to date input property causes this test to fail

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePickerV2Updated_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePickerV2Updated_spec.js
@@ -18,7 +18,7 @@ describe(
     });
 
     it("1. Datepicker tooltip renders if tooltip prop is not empty", () => {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       // enter tooltip in property pan
       cy.get(widgetsPage.inputTooltipControl).type(
         "Helpful text for tooltip !",
@@ -34,7 +34,7 @@ describe(
   { tags: ["@tag.Widget", "@tag.Datepicker"] },
   () => {
     it("should should bring up a required error state when value is cleared ", () => {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.wait(1000);
       //set the required condition to true in the property pane
       cy.get(".t--property-control-required label")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePickerV2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePickerV2_spec.js
@@ -24,7 +24,7 @@ describe(
     });
 
     it("1. Datepicker default date validation with js binding", function () {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.get(
         ".t--property-control-defaultdate .ads-v2-input__input-section-input",
       ).clear();
@@ -51,7 +51,7 @@ describe(
     });
 
     it("2. Text widgets binding with datepicker", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{DatePicker1.formattedDate}}");
       cy.closePropertyPane();
       EditorNavigation.SelectEntityByName("Text2", EntityType.Widget);
@@ -62,7 +62,7 @@ describe(
     });
 
     it("3. Text widgets binding with datepicker", function () {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.selectDateFormat("YYYY-MM-DD");
       cy.assertDateFormat();
       cy.selectDateFormat("YYYY-MM-DD HH:mm");
@@ -77,7 +77,7 @@ describe(
     });
 
     it("4. Datepicker default date validation message", function () {
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.testJsontext("defaultdate", "24-12-2021");
       cy.evaluateErrorMessage("Value does not match: ISO 8601 date string");
       cy.closePropertyPane();
@@ -86,7 +86,7 @@ describe(
     it("5. Datepicker should not change the display data unless user selects the date", () => {
       _.agHelper.AddDsl("datePickerdsl");
 
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
 
       cy.testJsontext(
         "defaultdate",
@@ -147,13 +147,13 @@ describe(
 
     it("7. Check isDirty meta property", function () {
       _.agHelper.AddDsl("datePickerdsl");
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{DatePicker1.isDirty}}`,
       );
       // Init isDirty
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.testJsontextclear("defaultdate");
       cy.get(formWidgetsPage.toggleJsDefaultDate).click();
       cy.get(
@@ -177,7 +177,7 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").first().should("contain", "true");
       // Change defaultDate
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
       cy.testJsontext("defaultdate", "");
       cy.get(formWidgetsPage.toggleJsDefaultDate).click();
       cy.get(
@@ -206,7 +206,7 @@ describe(
     it("onBlur and onFocus should be triggered from the datePicker widget", () => {
       cy.Createpage("New Page");
       cy.dragAndDropToCanvas("datepickerwidget2", { x: 300, y: 600 });
-      cy.openPropertyPane("datepickerwidget2");
+      _.propPane.openPropertyPane("datepickerwidget2");
 
       cy.get(widgetsPage.toggleOnFocus).click({ force: true });
       cy.testJsontext("onfocus", "{{showAlert('Focused','success')}}");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker_Toggle_js_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker_Toggle_js_spec.js
@@ -9,7 +9,7 @@ describe(
     before(() => {
       _.agHelper.AddDsl("newFormDsl");
 
-      cy.openPropertyPane("datepickerwidget");
+      _.propPane.openPropertyPane("datepickerwidget");
     });
 
     it("1. Datepicker default date validation with js binding", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker_With_Switch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker_With_Switch_spec.js
@@ -15,7 +15,7 @@ describe(
       _.agHelper.AddDsl("datepicker_switchDsl");
     });
     it("Switch Widget Functionality check with success message", function () {
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.widgetText(
         "Toggler",
         formWidgetsPage.switchWidget,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Dropdown/Dropdown_onOptionChange_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Dropdown/Dropdown_onOptionChange_spec.js
@@ -96,7 +96,7 @@ describe(
       // Going to HomePage where the button widget is located and opeing it's property pane.
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
       PageLeftPane.switchSegment(PagePaneSegment.UI);
-      _.propPane.openPropertyPane("selectwidget");
+      propPane.openPropertyPane("selectwidget");
       cy.reload();
       // Adding the query in the onOptionChangeAction of the dropdown widget.
       cy.executeDbQuery("Query1", "onOptionChange");
@@ -164,7 +164,7 @@ describe(
         .click({ force: true });
       cy.get(formWidgetsPage.apiCallToast).should("contain.text", "Success");
       deployMode.NavigateBacktoEditor();
-      _.propPane.openPropertyPane("selectwidget");
+      propPane.openPropertyPane("selectwidget");
     });
 
     it("6. Dropdown Widget Functionality to Verify On Option Change Action", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Dropdown/Dropdown_onOptionChange_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Dropdown/Dropdown_onOptionChange_spec.js
@@ -96,7 +96,7 @@ describe(
       // Going to HomePage where the button widget is located and opeing it's property pane.
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
       PageLeftPane.switchSegment(PagePaneSegment.UI);
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.reload();
       // Adding the query in the onOptionChangeAction of the dropdown widget.
       cy.executeDbQuery("Query1", "onOptionChange");
@@ -164,7 +164,7 @@ describe(
         .click({ force: true });
       cy.get(formWidgetsPage.apiCallToast).should("contain.text", "Success");
       deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
     });
 
     it("6. Dropdown Widget Functionality to Verify On Option Change Action", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Dropdown/Dropdown_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Dropdown/Dropdown_spec.js
@@ -17,7 +17,7 @@ describe(
     });
 
     it("should check that empty value is allowed in options", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       _.propPane.ToggleJSMode("sourcedata");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
@@ -52,7 +52,7 @@ describe(
     });
 
     it("should check that more than one empty value is not allowed in options", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[
@@ -76,7 +76,7 @@ describe(
     });
 
     it("should check that Objects can be added to Select Widget default value", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[{
@@ -101,7 +101,7 @@ describe(
     });
 
     it("should check that special strings are parsed as string in default value", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[{
@@ -123,14 +123,14 @@ describe(
       ).should("not.exist");
       cy.get(formWidgetsPage.dropdownDefaultButton).should("contain", "Blue");
 
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(".t--property-control-defaultselectedvalue", "120");
       cy.get(
         ".t--property-control-defaultselectedvalue .t--codemirror-has-error",
       ).should("not.exist");
       cy.get(formWidgetsPage.dropdownDefaultButton).should("contain", "Red");
 
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(
         ".t--property-control-defaultselectedvalue",
         "{{ 100 }}",
@@ -140,7 +140,7 @@ describe(
       ).should("not.exist");
       cy.get(formWidgetsPage.dropdownDefaultButton).should("contain", "Green");
 
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(
         ".t--property-control-defaultselectedvalue",
         "{{ null }}",
@@ -151,7 +151,7 @@ describe(
     });
 
     it("Dropdown Functionality To Check disabled Widget", function () {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       // Disable the visible JS
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
       _.deployMode.DeployApp();
@@ -161,7 +161,7 @@ describe(
     });
 
     it("Dropdown Functionality To UnCheck disabled Widget", function () {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       // Check the visible JS
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
@@ -19,7 +19,7 @@ describe(
     });
 
     it("1. Parse CSV,XLS,JSON,TSV,Binary,Text and Base64 file data to table Widget", () => {
-      _.propPane.openPropertyPane(widgetName);
+      propPane.openPropertyPane(widgetName);
       cy.get(
         `.t--property-control-dataformat ${commonlocators.helperText}`,
       ).should("not.exist");
@@ -137,14 +137,14 @@ describe(
 
       // Drag and drop a text widget for binding file data
       cy.dragAndDropToCanvas("textwidget", { x: 100, y: 100 });
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       propPane.UpdatePropertyFieldValue(
         "Text",
         `{{FilePicker1.files[0].data}}`,
       );
 
       // Test for Base64
-      _.propPane.openPropertyPane(widgetName);
+      propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(commonlocators.filePickerDataFormat, "Base64");
       cy.get(commonlocators.filePickerInput)
         .first()

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
@@ -19,7 +19,7 @@ describe(
     });
 
     it("1. Parse CSV,XLS,JSON,TSV,Binary,Text and Base64 file data to table Widget", () => {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.get(
         `.t--property-control-dataformat ${commonlocators.helperText}`,
       ).should("not.exist");
@@ -137,14 +137,14 @@ describe(
 
       // Drag and drop a text widget for binding file data
       cy.dragAndDropToCanvas("textwidget", { x: 100, y: 100 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       propPane.UpdatePropertyFieldValue(
         "Text",
         `{{FilePicker1.files[0].data}}`,
       );
 
       // Test for Base64
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.selectDropdownValue(commonlocators.filePickerDataFormat, "Base64");
       cy.get(commonlocators.filePickerInput)
         .first()

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_spec.js
@@ -18,7 +18,7 @@ describe(
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 300 });
       cy.get(widgetsPage.filepickerwidgetv2).should("exist");
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{FilePicker1.isDirty}}`,
@@ -44,7 +44,7 @@ describe(
 
     it("3. Check if the uploaded data does not reset when back from query page", () => {
       PageLeftPane.switchSegment(PagePaneSegment.UI);
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{FilePicker1.files[0].name}}`,
@@ -85,7 +85,7 @@ describe(
       // Go back to widgets page
       PageLeftPane.switchSegment(PagePaneSegment.UI);
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(".t--property-control-text", `{{FilePicker1.files}}`);
 
       cy.get(widgetsPage.filepickerwidgetv2).click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
@@ -11,7 +11,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
     });
 
     it("RichTextEditor required functionality", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWidget_spec.js
@@ -43,7 +43,7 @@ describe(
     });
 
     it("3. Form_Widget Minimize and maximize General Validation", function () {
-      cy.openPropertyPane("formwidget");
+      _.propPane.openPropertyPane("formwidget");
       cy.get(commonlocators.generalChevran).click({ force: true });
       cy.get(commonlocators.generalSection).should("not.be.visible");
       cy.get(commonlocators.generalChevran).click({ force: true });
@@ -66,7 +66,7 @@ describe(
     });
 
     //it("Form Widget Functionality", function() {
-    // cy.openPropertyPane("formwidget");
+    // _.propPane.openPropertyPane("formwidget");
     // /**
     //  * @param{Text} Random Text
     //  * @param{FormWidget}Mouseover
@@ -103,7 +103,7 @@ describe(
     //});
 
     it("4. Form Widget Functionality To Unchecked Visible Widget", function () {
-      cy.openPropertyPane("formwidget");
+      _.propPane.openPropertyPane("formwidget");
       // Uncheck the visble JS
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
       _.deployMode.DeployApp();
@@ -113,7 +113,7 @@ describe(
 
       //Check Visible
       // Open property pone
-      cy.openPropertyPane("formwidget");
+      _.propPane.openPropertyPane("formwidget");
       // Check the visible JS
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();
@@ -123,7 +123,7 @@ describe(
     });
 
     it("5. Toggle JS - Form-Unckeck Visible field Validation", function () {
-      cy.openPropertyPane("formwidget");
+      _.propPane.openPropertyPane("formwidget");
       //Uncheck the disabled checkbox using JS and validate
       cy.get(widgetsPage.toggleVisible).click({ force: true });
       cy.wait(1000);
@@ -133,7 +133,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //check visible:
-      cy.openPropertyPane("formwidget");
+      _.propPane.openPropertyPane("formwidget");
       //Check the disabled checkbox using JS and Validate
       cy.testJsontext("visible", "true");
       _.deployMode.DeployApp();
@@ -142,7 +142,7 @@ describe(
     });
 
     it("6. Form-Copy Verification", function () {
-      cy.openPropertyPane("formwidget");
+      _.propPane.openPropertyPane("formwidget");
       //Copy Form and verify all properties
       cy.copyWidget("formwidget", widgetsPage.formWidget);
       _.deployMode.DeployApp();
@@ -151,7 +151,7 @@ describe(
     /*
   it("Form-Delete Verification", function() {
     const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
-    cy.openPropertyPane("formwidget");
+    _.propPane.openPropertyPane("formwidget");
     // Delete the Form widget
     cy.get("body").type("{del}", { force: true });
     cy.wait("@updateLayout").should(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWithSwitch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/FormWithSwitch_spec.js
@@ -15,7 +15,7 @@ describe(
     });
     it("Switch Widget Functionality check with success message", function () {
       //Open switch widget
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       // Change name of switch widget
       cy.widgetText(
         "Toggler",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/Form_With_CheckBox_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Form/Form_With_CheckBox_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("1. Checkbox Functionality To Check required toggle for form", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       _.agHelper.CheckUncheck(commonlocators.requiredjs + " " + "input");
       _.deployMode.DeployApp();
       cy.wait(2000);
@@ -31,7 +31,7 @@ describe(
     });
 
     it("2. Checkbox Functionality To swap label alignment of checkbox", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       cy.get(publish.checkboxWidget + " " + ".t--checkbox-widget-label").should(
         "have.css",
         "text-align",
@@ -56,7 +56,7 @@ describe(
     });
 
     it("3. Checkbox Functionality To swap label position of checkbox", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       cy.get(publish.checkboxWidget + " " + ".bp3-align-right").should(
         "not.exist",
       );
@@ -77,7 +77,7 @@ describe(
     });
 
     it("4. Checkbox Functionality To change label color of checkbox", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       cy.moveToStyleTab();
       cy.get(".t--property-control-fontcolor .bp3-input").type("red");
       cy.wait(200);
@@ -91,7 +91,7 @@ describe(
     });
 
     it("5. Checkbox Functionality To change label size of checkbox", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       cy.moveToStyleTab();
       cy.get(widgetsPage.textSizeNew).last().click({ force: true });
       // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -107,7 +107,7 @@ describe(
     });
 
     it("6. Checkbox Functionality To change label style of checkbox", function () {
-      cy.openPropertyPane("checkboxwidget");
+      _.propPane.openPropertyPane("checkboxwidget");
       cy.moveToStyleTab();
       cy.get(".t--property-control-emphasis .t--button-group-BOLD").click();
       _.deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Iframe/Iframe_onSrcDocChange_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Iframe/Iframe_onSrcDocChange_spec.js
@@ -3,6 +3,7 @@ const { ObjectsRegistry } = require("../../../../../support/Objects/Registry");
 import EditorNavigation, {
   EntityType,
 } from "../../../../../support/Pages/EditorNavigation";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 
 const homePage = ObjectsRegistry.HomePage;
 const agHelper = ObjectsRegistry.AggregateHelper;

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Iframe/Iframe_onSrcDocChange_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Iframe/Iframe_onSrcDocChange_spec.js
@@ -34,7 +34,7 @@ describe(
       cy.wait(2000);
       PageList.ShowList();
       PageList.VerifyIsCurrentPage("Page1");
-      cy.openPropertyPane("iframewidget");
+      _.propPane.openPropertyPane("iframewidget");
       cy.testJsontext("srcdoc", "<h1>Hello World!</h1>");
       cy.wait(2000);
       PageList.VerifyIsCurrentPage("Page2");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_base64_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_base64_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("Image Widget Functionality Base64 validation", function () {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       /**
        * Test for Base64 encoded image
        */

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_spec.js
@@ -17,7 +17,7 @@ describe(
     });
 
     it("1. Image Widget Functionality", function () {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       /**
        * @param{Text} Random Text
        * @param{ImageWidget}Mouseover
@@ -42,7 +42,7 @@ describe(
     });
 
     it("2. No Zoom functionality check", function () {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       //Zoom validation
       cy.changeZoomLevel("1x (No Zoom)");
 
@@ -58,20 +58,20 @@ describe(
 
     it("3. Image Widget Functionality To Check/Uncheck Visible Widget", function () {
       deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
       deployMode.DeployApp();
       cy.get(publish.imageWidget).should("not.exist");
       deployMode.NavigateBacktoEditor();
       //Image Widget Functionality To Check Visible Widget", function () {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       deployMode.DeployApp(publish.imageWidget);
       deployMode.NavigateBacktoEditor();
     });
 
     it("4. In case of an image loading error, show off the error message", () => {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       // Invalid image url
       const invalidImageUrl =
         "http://host.docker.internal:4200/photo-not-exists.jpeg";

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_spec.js
@@ -6,7 +6,9 @@ import {
   agHelper,
   dataManager,
   deployMode,
+  propPane
 } from "../../../../../support/Objects/ObjectsCore";
+
 
 describe(
   "Image Widget Functionality",
@@ -17,7 +19,7 @@ describe(
     });
 
     it("1. Image Widget Functionality", function () {
-      _.propPane.openPropertyPane("imagewidget");
+      propPane.openPropertyPane("imagewidget");
       /**
        * @param{Text} Random Text
        * @param{ImageWidget}Mouseover
@@ -42,7 +44,7 @@ describe(
     });
 
     it("2. No Zoom functionality check", function () {
-      _.propPane.openPropertyPane("imagewidget");
+      propPane.openPropertyPane("imagewidget");
       //Zoom validation
       cy.changeZoomLevel("1x (No Zoom)");
 
@@ -58,20 +60,20 @@ describe(
 
     it("3. Image Widget Functionality To Check/Uncheck Visible Widget", function () {
       deployMode.NavigateBacktoEditor();
-      _.propPane.openPropertyPane("imagewidget");
+      propPane.openPropertyPane("imagewidget");
       agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
       deployMode.DeployApp();
       cy.get(publish.imageWidget).should("not.exist");
       deployMode.NavigateBacktoEditor();
       //Image Widget Functionality To Check Visible Widget", function () {
-      _.propPane.openPropertyPane("imagewidget");
+      propPane.openPropertyPane("imagewidget");
       agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       deployMode.DeployApp(publish.imageWidget);
       deployMode.NavigateBacktoEditor();
     });
 
     it("4. In case of an image loading error, show off the error message", () => {
-      _.propPane.openPropertyPane("imagewidget");
+      propPane.openPropertyPane("imagewidget");
       // Invalid image url
       const invalidImageUrl =
         "http://host.docker.internal:4200/photo-not-exists.jpeg";

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_validation_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. Check default image src", function () {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       cy.get(viewWidgetsPage.imageinner)
         .invoke("attr", "src")
         .should(
@@ -28,7 +28,7 @@ describe(
     });
 
     it("3. Remove both images and check empty screen", function () {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
 
       cy.get(".t--property-control-image").then(($el) =>
         cy.updateCodeInput($el, ""),
@@ -51,7 +51,7 @@ describe(
     });
 
     it("4. Add new image and check image src", function () {
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       cy.clearPropertyValue(0);
 
       cy.testCodeMirror(this.dataSet.NewImage);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_MaxChar_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_MaxChar_spec.js
@@ -25,14 +25,14 @@ describe(
     });
 
     it("Text Input maxChar shows error if inputText longer than maxChar", () => {
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       cy.clearComputedValueFirst();
       cy.testJsontext("defaultvalue", "");
       cy.closePropertyPane("inputwidgetv2");
 
       cy.get(widgetsPage.innertext).click({ force: true }).type("1234567");
 
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
 
       cy.testJsontext("maxcharacters", "3");
       cy.closePropertyPane("inputwidgetv2");
@@ -44,7 +44,7 @@ describe(
     });
 
     it("Number Input will not show error for maxChar validation", () => {
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       cy.selectDropdownValue(commonlocators.dataType, "Number");
       cy.get(".bp3-popover-content").should("not.exist");
     });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_Multiline_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_Multiline_spec.js
@@ -5,6 +5,8 @@ import {
   PROPERTY_SELECTOR,
 } from "../../../../../locators/WidgetLocators";
 import homePage from "../../../../../locators/HomePage";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+
 
 describe(
   "Input Widget Multiline feature",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_Multiline_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_Multiline_spec.js
@@ -44,7 +44,7 @@ describe(
     it("2. Multi-line text with different heights i.e. Auto height, Auto height with limit and Fixed", () => {
       const textMsg = "Dynamic panel validation for input widget wrt height";
       cy.dragAndDropToCanvas("inputwidgetv2", { x: 300, y: 300 });
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       cy.selectDropdownValue(widgetsPage.datatype, "Multi-line text");
       // verify height changes to auto height
 
@@ -84,7 +84,7 @@ describe(
             });
         });
       // select height as fixed for multiline datatype
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       cy.moveToContentTab();
       cy.get(widgetsPage.datatype).last().click({ force: true });
       cy.selectDropdownValue(commonlocators.heightDropdown, "Fixed");
@@ -124,7 +124,7 @@ describe(
 
     it("3. Enter key behaviour with single line and multi line selection", () => {
       cy.dragAndDropToCanvas("inputwidgetv2", { x: 300, y: 500 });
-      cy.openPropertyPane(WIDGET.INPUT_V2);
+      _.propPane.openPropertyPane(WIDGET.INPUT_V2);
       cy.get(PROPERTY_SELECTOR.onSubmit).find(".t--js-toggle").click();
       cy.updateCodeInput(
         PROPERTY_SELECTOR.onSubmit,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_OnFocus_OnBlur_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_OnFocus_OnBlur_spec.js
@@ -18,7 +18,7 @@ describe(
   function () {
     it("1. onBlur and onFocus should be triggered from the input widget", () => {
       cy.dragAndDropToCanvas(inputWidgetName, { x: 300, y: 200 });
-      cy.openPropertyPane(inputWidgetName);
+      _.propPane.openPropertyPane(inputWidgetName);
 
       cy.get(widgetsPage.toggleOnFocus).click({ force: true });
       cy.testJsontext("onfocus", "{{showAlert('Focused','success')}}");
@@ -28,13 +28,13 @@ describe(
       cy.get(widgetInput).click({ force: true });
       cy.validateToastMessage("Focused");
       agHelper.PressEscape();
-      cy.openPropertyPane(inputWidgetName);
+      _.propPane.openPropertyPane(inputWidgetName);
       cy.validateToastMessage("Blurred");
     });
 
     it("2. onBlur and onFocus should be triggered from the phone input widget", () => {
       cy.dragAndDropToCanvas(phoneInputWidgetName, { x: 300, y: 400 });
-      cy.openPropertyPane(phoneInputWidgetName);
+      _.propPane.openPropertyPane(phoneInputWidgetName);
 
       cy.get(widgetsPage.toggleOnFocus).click({ force: true });
       cy.testJsontext("onfocus", "{{showAlert('Focused','success')}}");
@@ -44,13 +44,13 @@ describe(
       cy.get(phoneInputWidget).click({ force: true });
       cy.validateToastMessage("Focused");
       agHelper.PressEscape();
-      cy.openPropertyPane(phoneInputWidgetName);
+      _.propPane.openPropertyPane(phoneInputWidgetName);
       cy.validateToastMessage("Blurred");
     });
 
     it("3. onBlur and onFocus should be triggered from the currency input widget", () => {
       cy.dragAndDropToCanvas(currencyInputWidgetName, { x: 300, y: 600 });
-      cy.openPropertyPane(currencyInputWidgetName);
+      _.propPane.openPropertyPane(currencyInputWidgetName);
 
       cy.get(widgetsPage.toggleOnFocus).click({ force: true });
       cy.testJsontext("onfocus", "{{showAlert('Focused','success')}}");
@@ -60,7 +60,7 @@ describe(
       cy.get(currencyInputWidget).click({ force: true });
       cy.validateToastMessage("Focused");
       agHelper.PressEscape();
-      cy.openPropertyPane(currencyInputWidgetName);
+      _.propPane.openPropertyPane(currencyInputWidgetName);
       cy.validateToastMessage("Blurred");
     });
   },

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_OnFocus_OnBlur_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_OnFocus_OnBlur_spec.js
@@ -1,5 +1,6 @@
 const widgetsPage = require("../../../../../locators/Widgets.json");
 import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 
 const inputWidgetName = "inputwidgetv2";
 const widgetInput = widgetsPage.inputWidget + " " + "input";

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input_spec.js
@@ -13,7 +13,7 @@ describe(
 
     // Note: commenting it out because Drag/Drop feature is not stable on cypress.
     // it("Checks if default values are not persisted in cache after delete", function() {
-    //   cy.openPropertyPane("inputwidgetv2");
+    //   _.propPane.openPropertyPane("inputwidgetv2");
     //   cy.get(widgetsPage.defaultInput)
     //     .type(this.dataSet.command)
     //     .type(this.dataSet.defaultdata);
@@ -32,7 +32,7 @@ describe(
     // });
 
     it("1. Input Widget Functionality", function () {
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       /**
        * @param{Text} Random Text
        * @param{InputWidget}Mouseover
@@ -47,7 +47,7 @@ describe(
       cy.get(widgetsPage.inputWidget + " " + "input")
         .invoke("attr", "value")
         .should("contain", this.dataSet.para);
-      //cy.openPropertyPane("inputwidgetv2");
+      //_.propPane.openPropertyPane("inputwidgetv2");
       _.propPane.UpdatePropertyFieldValue(
         "Default value",
         this.dataSet.defaultdata,
@@ -81,7 +81,7 @@ describe(
     });
 
     it("3. isSpellCheck: true", function () {
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.spellCheck + " " + "input");
       _.deployMode.DeployApp();
       cy.get(publish.inputWidget + " " + "input")
@@ -90,7 +90,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //isSpellCheck: false
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.spellCheck + " " + "input", false);
       _.deployMode.DeployApp();
       cy.get(publish.inputWidget + " " + "input")
@@ -100,28 +100,28 @@ describe(
     });
 
     it("4. Input Widget Functionality To Check Disabled Widget", function () {
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.Disablejs + " " + "input");
       _.deployMode.DeployApp();
       cy.get(publish.inputWidget + " " + "input").should("be.disabled");
       _.deployMode.NavigateBacktoEditor();
 
       //Input Widget Functionality To Check Enabled Widget
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.Disablejs + " " + "input", false);
       _.deployMode.DeployApp();
       cy.get(publish.inputWidget + " " + "input").should("be.enabled");
       _.deployMode.NavigateBacktoEditor();
     });
     it("5. Input Functionality To Unchecked Visible Widget", function () {
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
       _.deployMode.DeployApp();
       cy.get(publish.inputWidget + " " + "input").should("not.exist");
       _.deployMode.NavigateBacktoEditor();
 
       //Input Functionality To Check Visible Widget
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();
       cy.get(publish.inputWidget + " " + "input").should("be.visible");
@@ -129,7 +129,7 @@ describe(
     });
 
     it("6. Input Functionality To check number input type with custom regex", function () {
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       cy.selectDropdownValue(widgetsPage.datatype, "Number");
       cy.testJsontext("regex", "^s*(?=.*[1-9])d*(?:.d{1,2})?s*$");
       cy.get(widgetsPage.innertext).click().clear().type("1.255");
@@ -144,14 +144,14 @@ describe(
       //Input label wrapper do not show if lable and tooltip is empty
       cy.get("[data-testid='label-container']").should("not.exist");
 
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       // enter label in property pan
       cy.get(widgetsPage.inputTextControl).type("Label1");
       // test if label shows up with correct text
       cy.get(".t--input-widget-label").contains("Label1");
 
       //Input tooltip renders if tooltip prop is not empty
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       // enter tooltip in property pan
       cy.get(widgetsPage.inputTooltipControl).type("Helpfull text for input");
       // tooltip help icon shows

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_ShowStepArrows_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_ShowStepArrows_spec.js
@@ -1,5 +1,5 @@
 const widgetsPage = require("../../../../../locators/Widgets.json");
-const { agHelper } = require("../../../../../support/Objects/ObjectsCore");
+const { agHelper, propPane } = require("../../../../../support/Objects/ObjectsCore");
 
 const widgetName = "inputwidgetv2";
 
@@ -9,7 +9,7 @@ describe(
   function () {
     it("1. Validate that dataType - NUMBER, For new widgets being dragged, the value for showStepArrows should be set to false", () => {
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 400 });
-      _.propPane.openPropertyPane(widgetName);
+      propPane.openPropertyPane(widgetName);
 
       cy.selectDropdownValue(widgetsPage.inputPropsDataType, "Number");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_ShowStepArrows_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_ShowStepArrows_spec.js
@@ -9,7 +9,7 @@ describe(
   function () {
     it("1. Validate that dataType - NUMBER, For new widgets being dragged, the value for showStepArrows should be set to false", () => {
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 400 });
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
 
       cy.selectDropdownValue(widgetsPage.inputPropsDataType, "Number");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_inside_List_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_inside_List_spec.js
@@ -9,7 +9,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("1. Validate input widget resets OnSubmit", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.getAlert("onSubmit", "Submitted!!");
     cy.get(widgetInput).clear({ force: true });
     cy.wait(300);
@@ -48,7 +48,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("3. Validate DataType - NUMBER can be entered into Input widget", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Number");
 
     cy.get(".t--property-control-required label").last().click({ force: true });
@@ -95,7 +95,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("4. Validate DataType - PASSWORD can be entered into Input widget", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Password");
     [
       {
@@ -130,7 +130,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("5. Validate DataType - EMAIL can be entered into Input widget", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Email");
 
     cy.get(".t--property-control-required label").last().click({ force: true });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
@@ -8,7 +8,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
     cy.dragAndDropToCanvas(widgetName, { x: 300, y: 300 });
     cy.get(`.t--widget-${widgetName}`).should("exist");
     cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(
       ".t--property-control-text",
       `{{Input1.text}}:{{Input1.value}}:{{Input1.isValid}}`,
@@ -16,7 +16,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("2. Validate input widget resets OnSubmit", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.getAlert("onSubmit", "Submitted!!");
     cy.get(widgetInput).clear();
     cy.wait(300);
@@ -64,7 +64,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
       },
     ].forEach(({ expected, input }) => enterAndTest(input, expected));
 
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
 
     //required: on
     cy.get(".t--property-control-required label").last().click({ force: true });
@@ -106,7 +106,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("4. Validate DataType - NUMBER can be entered into Input widget", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Number");
     [
       {
@@ -192,7 +192,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("5. Validate DataType - PASSWORD can be entered into Input widget", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Password");
     [
       {
@@ -263,7 +263,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("6. Validate DataType - EMAIL can be entered into Input widget", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Email");
     [
       {
@@ -334,7 +334,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("7. Validating other properties - Input validity with #valid", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     [
       ["{{1 === 2}}", "false", true],
       ["", "true", false],
@@ -348,7 +348,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("8. onSubmit should be triggered with the whole input value", () => {
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(
       ".t--property-control-datatype input",
       "Single-line text",
@@ -361,7 +361,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
       "{{storeValue('textPayloadOnSubmit',Input1.text)}}",
     );
     // Bind to stored value above
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(
       ".t--property-control-text",
       "{{appsmith.store.textPayloadOnSubmit}}",
@@ -378,12 +378,12 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("9. changing default text should change text", () => {
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(
       ".t--property-control-text",
       `{{Input1.text}}:{{Input1.value}}:{{Input1.isValid}}`,
     );
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.updateCodeInput(".t--property-control-defaultvalue", `test`);
     // wait for evaluations
     cy.wait(300);
@@ -418,10 +418,10 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("10. Check isDirty meta property", function () {
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(".t--property-control-text", `{{Input1.isDirty}}`);
     // Init isDirty
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(
       ".t--property-control-datatype input",
       "Single-line text",
@@ -437,7 +437,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
     // Check if isDirty is set to true
     cy.get(".t--widget-textwidget").should("contain", "true");
     // Change defaultText
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.updateCodeInput(".t--property-control-defaultvalue", "c");
     // Check if isDirty is reset to false
     cy.get(".t--widget-textwidget").should("contain", "false");
@@ -457,8 +457,8 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   function validateAutocompleteAttribute() {
     //validate autocomplete behaviour for email and password
 
-    cy.openPropertyPane("textwidget");
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane(widgetName);
     //check if autofill toggle option is present and is checked by default
     cy.get(".t--property-control-allowautofill input").should("be.checked");
     //check if autocomplete attribute is not present in the text widget when autofill is enabled

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
@@ -1,4 +1,4 @@
-import { agHelper } from "../../../../../support/Objects/ObjectsCore";
+import { agHelper, propPane } from "../../../../../support/Objects/ObjectsCore";
 
 const widgetName = "inputwidgetv2";
 const widgetInput = `.t--widget-${widgetName} input`;
@@ -8,7 +8,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
     cy.dragAndDropToCanvas(widgetName, { x: 300, y: 300 });
     cy.get(`.t--widget-${widgetName}`).should("exist");
     cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-    _.propPane.openPropertyPane("textwidget");
+    propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(
       ".t--property-control-text",
       `{{Input1.text}}:{{Input1.value}}:{{Input1.isValid}}`,
@@ -16,7 +16,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("2. Validate input widget resets OnSubmit", () => {
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.getAlert("onSubmit", "Submitted!!");
     cy.get(widgetInput).clear();
     cy.wait(300);
@@ -64,7 +64,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
       },
     ].forEach(({ expected, input }) => enterAndTest(input, expected));
 
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
 
     //required: on
     cy.get(".t--property-control-required label").last().click({ force: true });
@@ -106,7 +106,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("4. Validate DataType - NUMBER can be entered into Input widget", () => {
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Number");
     [
       {
@@ -192,7 +192,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("5. Validate DataType - PASSWORD can be entered into Input widget", () => {
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Password");
     [
       {
@@ -263,7 +263,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("6. Validate DataType - EMAIL can be entered into Input widget", () => {
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype input", "Email");
     [
       {
@@ -334,7 +334,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("7. Validating other properties - Input validity with #valid", () => {
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     [
       ["{{1 === 2}}", "false", true],
       ["", "true", false],
@@ -348,7 +348,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("8. onSubmit should be triggered with the whole input value", () => {
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(
       ".t--property-control-datatype input",
       "Single-line text",
@@ -361,7 +361,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
       "{{storeValue('textPayloadOnSubmit',Input1.text)}}",
     );
     // Bind to stored value above
-    _.propPane.openPropertyPane("textwidget");
+    propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(
       ".t--property-control-text",
       "{{appsmith.store.textPayloadOnSubmit}}",
@@ -378,12 +378,12 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("9. changing default text should change text", () => {
-    _.propPane.openPropertyPane("textwidget");
+    propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(
       ".t--property-control-text",
       `{{Input1.text}}:{{Input1.value}}:{{Input1.isValid}}`,
     );
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.updateCodeInput(".t--property-control-defaultvalue", `test`);
     // wait for evaluations
     cy.wait(300);
@@ -418,10 +418,10 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   });
 
   it("10. Check isDirty meta property", function () {
-    _.propPane.openPropertyPane("textwidget");
+    propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(".t--property-control-text", `{{Input1.isDirty}}`);
     // Init isDirty
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.selectDropdownValue(
       ".t--property-control-datatype input",
       "Single-line text",
@@ -437,7 +437,7 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
     // Check if isDirty is set to true
     cy.get(".t--widget-textwidget").should("contain", "true");
     // Change defaultText
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane(widgetName);
     cy.updateCodeInput(".t--property-control-defaultvalue", "c");
     // Check if isDirty is reset to false
     cy.get(".t--widget-textwidget").should("contain", "false");
@@ -457,8 +457,8 @@ describe("Input widget V2 - ", { tags: ["@tag.Widget", "@tag.Input"] }, () => {
   function validateAutocompleteAttribute() {
     //validate autocomplete behaviour for email and password
 
-    _.propPane.openPropertyPane("textwidget");
-    _.propPane.openPropertyPane(widgetName);
+    propPane.openPropertyPane("textwidget");
+    propPane.openPropertyPane(widgetName);
     //check if autofill toggle option is present and is checked by default
     cy.get(".t--property-control-allowautofill input").should("be.checked");
     //check if autocomplete attribute is not present in the text widget when autofill is enabled

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_ArrayField_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_ArrayField_spec.js
@@ -48,7 +48,7 @@ describe(
         ],
       };
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(sourceData), true);
 
       deployMode.DeployApp();
@@ -87,7 +87,7 @@ describe(
     it("2. can add more items to the field", () => {
       cy.addDsl(dslWithSchema);
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       cy.get(`${education}-item`)
         .should("have.length", 1)
@@ -168,7 +168,7 @@ describe(
       cy.get(education).should("exist");
       agHelper.AssertElementExist(education);
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("education");
 
       // Visible -> false

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_ArrayField_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_ArrayField_spec.js
@@ -48,7 +48,7 @@ describe(
         ],
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(sourceData), true);
 
       deployMode.DeployApp();
@@ -87,7 +87,7 @@ describe(
     it("2. can add more items to the field", () => {
       cy.addDsl(dslWithSchema);
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       cy.get(`${education}-item`)
         .should("have.length", 1)
@@ -168,7 +168,7 @@ describe(
       cy.get(education).should("exist");
       agHelper.AssertElementExist(education);
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("education");
 
       // Visible -> false

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_AutoGenerateFormEnabled_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_AutoGenerateFormEnabled_spec.js
@@ -131,7 +131,7 @@ describe(
         ],
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext(
         "Source data",
         JSON.stringify(modifiedSourceData),

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_AutoGenerateFormEnabled_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_AutoGenerateFormEnabled_spec.js
@@ -131,7 +131,7 @@ describe(
         ],
       };
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext(
         "Source data",
         JSON.stringify(modifiedSourceData),

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Basic_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Basic_spec.js
@@ -16,7 +16,7 @@ describe(
     before(() => {
       cy.dragAndDropToCanvas("jsonformwidget", { x: 200, y: 200 });
       cy.fixture("TestDataSet1").then(function (dataSet) {
-        cy.openPropertyPane("jsonformwidget");
+        _.propPane.openPropertyPane("jsonformwidget");
         propPane.EnterJSContext(
           "Source data",
           JSON.stringify(dataSet.defaultSource),
@@ -27,7 +27,7 @@ describe(
     });
 
     it("json form widget validate default data", function () {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(jsonform.jsformInput).should(
         "have.value",
         this.dataSet.defaultSource.name,
@@ -72,7 +72,7 @@ describe(
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
       const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
       //copy and paste
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get("body").type(`{${modifierKey}}c`);
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(500);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Basic_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Basic_spec.js
@@ -16,7 +16,7 @@ describe(
     before(() => {
       cy.dragAndDropToCanvas("jsonformwidget", { x: 200, y: 200 });
       cy.fixture("TestDataSet1").then(function (dataSet) {
-        _.propPane.openPropertyPane("jsonformwidget");
+        propPane.openPropertyPane("jsonformwidget");
         propPane.EnterJSContext(
           "Source data",
           JSON.stringify(dataSet.defaultSource),
@@ -27,7 +27,7 @@ describe(
     });
 
     it("json form widget validate default data", function () {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.get(jsonform.jsformInput).should(
         "have.value",
         this.dataSet.defaultSource.name,
@@ -72,7 +72,7 @@ describe(
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
       const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
       //copy and paste
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.get("body").type(`{${modifierKey}}c`);
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(500);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_CustomField_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_CustomField_spec.js
@@ -25,7 +25,7 @@ describe(
 
       cy.addDsl(formDsl);
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
 
       // Add new custom field
       cy.get(".t--add-column-btn")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_CustomField_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_CustomField_spec.js
@@ -25,7 +25,7 @@ describe(
 
       cy.addDsl(formDsl);
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
 
       // Add new custom field
       cy.get(".t--add-column-btn")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldChange_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldChange_spec.js
@@ -24,7 +24,7 @@ describe(
     });
 
     it("1. modifies field type text to number", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       cy.get(`${fieldPrefix}-name`).find("button").should("not.exist");
       cy.openFieldConfiguration("name");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldChange_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldChange_spec.js
@@ -48,7 +48,7 @@ describe(
       deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
       cy.get(`${fieldPrefix}-name`).find("button").should("have.length", 2);
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("name");
       cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Text Input/);
     });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldChange_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldChange_spec.js
@@ -24,7 +24,7 @@ describe(
     });
 
     it("1. modifies field type text to number", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       cy.get(`${fieldPrefix}-name`).find("button").should("not.exist");
       cy.openFieldConfiguration("name");
@@ -48,7 +48,7 @@ describe(
       deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
       cy.get(`${fieldPrefix}-name`).find("button").should("have.length", 2);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("name");
       cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Text Input/);
     });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldEvents_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldEvents_1_spec.js
@@ -69,7 +69,7 @@ describe(
     });
 
     it("4. Shows updated formData values in onOptionChange binding", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("colors");
 
       // Enable JS mode for onOptionChange

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldEvents_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldEvents_1_spec.js
@@ -69,7 +69,7 @@ describe(
     });
 
     it("4. Shows updated formData values in onOptionChange binding", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("colors");
 
       // Enable JS mode for onOptionChange

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_1_spec.js
@@ -159,7 +159,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
       cy.openFieldConfiguration("check");
       cy.selectDropdownValue(commonlocators.jsonFormFieldType, "Checkbox");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_1_spec.js
@@ -159,7 +159,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
       cy.openFieldConfiguration("check");
       cy.selectDropdownValue(commonlocators.jsonFormFieldType, "Checkbox");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_2_spec.js
@@ -32,7 +32,7 @@ describe(
         name: "John",
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
     });
 
@@ -42,7 +42,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
       cy.openFieldConfiguration("switch");
       // assert default property
@@ -98,7 +98,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("state");
@@ -131,7 +131,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
       cy.openFieldConfiguration("hobbies");
       // assert valid default value
@@ -142,7 +142,7 @@ describe(
     });
 
     it("8. adds placeholder text", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("hobbies");
 
       cy.testJsontext("placeholder", "Select placeholder");
@@ -181,7 +181,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(sourceData), true);
 
       cy.openFieldConfiguration("radio");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FieldProperties_2_spec.js
@@ -32,7 +32,7 @@ describe(
         name: "John",
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
     });
 
@@ -42,7 +42,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
       cy.openFieldConfiguration("switch");
       // assert default property
@@ -98,7 +98,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("state");
@@ -131,7 +131,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
       cy.openFieldConfiguration("hobbies");
       // assert valid default value
@@ -142,7 +142,7 @@ describe(
     });
 
     it("8. adds placeholder text", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("hobbies");
 
       cy.testJsontext("placeholder", "Select placeholder");
@@ -181,7 +181,7 @@ describe(
       };
       agHelper.AddDsl("jsonFormDslWithoutSchema");
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(sourceData), true);
 
       cy.openFieldConfiguration("radio");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FilterText_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FilterText_spec.js
@@ -34,7 +34,7 @@ describe(
           color: "GREEN",
         };
         cy.addDsl(dslWithoutSchema);
-        _.propPane.openPropertyPane("jsonformwidget");
+        propPane.openPropertyPane("jsonformwidget");
         propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
         cy.openFieldConfiguration("color");
         cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Select$/);
@@ -45,7 +45,7 @@ describe(
     it("1. shows alert on filter text change", () => {
       const filterText = "Test string";
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("color");
 
       // Enable filterable
@@ -75,12 +75,12 @@ describe(
         colors: ["GREEN", "BLUE"],
       };
       cy.addDsl(dslWithoutSchema);
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       const filterText = "Test string";
 
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("colors");
 
       propPane.TogglePropertyState("Allow searching", "On");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FilterText_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FilterText_spec.js
@@ -34,7 +34,7 @@ describe(
           color: "GREEN",
         };
         cy.addDsl(dslWithoutSchema);
-        cy.openPropertyPane("jsonformwidget");
+        _.propPane.openPropertyPane("jsonformwidget");
         propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
         cy.openFieldConfiguration("color");
         cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Select$/);
@@ -45,7 +45,7 @@ describe(
     it("1. shows alert on filter text change", () => {
       const filterText = "Test string";
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("color");
 
       // Enable filterable
@@ -75,12 +75,12 @@ describe(
         colors: ["GREEN", "BLUE"],
       };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       const filterText = "Test string";
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("colors");
 
       propPane.TogglePropertyState("Allow searching", "On");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Footer_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Footer_spec.js
@@ -18,7 +18,7 @@ describe(
       const sourceData = {
         name: "John",
       };
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       _.propPane.EnterJSContext(
         "Source data",
         JSON.stringify(sourceData),
@@ -58,7 +58,7 @@ describe(
       _.agHelper.AddDsl("jsonFormDslWithSchema");
       _.agHelper.AddDsl("jsonFormDslWithSchema"); //Should not be needed, to check
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(_.locators._jsToggle("sourcedata")).click({ force: true });
       // check if fixed footer enabled
       cy.get(".t--property-control-fixedfooter")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormBindings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormBindings_spec.js
@@ -1,5 +1,6 @@
 const dslWithSchema = require("../../../../../fixtures/jsonFormDslWithSchema.json");
 const widgetsPage = require("../../../../../locators/Widgets.json");
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 
 const fieldPrefix = ".t--jsonformfield";
 const propertyControlPrefix = ".t--property-control";

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormBindings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormBindings_spec.js
@@ -20,7 +20,7 @@ describe(
     beforeEach(() => {
       agHelper.RestoreLocalStorageCache();
       cy.addDsl(dslWithSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
     });
 
@@ -44,7 +44,7 @@ describe(
         name: "Test",
       };
       // Bind formData to Text1 widget text property
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
       cy.closePropertyPane();
 
@@ -212,7 +212,7 @@ describe(
         },
       };
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.get(".t--property-control-text .CodeMirror textarea").first().clear({
         force: true,
       });
@@ -226,7 +226,7 @@ describe(
         cy.wrap(formData).should("deep.equal", expectedInitialFieldState);
       });
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
 
       // name.required -> true
       cy.openFieldConfiguration("name");
@@ -343,13 +343,13 @@ describe(
         },
       };
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.get(".t--property-control-text .CodeMirror textarea").first().clear({
         force: true,
       });
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.fieldState)}}");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
 
       // Change accessor name -> firstName
       cy.openFieldConfiguration("name");
@@ -384,7 +384,7 @@ describe(
         firstName: "John",
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
 
       // Change accessor name -> firstName
       cy.openFieldConfiguration("name");
@@ -401,7 +401,7 @@ describe(
 
       cy.wait(5000);
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
 
       cy.wait(1000);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormProperties_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormProperties_spec.js
@@ -6,6 +6,7 @@ const commonlocators = require("../../../../../locators/commonlocators.json");
 const dslWithSchema = require("../../../../../fixtures/jsonFormDslWithSchema.json");
 const dslWithoutSchema = require("../../../../../fixtures/jsonFormDslWithoutSchema.json");
 const widgetsPage = require("../../../../../locators/Widgets.json");
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 
 const backBtn = "[data-testid='t--property-pane-back-btn']";
 const fieldPrefix = ".t--jsonformfield";

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormProperties_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_FormProperties_spec.js
@@ -34,7 +34,7 @@ describe(
 
     before("Add dsl and check fields under field configuration", () => {
       cy.addDsl(dslWithSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       const fieldNames = [
         "name",
         "age",
@@ -51,7 +51,7 @@ describe(
     });
 
     it("1. Field Configuration - adds new custom field", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
 
       // Add new field
       cy.get(commonlocators.jsonFormAddNewCustomFieldBtn).click({
@@ -95,7 +95,7 @@ describe(
 
     it("3. Should set isValid to false when form is invalid", () => {
       EditorNavigation.SelectEntityByName("JSONForm1", EntityType.Widget);
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSONForm1.isValid}}");
       cy.get(`${widgetsPage.textWidget} .bp3-ui-text`).contains("true");
       cy.get(`${fieldPrefix}-name input`).clear().wait(300);
@@ -105,7 +105,7 @@ describe(
     });
 
     it("4. show show icon select when a collapsed section is opened", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.moveToStyleTab();
 
       // Click Icon property
@@ -124,10 +124,10 @@ describe(
         name: "",
       };
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSONForm1.isValid}}");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       // make name field required
@@ -148,10 +148,10 @@ describe(
         name: "",
       };
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSONForm1.isValid}}");
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       // make name field required
@@ -185,7 +185,7 @@ describe(
         age: 10,
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       agHelper.CheckUncheck(
@@ -195,7 +195,7 @@ describe(
       cy.openFieldConfiguration("age");
       agHelper.CheckUncheck(`${propertyControlPrefix}-visible input`, false);
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
 
       cy.get(".t--widget-textwidget .bp3-ui-text").contains(
@@ -213,7 +213,7 @@ describe(
         age: 10,
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       agHelper.CheckUncheck(
@@ -224,7 +224,7 @@ describe(
       cy.openFieldConfiguration("age");
       agHelper.CheckUncheck(`${propertyControlPrefix}-visible input`, false);
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
 
       cy.get(".t--widget-textwidget .bp3-ui-text").contains(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_1_spec.js
@@ -71,7 +71,7 @@ function changeFieldType(fieldName, fieldType) {
 }
 
 function addCustomField(fieldType) {
-  _.propPane.openPropertyPane("jsonformwidget");
+  propPane.openPropertyPane("jsonformwidget");
   cy.backFromPropertyPanel();
 
   // Add new field
@@ -83,7 +83,7 @@ function addCustomField(fieldType) {
 }
 
 function removeCustomField() {
-  _.propPane.openPropertyPane("jsonformwidget");
+  propPane.openPropertyPane("jsonformwidget");
   cy.deleteJSONFormField("customField1");
 }
 
@@ -93,7 +93,7 @@ describe(
   () => {
     before(() => {
       agHelper.AddDsl("jsonFormDslWithSchema");
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       EditorNavigation.SelectEntityByName("Text1", EntityType.Widget);
       propPane.UpdatePropertyFieldValue(
@@ -114,7 +114,7 @@ describe(
     });
 
     it("2. can hide Array Field's inner fields", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("education");
       cy.openFieldConfiguration("__array_item__", false);
       cy.openFieldConfiguration("college", false);
@@ -143,28 +143,28 @@ describe(
     });
 
     it("5. can hide Date Field", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("dob");
 
       hideAndVerifyProperties("dob", "10/12/1992");
     });
 
     it("6. can hide Input Field", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("name");
 
       hideAndVerifyProperties("name", "John");
     });
 
     it("7. can hide Multiselect Field", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("hobbies");
 
       hideAndVerifyProperties("hobbies", ["travelling", "swimming"]);
     });
 
     it("8. can hide Object Field", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("address");
 
       hideAndVerifyProperties("address", {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_1_spec.js
@@ -71,7 +71,7 @@ function changeFieldType(fieldName, fieldType) {
 }
 
 function addCustomField(fieldType) {
-  cy.openPropertyPane("jsonformwidget");
+  _.propPane.openPropertyPane("jsonformwidget");
   cy.backFromPropertyPanel();
 
   // Add new field
@@ -83,7 +83,7 @@ function addCustomField(fieldType) {
 }
 
 function removeCustomField() {
-  cy.openPropertyPane("jsonformwidget");
+  _.propPane.openPropertyPane("jsonformwidget");
   cy.deleteJSONFormField("customField1");
 }
 
@@ -93,7 +93,7 @@ describe(
   () => {
     before(() => {
       agHelper.AddDsl("jsonFormDslWithSchema");
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       EditorNavigation.SelectEntityByName("Text1", EntityType.Widget);
       propPane.UpdatePropertyFieldValue(
@@ -114,7 +114,7 @@ describe(
     });
 
     it("2. can hide Array Field's inner fields", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("education");
       cy.openFieldConfiguration("__array_item__", false);
       cy.openFieldConfiguration("college", false);
@@ -143,28 +143,28 @@ describe(
     });
 
     it("5. can hide Date Field", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("dob");
 
       hideAndVerifyProperties("dob", "10/12/1992");
     });
 
     it("6. can hide Input Field", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("name");
 
       hideAndVerifyProperties("name", "John");
     });
 
     it("7. can hide Multiselect Field", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("hobbies");
 
       hideAndVerifyProperties("hobbies", ["travelling", "swimming"]);
     });
 
     it("8. can hide Object Field", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("address");
 
       hideAndVerifyProperties("address", {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_2_spec.js
@@ -71,7 +71,7 @@ function changeFieldType(fieldName, fieldType) {
 }
 
 function addCustomField(fieldType) {
-  cy.openPropertyPane("jsonformwidget");
+  _.propPane.openPropertyPane("jsonformwidget");
   cy.get(".t--property-control-sourcedata")
     .find(".t--js-toggle")
     .click({ force: true });
@@ -86,7 +86,7 @@ function addCustomField(fieldType) {
 }
 
 function removeCustomField() {
-  cy.openPropertyPane("jsonformwidget");
+  _.propPane.openPropertyPane("jsonformwidget");
   cy.deleteJSONFormField("customField1");
 }
 
@@ -96,7 +96,7 @@ describe(
   () => {
     before(() => {
       agHelper.AddDsl("jsonFormDslWithSchema");
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       EditorNavigation.SelectEntityByName("Text1", EntityType.Widget);
       propPane.UpdatePropertyFieldValue(
@@ -151,7 +151,7 @@ describe(
     });
 
     it("5. hides fields on first load", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
 
       // hide education field
       cy.openFieldConfiguration("education");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_HiddenFields_2_spec.js
@@ -71,7 +71,7 @@ function changeFieldType(fieldName, fieldType) {
 }
 
 function addCustomField(fieldType) {
-  _.propPane.openPropertyPane("jsonformwidget");
+  propPane.openPropertyPane("jsonformwidget");
   cy.get(".t--property-control-sourcedata")
     .find(".t--js-toggle")
     .click({ force: true });
@@ -86,7 +86,7 @@ function addCustomField(fieldType) {
 }
 
 function removeCustomField() {
-  _.propPane.openPropertyPane("jsonformwidget");
+  propPane.openPropertyPane("jsonformwidget");
   cy.deleteJSONFormField("customField1");
 }
 
@@ -96,7 +96,7 @@ describe(
   () => {
     before(() => {
       agHelper.AddDsl("jsonFormDslWithSchema");
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       cy.get(locators._jsToggle("sourcedata")).click({ force: true });
       EditorNavigation.SelectEntityByName("Text1", EntityType.Widget);
       propPane.UpdatePropertyFieldValue(
@@ -151,7 +151,7 @@ describe(
     });
 
     it("5. hides fields on first load", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
 
       // hide education field
       cy.openFieldConfiguration("education");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_MultipleSourceData_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_MultipleSourceData_spec.js
@@ -18,7 +18,7 @@ describe(
     it("1. Validate calendar on clicking date field", () => {
       const schema = { Key: "20/03/1992" };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       _.propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.xpath(jsonform.datepickerContainer).click({
@@ -30,7 +30,7 @@ describe(
     it("2. Validate calendar on clicking date field", () => {
       const schema = { Key: true };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       _.propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.get(jsonform.switchStatus).should("be.visible");
@@ -40,7 +40,7 @@ describe(
     it("3. Validate email input field in form", () => {
       const schema = { Key: "Value@mail.com" };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       _.propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.xpath(jsonform.emailField).should("be.visible");
@@ -50,7 +50,7 @@ describe(
     it("4. Validate email input field in form", () => {
       const schema = { Key: "value" };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       _.propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.get(jsonform.keyInput).should("be.visible");
@@ -64,7 +64,7 @@ describe(
         employee_id: 1001,
       };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       _.propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.get(jsonform.settings)
@@ -91,7 +91,7 @@ describe(
 
     it("7. Verify property name change with json/text widget binding - Modify property name and check how the binding value changes", () => {
       cy.addDsl(jsonText);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.get(_.locators._jsToggle("sourcedata")).click({ force: true });
       cy.get(jsonform.settings)
         .first()

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_NestedField_Select_Multiselect.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_NestedField_Select_Multiselect.js
@@ -35,7 +35,7 @@ describe(
         ],
       };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("object");
@@ -43,7 +43,7 @@ describe(
       cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Select$/);
 
       cy.closePropertyPane();
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("array");
       cy.openFieldConfiguration("__array_item__", false);
       cy.openFieldConfiguration("select", false);
@@ -96,7 +96,7 @@ describe(
         ],
       };
       cy.addDsl(dslWithoutSchema);
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("object");
@@ -104,7 +104,7 @@ describe(
       cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Multiselect$/);
 
       cy.closePropertyPane();
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       cy.openFieldConfiguration("array");
       cy.openFieldConfiguration("__array_item__", false);
       cy.openFieldConfiguration("multiselect", false);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_NestedField_Select_Multiselect.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_NestedField_Select_Multiselect.js
@@ -7,6 +7,8 @@ const commonlocators = require("../../../../../locators/commonlocators.json");
 const dslWithoutSchema = require("../../../../../fixtures/jsonFormDslWithoutSchema.json");
 const fieldPrefix = ".t--jsonformfield";
 import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+
 let agHelper = ObjectsRegistry.AggregateHelper;
 let locators = ObjectsRegistry.CommonLocators;
 let propPane = ObjectsRegistry.PropertyPane;

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_RadioGroupField_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_RadioGroupField_spec.js
@@ -45,13 +45,13 @@ describe(
       agHelper.RestoreLocalStorageCache();
       cy.addDsl(dslWithoutSchema);
       // Bind formData to Text1 widget text property
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
       cy.closePropertyPane();
     });
 
     it("1. accepts numeric options value", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       const schema = {
         binary: 1,
       };
@@ -69,7 +69,7 @@ describe(
       ];
 
       // Apply schema and change the field type to radio group
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("binary");
@@ -100,7 +100,7 @@ describe(
     });
 
     it("2. accepts string options value", () => {
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       const schema = {
         accept: "N",
       };
@@ -119,7 +119,7 @@ describe(
       ];
 
       // Apply schema and change the field type to radio group
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("accept");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_RadioGroupField_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_RadioGroupField_spec.js
@@ -45,13 +45,13 @@ describe(
       agHelper.RestoreLocalStorageCache();
       cy.addDsl(dslWithoutSchema);
       // Bind formData to Text1 widget text property
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
       cy.closePropertyPane();
     });
 
     it("1. accepts numeric options value", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       const schema = {
         binary: 1,
       };
@@ -69,7 +69,7 @@ describe(
       ];
 
       // Apply schema and change the field type to radio group
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("binary");
@@ -100,7 +100,7 @@ describe(
     });
 
     it("2. accepts string options value", () => {
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       const schema = {
         accept: "N",
       };
@@ -119,7 +119,7 @@ describe(
       ];
 
       // Apply schema and change the field type to radio group
-      _.propPane.openPropertyPane("jsonformwidget");
+      propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(schema), true);
 
       cy.openFieldConfiguration("accept");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Reset_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Reset_spec.js
@@ -6,7 +6,7 @@ const fieldPrefix = ".t--jsonformfield";
 describe("JSON Form reset", { tags: ["@tag.Widget", "@tag.JSONForm"] }, () => {
   before(() => {
     cy.addDsl(dslWithSchema);
-    cy.openPropertyPane("jsonformwidget");
+    _.propPane.openPropertyPane("jsonformwidget");
     cy.get(locators._jsToggle("sourcedata")).click({ force: true });
   });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Reset_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_Reset_spec.js
@@ -2,6 +2,7 @@ const dslWithSchema = require("../../../../../fixtures/jsonFormDslWithSchema.jso
 import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
 const locators = ObjectsRegistry.CommonLocators;
 const fieldPrefix = ".t--jsonformfield";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 
 describe("JSON Form reset", { tags: ["@tag.Widget", "@tag.JSONForm"] }, () => {
   before(() => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_UnicodeKeys_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_UnicodeKeys_spec.js
@@ -2,6 +2,7 @@ const dslWithoutSchema = require("../../../../../fixtures/jsonFormDslWithoutSche
 const jsonFormUnicodeDSLWithoutSourceData = require("../../../../../fixtures/jsonFormUnicodeDSLWithoutSourceData.json");
 const widgetsPage = require("../../../../../locators/Widgets.json");
 import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 const agHelper = ObjectsRegistry.AggregateHelper;
 const locators = ObjectsRegistry.CommonLocators;
 const propPane = ObjectsRegistry.PropertyPane;

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_UnicodeKeys_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/JSONForm/JSONForm_UnicodeKeys_spec.js
@@ -35,7 +35,7 @@ describe(
         ],
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(sourceData), true);
 
       cy.closePropertyPane();
@@ -97,7 +97,7 @@ describe(
         ],
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext(
         "Source data",
         JSON.stringify(modifiedSourceData),
@@ -176,7 +176,7 @@ describe(
         ],
       };
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
       propPane.EnterJSContext("Source data", JSON.stringify(sourceData), true);
 
       cy.closePropertyPane();
@@ -208,7 +208,7 @@ describe(
       };
 
       // Bind formData to Text1 widget text property
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
       cy.closePropertyPane();
 
@@ -218,7 +218,7 @@ describe(
         cy.wrap(formData).should("deep.equal", expectedInitialFormData);
       });
 
-      cy.openPropertyPane("jsonformwidget");
+      _.propPane.openPropertyPane("jsonformwidget");
 
       // नाम field
       cy.openFieldConfiguration("xn__l2bm1c");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/List/List1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/List/List1_spec.js
@@ -8,7 +8,7 @@ describe(
     //const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
     it("1. Validate delete widget action from side bar", function () {
       _.agHelper.AddDsl("listRegressionDsl");
-      cy.openPropertyPane("listwidget");
+      _.propPane.openPropertyPane("listwidget");
       cy.verifyUpdatedWidgetName("Test");
       cy.verifyUpdatedWidgetName("#$%1234", "___1234");
       cy.verifyUpdatedWidgetName("56789");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/List/ListWidgetLintErrorValidation.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/List/ListWidgetLintErrorValidation.js
@@ -9,7 +9,7 @@ describe(
       _.agHelper.AddDsl("listWidgetLintDsl");
     });
     it("Linting Error validation on mouseover and errorlog tab", function () {
-      cy.openPropertyPane("listwidget");
+      _.propPane.openPropertyPane("listwidget");
       /**
        * @param{Text} Random Text
        * @param{CheckboxWidget}Mouseover

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_FilePicker_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_FilePicker_spec.js
@@ -25,7 +25,7 @@ describe(
         x: 150,
         y: 50,
       });
-      _.propPane.openPropertyPane("filepickerwidgetv2");
+      propPane.openPropertyPane("filepickerwidgetv2");
       cy.get(".t--property-control-required .t--js-toggle").click({
         force: true,
       });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_FilePicker_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_FilePicker_spec.js
@@ -25,7 +25,7 @@ describe(
         x: 150,
         y: 50,
       });
-      cy.openPropertyPane("filepickerwidgetv2");
+      _.propPane.openPropertyPane("filepickerwidgetv2");
       cy.get(".t--property-control-required .t--js-toggle").click({
         force: true,
       });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_Inputs_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_Inputs_spec.js
@@ -167,7 +167,7 @@ describe("Input Widgets", { tags: ["@tag.Widget", "@tag.List"] }, function () {
     const formattedText = "123,456,789";
 
     cy.addDsl(dslWithCurrencyWidget);
-    _.propPane.openPropertyPane("currencyinputwidget");
+    propPane.openPropertyPane("currencyinputwidget");
     cy.updateCodeInput(".t--property-control-defaultvalue", value);
 
     // Observe the value of 2nd item currency widget - formatted text

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_Inputs_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/List_Inputs_spec.js
@@ -167,7 +167,7 @@ describe("Input Widgets", { tags: ["@tag.Widget", "@tag.List"] }, function () {
     const formattedText = "123,456,789";
 
     cy.addDsl(dslWithCurrencyWidget);
-    cy.openPropertyPane("currencyinputwidget");
+    _.propPane.openPropertyPane("currencyinputwidget");
     cy.updateCodeInput(".t--property-control-defaultvalue", value);
 
     // Observe the value of 2nd item currency widget - formatted text

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/Listv2_Tabs_Widget_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/Listv2_Tabs_Widget_spec.js
@@ -7,7 +7,7 @@ describe("List v2- Tabs Widget", { tags: ["@tag.Widget", "@tag.List"] }, () => {
   });
 
   it("1. change in the properties of the tabs widget should retain the default selected tab", () => {
-    _.propPane.openPropertyPaneByWidgetName("Tabs1", "tabswidget");
+    cy.openPropertyPaneByWidgetName("Tabs1", "tabswidget");
 
     // Check if Tab1 selected
     cy.get(".t--page-switch-tab.is-active").contains("Tab 1");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/Listv2_Tabs_Widget_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Childwigets/Listv2_Tabs_Widget_spec.js
@@ -7,7 +7,7 @@ describe("List v2- Tabs Widget", { tags: ["@tag.Widget", "@tag.List"] }, () => {
   });
 
   it("1. change in the properties of the tabs widget should retain the default selected tab", () => {
-    cy.openPropertyPaneByWidgetName("Tabs1", "tabswidget");
+    _.propPane.openPropertyPaneByWidgetName("Tabs1", "tabswidget");
 
     // Check if Tab1 selected
     cy.get(".t--page-switch-tab.is-active").contains("Tab 1");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_PageNo_PageSize_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_PageNo_PageSize_spec.js
@@ -103,10 +103,10 @@ describe(
     });
 
     it("1. List widget V2 with client side pagination", () => {
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
       cy.testJsontext("items", JSON.stringify(listData));
       cy.wait("@updateLayout");
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", `PageSize {{List1.pageSize}}`);
       cy.wait("@updateLayout");
 
@@ -114,7 +114,7 @@ describe(
         .first()
         .should("have.text", "PageSize 4");
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", `Page Number {{List1.pageNo}}`);
       cy.wait("@updateLayout");
       cy.get(commonlocators.bodyTextStyle)
@@ -128,7 +128,7 @@ describe(
         .first()
         .should("have.text", "Page Number 2");
 
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
       cy.get(commonlocators.deleteWidget).click({ force: true });
     });
 
@@ -137,9 +137,9 @@ describe(
         x: 300,
         y: 300,
       });
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
 
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       _.propPane.UpdatePropertyFieldValue(
         "Text",
         "PageSize {{List1.pageSize}}",
@@ -150,7 +150,7 @@ describe(
         .should("have.text", "PageSize 3");
 
       // toggle serversidepagination -> true
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.serverSidePaginationCheckbox);
 
       cy.get(commonlocators.bodyTextStyle)
@@ -185,7 +185,7 @@ describe(
       cy.get(".t--list-widget-next-page").find("button").click({ force: true });
 
       // Change to client side pagination
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
       _.propPane.UpdatePropertyFieldValue("Items", "{{Query1.data}}");
       _.propPane.TogglePropertyState("Server side pagination", "Off");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_nested_List_widget_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_nested_List_widget_spec.js
@@ -38,7 +38,7 @@ describe(
 
     it("1. Pasting - should show toast when nesting is greater than 3", function () {
       agHelper.AddDsl("Listv2/copy_paste_listv2_dsl");
-      cy.openPropertyPaneByWidgetName("List1", "listwidgetv2");
+      _.propPane.openPropertyPaneByWidgetName("List1", "listwidgetv2");
       // Copy List1
       cy.get(widgetsPage.copyWidget).click({ force: true });
       cy.wait(500);
@@ -50,7 +50,7 @@ describe(
       cy.wait(500);
 
       //Copy List 2 and Paste inside list 2
-      cy.openPropertyPaneByWidgetName("List2", "listwidgetv2");
+      _.propPane.openPropertyPaneByWidgetName("List2", "listwidgetv2");
       cy.get(widgetsPage.copyWidget).click({ force: true });
       cy.wait(500);
       // Paste inside list 2
@@ -63,7 +63,7 @@ describe(
       //Now Both List1 and List2 are n-2 levels
 
       //Copy List2 and Past in List 1
-      cy.openPropertyPaneByWidgetName("List2", "listwidgetv2");
+      _.propPane.openPropertyPaneByWidgetName("List2", "listwidgetv2");
       cy.get(widgetsPage.copyWidget).click({ force: true });
       cy.wait(500);
       cy.get(`${widgetSelector("List1Copy")} [type="CONTAINER_WIDGET"]`)
@@ -143,7 +143,7 @@ describe(
           .should("have.length", 3),
       );
 
-      cy.openPropertyPaneByWidgetName("Text4", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text4", "textwidget");
       propPane.RemoveText("Text");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
         "{{level_1.currentView.List3.currentItemsView",
@@ -156,7 +156,7 @@ describe(
         .first()
         .should("be.empty");
 
-      cy.openPropertyPaneByWidgetName("Text4", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text4", "textwidget");
 
       propPane.RemoveText("Text");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -171,7 +171,7 @@ describe(
         .first()
         .should("be.empty");
 
-      cy.openPropertyPaneByWidgetName("Text5", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text5", "textwidget");
       propPane.RemoveText("Text");
 
       cy.get(".t--property-control-text .CodeMirror textarea").type(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_nested_List_widget_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_nested_List_widget_spec.js
@@ -38,7 +38,7 @@ describe(
 
     it("1. Pasting - should show toast when nesting is greater than 3", function () {
       agHelper.AddDsl("Listv2/copy_paste_listv2_dsl");
-      _.propPane.openPropertyPaneByWidgetName("List1", "listwidgetv2");
+      cy.openPropertyPaneByWidgetName("List1", "listwidgetv2");
       // Copy List1
       cy.get(widgetsPage.copyWidget).click({ force: true });
       cy.wait(500);
@@ -50,7 +50,7 @@ describe(
       cy.wait(500);
 
       //Copy List 2 and Paste inside list 2
-      _.propPane.openPropertyPaneByWidgetName("List2", "listwidgetv2");
+      cy.openPropertyPaneByWidgetName("List2", "listwidgetv2");
       cy.get(widgetsPage.copyWidget).click({ force: true });
       cy.wait(500);
       // Paste inside list 2
@@ -63,7 +63,7 @@ describe(
       //Now Both List1 and List2 are n-2 levels
 
       //Copy List2 and Past in List 1
-      _.propPane.openPropertyPaneByWidgetName("List2", "listwidgetv2");
+      cy.openPropertyPaneByWidgetName("List2", "listwidgetv2");
       cy.get(widgetsPage.copyWidget).click({ force: true });
       cy.wait(500);
       cy.get(`${widgetSelector("List1Copy")} [type="CONTAINER_WIDGET"]`)
@@ -143,7 +143,7 @@ describe(
           .should("have.length", 3),
       );
 
-      _.propPane.openPropertyPaneByWidgetName("Text4", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text4", "textwidget");
       propPane.RemoveText("Text");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
         "{{level_1.currentView.List3.currentItemsView",
@@ -156,7 +156,7 @@ describe(
         .first()
         .should("be.empty");
 
-      _.propPane.openPropertyPaneByWidgetName("Text4", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text4", "textwidget");
 
       propPane.RemoveText("Text");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -171,7 +171,7 @@ describe(
         .first()
         .should("be.empty");
 
-      _.propPane.openPropertyPaneByWidgetName("Text5", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text5", "textwidget");
       propPane.RemoveText("Text");
 
       cy.get(".t--property-control-text .CodeMirror textarea").type(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicClientSideData_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicClientSideData_spec.js
@@ -138,7 +138,7 @@ describe(
           .should("have.length", 2),
       );
 
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.serverSidePaginationCheckbox);
 
       // Page number resets

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicServerSideData_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicServerSideData_spec.js
@@ -61,14 +61,14 @@ describe(
 
     it("3. re-runs query of page 1 when reset", () => {
       // Modify onPageChange
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
       cy.get(toggleJSButton("onpagechange")).click({ force: true });
       cy.testJsontext(
         "onpagechange",
         "{{Query1.run(() => {showAlert(`Query Ran ${new Date().getTime()}`)}, () => {})}}",
       );
 
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
 
       cy.get(toggleJSButton("onclick")).click({ force: true });
 
@@ -153,7 +153,7 @@ describe(
     });
 
     it("5. Total Record Count", () => {
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
 
       cy.updateCodeInput(".t--property-control-totalrecords", `{{10}}`);
 
@@ -213,7 +213,7 @@ describe(
 
       cy.wait(1000);
 
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
 
       cy.testJsontext("items", "{{Query2.data}}");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Copy_Paste_Delete_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Copy_Paste_Delete_spec.js
@@ -11,11 +11,11 @@ describe(
         x: 300,
         y: 300,
       });
-      cy.openPropertyPane("imagewidget");
+      _.propPane.openPropertyPane("imagewidget");
       cy.get(commonlocators.PropertyPaneSearchInput).type("border");
       cy.get(commonlocators.BorderRadius0px).click({ force: true });
 
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
 
       cy.get("body").type(`{${modifierKey}}c`);
       cy.wait(500);
@@ -40,7 +40,7 @@ describe(
       // Represents the toast message is closed
       cy.get(commonlocators.toastmsg).should("not.exist");
 
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
       cy.get("[data-testid='t--delete-widget']").click({ force: true });
       cy.get(".Toastify__toast-body").eq(0).contains("List1 is removed");
       cy.wait("@updateLayout").should(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Copy_Paste_Delete_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Copy_Paste_Delete_spec.js
@@ -1,5 +1,5 @@
 const commonlocators = require("../../../../../locators/commonlocators.json");
-
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
 
 describe(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
@@ -32,7 +32,7 @@ describe(
       }]}}`,
       );
 
-      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       [
         ["{{currentItem.name}}", "Blue"],
@@ -57,7 +57,7 @@ describe(
     });
 
     it("2. List widget V2 with error input", () => {
-      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       [
         ["{{currentItem}}", "This value does not evaluate to type string"],

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
@@ -32,7 +32,7 @@ describe(
       }]}}`,
       );
 
-      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       [
         ["{{currentItem.name}}", "Blue"],
@@ -57,7 +57,7 @@ describe(
     });
 
     it("2. List widget V2 with error input", () => {
-      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       [
         ["{{currentItem}}", "This value does not evaluate to type string"],

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
@@ -98,7 +98,7 @@ describe(
 
       cy.wait(1000);
 
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
 
       testJsontextClear("items");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Nested_EventBindings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Nested_EventBindings_spec.js
@@ -12,7 +12,7 @@ describe(
       cy.addDsl(nestedListDSL);
       cy.wait(4000);
       // Open the property pane of button in the inner list widget
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
 
       // Enable JS mode for onClick
       cy.get(toggleJSButton("onclick")).click({ force: true });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Nested_EventBindings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Nested_EventBindings_spec.js
@@ -1,6 +1,6 @@
 const nestedListDSL = require("../../../../../fixtures/Listv2/nestedList.json");
 const commonlocators = require("../../../../../locators/commonlocators.json");
-
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 const toggleJSButton = (name) => `.t--property-control-${name} .t--js-toggle`;
 const widgetSelector = (name) => `[data-widgetname-cy="${name}"]`;
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_TriggerRow_SelectedRow.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_TriggerRow_SelectedRow.js
@@ -51,7 +51,7 @@ describe(
       cy.wait("@updateLayout");
 
       // Update widgets with right data and confirm
-      _.propPane.openPropertyPaneByWidgetName("TriggeredRow", "textwidget");
+      cy.openPropertyPaneByWidgetName("TriggeredRow", "textwidget");
       cy.testJsontext("text", `{{List1.triggeredItemView}}`);
       cy.get(
         `${widgetSelector("TriggeredRow")} ${commonlocators.bodyTextStyle}`,
@@ -59,13 +59,13 @@ describe(
         .first()
         .should("have.text", JSON.stringify({}));
 
-      _.propPane.openPropertyPaneByWidgetName("SelectedRow", "textwidget");
+      cy.openPropertyPaneByWidgetName("SelectedRow", "textwidget");
       cy.testJsontext("text", `{{List1.selectedItemView}}`);
       cy.get(`${widgetSelector("SelectedRow")} ${commonlocators.bodyTextStyle}`)
         .first()
         .should("have.text", JSON.stringify({}));
 
-      _.propPane.openPropertyPaneByWidgetName("SelectedItem", "textwidget");
+      cy.openPropertyPaneByWidgetName("SelectedItem", "textwidget");
       cy.testJsontext("text", `{{List1.selectedItem}}`);
       cy.get(
         `${widgetSelector("SelectedItem")} ${commonlocators.bodyTextStyle}`,
@@ -73,13 +73,13 @@ describe(
         .first()
         .should("not.have.text");
 
-      _.propPane.openPropertyPaneByWidgetName("PageNumber", "textwidget");
+      cy.openPropertyPaneByWidgetName("PageNumber", "textwidget");
       cy.testJsontext("text", `{{List1.pageNo}}`);
       cy.get(`${widgetSelector("PageNumber")} ${commonlocators.bodyTextStyle}`)
         .first()
         .should("have.text", "1");
 
-      _.propPane.openPropertyPaneByWidgetName("PageSize", "textwidget");
+      cy.openPropertyPaneByWidgetName("PageSize", "textwidget");
       cy.testJsontext("text", `{{List1.pageSize}}`);
 
       cy.get(`${widgetSelector("PageSize")} ${commonlocators.bodyTextStyle}`)

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_TriggerRow_SelectedRow.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_TriggerRow_SelectedRow.js
@@ -46,12 +46,12 @@ describe(
     });
 
     it("1. Setup necessary data and widgets", () => {
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
 
       cy.wait("@updateLayout");
 
       // Update widgets with right data and confirm
-      cy.openPropertyPaneByWidgetName("TriggeredRow", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("TriggeredRow", "textwidget");
       cy.testJsontext("text", `{{List1.triggeredItemView}}`);
       cy.get(
         `${widgetSelector("TriggeredRow")} ${commonlocators.bodyTextStyle}`,
@@ -59,13 +59,13 @@ describe(
         .first()
         .should("have.text", JSON.stringify({}));
 
-      cy.openPropertyPaneByWidgetName("SelectedRow", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("SelectedRow", "textwidget");
       cy.testJsontext("text", `{{List1.selectedItemView}}`);
       cy.get(`${widgetSelector("SelectedRow")} ${commonlocators.bodyTextStyle}`)
         .first()
         .should("have.text", JSON.stringify({}));
 
-      cy.openPropertyPaneByWidgetName("SelectedItem", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("SelectedItem", "textwidget");
       cy.testJsontext("text", `{{List1.selectedItem}}`);
       cy.get(
         `${widgetSelector("SelectedItem")} ${commonlocators.bodyTextStyle}`,
@@ -73,13 +73,13 @@ describe(
         .first()
         .should("not.have.text");
 
-      cy.openPropertyPaneByWidgetName("PageNumber", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("PageNumber", "textwidget");
       cy.testJsontext("text", `{{List1.pageNo}}`);
       cy.get(`${widgetSelector("PageNumber")} ${commonlocators.bodyTextStyle}`)
         .first()
         .should("have.text", "1");
 
-      cy.openPropertyPaneByWidgetName("PageSize", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("PageSize", "textwidget");
       cy.testJsontext("text", `{{List1.pageSize}}`);
 
       cy.get(`${widgetSelector("PageSize")} ${commonlocators.bodyTextStyle}`)

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_autocomplete_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_autocomplete_spec.js
@@ -20,7 +20,7 @@ describe(
 
     it("1. shows autocomplete for currentItem/currentIndex/currentView for level_1 list", () => {
       // Open the property pane of level 1 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type("{{curr", {
@@ -33,7 +33,7 @@ describe(
 
     it("2. shows autocomplete for currentItem/currentIndex/currentView for level_2 list", () => {
       // Open the property pane of level 2 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text5", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text5", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type("{{curr", {
@@ -46,7 +46,7 @@ describe(
 
     it("3. shows autocomplete for level_1's currentItem/currentIndex/currentView for level_2 list", () => {
       // Open the property pane of level 2 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text5", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text5", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -60,7 +60,7 @@ describe(
 
     it("4. shows autocomplete for currentItem/currentIndex/currentView for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type("{{curr", {
@@ -73,7 +73,7 @@ describe(
 
     it("5. shows autocomplete for level_1's currentItem/currentIndex/currentView for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -87,7 +87,7 @@ describe(
 
     it("6. shows autocomplete for level_2's currentItem/currentIndex/currentView for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -101,7 +101,7 @@ describe(
 
     it("7. should not show List's currentItemsView in currentView of level_1/level_2 properties", () => {
       // Open the property pane of level 3 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       // level_1 List currentItemsView should not exist
       cy.testJsontext("text", "");
@@ -126,7 +126,7 @@ describe(
 
     it("8. currentItem should reflect appropriate data types", () => {
       // Open the property pane of level 1 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -141,7 +141,7 @@ describe(
 
     it("9. currentView should reflect appropriate widgets for level_1 for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      _.propPane.openPropertyPaneByWidgetName("Text6", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text6", "textwidget");
 
       // level_1.currentView
       cy.testJsontext("text", "");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_autocomplete_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_autocomplete_spec.js
@@ -20,7 +20,7 @@ describe(
 
     it("1. shows autocomplete for currentItem/currentIndex/currentView for level_1 list", () => {
       // Open the property pane of level 1 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type("{{curr", {
@@ -33,7 +33,7 @@ describe(
 
     it("2. shows autocomplete for currentItem/currentIndex/currentView for level_2 list", () => {
       // Open the property pane of level 2 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text5", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text5", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type("{{curr", {
@@ -46,7 +46,7 @@ describe(
 
     it("3. shows autocomplete for level_1's currentItem/currentIndex/currentView for level_2 list", () => {
       // Open the property pane of level 2 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text5", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text5", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -60,7 +60,7 @@ describe(
 
     it("4. shows autocomplete for currentItem/currentIndex/currentView for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type("{{curr", {
@@ -73,7 +73,7 @@ describe(
 
     it("5. shows autocomplete for level_1's currentItem/currentIndex/currentView for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -87,7 +87,7 @@ describe(
 
     it("6. shows autocomplete for level_2's currentItem/currentIndex/currentView for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -101,7 +101,7 @@ describe(
 
     it("7. should not show List's currentItemsView in currentView of level_1/level_2 properties", () => {
       // Open the property pane of level 3 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text7", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text7", "textwidget");
 
       // level_1 List currentItemsView should not exist
       cy.testJsontext("text", "");
@@ -126,7 +126,7 @@ describe(
 
     it("8. currentItem should reflect appropriate data types", () => {
       // Open the property pane of level 1 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       cy.testJsontext("text", "");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
@@ -141,7 +141,7 @@ describe(
 
     it("9. currentView should reflect appropriate widgets for level_1 for level_3 list", () => {
       // Open the property pane of level 3 list widget's Text widget
-      cy.openPropertyPaneByWidgetName("Text6", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text6", "textwidget");
 
       // level_1.currentView
       cy.testJsontext("text", "");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_container_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_container_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. can open property pane of container widget", () => {
-      _.propPane.openPropertyPaneByWidgetName("Container1", "containerwidget");
+      cy.openPropertyPaneByWidgetName("Container1", "containerwidget");
 
       cy.get(".t--propertypane").contains("Container1");
     });
@@ -18,7 +18,7 @@ describe(
     it("2. currentItem can be used in the container", () => {
       const colors = ["rgb(0, 0, 255)", "rgb(0, 128, 0)", "rgb(255, 0, 0)"];
 
-      _.propPane.openPropertyPaneByWidgetName("Container1", "containerwidget");
+      cy.openPropertyPaneByWidgetName("Container1", "containerwidget");
 
       // Open style table
       cy.get(commonlocators.propertyStyle).first().click({ force: true });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_container_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_container_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. can open property pane of container widget", () => {
-      cy.openPropertyPaneByWidgetName("Container1", "containerwidget");
+      _.propPane.openPropertyPaneByWidgetName("Container1", "containerwidget");
 
       cy.get(".t--propertypane").contains("Container1");
     });
@@ -18,7 +18,7 @@ describe(
     it("2. currentItem can be used in the container", () => {
       const colors = ["rgb(0, 0, 255)", "rgb(0, 128, 0)", "rgb(255, 0, 0)"];
 
-      cy.openPropertyPaneByWidgetName("Container1", "containerwidget");
+      _.propPane.openPropertyPaneByWidgetName("Container1", "containerwidget");
 
       // Open style table
       cy.get(commonlocators.propertyStyle).first().click({ force: true });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_onItemClick_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_onItemClick_spec.js
@@ -37,7 +37,7 @@ describe(
         x: 300,
         y: 300,
       });
-      _.propPane.openPropertyPane("listwidgetv2");
+      propPane.openPropertyPane("listwidgetv2");
 
       cy.get(toggleJSButton("onitemclick")).click({ force: true });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_onItemClick_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_onItemClick_spec.js
@@ -37,7 +37,7 @@ describe(
         x: 300,
         y: 300,
       });
-      cy.openPropertyPane("listwidgetv2");
+      _.propPane.openPropertyPane("listwidgetv2");
 
       cy.get(toggleJSButton("onitemclick")).click({ force: true });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_regression_fix_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_regression_fix_spec.js
@@ -11,7 +11,7 @@ describe(
         x: 300,
         y: 300,
       });
-      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
+      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       cy.get(widgetsPage.toggleVisible).click({ force: true });
       cy.testJsontext("visible", "false");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_regression_fix_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_regression_fix_spec.js
@@ -11,7 +11,7 @@ describe(
         x: 300,
         y: 300,
       });
-      cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+      _.propPane.openPropertyPaneByWidgetName("Text1", "textwidget");
 
       cy.get(widgetsPage.toggleVisible).click({ force: true });
       cy.testJsontext("visible", "false");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Modal/Modal_focus_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Modal/Modal_focus_spec.js
@@ -51,7 +51,7 @@ describe("Modal focus", { tags: ["@tag.Widget", "@tag.Modal"] }, function () {
 
   it("1. Should focus on the input field when autofocus for the input field is enabled", () => {
     setupModalWithInputWidget();
-    _.propPane.openPropertyPaneFromModal("inputwidgetv2");
+    cy.openPropertyPaneFromModal("inputwidgetv2");
 
     // autofocus for input field is enabled
     cy.get(".t--property-control-autofocus")
@@ -73,7 +73,7 @@ describe("Modal focus", { tags: ["@tag.Widget", "@tag.Modal"] }, function () {
     cy.focused().should("have.value", someInputText);
   });
   it("2. Should not focus on the input field if autofocus is disabled", () => {
-    _.propPane.openPropertyPaneFromModal("inputwidgetv2");
+    cy.openPropertyPaneFromModal("inputwidgetv2");
     // autofocus for input field is disabled
     cy.get(".t--property-control-autofocus")
       .find(".ads-v2-switch")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Modal/Modal_focus_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Modal/Modal_focus_spec.js
@@ -12,7 +12,7 @@ describe("Modal focus", { tags: ["@tag.Widget", "@tag.Modal"] }, function () {
   function setupModalWithInputWidget() {
     //drag a button to open modal
     cy.dragAndDropToCanvas("buttonwidget", { x: 400, y: 550 });
-    cy.openPropertyPane("buttonwidget");
+    _.propPane.openPropertyPane("buttonwidget");
     cy.get(widgets.toggleOnClick).click();
 
     cy.updateCodeInput(
@@ -51,7 +51,7 @@ describe("Modal focus", { tags: ["@tag.Widget", "@tag.Modal"] }, function () {
 
   it("1. Should focus on the input field when autofocus for the input field is enabled", () => {
     setupModalWithInputWidget();
-    cy.openPropertyPaneFromModal("inputwidgetv2");
+    _.propPane.openPropertyPaneFromModal("inputwidgetv2");
 
     // autofocus for input field is enabled
     cy.get(".t--property-control-autofocus")
@@ -73,7 +73,7 @@ describe("Modal focus", { tags: ["@tag.Widget", "@tag.Modal"] }, function () {
     cy.focused().should("have.value", someInputText);
   });
   it("2. Should not focus on the input field if autofocus is disabled", () => {
-    cy.openPropertyPaneFromModal("inputwidgetv2");
+    _.propPane.openPropertyPaneFromModal("inputwidgetv2");
     // autofocus for input field is disabled
     cy.get(".t--property-control-autofocus")
       .find(".ads-v2-switch")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect1_spec.js
@@ -14,7 +14,7 @@ describe(
     it("1. Add new multiselect widget", () => {
       _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.MULTISELECT);
       //should check that empty value is allowed in options", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       _.propPane.ToggleJSMode("sourcedata");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
@@ -49,7 +49,7 @@ describe(
     });
 
     it("2. should check that more that one empty value is not allowed in options", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[
@@ -73,7 +73,7 @@ describe(
     });
 
     it("3. should check that Objects can be added to multiselect Widget default value", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[
@@ -114,7 +114,7 @@ describe(
     });
 
     it("4. should display the right label", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect2_spec.js
@@ -21,7 +21,7 @@ describe(
     });
 
     it("1. Selects value with invalid default value", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       _.propPane.ToggleJSMode("sourcedata");
       _.propPane.UpdatePropertyFieldValue(
         "Source Data",
@@ -89,7 +89,7 @@ describe(
         "Option 2",
       );
       // Close the widget
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       // Reopen the widget
       cy.get(formWidgetsPage.multiselectwidgetv2)
         .find(".rc-select-selection-search-input")
@@ -118,7 +118,7 @@ describe(
         .contains("Option 2")
         .click({ force: true });
       // Close the widget
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       // Reopen the widget
       cy.get(formWidgetsPage.multiselectwidgetv2)
         .find(".rc-select-selection-search-input")
@@ -148,7 +148,7 @@ describe(
         .first()
         .should("not.have.text", "Select all");
       // enable select all option from property pane
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.allowSelectAllCheckbox);
 
       // press select all option
@@ -171,10 +171,10 @@ describe(
     });
 
     it("6. Check isDirty meta property", function () {
-      cy.openPropertyPane(_.draggableWidgets.TEXT);
+      _.propPane.openPropertyPane(_.draggableWidgets.TEXT);
       cy.updateCodeInput(PROPERTY_SELECTOR.text, `{{MultiSelect2.isDirty}}`);
       // Init isDirty by changing defaultOptionValue
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       cy.updateCodeInput(
         PROPERTY_SELECTOR.defaultValue,
         '[\n  {\n    "label": "Option 1",\n    "value": "1"\n  }\n]',
@@ -251,7 +251,7 @@ describe(
         const { defaultValue, options, optionsToDeselect, optionsToSelect } =
           testCase;
 
-        cy.openPropertyPane("multiselectwidgetv2");
+        _.propPane.openPropertyPane("multiselectwidgetv2");
         // set options
         _.propPane.UpdatePropertyFieldValue(
           "Source Data",
@@ -285,7 +285,7 @@ describe(
     });
 
     it("7. Verify MultiSelect deselection behavior", function () {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       // set options
       _.propPane.UpdatePropertyFieldValue(
         "Source Data",
@@ -306,7 +306,7 @@ describe(
       );
       _.deployMode.NavigateBacktoEditor();
       // Dropdown Functionality To Check Visible Widget", function () {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();
       cy.get(publish.multiselectwidgetv2 + " " + ".rc-select-selector").should(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect4_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect4_spec.js
@@ -65,10 +65,10 @@ describe(
     });
 
     it("2. Copy and paste multiselect widget", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
       //copy and paste
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       cy.get("body").type(`{${modifierKey}}c`);
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(500);
@@ -97,7 +97,7 @@ describe(
     });
 
     it("3. Select tooltip renders if tooltip prop is not empty", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       // enter tooltip in property pan
       cy.get(widgetsPage.inputTooltipControl).type(
         "Helpful text for tooltip !",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect_label_value.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect_label_value.ts
@@ -116,7 +116,7 @@ describe(
         cy.get(commonlocators.TextInside).first().should("have.text", d.text);
       });
 
-      (cy as any).openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
 
       _.propPane.SelectPropertiesDropDown("label", "test2");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiTreeSelect_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiTreeSelect_spec.js
@@ -14,7 +14,7 @@ describe(
     });
 
     it("should check that empty value is allowed in options", () => {
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
       cy.updateCodeInput(
         ".t--property-control-options",
         `[
@@ -48,7 +48,7 @@ describe(
     });
 
     it("should check that more thatn empty value is not allowed in options", () => {
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
       cy.updateCodeInput(
         ".t--property-control-options",
         `[

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/Multi_Select_Tree_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Multiselect/Multi_Select_Tree_spec.js
@@ -14,13 +14,13 @@ describe(
 
     it("1. Check isDirty meta property", function () {
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{MultiSelectTree1.isDirty}}`,
       );
       // Change defaultValue
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
       cy.testJsontext("defaultselectedvalues", "GREEN\n");
       // Check if isDirty is set to false
       cy.get(".t--widget-textwidget").should("contain", "false");
@@ -40,7 +40,7 @@ describe(
     });
 
     it("2. Selects value with enter in default value", () => {
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
       cy.testJsontext("defaultselectedvalues", "RED\n");
       cy.get(formWidgetsPage.multiselecttreeWidget)
         .find(".rc-tree-select-selection-item-content")
@@ -58,7 +58,7 @@ describe(
     it("3. Clears the search field when widget is closed", () => {
       // open the multi-tree select widget
       // search for option Red in the search input
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
       cy.testJsontext("defaultselectedvalues", "");
       cy.wait(2000)
         .get(formWidgetsPage.treeSelectInput)
@@ -109,7 +109,7 @@ describe(
     });
 
     it("6. To Check Visible Widget", function () {
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();
       cy.get(
@@ -131,7 +131,7 @@ describe(
     });
 
     it("8. Select tooltip renders if tooltip prop is not empty", () => {
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
       // enter tooltip in property pan
       cy.get(widgetsPage.inputTooltipControl).type(
         "Helpful text for tooltip !",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Autocomplete_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Autocomplete_spec.js
@@ -14,7 +14,7 @@ describe(
     });
 
     it("Slash command and mustache autocomplete validation for button widget", function () {
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.testCodeMirror("/").then(() => {
         cy.get(dynamicInputLocators.hints).should("exist");
         // validates all autocomplete commands on entering / in label field
@@ -80,7 +80,7 @@ describe(
       "Slash command and mustache autocomplete validation for textbox widget",
       { tags: ["@tag.excludeForAirgap"] },
       function () {
-        cy.openPropertyPane("textwidget");
+        _.propPane.openPropertyPane("textwidget");
         cy.EnableAllCodeEditors();
         cy.testCodeMirror("/").then(() => {
           cy.get(dynamicInputLocators.hints).should("exist");
@@ -112,7 +112,7 @@ describe(
       "airgap",
       "Slash command and mustache autocomplete validation for textbox widget for airgap",
       function () {
-        cy.openPropertyPane("textwidget");
+        _.propPane.openPropertyPane("textwidget");
         cy.EnableAllCodeEditors();
         cy.testCodeMirror("/").then(() => {
           cy.get(dynamicInputLocators.hints).should("exist");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Camera_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Camera_spec.js
@@ -6,7 +6,7 @@ describe("Camera Widget", { tags: ["@tag.Widget", "@tag.Image"] }, () => {
   });
 
   beforeEach(() => {
-    cy.openPropertyPane("camerawidget");
+    _.propPane.openPropertyPane("camerawidget");
   });
 
   it("1. Check isDirty, onImageSave, imageBlobURL, imageDataURL", () => {
@@ -17,7 +17,7 @@ describe("Camera Widget", { tags: ["@tag.Widget", "@tag.Image"] }, () => {
 
     cy.testJsontext("onimagecapture", "{{showAlert('captured','success')}}");
 
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(
       ".t--property-control-text",
       `{{Camera1.isDirty}}:{{Camera1.imageDataURL}}:{{Camera1.imageBlobURL}}`,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/IconButton_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/IconButton_spec.js
@@ -50,7 +50,7 @@ describe(
     });
 
     it("4. should not show alert onclick if button is disabled", function () {
-      cy.openPropertyPane("iconbuttonwidget");
+      _.propPane.openPropertyPane("iconbuttonwidget");
       cy.CheckWidgetProperties(commonlocators.disableCheckbox);
       cy.get(widgetsPage.iconWidgetBtn).click({ force: true });
       cy.get(commonlocators.toastmsg).should("not.exist");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/MenuButton_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/MenuButton_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("1. Icon alignment should not change when changing the icon", () => {
-      cy.openPropertyPane("menubuttonwidget");
+      _.propPane.openPropertyPane("menubuttonwidget");
       cy.moveToStyleTab();
       // Add an icon
       cy.get(".t--property-control-icon .bp3-icon-caret-down").click({
@@ -52,7 +52,7 @@ describe(
     });
 
     it("2. MenuButton widget functionality on undo after delete", function () {
-      cy.openPropertyPane("menubuttonwidget");
+      _.propPane.openPropertyPane("menubuttonwidget");
       cy.moveToContentTab();
       // Delete Second Menu Item
       cy.get(".t--property-control-menuitems .t--delete-column-btn")
@@ -93,7 +93,7 @@ describe(
     });
 
     it("3. MenuButton widget functionality to add dynamic menu items", function () {
-      cy.openPropertyPane("menubuttonwidget");
+      _.propPane.openPropertyPane("menubuttonwidget");
       cy.moveToContentTab();
 
       // Select menu items source as Dynamic
@@ -135,7 +135,7 @@ describe(
     });
 
     it("4. Disable one dynamic item using {{currentItem}} binding", function () {
-      cy.openPropertyPane("menubuttonwidget");
+      _.propPane.openPropertyPane("menubuttonwidget");
       cy.moveToContentTab();
 
       // Open configure array item panel
@@ -163,7 +163,7 @@ describe(
     });
 
     it("5. Apply background color to dynamic items using {{currentItem}} binding", function () {
-      cy.openPropertyPane("menubuttonwidget");
+      _.propPane.openPropertyPane("menubuttonwidget");
       cy.moveToContentTab();
 
       // Open configure array item panel

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Progress_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Progress_spec.js
@@ -21,7 +21,7 @@ describe(
 
     // Linear progress
     it("1. Property: isIndeterminate, Toggle infinite loading", function () {
-      cy.openPropertyPane("progresswidget");
+      _.propPane.openPropertyPane("progresswidget");
       // enable infinite loading
       agHelper.CheckUncheck(widgets.infiniteLoading);
       // show indeterminate linear progress
@@ -69,7 +69,7 @@ describe(
       cy.get("[data-testid='circular']").should("exist");
     });
     it("6. Property: isIndeterminate, Toggle infinite loading", function () {
-      cy.openPropertyPane("progresswidget");
+      _.propPane.openPropertyPane("progresswidget");
       // enable infinite loading
       agHelper.CheckUncheck(widgets.infiniteLoading);
       // show indeterminate linear progress
@@ -128,7 +128,7 @@ describe(
     });
 
     it("11. The binding property, progress should be exposed for an auto suggestion", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
         "{{Progress1.",
         { force: true },

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Progress_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Others/Progress_spec.js
@@ -21,7 +21,7 @@ describe(
 
     // Linear progress
     it("1. Property: isIndeterminate, Toggle infinite loading", function () {
-      _.propPane.openPropertyPane("progresswidget");
+      propPane.openPropertyPane("progresswidget");
       // enable infinite loading
       agHelper.CheckUncheck(widgets.infiniteLoading);
       // show indeterminate linear progress
@@ -69,7 +69,7 @@ describe(
       cy.get("[data-testid='circular']").should("exist");
     });
     it("6. Property: isIndeterminate, Toggle infinite loading", function () {
-      _.propPane.openPropertyPane("progresswidget");
+      propPane.openPropertyPane("progresswidget");
       // enable infinite loading
       agHelper.CheckUncheck(widgets.infiniteLoading);
       // show indeterminate linear progress
@@ -128,7 +128,7 @@ describe(
     });
 
     it("11. The binding property, progress should be exposed for an auto suggestion", function () {
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       cy.get(".t--property-control-text .CodeMirror textarea").type(
         "{{Progress1.",
         { force: true },

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInputDynamicValue_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInputDynamicValue_spec.js
@@ -43,7 +43,7 @@ describe(
     });
 
     it("2. should check that widget can be used with dynamic default dial code", () => {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.get(".t--property-control-defaultcountrycode .CodeMirror-code").should(
         "contain",
         "{{appsmith.store.test}}",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInputDynamicValue_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInputDynamicValue_spec.js
@@ -43,7 +43,7 @@ describe(
     });
 
     it("2. should check that widget can be used with dynamic default dial code", () => {
-      _.propPane.openPropertyPane(widgetName);
+      propPane.openPropertyPane(widgetName);
       cy.get(".t--property-control-defaultcountrycode .CodeMirror-code").should(
         "contain",
         "{{appsmith.store.test}}",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/Phone_input_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/Phone_input_spec.js
@@ -25,7 +25,7 @@ describe(
       cy.dragAndDropToCanvas(widgetName, { x: 300, y: 300 });
       cy.get(`.t--widget-${widgetName}`).should("exist");
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{PhoneInput1.text}}:{{PhoneInput1.countryCode}}:{{PhoneInput1.dialCode}}`,
@@ -38,7 +38,7 @@ describe(
       cy.get(`.t--widget-${widgetName} input`).type("9999999999");
       cy.get(".t--widget-textwidget").should("contain", "(999) 999-9999:US:+1");
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       searchAndSelectOption("Afghanistan (+93)");
       cy.get(`.t--widget-${widgetName} input`).clear();
       cy.wait(500);
@@ -68,7 +68,7 @@ describe(
       cy.get(`.t--widget-${widgetName} input`).type("9999999999");
       cy.get(".t--widget-textwidget").should("contain", "9999999999:US:+1");
 
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       searchAndSelectOption("India (+91)");
       cy.get(`.t--widget-${widgetName} input`).clear();
       cy.wait(500);
@@ -78,12 +78,12 @@ describe(
     });
 
     it("3. Should check that widget input resets on submit", () => {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{PhoneInput1.text}}:{{PhoneInput1.value}}`,
       );
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.getAlert("onSubmit", "Submitted!!");
 
       cy.get(widgetInput).clear();
@@ -101,13 +101,13 @@ describe(
     });
 
     it("4. Check isDirty meta property", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{PhoneInput1.isDirty}}`,
       );
       // Change defaultText
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.updateCodeInput(".t--property-control-defaultvalue", "1");
       cy.closePropertyPane();
       // Check if isDirty is set to false
@@ -120,14 +120,14 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").should("contain", "true");
       // Reset isDirty by changing defaultText
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
       cy.updateCodeInput(".t--property-control-defaultvalue", "3");
       // Check if isDirty is set to false
       cy.get(".t--widget-textwidget").should("contain", "false");
     });
 
     it("5. Currency change dropdown should not close unexpectedly", function () {
-      cy.openPropertyPane(widgetName);
+      _.propPane.openPropertyPane(widgetName);
 
       // Select the Currency dropdown option from property pane
       // and enter a value that has space and returns 0 results

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_1_spec.js
@@ -42,7 +42,7 @@ describe(
 
     beforeEach(() => {
       cy.wait(3000);
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
     });
 
     it("1. RichTextEditor-Edit Text area with HTML body functionality", function () {
@@ -85,7 +85,7 @@ describe(
         commonlocators.disabledBtn,
       );
       _.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
 
       //Check the Disabled checkbox
       cy.CheckWidgetProperties(formWidgetsPage.disableJs);
@@ -109,7 +109,7 @@ describe(
       cy.get(publishPage.richTextEditorWidget).should("not.exist");
 
       _.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
 
       // RichTextEditor-uncheck Visible field validation
       cy.CheckWidgetProperties(commonlocators.visibleCheckbox);
@@ -132,7 +132,7 @@ describe(
       );
 
       _.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
 
       //RichTextEditor-uncheck Hide toolbar field validation - // Uncheck the Hide toolbar checkbox
       cy.UncheckWidgetProperties(commonlocators.hideToolbarCheckbox);
@@ -159,7 +159,7 @@ describe(
         "h1",
         "content",
       );
-      cy.openPropertyPane("buttonwidget");
+      _.propPane.openPropertyPane("buttonwidget");
       cy.get(".t--property-control-onclick")
         .find(".t--js-toggle")
         .click({ force: true });
@@ -174,12 +174,12 @@ describe(
     });
 
     it("6. Check isDirty meta property", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{RichtextEditor.isDirty}}`,
       );
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
       // Change defaultText
       cy.testJsontext("defaultvalue", "a");
       // Check if isDirty has been changed into false
@@ -194,7 +194,7 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").should("contain", "true");
       // Change defaultText
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
       cy.testJsontext("defaultvalue", "b");
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget").should("contain", "false");
@@ -205,7 +205,7 @@ describe(
        */
       cy.get(".t--widget-buttonwidget .bp3-button").click({ force: true });
       cy.wait(500);
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
       cy.testJsontext("defaultvalue", "c");
       cy.get(".t--widget-textwidget").should("contain", "false");
     });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_2_spec.js
@@ -42,24 +42,24 @@ describe(
 
     beforeEach(() => {
       cy.wait(3000);
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
     });
 
     it("1. Check if the binding is getting removed from the text and the RTE widget", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{RichTextEditor1.text}}`,
       );
       // Change defaultText of the RTE
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
       cy.testJsontext("defaultvalue", "Test Content");
 
       //Check if the text widget has the defaultText of RTE
       cy.get(".t--widget-textwidget").should("contain", "Test Content");
 
       //Clear the default text from RTE
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
       cy.testJsontext("defaultvalue", "");
 
       //Check if text widget and RTE widget does not have any text in it.
@@ -100,7 +100,7 @@ describe(
       setRTEContent("{selectAll}{del}");
 
       // Changing the input type to markdown and again testing the cursor position
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
       cy.get("span:contains('Markdown')").eq(0).click({ force: true });
       setRTEContent(testString);
       testCursorPoistion(testStringLen, tinyMceId);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_Validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_Validation_spec.js
@@ -12,7 +12,7 @@ describe(
 
     beforeEach(() => {
       cy.wait(7000);
-      cy.openPropertyPane("richtexteditorwidget");
+      _.propPane.openPropertyPane("richtexteditorwidget");
     });
 
     it("RichTextEditor-required with empty content show error border for textarea", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup1_spec.js
@@ -14,7 +14,7 @@ describe(
     });
 
     it("should check that empty value is allowed in options", () => {
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
       cy.get(".t--property-control-options")
         .find(".t--js-toggle")
         .click({ force: true });
@@ -37,7 +37,7 @@ describe(
     });
 
     it("should check that more thatn empty value is not allowed in options", () => {
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
       cy.updateCodeInput(
         ".t--property-control-options",
         `[

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup2_spec.js
@@ -5,7 +5,7 @@ describe("Radio Group Widget", { tags: ["@tag.Widget", "@tag.Radio"] }, () => {
     cy.dragAndDropToCanvas(widgetName, { x: 300, y: 300 });
     cy.get(`.t--widget-${widgetName}`).should("exist");
     cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(".t--property-control-text", `{{RadioGroup1.isDirty}}`);
   });
 
@@ -17,7 +17,7 @@ describe("Radio Group Widget", { tags: ["@tag.Widget", "@tag.Radio"] }, () => {
     // Check if isDirty is set to true
     cy.get(".t--widget-textwidget").should("contain", "true");
     // Change defaultOptionValue
-    cy.openPropertyPane(widgetName);
+    _.propPane.openPropertyPane(widgetName);
     cy.updateCodeInput(".t--property-control-defaultselectedvalue", "N");
     // Check if isDirty is reset to false
     cy.get(".t--widget-textwidget").should("contain", "false");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup2_spec.js
@@ -1,3 +1,4 @@
+import * as _ from "../../../../../support/Objects/ObjectsCore";
 const widgetName = "radiogroupwidget";
 
 describe("Radio Group Widget", { tags: ["@tag.Widget", "@tag.Radio"] }, () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup_Int_Value_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/RadioGroup_Int_Value_spec.js
@@ -19,7 +19,7 @@ describe(
     });
 
     it("Radio widget check selection with value property as integer", function () {
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
 
       //Check radio with value=1 is selected
       checkSelectedRadioValue(formWidgetsPage.radioWidget, "1");
@@ -45,7 +45,7 @@ describe(
     });
 
     it("Radio widget check selection with value property as string", function () {
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
 
       cy.updateCodeInput(
         ".t--property-control-options",
@@ -96,7 +96,7 @@ describe(
        */
 
       //Base-line scenario
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
 
       cy.updateCodeInput(
         ".t--property-control-options",
@@ -204,7 +204,7 @@ describe(
        */
 
       //Base-line scenario
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
 
       cy.updateCodeInput(
         ".t--property-control-options",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/Radio_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/Radio_spec.js
@@ -63,13 +63,13 @@ describe(
     });
 
     it("2. Radio Functionality To Check/Uncheck Visible property", function () {
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
       propPane.TogglePropertyState("Visible", "Off");
       deployMode.DeployApp();
       cy.get(publish.radioWidget + " " + "input").should("not.exist");
       deployMode.NavigateBacktoEditor();
       //Radio Functionality To Check Visible Widget
-      cy.openPropertyPane("radiogroupwidget");
+      _.propPane.openPropertyPane("radiogroupwidget");
       propPane.TogglePropertyState("Visible", "On");
       deployMode.DeployApp();
       agHelper.AssertExistingCheckedState(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/Radio_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Radio/Radio_spec.js
@@ -63,13 +63,13 @@ describe(
     });
 
     it("2. Radio Functionality To Check/Uncheck Visible property", function () {
-      _.propPane.openPropertyPane("radiogroupwidget");
+      propPane.openPropertyPane("radiogroupwidget");
       propPane.TogglePropertyState("Visible", "Off");
       deployMode.DeployApp();
       cy.get(publish.radioWidget + " " + "input").should("not.exist");
       deployMode.NavigateBacktoEditor();
       //Radio Functionality To Check Visible Widget
-      _.propPane.openPropertyPane("radiogroupwidget");
+      propPane.openPropertyPane("radiogroupwidget");
       propPane.TogglePropertyState("Visible", "On");
       deployMode.DeployApp();
       agHelper.AssertExistingCheckedState(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_TreeSelect_MultiSelect_OnFocus_OnBlur_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_TreeSelect_MultiSelect_OnFocus_OnBlur_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. onDropdownOpen and onDropdownClose should be triggered from the select widget", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
 
       _.propPane.EnterJSContext(
         "onDropdownOpen",
@@ -28,7 +28,7 @@ describe(
     });
 
     it("2. onDropdownOpen and onDropdownClose should be triggered from the multiselect widget", () => {
-      cy.openPropertyPane("multiselectwidgetv2");
+      _.propPane.openPropertyPane("multiselectwidgetv2");
       _.propPane.EnterJSContext(
         "onDropdownOpen",
         "{{showAlert('MultiSelect1 dropdown opened', 'success')}}",
@@ -45,7 +45,7 @@ describe(
     });
 
     it("3. onDropdownOpen and onDropdownClose should be triggered from the treeselect widget", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       _.propPane.EnterJSContext(
         "onDropdownOpen",
         "{{showAlert('TreeSelect1 dropdown opened', 'success')}}",
@@ -63,7 +63,7 @@ describe(
     });
 
     it("4. onDropdownOpen and onDropdownClose should be triggered from the multitreeselect widget", () => {
-      cy.openPropertyPane("multiselecttreewidget");
+      _.propPane.openPropertyPane("multiselecttreewidget");
 
       _.propPane.EnterJSContext(
         "onDropdownOpen",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_Validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_Validation_spec.js
@@ -23,7 +23,7 @@ describe(
       cy.get(".bp3-disabled").should("be.visible");
       _.deployMode.NavigateBacktoEditor();
       //Enable the widget and check in publish mode", function () {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       EditorNavigation.SelectEntityByName("SelectRenamed", EntityType.Widget);
       cy.get(".bp3-disabled").should("be.visible");
       _.propPane.TogglePropertyState("Disabled", "Off");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
@@ -131,7 +131,7 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
   });
 
   it("6. Select tooltip renders if tooltip prop is not empty", () => {
-    cy.openPropertyPane("selectwidget");
+    _.propPane.openPropertyPane("selectwidget");
     // enter tooltip in property pan
     cy.get(widgetsPage.inputTooltipControl).type("Helpful text for tooltip !");
     // tooltip help icon shows

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
@@ -131,7 +131,7 @@ describe("Select widget", { tags: ["@tag.Widget", "@tag.Select"] }, () => {
   });
 
   it("6. Select tooltip renders if tooltip prop is not empty", () => {
-    _.propPane.openPropertyPane("selectwidget");
+    propPane.openPropertyPane("selectwidget");
     // enter tooltip in property pan
     cy.get(widgetsPage.inputTooltipControl).type("Helpful text for tooltip !");
     // tooltip help icon shows

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/select_Widget_Bug_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/select_Widget_Bug_spec.js
@@ -13,7 +13,7 @@ describe(
     });
 
     it("Select Widget name update", function () {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.widgetText(
         "Select1",
         widgetsPage.selectwidget,
@@ -22,7 +22,7 @@ describe(
     });
 
     it("should check that virtualization works well", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       _.propPane.ToggleJSMode("sourcedata");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
@@ -166,7 +166,7 @@ describe(
     });
 
     it("should check that filtering works well", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[
@@ -223,7 +223,7 @@ describe(
     });
 
     it("enable the widget and check in publish mode", function () {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.get(".bp3-disabled").should("be.visible");
       cy.get(widgetsPage.disable).scrollIntoView({ force: true });
       cy.get(widgetsPage.selectWidgetDisabled).click({ force: true });
@@ -249,7 +249,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
     });
     it("should check that filtering works well using numeric labels", () => {
-      cy.openPropertyPane("selectwidget");
+      _.propPane.openPropertyPane("selectwidget");
       cy.updateCodeInput(
         ".t--property-control-sourcedata",
         `[
@@ -268,7 +268,7 @@ describe(
       ]`,
       );
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 80 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.testJsontext("text", "{{typeof Select1.selectedOptionLabel}}");
       // Filtering the option
       cy.get(formWidgetsPage.selectWidget)

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/SwitchGroup2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/SwitchGroup2_spec.js
@@ -12,13 +12,13 @@ describe(
     });
 
     it("1. Check isDirty meta property", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{SwitchGroupTest.isDirty}}`,
       );
       // Change defaultSelectedValues
-      cy.openPropertyPane("switchgroupwidget");
+      _.propPane.openPropertyPane("switchgroupwidget");
       cy.updateCodeInput(
         ".t--property-control-defaultselectedvalues",
         `[\n"BLUE"\n]`,
@@ -31,7 +31,7 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").should("contain", "true");
       // Change defaultSelectedValues
-      cy.openPropertyPane("switchgroupwidget");
+      _.propPane.openPropertyPane("switchgroupwidget");
       cy.updateCodeInput(
         ".t--property-control-defaultselectedvalues",
         `[\n"GREEN"\n]`,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/Switch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/Switch_spec.js
@@ -12,7 +12,7 @@ describe(
       _.agHelper.AddDsl("newFormDsl");
     });
     it("1. Switch Widget Functionality", function () {
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       /**
        * @param{Text} Random Text
        * @param{SwitchWidget}Mouseover
@@ -47,28 +47,28 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //Switch Functionality To Check Disabled Widget
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       _.agHelper.CheckUncheck(commonlocators.Disablejs + " " + "input");
       _.deployMode.DeployApp();
       cy.get(publish.switchwidget + " " + "input").should("be.disabled");
       _.deployMode.NavigateBacktoEditor();
 
       //Switch Functionality To Check Enabled Widget
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       _.agHelper.CheckUncheck(commonlocators.Disablejs + " " + "input", false);
       _.deployMode.DeployApp();
       cy.get(publish.switchwidget + " " + "input").should("be.enabled");
       _.deployMode.NavigateBacktoEditor();
 
       //Switch Functionality To Unchecked Visible Widget
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
       _.deployMode.DeployApp();
       cy.get(publish.switchwidget + " " + "input").should("not.exist");
       _.deployMode.NavigateBacktoEditor();
 
       // Switch Functionality To Check Visible Widget
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       _.agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       _.deployMode.DeployApp();
       cy.get(publish.switchwidget + " " + "input").should("be.checked");
@@ -76,7 +76,7 @@ describe(
     });
 
     it("3. Switch Functionality To swap label alignment of switch", function () {
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.get(publish.switchwidget + " " + ".t--switch-widget-label").should(
         "have.css",
         "text-align",
@@ -95,7 +95,7 @@ describe(
     });
 
     it("4. Switch Functionality To swap label position of switch", function () {
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.get(publish.switchwidget + " " + ".bp3-align-left").should("exist");
       cy.get(publish.switchwidget + " " + ".bp3-align-right").should(
         "not.exist",
@@ -114,7 +114,7 @@ describe(
     });
 
     it("5. Switch Functionality To change label color of switch", function () {
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.moveToStyleTab();
       cy.get(".t--property-control-fontcolor .bp3-input").type("red");
       cy.wait(200);
@@ -127,7 +127,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //Switch Functionality To change label size of switch
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.moveToStyleTab();
       cy.get(widgetsPage.textSizeNew).last().click({ force: true });
       // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -142,7 +142,7 @@ describe(
       _.deployMode.NavigateBacktoEditor();
 
       //Switch Functionality To change label style of switch
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.moveToStyleTab();
       cy.get(".t--property-control-emphasis .t--button-group-BOLD").click();
       _.deployMode.DeployApp();
@@ -155,10 +155,10 @@ describe(
     });
 
     it("6. Check isDirty meta property", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(".t--property-control-text", `{{Toggler.isDirty}}`);
       // Change defaultSwitchState property
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.get(".t--property-control-defaultstate label").last().click();
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget")
@@ -171,7 +171,7 @@ describe(
         .scrollIntoView()
         .should("contain", "true");
       // Change defaultSwitchState property
-      cy.openPropertyPane("switchwidget");
+      _.propPane.openPropertyPane("switchwidget");
       cy.get(".t--property-control-defaultstate input").last().click();
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_Duplicate_TabName_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_Duplicate_TabName_spec.js
@@ -8,7 +8,7 @@ describe(
       _.agHelper.AddDsl("tabsWidgetDsl");
     });
     it("Tab Widget Functionality Test with Modal on change of selected tab", function () {
-      cy.openPropertyPane("tabswidget");
+      _.propPane.openPropertyPane("tabswidget");
       // added duplicate tab names
       cy.tabPopertyUpdate("tab2", "TestUpdated");
       cy.tabPopertyUpdate("tab4", "TestUpdated");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_OnEvent_Navigation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_OnEvent_Navigation_spec.js
@@ -9,7 +9,7 @@ describe(
     });
 
     it("1.On change of tab selection Navigate to a URL", function () {
-      cy.openPropertyPane("tabswidget");
+      _.propPane.openPropertyPane("tabswidget");
       _.propPane.SelectPlatformFunction("onTabSelected", "Navigate to");
       cy.wait(1000);
       _.agHelper.GetNClick(_.propPane._navigateToType("URL"));

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_new_scenario_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_new_scenario_spec.js
@@ -8,7 +8,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
     _.agHelper.AddDsl("tabsWithWidgetDsl");
   });
   it("Tab Widget Functionality Test with Modal on change of selected tab", function () {
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     cy.widgetText("tab", Layoutpage.tabWidget, widgetsPage.widgetNameSpan);
     cy.AddActionWithModal();
     cy.get(".t--draggable-buttonwidget:contains('Close')").click({

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_spec.js
@@ -13,7 +13,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
     agHelper.AddDsl("layoutdsl");
   });
   it("1. Tab Widget Functionality Test", function () {
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     /**
      * @param{Text} Random Text
      * @param{TabWidget}Mouseover
@@ -62,7 +62,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("3. Tab Widget Functionality To Unchecked Visible Widget", function () {
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
     deployMode.DeployApp();
     cy.get(publish.tabWidget).should("not.exist");
@@ -70,7 +70,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("4. Tab Widget Functionality To Check Visible Widget", function () {
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     agHelper.CheckUncheck(commonlocators.visibleCheckbox);
     deployMode.DeployApp();
     cy.get(publish.tabWidget).should("be.visible");
@@ -78,7 +78,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("5. Tab Widget Functionality To Check tab invisiblity", function () {
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     cy.xpath(Layoutpage.tabEdit.replace("tabName", "Tab 1")).click({
       force: true,
     });
@@ -90,7 +90,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("6. Tab Widget Functionality To Check tab visibility", function () {
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     cy.xpath(Layoutpage.tabEdit.replace("tabName", "Tab 1")).click({
       force: true,
     });
@@ -102,7 +102,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
   /* Test to be revisted as the undo action is inconsistent in automation
   it("7. Tab Widget Functionality To Check undo action after delete", function() {
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     cy.get(Layoutpage.tabDelete)
       .eq(1)
       .click({ force: true });
@@ -131,7 +131,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
     const leftNavButtonSelector =
       Layoutpage.tabWidget + " .scroll-nav-left-button";
 
-    cy.openPropertyPane("tabswidget");
+    _.propPane.openPropertyPane("tabswidget");
     // Add a new tab
     agHelper.ClickButton("Add tab");
     agHelper.ClickButton("Add tab");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tab_spec.js
@@ -13,7 +13,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
     agHelper.AddDsl("layoutdsl");
   });
   it("1. Tab Widget Functionality Test", function () {
-    _.propPane.openPropertyPane("tabswidget");
+    propPane.openPropertyPane("tabswidget");
     /**
      * @param{Text} Random Text
      * @param{TabWidget}Mouseover
@@ -62,7 +62,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("3. Tab Widget Functionality To Unchecked Visible Widget", function () {
-    _.propPane.openPropertyPane("tabswidget");
+    propPane.openPropertyPane("tabswidget");
     agHelper.CheckUncheck(commonlocators.visibleCheckbox, false);
     deployMode.DeployApp();
     cy.get(publish.tabWidget).should("not.exist");
@@ -70,7 +70,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("4. Tab Widget Functionality To Check Visible Widget", function () {
-    _.propPane.openPropertyPane("tabswidget");
+    propPane.openPropertyPane("tabswidget");
     agHelper.CheckUncheck(commonlocators.visibleCheckbox);
     deployMode.DeployApp();
     cy.get(publish.tabWidget).should("be.visible");
@@ -78,7 +78,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("5. Tab Widget Functionality To Check tab invisiblity", function () {
-    _.propPane.openPropertyPane("tabswidget");
+    propPane.openPropertyPane("tabswidget");
     cy.xpath(Layoutpage.tabEdit.replace("tabName", "Tab 1")).click({
       force: true,
     });
@@ -90,7 +90,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
 
   it("6. Tab Widget Functionality To Check tab visibility", function () {
-    _.propPane.openPropertyPane("tabswidget");
+    propPane.openPropertyPane("tabswidget");
     cy.xpath(Layoutpage.tabEdit.replace("tabName", "Tab 1")).click({
       force: true,
     });
@@ -102,7 +102,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
   });
   /* Test to be revisted as the undo action is inconsistent in automation
   it("7. Tab Widget Functionality To Check undo action after delete", function() {
-    _.propPane.openPropertyPane("tabswidget");
+    propPane.openPropertyPane("tabswidget");
     cy.get(Layoutpage.tabDelete)
       .eq(1)
       .click({ force: true });
@@ -131,7 +131,7 @@ describe("Tab widget test", { tags: ["@tag.Widget", "@tag.Tab"] }, function () {
     const leftNavButtonSelector =
       Layoutpage.tabWidget + " .scroll-nav-left-button";
 
-    _.propPane.openPropertyPane("tabswidget");
+    propPane.openPropertyPane("tabswidget");
     // Add a new tab
     agHelper.ClickButton("Add tab");
     agHelper.ClickButton("Add tab");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab_reset_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab_reset_spec.js
@@ -29,7 +29,7 @@ describe(
 
       cy.get(widgetsPage.textWidget).contains("Tab 2");
 
-      cy.openPropertyPane("tabswidget");
+      _.propPane.openPropertyPane("tabswidget");
       cy.get(".t--property-control-defaulttab .CodeMirror .CodeMirror-code")
         .first()
         .should("have.text", "Tab 2");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Button_Icon_validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Button_Icon_validation_spec.js
@@ -13,7 +13,7 @@ describe(
     });
 
     it("1. Table widget with with modal popup", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       //update Table name with _
       cy.widgetText(
         "Table_1",
@@ -28,7 +28,7 @@ describe(
     });
 
     it("2. Table widget with button colour change validation", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Open column details of "id".
       cy.editColumn("id");
       cy.get(widgetsPage.tableBtn).should("not.exist");
@@ -53,7 +53,7 @@ describe(
     });
 
     it("3. Table widget icon type and colour validation", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Open column details of "id".
       cy.get(commonlocators.editPropBackButton).click({ force: true });
       cy.editColumn("id");
@@ -73,7 +73,7 @@ describe(
     });
 
     it("4. Table widget validation of a field without js ", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.editColumn("email");
       cy.clearPropertyValue(0);
       //toggle js for visiblity
@@ -85,7 +85,7 @@ describe(
     });
 
     it("5. Table widget column reorder and reload function", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.get(commonlocators.editPropBackButton).click({ force: true });
       cy.hideColumn("email");
       cy.hideColumn("userName");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Color_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Color_spec.js
@@ -11,7 +11,7 @@ describe(
 
     it("1. Test to validate text color and text background", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       //cy.moveToStyleTab();
       // Click on text color input field
       cy.selectColor("textcolor");
@@ -47,7 +47,7 @@ describe(
         "rgb(219, 234, 254)",
       );
       _.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       // Change the cell background color and enter purple in input field
       cy.get(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_EmptyRow_Color_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_EmptyRow_Color_spec.js
@@ -11,7 +11,7 @@ describe(
 
     it("1. Validate cell background of columns", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // give general color to all table row
       cy.selectColor("cellbackgroundcolor", -17);
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_FilteredTableData_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_FilteredTableData_spec.js
@@ -17,7 +17,7 @@ describe(
     });
 
     it("Table Widget Functionality To Filter and search data", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.get(publish.searchInput).first().type("query");
       cy.get(publish.filterBtn).click();
       cy.get(publish.attributeDropdown).click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_GeneralProperty_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_GeneralProperty_spec.js
@@ -25,7 +25,7 @@ describe(
 
     it("2. Test to validate text allignment", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Change the text align to center
       cy.xpath(widgetsPage.textCenterAlign).first().click({ force: true });
       // Verify the center text alignment
@@ -41,7 +41,7 @@ describe(
     });
 
     it("3. Test to validate column heading allignment", function () {
-      // cy.openPropertyPane("tablewidget");
+      // _.propPane.openPropertyPane("tablewidget");
       // Change the text align to center
       cy.xpath(widgetsPage.textCenterAlign).first().click({ force: true });
       // Verify the column headings are center aligned
@@ -84,7 +84,7 @@ describe(
     });
 
     it("5. Test to validate vertical allignment", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Select the top vertical alignment
       cy.get(widgetsPage.verticalTop).click({ force: true });
       // verify vertical alignment is top
@@ -140,7 +140,7 @@ describe(
 
     it("8. Test to validate open new tab icon shows when URL type data validate link text ", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       // go back to 1st
       cy.get(commonlocators.editPropBackButton).click({ force: true });
@@ -176,7 +176,7 @@ describe(
     });
 
     it("10. Edit Row height and test table for changes", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.get(widgetsPage.rowHeight).last().click({ force: true });
       cy.get(".t--dropdown-option").contains("Short").click({ force: true });
       cy.wait(2000);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_MultiRowSelect_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_MultiRowSelect_spec.js
@@ -11,7 +11,7 @@ describe(
     });
 
     it("1. Test multi select column shows when enable Multirowselection is true", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.get(widgetsPage.toggleEnableMultirowselection_tablev1)
         .first()
         .click({ force: true });
@@ -34,7 +34,7 @@ describe(
       );
     });
     it("2. Test action configured on onRowSelected get triggered whenever a table row is selected", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.getAlert("onRowSelected", "Row Selected");
       // un select first row
       cy.get(".t--table-multiselect").first().click({ force: true });
@@ -45,7 +45,7 @@ describe(
     });
 
     it("3. It should deselected default Selected Row when the header cell is clicked", () => {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.testJsontext("defaultselectedrow", 0);
 
       // click on header check cell

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Number_column_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Number_column_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("Check number key in table data convert table binding and header properly", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       // numeric table data
       const tableData = [

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_1_spec.js
@@ -14,7 +14,7 @@ describe(
     // To be done:
     // Column Data type: Video
     it("1. Check open section and column data in property pane", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       // Validate the columns are visible in the property pane
       cy.tableColumnDataValidation("id");
@@ -47,7 +47,7 @@ describe(
       cy.makeColumnVisible("userName");
       cy.makeColumnVisible("productName");
       cy.makeColumnVisible("orderAmount");
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       // Open column detail to be edited by draggable id
       cy.editColumn("id");
@@ -178,7 +178,7 @@ describe(
     });
 
     it("6. Test to validate text color and text background", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       // Changing text color to rgb(219, 234, 254) and validate
       cy.selectColor("textcolor");
@@ -219,7 +219,7 @@ describe(
 
     it("7. Table-Delete Verification", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Delete the Table widget
       cy.deleteWidget(widgetsPage.tableWidget);
       _.deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_2_spec.js
@@ -20,7 +20,7 @@ describe(
 
     it("1. Verify On Row Selected Action", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Select show message in the "on selected row" dropdown
       cy.getAlert("onRowSelected", "Row is selected");
       deployMode.DeployApp(locators._widgetInDeployed("tablewidget"));
@@ -34,7 +34,7 @@ describe(
 
     it("2. Check On Page Change Action", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Select show message in the "on selected row" dropdown
       cy.getAlert("onPageChange", "Page Changed");
       deployMode.DeployApp(locators._widgetInDeployed("tablewidget"));
@@ -49,7 +49,7 @@ describe(
 
     it("3. Verify On Search Text Change Action", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Show Message on Search text change Action
       cy.getAlert("onSearchTextChanged", "Search Text Changed");
       deployMode.DeployApp(locators._widgetInDeployed("tablewidget"));
@@ -62,7 +62,7 @@ describe(
     });
 
     it("4. Test to validate text format", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.editColumn("id");
       // Validate Bold text
       cy.get(widgetsPage.bold).click({ force: true });
@@ -76,7 +76,7 @@ describe(
 
     it("5. Verify default search text", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.backFromPropertyPanel();
       // Chage deat search text value to "data"
       cy.testJsontext("defaultsearchtext", "data");
@@ -89,7 +89,7 @@ describe(
 
     it("6. Verify default selected row", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.backFromPropertyPanel();
       cy.testJsontext("defaultsearchtext", "");
       // Change default selected row value to 1
@@ -108,7 +108,7 @@ describe(
 
     it("7. Verify table column type button with button variant", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Add new column in the table with name "CustomColumn"
       cy.addColumn("CustomColumn");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_2_spec.js
@@ -5,6 +5,7 @@ import {
   deployMode,
   locators,
   table,
+  propPane
 } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
@@ -20,7 +21,7 @@ describe(
 
     it("1. Verify On Row Selected Action", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // Select show message in the "on selected row" dropdown
       cy.getAlert("onRowSelected", "Row is selected");
       deployMode.DeployApp(locators._widgetInDeployed("tablewidget"));
@@ -34,7 +35,7 @@ describe(
 
     it("2. Check On Page Change Action", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // Select show message in the "on selected row" dropdown
       cy.getAlert("onPageChange", "Page Changed");
       deployMode.DeployApp(locators._widgetInDeployed("tablewidget"));
@@ -49,7 +50,7 @@ describe(
 
     it("3. Verify On Search Text Change Action", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // Show Message on Search text change Action
       cy.getAlert("onSearchTextChanged", "Search Text Changed");
       deployMode.DeployApp(locators._widgetInDeployed("tablewidget"));
@@ -62,7 +63,7 @@ describe(
     });
 
     it("4. Test to validate text format", function () {
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       cy.editColumn("id");
       // Validate Bold text
       cy.get(widgetsPage.bold).click({ force: true });
@@ -76,7 +77,7 @@ describe(
 
     it("5. Verify default search text", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       cy.backFromPropertyPanel();
       // Chage deat search text value to "data"
       cy.testJsontext("defaultsearchtext", "data");
@@ -89,7 +90,7 @@ describe(
 
     it("6. Verify default selected row", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       cy.backFromPropertyPanel();
       cy.testJsontext("defaultsearchtext", "");
       // Change default selected row value to 1
@@ -108,7 +109,7 @@ describe(
 
     it("7. Verify table column type button with button variant", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // Add new column in the table with name "CustomColumn"
       cy.addColumn("CustomColumn");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_IconName_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_PropertyPane_IconName_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("Verify table column type changes effect on menuButton and iconButton", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.addColumn("CustomColumn");
       cy.editColumn("customColumn1");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Property_JsonUpdate_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Property_JsonUpdate_spec.js
@@ -85,7 +85,7 @@ describe(
     it("4. Check Selected Row(s) Resets When Table data Changes", function () {
       // Select 1st row
       _.table.SelectTableRow(1);
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Empty first row
       cy.testJsontext("tabledata", "[]");
       cy.wait("@updateLayout");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Switch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Switch_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("Table Widget Data validation with Switch ON", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.readTabledataPublish("1", "1").then((tabData) => {
         const tabValue = tabData;
         expect(tabValue).to.be.equal("30");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Add_button_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("1. Table widget with Add button test and validation", function () {
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // Open column details of "id".
       cy.editColumn("id");
       cy.get(widgetsPage.tableBtn).should("not.exist");
@@ -69,7 +69,7 @@ describe(
     });
 
     it("2. Table Button color validation", function () {
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // Open column details of "id".
       cy.editColumn("id");
       // Changing column data type to "Button"
@@ -160,7 +160,7 @@ describe(
     });
 
     it("5. Table widget add new menu button column", function () {
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // click on Add new Column.
       cy.get(".t--add-column-btn").click();
       //Open New Custom Column
@@ -285,7 +285,7 @@ describe(
       });
 
       // Close Property pane
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       // Click on the Menu button
       cy.contains("Menu button").click({
         force: true,
@@ -309,7 +309,7 @@ describe(
       cy.closePropertyPane();
 
       // disable menu item 3
-      //_.propPane.openPropertyPane("tablewidget");
+      //propPane.openPropertyPane("tablewidget");
 
       //cy.editColumn("customColumn1");
       // Edit a Menu item

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Add_button_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("1. Table widget with Add button test and validation", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Open column details of "id".
       cy.editColumn("id");
       cy.get(widgetsPage.tableBtn).should("not.exist");
@@ -69,7 +69,7 @@ describe(
     });
 
     it("2. Table Button color validation", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Open column details of "id".
       cy.editColumn("id");
       // Changing column data type to "Button"
@@ -160,7 +160,7 @@ describe(
     });
 
     it("5. Table widget add new menu button column", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // click on Add new Column.
       cy.get(".t--add-column-btn").click();
       //Open New Custom Column
@@ -285,7 +285,7 @@ describe(
       });
 
       // Close Property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Click on the Menu button
       cy.contains("Menu button").click({
         force: true,
@@ -309,7 +309,7 @@ describe(
       cy.closePropertyPane();
 
       // disable menu item 3
-      //cy.openPropertyPane("tablewidget");
+      //_.propPane.openPropertyPane("tablewidget");
 
       //cy.editColumn("customColumn1");
       // Edit a Menu item

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Copy_Paste_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Copy_Paste_spec.js
@@ -9,6 +9,7 @@ const widgetsPage = require("../../../../../locators/Widgets.json");
 import {
   agHelper,
   entityExplorer,
+  propPane
 } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
@@ -21,7 +22,7 @@ describe(
 
     it("Copy paste table widget and valdiate application status", function () {
       const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
-      _.propPane.openPropertyPane("tablewidget");
+      propPane.openPropertyPane("tablewidget");
       cy.widgetText(
         "Table1",
         widgetsPage.tableWidget,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Copy_Paste_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Copy_Paste_spec.js
@@ -21,7 +21,7 @@ describe(
 
     it("Copy paste table widget and valdiate application status", function () {
       const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.widgetText(
         "Table1",
         widgetsPage.tableWidget,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Default_Row_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Default_Row_spec.js
@@ -13,7 +13,7 @@ describe(
 
     it("Verify default table row Data", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.wait(2000);
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Derived_Column_Computed_value_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Derived_Column_Computed_value_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("Test to add column", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Adding new column
       cy.addColumn("CustomColumn");
       cy.tableColumnDataValidation("customColumn1"); //To be updated later

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Selected_row_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Widget_Selected_row_spec.js
@@ -8,7 +8,7 @@ describe(
       _.agHelper.AddDsl("tableAndTextDsl");
     });
     it("Table widget new menu button column should not deselect row", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       cy.get(".t--widget-textwidget").should("have.text", "0");
       cy.contains("Open Menu").click({

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("Table Widget Functionality", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       /**
        * @param{Text} Random Text
@@ -52,7 +52,7 @@ describe(
     });
 
     it("Table Widget Functionality To Show a Base64 Image", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       cy.editColumn("image");
       cy.changeColumnType("Image", false);
       _.table.SelectTableRow(1);
@@ -66,7 +66,7 @@ describe(
 
     it("Table Widget Functionality To Check if Table is Sortable", function () {
       cy.get(commonlocators.editPropBackButton).click();
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Confirm if isSortable is true
       cy.get(commonlocators.isSortable_tablev1).should("be.checked");
       // Publish App
@@ -97,7 +97,7 @@ describe(
       // Back to edit page
       _.deployMode.NavigateBacktoEditor();
 
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
       // Disable isSortable
       // Confirm if isSortable is false
       _.agHelper.CheckUncheck(commonlocators.isSortable_tablev1, false);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_tabledata_schema_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_tabledata_schema_spec.js
@@ -14,7 +14,7 @@ describe("Table Widget", { tags: ["@tag.Widget", "@tag.Table"] }, function () {
     cy.wait(5000);
     cy.dragAndDropToCanvas("switchwidget", { x: 200, y: 200 });
     cy.wait(2000);
-    cy.openPropertyPane("tablewidget");
+    _.propPane.openPropertyPane("tablewidget");
     cy.get(".t--property-control-tabledata").then(($el) => {
       cy.updateCodeInput($el, jsContext);
     });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/table_with_text_no_2dArray_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/table_with_text_no_2dArray_spec.js
@@ -13,7 +13,7 @@ describe(
     it("Check if the selectedRowIndices does not contain 2d array", function () {
       testTimeout(seconds(120)); //2mins
 
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       //Enable Multi row select
       cy.get(widgetsPage.toggleEnableMultirowselection_tablev1)

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/table_with_text_selRowIndices_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV1/table_with_text_selRowIndices_spec.js
@@ -11,7 +11,7 @@ describe(
     });
 
     it("Check if the selectedRowIndices does not contain -1", function () {
-      cy.openPropertyPane("tablewidget");
+      _.propPane.openPropertyPane("tablewidget");
 
       //Update the property default selected row to blank
       cy.updateCodeInput(".t--property-control-defaultselectedrow", "");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow1_spec.js
@@ -12,7 +12,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
   });
 
   it("1.1. should test that allow Add new row property is present", () => {
-    cy.openPropertyPane("tablewidgetv2");
+    _.propPane.openPropertyPane("tablewidgetv2");
     cy.get(".t--property-control-allowaddingarow").should("exist");
     cy.get(".t--property-control-allowaddingarow input").should("exist");
     cy.get(".t--add-new-row").should("not.exist");
@@ -32,7 +32,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
     table.toggleColumnEditableViaColSettingsPane("step");
     cy.editTableCell(0, 0);
     cy.get(".t--add-new-row.disabled").should("exist");
-    cy.openPropertyPane("tablewidgetv2");
+    _.propPane.openPropertyPane("tablewidgetv2");
     cy.get(".tableWrap .new-row").should("not.exist");
     // clicking on add new row link adds an empty row at the top of the table
     cy.get(".t--add-new-row").click();
@@ -125,7 +125,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
     cy.enterTableCellValue(0, 0, "22");
     cy.enterTableCellValue(1, 0, "21");
     cy.dragAndDropToCanvas("textwidget", { x: 300, y: 600 });
-    cy.openPropertyPane("textwidget");
+    _.propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(".t--property-control-text", `{{Table1.newRow}}`);
     cy.get(".t--widget-textwidget .bp3-ui-text").should(
       "contain",
@@ -134,7 +134,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
   });
 
   it("1.6. should test that non data (iconBitton, button, menubutton) column cells are not showing up", () => {
-    cy.openPropertyPane("tablewidgetv2");
+    _.propPane.openPropertyPane("tablewidgetv2");
     table.toggleColumnEditableViaColSettingsPane("step", "v2", false, false);
     ["Button", "Menu button", "Icon button"].forEach((columnType) => {
       cy.get(commonlocators.changeColType).last().click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow1_spec.js
@@ -12,7 +12,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
   });
 
   it("1.1. should test that allow Add new row property is present", () => {
-    _.propPane.openPropertyPane("tablewidgetv2");
+    propPane.openPropertyPane("tablewidgetv2");
     cy.get(".t--property-control-allowaddingarow").should("exist");
     cy.get(".t--property-control-allowaddingarow input").should("exist");
     cy.get(".t--add-new-row").should("not.exist");
@@ -32,7 +32,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
     table.toggleColumnEditableViaColSettingsPane("step");
     cy.editTableCell(0, 0);
     cy.get(".t--add-new-row.disabled").should("exist");
-    _.propPane.openPropertyPane("tablewidgetv2");
+    propPane.openPropertyPane("tablewidgetv2");
     cy.get(".tableWrap .new-row").should("not.exist");
     // clicking on add new row link adds an empty row at the top of the table
     cy.get(".t--add-new-row").click();
@@ -125,7 +125,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
     cy.enterTableCellValue(0, 0, "22");
     cy.enterTableCellValue(1, 0, "21");
     cy.dragAndDropToCanvas("textwidget", { x: 300, y: 600 });
-    _.propPane.openPropertyPane("textwidget");
+    propPane.openPropertyPane("textwidget");
     cy.updateCodeInput(".t--property-control-text", `{{Table1.newRow}}`);
     cy.get(".t--widget-textwidget .bp3-ui-text").should(
       "contain",
@@ -134,7 +134,7 @@ describe("Basic flow ", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
   });
 
   it("1.6. should test that non data (iconBitton, button, menubutton) column cells are not showing up", () => {
-    _.propPane.openPropertyPane("tablewidgetv2");
+    propPane.openPropertyPane("tablewidgetv2");
     table.toggleColumnEditableViaColSettingsPane("step", "v2", false, false);
     ["Button", "Menu button", "Icon button"].forEach((columnType) => {
       cy.get(commonlocators.changeColType).last().click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow2_spec.js
@@ -9,7 +9,7 @@ describe("Validation flow", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
   });
 
   it("2.1. should test that validation is working for a new row cell", () => {
-    cy.openPropertyPane("tablewidgetv2");
+    _.propPane.openPropertyPane("tablewidgetv2");
     _.propPane.TogglePropertyState("Allow adding a row", "On");
     cy.get(".t--add-new-row").click();
     _.table.toggleColumnEditableViaColSettingsPane("step", "v2", true, false);
@@ -137,7 +137,7 @@ describe("Validation flow", { tags: ["@tag.Widget", "@tag.Table"] }, () => {
     cy.get(".error-tooltip .bp3-popover-content").should("not.exist");
     cy.get(`[data-colindex=1][data-rowindex=0] input`).focus();
     cy.get(".error-tooltip .bp3-popover-content").should("have.length", 1);
-    cy.openPropertyPane("tablewidgetv2");
+    _.propPane.openPropertyPane("tablewidgetv2");
     cy.get(".error-tooltip .bp3-popover-content").should("not.exist");
     cy.get(`[data-colindex=0][data-rowindex=0] input`).focus();
     cy.get(".error-tooltip .bp3-popover-content").should("have.length", 1);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/AddNewRow3_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("3.1. should test that discard button is undoing the add new feature", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       _.propPane.TogglePropertyState("Allow adding a row", "On");
       cy.get(".tableWrap .new-row").should("not.exist");
       cy.get(".t--add-new-row").click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Custom_column_alias_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Custom_column_alias_spec.js
@@ -21,7 +21,7 @@ describe(
     });
 
     it("1. should test that custom column has alias property", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       _.propPane.UpdatePropertyFieldValue("Table data", JSON.stringify(data));
       cy.wait("@updateLayout");
       cy.wait(1000);
@@ -37,9 +37,9 @@ describe(
 
     it("2. should test that custom alias is used in the selectedRow", () => {
       cy.dragAndDropToCanvas("textwidget", { x: 200, y: 100 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       _.propPane.UpdatePropertyFieldValue("Text", "{{Table1.selectedRow}}");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("customColumn1");
       _.propPane.UpdatePropertyFieldValue("Property Name", "columnAlias");
       cy.get(".t--widget-textwidget .bp3-ui-text").should(
@@ -54,9 +54,9 @@ describe(
     });
 
     it("3. should test that custom alias is used in the triggeredRow", () => {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       _.propPane.UpdatePropertyFieldValue("Text", "{{Table1.triggeredRow}}");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.backFromPropertyPanel();
       cy.get(widgetsPage.addColumn).scrollIntoView();
       cy.get(widgetsPage.addColumn).click({ force: true });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Edge_case_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Edge_case_spec.js
@@ -46,7 +46,7 @@ describe(
     });
 
     it("2. Check if the selectedRowIndices does not contain -1", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
 
       //Update the property default selected row to blank
       cy.updateCodeInput(".t--property-control-defaultselectedrow", "");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Edge_case_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Edge_case_spec.js
@@ -46,7 +46,7 @@ describe(
     });
 
     it("2. Check if the selectedRowIndices does not contain -1", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       //Update the property default selected row to blank
       cy.updateCodeInput(".t--property-control-defaultselectedrow", "");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Image_resize_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Image_resize_spec.js
@@ -13,7 +13,7 @@ describe(
         cy.get(`${selector} img`).should("have.css", "height", "32px");
       });
 
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("image");
       cy.moveToStyleTab();
 
@@ -36,7 +36,7 @@ describe(
     });
 
     it("2. Verify image size with cell wrapping turned on", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("title");
       cy.moveToContentTab();
       cy.get(".t--property-control-cellwrapping input").click();
@@ -46,7 +46,7 @@ describe(
         cy.get(`${selector} img`).should("have.css", "height", "32px");
       });
 
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("image");
       cy.moveToStyleTab();
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_1_spec.js
@@ -17,7 +17,7 @@ describe(
     let propPaneBack = "[data-testid='t--property-pane-back-btn']";
 
     it("1. should check that editable property is only available for Plain text & number columns", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       [
         {
@@ -68,7 +68,7 @@ describe(
     });
 
     it("2. should check that inline save option is shown only when a column is made editable", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(".t--property-control-updatemode").should("not.exist");
 
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
@@ -77,7 +77,7 @@ describe(
       cy.get(".t--property-control-updatemode").should("exist");
 
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 600 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{Table1.inlineEditingSaveOption}}`,
@@ -89,7 +89,7 @@ describe(
     });
 
     it("3. should check that save/discard column is added when a column is made editable and removed when made uneditable", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.get("[data-rbd-draggable-id='EditActions1']").should("exist");
       cy.get(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_1_spec.js
@@ -1,5 +1,5 @@
 const commonlocators = require("../../../../../locators/commonlocators.json");
-import { agHelper, table } from "../../../../../support/Objects/ObjectsCore";
+import { agHelper, table, propPane } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
   "Table widget inline editing functionality",
@@ -17,7 +17,7 @@ describe(
     let propPaneBack = "[data-testid='t--property-pane-back-btn']";
 
     it("1. should check that editable property is only available for Plain text & number columns", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       [
         {
@@ -68,7 +68,7 @@ describe(
     });
 
     it("2. should check that inline save option is shown only when a column is made editable", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.get(".t--property-control-updatemode").should("not.exist");
 
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
@@ -77,7 +77,7 @@ describe(
       cy.get(".t--property-control-updatemode").should("exist");
 
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 600 });
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{Table1.inlineEditingSaveOption}}`,
@@ -89,7 +89,7 @@ describe(
     });
 
     it("3. should check that save/discard column is added when a column is made editable and removed when made uneditable", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.get("[data-rbd-draggable-id='EditActions1']").should("exist");
       cy.get(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -29,7 +29,7 @@ describe(
     let propPaneBack = "[data-testid='t--property-pane-back-btn']";
 
     it("1. should check that onDiscard event is working", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editColumn("EditActions1");
       cy.get(".t--property-pane-section-collapse-savebutton").click();
@@ -37,7 +37,7 @@ describe(
       cy.getAlert("onDiscard", "discarded!!");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "NewValue");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.discardTableRow(4, 0);
       cy.get(widgetsPage.toastAction).should("be.visible");
       cy.get(widgetsPage.toastActionText)
@@ -50,7 +50,7 @@ describe(
 
     it("2. should check that inline editing works with text wrapping disabled", () => {
       agHelper.AddDsl("Table/InlineEditingDSL");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", false, true);
       cy.editTableCell(0, 0);
       cy.get(
@@ -59,7 +59,7 @@ describe(
     });
 
     it("3. should check that inline editing works with text wrapping enabled", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editColumn("step");
       cy.get(".t--property-control-cellwrapping .ads-v2-switch")
@@ -128,7 +128,7 @@ describe(
       // case 1: check if updatedRowIndex has -1 as the default value:
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);
 
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
 
       table.toggleColumnEditableViaColSettingsPane("step", "v2", false, true);
       cy.wait(1000);
@@ -152,7 +152,7 @@ describe(
       cy.wait(1000);
       cy.editTableCell(0, 2);
       cy.enterTableCellValue(0, 2, "#14").type("{enter}");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.get(widgetsPage.tabedataField).type("{cmd}{a} {backspace}");
       cy.wait(300);
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);
@@ -193,7 +193,7 @@ describe(
       cy.wait(1000);
       table.EditTableCell(2, 0, "#14");
       cy.get(commonlocators.textWidgetContainer).should("contain.text", 2);
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.get(widgetsPage.tabedataField).type("{cmd}{a} {backspace}");
       cy.wait(300);
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -29,7 +29,7 @@ describe(
     let propPaneBack = "[data-testid='t--property-pane-back-btn']";
 
     it("1. should check that onDiscard event is working", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editColumn("EditActions1");
       cy.get(".t--property-pane-section-collapse-savebutton").click();
@@ -37,7 +37,7 @@ describe(
       cy.getAlert("onDiscard", "discarded!!");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "NewValue");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.discardTableRow(4, 0);
       cy.get(widgetsPage.toastAction).should("be.visible");
       cy.get(widgetsPage.toastActionText)
@@ -50,7 +50,7 @@ describe(
 
     it("2. should check that inline editing works with text wrapping disabled", () => {
       agHelper.AddDsl("Table/InlineEditingDSL");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", false, true);
       cy.editTableCell(0, 0);
       cy.get(
@@ -59,7 +59,7 @@ describe(
     });
 
     it("3. should check that inline editing works with text wrapping enabled", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editColumn("step");
       cy.get(".t--property-control-cellwrapping .ads-v2-switch")
@@ -128,7 +128,7 @@ describe(
       // case 1: check if updatedRowIndex has -1 as the default value:
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);
 
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       table.toggleColumnEditableViaColSettingsPane("step", "v2", false, true);
       cy.wait(1000);
@@ -152,7 +152,7 @@ describe(
       cy.wait(1000);
       cy.editTableCell(0, 2);
       cy.enterTableCellValue(0, 2, "#14").type("{enter}");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(widgetsPage.tabedataField).type("{cmd}{a} {backspace}");
       cy.wait(300);
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);
@@ -193,7 +193,7 @@ describe(
       cy.wait(1000);
       table.EditTableCell(2, 0, "#14");
       cy.get(commonlocators.textWidgetContainer).should("contain.text", 2);
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(widgetsPage.tabedataField).type("{cmd}{a} {backspace}");
       cy.wait(300);
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -21,7 +21,7 @@ describe(
     let propPaneBack = "[data-testid='t--property-pane-back-btn']";
 
     it("1. should check that save/discard column is added/removed when inline save option is changed", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.get("[data-rbd-draggable-id='EditActions1']").should("exist");
       cy.get(".t--property-control-updatemode .t--property-control-label")
@@ -65,7 +65,7 @@ describe(
     });
 
     it("2. should check that cell of an editable column is editable", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       // click the edit icon
       cy.editTableCell(0, 0);
@@ -74,7 +74,7 @@ describe(
       ).should("not.be.disabled");
 
       //double click the cell
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         `[data-colindex=0][data-rowindex=0] .t--inlined-cell-editor input.bp3-input`,
       ).should("not.exist");
@@ -90,7 +90,7 @@ describe(
     });
 
     it("3. should check that changes can be discarded by clicking escape", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       let value;
       cy.readTableV2data(0, 0).then((val) => {
         value = val;
@@ -108,7 +108,7 @@ describe(
     });
 
     it("4. should check that changes can be saved by pressing enter or clicking outside", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       let value;
       cy.readTableV2data(0, 0).then((val) => {
         value = val;
@@ -127,7 +127,7 @@ describe(
       });
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "someOtherNewValue");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         `[data-colindex="0"][data-rowindex="0"] .t--inlined-cell-editor input.bp3-input`,
       ).should("not.exist");
@@ -139,9 +139,9 @@ describe(
 
     it("5. should check that updatedRows and updatedRowIndices have correct values", () => {
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(".t--property-control-text", `{{Table1.updatedRows}}`);
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "newValue");
@@ -150,7 +150,7 @@ describe(
         "contain",
         `[  {    "index": 0,    "updatedFields": {      "step": "newValue"    },    "allFields": {      "step": "newValue",      "task": "Drop a table",      "status": "✅"    }  }]`,
       );
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{Table1.updatedRowIndices}}`,
@@ -159,7 +159,7 @@ describe(
     });
 
     it("6. should check that onsubmit event is available for the columns that are editable", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       cy.wait(500);
       [
@@ -268,7 +268,7 @@ describe(
     });
 
     it("7. should check that onsubmit event is triggered when changes are saved", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane(
         "step",
         "v2",
@@ -291,7 +291,7 @@ describe(
 
     it("8. should check that onSubmit events has access to edit values through triggeredRow", () => {
       const value = "newCellValue";
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane(
         "step",
         "v2",
@@ -313,7 +313,7 @@ describe(
     });
 
     it("9. should check that onSave is working", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.editColumn("EditActions1");
       //cy.get(".t--property-pane-section-collapse-savebutton").click({force:true});
@@ -323,7 +323,7 @@ describe(
       cy.getAlert("onSave", "Saved!!");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "NewValue");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.saveTableRow(4, 0);
       cy.get(widgetsPage.toastAction).should("be.visible");
       cy.get(widgetsPage.toastActionText)
@@ -335,7 +335,7 @@ describe(
     });
 
     it("10. should check that onSave events has access to edit values through triggeredRow", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.editColumn("EditActions1");
       //cy.get(".t--property-pane-section-collapse-savebutton").click({force:true});
@@ -351,7 +351,7 @@ describe(
     */
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "NewValue");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.saveTableRow(4, 0);
       cy.get(widgetsPage.toastAction).should("be.visible");
       cy.get(widgetsPage.toastActionText)

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -3,6 +3,7 @@ const widgetsPage = require("../../../../../locators/Widgets.json");
 import {
   agHelper,
   table as tableHelper,
+  propPane
 } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
@@ -21,7 +22,7 @@ describe(
     let propPaneBack = "[data-testid='t--property-pane-back-btn']";
 
     it("1. should check that save/discard column is added/removed when inline save option is changed", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.get("[data-rbd-draggable-id='EditActions1']").should("exist");
       cy.get(".t--property-control-updatemode .t--property-control-label")
@@ -65,7 +66,7 @@ describe(
     });
 
     it("2. should check that cell of an editable column is editable", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       // click the edit icon
       cy.editTableCell(0, 0);
@@ -74,7 +75,7 @@ describe(
       ).should("not.be.disabled");
 
       //double click the cell
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         `[data-colindex=0][data-rowindex=0] .t--inlined-cell-editor input.bp3-input`,
       ).should("not.exist");
@@ -90,7 +91,7 @@ describe(
     });
 
     it("3. should check that changes can be discarded by clicking escape", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       let value;
       cy.readTableV2data(0, 0).then((val) => {
         value = val;
@@ -108,7 +109,7 @@ describe(
     });
 
     it("4. should check that changes can be saved by pressing enter or clicking outside", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       let value;
       cy.readTableV2data(0, 0).then((val) => {
         value = val;
@@ -127,7 +128,7 @@ describe(
       });
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "someOtherNewValue");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         `[data-colindex="0"][data-rowindex="0"] .t--inlined-cell-editor input.bp3-input`,
       ).should("not.exist");
@@ -139,9 +140,9 @@ describe(
 
     it("5. should check that updatedRows and updatedRowIndices have correct values", () => {
       cy.dragAndDropToCanvas("textwidget", { x: 300, y: 500 });
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(".t--property-control-text", `{{Table1.updatedRows}}`);
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "newValue");
@@ -150,7 +151,7 @@ describe(
         "contain",
         `[  {    "index": 0,    "updatedFields": {      "step": "newValue"    },    "allFields": {      "step": "newValue",      "task": "Drop a table",      "status": "✅"    }  }]`,
       );
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{Table1.updatedRowIndices}}`,
@@ -159,7 +160,7 @@ describe(
     });
 
     it("6. should check that onsubmit event is available for the columns that are editable", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       cy.wait(500);
       [
@@ -268,7 +269,7 @@ describe(
     });
 
     it("7. should check that onsubmit event is triggered when changes are saved", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane(
         "step",
         "v2",
@@ -291,7 +292,7 @@ describe(
 
     it("8. should check that onSubmit events has access to edit values through triggeredRow", () => {
       const value = "newCellValue";
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane(
         "step",
         "v2",
@@ -313,7 +314,7 @@ describe(
     });
 
     it("9. should check that onSave is working", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.editColumn("EditActions1");
       //cy.get(".t--property-pane-section-collapse-savebutton").click({force:true});
@@ -323,7 +324,7 @@ describe(
       cy.getAlert("onSave", "Saved!!");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "NewValue");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.saveTableRow(4, 0);
       cy.get(widgetsPage.toastAction).should("be.visible");
       cy.get(widgetsPage.toastActionText)
@@ -335,7 +336,7 @@ describe(
     });
 
     it("10. should check that onSave events has access to edit values through triggeredRow", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       tableHelper.toggleColumnEditableViaColSettingsPane("step");
       cy.editColumn("EditActions1");
       //cy.get(".t--property-pane-section-collapse-savebutton").click({force:true});
@@ -351,7 +352,7 @@ describe(
     */
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "NewValue");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.saveTableRow(4, 0);
       cy.get(widgetsPage.toastAction).should("be.visible");
       cy.get(widgetsPage.toastActionText)

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Button_Icon_validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Button_Icon_validation_spec.js
@@ -13,7 +13,7 @@ describe(
     });
 
     it("1. Table widget V2 with with modal popup", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       //update Table name with _
       cy.widgetText(
         "Table_1",
@@ -29,7 +29,7 @@ describe(
     });
 
     it("2. Table widget V2 with button colour change validation", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Open column details of "id".
       cy.editColumn("id");
       cy.get(widgetsPage.tableV2Btn).should("not.exist");
@@ -55,7 +55,7 @@ describe(
     });
 
     it("3. Table widget icon type and colour validation", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Open column details of "id".
       cy.get(commonlocators.editPropBackButton).click({ force: true });
       cy.editColumn("id");
@@ -75,7 +75,7 @@ describe(
     });
 
     it("4. Table widget v2 column reorder and reload function", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(commonlocators.editPropBackButton).click({ force: true });
       cy.hideColumn("email");
       cy.hideColumn("userName");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Color_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Color_spec.js
@@ -19,7 +19,7 @@ describe(
 
     it("1. Test to validate text color and text background", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Click on text color input field
       cy.selectColor("textcolor");
@@ -55,7 +55,7 @@ describe(
         "rgb(219, 234, 254)",
       );
       _.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Change the cell background color and enter purple in input field
       cy.get(
@@ -79,7 +79,7 @@ describe(
     });
 
     it("2. check background of the edit action column", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       _.table.toggleColumnEditableViaColSettingsPane("id", "v2", true, true);
       cy.readTableV2dataValidateCSS(
         0,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_FilteredTableData_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_FilteredTableData_spec.js
@@ -15,7 +15,7 @@ describe(
   function () {
     before("Table Widget V2 Functionality", () => {
       _.agHelper.AddDsl("tableV2AndTextDsl");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
     });
 
     it("1. Table Widget V2 Functionality To Filter and search data", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_GeneralProperty_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_GeneralProperty_spec.js
@@ -7,6 +7,7 @@ import {
   agHelper,
   deployMode,
   table,
+  propPane
 } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
@@ -34,7 +35,7 @@ describe(
 
     it("2. Test to validate text allignment", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Change the text align to center
       cy.xpath(widgetsPage.textCenterAlign).first().click({ force: true });
@@ -51,7 +52,7 @@ describe(
     });
 
     it("3. Test to validate column heading allignment", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Change the text align to center
       cy.xpath(widgetsPage.textCenterAlign).first().click({ force: true });
@@ -98,7 +99,7 @@ describe(
     });
 
     it("5. Test to validate vertical allignment", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Select the top vertical alignment
       cy.get(widgetsPage.verticalTop).click({ force: true });
@@ -151,7 +152,7 @@ describe(
 
     it("8. Test to validate open new tab icon shows when URL type data validate link text ", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
 
       // go back to 1st
       cy.get(commonlocators.editPropBackButton).click({ force: true });
@@ -176,7 +177,7 @@ describe(
     });
 
     it("10. Edit Row height and test table for changes", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       cy.get("[data-value='SHORT']").click({ force: true });
       cy.wait(2000);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_GeneralProperty_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_GeneralProperty_spec.js
@@ -34,7 +34,7 @@ describe(
 
     it("2. Test to validate text allignment", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Change the text align to center
       cy.xpath(widgetsPage.textCenterAlign).first().click({ force: true });
@@ -51,7 +51,7 @@ describe(
     });
 
     it("3. Test to validate column heading allignment", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Change the text align to center
       cy.xpath(widgetsPage.textCenterAlign).first().click({ force: true });
@@ -98,7 +98,7 @@ describe(
     });
 
     it("5. Test to validate vertical allignment", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       // Select the top vertical alignment
       cy.get(widgetsPage.verticalTop).click({ force: true });
@@ -151,7 +151,7 @@ describe(
 
     it("8. Test to validate open new tab icon shows when URL type data validate link text ", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       // go back to 1st
       cy.get(commonlocators.editPropBackButton).click({ force: true });
@@ -176,7 +176,7 @@ describe(
     });
 
     it("10. Edit Row height and test table for changes", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToStyleTab();
       cy.get("[data-value='SHORT']").click({ force: true });
       cy.wait(2000);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_MultiRowSelect_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_MultiRowSelect_spec.js
@@ -11,7 +11,7 @@ describe(
     });
 
     it("1. Test multi select column shows when enable Multirowselection is true", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(widgetsPage.toggleEnableMultirowselection)
         .first()
         .click({ force: true });
@@ -40,7 +40,7 @@ describe(
     });
 
     it("4. Test action configured on onRowSelected get triggered whenever a table row is selected", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.getAlert("onRowSelected", "Row Selected");
       // un select first row
       cy.get(".t--table-multiselect").first().click({ force: true });
@@ -53,7 +53,7 @@ describe(
     });
 
     it("5. It should deselected default Selected Row when the header cell is clicked", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.testJsontext("defaultselectedrows", "[0]");
 
       // click on header check cell

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_1_spec.js
@@ -27,7 +27,7 @@ describe(
     // Column Data type: Video
     it("1. Verify default array data", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Drag and drop table widget
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 300, 200);
       EditorNavigation.SelectEntityByName("Table2", EntityType.Widget);
@@ -62,7 +62,7 @@ describe(
 
     it("3. Verify On Row Selected Action", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Select show message in the "on selected row" dropdown
       cy.getAlert("onRowSelected", "Row is selected");
       deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.TABLE));
@@ -76,7 +76,7 @@ describe(
 
     it("4. Verify On Search Text Change Action", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Show Message on Search text change Action
       cy.getAlert("onSearchTextChanged", "Search Text Changed");
       deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.TABLE));
@@ -90,7 +90,7 @@ describe(
 
     it("5. Check On Page Change Action", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(".t--property-control-serversidepagination input").click({
         force: true,
       });
@@ -107,7 +107,7 @@ describe(
     });
 
     it("6. Check open section and column data in property pane", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       // Validate the columns are visible in the property pane
       cy.tableV2ColumnDataValidation("id");
@@ -135,13 +135,13 @@ describe(
     });
 
     it("7. Column Detail - Edit column name and validate test for computed value based on column type selected", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.wait(1000);
       cy.makeColumnVisible("email");
       cy.makeColumnVisible("userName");
       cy.makeColumnVisible("productName");
       cy.makeColumnVisible("orderAmount");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       // Open column detail to be edited by draggable id
       cy.editColumn("id");
@@ -235,7 +235,7 @@ describe(
     });
 
     it("8. Test to validate text allignment", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(commonlocators.changeColType).last().click();
       cy.get(".t--dropdown-option").children().contains("URL").click();
       // cy.get(".t--property-control-visible span.bp3-control-indicator").click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_1_spec.js
@@ -27,7 +27,7 @@ describe(
     // Column Data type: Video
     it("1. Verify default array data", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       // Drag and drop table widget
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 300, 200);
       EditorNavigation.SelectEntityByName("Table2", EntityType.Widget);
@@ -62,7 +62,7 @@ describe(
 
     it("3. Verify On Row Selected Action", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       // Select show message in the "on selected row" dropdown
       cy.getAlert("onRowSelected", "Row is selected");
       deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.TABLE));
@@ -76,7 +76,7 @@ describe(
 
     it("4. Verify On Search Text Change Action", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       // Show Message on Search text change Action
       cy.getAlert("onSearchTextChanged", "Search Text Changed");
       deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.TABLE));
@@ -90,7 +90,7 @@ describe(
 
     it("5. Check On Page Change Action", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.get(".t--property-control-serversidepagination input").click({
         force: true,
       });
@@ -107,7 +107,7 @@ describe(
     });
 
     it("6. Check open section and column data in property pane", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
 
       // Validate the columns are visible in the property pane
       cy.tableV2ColumnDataValidation("id");
@@ -135,13 +135,13 @@ describe(
     });
 
     it("7. Column Detail - Edit column name and validate test for computed value based on column type selected", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.wait(1000);
       cy.makeColumnVisible("email");
       cy.makeColumnVisible("userName");
       cy.makeColumnVisible("productName");
       cy.makeColumnVisible("orderAmount");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
 
       // Open column detail to be edited by draggable id
       cy.editColumn("id");
@@ -235,7 +235,7 @@ describe(
     });
 
     it("8. Test to validate text allignment", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.get(commonlocators.changeColType).last().click();
       cy.get(".t--dropdown-option").children().contains("URL").click();
       // cy.get(".t--property-control-visible span.bp3-control-indicator").click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_2_spec.js
@@ -18,7 +18,7 @@ describe(
     });
 
     it("1. Test to validate text color and text background", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("id");
       cy.moveToStyleTab();
       // Changing text color to rgb(219, 234, 254) and validate
@@ -59,7 +59,7 @@ describe(
 
     it("2. Verify default search text", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.moveToContentTab();
       // Chage deat search text value to "data"
       cy.backFromPropertyPanel();
@@ -73,7 +73,7 @@ describe(
 
     it("3. Verify custom column property name changes with change in column name ([FEATURE]: #17142)", function () {
       // Open property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.moveToContentTab();
       cy.addColumnV2("customColumn18");
       cy.editColumn("customColumn1");
@@ -113,7 +113,7 @@ describe(
 
     it("4. It provides currentRow and currentIndex properties in min validation field", function () {
       agHelper.AddDsl("tableV2NewDslWithPagination");
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane(
         "orderAmount",
         "v2",
@@ -253,7 +253,7 @@ describe(
     });
 
     it("5. Verify default prompt message for min field", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane(
         "orderAmount",
         "v2",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_2_spec.js
@@ -18,7 +18,7 @@ describe(
     });
 
     it("1. Test to validate text color and text background", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("id");
       cy.moveToStyleTab();
       // Changing text color to rgb(219, 234, 254) and validate
@@ -59,7 +59,7 @@ describe(
 
     it("2. Verify default search text", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToContentTab();
       // Chage deat search text value to "data"
       cy.backFromPropertyPanel();
@@ -73,7 +73,7 @@ describe(
 
     it("3. Verify custom column property name changes with change in column name ([FEATURE]: #17142)", function () {
       // Open property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.moveToContentTab();
       cy.addColumnV2("customColumn18");
       cy.editColumn("customColumn1");
@@ -113,7 +113,7 @@ describe(
 
     it("4. It provides currentRow and currentIndex properties in min validation field", function () {
       agHelper.AddDsl("tableV2NewDslWithPagination");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane(
         "orderAmount",
         "v2",
@@ -253,7 +253,7 @@ describe(
     });
 
     it("5. Verify default prompt message for min field", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane(
         "orderAmount",
         "v2",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_IconName_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_IconName_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. Verify table column type changes effect on menuButton and iconButton", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.addColumnV2("CustomColumn");
       cy.editColumn("customColumn1");
       _.propPane.SelectPropertiesDropDown("Column type", "Menu button");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Property_JsonUpdate_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Property_JsonUpdate_spec.js
@@ -85,7 +85,7 @@ describe(
     it("4. Check Selected Row(s) Resets When Table data Changes", function () {
       // Select 1st row
       _.table.SelectTableRow(1, 0, true, "v2");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Empty first row
       cy.testJsontext("tabledata", "[]");
       cy.wait("@updateLayout");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Sorting_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Sorting_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("verifies that table sorting works for a custom column with computed value even when it is renamed", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.addColumnV2("customColumn1");
       cy.editColumn("customColumn1");
       cy.updateComputedValueV2(testdata.currentIndex);
@@ -35,7 +35,7 @@ describe(
       });
 
       // Rename customColumn1 to customColumn2
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("customColumn1");
       cy.get(".t--property-pane-title").click({ force: true });
       cy.get(".t--property-pane-title")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Switch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Switch_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. Table Widget V2 Data validation with Switch ON", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.readTableV2dataPublish("1", "1").then((tabData) => {
         const tabValue = tabData;
         expect(tabValue).to.be.equal("30");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Add_button_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Add_button_spec.js
@@ -56,7 +56,7 @@ describe(
     });
 
     it("2. Table Button color validation", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Open column details of "id".
       cy.editColumn("id");
       const color1 = "rgb(255, 0, 0)";
@@ -124,7 +124,7 @@ describe(
     });
 
     it("4. Table widget add new menu button column", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // click on Add new Column.
       cy.get(".t--add-column-btn").click();
       //Open New Custom Column
@@ -238,7 +238,7 @@ describe(
       });
 
       // Close Property pane
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Click on the Menu button
       cy.contains("Menu button").click({
         force: true,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Add_button_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Add_button_spec.js
@@ -10,6 +10,7 @@ import {
   agHelper,
   propPane,
   table,
+  propPane
 } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
@@ -56,7 +57,7 @@ describe(
     });
 
     it("2. Table Button color validation", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       // Open column details of "id".
       cy.editColumn("id");
       const color1 = "rgb(255, 0, 0)";
@@ -124,7 +125,7 @@ describe(
     });
 
     it("4. Table widget add new menu button column", function () {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       // click on Add new Column.
       cy.get(".t--add-column-btn").click();
       //Open New Custom Column
@@ -238,7 +239,7 @@ describe(
       });
 
       // Close Property pane
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       // Click on the Menu button
       cy.contains("Menu button").click({
         force: true,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Copy_Paste_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Copy_Paste_spec.js
@@ -10,6 +10,7 @@ import { featureFlagIntercept } from "../../../../../support/Objects/FeatureFlag
 import {
   agHelper,
   entityExplorer,
+  propPane
 } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
@@ -21,7 +22,7 @@ describe(
     });
     it("1. Copy paste table widget and valdiate application status", function () {
       const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.widgetText(
         "Table1",
         widgetsPage.tableWidgetV2,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Copy_Paste_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Copy_Paste_spec.js
@@ -21,7 +21,7 @@ describe(
     });
     it("1. Copy paste table widget and valdiate application status", function () {
       const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.widgetText(
         "Table1",
         widgetsPage.tableWidgetV2,

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Derived_Column_Computed_value_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Widget_Derived_Column_Computed_value_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. Test to add column", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Adding new column
       cy.addColumnV2("CustomColumn");
       cy.tableV2ColumnDataValidation("customColumn1"); //To be updated later

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_misc.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_misc.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. when the column label value is a valid string should show the evaluated string", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       ).clear();
@@ -26,7 +26,7 @@ describe(
     });
 
     it("2. when the column label value is a boolean replace column name with default column name", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       ).clear();
@@ -41,7 +41,7 @@ describe(
     });
 
     it("3. when the column label value is a number replace column name with default column name", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       ).clear();
@@ -68,7 +68,7 @@ describe(
     });
 
     it("4. when the column label value is an object replace column name with default column name", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       ).clear();
@@ -83,7 +83,7 @@ describe(
     });
 
     it("5. when the column label value is undefined replace column name with default column name", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(
         ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       ).clear();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_pagination_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_pagination_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. updates previous and next pagination propeties properly in non server side pagination mode", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       // The text field has two bindings in its text value, as below
       // "{{Table1.previousPageVisited}} {{Table1.nextPageVisited}}"

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_spec.js
@@ -12,7 +12,7 @@ describe(
     });
 
     it("1. Table Widget V2 Functionality", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       /**
        * @param{Text} Random Text
@@ -37,7 +37,7 @@ describe(
     });
 
     it("3. Table Widget V2 Functionality To Show a Base64 Image", function () {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("image");
       cy.changeColumnType("Image");
       _.table.SelectTableRow(1, 0, true, "v2");
@@ -51,7 +51,7 @@ describe(
 
     it("4. Table Widget V2 Functionality To Check if Table is Sortable", function () {
       cy.get(commonlocators.editPropBackButton).click();
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Confirm if isSortable is true
       cy.get(commonlocators.isSortable).should("be.checked");
       // Publish App
@@ -84,7 +84,7 @@ describe(
       // Back to edit page
       _.deployMode.NavigateBacktoEditor();
 
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       // Disable isSortable
       // Confirm if isSortable is false
       _.agHelper.CheckUncheck(commonlocators.isSortable, false);
@@ -118,7 +118,7 @@ describe(
     });
 
     it("5. Verify that table filter dropdown only includes filterable columns", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.wait(500);
       _.propPane.UpdatePropertyFieldValue(
         "Table data",
@@ -191,7 +191,7 @@ describe(
     });
 
     it("6. Verify that table filter is retained when the tableData scehma doesn't change", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       _.propPane.UpdatePropertyFieldValue(
         "Table data",
         `{{[{number: "1", work: "test"}, {number: "2", work: "celebrate!"}]}}`,
@@ -236,7 +236,7 @@ describe(
 
     it("7. should check that adding cyclic dependency in the table doesn't crash the app", () => {
       //_.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
 
       cy.updateCodeInput(
         ".t--property-control-defaultselectedrow",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Text_wrapping_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Text_wrapping_spec.js
@@ -20,7 +20,7 @@ describe(
       });
 
       // Enable cell wrapping and check that height is more than 28px
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("image");
 
       propPane.TogglePropertyState("Cell wrapping", "On");
@@ -61,7 +61,7 @@ describe(
       });
 
       // Enable cell wrapping and check that height is more than 28px
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.wait(2000);
       cy.editColumn("email");
 
@@ -72,7 +72,7 @@ describe(
     });
 
     it("4. should check that cell wrapping option is only available for plain text, number and URL", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("email");
       [
         {
@@ -123,7 +123,7 @@ describe(
     });
 
     it("5. should check that plain text, number and URL column is getting wrapped when cell wrapping is enabled", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("id");
 
       ["URL", "Number", "Plain text"].forEach((data, i) => {
@@ -143,7 +143,7 @@ describe(
     });
 
     it("6. should check that pageSize does not change when cell wrapping is enabled", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("image");
       let pageSizeBeforeWrapping;
       cy.get(".t--widget-textwidget .bp3-ui-text")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Text_wrapping_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Text_wrapping_spec.js
@@ -20,7 +20,7 @@ describe(
       });
 
       // Enable cell wrapping and check that height is more than 28px
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("image");
 
       propPane.TogglePropertyState("Cell wrapping", "On");
@@ -61,7 +61,7 @@ describe(
       });
 
       // Enable cell wrapping and check that height is more than 28px
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.wait(2000);
       cy.editColumn("email");
 
@@ -72,7 +72,7 @@ describe(
     });
 
     it("4. should check that cell wrapping option is only available for plain text, number and URL", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("email");
       [
         {
@@ -123,7 +123,7 @@ describe(
     });
 
     it("5. should check that plain text, number and URL column is getting wrapped when cell wrapping is enabled", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("id");
 
       ["URL", "Number", "Plain text"].forEach((data, i) => {
@@ -143,7 +143,7 @@ describe(
     });
 
     it("6. should check that pageSize does not change when cell wrapping is enabled", () => {
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("image");
       let pageSizeBeforeWrapping;
       cy.get(".t--widget-textwidget .bp3-ui-text")

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -17,7 +17,7 @@ describe(
     });
 
     it("1. should check that select column is available in the column dropdown options", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
 
       cy.get(commonlocators.changeColType).last().click();
@@ -155,7 +155,7 @@ describe(
 
     it("5. should check that on option select is working", () => {
       featureFlagIntercept({ release_table_cell_label_value_enabled: true });
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       cy.get(".t--property-control-onoptionchange .t--js-toggle").click();
       cy.updateCodeInput(
@@ -361,7 +361,7 @@ describe(
       cy.get(".t--run-query").click();
       cy.wait("@postExecute");
       PageLeftPane.switchSegment(PagePaneSegment.UI);
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       cy.get(".t--property-control-serversidefiltering input").click();
       cy.updateCodeInput(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/checkboxCell_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/checkboxCell_spec.js
@@ -52,7 +52,7 @@ describe(
         cy.get(selector).should("not.exist");
       });
       _.deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("completed");
       _.propPane.TogglePropertyState("Visible");
       cy.getTableV2DataSelector("0", "4").then((selector) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/menubutton_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/menubutton_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("1. should check that menuitems background color property has access to currentRow", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("task");
       cy.changeColumnType("Menu button");
       cy.get(".t--add-menu-item-btn").click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/switchCell_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/switchCell_spec.js
@@ -58,7 +58,7 @@ describe(
         cy.get(selector).should("not.exist");
       });
       deployMode.NavigateBacktoEditor();
-      _.propPane.openPropertyPane("tablewidgetv2");
+      propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("completed");
       propPane.TogglePropertyState("Visible");
       cy.getTableV2DataSelector("0", "4").then((selector) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/switchCell_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/switchCell_spec.js
@@ -58,7 +58,7 @@ describe(
         cy.get(selector).should("not.exist");
       });
       deployMode.NavigateBacktoEditor();
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("completed");
       propPane.TogglePropertyState("Visible");
       cy.getTableV2DataSelector("0", "4").then((selector) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column1_spec.js
@@ -29,7 +29,7 @@ describe(
       cy.wait(1000);
       cy.get(widgetsPage.tableWidgetV2).then(($elem) => {
         if ($elem) {
-          cy.openPropertyPane(_.draggableWidgets.TABLE);
+          _.propPane.openPropertyPane(_.draggableWidgets.TABLE);
           cy.deleteWidget(widgetsPage.tableWidgetV2);
         }
       });
@@ -39,7 +39,7 @@ describe(
       { tags: ["@tag.Widget", "@tag.Table"] },
       () => {
         it("1.1.1 Freeze column to left", () => {
-          cy.openPropertyPane(_.draggableWidgets.TABLE);
+          _.propPane.openPropertyPane(_.draggableWidgets.TABLE);
           cy.openFieldConfiguration("step");
           cy.get(
             ".t--property-control-columnfreeze span[data-value='left']",
@@ -117,7 +117,7 @@ describe(
       { tags: ["@tag.Widget", "@tag.Table"] },
       () => {
         it("1.2.1 Check if column freeze for user mode is enabled", () => {
-          cy.openPropertyPane(_.draggableWidgets.TABLE);
+          _.propPane.openPropertyPane(_.draggableWidgets.TABLE);
 
           cy.get(
             ".t--property-control-allowcolumnfreeze input[type='checkbox']",
@@ -196,7 +196,7 @@ describe(
         });
 
         it("1.2.6 Check if column freeze for user mode is disabled", () => {
-          cy.openPropertyPane(_.draggableWidgets.TABLE);
+          _.propPane.openPropertyPane(_.draggableWidgets.TABLE);
           cy.get(
             ".t--property-control-allowcolumnfreeze input[type='checkbox']",
           ).click({

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column2_spec.js
@@ -154,7 +154,7 @@ describe(
       { tags: ["@tag.Widget", "@tag.Table"] },
       () => {
         it("2.3.1 Hide left frozen column and check it's position is before right frozen columns", () => {
-          cy.openPropertyPane(_.draggableWidgets.TABLE);
+          _.propPane.openPropertyPane(_.draggableWidgets.TABLE);
           cy.hideColumn("action");
           cy.getTableV2DataSelector("0", "2").then((selector) => {
             cy.get(selector).should("have.class", "hidden-cell");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column_query_change_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column_query_change_spec.js
@@ -17,7 +17,7 @@ describe(
     before(() => {
       cy.dragAndDropToCanvas(WIDGET.TABLE, { x: 600, y: 200 });
       cy.wait(2000);
-      cy.openPropertyPane(WIDGET.TABLE);
+      _.propPane.openPropertyPane(WIDGET.TABLE);
       _.propPane.EnterJSContext("Table data", TABLE_DATA_STATIC);
     });
 
@@ -26,7 +26,7 @@ describe(
       cy.freezeColumnFromDropdown("id", "right");
 
       //Change the table data:
-      cy.openPropertyPane(WIDGET.TABLE);
+      _.propPane.openPropertyPane(WIDGET.TABLE);
       _.propPane.EnterJSContext("Table data", TABLE_DATA_DYNAMIC);
 
       //Check the id column is still frozen to the right:
@@ -43,7 +43,7 @@ describe(
       cy.freezeColumnFromDropdown("customColumn1", "right");
 
       // Change the table data:
-      cy.openPropertyPane(WIDGET.TABLE);
+      _.propPane.openPropertyPane(WIDGET.TABLE);
       cy.updateCodeInput(PROPERTY_SELECTOR.tableData, TABLE_DATA_STATIC);
 
       //Check the id column is still frozen to the right:

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/inline_editing_validations_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/inline_editing_validations_spec.js
@@ -16,7 +16,7 @@ describe(
     });
 
     it("1. should check that validation only appears when editable enabled", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       cy.get(".t--property-pane-section-collapse-validation").should(
         "not.exist",
@@ -30,7 +30,7 @@ describe(
     });
 
     it("2. should check that validation only appears for plain text and number", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       _.propPane.TogglePropertyState("Editable", "On");
       cy.get(".t--property-pane-section-collapse-validation").should("exist");
@@ -53,7 +53,7 @@ describe(
     });
 
     it("3. should check that regex, valid & required appear for plain text column", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       _.propPane.TogglePropertyState("Editable", "On");
       cy.get(".t--property-pane-section-collapse-validation").should("exist");
@@ -63,7 +63,7 @@ describe(
     });
 
     it("4. should check that min, max, regex, valid & required appear for number column", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       _.propPane.TogglePropertyState("Editable", "On");
       cy.get(commonlocators.changeColType).last().click();
@@ -82,7 +82,7 @@ describe(
       { tags: ["@tag.Widget", "@tag.Table"] },
       () => {
         it("a. Regex", () => {
-          cy.openPropertyPane("tablewidgetv2");
+          _.propPane.openPropertyPane("tablewidgetv2");
           cy.editColumn("step");
           _.propPane.TogglePropertyState("Editable", "On");
           _.propPane.UpdatePropertyFieldValue("Regex", "^#1$");
@@ -96,7 +96,7 @@ describe(
         });
 
         it("b. Valid", () => {
-          cy.openPropertyPane("tablewidgetv2");
+          _.propPane.openPropertyPane("tablewidgetv2");
           cy.editColumn("step");
           _.propPane.TogglePropertyState("Editable", "On");
           _.propPane.UpdatePropertyFieldValue(
@@ -113,7 +113,7 @@ describe(
         });
 
         it("c. Required", () => {
-          cy.openPropertyPane("tablewidgetv2");
+          _.propPane.openPropertyPane("tablewidgetv2");
           cy.editColumn("step");
           _.propPane.TogglePropertyState("Editable", "On");
           _.propPane.TogglePropertyState("Required", "On");
@@ -135,7 +135,7 @@ describe(
       { tags: ["@tag.Widget", "@tag.Table"] },
       () => {
         it("a. Min", () => {
-          cy.openPropertyPane("tablewidgetv2");
+          _.propPane.openPropertyPane("tablewidgetv2");
           cy.editColumn("step");
           _.propPane.TogglePropertyState("Editable", "On");
 
@@ -161,7 +161,7 @@ describe(
         });
 
         it("b. Max", () => {
-          cy.openPropertyPane("tablewidgetv2");
+          _.propPane.openPropertyPane("tablewidgetv2");
           cy.editColumn("step");
           _.propPane.TogglePropertyState("Editable", "On");
 
@@ -189,7 +189,7 @@ describe(
     );
 
     it("7. should check the error message property", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       _.propPane.TogglePropertyState("Editable", "On");
       _.propPane.UpdatePropertyFieldValue("Valid", "{{editedValue === '#1'}}");
@@ -211,7 +211,7 @@ describe(
       { tags: ["@tag.Widget", "@tag.Table"] },
       () => {
         it("a. save should only work when there is no error", () => {
-          cy.openPropertyPane("tablewidgetv2");
+          _.propPane.openPropertyPane("tablewidgetv2");
           cy.editColumn("step");
           _.propPane.TogglePropertyState("Editable", "On");
           cy.getAlert("onSubmit", "Saved!!");
@@ -242,7 +242,7 @@ describe(
         });
 
         it("b. discard should only work when there is no error", () => {
-          cy.openPropertyPane("tablewidgetv2");
+          _.propPane.openPropertyPane("tablewidgetv2");
           cy.editColumn("step");
           _.propPane.TogglePropertyState("Editable", "On");
           _.propPane.UpdatePropertyFieldValue(
@@ -277,18 +277,18 @@ describe(
     );
 
     it("should check that save/discard button is disabled when there is a validation error", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       _.propPane.TogglePropertyState("Editable", "On");
       _.propPane.UpdatePropertyFieldValue("Valid", "{{editedValue === '#1'}}");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "123");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(`[data-colindex="${4}"][data-rowindex="${0}"] button`).should(
         "be.disabled",
       );
       cy.enterTableCellValue(0, 0, "#1");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.get(`[data-colindex="${4}"][data-rowindex="${0}"] button`).should(
         "not.be.disabled",
       );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/non_ascii_column_name_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/non_ascii_column_name_spec.js
@@ -20,7 +20,7 @@ describe(
     });
 
     it("1. should test that Non ASCII characters in the tableData are shown in the table column header", () => {
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       _.propPane.UpdatePropertyFieldValue("Table data", JSON.stringify(data));
       cy.wait("@updateLayout");
       Object.keys(data[0]).forEach((column) => {
@@ -32,7 +32,7 @@ describe(
 
     it("2. should test that selectedRow also retains the non-ascii characters", () => {
       cy.dragAndDropToCanvas("textwidget", { x: 200, y: 100 });
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       _.propPane.UpdatePropertyFieldValue("Text", "{{Table1.selectedRow}}");
       cy.get(".t--widget-textwidget .bp3-ui-text").should(
         "contain",
@@ -46,9 +46,9 @@ describe(
     });
 
     it("3. should test that triggeredRow also retains the non-ascii characters", () => {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       _.propPane.UpdatePropertyFieldValue("Text", "{{Table1.triggeredRow}}");
-      cy.openPropertyPane("tablewidgetv2");
+      _.propPane.openPropertyPane("tablewidgetv2");
       cy.addColumnV2("button");
       cy.editColumn("customColumn1");
       cy.get(commonlocators.changeColType).last().click();

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/TextWidget_BgColor_TextSize_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/TextWidget_BgColor_TextSize_spec.js
@@ -10,7 +10,7 @@ describe(
       _.agHelper.AddDsl("textWidgetDsl");
     });
     it("Change the cell background color", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.moveToStyleTab();
       /**
        * @param{Text} Random Text
@@ -65,7 +65,7 @@ describe(
     });
 
     it("Change the text sizes", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.moveToStyleTab();
 
       //Check the label text size with dropdown

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/TextWidget_LintErrorValidation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/TextWidget_LintErrorValidation_spec.js
@@ -9,7 +9,7 @@ describe(
       _.agHelper.AddDsl("textLintErrorDsl");
     });
     it("Linting Error validation on mouseover and errorlog tab", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       /**
        * @param{Text} Random Text
        * @param{CheckboxWidget}Mouseover

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_new_feature_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_new_feature_spec.js
@@ -15,7 +15,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
     });
     it("1. Test to validate parsing link", function () {
       // Add link to text widget

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_new_feature_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_new_feature_spec.js
@@ -15,7 +15,7 @@ describe(
     });
 
     beforeEach(() => {
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
     });
     it("1. Test to validate parsing link", function () {
       // Add link to text widget

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_spec.js
@@ -11,7 +11,7 @@ describe(
     });
 
     beforeEach(() => {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
     });
 
     it("1. Text-TextStyle Heading, Text Name Validation", function () {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_truncate_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Text/Text_truncate_spec.js
@@ -10,7 +10,7 @@ describe(
     });
 
     it("Check default overflow property is No overflow", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.get("[data-value='NONE']")
         .last()
         .should("have.attr", "data-selected", "true");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Single_Select_Tree_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Single_Select_Tree_spec.ts
@@ -20,13 +20,13 @@ describe(
     });
 
     it("1. Check isDirty meta property", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{SingleSelectTree1.isDirty}}`,
       );
       // Change defaultText
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       propPane.UpdatePropertyFieldValue("Default selected value", "GREEN");
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget").should("contain", "false");
@@ -41,14 +41,14 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").should("contain", "true");
       // Change defaultText
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       cy.updateCodeInput(".t--property-control-defaultselectedvalue", "RED");
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget").should("contain", "false");
     });
 
     it("2. Selects value with enter in default value", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       cy.testJsontext("defaultselectedvalue", "RED\n");
       cy.get(formWidgetsPage.singleselecttreeWidget)
         .find(".rc-tree-select-selection-item")
@@ -104,7 +104,7 @@ describe(
     });
 
     it("6. To Check Visible Widget", function () {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       deployMode.DeployApp();
       cy.get(
@@ -126,12 +126,12 @@ describe(
     });
 
     it("8. To Check Clear all functionality", function () {
-      cy.openPropertyPane("textwidget");
+      _.propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{SingleSelectTree1.selectedOptionValue}}`,
       );
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       agHelper.CheckUncheck(commonlocators.allowclearingValueInput);
 
       cy.get(formWidgetsPage.treeSelectClearAll).last().click({ force: true });
@@ -145,7 +145,7 @@ describe(
     });
 
     it("9. Select tooltip renders if tooltip prop is not empty", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       // enter tooltip in property pan
       cy.get(widgetsPage.inputTooltipControl).type(
         "Helpful text for tooltip !",
@@ -155,7 +155,7 @@ describe(
     });
 
     it("10. To Validate onOptionChange Event gets triggered only when option is changed", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       // Click onOptionChange Event from propertypane
       cy.get(toggleJSButton("onoptionchange")).click({ force: true });
       // Add a message to alert event in onOptionChange

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Single_Select_Tree_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Single_Select_Tree_spec.ts
@@ -20,13 +20,13 @@ describe(
     });
 
     it("1. Check isDirty meta property", function () {
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{SingleSelectTree1.isDirty}}`,
       );
       // Change defaultText
-      _.propPane.openPropertyPane("singleselecttreewidget");
+      propPane.openPropertyPane("singleselecttreewidget");
       propPane.UpdatePropertyFieldValue("Default selected value", "GREEN");
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget").should("contain", "false");
@@ -41,14 +41,14 @@ describe(
       // Check if isDirty is set to true
       cy.get(".t--widget-textwidget").should("contain", "true");
       // Change defaultText
-      _.propPane.openPropertyPane("singleselecttreewidget");
+      propPane.openPropertyPane("singleselecttreewidget");
       cy.updateCodeInput(".t--property-control-defaultselectedvalue", "RED");
       // Check if isDirty is reset to false
       cy.get(".t--widget-textwidget").should("contain", "false");
     });
 
     it("2. Selects value with enter in default value", () => {
-      _.propPane.openPropertyPane("singleselecttreewidget");
+      propPane.openPropertyPane("singleselecttreewidget");
       cy.testJsontext("defaultselectedvalue", "RED\n");
       cy.get(formWidgetsPage.singleselecttreeWidget)
         .find(".rc-tree-select-selection-item")
@@ -104,7 +104,7 @@ describe(
     });
 
     it("6. To Check Visible Widget", function () {
-      _.propPane.openPropertyPane("singleselecttreewidget");
+      propPane.openPropertyPane("singleselecttreewidget");
       agHelper.CheckUncheck(commonlocators.visibleCheckbox);
       deployMode.DeployApp();
       cy.get(
@@ -126,12 +126,12 @@ describe(
     });
 
     it("8. To Check Clear all functionality", function () {
-      _.propPane.openPropertyPane("textwidget");
+      propPane.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{SingleSelectTree1.selectedOptionValue}}`,
       );
-      _.propPane.openPropertyPane("singleselecttreewidget");
+      propPane.openPropertyPane("singleselecttreewidget");
       agHelper.CheckUncheck(commonlocators.allowclearingValueInput);
 
       cy.get(formWidgetsPage.treeSelectClearAll).last().click({ force: true });
@@ -145,7 +145,7 @@ describe(
     });
 
     it("9. Select tooltip renders if tooltip prop is not empty", () => {
-      _.propPane.openPropertyPane("singleselecttreewidget");
+      propPane.openPropertyPane("singleselecttreewidget");
       // enter tooltip in property pan
       cy.get(widgetsPage.inputTooltipControl).type(
         "Helpful text for tooltip !",
@@ -155,7 +155,7 @@ describe(
     });
 
     it("10. To Validate onOptionChange Event gets triggered only when option is changed", () => {
-      _.propPane.openPropertyPane("singleselecttreewidget");
+      propPane.openPropertyPane("singleselecttreewidget");
       // Click onOptionChange Event from propertypane
       cy.get(toggleJSButton("onoptionchange")).click({ force: true });
       // Add a message to alert event in onOptionChange

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_spec.ts
@@ -17,7 +17,7 @@ describe(
     });
 
     it("2. toggle on allow clear selection and clear the input", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       // toggle on allow clear selection
       _.agHelper.CheckUncheck(commonlocators.allowclearingValueInput);
       // assert if cancel icon exists on the widget input
@@ -51,7 +51,7 @@ describe(
     });
 
     it("3. toggle of allow clear selection", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       // toggle off allow clear selection
       _.agHelper.CheckUncheck(commonlocators.allowclearingValueInput, false);
       // assert if cancel icon does not exists on the widget input
@@ -74,7 +74,7 @@ describe(
     });
 
     it("4. should check that empty value is allowed in options", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       cy.updateCodeInput(
         ".t--property-control-options",
         `[
@@ -108,7 +108,7 @@ describe(
     });
 
     it("5. should check that more than empty value is not allowed in options", () => {
-      cy.openPropertyPane("singleselecttreewidget");
+      _.propPane.openPropertyPane("singleselecttreewidget");
       cy.updateCodeInput(
         ".t--property-control-options",
         `[

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Video/Video_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Video/Video_spec.ts
@@ -16,7 +16,7 @@ describe(
     });
 
     it("1. Video Widget play functionality validation", function () {
-      cy.openPropertyPane("videowidget");
+      _.propPane.openPropertyPane("videowidget");
       cy.getAlert("onPlay", "Play success");
       cy.get(widgetsPage.autoPlay).click();
       cy.wait("@updateLayout").should(
@@ -84,7 +84,7 @@ describe(
       propPane.UpdatePropertyFieldValue("Text", "{{Video1.playState}}");
       agHelper.Sleep(1500); // Wait time added for the widget to load current video state
 
-      cy.openPropertyPane("videowidget");
+      _.propPane.openPropertyPane("videowidget");
       propPane.TogglePropertyState("Autoplay", "On");
       agHelper.Sleep(1500); // Wait time added for the widget to load current video state
       cy.get(".t--widget-textwidget").should("contain", "ENDED");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Video/Video_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Video/Video_spec.ts
@@ -16,7 +16,7 @@ describe(
     });
 
     it("1. Video Widget play functionality validation", function () {
-      _.propPane.openPropertyPane("videowidget");
+      propPane.openPropertyPane("videowidget");
       cy.getAlert("onPlay", "Play success");
       cy.get(widgetsPage.autoPlay).click();
       cy.wait("@updateLayout").should(
@@ -84,7 +84,7 @@ describe(
       propPane.UpdatePropertyFieldValue("Text", "{{Video1.playState}}");
       agHelper.Sleep(1500); // Wait time added for the widget to load current video state
 
-      _.propPane.openPropertyPane("videowidget");
+      propPane.openPropertyPane("videowidget");
       propPane.TogglePropertyState("Autoplay", "On");
       agHelper.Sleep(1500); // Wait time added for the widget to load current video state
       cy.get(".t--widget-textwidget").should("contain", "ENDED");

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
@@ -49,7 +49,7 @@ describe(
           dataSources.EnterQuery("SELECT * FROM users LIMIT 10");
         });
         PageLeftPane.switchSegment(PagePaneSegment.UI);
-        _.propPane.openPropertyPane("inputwidgetv2");
+        propPane.openPropertyPane("inputwidgetv2");
         cy.get(widgetsPage.defaultInput).type(
           "{{" + queryName + ".data[0].gender",
         );
@@ -76,7 +76,7 @@ describe(
         dataSources.EnterQuery("SELECT * FROM users LIMIT 10");
         dataSources.ToggleUsePreparedStatement(false);
         PageLeftPane.switchSegment(PagePaneSegment.UI);
-        _.propPane.openPropertyPane("inputwidgetv2");
+        propPane.openPropertyPane("inputwidgetv2");
         cy.get(widgetsPage.defaultInput).type(
           "{{" + queryName + ".data[0].gender",
         );
@@ -93,7 +93,7 @@ describe(
     it("2. Reload Page and it should not provide errors in response & update input widget's placeholder property and check errors array to be empty", () => {
       // cy.get(widgetsPage.NavHomePage).click({ force: true });
       cy.reload();
-      _.propPane.openPropertyPane("inputwidgetv2");
+      propPane.openPropertyPane("inputwidgetv2");
       cy.wait("@getConsolidatedData").should(
         "have.nested.property",
         "response.body.data.pageWithMigratedDsl.data.layouts[0].layoutOnLoadActionErrors.length",

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
@@ -49,7 +49,7 @@ describe(
           dataSources.EnterQuery("SELECT * FROM users LIMIT 10");
         });
         PageLeftPane.switchSegment(PagePaneSegment.UI);
-        cy.openPropertyPane("inputwidgetv2");
+        _.propPane.openPropertyPane("inputwidgetv2");
         cy.get(widgetsPage.defaultInput).type(
           "{{" + queryName + ".data[0].gender",
         );
@@ -76,7 +76,7 @@ describe(
         dataSources.EnterQuery("SELECT * FROM users LIMIT 10");
         dataSources.ToggleUsePreparedStatement(false);
         PageLeftPane.switchSegment(PagePaneSegment.UI);
-        cy.openPropertyPane("inputwidgetv2");
+        _.propPane.openPropertyPane("inputwidgetv2");
         cy.get(widgetsPage.defaultInput).type(
           "{{" + queryName + ".data[0].gender",
         );
@@ -93,7 +93,7 @@ describe(
     it("2. Reload Page and it should not provide errors in response & update input widget's placeholder property and check errors array to be empty", () => {
       // cy.get(widgetsPage.NavHomePage).click({ force: true });
       cy.reload();
-      cy.openPropertyPane("inputwidgetv2");
+      _.propPane.openPropertyPane("inputwidgetv2");
       cy.wait("@getConsolidatedData").should(
         "have.nested.property",
         "response.body.data.pageWithMigratedDsl.data.layouts[0].layoutOnLoadActionErrors.length",

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -692,6 +692,8 @@ export class PropertyPane {
     cy.get(".t--widget-propertypane-toggle > .t--widget-name")
       .first()
       .click({ force: true });
+    cy.get(".bp3-panel-stack-view")
+      .should('exist'); 
   }
   
 }

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -684,4 +684,14 @@ export class PropertyPane {
       .GetElement(this._propertyToggle(propertyName))
       .should(state === "enabled" ? "be.checked" : "not.be.checked");
   }
+
+  public openPropertyPane(widgetType: string): void {
+    const selector = `.t--draggable-${widgetType}`;
+    cy.get(selector).first().trigger("mouseover", { force: true }).wait(500);
+    cy.get(`${selector}:first-of-type`).first().click({ force: true }).wait(500);
+    cy.get(".t--widget-propertypane-toggle > .t--widget-name")
+      .first()
+      .click({ force: true });
+  }
+  
 }

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -184,7 +184,7 @@ Cypress.Commands.add("LogintoApp", (uname, pword) => {
 });
 
 Cypress.Commands.add("LoginFromAPI", (uname, pword) => {
-  homePageTS.LogOutviaAPI();
+  //homePageTS.LogOutviaAPI();
   let baseURL = Cypress.config().baseUrl;
   baseURL = baseURL.endsWith("/") ? baseURL.slice(0, -1) : baseURL;
 

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1056,17 +1056,17 @@ Cypress.Commands.add("tabVerify", (index, text) => {
     .should("be.visible");
 });
 
-Cypress.Commands.add("openPropertyPane", (widgetType) => {
-  const selector = `.t--draggable-${widgetType}`;
-  cy.wait(500);
-  cy.get(selector).first().trigger("mouseover", { force: true }).wait(500);
-  cy.get(`${selector}:first-of-type`).first().click({ force: true }).wait(500);
-  cy.get(".t--widget-propertypane-toggle > .t--widget-name")
-    .first()
-    .click({ force: true });
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(1000);
-});
+// Cypress.Commands.add("openPropertyPane", (widgetType) => {
+//   const selector = `.t--draggable-${widgetType}`;
+//   cy.wait(500);
+//   cy.get(selector).first().trigger("mouseover", { force: true }).wait(500);
+//   cy.get(`${selector}:first-of-type`).first().click({ force: true }).wait(500);
+//   cy.get(".t--widget-propertypane-toggle > .t--widget-name")
+//     .first()
+//     .click({ force: true });
+//   // eslint-disable-next-line cypress/no-unnecessary-waiting
+//   cy.wait(1000);
+// });
 
 Cypress.Commands.add("openPropertyPaneFromModal", (widgetType) => {
   const selector = `.t--draggable-${widgetType}`;
@@ -1132,7 +1132,7 @@ Cypress.Commands.add("copyWidget", (widget, widgetLocator) => {
       cy.wait(1000);
       cy.get("body").type(`{${modifierKey}}v`);
       cy.wait(3000);
-      cy.openPropertyPaneCopy(widget);
+      _.propPane.openPropertyPaneCopy(widget);
       cy.get(widgetsPage.propertypaneText)
         .children()
         .last()

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1132,7 +1132,7 @@ Cypress.Commands.add("copyWidget", (widget, widgetLocator) => {
       cy.wait(1000);
       cy.get("body").type(`{${modifierKey}}v`);
       cy.wait(3000);
-      _.propPane.openPropertyPaneCopy(widget);
+      cy.openPropertyPaneCopy(widget);
       cy.get(widgetsPage.propertypaneText)
         .children()
         .last()


### PR DESCRIPTION
## Description
Task to remove one helper. It is to test app behaviour with new helper from TS.


Fixes #`35263`  

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10156395702>
> Commit: 0b86f6393a9ea3dbd8a6edee5faea7335473f2f8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10156395702&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 30 Jul 2024 06:48:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new method in the PropertyPane class to automate interactions with various widget property panes.

- **Refactor**
	- Updated the method for accessing the property pane in multiple test cases to improve maintainability and organization.
	- Transitioned from `cy.openPropertyPane` to `_.propPane.openPropertyPane` across various widget tests, ensuring consistency in the test suite.

These changes enhance the clarity and structure of our test code while expanding interaction capabilities within the UI testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->