### PR TITLE
fix: updated code to show renamed app name in toast message

### DIFF
--- a/app/client/cypress/e2e/Regression/Apps/ExportApplicationToastMessage.spec.js
+++ b/app/client/cypress/e2e/Regression/Apps/ExportApplicationToastMessage.spec.js
@@ -1,0 +1,24 @@
+import homePageLocatores from "../../../locators/HomePage";
+import { homePage } from "../../../support/Objects/ObjectsCore";
+
+describe("Export application shows valid toast message", function () {
+  const updatedAppName = "sample";
+  const applicationNameClass = ".bp3-editable-text-content";
+  const renameAppInputClass = ".bp3-editable-text-input";
+
+  it("Toast message shows updated app name when app is exported after renaming the application", function () {
+    homePage.NavigateToHome();
+
+    cy.get(homePageLocatores.appMoreIcon).first().click({ force: true });
+
+    //Rename application name
+    cy.get(applicationNameClass).click({ force: true });
+    cy.get(renameAppInputClass).clear().type(`${updatedAppName}`);
+
+    // export application
+    cy.get(homePageLocatores.exportAppFromMenu).click({ force: true });
+
+    // checking updated name in toast message
+    cy.get(homePageLocatores.toastMessage).should("contain", updatedAppName);
+  });
+});

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useCallback,
   useMemo,
+  useRef,
 } from "react";
 import styled, { ThemeContext } from "styled-components";
 import type { ApplicationPayload } from "@appsmith/constants/ReduxActionConstants";
@@ -112,7 +113,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isForkApplicationModalopen, setForkApplicationModalOpen] =
     useState(false);
-  const [lastUpdatedValue, setLastUpdatedValue] = useState("");
+  const lastUpdatedValueRef = useRef(props.application.name);
   const dispatch = useDispatch();
 
   const applicationId = props.application?.id;
@@ -212,7 +213,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
       link.click();
     }
     setIsMenuOpen(false);
