### PR TITLE
chore: Ability to run PR automations every time PR updates

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -35,7 +35,7 @@ jobs:
             }
 
   mark-stale:
-    needs: [ check-label ]
+    needs: [ checkTestLabel ]
     if: needs.checkTestLabel.outputs.ok_to_test == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
             }
 
   parse-tags:
-    needs: [ check-label ]
+    needs: [ checkTestLabel ]
     if: needs.checkTestLabel.outputs.ok_to_test == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -13,8 +13,6 @@ jobs:
     outputs:
       ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Check PR Label
         id: checkLabel

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -53,6 +53,17 @@ jobs:
         with:
           repository: appsmithorg/appsmith
 
+      # In case of a no label present, mark the Cypress status to be stale
+      - name: Mark the Cypress response to be stale
+        uses: actions/github-script@v7
+        env:
+          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
+          BODY: |
+            Tests have not run on the HEAD ${{ github.event.pull_request.head.sha }} yet
+        with:
+          script: |
+            require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
+
       # Reads the PR description to retrieve the /ok-to-test or, if that's absent, the /test command
       - name: Read tags from PR description
         uses: actions/github-script@v7

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -61,7 +61,9 @@ jobs:
           NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
         with:
           script: |
-            require("test-tag-parser.js")({core, context, github})
+            if(${{ steps.checkLabel.outputs.ok_to_test == 'true' }}) {
+              require("test-tag-parser.js")({core, context, github})
+            }
 
       # In case of a run with all test cases, allocate a larger matrix
       - name: Check if @tag.All is present in tags

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -14,7 +14,7 @@ jobs:
       ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check PR Label
         id: checkLabel

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -62,7 +62,9 @@ jobs:
             Tests have not run on the HEAD ${{ github.event.pull_request.head.sha }} yet
         with:
           script: |
-            require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
+            if(${{ steps.checkLabel.outputs.ok_to_test == 'false' }}) {
+              require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
+            }
 
       # Reads the PR description to retrieve the /ok-to-test or, if that's absent, the /test command
       - name: Read tags from PR description

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -8,7 +8,7 @@ on:
     types: [ labeled, synchronize ]
 
 jobs:
-  check-label:
+  checkTestLabel:
     runs-on: ubuntu-latest
     outputs:
       ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}
@@ -33,8 +33,28 @@ jobs:
               console.log("Label 'ok-to-test' is not present");
               core.setOutput("ok_to_test", "false");
             }
+
+  mark-stale:
+    needs: [ check-label ]
+    if: needs.checkTestLabel.outputs.ok_to_test == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # In case of a no label present, mark the Cypress status to be stale
+      - name: Mark the Cypress response to be stale
+        uses: actions/github-script@v7
+        env:
+          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
+          BODY: |
+            Tests have not run on the HEAD ${{ github.event.pull_request.head.sha }} yet
+        with:
+          script: |
+            if(${{ steps.checkLabel.outputs.ok_to_test == 'false' }}) {
+              require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
+            }
+
   parse-tags:
     needs: [ check-label ]
+    if: needs.checkTestLabel.outputs.ok_to_test == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -53,19 +73,6 @@ jobs:
         with:
           repository: appsmithorg/appsmith
 
-      # In case of a no label present, mark the Cypress status to be stale
-      - name: Mark the Cypress response to be stale
-        uses: actions/github-script@v7
-        env:
-          NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
-          BODY: |
-            Tests have not run on the HEAD ${{ github.event.pull_request.head.sha }} yet
-        with:
-          script: |
-            if(${{ steps.checkLabel.outputs.ok_to_test == 'false' }}) {
-              require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
-            }
-
       # Reads the PR description to retrieve the /ok-to-test or, if that's absent, the /test command
       - name: Read tags from PR description
         uses: actions/github-script@v7
@@ -74,9 +81,7 @@ jobs:
           NODE_PATH: "${{ github.workspace }}/.github/workflows/scripts"
         with:
           script: |
-            if(${{ steps.checkLabel.outputs.ok_to_test == 'true' }}) {
-              require("test-tag-parser.js")({core, context, github})
-            }
+            require("test-tag-parser.js")({core, context, github})
 
       # In case of a run with all test cases, allocate a larger matrix
       - name: Check if @tag.All is present in tags

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -5,13 +5,34 @@ on:
     branches:
       - release
       - pg
-    types:
-      - labeled
+    types: [ labeled, synchronize ]
 
 jobs:
