### PR TITLE
chore: created utils package and moved objectKeys function to it

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -106,6 +106,7 @@
     "@welldone-software/why-did-you-render": "^4.2.5",
     "algoliasearch": "^4.2.0",
     "appsmith-icons": "workspace:^",
+    "appsmith-utils": "workspace:^",
     "assert-never": "^1.2.1",
     "astring": "^1.7.5",
     "async-mutex": "^0.5.0",

--- a/app/client/packages/design-system/widgets/src/components/Button/chromatic/Button.chromatic.stories.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Button/chromatic/Button.chromatic.stories.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { StoryGrid, DataAttrWrapper } from "@design-system/storybook";
-import {
-  Button,
-  BUTTON_VARIANTS,
-  COLORS,
-  objectKeys,
-} from "@design-system/widgets";
+import { Button, BUTTON_VARIANTS, COLORS } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 
 const variants = objectKeys(BUTTON_VARIANTS);
 const colors = Object.values(COLORS);

--- a/app/client/packages/design-system/widgets/src/components/Button/stories/Button.stories.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Button/stories/Button.stories.tsx
@@ -6,8 +6,8 @@ import {
   BUTTON_VARIANTS,
   COLORS,
   SIZES,
-  objectKeys,
 } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 
 /**
  * A button is a clickable element that is used to trigger an action.

--- a/app/client/packages/design-system/widgets/src/components/IconButton/stories/IconButton.stories.tsx
+++ b/app/client/packages/design-system/widgets/src/components/IconButton/stories/IconButton.stories.tsx
@@ -6,8 +6,8 @@ import {
   SIZES,
   BUTTON_VARIANTS,
   COLORS,
-  objectKeys,
 } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 
 /**
  * Icon Button is a button component that only contains an icon.

--- a/app/client/packages/design-system/widgets/src/components/InlineButtons/stories/InlineButtons.stories.tsx
+++ b/app/client/packages/design-system/widgets/src/components/InlineButtons/stories/InlineButtons.stories.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import {
   InlineButtons,
   Flex,
-  objectKeys,
   BUTTON_VARIANTS,
   COLORS,
   SIZES,
 } from "@design-system/widgets";
 import type { Meta, StoryObj } from "@storybook/react";
+import { objectKeys } from "appsmith-utils/src/object";
 import {
   itemList,
   longItemList,

--- a/app/client/packages/design-system/widgets/src/components/ToolbarButtons/stories/ToolbarButtons.stories.tsx
+++ b/app/client/packages/design-system/widgets/src/components/ToolbarButtons/stories/ToolbarButtons.stories.tsx
@@ -4,10 +4,10 @@ import {
   BUTTON_VARIANTS,
   COLORS,
   Flex,
-  objectKeys,
   ToolbarButtons,
   SIZES,
 } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 import {
   itemList,
   itemListWithIcons,

--- a/app/client/packages/design-system/widgets/src/utils/index.ts
+++ b/app/client/packages/design-system/widgets/src/utils/index.ts
@@ -1,2 +1,1 @@
 export { filterDataProps } from "./filterDataProps";
-export { objectKeys } from "./objectKeys";

--- a/app/client/packages/utils/.eslintrc.json
+++ b/app/client/packages/utils/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.eslintrc.base.json"]
+}

--- a/app/client/packages/utils/index.d.ts
+++ b/app/client/packages/utils/index.d.ts
@@ -1,0 +1,1 @@
+declare module "appsmith-utils";

--- a/app/client/packages/utils/jest.config.js
+++ b/app/client/packages/utils/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.(png|js|ts|tsx)$": ["ts-jest", {
+      isolatedModules: true,
+    }],
+  },
+  testTimeout: 9000,
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx|ts|js)?$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  moduleDirectories: ["node_modules", "src"],
+};

--- a/app/client/packages/utils/package.json
+++ b/app/client/packages/utils/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "appsmith-utils",
+  "version": "1.0.0",
+  "description": "This package has all the shared util functions which can be used in different packages e.g. client, rts etc",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "yarn g:jest"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "typescript": "^5.5.4"
+  }
+}

--- a/app/client/packages/utils/src/index.ts
+++ b/app/client/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * as object from "./object";

--- a/app/client/packages/utils/src/object/index.ts
+++ b/app/client/packages/utils/src/object/index.ts
@@ -1,0 +1,1 @@
+export { default as objectKeys } from "./keys";

--- a/app/client/packages/utils/src/object/keys.test.ts
+++ b/app/client/packages/utils/src/object/keys.test.ts
@@ -1,0 +1,7 @@
+import objectKeys from "./keys";
+
+test("objectKeys should return all the keys in the object map pass to it.", () => {
+  const objectMap = { a: 1, b: 2, c: 3 };
+  const keys = objectKeys(objectMap);
+  expect(keys).toStrictEqual(["a", "b", "c"]);
+});

--- a/app/client/packages/utils/src/object/keys.ts
+++ b/app/client/packages/utils/src/object/keys.ts
@@ -4,11 +4,14 @@
  * when looping through the keys. This function returns an array of keys with the correct type information.
  *
  * with classic Object.keys: Object.keys({ a: 1, b: 2 }) -> string[]
- * with objeetKeys: objectKeys({ a: 1, b: 2 }) -> ("a" | "b")[]
+ * with objectKeys: objectKeys({ a: 1, b: 2 }) -> ("a" | "b")[]
  *
  * @param object
  * @returns array of keys with correct type information
  */
