### PR TITLE
chore: fix reconnect datasource spec

### DIFF
--- a/app/client/cypress/e2e/Smoke/Apps/ReconnectDatasource_spec.js
+++ b/app/client/cypress/e2e/Smoke/Apps/ReconnectDatasource_spec.js
@@ -7,7 +7,7 @@ import {
 
 describe(
   "Reconnect Datasource Modal validation while importing application",
-  { tags: ["@tag.Datasource", "@tag.Sanity"] },
+  { tags: ["@tag.Datasource", "@tag.Sanity", "@tag.test"] },
   function () {
     let workspaceId;
     let appid;
@@ -52,18 +52,18 @@ describe(
               );
             }
             // check datasource configured success modal
-            cy.get(".t--import-app-success-modal").should("be.visible");
-            cy.get(".t--import-app-success-modal").should(
-              "contain",
-              "All your datasources are configured and ready to use.",
-            );
+            cy.get(".t--import-app-success-modal")
+              .should("be.visible")
+              .and(
+                "contain",
+                "All your datasources are configured and ready to use.",
+              );
+
             cy.get(".t--import-success-modal-got-it").click({ force: true });
             cy.get(".t--import-app-success-modal").should("not.exist");
             cy.wait("@getWorkspace");
 
-            const uuid = () => Cypress._.random(0, 1e4);
-            const name = uuid();
-            appName = `app${name}`;
+            appName = `app${Cypress._.random(0, 1e4)}`;
             cy.get(homePageLocators.applicationName).click({ force: true });
             cy.get(homePageLocators.portalMenuItem)
               .contains("Rename", { matchCase: false })

--- a/app/client/cypress/e2e/Smoke/Apps/ReconnectDatasource_spec.js
+++ b/app/client/cypress/e2e/Smoke/Apps/ReconnectDatasource_spec.js
@@ -15,7 +15,7 @@ describe(
     let appName;
     it("1. Import application from json with one postgres and success modal", function () {
       homePage.NavigateToHome();
-      // import application
+      // import application test
       cy.generateUUID().then((uid) => {
         workspaceId = uid;
         cy.createWorkspace();

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Smoke/Apps/ReconnectDatasource_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/tags.js
+++ b/app/client/cypress/tags.js
@@ -68,5 +68,6 @@ module.exports = {
     "@tag.Workspace",
     "@tag.airgap",
     "@tag.excludeForAirgap",
+    "@tag.test",
   ],
 };


### PR DESCRIPTION
## Description

Fixes #35138 

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10330293342>
> Commit: c5d708c75e355e1dab99ffea8ad066c7630a1308
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10330293342&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Sat, 10 Aug 2024 08:59:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
  - Enhanced end-to-end testing specification with improved comments for clarity.
  - Added a new tag, `@tag.test`, to the tagging system, allowing for more granular test categorization.
  - Updated the list of test specifications to shift focus from a regression test to smoke testing of the reconnect datasource functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->