### PR TITLE
chore: WDS adjust `bgNeutral`

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -306,11 +306,6 @@ export class DarkModeTheme implements ColorModeTheme {
     // Low chroma, but not 0, if possible, to produce harmony with accents in the UI
     const color = this.bgAccent.clone();
 
-    // For darker accents it helps to increase neutral's lightness a little, so it's visible against bg
-    if (this.bgAccent.oklch.l < 0.5) {
-      color.oklch.l += 0.05;
-    }
-
     if (this.seedIsAchromatic) {
       color.oklch.c = 0;
     }
@@ -321,6 +316,18 @@ export class DarkModeTheme implements ColorModeTheme {
 
     if (!this.seedIsCold && !this.seedIsAchromatic) {
       color.oklch.c = 0.01;
+    }
+
+    if (color.oklch.l > 0.8) {
+      color.oklch.l -= 0.32;
+    }
+
+    if (color.oklch.l > 0.6 && color.oklch.l <= 0.8) {
+      color.oklch.l -= 0.27;
+    }
+
+    if (color.oklch.l > 0.45 && color.oklch.l <= 0.6) {
+      color.oklch.l -= 0.2;
     }
 
     return color;

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -303,12 +303,12 @@ export class LightModeTheme implements ColorModeTheme {
     const color = this.bgAccent.clone();
 
     // For bright accents it helps to make neutral a bit darker to differentiate with bgAccent
-    if (this.bgAccent.oklch.l >= 0.85) {
-      color.oklch.l -= 0.2;
+    if (this.bgAccent.oklch.l >= 0.7) {
+      color.oklch.l -= 0.55;
     }
 
-    if (this.bgAccent.oklch.l > 0.25 && this.bgAccent.oklch.l < 0.85) {
-      color.oklch.l -= 0.1;
+    if (this.bgAccent.oklch.l > 0.2 && this.bgAccent.oklch.l < 0.85) {
+      color.oklch.l -= 0.35;
     }
 
     if (this.seedIsAchromatic) {
@@ -345,23 +345,23 @@ export class LightModeTheme implements ColorModeTheme {
     // Simplified and adjusted version of bgAccentHover algorithm (bgNeutral has very low or no chroma)
 
     if (this.bgNeutral.oklch.l < 0.06) {
-      color.oklch.l += 0.21;
+      color.oklch.l += 0.3;
     }
 
     if (this.bgNeutral.oklch.l > 0.06 && this.bgNeutral.oklch.l < 0.14) {
-      color.oklch.l += 0.12;
+      color.oklch.l += 0.19;
     }
 
     if (this.bgNeutral.oklch.l >= 0.14 && this.bgNeutral.oklch.l < 0.21) {
-      color.oklch.l += 0.06;
+      color.oklch.l += 0.11;
     }
 
     if (this.bgNeutral.oklch.l >= 0.21 && this.bgNeutral.oklch.l < 0.7) {
-      color.oklch.l += 0.04;
+      color.oklch.l += 0.07;
     }
 
     if (this.bgNeutral.oklch.l >= 0.7 && this.bgNeutral.oklch.l < 0.955) {
-      color.oklch.l += 0.02;
+      color.oklch.l += 0.04;
     }
 
     if (this.bgNeutral.oklch.l >= 0.955) {

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -190,22 +190,22 @@ describe("bgAssistive color", () => {
 describe("bgNeutral color", () => {
   it("should return correct color when lightness < 0.5", () => {
     const { bgNeutral } = new DarkModeTheme("oklch(0.3 0.09 231)").getColors();
-    expect(bgNeutral).toEqual("rgb(18.887% 23.77% 26.341%)");
+    expect(bgNeutral).toEqual("rgb(14.004% 18.746% 21.224%)");
   });
 
   it("should return correct color when chroma < 0.04", () => {
     const { bgNeutral } = new DarkModeTheme("oklch(0.95 0.02 170)").getColors();
-    expect(bgNeutral).toEqual("rgb(93.448% 93.448% 93.448%)");
+    expect(bgNeutral).toEqual("rgb(23.919% 23.919% 23.919%)");
   });
 
   it("should return correct color when hue is between 120 and 300 and chroma is not less than 0.04", () => {
     const { bgNeutral } = new DarkModeTheme("oklch(0.95 0.06 240)").getColors();
-    expect(bgNeutral).toEqual("rgb(89.041% 94.38% 98.38%)");
+    expect(bgNeutral).toEqual("rgb(20.329% 24.6% 27.739%)");
   });
 
   it("should return correct color when hue is not between 120 and 300 and chroma is not less than 0.04", () => {
     const { bgNeutral } = new DarkModeTheme("oklch(0.95 0.06 30)").getColors();
-    expect(bgNeutral).toEqual("rgb(96.118% 92.595% 91.947%)");
+    expect(bgNeutral).toEqual("rgb(25.969% 23.236% 22.736%)");
   });
 });
 
@@ -223,28 +223,28 @@ describe("bgNeutralHover color", () => {
     const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.86 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(73.075% 73.075% 73.075%)");
+    expect(bgNeutralHover).toEqual("rgb(25.976% 25.976% 25.976%)");
   });
 
   it("should return correct color when lightness is between 0.77 and 0.85", () => {
     const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.80 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(79.34% 79.34% 79.34%)");
+    expect(bgNeutralHover).toEqual("rgb(24.944% 24.944% 24.944%)");
   });
 
   it("should return correct color when lightness is between 0.45 and 0.77", () => {
     const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.60 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(53.715% 53.715% 53.715%)");
+    expect(bgNeutralHover).toEqual("rgb(32.307% 32.307% 32.307%)");
   });
 
   it("should return correct color when lightness is between 0.3 and 0.45", () => {
     const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.35 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(32.307% 32.307% 32.307%)");
+    expect(bgNeutralHover).toEqual("rgb(27.015% 27.015% 27.015%)");
   });
 });
 
@@ -253,28 +253,28 @@ describe("bgNeutralActive color", () => {
     const { bgNeutralActive } = new DarkModeTheme(
       "oklch(0.39 0.03 170)",
     ).getColors();
-    expect(bgNeutralActive).toEqual("rgb(28.06% 28.06% 28.06%)");
+    expect(bgNeutralActive).toEqual("rgb(25.976% 25.976% 25.976%)");
   });
 
   it("should return correct color when lightness is between 0.4 and 0.7", () => {
     const { bgNeutralActive } = new DarkModeTheme(
       "oklch(0.6 0.03 170)",
     ).getColors();
-    expect(bgNeutralActive).toEqual("rgb(45.608% 45.608% 45.608%)");
+    expect(bgNeutralActive).toEqual("rgb(27.015% 27.015% 27.015%)");
   });
 
   it("should return correct color when lightness is between 0.7 and 0.85", () => {
     const { bgNeutralActive } = new DarkModeTheme(
       "oklch(0.8 0.03 170)",
     ).getColors();
-    expect(bgNeutralActive).toEqual("rgb(68.134% 68.134% 68.134%)");
+    expect(bgNeutralActive).toEqual("rgb(19.892% 19.892% 19.892%)");
   });
 
   it("should return correct color when lightness > or equal to 0.85", () => {
     const { bgNeutralActive } = new DarkModeTheme(
       "oklch(0.9 0.03 170)",
     ).getColors();
-    expect(bgNeutralActive).toEqual("rgb(70.597% 70.597% 70.597%)");
+    expect(bgNeutralActive).toEqual("rgb(24.944% 24.944% 24.944%)");
   });
 });
 
@@ -839,7 +839,7 @@ describe("bdOnNeutral", () => {
     const { bdOnNeutral } = new DarkModeTheme(
       "oklch(0.45 0.03 60)",
     ).getColors();
-    expect(bdOnNeutral).toEqual("rgb(9.4978% 9.4978% 9.4978%)");
+    expect(bdOnNeutral).toEqual("rgb(5.1758% 5.1758% 5.1758%)");
   });
 });
 

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -198,31 +198,31 @@ describe("bgNeutral color", () => {
     const { bgNeutral } = new LightModeTheme(
       "oklch(0.95 0.03 170)",
     ).getColors();
-    expect(bgNeutral).toEqual("rgb(56.074% 56.074% 56.074%)");
+    expect(bgNeutral).toEqual("rgb(0% 0% 0%)");
   });
 
   it("should return correct color when lightness is between 0.25 and 0.85", () => {
     const { bgNeutral } = new LightModeTheme("oklch(0.5 0.09 231)").getColors();
-    expect(bgNeutral).toEqual("rgb(27.672% 28.158% 28.423%)");
+    expect(bgNeutral).toEqual("rgb(4.0418% 4.4239% 4.6309%)");
   });
 
   it("should return correct color when chroma < 0.04", () => {
     const { bgNeutral } = new LightModeTheme(
       "oklch(0.95 0.02 170)",
     ).getColors();
-    expect(bgNeutral).toEqual("rgb(56.074% 56.074% 56.074%)");
+    expect(bgNeutral).toEqual("rgb(0% 0% 0%)");
   });
 
   it("should return correct color when hue is between 120 and 300 and chroma is not less than 0.04", () => {
     const { bgNeutral } = new LightModeTheme(
       "oklch(0.95 0.06 240)",
     ).getColors();
-    expect(bgNeutral).toEqual("rgb(55.68% 56.161% 56.526%)");
+    expect(bgNeutral).toEqual("rgb(0% 0% 0%)");
   });
 
   it("should return correct color when hue is not between 120 and 300 and chroma is not less than 0.04", () => {
     const { bgNeutral } = new LightModeTheme("oklch(0.95 0.06 30)").getColors();
-    expect(bgNeutral).toEqual("rgb(56.319% 55.997% 55.937%)");
+    expect(bgNeutral).toEqual("rgb(0% 0% 0%)");
   });
 });
 
@@ -240,42 +240,42 @@ describe("bgNeutralHover color", () => {
     const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.05 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(14.087% 14.087% 14.087%)");
+    expect(bgNeutralHover).toEqual("rgb(22.901% 22.901% 22.901%)");
   });
 
   it("should return correct color when lightness is between 0.06 and 0.14", () => {
     const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.10 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(10.396% 10.396% 10.396%)");
+    expect(bgNeutralHover).toEqual("rgb(16.952% 16.952% 16.952%)");
   });
 
   it("should return correct color when lightness is between 0.14 and 0.21", () => {
     const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.17 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(11.304% 11.304% 11.304%)");
+    expect(bgNeutralHover).toEqual("rgb(15.988% 15.988% 15.988%)");
   });
 
   it("should return correct color when lightness is between 0.21 and 0.7", () => {
     const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.35 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(16.952% 16.952% 16.952%)");
+    expect(bgNeutralHover).toEqual("rgb(17.924% 17.924% 17.924%)");
   });
 
   it("should return correct color when lightness is between 0.7 and 0.955", () => {
     const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.75 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(60.846% 60.846% 60.846%)");
+    expect(bgNeutralHover).toEqual("rgb(4.3484% 4.3484% 4.3484%)");
   });
 
   it("should return correct color when lightness > or equal to 0.955", () => {
     const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.96 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover).toEqual("rgb(60.846% 60.846% 60.846%)");
+    expect(bgNeutralHover).toEqual("rgb(4.3484% 4.3484% 4.3484%)");
   });
 });
 