-export function objectKeys<T extends object>(object: T) {
+
+export default function objectKeys<T extends object>(
+  object: T,
+): Array<keyof T> {
   return Object.keys(object) as Array<keyof T>;
 }

--- a/app/client/packages/utils/tsconfig.json
+++ b/app/client/packages/utils/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/app/client/src/widgets/wds/WDSButtonWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSButtonWidget/config/defaultsConfig.ts
@@ -1,6 +1,7 @@
 import { RecaptchaTypes } from "components/constants";
-import { COLORS, BUTTON_VARIANTS, objectKeys } from "@design-system/widgets";
+import { COLORS, BUTTON_VARIANTS } from "@design-system/widgets";
 import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
+import { objectKeys } from "appsmith-utils/src/object";
 import {
   BUTTON_WIDGET_DEFAULT_LABEL,
   createMessage,

--- a/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/styleConfig.ts
+++ b/app/client/src/widgets/wds/WDSButtonWidget/config/propertyPaneConfig/styleConfig.ts
@@ -1,6 +1,7 @@
 import { capitalize } from "lodash";
 import { ValidationTypes } from "constants/WidgetValidation";
-import { COLORS, BUTTON_VARIANTS, objectKeys } from "@design-system/widgets";
+import { COLORS, BUTTON_VARIANTS } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 
 export const propertyPaneStyleConfig = [
   {

--- a/app/client/src/widgets/wds/WDSIconButtonWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSIconButtonWidget/config/defaultsConfig.ts
@@ -1,4 +1,5 @@
-import { BUTTON_VARIANTS, COLORS, objectKeys } from "@design-system/widgets";
+import { BUTTON_VARIANTS, COLORS } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
 
 export const defaultsConfig = {

--- a/app/client/src/widgets/wds/WDSIconButtonWidget/config/propertyPaneConfig/styleConfig.ts
+++ b/app/client/src/widgets/wds/WDSIconButtonWidget/config/propertyPaneConfig/styleConfig.ts
@@ -1,5 +1,6 @@
 import { capitalize } from "lodash";
-import { BUTTON_VARIANTS, COLORS, objectKeys } from "@design-system/widgets";
+import { BUTTON_VARIANTS, COLORS } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 import { ValidationTypes } from "constants/WidgetValidation";
 
 export const propertyPaneStyleConfig = [

--- a/app/client/src/widgets/wds/WDSInlineButtonsWidget/config/propertyPaneConfig/contentConfig.ts
+++ b/app/client/src/widgets/wds/WDSInlineButtonsWidget/config/propertyPaneConfig/contentConfig.ts
@@ -1,10 +1,11 @@
-import { BUTTON_VARIANTS, COLORS, objectKeys } from "@design-system/widgets";
+import { BUTTON_VARIANTS, COLORS } from "@design-system/widgets";
 import {
   BUTTON_WIDGET_DEFAULT_LABEL,
   createMessage,
 } from "ee/constants/messages";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { capitalize } from "lodash";
+import { objectKeys } from "appsmith-utils/src/object";
 
 export const propertyPaneContentConfig = [
   {

--- a/app/client/src/widgets/wds/WDSMenuButtonWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSMenuButtonWidget/config/defaultsConfig.ts
@@ -1,5 +1,6 @@
-import { BUTTON_VARIANTS, COLORS, objectKeys } from "@design-system/widgets";
+import { BUTTON_VARIANTS, COLORS } from "@design-system/widgets";
 import type { WidgetDefaultProps } from "WidgetProvider/constants";
+import { objectKeys } from "appsmith-utils/src/object";
 
 export const defaultsConfig = {
   label: "Open The Menu…",

--- a/app/client/src/widgets/wds/WDSMenuButtonWidget/config/propertyPaneConfig/styleConfig.ts
+++ b/app/client/src/widgets/wds/WDSMenuButtonWidget/config/propertyPaneConfig/styleConfig.ts
@@ -1,11 +1,7 @@
 import { capitalize } from "lodash";
 import { ValidationTypes } from "constants/WidgetValidation";
-import {
-  BUTTON_VARIANTS,
-  COLORS,
-  ICONS,
-  objectKeys,
-} from "@design-system/widgets";
+import { BUTTON_VARIANTS, COLORS, ICONS } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 
 import type { MenuButtonWidgetProps } from "../../widget/types";
 

--- a/app/client/src/widgets/wds/WDSTableWidget/config/propertyPaneConfig/PanelConfig/General.ts
+++ b/app/client/src/widgets/wds/WDSTableWidget/config/propertyPaneConfig/PanelConfig/General.ts
@@ -2,7 +2,8 @@ import { ValidationTypes } from "constants/WidgetValidation";
 import type { TableWidgetProps } from "widgets/wds/WDSTableWidget/constants";
 import { ColumnTypes } from "widgets/wds/WDSTableWidget/constants";
 import { hideByColumnType } from "../../../widget/propertyUtils";
-import { BUTTON_VARIANTS, objectKeys } from "@design-system/widgets";
+import { BUTTON_VARIANTS } from "@design-system/widgets";
+import { objectKeys } from "appsmith-utils/src/object";
 
 export default {
   sectionName: "General",

--- a/app/client/src/widgets/wds/WDSToolbarButtonsWidget/config/propertyPaneConfig/styleConfig.ts
+++ b/app/client/src/widgets/wds/WDSToolbarButtonsWidget/config/propertyPaneConfig/styleConfig.ts
@@ -1,6 +1,7 @@
-import { BUTTON_VARIANTS, COLORS, objectKeys } from "@design-system/widgets";
+import { BUTTON_VARIANTS, COLORS } from "@design-system/widgets";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { capitalize } from "lodash";
+import { objectKeys } from "appsmith-utils/src/object";
 
 export const propertyPaneStyleConfig = [
   {

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -10916,13 +10916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:*, @types/jest@npm:^29.2.3":
-  version: 29.4.0
-  resolution: "@types/jest@npm:29.4.0"
+"@types/jest@npm:*, @types/jest@npm:^29.2.3, @types/jest@npm:^29.5.12":
+  version: 29.5.12
+  resolution: "@types/jest@npm:29.5.12"
   dependencies:
     expect: ^29.0.0
     pretty-format: ^29.0.0
-  checksum: 23760282362a252e6690314584d83a47512d4cd61663e957ed3398ecf98195fe931c45606ee2f9def12f8ed7d8aa102d492ec42d26facdaf8b78094a31e6568e
+  checksum: 19b1efdeed9d9a60a81edc8226cdeae5af7479e493eaed273e01243891c9651f7b8b4c08fc633a7d0d1d379b091c4179bbaa0807af62542325fd72f2dd17ce1c
   languageName: node
   linkType: hard
 
@@ -13150,6 +13150,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"appsmith-utils@workspace:^, appsmith-utils@workspace:packages/utils":
+  version: 0.0.0-use.local
+  resolution: "appsmith-utils@workspace:packages/utils"
+  dependencies:
+    "@types/jest": ^29.5.12
+    jest: ^29.7.0
+    ts-jest: ^29.2.4
+    typescript: ^5.5.4
+  languageName: unknown
+  linkType: soft
+
 "appsmith@workspace:.":
   version: 0.0.0-use.local
   resolution: "appsmith@workspace:."
@@ -13272,6 +13283,7 @@ __metadata:
     "@welldone-software/why-did-you-render": ^4.2.5
     algoliasearch: ^4.2.0
     appsmith-icons: "workspace:^"
+    appsmith-utils: "workspace:^"
     assert-never: ^1.2.1
     astring: ^1.7.5
     async-mutex: ^0.5.0
@@ -23772,7 +23784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.3.1, jest@npm:^29.5.0, jest@npm:^29.6.4":
+"jest@npm:^29.3.1, jest@npm:^29.5.0, jest@npm:^29.6.4, jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest@npm:29.7.0"
   dependencies:
@@ -34061,7 +34073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:29.1.0, ts-jest@npm:^29.1.0":
+"ts-jest@npm:29.1.0":
   version: 29.1.0
   resolution: "ts-jest@npm:29.1.0"
   dependencies:
@@ -34091,6 +34103,43 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 535dc42ad523cbe1e387701fb2e448518419b515c082f09b25411f0b3dd0b854cf3e8141c316d6f4b99883aeb4a4f94159cbb1edfb06d7f77ea6229fadb2e1bf
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:^29.1.0, ts-jest@npm:^29.2.4":
+  version: 29.2.4
+  resolution: "ts-jest@npm:29.2.4"
+  dependencies:
+    bs-logger: 0.x
+    ejs: ^3.1.10
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.3
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: ^7.5.3
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/transform": ^29.0.0
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/transform":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 142246f12bb11d5edbfb5a65e298097667e2c4d390e316e356416ce00d3cd157220dbfb9de2a56b38f30776bc92ba59eff9fd78e9345ba4c6712783f27f5475a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Created a shared utils package to move common util functions to it. This PR currently handles the `objectKeys` function which was earlier being used from design-system package.


Fixes #35508 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
