### PR TITLE
fix: table preview from schema for tables with hyphens in names

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -884,7 +884,7 @@ public class PostgresPlugin extends BasePlugin {
                                     setFragments.deleteCharAt(setFragments.length() - 1);
                                 }
 
-                                final String quotedTableName = table.getName().replaceFirst("\\.(\\w+)", ".\"$1\"");
+                                final String quotedTableName = table.getName().replaceFirst("\\.([\\w-]+)", ".\"$1\"");
                                 table.getTemplates()
                                         .addAll(List.of(
                                                 new DatasourceStructure.Template(


### PR DESCRIPTION
### PR Description: 
- Issue fixed: #30692 
- Description: Table preview was failing  and showing error if the table name contains hyphen(-) in it internally postgres server was not able to process that due to `-` and was responding syntax error.
- I have attached the video demoing & explaining the approach: [Video Url](https://www.loom.com/share/0f49f70892404b48af8c827300443776?sid=5932c23a-586b-4359-958f-f289a5082d6b)
- Added the unit test case.
- Changes in PR: 
  - Updated the regex to get the table name correctly even if the name contains `-` in it. 
  - Added the unit test case for the scenario. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced support for table names with special characters, including hyphens, in the PostgreSQL plugin.
  
- **Bug Fixes**
  - Improved table name processing to accommodate a wider range of formats, ensuring accurate representation in datasource structures.

- **Tests**
  - Added new tests to verify functionality and structure for tables with hyphens, increasing overall test coverage and robustness of the PostgreSQL plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->