### PR TITLE
ci: Add pre push hook to not allow ee changes in ce

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -227,6 +227,7 @@ jobs:
           reponame: ${{ github.event.repository.name }}
           gituser: ${{ secrets.CACHE_GIT_USER }}
           gituseremail: ${{ secrets.CACHE_GIT_EMAIL }}
+        # git lfs update --force in the script below overrides appsmith git hooks with git lfs hooks since appsmith hooks are not required during workflow runs
         run: |
           pwd
           mkdir cacherepo

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -234,6 +234,7 @@ jobs:
           git config --global user.email "$gituseremail"
           git config --global user.name "$gituser"
           git clone https://$cachetoken@github.com/appsmithorg/cibuildcache.git
+          git lfs update --force
           git lfs install
           cd cibuildcache/
           if [ "$reponame" = "appsmith" ]; then export repodir="CE"; fi

--- a/app/client/.husky/pre-push
+++ b/app/client/.husky/pre-push
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+echo "Pre push hook called"
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+
+appsmith_ee_url="appsmith-ee.git"
+appsmith_ce_url="appsmithorg/appsmith.git"
+
+# Define the null SHA. 
+null_sha="0000000000000000000000000000000000000000"
+
+# Function to get list of files between two commits
+do_commits_contain_ee_files() {
+    # Store the commit hashes
+    from_commit=$1
+    to_commit=$2
+    string_to_match="app/client/src/ee"
+    
+    # to_commit sha can be null if a branch is being pushed for the first to remote
+    # In that case, we would need to compare the diff against a default branch, like release.
+    if [ "$to_commit" == "$null_sha" ]; then
+        echo "comparing changes against release"
+
+        remote_name=$(git remote -v | grep -i $appsmith_ce_url | grep -i fetch | awk '{print $1}')
+        echo "remote name is $remote_name"
+
+        git fetch $remote_name release
+        to_commit=$remote_name/release
+    fi
+
+    echo "to_commit in function is $to_commit"
+    echo "from_commit is $from_commit"
+    
+    # Get the list of files between the two commits
+    files=$(git diff --name-only $from_commit $to_commit)
+
+    # Iterate over each file
+    for file in $files; do
+        # Check if the file path contains the string
+        if [[ "$file" == *"$string_to_match"* ]]; then
+            echo "File '$file' matches the string '$string_to_match'"
+            return 0
+        fi
+    done
+    return 1
+}
+
+
+remote="$1"
+url="$2"
+
+echo "URL is $url"
+echo "remote is $remote"
+echo "remote sha is $remote_sha"
+
+if [[ "$url" == *"$appsmith_ee_url"* ]]; then
+    echo "Hook invoked on EE repo. Ignoring pre-push hook checks"
+    exit 0
+fi
+
+while read local_ref local_sha remote_ref remote_sha
+do
+    echo "pushing from $local_sha to $remote_sha"
+    echo "local ref is " $local_ref
+    echo "remote ref is " $remote_ref
+    
+    if [ "$local_sha" == "$null_sha" ]; then
+        echo "Branch is being deleted. Allow push"
+        exit 0
+    fi
+
+    if do_commits_contain_ee_files $local_sha $remote_sha
+    then
+        echo -e "Found EE changes in the commits\n"
+        exit 1
+    else
+        echo -e "Didn't find ee changes in the commits\n"
+        exit 0
+    fi
+done


### PR DESCRIPTION
## Description
This PR fixes failure in the CI build workflow. The workflow was failing in `Put release build in cache` job. The workflow was failing because while installing git lfs, there was a conflict with the newly added pre push hook. git lfs also contains its pre push hooks which was conflicting with our hooks. In this PR, I have configured the workflow for git lfs pre push hooks to override appsmith pre push commit since appsmith git hooks are not required during workflows.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a pre-push hook to ensure integrity by preventing inadvertent pushes of certain files to the repository.
  
- **Improvements**
	- Updated GitHub Actions workflow to enhance management of large files, ensuring the latest configurations are applied before builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->