@@ -284,21 +284,21 @@ describe("bgNeutralActive color", () => {
     const { bgNeutralActive } = new LightModeTheme(
       "oklch(0.35 0.03 170)",
     ).getColors();
-    expect(bgNeutralActive).toEqual("rgb(10.396% 10.396% 10.396%)");
+    expect(bgNeutralActive).toEqual("rgb(0% 0% 0%)");
   });
 
   it("should return correct color when lightness is between 0.4 and 0.955", () => {
     const { bgNeutralActive } = new LightModeTheme(
       "oklch(0.80 0.03 170)",
     ).getColors();
-    expect(bgNeutralActive).toEqual("rgb(60.846% 60.846% 60.846%)");
+    expect(bgNeutralActive).toEqual("rgb(0% 0% 0%)");
   });
 
   it("should return correct color when lightness > or equal to 0.955", () => {
     const { bgNeutralActive } = new LightModeTheme(
       "oklch(0.96 0.03 170)",
     ).getColors();
-    expect(bgNeutralActive).toEqual("rgb(54.892% 54.892% 54.892%)");
+    expect(bgNeutralActive).toEqual("rgb(0% 0% 0%)");
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #34856 

| Before | After |
|--------|--------|
| <img width="945" alt="Screenshot 2024-08-02 at 14 21 12" src="https://github.com/user-attachments/assets/f157d616-6b42-4d56-be20-da778e5a9ba3"> | <img width="950" alt="Screenshot 2024-08-02 at 14 38 02" src="https://github.com/user-attachments/assets/2e565b64-2379-4499-8e95-f1e58a5b7e55"> |
| <img width="934" alt="Screenshot 2024-08-02 at 14 21 21" src="https://github.com/user-attachments/assets/760d1264-25ab-4c0f-9ae3-85c17dea0602"> | <img width="939" alt="Screenshot 2024-08-02 at 14 49 57" src="https://github.com/user-attachments/assets/7c2c1671-75a2-4d46-9c23-96c46e4c1013"> | 

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10216260757>
> Commit: e865f449f68767e53d0a0e4b19ae3294bea3987c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10216260757&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Anvil
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxGroupWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCurrencyInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilHeadingWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilIconButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInlineButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilParagraphWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilPhoneInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilRadioGroupWidgetSnapshot_spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Fri, 02 Aug 2024 13:46:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced color adjustment logic for both Dark and Light Mode themes to improve visual harmony and accessibility.
  
- **Bug Fixes**
	- Updated expected RGB values for neutral background colors in both Dark and Light Mode in tests.

- **Refactor**
	- Reworked lightness thresholds and adjustments for color properties for a more refined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->