### PR TITLE
fix: allow currentRow for onClick in menuButton item in Table widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/ColumnTypeMenubutton_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/ColumnTypeMenubutton_spec.js
@@ -163,5 +163,15 @@ describe(
       });
       cy.get(".table-menu-button-popover li a").should("not.exist");
     });
+    it("5. should check that menuitems onClick property has access to currentRow", () => {
+      _.propPane.EnterJSContext("onClick", "");
+      _.propPane.TypeTextIntoField("onClick", "{{currentR");
+      _.agHelper.AssertElementExist(_.locators._hints);
+      _.agHelper.GetNAssertElementText(
+        _.locators._hints,
+        "currentRow",
+        "contain.text",
+      );
+    });
   },
 );

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Basic.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Basic.ts
@@ -251,6 +251,7 @@ export default {
                 isBindProperty: true,
                 isTriggerProperty: true,
                 dependencies: ["primaryColumns", "columnOrder"],
+                customJSControl: "TABLE_COMPUTE_VALUE",
               },
             ],
           },


### PR DESCRIPTION
Fixes #26052 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `customJSControl`, for enhanced configuration in the Table Widget, allowing for dynamic table data handling.
	- Added a new test case to ensure the menu button's `onClick` property correctly accesses the `currentRow` context, improving the robustness of the component.

- **Bug Fixes**
	- Enhanced testing coverage for the table menu button component to ensure correct behavior of dynamic properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->