### PR TITLE
test: Adding feature to run a spec file with count

### DIFF
--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -1,0 +1,432 @@
+name: Appsmith CI run limited Tests Workflow with count
+
+on:
+  # This line enables manual triggering of this workflow.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number"
+        required: false
+        type: number
+        default: 0
+      previous-workflow-run-id:
+        description: "Workflow ID (To Download cicontainer)"
+        required: false
+        type: number
+        default: 0
+      run_count:
+        description: 'Number of times to repeat the test run'
+        required: false
+        type: number 
+        default: 1
+  workflow_call:
+    inputs:
+      pr:
+        description: "This is the PR number in case the workflow is being called in a pull request"
+        required: false
+        type: number
+      previous-workflow-run-id:
+        description: "This is the PR number in case the workflow is being called in a pull request"
+        required: false
+        type: number
+        default: 0
+      run_count:
+        description: 'Number of times to repeat the test run'
+        required: false
+        type: number
+        default: 1
+
+jobs:
+  ci-test-limited:
+    runs-on: ubuntu-latest
+    #timeout-minutes: 50
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'repository_dispatch'
+    defaults:
+      run:
+        shell: bash
+
+    # Service containers to run with this job. Required for running tests
+    services:
+      # Label used to access the service container
+      redis:
+        # Docker Hub image for Redis
+        image: redis
+        ports:
+          # Opens tcp port 6379 on the host and service container
+          - 6379:6379
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
+
+    steps:
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # Check out merge commit
+      - name: Fork based /ok-to-test checkout
+        if: inputs.pr != 0
+        uses: actions/checkout@v4
+        with:
+          ref: "refs/pull/${{ inputs.pr }}/merge"
+
+      # Checkout the code in the current branch in case the workflow is called because of a branch push event
+      - name: Checkout the head commit of the branch
+        if: inputs.pr == 0
+        uses: actions/checkout@v4
+
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "timestamp=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        id: cache-appsmith
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
+      - name: Get the previous run result
+        if: steps.cache-appsmith.outputs.cache-hit == 'true'
+        id: run_result
+        run: |
+          run_result_env=$(cat ~/run_result)
+          echo "run_result=$run_result_env" >> $GITHUB_OUTPUT
+          if [[ "$run_result_env" == "failedtest" ]]; then
+            echo "rerun=true" >> $GITHUB_OUTPUT
+          else
+            echo "rerun=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Get specs to run
+      - name: Get specs to run
+        if: steps.run_result.outputs.run_result != 'success' && steps.run_result.outputs.run_result != 'failedtest'
+        run: |
+          specs_to_run=""
+          while IFS= read -r line
+          do
+            if [[ $line =~ ^#|^\/\/ ]]; then
+              continue
+            else
+              specs_to_run="$specs_to_run,$line"
+            fi
+          done < app/client/cypress/limited-tests.txt
+          specs_to_run=${specs_to_run#,}
+          echo "specs_to_run=$specs_to_run" >> $GITHUB_ENV
+
+      # In case of run-id provided download the artifact from the previous run
+      - name: Download Docker image artifact
+        if: inputs.previous-workflow-run-id != 0
+        uses: actions/cache@v4
+        with:
+          path: cicontainer.tar.gz
+          key: docker-image-${{ inputs.previous-workflow-run-id }}
+
+      # In case of run-id is 0 download the artifact from the current run
+      - name: Download Docker image artifact
+        if: inputs.previous-workflow-run-id == 0
+        uses: actions/cache@v4
+        with:
+          path: cicontainer.tar.gz
+          key: docker-image-${{github.run_id}}
+
+      - name: Load Docker image from tar file
+        run: |
+          gunzip cicontainer.tar.gz
+          docker load -i cicontainer.tar
+
+      - name: Create folder
+        if: steps.run_result.outputs.run_result != 'success'
+        working-directory: "."
+        run: |
+          mkdir -p cicontainerlocal/stacks/configuration/
+
+      - name: Run Appsmith & TED docker image
+        if: steps.run_result.outputs.run_result != 'success'
+        working-directory: "."
+        run: |
+          sudo /etc/init.d/ssh stop ;
+          mkdir -p ~/git-server/keys
+          docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
+            -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
+            appsmith/test-event-driver:latest
+          docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \
+            --privileged --pid=host --ipc=host --add-host=host.docker.internal:host-gateway\
+            -e APPSMITH_CLOUD_SERVICES_MONGODB_URI=mongodb://host.docker.internal:27017 \
+            -e APPSMITH_CLOUD_SERVICES_MONGODB_DATABASE=cs \
+            -e APPSMITH_CLOUD_SERVICES_MONGODB_AUTH_DATABASE=admin \
+            -e APPSMITH_REDIS_URL=redis://host.docker.internal:6379/ \
+            -e APPSMITH_APPS_API_KEY=dummy-api-key \
+            -e APPSMITH_REMOTE_API_KEY=dummy-api-key \
+            -e APPSMITH_GITHUB_API_KEY=dummy-appsmith-gh-api-key \
+            -e APPSMITH_JWT_SECRET=appsmith-cloud-services-jwt-secret-dummy-key \
+            -e APPSMITH_ENCRYPTION_SALT=encryption-salt \
+            -e APPSMITH_ENCRYPTION_PASSWORD=encryption-password \
+            -e APPSMITH_CLOUD_SERVICES_URL=https://cs-dev.appsmith.com \
+            -e APPSMITH_CUSTOMER_PORTAL_URL=https://dev.appsmith.com \
+            -e APPSMITH_CLOUD_SERVICES_BASE_URL=https://cs-dev.appsmith.com \
+            -e APPSMITH_CLOUD_SERVER_BASE_URL=https://release.app.appsmith.com \
+            -e AUTH0_ISSUER_URL=https://login.release-customer.appsmith.com/ \
+            -e AUTH0_CLIENT_ID=dummy-client-id \
+            -e AUTH0_CLIENT_SECRET=dummy-secret-id \
+            -e AUTH0_AUDIENCE_URL=https://login.local-customer.appsmith.com/ \
+            -e CLOUDSERVICES_URL=cs-dev.appsmith.com \
+            -e CUSTOMER_URL=dev.appsmith.com  \
+            -e ENTERPRISE_USER_NAME=ent-user@appsmith.com \
+            -e ENTERPRISE_USER_PASSWORD=ent_user_password \
+            -e ENTERPRISE_ADMIN_NAME=ent-admin@appsmith.com \
+            -e ENTERPRISE_ADMIN_PASSWORD=ent_admin_password \
+            -e LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY=$LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY \
+            appsmith/cloud-services:release
+          cd cicontainerlocal
+          docker run -d --name appsmith -p 80:80 \
+            -v "$PWD/stacks:/appsmith-stacks" \
+            -e APPSMITH_DISABLE_TELEMETRY=true \
+            -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \
+            -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
+            --add-host=host.docker.internal:host-gateway --add-host=api.segment.io:host-gateway --add-host=t.appsmith.com:host-gateway \
+            cicontainer
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+
+      # actions/setup-node@v4 doesn’t work properly with Yarn 3
+      # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
+      # Restoring the cache manually instead
+      - name: Restore Yarn cache
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/client/.yarn/cache
+            app/client/node_modules/.cache/webpack/
+          key: v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+
+      # Install all the dependencies
+      - name: Install dependencies
+        working-directory: app/client
+        run: |
+          yarn install --immutable
+
+      - name: Setting up the cypress tests
+        if: steps.run_result.outputs.run_result != 'success'
+        shell: bash
+        run: |
+          cd app/client
+          chmod a+x ./cypress/setup-test-ci.sh
+          ./cypress/setup-test-ci.sh
+
+      - uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
+      - run: |
+          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+
+      - name: Save Git values
+        # pass env variables from this step to other steps
+        # using GitHub Actions environment file
+        # https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#environment-files
+        run: |
+          echo COMMIT_INFO_BRANCH=$(git rev-parse --abbrev-ref HEAD) >> $GITHUB_ENV
+          echo COMMIT_INFO_MESSAGE=LimitedTests run on PR# ${{ inputs.pr }} >> $GITHUB_ENV
+          echo COMMIT_INFO_EMAIL=$(git show -s --pretty=%ae) >> $GITHUB_ENV
+          echo COMMIT_INFO_AUTHOR=$(git show -s --pretty=%an) >> $GITHUB_ENV
+          echo COMMIT_INFO_SHA=$(git show -s --pretty=%H) >> $GITHUB_ENV
+          echo COMMIT_INFO_TIMESTAMP=$(git show -s --pretty=%ct) >> $GITHUB_ENV
+          echo COMMIT_INFO_REMOTE=$(git config --get remote.origin.url) >> $GITHUB_ENV
+          # delete the .git folder afterwords to use the environment values
+          rm -rf .git
+
+      - name: Show Git values
+        run: |
+          echo Branch $COMMIT_INFO_BRANCH
+          echo Message $COMMIT_INFO_MESSAGE
+          echo Email $COMMIT_INFO_EMAIL
+          echo Author $COMMIT_INFO_AUTHOR
+          echo SHA $COMMIT_INFO_SHA
+          echo Timestamp $COMMIT_INFO_TIMESTAMP
+          echo Remote $COMMIT_INFO_REMOTE
+
+      - name: Set Commit Message
+        env:
+          EVENT_COMMITS: ${{ toJson(github.event.commits[0].message) }}
+        run: |
+          if [[ ${{ inputs.pr }} -ne 0 && ${{github.event_name}} == 'repository_dispatch' ]]; then
+            echo "COMMIT_INFO_MESSAGE=${{ env.COMMIT_INFO_MESSAGE }}" >> $GITHUB_ENV
+          elif [[ ${{ inputs.pr }} -ne 0 && ${{github.event_name}} == 'workflow_dispatch' ]]; then
+            echo "COMMIT_INFO_MESSAGE=Workflow run on PR# ${{ inputs.pr }}" >> $GITHUB_ENV
+          else
+            if [[ '${{env.EVENT_COMMITS}}' == 'null' ]]; then
+              echo "COMMIT_INFO_MESSAGE=${{ github.event_name }} by ${{ env.COMMIT_INFO_AUTHOR }}" >> $GITHUB_ENV
+            else
+              echo "COMMIT_INFO_MESSAGE=$(echo \"${{ env.EVENT_COMMITS }}\" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')" >> $GITHUB_ENV
+            fi
+          fi
+
+      - name: Run the cypress test
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            CYPRESS_USERNAME: ${{ secrets.CYPRESS_USERNAME }}
+            CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
+            CYPRESS_TESTUSERNAME1: ${{ secrets.CYPRESS_TESTUSERNAME1 }}
+            CYPRESS_TESTPASSWORD1: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
+            CYPRESS_TESTUSERNAME2: ${{ secrets.CYPRESS_TESTUSERNAME2 }}
+            CYPRESS_TESTPASSWORD2: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
+            CYPRESS_TESTUSERNAME3: ${{ secrets.CYPRESS_TESTUSERNAME3 }}
+            CYPRESS_TESTPASSWORD3: ${{ secrets.CYPRESS_TESTPASSWORD3 }}
+            CYPRESS_TESTUSERNAME4: ${{ secrets.CYPRESS_TESTUSERNAME4 }}
+            CYPRESS_TESTPASSWORD4: ${{ secrets.CYPRESS_TESTPASSWORD4 }}
+            CYPRESS_S3_ACCESS_KEY: ${{ secrets.CYPRESS_S3_ACCESS_KEY }}
+            CYPRESS_S3_SECRET_KEY: ${{ secrets.CYPRESS_S3_SECRET_KEY }}
+            CYPRESS_AIRTABLE_BEARER: ${{ secrets.AIRTABLE_BEARER }}
+            CYPRESS_ORACLE_HOST: ${{ secrets.ORACLE_HOST }}
+            CYPRESS_ORACLE_SERVICE: ${{ secrets.ORACLE_SERVICE }}
+            CYPRESS_ORACLE_USERNAME: ${{ secrets.ORACLE_USERNAME }}
+            CYPRESS_ORACLE_PASSWORD: ${{ secrets.ORACLE_PASSWORD }}
+            CYPRESS_FIRESTORE_PRIVATE_KEY: ${{ secrets.FIRESTORE_PRIVATE_KEY }}
+            CYPRESS_APPSMITH_OAUTH2_GOOGLE_CLIENT_ID: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_GOOGLE_CLIENT_ID }}
+            CYPRESS_APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET }}
+            CYPRESS_APPSMITH_OAUTH2_GITHUB_CLIENT_ID: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_GITHUB_CLIENT_ID }}
+            CYPRESS_APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET }}
+            CYPRESS_OAUTH_SAML_EMAIL: ${{ secrets.CYPRESS_OAUTH_SAML_EMAIL }}
+            CYPRESS_OAUTH_SAML_ENTITY_ID: ${{ secrets.CYPRESS_OAUTH_SAML_ENTITY_ID }}
+            CYPRESS_OAUTH_SAML_METADATA_URL: ${{ secrets.CYPRESS_OAUTH_SAML_METADATA_URL }}
+            CYPRESS_OAUTH_SAML_METADATA_XML: ${{ secrets.CYPRESS_OAUTH_SAML_METADATA_XML }}
+            CYPRESS_OAUTH_SAML_PUB_CERT: ${{ secrets.CYPRESS_OAUTH_SAML_PUB_CERT }}
+            CYPRESS_OAUTH_SAML_SSO_URL: ${{ secrets.CYPRESS_OAUTH_SAML_SSO_URL }}
+            CYPRESS_OAUTH_SAML_REDIRECT_URL: ${{ secrets.CYPRESS_OAUTH_SAML_REDIRECT_URL }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_CLIENT_ID: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_CLIENT_ID }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_CLIENT_SECRET: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_CLIENT_SECRET }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_AUTH_URL: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_AUTH_URL }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_TOKEN_URL: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_TOKEN_URL }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_USER_INFO: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_USER_INFO }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_JWKS_URL: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_JWKS_URL }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_OKTA_PASSWORD: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_OKTA_PASSWORD }}
+            CYPRESS_APPSMITH_OAUTH2_OIDC_DIRECT_URL: ${{ secrets.CYPRESS_APPSMITH_OAUTH2_OIDC_DIRECT_URL }}
+            CYPRESS_EXCLUDE_TAGS: "airgap"
+            CYPRESS_AIRGAPPED: false
+            APPSMITH_DISABLE_TELEMETRY: true
+            APPSMITH_GOOGLE_MAPS_API_KEY: ${{ secrets.APPSMITH_GOOGLE_MAPS_API_KEY }}
+            POSTGRES_PASSWORD: postgres
+            CYPRESS_VERIFY_TIMEOUT: 100000
+            COMMIT_INFO_MESSAGE: ${{ env.COMMIT_INFO_MESSAGE }}
+            RUNID: ${{ github.run_id }}
+            ATTEMPT_NUMBER: ${{ github.run_attempt }}
+            REPOSITORY: ${{ github.repository }}
+            COMMITTER: ${{ env.COMMIT_INFO_AUTHOR }}
+            TAG: ${{ github.event_name }}
+            BRANCH: ${{ env.COMMIT_INFO_BRANCH }}
+            THIS_RUNNER: ${{ strategy.job-index }}
+            TOTAL_RUNNERS: ${{ strategy.job-total }}
+            CYPRESS_SPECS: ${{ env.specs_to_run }}
+            CYPRESS_RERUN: ${{steps.run_result.outputs.rerun}}
+            CYPRESS_DB_USER: ${{ secrets.CYPRESS_DB_USER }}
+            CYPRESS_DB_HOST: ${{ secrets.CYPRESS_DB_HOST }}
+            CYPRESS_DB_NAME: ${{ secrets.CYPRESS_DB_NAME }}
+            CYPRESS_DB_PWD: ${{ secrets.CYPRESS_DB_PWD }}
+            CYPRESS_S3_ACCESS: ${{ secrets.CYPRESS_S3_ACCESS }}
+            CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
+            CYPRESS_STATIC_ALLOCATION: true
+            NODE_ENV: development
+        run: |
+            cd app/client
+            npx cypress-repeat run -n ${{ github.event.inputs.run_count }} --force \
+                --spec ${{ env.specs_to_run }} \
+                --config-file "cypress_ci_custom.config.ts"   
+
+      - name: Trim number of cypress log files
+        if: failure()
+        run: |
+          find ${{ github.workspace }}/app/client/cypress/cypress-logs -name '*.json' -type f | tail -n +11 | xargs -I {} rm -- {}
+
+      - name: Upload failed test cypress logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-console-logs
+          path: ${{ github.workspace }}/app/client/cypress/cypress-logs
+          overwrite: true
+
+      - name: Upload cypress snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots
+          path: ${{ github.workspace }}/app/client/cypress/snapshots
+          overwrite: true
+
+      - name: Collect CI container logs
+        if: failure()
+        working-directory: "."
+        run: |
+          mkdir -p  ~/dockerlogs
+          docker logs appsmith 2>&1 > ~/dockerlogs/dockerlogs-log.txt
+
+      # Upload docker logs
+      - name: Upload failed test list artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dockerlogs
+          path: ~/dockerlogs
+          overwrite: true
+
+      - name: Rename reports
+        if: failure()
+        run: |
+          mkdir -p ~/results
+          mv ${{ github.workspace }}/app/client/results ~/results
+
+      - name: Upload cypress report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-${{github.run_attempt}}
+          path: ~/results
+          overwrite: true
+
+      # Set status = failedtest
+      - name: Set fail if there are test failures
+        if: failure()
+        run: |
+          echo "failedtest" > ~/run_result
+
+      # Force store previous run result to cache
+      - name: Store the previous run result
+        if: failure()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}
+
+      # Upload the log artifact so that it can be used by the test & deploy job in the workflow
+      - name: Upload server logs bundle on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: server-logs
+          path: app/server/server-logs.log
+          overwrite: true
+
+      # Set status = success
+      - name: Save the status of the run
+        run: |
+          echo "run_result=success" >> $GITHUB_OUTPUT
+          echo "success" > ~/run_result

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -118,6 +118,7 @@
     "craco-babel-loader": "^1.0.4",
     "cssnano": "^6.0.1",
     "cypress-log-to-output": "^1.1.2",
