### PR TITLE
fix: collapse params & query params in action selector if value is not changed

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/NavigateTo_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/NavigateTo_spec.ts
@@ -23,6 +23,7 @@ describe("Navigate To feature", { tags: ["@tag.JS"] }, () => {
     EditorNavigation.SelectEntityByName("Button1", EntityType.Widget);
     propPane.SelectPlatformFunction("onClick", "Navigate to");
     dataSources.ValidateNSelectDropdown("Choose page", "Select page", "Page1");
+    agHelper.GetNClick(propPane._actionCollapsibleHeader("Query params"));
     propPane.UpdatePropertyFieldValue(
       "Query params",
       `{{

--- a/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/uiToCode_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/uiToCode_spec.ts
@@ -368,6 +368,7 @@ describe("UI to Code", { tags: ["@tag.JS"] }, () => {
 
     // Edit the success callback of the nested Api2.run
     propPane.SelectActionByTitleAndValue("Execute a query", "Api2.run");
+    agHelper.GetNClick(propPane._actionCollapsibleHeader("Params"));
     agHelper.EnterActionValue(
       "Params",
       `{{{

--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/ButtonWidgets_NavigateTo_validation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/ButtonWidgets_NavigateTo_validation_spec.js
@@ -21,6 +21,7 @@ describe(
       agHelper.GetNClick(propPane._navigateToType("URL"));
       cy.get("label")
         .contains("Enter URL")
+        .parent()
         .siblings("div")
         .within(() => {
           cy.get(".t--code-editor-wrapper").type(testdata.externalPage);

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -116,7 +116,11 @@ export class CommonLocators {
   _selectedDropdownValue =
     "//button[contains(@class, 'select-button')]/span[@class='bp3-button-text']";
   _actionTextArea = (actionName: string) =>
-    `label[for="${actionName}"] + div .CodeMirror textarea, .ads-v2-collapsible__header:has(label[for="${actionName}"]) + div .CodeMirror textarea`;
+    "//label[text()='" +
+    actionName +
+    "']/following-sibling::div//div[contains(@class, 'CodeMirror')]//textarea | //label[text()='" +
+    actionName +
+    "']/parent::div/following-sibling::div//div[contains(@class, 'CodeMirror')]//textarea";
   _existingDefaultTextInput =
     ".t--property-control-defaulttext .CodeMirror-code";
   _widgetPageIcon = (widgetType: string) =>

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -116,9 +116,7 @@ export class CommonLocators {
   _selectedDropdownValue =
     "//button[contains(@class, 'select-button')]/span[@class='bp3-button-text']";
   _actionTextArea = (actionName: string) =>
-    "//label[text()='" +
-    actionName +
-    "']/following-sibling::div//div[contains(@class, 'CodeMirror')]//textarea";
+    `label[for="${actionName}"] + div .CodeMirror textarea, .ads-v2-collapsible__header:has(label[for="${actionName}"]) + div .CodeMirror textarea`;
   _existingDefaultTextInput =
     ".t--property-control-defaulttext .CodeMirror-code";
   _widgetPageIcon = (widgetType: string) =>

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -142,7 +142,9 @@ export class CommonLocators {
     fieldName.replace(/ +/g, "").toLowerCase() +
     "')] | //label[text()='" +
     fieldName +
-    "']/following-sibling::div";
+    "']/following-sibling::div | //label[text()='" +
+    fieldName +
+    "']/parent::div/following-sibling::div";
   _existingFieldValueByName = (fieldName: string) =>
     this._existingFieldTextByName(fieldName) +
     "//div[contains(@class,'CodeMirror-code')]";

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -67,9 +67,9 @@ export class PropertyPane {
     "//h3[text()='" + option + " Color']//parent::div";
   _actionSelectorPopup = ".t--action-selector-popup";
   _actionSelectorFieldByLabel = (label: string) =>
-    `.t--action-selector-popup label[for="${label}"] + div .CodeMirror textarea`;
+    `.t--action-selector-popup label[for="${label}"] + div .CodeMirror textarea, .t--action-selector-popup .ads-v2-collapsible__header:has(label[for="${label}"]) + div .CodeMirror textarea`;
   _actionSelectorFieldContentByLabel = (label: string) =>
-    `.t--action-selector-popup label[for="${label}"] + div`;
+    `.t--action-selector-popup label[for="${label}"] + div, .t--action-selector-popup .ads-v2-collapsible__header:has(label[for="${label}"]) + div`;
   _actionCardByTitle = (title: string) =>
     `[data-testid='action-card-${title}']`;
   _actionCallbacks = ".t--action-callbacks";

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -66,6 +66,8 @@ export class PropertyPane {
   _colorInputField = (option: string) =>
     "//h3[text()='" + option + " Color']//parent::div";
   _actionSelectorPopup = ".t--action-selector-popup";
+  _actionCollapsibleHeader = (label: string) =>
+    `.ads-v2-collapsible__header:has(label[for="${label}"])`;
   _actionSelectorFieldByLabel = (label: string) =>
     `.t--action-selector-popup label[for="${label}"] + div .CodeMirror textarea, .t--action-selector-popup .ads-v2-collapsible__header:has(label[for="${label}"]) + div .CodeMirror textarea`;
   _actionSelectorFieldContentByLabel = (label: string) =>

--- a/app/client/src/components/editorComponents/ActionCreator/Field/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Field/index.tsx
@@ -161,8 +161,8 @@ export function Field(props: FieldProps) {
       });
       break;
     case FieldType.PARAMS_FIELD:
-      viewElement = (view as (props: SelectorViewProps) => JSX.Element)({
-        options: options as TreeDropdownOption[],
+      viewElement = (view as (props: TextViewProps) => JSX.Element)({
+        exampleText: exampleText,
         label: label,
         get: (value: string) => getterFunction(value, props.field.position),
         set: (value: string | DropdownOption) => {
@@ -174,7 +174,9 @@ export function Field(props: FieldProps) {
           props.onValueChange(finalValueToSet, false);
         },
         value: value,
-        defaultText: defaultText,
+        isValueChanged: (value: string) => {
+          return value !== getterFunction("");
+        },
       });
       break;
     case FieldType.KEY_VALUE_FIELD:
@@ -190,12 +192,29 @@ export function Field(props: FieldProps) {
         defaultText: defaultText,
       });
       break;
+    case FieldType.QUERY_PARAMS_FIELD:
+      viewElement = (view as (props: TextViewProps) => JSX.Element)({
+        label: label,
+        toolTip: toolTip,
+        exampleText: exampleText,
+        get: getterFunction,
+        set: (value: string | DropdownOption, isUpdatedViaKeyboard = false) => {
+          const finalValueToSet = fieldConfig.setter(value, props.value);
+          props.onValueChange(finalValueToSet, isUpdatedViaKeyboard, true);
+        },
+        value: value,
+        additionalAutoComplete: props.additionalAutoComplete,
+        dataTreePath: props.dataTreePath,
+        isValueChanged: (value: string) => {
+          return value !== getterFunction("");
+        },
+      });
+      break;
     case FieldType.ALERT_TEXT_FIELD:
     case FieldType.URL_FIELD:
     case FieldType.KEY_TEXT_FIELD_STORE_VALUE:
     case FieldType.KEY_TEXT_FIELD_REMOVE_VALUE:
     case FieldType.VALUE_TEXT_FIELD:
-    case FieldType.QUERY_PARAMS_FIELD:
     case FieldType.DOWNLOAD_DATA_FIELD:
     case FieldType.DOWNLOAD_FILE_NAME_FIELD:
     case FieldType.COPY_TEXT_FIELD:

--- a/app/client/src/components/editorComponents/ActionCreator/Field/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Field/index.tsx
@@ -206,6 +206,8 @@ export function Field(props: FieldProps) {
         additionalAutoComplete: props.additionalAutoComplete,
         dataTreePath: props.dataTreePath,
         isValueChanged: (value: string) => {
+          // This function checks whether the param value is changed from the default value.
+          // getterFunction("") -> passing empty string will return the default value
           return value !== getterFunction("");
         },
       });

--- a/app/client/src/components/editorComponents/ActionCreator/types.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/types.ts
@@ -61,6 +61,7 @@ export type TextViewProps = ViewProps & {
   additionalAutoComplete?: AdditionalDynamicDataTree;
   toolTip?: string;
   dataTreePath?: string | undefined;
+  isValueChanged?: (value: string) => boolean;
 };
 
 export type TabViewProps = Omit<ViewProps, "get" | "set"> & SwitcherProps;

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/TextView/TextView.test.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/TextView/TextView.test.tsx
@@ -20,4 +20,65 @@ describe("Text view component", () => {
     render(<TextView {...props} />);
     expect(screen.getByTestId("text-view-label")).toHaveTextContent("Key");
   });
+
+  const propsQueryParams = {
+    dataTreePath: "Button1.onClick",
+    exampleText: "navigateTo('Page1', { a: 1 }, 'SAME_WINDOW')",
+    get: () => {
+      return "";
+    },
+    set: () => {
+      return 1;
+    },
+    isValueChanged: () => {
+      return false;
+    },
+    label: "Query params",
+    value: "{{navigateTo('', {}, 'SAME_WINDOW');}}",
+  };
+
+  test("Renders Text view with Query Params field collapsed for navigateTo action", () => {
+    render(<TextView {...propsQueryParams} />);
+    const queryParamsBody =
+      screen.getByText("Query params").parentNode?.nextSibling;
+    expect(queryParamsBody).toHaveStyle({ display: "none" });
+  });
+
+  test("Renders Text view with Query Params field expanded for navigateTo action", () => {
+    propsQueryParams.isValueChanged = () => true;
+    render(<TextView {...propsQueryParams} />);
+    const queryParamsBodyUpdated =
+      screen.getByText("Query params").parentNode?.nextSibling;
+    expect(queryParamsBodyUpdated).toHaveStyle({ display: "flex" });
+  });
+
+  const propsParams = {
+    dataTreePath: "Button1.onClick",
+    exampleText: "Api1.run({ a: 1 })",
+    get: () => {
+      return "";
+    },
+    set: () => {
+      return 1;
+    },
+    isValueChanged: () => {
+      return false;
+    },
+    label: "Params",
+    value: "{{Api1.run();}}",
+  };
+
+  test("Renders Text view with Params field collapsed for Query action selected", () => {
+    render(<TextView {...propsParams} />);
+    const queryParamsBody = screen.getByText("Params").parentNode?.nextSibling;
+    expect(queryParamsBody).toHaveStyle({ display: "none" });
+  });
+  test("Renders Text view with Params field expanded for Query action selected", () => {
+    propsParams.isValueChanged = () => true;
+
+    render(<TextView {...propsParams} />);
+    const queryParamsBodyUpdated =
+      screen.getByText("Params").parentNode?.nextSibling;
+    expect(queryParamsBodyUpdated).toHaveStyle({ display: "flex" });
+  });
 });

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/TextView/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/TextView/index.tsx
@@ -5,7 +5,7 @@ import {
 } from "components/propertyControls/StyledControls";
 import { InputText } from "components/propertyControls/InputTextControl";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { getCodeFromMoustache } from "../../utils";
 import { useDispatch, useSelector } from "react-redux";
 import { EVAL_WORKER_ACTIONS } from "@appsmith/workers/Evaluation/evalWorkerActions";
@@ -15,10 +15,16 @@ import {
   evaluateActionSelectorField,
 } from "actions/actionSelectorActions";
 import { isFunctionPresent } from "@shared/ast";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleHeader,
+} from "design-system";
 
 export function TextView(props: TextViewProps) {
   const id = useMemo(() => generateReactKey(), []);
   const textValue = props.get(props.value, props.index, false) as string;
+  const [isDefaultOpenFlag, setIsDefaultOpenFlag] = useState<boolean>(true);
 
   const dispatch = useDispatch();
 
@@ -50,9 +56,15 @@ export function TextView(props: TextViewProps) {
 
   const value = evaluatedCodeValue?.value || codeWithoutMoustache;
 
+  useEffect(() => {
+    if (typeof props.isValueChanged === "function") {
+      setIsDefaultOpenFlag(props.isValueChanged(textValue));
+    }
+  }, []);
+
   return (
-    <FieldWrapper className="text-view">
-      <ControlWrapper isAction key={props.label}>
+    <Collapsible isOpen={isDefaultOpenFlag} key={props.label}>
+      <CollapsibleHeader>
         {props.label && (
           <label
             className="!text-gray-600 !text-xs"
@@ -62,30 +74,36 @@ export function TextView(props: TextViewProps) {
             {props.label}
           </label>
         )}
-        <InputText
-          additionalAutocomplete={props.additionalAutoComplete}
-          dataTreePath={props.dataTreePath}
-          enableAI={false}
-          evaluatedValue={value}
-          expected={{
-            type: "string",
-            example: props.exampleText,
-            autocompleteDataType: AutocompleteDataType.STRING,
-            openExampleTextByDefault: true,
-          }}
-          label={props.label}
-          // TODO: Fix this the next time the file is edited
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          onChange={(event: any) => {
-            if (event.target) {
-              props.set(event.target.value, true);
-            } else {
-              props.set(event, true);
-            }
-          }}
-          value={textValue}
-        />
-      </ControlWrapper>
-    </FieldWrapper>
+      </CollapsibleHeader>
+      <CollapsibleContent>
+        <FieldWrapper className="text-view">
+          <ControlWrapper isAction key={props.label}>
+            <InputText
+              additionalAutocomplete={props.additionalAutoComplete}
+              dataTreePath={props.dataTreePath}
+              enableAI={false}
+              evaluatedValue={value}
+              expected={{
+                type: "string",
+                example: props.exampleText,
+                autocompleteDataType: AutocompleteDataType.STRING,
+                openExampleTextByDefault: true,
+              }}
+              label={props.label}
+              // TODO: Fix this the next time the file is edited
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              onChange={(event: any) => {
+                if (event.target) {
+                  props.set(event.target.value, true);
+                } else {
+                  props.set(event, true);
+                }
+              }}
+              value={textValue}
+            />
+          </ControlWrapper>
+        </FieldWrapper>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }


### PR DESCRIPTION
## Description
Problem statement:
The params section has been a source of confusion as seen in user tests, repeatedly. For an optional field and one that is not at all used -- it occupies prominent space in the action selector. We could address this by hiding this section by default when there are no params configured. (This should be in-line with the behaviour of a JS function which does not have any params configured)

Solution:
This PR solves this problem by collapsing the params section whenever we `select a query` to execute using action selector or whenever we are using `navigateTo` we collapse query params as well, this way we are not confusing new users by providing lots of options in the beginning and users can eventually discover this feature as when they require it.

Fixes #32872 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS, @tag.Datasource, @tag.Binding, @tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10210743155>
> Commit: ad5b310ef29d4e86de826cdb441a7040e11f72f8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10210743155&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS, @tag.Datasource, @tag.Binding, @tag.Widget`
> Spec:
> <hr>Fri, 02 Aug 2024 07:26:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the Field component to support new field types and improved data presentation.
	- Introduced a collapsible UI for the TextView component, enhancing interactivity and user experience.

- **Improvements**
	- Added the ability to track value changes via a new `isValueChanged` property in the TextViewProps interface.
	- Updated element selectors for greater flexibility and robustness in UI interactions.

- **Bug Fixes**
	- Standardized behavior for detecting value changes across different field types, ensuring consistency in user interactions.
	- Improved test coverage for the TextView component to ensure proper handling of dynamic input conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->