### PR TITLE
fix: overflow hidden was restricting the visibility of show bindings menu

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/Explorer.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/Explorer.tsx
@@ -34,7 +34,6 @@ const EditorPaneExplorer = () => {
       }
       className="relative ide-editor-left-pane__content"
       flexDirection="column"
-      overflow="hidden"
       width={
         ideViewMode === EditorViewMode.FullScreen
           ? DEFAULT_EXPLORER_PANE_WIDTH

--- a/app/client/src/pages/Editor/IDE/EditorPane/index.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/index.tsx
@@ -25,7 +25,6 @@ const EditorPane = () => {
       // @ts-expect-error Fix this the next time the file is edited
       gap="spacing-2"
       height="100%"
-      overflow="hidden"
       width={width}
     >
       <EditorPaneExplorer />


### PR DESCRIPTION
## Description
There was an IDE PR : https://github.com/appsmithorg/appsmith/pull/35114 , that got merged which added the `overflow: hidden` property to the entity explorer which made the show bindings menu disappear from the view port. Hence, that change is fixed with this PR. 


Fixes #35584
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10347893824>
> Commit: 05dd349a6f417e92f412eb6c29201296502c1d9f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10347893824&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 12 Aug 2024 08:12:07 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface Changes**
	- Adjusted the rendering behavior of the editor pane, allowing overflow content to be visible, which may enhance the user experience within the IDE.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->