+    "cypress-repeat-updated": "^1.0.1",
     "d3-geo": "^3.1.0",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -13328,6 +13328,7 @@ __metadata:
     cypress-network-idle: ^1.14.2
     cypress-plugin-tab: ^1.0.5
     cypress-real-events: ^1.8.1
+    cypress-repeat-updated: ^1.0.1
     cypress-tags: ^1.1.2
     cypress-terminal-report: ^5.3.6
     cypress-wait-until: ^1.7.2
@@ -13558,17 +13559,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arg@npm:5.0.2, arg@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "arg@npm:5.0.2"
+  checksum: 6c69ada1a9943d332d9e5382393e897c500908d91d5cb735a01120d5f71daf1b339b7b8980cbeaba8fd1afc68e658a739746179e4315a26e8a28951ff9930078
+  languageName: node
+  linkType: hard
+
 "arg@npm:^4.1.0":
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
   checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
-  languageName: node
-  linkType: hard
-
-"arg@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "arg@npm:5.0.2"
-  checksum: 6c69ada1a9943d332d9e5382393e897c500908d91d5cb735a01120d5f71daf1b339b7b8980cbeaba8fd1afc68e658a739746179e4315a26e8a28951ff9930078
   languageName: node
   linkType: hard
 
@@ -14492,7 +14493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:^3.5.5, bluebird@npm:^3.7.2":
+"bluebird@npm:3.7.2, bluebird@npm:^3.5.5, bluebird@npm:^3.7.2":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
   checksum: 869417503c722e7dc54ca46715f70e15f4d9c602a423a02c825570862d12935be59ed9c7ba34a9b31f186c017c23cac6b54e35446f8353059c101da73eac22ef
