### PR TITLE
chore: Updated dispatch command

### DIFF
--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -2,7 +2,7 @@ name: Build Client, Server & Run only Cypress
 
 on:
   repository_dispatch:
-    types: [ci-test-limit-count]
+    types: [ci-test-limit-count-command]
 
 jobs:
   file-check:


### PR DESCRIPTION
## Description
It is for running a spec file with given run_count

Fixes #`34956`  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10260756232>
> Commit: 0d4867a9068a353614cfc71374efeb8bc737fcfd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10260756232&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 06 Aug 2024 05:40:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the event type for the GitHub Actions workflow to enhance clarity and specificity in triggering associated jobs. Users will now need to use the new event type `ci-test-limit-count-command` for interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->