### PR TITLE
test: remove wait in GetNClickContains

### DIFF
--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -993,7 +993,7 @@ export class AggregateHelper {
     containsText: string | RegExp,
     index = 0,
     force = true,
-    waitTimeInterval = 500,
+    waitTimeInterval = 0,
   ) {
     return cy
       .get(selector)


### PR DESCRIPTION
As a process Improvement we are reducing wait in GetNClickContains
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10301943445>
> Commit: cda518fb5d1b56653fa9f6b327914a6b963dff2d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10301943445&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/10301943445" target="_blank">workflow here</a>.
> <hr>Thu, 08 Aug 2024 13:21:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `AggregateHelper` class to reduce the default wait time from `500` to `0`, enabling immediate execution of methods.

- **Impact**
	- This change enhances performance but necessitates user awareness regarding potential timing issues in operations that rely on state resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->