### PR TITLE
chore: add isError to return value of extractIdentifierInfoFromCode in AST

### DIFF
--- a/app/client/packages/ast/src/index.ts
+++ b/app/client/packages/ast/src/index.ts
@@ -399,6 +399,7 @@ export interface IdentifierInfo {
   references: string[];
   functionalParams: string[];
   variables: string[];
+  isError: boolean;
 }
 export const extractIdentifierInfoFromCode = (
   code: string,
@@ -435,6 +436,7 @@ export const extractIdentifierInfoFromCode = (
       references: referencesArr,
       functionalParams: Array.from(functionalParams),
       variables: Array.from(variableDeclarations),
+      isError: false,
     };
   } catch (e) {
     if (e instanceof SyntaxError) {
@@ -443,6 +445,7 @@ export const extractIdentifierInfoFromCode = (
         references: [],
         functionalParams: [],
         variables: [],
+        isError: true,
       };
     }
     throw e;

--- a/app/client/packages/rts/src/test/server.test.ts
+++ b/app/client/packages/rts/src/test/server.test.ts
@@ -109,6 +109,7 @@ describe("AST tests", () => {
       references: ["str.data", "Api1.data"],
       functionalParams: [],
       variables: ["Api2"],
+      isError: false,
     };
 
     await supertest(app)
@@ -129,11 +130,13 @@ describe("AST tests", () => {
         references: ["Api1.data"],
         functionalParams: [],
         variables: [],
+        isError: false,
       },
       {
         references: ["Api1.data"],
         functionalParams: [],
         variables: ["str"],
+        isError: false,
       },
     ];
 


### PR DESCRIPTION
## Description
Adds an isError flag to know if there is a syntax error while parsing

PR for https://github.com/appsmithorg/appsmith-ee/pull/4547

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10295486363>
> Commit: d69958d73ceb625ce82101ee98e5c81fe3d46697
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10295486363&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 08 Aug 2024 06:45:00 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new `isError` property in the identifier information interface, enhancing error reporting during code extraction.

- **Bug Fixes**
  - Updated extraction function to properly set the `isError` property based on success or `SyntaxError`, improving clarity on extraction outcomes.

- **Tests**
  - Enhanced test cases by incorporating the `isError` property, improving clarity on expected outcomes and robustness of the testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->