### PR TITLE
[DO NOT MERGE]: 33812 commit icon GitHub app crashes

### DIFF
--- a/app/client/src/pages/Editor/gitSync/components/ReconnectSSHError.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/ReconnectSSHError.tsx
@@ -58,7 +58,7 @@ function ReconnectSSHError() {
 
   if (
     errorData &&
-    errorData.response.responseMeta.error.code === "AE-GIT-4044"
+    errorData?.response?.responseMeta?.error?.code === "AE-GIT-4044"
   ) {
     return (
       <StyledCallout


### PR DESCRIPTION
## Description
TESTs for contributor PR https://github.com/appsmithorg/appsmith/pull/34673
Please do not merge

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10265761778>
> Commit: 5244ce786287de1f859f960ef916f44827883b75
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10265761778&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Tue, 06 Aug 2024 12:05:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
