### PR TITLE
test: Testing pipeline with build yaml and run_count

### DIFF
--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -14,6 +14,7 @@ jobs:
       pr: ${{steps.args.outputs.pr}}
       runId: ${{steps.args.outputs.runId}}
       matrix_count: ${{steps.matrix.outputs.matrix_count}}
+      run_count: ${{ steps.args.outputs.run_count }}
     steps:
       - name: Checkout the head commit of the branch
         uses: actions/checkout@v4
@@ -27,12 +28,18 @@ jobs:
         id: args
         run: |
           echo "pr=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "run_count=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
           checkArg=`echo '${{toJSON(github.event.client_payload.slash_command.args.named)}}' | jq 'has("runId")'`
           if [[ $checkArg == 'true' ]]; then
             echo "runId=${{ github.event.client_payload.slash_command.args.named.runId }}" >> $GITHUB_OUTPUT
           else
             echo "runId=0" >> $GITHUB_OUTPUT
           fi
+          checkRunCount=`echo '${{ toJSON(github.event.client_payload.slash_command.args.named) }}' | jq 'has("run_count")'`
+          if [[ $checkRunCount == 'true' ]]; then
+            echo "run_count=${{ github.event.client_payload.slash_command.args.named.run_count }}" >> $GITHUB_OUTPUT
+          else
+            echo "run_count=1" >> $GITHUB_OUTPUT
 
       - name: Get the diff from base branch
         continue-on-error: true
@@ -131,7 +138,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
-      run_count: ${{ github.event.client_payload.slash_command.args.named.run_count }}
+      run_count: ${{fromJson(needs.file-check.outputs.run_count)}}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]

--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -131,7 +131,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
-      run_count: ${{ github.event.inputs.run_count }}
+      run_count: ${{ github.event.client_payload.slash_command.args.named.run_count }}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]

--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -131,6 +131,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      run_count: ${{ github.event.inputs.run_count }}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]

--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -1,4 +1,4 @@
-name: Build Client, Server & Run only Cypress
+name: Build Client, Server & Run only Cypress with count
 
 on:
   repository_dispatch:
@@ -150,6 +150,7 @@ jobs:
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
       previous-workflow-run-id: ${{ fromJson(needs.file-check.outputs.runId) }}
+      run_count: ${{fromJson(needs.file-check.outputs.run_count)}}
 
   ci-test-limited-result:
     needs: [file-check, ci-test-limited]

--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -3,6 +3,41 @@ name: Build Client, Server & Run only Cypress with count
 on:
   repository_dispatch:
     types: [ci-test-limit-count-command]
+  workflow_dispatch:
+    inputs:
+        pr:
+            description: "PR number"
+            required: false
+            type: number
+            default: 0
+        previous-workflow-run-id:
+            description: "Workflow ID (To Download cicontainer)"
+            required: false
+            type: number
+            default: 0
+        run_count:
+            description: 'Number of times to repeat the test run'
+            required: false
+            type: number 
+            default: 1
+
+
+  workflow_call:
+    inputs:
+        pr:
+            description: "This is the PR number in case the workflow is being called in a pull request"
+            required: false
+            type: number
+        previous-workflow-run-id:
+            description: "This is the PR number in case the workflow is being called in a pull request"
+            required: false
+            type: number
+            default: 0
+        run_count:
+            description: 'Number of times to repeat the test run'
+            required: false
+            type: number
+            default: 1  
 
 jobs:
   file-check:

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -209,14 +209,14 @@ jobs:
       # actions/setup-node@v4 doesn’t work properly with Yarn 3
       # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
       # Restoring the cache manually instead
-      - name: Restore Yarn cache
-        if: steps.run_result.outputs.run_result != 'success'
-        uses: actions/cache@v4
-        with:
-          path: |
-            app/client/.yarn/cache
-            app/client/node_modules/.cache/webpack/
-          key: v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+      # - name: Restore Yarn cache
+      #   if: steps.run_result.outputs.run_result != 'success'
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: |
+      #       app/client/.yarn/cache
+      #       app/client/node_modules/.cache/webpack/
+      #     key: v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
 
       # Install all the dependencies
       - name: Install dependencies

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Fork/ForkApplication_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Fork/ForkApplication_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
Testing the yaml with slash command.

Fixes #`34956`  


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10316110580>
> Commit: 41a74c726e332c4d9adeef876d60766f0c09c33a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10316110580&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 09 Aug 2024 08:43:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to disable Yarn cache restoration, which may affect build times.
	- Modified Cypress test specifications to focus on the Fork application instead of templates, refining test execution priorities.
	- Enhanced the GitHub Actions workflow with a new input parameter, `run_count`, improving configurability and responsiveness to events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->