### PR TITLE
chore: Update env variable used for update persistent DB URL

### DIFF
--- a/app/client/src/pages/AdminSettings/config/advanced.ts
+++ b/app/client/src/pages/AdminSettings/config/advanced.ts
@@ -19,9 +19,9 @@ export const config: AdminConfigType = {
       category: SettingCategories.ADVANCED,
       controlType: SettingTypes.TEXTINPUT,
       controlSubType: SettingSubtype.TEXT,
-      label: "MongoDB URI",
+      label: "Appsmith DB URL",
       subText:
-        "* Appsmith internally uses MongoDB. Change to an external MongoDB for clustering",
+        "* Persistence database URL for Appsmith instance. Change this to an external database for clustering",
     },
     {
       id: "APPSMITH_REDIS_URL",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/EnvVariables.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/EnvVariables.java
@@ -2,7 +2,7 @@ package com.appsmith.server.constants;
 
 public enum EnvVariables {
     APPSMITH_INSTANCE_NAME,
-    APPSMITH_MONGODB_URI,
+    APPSMITH_DB_URL,
     APPSMITH_REDIS_URL,
     APPSMITH_MAIL_ENABLED,
     APPSMITH_MAIL_FROM,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -116,25 +116,25 @@ public class EnvManagerTest {
     @Test
     public void simpleSample() {
         final String content =
-                "APPSMITH_MONGODB_URI='first value'\nAPPSMITH_REDIS_URL='second value'\n\nAPPSMITH_INSTANCE_NAME='third value'";
+                "APPSMITH_DB_URL='first value'\nAPPSMITH_REDIS_URL='second value'\n\nAPPSMITH_INSTANCE_NAME='third value'";
 
-        assertThat(envManager.transformEnvContent(content, Map.of("APPSMITH_MONGODB_URI", "new first value")))
+        assertThat(envManager.transformEnvContent(content, Map.of("APPSMITH_DB_URL", "new first value")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='new first value'",
+                        "APPSMITH_DB_URL='new first value'",
                         "APPSMITH_REDIS_URL='second value'",
                         "",
                         "APPSMITH_INSTANCE_NAME='third value'");
 
         assertThat(envManager.transformEnvContent(content, Map.of("APPSMITH_REDIS_URL", "new second value")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='first value'",
+                        "APPSMITH_DB_URL='first value'",
                         "APPSMITH_REDIS_URL='new second value'",
                         "",
                         "APPSMITH_INSTANCE_NAME='third value'");
 
         assertThat(envManager.transformEnvContent(content, Map.of("APPSMITH_INSTANCE_NAME", "new third value")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='first value'",
+                        "APPSMITH_DB_URL='first value'",
                         "APPSMITH_REDIS_URL='second value'",
                         "",
                         "APPSMITH_INSTANCE_NAME='new third value'");
@@ -142,10 +142,10 @@ public class EnvManagerTest {
         assertThat(envManager.transformEnvContent(
                         content,
                         Map.of(
-                                "APPSMITH_MONGODB_URI", "new first value",
+                                "APPSMITH_DB_URL", "new first value",
                                 "APPSMITH_INSTANCE_NAME", "new third value")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='new first value'",
+                        "APPSMITH_DB_URL='new first value'",
                         "APPSMITH_REDIS_URL='second value'",
                         "",
                         "APPSMITH_INSTANCE_NAME='new third value'");
@@ -153,43 +153,39 @@ public class EnvManagerTest {
 
     @Test
     public void emptyValues() {
-        final String content =
-                "APPSMITH_MONGODB_URI=first value\nAPPSMITH_REDIS_URL=\n\nAPPSMITH_INSTANCE_NAME=third value";
+        final String content = "APPSMITH_DB_URL=first value\nAPPSMITH_REDIS_URL=\n\nAPPSMITH_INSTANCE_NAME=third value";
 
         assertThat(envManager.transformEnvContent(content, Map.of("APPSMITH_REDIS_URL", "new second value")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI=first value",
+                        "APPSMITH_DB_URL=first value",
                         "APPSMITH_REDIS_URL='new second value'",
                         "",
                         "APPSMITH_INSTANCE_NAME=third value");
 
         assertThat(envManager.transformEnvContent(content, Map.of("APPSMITH_REDIS_URL", "")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI=first value",
-                        "APPSMITH_REDIS_URL=",
-                        "",
-                        "APPSMITH_INSTANCE_NAME=third value");
+                        "APPSMITH_DB_URL=first value", "APPSMITH_REDIS_URL=", "", "APPSMITH_INSTANCE_NAME=third value");
     }
 
     @Test
     public void quotedValues() {
         final String content =
-                "APPSMITH_MONGODB_URI='first value'\nAPPSMITH_REDIS_URL=\"quoted value\"\n\nAPPSMITH_INSTANCE_NAME='third value'";
+                "APPSMITH_DB_URL='first value'\nAPPSMITH_REDIS_URL=\"quoted value\"\n\nAPPSMITH_INSTANCE_NAME='third value'";
 
         assertThat(envManager.transformEnvContent(
                         content,
                         Map.of(
-                                "APPSMITH_MONGODB_URI", "new first value",
+                                "APPSMITH_DB_URL", "new first value",
                                 "APPSMITH_REDIS_URL", "new second value")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='new first value'",
+                        "APPSMITH_DB_URL='new first value'",
                         "APPSMITH_REDIS_URL='new second value'",
                         "",
                         "APPSMITH_INSTANCE_NAME='third value'");
 
         assertThat(envManager.transformEnvContent(content, Map.of("APPSMITH_REDIS_URL", "")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='first value'",
+                        "APPSMITH_DB_URL='first value'",
                         "APPSMITH_REDIS_URL=",
                         "",
                         "APPSMITH_INSTANCE_NAME='third value'");
@@ -200,7 +196,7 @@ public class EnvManagerTest {
                                 "APPSMITH_INSTANCE_NAME", "Sponge-bob's Instance",
                                 "APPSMITH_REDIS_URL", "value with \" char in it")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='first value'",
+                        "APPSMITH_DB_URL='first value'",
                         "APPSMITH_REDIS_URL='value with \" char in it'",
                         "",
                         "APPSMITH_INSTANCE_NAME='Sponge-bob'\"'\"'s Instance'");
@@ -209,11 +205,10 @@ public class EnvManagerTest {
     @Test
     public void parseEmptyValues() {
 
-        assertThat(
-                        envManager.parseToMap(
-                                "APPSMITH_MONGODB_URI='first value'\nAPPSMITH_REDIS_URL=\n\nAPPSMITH_INSTANCE_NAME='third value'"))
+        assertThat(envManager.parseToMap(
+                        "APPSMITH_DB_URL='first value'\nAPPSMITH_REDIS_URL=\n\nAPPSMITH_INSTANCE_NAME='third value'"))
                 .containsExactlyInAnyOrderEntriesOf(Map.of(
-                        "APPSMITH_MONGODB_URI", "first value",
+                        "APPSMITH_DB_URL", "first value",
                         "APPSMITH_REDIS_URL", "",
                         "APPSMITH_INSTANCE_NAME", "third value"));
     }
@@ -223,9 +218,9 @@ public class EnvManagerTest {
 
         assertThat(
                         envManager.parseToMap(
-                                "APPSMITH_MONGODB_URI=first\nAPPSMITH_REDIS_URL=\"quoted value\"\n\nAPPSMITH_INSTANCE_NAME='third value'"))
+                                "APPSMITH_DB_URL=first\nAPPSMITH_REDIS_URL=\"quoted value\"\n\nAPPSMITH_INSTANCE_NAME='third value'"))
                 .containsExactlyInAnyOrderEntriesOf(Map.of(
-                        "APPSMITH_MONGODB_URI", "first",
+                        "APPSMITH_DB_URL", "first",
                         "APPSMITH_REDIS_URL", "quoted value",
                         "APPSMITH_INSTANCE_NAME", "third value"));
 
@@ -245,12 +240,12 @@ public class EnvManagerTest {
     @Test
     public void disallowedVariable() {
         final String content =
-                "APPSMITH_MONGODB_URI=first value\nDISALLOWED_NASTY_STUFF=\"quoted value\"\n\nAPPSMITH_INSTANCE_NAME=third value";
+                "APPSMITH_DB_URL=first value\nDISALLOWED_NASTY_STUFF=\"quoted value\"\n\nAPPSMITH_INSTANCE_NAME=third value";
 
         assertThatThrownBy(() -> envManager.transformEnvContent(
                         content,
                         Map.of(
-                                "APPSMITH_MONGODB_URI", "new first value",
+                                "APPSMITH_DB_URL", "new first value",
                                 "DISALLOWED_NASTY_STUFF", "new second value")))
                 .matches(value -> value instanceof AppsmithException
                         && AppsmithError.GENERIC_BAD_REQUEST.equals(((AppsmithException) value).getError()));
@@ -259,15 +254,15 @@ public class EnvManagerTest {
     @Test
     public void addNewVariable() {
         final String content =
-                "APPSMITH_MONGODB_URI='first value'\nAPPSMITH_REDIS_URL='quoted value'\n\nAPPSMITH_INSTANCE_NAME='third value'";
+                "APPSMITH_DB_URL='first value'\nAPPSMITH_REDIS_URL='quoted value'\n\nAPPSMITH_INSTANCE_NAME='third value'";
 
         assertThat(envManager.transformEnvContent(
                         content,
                         Map.of(
-                                "APPSMITH_MONGODB_URI", "new first value",
+                                "APPSMITH_DB_URL", "new first value",
                                 "APPSMITH_DISABLE_TELEMETRY", "false")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI='new first value'",
+                        "APPSMITH_DB_URL='new first value'",
                         "APPSMITH_REDIS_URL='quoted value'",
                         "",
                         "APPSMITH_INSTANCE_NAME='third value'",
@@ -277,15 +272,15 @@ public class EnvManagerTest {
     @Test
     public void setValueWithQuotes() {
         final String content =
-                "APPSMITH_MONGODB_URI='first value'\nAPPSMITH_REDIS_URL='quoted value'\n\nAPPSMITH_INSTANCE_NAME='third value'";
+                "APPSMITH_DB_URL='first value'\nAPPSMITH_REDIS_URL='quoted value'\n\nAPPSMITH_INSTANCE_NAME='third value'";
 
         assertThat(envManager.transformEnvContent(
                         content,
                         Map.of(
-                                "APPSMITH_MONGODB_URI", "'just quotes'",
+                                "APPSMITH_DB_URL", "'just quotes'",
                                 "APPSMITH_DISABLE_TELEMETRY", "some quotes 'inside' it")))
                 .containsExactly(
-                        "APPSMITH_MONGODB_URI=\"'\"'just quotes'\"'\"",
+                        "APPSMITH_DB_URL=\"'\"'just quotes'\"'\"",
                         "APPSMITH_REDIS_URL='quoted value'",
                         "",
                         "APPSMITH_INSTANCE_NAME='third value'",
@@ -310,7 +305,7 @@ public class EnvManagerTest {
         EnvManager envManagerInner = Mockito.mock(EnvManagerImpl.class);
 
         Map<String, String> envs = new HashMap<>();
-        envs.put("APPSMITH_MONGODB_URI", "mongo-url");
+        envs.put("APPSMITH_DB_URL", "mongo-url");
         envs.put("APPSMITH_DISABLE_TELEMETRY", "");
 
         Mockito.when(envManagerInner.getAll()).thenReturn(Mono.just(envs));


### PR DESCRIPTION
## Description
PR to fix the issue with DB url update from admin settings page. When we migrated the env variable to `APPSMITH_DB_URL` instead of `APPSMITH_MONGODB_URI` this functionality broke. We had a discussion to remove this update functionality as this does not work in all the setups. But as QA has already started pointing this as an issue raising this PR.  

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10297374384>
> Commit: dbef20ca923a1cba0d7687766481060eab5057fa
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10297374384&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Thu, 08 Aug 2024 07:13:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the database connection string naming from "MongoDB URI" to "Appsmith DB URL" in the Admin Settings, enhancing clarity in configuration.
	- Revised subtext in Admin Settings for improved user understanding of the database URL's purpose.
  
- **Bug Fixes**
	- Adjusted test cases to reflect the new naming convention, ensuring consistent references to "APPSMITH_DB_URL" across various tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->