### PR TITLE
feat:sort workspaces on homepage in fixed alphabetical order

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/WorkspaceControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/WorkspaceControllerCE.java
@@ -110,7 +110,7 @@ public class WorkspaceControllerCE {
     @GetMapping("/home")
     public Mono<ResponseDTO<List<Workspace>>> workspacesForHome() {
         return userWorkspaceService
-                .getUserWorkspacesByRecentlyUsedOrder()
+                .getUserWorkspaceInAlphabeticalOrder()
                 .map(workspaces -> new ResponseDTO<>(HttpStatus.OK.value(), workspaces, null));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCE.java
@@ -25,4 +25,6 @@ public interface UserWorkspaceServiceCE {
     Boolean isLastAdminRoleEntity(PermissionGroup permissionGroup);
 
     Mono<List<Workspace>> getUserWorkspacesByRecentlyUsedOrder();
+
+    Mono<List<Workspace>> getUserWorkspaceInAlphabeticalOrder();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCEImpl.java
@@ -32,6 +32,7 @@ import reactor.util.function.Tuple2;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -413,5 +414,33 @@ public class UserWorkspaceServiceCEImpl implements UserWorkspaceServiceCE {
                 .transform(domainFlux -> sortDomainsBasedOnOrderedDomainIds(domainFlux, workspaceIds))
                 // collect to list to keep the order of the workspaces
                 .collectList());
+    }
+
+    /**
+    * Returns a list of workspaces for the current user, sorted in alphabetical order.
+    *
+    * @return Mono containing the list of workspaces
+    */
+
+    @Override
+    public Mono<List<Workspace>> getUserWorkspaceInAlphabeticalOrder() {
+        Mono<List<String>> workspaceIdsMono = userDataService
+            .getForCurrentUser()
+            .defaultIfEmpty(new UserData())
+            .map(userData -> {
+                if (userData.getRecentlyUsedEntityIds() == null) {
+                    return Collections.emptyList();
+                }
+                return userData.getRecentlyUsedEntityIds().stream()
+                    .map(RecentlyUsedEntityDTO::getWorkspaceId)
+                    .collect(Collectors.toList());
+            });
+
+        return workspaceIdsMono.flatMap(workspaceIds -> workspaceService
+            .getAll(workspacePermission.getReadPermission())
+            // Sort by workspace names alphabetically
+            .sort(Comparator.comparing(workspace -> workspace.getName().toLowerCase()))
+            // Collect to list to keep the order of the workspaces
+            .collectList());
     }
 }


### PR DESCRIPTION
[Issue](https://github.com/appsmithorg/appsmith/issues/31108)

### Description
- added a new service which return workspaces of the user in alphabetical order along with its interface
- added this service call in controller.

### Screenshots

![image](https://github.com/user-attachments/assets/ca3566cb-33c0-467c-9513-17ccd24058ca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User workspaces can now be retrieved in alphabetical order, enhancing usability and organization.
  
- **Bug Fixes**
  - Improved handling of null values for recently used entity IDs, ensuring a consistent response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->