### PR TITLE
fix: issue with opening custom widget source editor 

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -162,6 +162,7 @@ import {
 } from "actions/activeFieldActions";
 import CodeMirrorTernService from "utils/autocomplete/CodemirrorTernService";
 import { getEachEntityInformation } from "ee/utils/autocomplete/EntityDefinitions";
+import { getCurrentPageId } from "selectors/editorSelectors";
 
 type ReduxStateProps = ReturnType<typeof mapStateToProps>;
 type ReduxDispatchProps = ReturnType<typeof mapDispatchToProps>;
@@ -1771,26 +1772,33 @@ class CodeEditor extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: AppState, props: EditorProps) => ({
-  dynamicData: getDataTreeForAutocomplete(state),
-  datasources: state.entities.datasources,
-  pluginIdToPlugin: getPluginIdToPlugin(state),
-  recentEntities: getRecentEntityIds(state),
-  lintErrors: getEntityLintErrors(state, props.dataTreePath),
-  editorIsFocused: getIsInputFieldFocused(state, getEditorIdentifier(props)),
-  editorLastCursorPosition: getCodeEditorLastCursorPosition(
-    state,
-    getEditorIdentifier(props),
-  ),
-  entitiesForNavigation: getEntitiesForNavigation(
-    state,
-    props.dataTreePath?.split(".")[0],
-  ),
-  featureFlags: selectFeatureFlags(state),
-  datasourceTableKeys: getAllDatasourceTableKeys(state, props.dataTreePath),
-  installedLibraries: selectInstalledLibraries(state),
-  focusedProperty: getFocusablePropertyPaneField(state),
-});
+const mapStateToProps = (state: AppState, props: EditorProps) => {
+  const currentPageId: string = getCurrentPageId(state);
+  let entitiesForNavigation: EntityNavigationData = {};
+  if (currentPageId) {
+    entitiesForNavigation = getEntitiesForNavigation(
+      state,
+      props.dataTreePath?.split(".")[0],
+    );
+  }
+  return {
+    dynamicData: getDataTreeForAutocomplete(state),
+    datasources: state.entities.datasources,
+    pluginIdToPlugin: getPluginIdToPlugin(state),
+    recentEntities: getRecentEntityIds(state),
+    lintErrors: getEntityLintErrors(state, props.dataTreePath),
+    editorIsFocused: getIsInputFieldFocused(state, getEditorIdentifier(props)),
+    editorLastCursorPosition: getCodeEditorLastCursorPosition(
+      state,
+      getEditorIdentifier(props),
+    ),
+    entitiesForNavigation,
+    featureFlags: selectFeatureFlags(state),
+    datasourceTableKeys: getAllDatasourceTableKeys(state, props.dataTreePath),
+    installedLibraries: selectInstalledLibraries(state),
+    focusedProperty: getFocusablePropertyPaneField(state),
+  };
+};
 
 // TODO: Fix this the next time the file is edited
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description
Custom widget source editor crashes when open from an application connected to packages


Fixes https://github.com/appsmithorg/appsmith/issues/35462

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10271875888>
> Commit: f36faa4eb9e4dee68c52b50ccd5bac26fe5fa5b5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10271875888&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 06 Aug 2024 19:15:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation entity logic in the Code Editor for improved performance.
	- Conditional loading of navigation entities based on the current page context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->