### PR TITLE
fix: Allow serializing child widget if it is a substring of the conta…

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
@@ -266,7 +266,7 @@ public class FileUtilsCEImpl implements FileInterface {
                     if (!DSLTransformerHelper.hasChildren(jsonObject)
                             && !DSLTransformerHelper.isTabsWidget(jsonObject)) {
                         // Save the widget as a directory or Save the widget as a file
-                        childPath = childPath.replace(widgetName, CommonConstants.EMPTY_STRING);
+                        childPath = childPath.replaceAll(widgetName + "$", CommonConstants.EMPTY_STRING);
                     }
                     Path path = Paths.get(
                             String.valueOf(pageSpecificDirectory.resolve(CommonConstants.WIDGETS)), childPath);

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
@@ -257,17 +257,10 @@ public class FileUtilsCEImpl implements FileInterface {
                 Map<String, JSONObject> result = DSLTransformerHelper.flatten(
                         new JSONObject(applicationGitReference.getPageDsl().get(pageName)));
                 result.forEach((key, jsonObject) -> {
-                    // get path with splitting the name via key
                     String widgetName = key.substring(key.lastIndexOf(CommonConstants.DELIMITER_POINT) + 1);
-                    String childPath = key.replace(CommonConstants.MAIN_CONTAINER, CommonConstants.EMPTY_STRING)
-                            .replace(CommonConstants.DELIMITER_POINT, CommonConstants.DELIMITER_PATH);
-                    // Replace the canvas Widget as a child and add it to the same level as parent
-                    childPath = childPath.replaceAll(CANVAS_WIDGET, CommonConstants.EMPTY_STRING);
-                    if (!DSLTransformerHelper.hasChildren(jsonObject)
-                            && !DSLTransformerHelper.isTabsWidget(jsonObject)) {
-                        // Save the widget as a directory or Save the widget as a file
-                        childPath = childPath.replaceAll(widgetName + "$", CommonConstants.EMPTY_STRING);
-                    }
+
+                    String childPath = DSLTransformerHelper.getPathToWidgetFile(key, jsonObject, widgetName);
+
                     Path path = Paths.get(
                             String.valueOf(pageSpecificDirectory.resolve(CommonConstants.WIDGETS)), childPath);
                     validWidgetToParentMap.put(widgetName, path.toFile().toString());

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/DSLTransformerHelper.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/DSLTransformerHelper.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static com.appsmith.git.constants.CommonConstants.CANVAS_WIDGET;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -60,7 +62,7 @@ public class DSLTransformerHelper {
         if (children.length() != 0) {
             for (int i = 0; i < children.length(); i++) {
                 JSONObject child = children.getJSONObject(i);
-                if (!CommonConstants.CANVAS_WIDGET.equals(child.optString(CommonConstants.WIDGET_TYPE))) {
+                if (!CANVAS_WIDGET.equals(child.optString(CommonConstants.WIDGET_TYPE))) {
                     jsonObject.remove(CommonConstants.CHILDREN);
                 } else {
                     JSONObject childCopy = new JSONObject(child.toString());
@@ -94,7 +96,7 @@ public class DSLTransformerHelper {
     }
 
     public static boolean isCanvasWidget(JSONObject jsonObject) {
-        return jsonObject.optString(CommonConstants.WIDGET_TYPE).startsWith(CommonConstants.CANVAS_WIDGET);
+        return jsonObject.optString(CommonConstants.WIDGET_TYPE).startsWith(CANVAS_WIDGET);
     }
 
     public static Map<String, List<String>> calculateParentDirectories(List<String> paths) {
@@ -189,7 +191,7 @@ public class DSLTransformerHelper {
             // Is the children CANVAS_WIDGET
             if (children.length() == 1) {
                 JSONObject childObject = children.getJSONObject(0);
-                if (CommonConstants.CANVAS_WIDGET.equals(childObject.optString(CommonConstants.WIDGET_TYPE))) {
+                if (CANVAS_WIDGET.equals(childObject.optString(CommonConstants.WIDGET_TYPE))) {
                     childObject.put(CommonConstants.CHILDREN, childWidgets);
                 }
             } else if (children.length() > 1) { // Tabs Widget children mapping case
@@ -223,5 +225,19 @@ public class DSLTransformerHelper {
             widgetIdWidgetNameMapping.put(existingChild.optString(CommonConstants.WIDGET_ID), existingChild);
         }
         return widgetIdWidgetNameMapping;
+    }
+
+    public static String getPathToWidgetFile(String key, JSONObject jsonObject, String widgetName) {
+        // get path with splitting the name via key
+        String childPath = key.replace(CommonConstants.MAIN_CONTAINER, CommonConstants.EMPTY_STRING)
+                .replace(CommonConstants.DELIMITER_POINT, CommonConstants.DELIMITER_PATH);
+        // Replace the canvas Widget as a child and add it to the same level as parent
+        childPath = childPath.replaceAll(CANVAS_WIDGET, CommonConstants.EMPTY_STRING);
+        if (!DSLTransformerHelper.hasChildren(jsonObject) && !DSLTransformerHelper.isTabsWidget(jsonObject)) {
+            // Save the widget as a directory or Save the widget as a file
+            childPath = childPath.replaceAll(widgetName + "$", CommonConstants.EMPTY_STRING);
+        }
+
+        return childPath;
     }
 }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/DSLTransformerHelper.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/DSLTransformerHelper.java
@@ -235,6 +235,8 @@ public class DSLTransformerHelper {
         childPath = childPath.replaceAll(CANVAS_WIDGET, CommonConstants.EMPTY_STRING);
         if (!DSLTransformerHelper.hasChildren(jsonObject) && !DSLTransformerHelper.isTabsWidget(jsonObject)) {
             // Save the widget as a directory or Save the widget as a file
+            // Only consider widgetName at the end of the childPath to reset
+            // For example, "foobar/bar" should convert into "foobar/"
             childPath = childPath.replaceAll(widgetName + "$", CommonConstants.EMPTY_STRING);
         }
 

--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/DSLTransformerHelperTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/DSLTransformerHelperTest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DSLTransformHelperTest {
+public class DSLTransformerHelperTest {
 
     private Map<String, JSONObject> jsonMap;
     private Map<String, List<String>> pathMapping;
@@ -295,5 +295,14 @@ public class DSLTransformHelperTest {
                 assertThat(relativePath.endsWith("CurrencyInput1")).isTrue();
             }
         }
+    }
+
+    @Test
+    void testGetPathToWidgetFile_whenChildWidgetIsSubstringOfParent_returnsParentWidgetPath() {
+
+        JSONObject jsonObject = new JSONObject(Map.of("widgetName", "bar"));
+        String pathToWidgetFile = DSLTransformerHelper.getPathToWidgetFile("foobar.bar", jsonObject, "bar");
+
+        org.assertj.core.api.Assertions.assertThat(pathToWidgetFile).isEqualTo("foobar/");
     }
 }


### PR DESCRIPTION
…iner

## Description


Fixes #35224

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10177962011>
> Commit: 2c3878c285f6c34fa0f9e04c29fa6c022d8e6086
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10177962011&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Wed, 31 Jul 2024 10:09:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to generate the correct path for canvas widgets, enhancing the handling and organization of widget files.
  
- **Bug Fixes**
  - Improved the handling of widget names in file paths to ensure only the trailing instance is removed, enhancing path integrity and preventing unintended modifications.
  
- **Tests**
  - Added a new test case to validate the path generation for canvas widgets, expanding coverage and ensuring functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->