### PR TITLE
fix: Clone js obj should allow action to contain collection id

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/clonepage/ActionClonePageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/clonepage/ActionClonePageServiceCEImpl.java
@@ -12,6 +12,7 @@ import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.solutions.ActionPermission;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -33,6 +34,14 @@ public class ActionClonePageServiceCEImpl implements ClonePageServiceCE<NewActio
                     actionDTO.setBranchName(clonePageMetaDTO.getBranchName());
 
                     actionDTO.setPageId(clonePageMetaDTO.getClonedPageDTO().getId());
+
+                    boolean isJsAction = StringUtils.hasLength(actionDTO.getCollectionId());
+
+                    if (isJsAction) {
+                        String newCollectionId =
+                                clonePageMetaDTO.getOldToNewCollectionIds().get(actionDTO.getCollectionId());
+                        actionDTO.setCollectionId(newCollectionId);
+                    }
                     /*
                      * - Now create the new action from the template of the source action.
                      * - Use CLONE_PAGE context to make sure that page / application clone quirks are
@@ -45,7 +54,7 @@ public class ActionClonePageServiceCEImpl implements ClonePageServiceCE<NewActio
                     // Indicates that source of action creation is clone page action
                     cloneActionDTO.setSource(ActionCreationSourceTypeEnum.CLONE_PAGE);
                     copyNestedNonNullProperties(actionDTO, cloneActionDTO);
-                    return layoutActionService.createAction(cloneActionDTO, eventContext, Boolean.FALSE);
+                    return layoutActionService.createAction(cloneActionDTO, eventContext, isJsAction);
                 })
                 .then();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -746,6 +746,16 @@ public class PageServiceTest {
                     assertThat(collections.get(0).getUnpublishedCollection().getPageId())
                             .isEqualTo(clonedPage.getId());
 
+                    NewAction actionWithCollection = actions.stream()
+                            .filter(newAction -> StringUtils.hasLength(
+                                    newAction.getUnpublishedAction().getCollectionId()))
+                            .findFirst()
+                            .orElse(null);
+
+                    // Confirm that js action has correct collection id reference
+                    assertThat(actionWithCollection.getUnpublishedAction().getCollectionId())
+                            .isEqualTo(collections.get(0).getId());
+
                     // Check if the parent page collections are not altered
                     List<ActionCollection> parentPageCollections = tuple.getT4();
                     assertThat(parentPageCollections).hasSize(1);


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes https://github.com/appsmithorg/appsmith/issues/35565

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the cloning functionality to support JavaScript actions, ensuring correct collection ID referencing.
  
- **Bug Fixes**
	- Improved verification process in tests to validate JavaScript action relationships post-cloning, ensuring integrity of cloned actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->