### PR TITLE
chore: Flaky test in `AuthenticationServiceTest`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
@@ -140,8 +140,8 @@ public class AuthenticationServiceCEImpl implements AuthenticationServiceCE {
                 })
                 .switchIfEmpty(Mono.error(
                         new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasourceId)))
-                .flatMap(this::validateRequiredFieldsForGenericOAuth2)
-                .zipWith(Mono.zip(workspaceIdMono, trueEnvironmentIdCached, newPageMono))
+                .flatMap(ds -> this.validateRequiredFieldsForGenericOAuth2(ds)
+                        .zipWith(Mono.zip(workspaceIdMono, trueEnvironmentIdCached, newPageMono)))
                 .flatMap(tuple2 -> {
                     DatasourceStorage datasourceStorage = tuple2.getT1();
                     String workspaceId = tuple2.getT2().getT1();


### PR DESCRIPTION
## Description
- Flaky testcase: `AuthenticationServiceTest.testGetAuthorizationCodeURL_missingDatasource`
- Reason: Hot publisher `newPageMono` was getting executed before the `datasourceMonoCached` can complete the execution.
- Fix: With this PR we are making sure `newPageMono` get's called only after the execution of datasourceMono is completed. 

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10298256036>
> Commit: 16f3efb81a3beaf084bef97f60ea29232ea998a7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10298256036&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 08 Aug 2024 08:20:46 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced clarity in the authorization code URL generation process for OAuth2, resulting in better maintainability and readability.
	- Explicit handling of data sources to improve the logic flow associated with OAuth2 validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->