### PR TITLE
feat: added the code to sort the collection in the proper order.

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
@@ -27,6 +27,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -128,19 +129,23 @@ public class DatasourceTriggerSolutionCEImpl implements DatasourceTriggerSolutio
                                 entitySelectorTriggerSolution(datasourceId, triggerRequestDTO, trueEnvironmentId))
                         .map(Tuple2::getT2))
                 .map(entityNames -> {
-                    List<Object> result = new ArrayList<>();
+                    List<Map<String, String>> result = new ArrayList<>();
 
                     if (ClientDataDisplayType.DROP_DOWN.equals(displayType)) {
-                        // label, value
+                        // Create maps and add them to the result list
                         for (String entityName : entityNames) {
                             Map<String, String> entity = new HashMap<>();
                             entity.put("label", entityName);
                             entity.put("value", entityName);
                             result.add(entity);
                         }
+                        // Sort the list of maps based on the 'label' value
+                        result.sort(Comparator.comparing(
+                                entity -> entity.get("label").toLowerCase()));
                     }
-
-                    return new TriggerResultDTO(result);
+                    // Convert the result into a list of objects
+                    List<Object> objectResult = new ArrayList<>(result);
+                    return new TriggerResultDTO(objectResult);
                 });
 
         return resultFromPluginMono.switchIfEmpty(defaultResultMono);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceTriggerSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceTriggerSolutionTest.java
@@ -202,4 +202,71 @@ public class DatasourceTriggerSolutionTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void datasourceTriggerTest_should_return_collections_inorder() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        DatasourceStructure.Column[] table1Columns = {
+            new DatasourceStructure.Column("_id1", "ObjectId", null, true),
+            new DatasourceStructure.Column("age1", "Integer", null, false),
+            new DatasourceStructure.Column("dob1", "Date", null, false),
+            new DatasourceStructure.Column("gender1", "String", null, false),
+            new DatasourceStructure.Column("luckyNumber1", "Long", null, false),
+            new DatasourceStructure.Column("name1", "String", null, false),
+            new DatasourceStructure.Column("netWorth1", "BigDecimal", null, false),
+            new DatasourceStructure.Column("updatedByCommand1", "Object", null, false),
+        };
+
+        DatasourceStructure.Table table1 =
+                new DatasourceStructure.Table(TABLE, null, "Table1", List.of(table1Columns), null, null);
+
+        DatasourceStructure.Column[] table2Columns = {
+            new DatasourceStructure.Column("_id2", "ObjectId", null, true),
+            new DatasourceStructure.Column("age2", "Integer", null, false),
+            new DatasourceStructure.Column("dob2", "Date", null, false),
+            new DatasourceStructure.Column("gender2", "String", null, false),
+            new DatasourceStructure.Column("luckyNumber2", "Long", null, false),
+            new DatasourceStructure.Column("name2", "String", null, false),
+            new DatasourceStructure.Column("netWorth2", "BigDecimal", null, false),
+            new DatasourceStructure.Column("updatedByCommand2", "Object", null, false),
+        };
+
+        DatasourceStructure.Table table2 =
+                new DatasourceStructure.Table(TABLE, null, "Table2", List.of(table2Columns), null, null);
+
+        DatasourceStructure testStructure = new DatasourceStructure(List.of(table1, table2));
+
+        Mockito.when(datasourceStructureSolution.getStructure(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any()))
+                .thenReturn(Mono.just(testStructure));
+
+        datasourceService
+                .findById(datasourceId, datasourcePermission.getReadPermission())
+                .block();
+        Mockito.doReturn(Mono.just(Boolean.TRUE)).when(featureFlagService).check(Mockito.any());
+
+        Mono<TriggerResultDTO> tableNameMono = datasourceTriggerSolution.trigger(
+                datasourceId,
+                defaultEnvironmentId,
+                new TriggerRequestDTO("ENTITY_SELECTOR", Map.of(), ClientDataDisplayType.DROP_DOWN));
+
+        Mono<TriggerResultDTO> columnNamesMono = datasourceTriggerSolution.trigger(
+                datasourceId,
+                defaultEnvironmentId,
+                new TriggerRequestDTO(
+                        "ENTITY_SELECTOR", Map.of("tableName", "Table1"), ClientDataDisplayType.DROP_DOWN));
+
+        StepVerifier.create(tableNameMono)
+                .assertNext(tablesResult -> {
+                    List<Map<String, String>> tables = (List<Map<String, String>>) tablesResult.getTrigger();
+
+                    assertEquals(2, tables.size());
+                    // Check the order of the tables
+                    assertEquals("Table1", tables.get(0).get("label"));
+                    assertEquals("Table2", tables.get(1).get("label"));
+                })
+                .verifyComplete();
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceTriggerSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceTriggerSolutionTest.java
@@ -221,7 +221,7 @@ public class DatasourceTriggerSolutionTest {
         };
 
         DatasourceStructure.Table table1 =
