### PR TITLE
chore: injecting env value into client build script

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -165,6 +165,7 @@ jobs:
             REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_EDITION="Community" \
+            APPSMITH_CLOUD_HOSTING=${{ secrets.APPSMITH_CLOUD_HOSTING }} \
             yarn build
 
       # Saving the cache to use it in subsequent runs

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -161,7 +161,6 @@ jobs:
           else
             export REACT_APP_SEGMENT_CE_KEY="${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}"
           fi
-          echo "script updated"
           REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} \
             APPSMITH_CLOUD_HOSTING=${{ secrets.APPSMITH_CLOUD_HOSTING }} \
             REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -161,11 +161,12 @@ jobs:
           else
             export REACT_APP_SEGMENT_CE_KEY="${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}"
           fi
+          echo "script updated"
           REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} \
+            APPSMITH_CLOUD_HOSTING=${{ secrets.APPSMITH_CLOUD_HOSTING }} \
             REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_EDITION="Community" \
-            APPSMITH_CLOUD_HOSTING=${{ secrets.APPSMITH_CLOUD_HOSTING }} \
             yarn build
 
       # Saving the cache to use it in subsequent runs

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -18,7 +18,7 @@ export REACT_APP_SENTRY_RELEASE=$GIT_SHA
 export REACT_APP_CLIENT_LOG_LEVEL=ERROR
 # Disable CRA built-in ESLint checks since we have our own config and a separate step for this
 export DISABLE_ESLINT_PLUGIN=true
-echo "debug client build setting $REACT_APP_CLOUD_HOSTING $APPSMITH_CLOUD_HOSTING"
+echo "debug client build setting $APPSMITH_CLOUD_HOSTING"
 if [ "$APPSMITH_CLOUD_HOSTING" == "true" ]; then
     echo "Building profiled build"
     craco --max-old-space-size=7168 build --profile --config craco.build.config.js --verbose

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -19,7 +19,7 @@ export REACT_APP_CLIENT_LOG_LEVEL=ERROR
 # Disable CRA built-in ESLint checks since we have our own config and a separate step for this
 export DISABLE_ESLINT_PLUGIN=true
 echo "debug client build setting $REACT_APP_CLOUD_HOSTING $APPSMITH_CLOUD_HOSTING"
-if [ "$REACT_APP_CLOUD_HOSTING" == "true" ]; then
+if [ "$APPSMITH_CLOUD_HOSTING" == "true" ]; then
     echo "Building profiled build"
     craco --max-old-space-size=7168 build --profile --config craco.build.config.js --verbose
 else

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -18,7 +18,8 @@ export REACT_APP_SENTRY_RELEASE=$GIT_SHA
 export REACT_APP_CLIENT_LOG_LEVEL=ERROR
 # Disable CRA built-in ESLint checks since we have our own config and a separate step for this
 export DISABLE_ESLINT_PLUGIN=true
-if [ "$APPSMITH_CLOUD_HOSTING" == "true" ]; then
+echo "debug client build setting $REACT_APP_CLOUD_HOSTING $APPSMITH_CLOUD_HOSTING"
+if [ "$REACT_APP_CLOUD_HOSTING" == "true" ]; then
     echo "Building profiled build"
     craco --max-old-space-size=7168 build --profile --config craco.build.config.js --verbose
 else


### PR DESCRIPTION
## Description
The `APPSMITH_CLOUD_HOSTING` env value is not accessible within the client build script, we are fixing it by injecting it in the client build workflow.

Fixes #35184
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10161480342>
> Commit: 443c4ab7a6a08332efec5b7fd91927eeaf4e9707
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10161480342&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 30 Jul 2024 11:57:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Enhanced visibility of environment variables during the build process with a debug echo statement.
	- Introduced the `APPSMITH_CLOUD_HOSTING` environment variable in the GitHub Actions workflow, improving configurability for various deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->