### PR TITLE
chore: system print added instead of log.info

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -374,14 +374,12 @@ public class MySqlPlugin extends BasePlugin {
                                 Optional<PoolMetrics> poolMetricsOptional = connectionPool.getMetrics();
                                 if (poolMetricsOptional.isPresent()) {
                                     PoolMetrics poolMetrics = poolMetricsOptional.get();
-                                    log.info(
-                                            "Execute query: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}, Max allocations: {}, Max pending acquire: {}",
-                                            poolMetrics.acquiredSize(),
-                                            poolMetrics.pendingAcquireSize(),
-                                            poolMetrics.allocatedSize(),
-                                            poolMetrics.idleSize(),
-                                            poolMetrics.getMaxAllocatedSize(),
-                                            poolMetrics.getMaxPendingAcquireSize());
+                                    System.out.println("Execute query: connection Pool Metrics: Acquired: "
+                                            + poolMetrics.acquiredSize() + ", Pending: "
+                                            + poolMetrics.pendingAcquireSize() + ", Allocated: "
+                                            + poolMetrics.allocatedSize() + ", idle: " + poolMetrics.idleSize()
+                                            + ", Max allocations: " + poolMetrics.getMaxAllocatedSize()
+                                            + ", Max pending acquire: " + poolMetrics.getMaxPendingAcquireSize());
                                 }
 
                                 return resultMono
@@ -734,14 +732,13 @@ public class MySqlPlugin extends BasePlugin {
                                         Optional<PoolMetrics> poolMetricsOptional = connectionPool.getMetrics();
                                         if (poolMetricsOptional.isPresent()) {
                                             PoolMetrics poolMetrics = poolMetricsOptional.get();
-                                            log.info(
-                                                    "Get structure: connection Pool Metrics: Acquired {}, Pending: {}, Allocated: {}, idle: {}, Max allocations: {}, Max pending acquire: {}",
-                                                    poolMetrics.acquiredSize(),
-                                                    poolMetrics.pendingAcquireSize(),
-                                                    poolMetrics.allocatedSize(),
-                                                    poolMetrics.idleSize(),
-                                                    poolMetrics.getMaxAllocatedSize(),
-                                                    poolMetrics.getMaxPendingAcquireSize());
+                                            System.out.println("Get structure: connection Pool Metrics: Acquired: "
+                                                    + poolMetrics.acquiredSize() + ", Pending: "
+                                                    + poolMetrics.pendingAcquireSize() + ", Allocated: "
+                                                    + poolMetrics.allocatedSize() + ", idle: " + poolMetrics.idleSize()
+                                                    + ", Max allocations: " + poolMetrics.getMaxAllocatedSize()
+                                                    + ", Max pending acquire: "
+                                                    + poolMetrics.getMaxPendingAcquireSize());
                                         }
                                         if (isValid) {
                                             return connection


### PR DESCRIPTION
## Description
This PR replaces logs added in [PR](https://github.com/appsmithorg/appsmith/issues/35330) with System.out.println as log.info does not show up logs on mezmo.


Fixes #`Issue Number`  
_or_  
Fixes https://github.com/appsmithorg/appsmith/issues/35331
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10193728337>
> Commit: 817f2d09ecf0f74ade574ff07a86703089f9675f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10193728337&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Thu, 01 Aug 2024 07:42:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated logging approach in the MySqlPlugin to use standard output instead of the logging framework.
	- Maintained the same information output while altering the method of logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->