-    toast.show(`Successfully exported ${props.application.name}`, {
+    toast.show(`Successfully exported ${lastUpdatedValueRef.current }`, {
       kind: "success",
     });
   };
@@ -274,10 +275,10 @@ export function ApplicationCard(props: ApplicationCardProps) {
       setIsMenuOpen(false);
       setShowOverlay(false);
       addDeleteOption();
-      if (lastUpdatedValue && props.application.name !== lastUpdatedValue) {
+      if (props.application.name !== lastUpdatedValueRef.current) {
         props.update &&
           props.update(applicationId, {
-            name: lastUpdatedValue,
+            name: lastUpdatedValueRef.current,
           });
       }
     } else {
@@ -297,6 +298,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
             kind="tertiary"
             size="sm"
             startIcon="context-menu"
+            onClick={() => handleMenuOnClose(true)}
           />
         </MenuTrigger>
         <MenuContent side="right" style={{ maxHeight: "unset" }}>
@@ -329,7 +331,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
                     });
                 }}
                 onTextChanged={(value: string) => {
-                  setLastUpdatedValue(value);
+                  lastUpdatedValueRef.current = value;
                 }}
                 placeholder={"Edit text input"}
                 savingState={

--- a/app/client/src/pages/Applications/ExportApplicationToastMessage.test.tsx
+++ b/app/client/src/pages/Applications/ExportApplicationToastMessage.test.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import ApplicationCard from "./ApplicationCard";
+import {
+  getIsErroredSavingAppName,
+  getIsSavingAppName,
+} from "@appsmith/selectors/applicationSelectors";
+import { getIsGitConnected } from "../../selectors/gitSyncSelectors";
+import { isEditOnlyModeSelector } from "../../selectors/editorSelectors";
+import { ThemeProvider } from "styled-components";
+import { toast } from "design-system";
+
+jest.mock("design-system", () => ({
+  ...jest.requireActual("design-system"),
+  toast: {
+    show: jest.fn(),
+  },
+}));
+
+const mockStore = configureStore([]);
+
+const store = mockStore({
+  applicationName: "My first application",
+  ui: {
+    workspaces: {
+      list: [
+        {
+          id: "12345",
+          name: "Test Workspace",
+        },
+      ],
+    },
+    applications: {
+      forkingApplication: false,
+    },
+    selectedWorkspace: {
+      loadingStates: {
+        isFetchingApplications: false,
+      },
+    },
+  },
+});
+
+const mockProps = {
+  application: {
+    id: "1234",
+    name: "My first application",
+    color: "#F4FFDE",
+    icon: "#fffff",
+    workspaceId: "12345",
+    defaultPageId: "6697a252ac5b7a4f2c13cbab",
+    isPublic: false,
+    userPermissions: [
+      "export:applications",
+      "read:applications",
+      "create:pages",
+      "manageAutoCommit:applications",
+      "canComment:applications",
+      "delete:applicationPages",
+      "manage:applications",
+      "manageProtectedBranches:applications",
+      "manageDefaultBranches:applications",
+      "connectToGit:applications",
+      "publish:applications",
+      "delete:applications",
+      "makePublic:applications",
+    ],
+    appIsExample: false,
+    slug: "my-first-application",
+    pages: [
+      {
+        id: "6697a252ac5b7a4f2c13cbab",
+        isDefault: true,
+        name: "Default Page",
+        slug: "default-page",
+      },
+    ],
+    modifiedAt: "2024-07-31T10:23:44.189Z",
+    applicationVersion: 2,
+  },
+  isFetchingApplications: false,
+  share: jest.fn(),
+  delete: jest.fn(),
+  update: jest.fn(),
+  enableImportExport: true,
+  workspaceId: "12345",
+};
+
+const mockTheme = {
+  colors: {
+    appCardColors: ["#FFFFFF", "#000000"],
+    applications: {
+      cardMenuIcon: "#000000",
+    },
+    text: {
+      heading: "#ffffff",
+    },
+  },
+  card: {
+    minWidth: 200,
+    minHeight: 100,
+  },
+};
+
+jest.mock("@appsmith/selectors/applicationSelectors", () => {
+  const originalModule = jest.requireActual(
+    "@appsmith/selectors/applicationSelectors",
+  );
+  return {
+    __esModule: true,
+    ...originalModule,
+    getIsSavingAppName: jest.fn(),
+    getIsErroredSavingAppName: jest.fn(),
+  };
+});
+
+jest.mock("../../selectors/gitSyncSelectors", () => {
+  const originalModule = jest.requireActual("../../selectors/gitSyncSelectors");
+  return {
+    __esModule: true,
+    ...originalModule,
+    getIsGitConnected: jest.fn(),
+  };
+});
+
+jest.mock("../../selectors/editorSelectors", () => {
+  const originalModule = jest.requireActual("../../selectors/editorSelectors");
+  return {
+    __esModule: true,
+    ...originalModule,
+    isEditOnlyModeSelector: jest.fn(),
+  };
+});
+
+describe("ApplicationCard", () => {
+  test("triggers update on name change", async () => {
+    jest.clearAllMocks();
+    (getIsSavingAppName as jest.Mock).mockReturnValue(true);
+    (getIsErroredSavingAppName as jest.Mock).mockReturnValue(false);
+    (getIsGitConnected as unknown as jest.Mock).mockReturnValue(true);
+    (isEditOnlyModeSelector as unknown as jest.Mock).mockReturnValue(true);
+
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={mockTheme}>
+          <ApplicationCard {...mockProps} />
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    const moreButton = document.getElementsByClassName("m-0.5");
+    const moreButtonElement = moreButton[0] as HTMLElement;
+    expect(moreButtonElement).toBeInTheDocument();
+    fireEvent.click(moreButtonElement);
+
+    const menu = await screen.findByTestId("t--export-app");
+    expect(menu).toBeInTheDocument();
+
+    const appNameInput = screen.getAllByText("My first application")[1];
+    fireEvent.click(appNameInput);
+    await waitFor(() => {
+      const inputField = screen.getByPlaceholderText(
+        "Edit text input",
+      ) as HTMLInputElement;
+
+      fireEvent.change(inputField, {
+        target: { value: "Renamed application" },
+      });
+      expect(inputField.value).toBe("Renamed application");
+    });
+
+    const exportButton = screen.getByText("Export");
+    fireEvent.click(exportButton);
+
+    expect(toast.show).toHaveBeenCalledWith(
+      `Successfully exported Renamed application`,
+      {
+        kind: "success",
+      },
+    );
+  });
+});


### PR DESCRIPTION
### [Issue](https://github.com/appsmithorg/appsmith/issues/13650)

#### Description:

Updated the code to show updated application name in toast message when the application is exported after renaming it's name.

##### Screenshots:

###### ->Initially app name is "My App":

![image](https://github.com/user-attachments/assets/f2944545-74eb-4a6d-90d5-e906373f7ff7)

###### ->App name updated to "New Application":

![image](https://github.com/user-attachments/assets/37c3e376-23da-461f-af99-0f628720b4b1)
![image](https://github.com/user-attachments/assets/c006295a-acae-47f0-ad27-a6f7c17a5b2e)

###### ->After exporting the app the toast message contains updated name:

![image](https://github.com/user-attachments/assets/85b6e0ee-80c3-474d-bc68-0023f8719872)

###### Screenshot of unit test case:
![image](https://github.com/user-attachments/assets/7c66d9aa-6a5a-4c56-8937-d13ae890f898)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new end-to-end test to verify toast message display upon application renaming and exporting.
	- Added unit tests for the `ApplicationCard` component focusing on the export functionality and toast notification.

- **Bug Fixes**
	- Improved performance and state management in the `ApplicationCard` by using a mutable reference for tracking the last updated application name, reducing unnecessary re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->