-                new DatasourceStructure.Table(TABLE, null, "Table1", List.of(table1Columns), null, null);
+                new DatasourceStructure.Table(TABLE, null, "TableSecond", List.of(table1Columns), null, null);
 
         DatasourceStructure.Column[] table2Columns = {
             new DatasourceStructure.Column("_id2", "ObjectId", null, true),
@@ -235,7 +235,7 @@ public class DatasourceTriggerSolutionTest {
         };
 
         DatasourceStructure.Table table2 =
-                new DatasourceStructure.Table(TABLE, null, "Table2", List.of(table2Columns), null, null);
+                new DatasourceStructure.Table(TABLE, null, "TableFirst", List.of(table2Columns), null, null);
 
         DatasourceStructure testStructure = new DatasourceStructure(List.of(table1, table2));
 
@@ -252,20 +252,14 @@ public class DatasourceTriggerSolutionTest {
                 defaultEnvironmentId,
                 new TriggerRequestDTO("ENTITY_SELECTOR", Map.of(), ClientDataDisplayType.DROP_DOWN));
 
-        Mono<TriggerResultDTO> columnNamesMono = datasourceTriggerSolution.trigger(
-                datasourceId,
-                defaultEnvironmentId,
-                new TriggerRequestDTO(
-                        "ENTITY_SELECTOR", Map.of("tableName", "Table1"), ClientDataDisplayType.DROP_DOWN));
-
         StepVerifier.create(tableNameMono)
                 .assertNext(tablesResult -> {
                     List<Map<String, String>> tables = (List<Map<String, String>>) tablesResult.getTrigger();
 
                     assertEquals(2, tables.size());
                     // Check the order of the tables
-                    assertEquals("Table1", tables.get(0).get("label"));
-                    assertEquals("Table2", tables.get(1).get("label"));
+                    assertEquals("TableFirst", tables.get(0).get("label"));
+                    assertEquals("TableSecond", tables.get(1).get("label"));
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
**Description:**
The collection dropdown in MongoDB query editor isn't sorted, typing to filter doesn't work, and hitting a key like u doesn't scroll to the next item starting with you.

fixes: [28190](https://github.com/appsmithorg/appsmith/issues/28190)

**Updated in PR:**
1.Added the sort code to the collection after Api trgger.
2.Added the test case for this scenario.

**snap shots:**
![Screenshot from 2024-08-05 16-07-18](https://github.com/user-attachments/assets/8c75866f-c843-455e-80e0-1cb6d4e893ce)
![Screenshot from 2024-08-05 16-22-29](https://github.com/user-attachments/assets/4452f99d-2b6e-42aa-82b3-38bc256af216)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the output structure of the datasource trigger, providing a clearer representation of entities with labels and values.
	- Implemented case-insensitive sorting for the returned collections, improving data usability.

- **Tests**
	- Added a new test to validate the ordering of collections returned by the datasource trigger, ensuring data integrity and expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->