### PR TITLE
test: fix flaky inline editing 2 spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -26,8 +26,6 @@ describe(
       agHelper.AddDsl("Table/InlineEditingDSL");
     });
 
-    let propPaneBack = "[data-testid='t--property-pane-back-btn']";
-
     it("1. should check that onDiscard event is working", () => {
       cy.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
@@ -51,7 +49,7 @@ describe(
     it("2. should check that inline editing works with text wrapping disabled", () => {
       agHelper.AddDsl("Table/InlineEditingDSL");
       cy.openPropertyPane("tablewidgetv2");
-      table.toggleColumnEditableViaColSettingsPane("step", "v2", false, true);
+      table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editTableCell(0, 0);
       cy.get(
         "[data-colindex=0][data-rowindex=0] .t--inlined-cell-editor input.bp3-input",
@@ -71,13 +69,16 @@ describe(
       ).should("not.be.disabled");
     });
 
-    it("4. should check that doesn't grow taller when text wrapping is disabled", () => {
+    it("4. should check that cell column height doesn't grow taller when text wrapping is disabled", () => {
+      const DEFAULT_NON_WRAP_CELL_COLUMN_HEIGHT = 29;
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
-      table.EnableEditableOfColumn("step");
+      table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       table.EditTableCell(0, 0, "", false);
       agHelper.GetHeight(table._editCellEditor);
       cy.get("@eleHeight").then(($initiaHeight) => {
-        expect(Number($initiaHeight)).to.eq(28);
+        expect(Number($initiaHeight.toFixed())).to.eq(
+          DEFAULT_NON_WRAP_CELL_COLUMN_HEIGHT,
+        );
         table.EditTableCell(
           1,
           0,
@@ -91,9 +92,10 @@ describe(
       });
     });
 
-    it("5. should check that grows taller when text wrapping is enabled", () => {
+    it("5. should check that cell column height grows taller when text wrapping is enabled", () => {
+      const MIN_WRAP_CELL_COLUMN_HEIGHT = 34;
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
-      table.EnableEditableOfColumn("step");
+      table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       table.EditColumn("step");
       propPane.TogglePropertyState("Cell Wrapping", "On");
       table.EditTableCell(
@@ -104,7 +106,9 @@ describe(
       );
       agHelper.GetHeight(table._editCellEditor);
       cy.get("@eleHeight").then(($newHeight) => {
-        expect(Number($newHeight)).to.be.greaterThan(34);
+        expect(Number($newHeight)).to.be.greaterThan(
+          MIN_WRAP_CELL_COLUMN_HEIGHT,
+        );
       });
     });
 
@@ -130,7 +134,7 @@ describe(
 
       cy.openPropertyPane("tablewidgetv2");
 
-      table.toggleColumnEditableViaColSettingsPane("step", "v2", false, true);
+      table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.wait(1000);
 
       // case 2: check if updatedRowIndex is 0, when cell at row 0 is updated.
@@ -175,7 +179,7 @@ describe(
       );
 
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
-      table.EnableEditableOfColumn("step");
+      table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       agHelper.GetNClick(table._updateMode("Multi"), 0, false, 1000);
 
       // case 1: check if updatedRowIndex is 0, when cell at row 0 is updated.

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -70,7 +70,7 @@ describe(
     });
 
     it("4. should check that cell column height doesn't grow taller when text wrapping is disabled", () => {
-      const DEFAULT_NON_WRAP_CELL_COLUMN_HEIGHT = 29;
+      const DEFAULT_NON_WRAP_CELL_COLUMN_HEIGHT = 28;
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       table.EditTableCell(0, 0, "", false);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -135,7 +135,6 @@ describe(
       cy.openPropertyPane("tablewidgetv2");
 
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
-      cy.wait(1000);
 
       // case 2: check if updatedRowIndex is 0, when cell at row 0 is updated.
       cy.editTableCell(0, 0);
@@ -153,7 +152,6 @@ describe(
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);
 
       // case 5: check if the updatedRowIndex changes to -1 when the table data changes.
-      cy.wait(1000);
       cy.editTableCell(0, 2);
       cy.enterTableCellValue(0, 2, "#14").type("{enter}");
       cy.openPropertyPane("tablewidgetv2");
@@ -194,7 +192,6 @@ describe(
       cy.get(commonlocators.textWidgetContainer).should("contain.text", -1);
 
       // case 3: check if the updatedRowIndex changes to -1 when the table data changes.
-      cy.wait(1000);
       table.EditTableCell(2, 0, "#14");
       cy.get(commonlocators.textWidgetContainer).should("contain.text", 2);
       cy.openPropertyPane("tablewidgetv2");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -161,13 +161,13 @@ describe(
     });
 
     it("7. should check if updatedRowIndex is getting updated for multi row update mode", () => {
-      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TEXT, 400, 400);
+      cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
       cy.get(".t--widget-textwidget").should("exist");
       cy.updateCodeInput(
         ".t--property-control-text",
         `{{Table1.updatedRowIndex}}`,
       );
-      entityExplorer.DragDropWidgetNVerify(draggableWidgets.BUTTON, 300, 300);
+      cy.dragAndDropToCanvas("buttonwidget", { x: 300, y: 300 });
       cy.get(".t--widget-buttonwidget").should("exist");
       cy.get(PROPERTY_SELECTOR.onClick).find(".t--js-toggle").click();
       cy.updateCodeInput(".t--property-control-label", "Reset");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
Fix flaky test - `Inline_editing_2_spec.js`

Related EE PR for fix - https://github.com/appsmithorg/appsmith-ee/pull/4819

**Problems**
Previous change made to remove the editable checkbox from the columns list on the table property pane made the `table.EnableEditableOfColumn` obsolete as a method for enabling edit mode on specific columns. There is a newly introduced method `toggleColumnEditableViaColSettingsPane` was swapped only in some cases, not implemented correctly, and in some other cases, the `table.EnableEditableOfColumn` still existed, causing the test to fail.

**Solution**
1. Fix the implementation of the `table.toggleColumnEditableViaColSettingsPane` in all instances in the test suit
2. Replace `table.EnableEditableOfColumn` with `table.toggleColumnEditableViaColSettingsPane` in tests
3. Move standalone values into consts for readability
4. Remove unused const


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10352974239>
> Commit: 83116d9c64f95946ab0ba7399c7e1c491f2d2851
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10352974239&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 12 Aug 2024 14:08:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of inline editing tests for the table widget, ensuring consistent behavior when editing columns.

- **Improvements**
	- Enhanced clarity of test case descriptions regarding cell column height behavior with text wrapping.
	- Updated height assertions to use constants for better readability and maintainability.

- **Chores**
	- Changed focus of limited tests from template-related tests to inline editing functionality tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->