### PR TITLE
Revert "fix: ignored target directory for spotless JSON formatting"

### DIFF
--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -159,9 +159,6 @@
                         <formatAnnotations/>
                     </java>
                     <json>
-                        <excludes>
-                            <exclude>**/target/**/*.json</exclude>
-                        </excludes>
                         <includes>
                             <include>**/*.json</include>
                         </includes>


### PR DESCRIPTION
Reverts appsmithorg/appsmith#35407
Reverting as formatter is changing the sorting order of JSON keys, will add back with the config for maintaining order.
Ref: https://theappsmith.slack.com/archives/CGBPVEJ5C/p1722929754593669?thread_ts=1722916121.682699&cid=CGBPVEJ5C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed exclusion of JSON files from the build process, allowing all JSON files to be included, which may improve file accessibility but could lead to unwanted files in the output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->