@@ -16955,6 +16956,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cypress-repeat-updated@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "cypress-repeat-updated@npm:1.0.1"
+  dependencies:
+    arg: 5.0.2
+    bluebird: 3.7.2
+    debug: 4.3.5
+    dotenv: 8.2.0
+  peerDependencies:
+    cypress: ">=5.3.0"
+  bin:
+    cypress-repeat: index.js
+  checksum: 842107e5e1c17b9b1e4d910bfe429b6c1ca8ae6765cd985fc5f08087da36b47e19c52fbc99f936a698cfa18f364c2f674f4af0e2ed9d41fd216f594e72b2506b
+  languageName: node
+  linkType: hard
+
 "cypress-tags@npm:^1.1.2":
   version: 1.1.2
   resolution: "cypress-tags@npm:1.1.2"
@@ -17140,7 +17157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:~4.3.1, debug@npm:~4.3.2":
+"debug@npm:4, debug@npm:4.3.5, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:~4.3.1, debug@npm:~4.3.2":
   version: 4.3.5
   resolution: "debug@npm:4.3.5"
   dependencies:
@@ -17981,6 +17998,13 @@ __metadata:
   version: 5.1.0
   resolution: "dotenv-expand@npm:5.1.0"
   checksum: 8017675b7f254384915d55f9eb6388e577cf0a1231a28d54b0ca03b782be9501b0ac90ac57338636d395fa59051e6209e9b44b8ddf169ce6076dffb5dea227d3
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:8.2.0":
+  version: 8.2.0
+  resolution: "dotenv@npm:8.2.0"
+  checksum: ad4c8e0df3e24b4811c8e93377d048a10a9b213dcd9f062483b4a2d3168f08f10ec9c618c23f5639060d230ccdb174c08761479e9baa29610aa978e1ee66df76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
It is for running a spec file with given run_count

Fixes #`34956`  

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions CI workflow for running limited tests, enhancing the flexibility and management of the testing process.
	- Added a new dependency for improved Cypress testing capabilities, allowing for more efficient test execution.

- **Improvements**
	- Enhanced artifact management for test runs and results within the CI workflow for a more robust development lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->