### PR TITLE
chore: reverted client profiled build

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -162,7 +162,6 @@ jobs:
             export REACT_APP_SEGMENT_CE_KEY="${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}"
           fi
           REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} \
-            APPSMITH_CLOUD_HOSTING=${{ secrets.APPSMITH_CLOUD_HOSTING }} \
             REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_EDITION="Community" \

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -18,13 +18,6 @@ export REACT_APP_SENTRY_RELEASE=$GIT_SHA
 export REACT_APP_CLIENT_LOG_LEVEL=ERROR
 # Disable CRA built-in ESLint checks since we have our own config and a separate step for this
 export DISABLE_ESLINT_PLUGIN=true
-echo "debug client build setting $APPSMITH_CLOUD_HOSTING"
-if [ "$APPSMITH_CLOUD_HOSTING" == "true" ]; then
-    echo "Building profiled build"
-    craco --max-old-space-size=7168 build --profile --config craco.build.config.js --verbose
-else
-    craco --max-old-space-size=7168 build --config craco.build.config.js
-fi
-
+craco --max-old-space-size=7168 build --config craco.build.config.js
 
 echo "build finished"


### PR DESCRIPTION
## Description
Reverted client profiled build script, we will instead generate a docker custom image.


Fixes https://github.com/appsmithorg/appsmith/issues/35184

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10177617441>
> Commit: 3ff5d304aacb08cabb529b6553b2319d688000ff
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10177617441&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 31 Jul 2024 09:52:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Removed the dependency on the `APPSMITH_CLOUD_HOSTING` environment variable during the build process, streamlining the workflow and build script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->