### PR TITLE
test: fix flaky case for forkapp

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Fork/ForkApplication_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Fork/ForkApplication_spec.ts
@@ -14,6 +14,7 @@ import {
   fakerHelper,
   homePage,
   inviteModal,
+  dataSources
 } from "../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
   AppSidebar,
@@ -110,6 +111,7 @@ describe(
         cy.log("isPartialImport : ", isPartialImport);
         if (isPartialImport) {
           agHelper.WaitUntilEleAppear(reconnectDatasourceModal.SkipToAppBtn);
+          agHelper.WaitUntilEleAppear(dataSources._saveDs);
           agHelper.GetNClick(reconnectDatasourceModal.SkipToAppBtn, 0, true);
           agHelper.WaitUntilEleDisappear(reconnectDatasourceModal.SkipToAppBtn);
         }

--- a/app/client/cypress/e2e/Regression/ClientSide/Fork/ForkApplication_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Fork/ForkApplication_spec.ts
@@ -14,7 +14,7 @@ import {
   fakerHelper,
   homePage,
   inviteModal,
-  dataSources
+  dataSources,
 } from "../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
   AppSidebar,


### PR DESCRIPTION
## Description
Fix case with adding one more assertion with wait.
RCA: 
The issue was not with the function itself but rather with the flaky behavior of the Cypress code. The modal was opening, and our code was attempting to click the “Skip to Application” button too quickly. The actual validation was only for SkipToAppBtn, but in the application, the modal was still loading, causing Cypress to perform the action prematurely, which led to failures. To address this, I added an additional wait for another element, and this resolved the issue.


Fixes #`35375`  


## Automation

/ok-to-test tags="@tag.Fork"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10279433214>
> Commit: 748f4f7cf960355a957e59f3956a47880494da93
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10279433214&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Fork`
> Spec:
> <hr>Wed, 07 Aug 2024 07:08:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced test robustness for the ForkApplication component by implementing a prerequisite check for the presence of a critical UI element linked to data sources.

- **Bug Fixes**
	- Improved control flow in tests to ensure that necessary elements are available before proceeding with actions, reducing the likelihood of test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->