-  parse-tags:
+  check-label:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'ok-to-test'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check PR Label
+        uses: actions/github-script@v7
+        with:
+          # This script will check if the PR has ok-to-test label.
+          # To avoid being dependent on the event which triggered this workflow,
+          # we will always get the pull request labels directly from the context
+          # It will later set the output to be "true" or "false".
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            if (labels.includes("ok-to-test")) {
+              console.log("Label 'ok-to-test' is present");
+              core.setOutput("ok_to_test", "true");
+            } else {
+              console.log("Label 'ok-to-test' is not present");
+              core.setOutput("ok_to_test", "false");
+  parse-tags:
+    needs: [ check-label ]
+    runs-on: ubuntu-latest
+    if: ${{ steps.check-label.outputs.ok_to_test == 'true' }}
     permissions:
       pull-requests: write
     defaults:
@@ -27,7 +48,7 @@ jobs:
       - name: Checkout the head commit of the branch
         uses: actions/checkout@v4
         with:
-            repository: appsmithorg/appsmith
+          repository: appsmithorg/appsmith
 
       # Reads the PR description to retrieve the /ok-to-test or, if that's absent, the /test command
       - name: Read tags from PR description
@@ -72,7 +93,7 @@ jobs:
 
   # Call the workflow to run Cypress tests
   perform-test:
-    needs: [parse-tags]
+    needs: [ parse-tags ]
     if: success()
     uses: ./.github/workflows/pr-cypress.yml
     secrets: inherit

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -38,6 +38,9 @@ jobs:
     needs: [ checkTestLabel ]
     if: needs.checkTestLabel.outputs.ok_to_test == 'false'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       # In case of a no label present, mark the Cypress status to be stale
       - name: Mark the Cypress response to be stale

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,5 +1,9 @@
 name: PR Automation test suite
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -10,11 +10,14 @@ on:
 jobs:
   check-label:
     runs-on: ubuntu-latest
+    outputs:
+      ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Check PR Label
+        id: checkLabel
         uses: actions/github-script@v7
         with:
           # This script will check if the PR has ok-to-test label.

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -36,7 +36,7 @@ jobs:
 
   mark-stale:
     needs: [ checkTestLabel ]
-    if: needs.checkTestLabel.outputs.ok_to_test == 'true'
+    if: needs.checkTestLabel.outputs.ok_to_test == 'false'
     runs-on: ubuntu-latest
     steps:
       # In case of a no label present, mark the Cypress status to be stale

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -48,9 +48,7 @@ jobs:
             Tests have not run on the HEAD ${{ github.event.pull_request.head.sha }} yet
         with:
           script: |
-            if(${{ steps.checkLabel.outputs.ok_to_test == 'false' }}) {
-              require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
-            }
+            require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
 
   parse-tags:
     needs: [ checkTestLabel ]

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -32,6 +32,7 @@ jobs:
             } else {
               console.log("Label 'ok-to-test' is not present");
               core.setOutput("ok_to_test", "false");
+            }
   parse-tags:
     needs: [ check-label ]
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -38,6 +38,8 @@ jobs:
     needs: [ checkTestLabel ]
     if: needs.checkTestLabel.outputs.ok_to_test == 'false'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -44,6 +44,8 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       # In case of a no label present, mark the Cypress status to be stale
       - name: Mark the Cypress response to be stale
         uses: actions/github-script@v7

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -35,7 +35,6 @@ jobs:
   parse-tags:
     needs: [ check-label ]
     runs-on: ubuntu-latest
-    if: ${{ steps.check-label.outputs.ok_to_test == 'true' }}
     permissions:
       pull-requests: write
     defaults:


### PR DESCRIPTION
## Description

By changing the workflow trigger and the way to check for correct labels, we are trying to allow the PR integrations tests to run every time the PR is updated. That means, if you push changes, and the PR already has ok-to-test label, it will rerun the tests based on new changes



## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10296910575>
> Commit: c59583ba28c8cdff35a12422b8c73838c6efdc85
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10296910575&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 08 Aug 2024 06:32:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job, `checkTestLabel`, to verify the presence of the "ok-to-test" label on pull requests.
	- Added a new job, `mark-stale`, to mark the Cypress status as stale when the label is absent.
- **Improvements**
	- Updated the `parse-tags` job to run only after the `checkTestLabel` job, enhancing workflow control.
	- Modified the conditions for executing the `parse-tags` job based on the output of the `checkTestLabel` job.
- **Style**
	- Minor formatting adjustments for job dependencies in the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->