### PR TITLE
fix: js object editor overflowing fixed

### DIFF
--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -91,6 +91,7 @@ const Wrapper = styled.div`
   flex-direction: row;
   height: 100%;
   width: 100%;
+  overflow: hidden;
 `;
 
 const SecondaryWrapper = styled.div`


### PR DESCRIPTION
## Description
There was some weird scenario of clicking on the scrollbar which was making the code editor of js object increase its width and height to move the run button out of sight. And also if the size of the js object body increases more than the viewport the response tab becomes out of sight if its closed and the js object icon button displaces from its position. Attaching some loom videos to display the reproduction steps :
- https://www.loom.com/share/07688855c33b4041aecdada2958f6352
- https://www.loom.com/share/d3b7e6edce7e4758a566b3998da8629d

EE PR : https://github.com/appsmithorg/appsmith-ee/pull/4850

Fixes #34275
Fixes #35302 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS, @tag.Binding"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10304090951>
> Commit: f5ecc9e9ef45a3efe03f5a928a9a6bb1331469a2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10304090951&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS, @tag.Binding`
> Spec:
> <hr>Thu, 08 Aug 2024 15:11:33 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved layout control by adding CSS property to prevent content overflow in the editor interface, enhancing visual cleanliness and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->