### PR TITLE
chore: Add hostname as common attr on all spans

### DIFF
--- a/app/client/src/UITelemetry/generateTraces.ts
+++ b/app/client/src/UITelemetry/generateTraces.ts
@@ -42,6 +42,7 @@ const getCommonTelemetryAttributes = () => {
     browserName,
     browserVersion,
     otlpSessionId: OTLP_SESSION_ID,
+    hostname: window.location.hostname,
   };
 };
 


### PR DESCRIPTION
## Description
Some of the self hosted instances are sending data with the entitiy.name as Appsmith Production OTLP. Therefore we need another attribute to slice all the cloud data and hostname will be unique to each instance.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10234910845>
> Commit: b616a08165d404f8d4fc4a5cc8d467ce4a7476a6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10234910845&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Sun, 04 Aug 2024 09:13:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced telemetry data by adding a new `hostname` property, improving tracking and analysis of telemetry events based on the specific web page host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->