### PR TITLE
chore: Fix parameter call from build file

### DIFF
--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -173,7 +173,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
-      run_count: ${{fromJson(needs.file-check.outputs.run_count)}}
+      run_count: ${{needs.file-check.outputs.run_count}}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]
@@ -185,7 +185,7 @@ jobs:
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
       previous-workflow-run-id: ${{ fromJson(needs.file-check.outputs.runId) }}
-      run_count: ${{fromJson(needs.file-check.outputs.run_count)}}
+      run_count: ${{needs.file-check.outputs.run_count}}
 
   ci-test-limited-result:
     needs: [file-check, ci-test-limited]

--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -3,41 +3,7 @@ name: Build Client, Server & Run only Cypress with count
 on:
   repository_dispatch:
     types: [ci-test-limit-count-command]
-  workflow_dispatch:
-    inputs:
-        pr:
-            description: "PR number"
-            required: false
-            type: number
-            default: 0
-        previous-workflow-run-id:
-            description: "Workflow ID (To Download cicontainer)"
-            required: false
-            type: number
-            default: 0
-        run_count:
-            description: 'Number of times to repeat the test run'
-            required: false
-            type: number 
-            default: 1
 
-
-  workflow_call:
-    inputs:
-        pr:
-            description: "This is the PR number in case the workflow is being called in a pull request"
-            required: false
-            type: number
-        previous-workflow-run-id:
-            description: "This is the PR number in case the workflow is being called in a pull request"
-            required: false
-            type: number
-            default: 0
-        run_count:
-            description: 'Number of times to repeat the test run'
-            required: false
-            type: number
-            default: 1  
 
 jobs:
   file-check:
@@ -49,7 +15,7 @@ jobs:
       pr: ${{steps.args.outputs.pr}}
       runId: ${{steps.args.outputs.runId}}
       matrix_count: ${{steps.matrix.outputs.matrix_count}}
-      run_count: ${{ steps.args.outputs.run_count }}
+      run_count: ${{ steps.countArgs.outputs.run_count }}
     steps:
       - name: Checkout the head commit of the branch
         uses: actions/checkout@v4
@@ -63,18 +29,24 @@ jobs:
         id: args
         run: |
           echo "pr=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "run_count=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
-          checkArg=`echo '${{toJSON(github.event.client_payload.slash_command.args.named)}}' | jq 'has("runId")'`
-          if [[ $checkArg == 'true' ]]; then
-            echo "runId=${{ github.event.client_payload.slash_command.args.named.runId }}" >> $GITHUB_OUTPUT
+          checkArg=${{ github.event.client_payload.slash_command.args.named.runId }}
+          if [[ -z "$checkArg" ]]; then
+              echo "runId=0" >> $GITHUB_OUTPUT
           else
-            echo "runId=0" >> $GITHUB_OUTPUT
+              runId=$((checkArg + 0))
+              echo "runId=$runId" >> $GITHUB_OUTPUT
           fi
-          checkRunCount=`echo '${{ toJSON(github.event.client_payload.slash_command.args.named) }}' | jq 'has("run_count")'`
-          if [[ $checkRunCount == 'true' ]]; then
-            echo "run_count=${{ github.event.client_payload.slash_command.args.named.run_count }}" >> $GITHUB_OUTPUT
+       
+      - name: Set run count
+        id: countArgs
+        run: |    
+          checkRunCount=${{ github.event.client_payload.slash_command.args.named.run_count }}
+          if [[ -z "$checkRunCount" ]]; then
+              echo "run_count=1" >> $GITHUB_OUTPUT  # Set default to 1 if empty
           else
-            echo "run_count=1" >> $GITHUB_OUTPUT
+              run_count=$((checkRunCount + 0))
+              echo "run_count=$run_count" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get the diff from base branch
         continue-on-error: true
@@ -173,7 +145,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
-      run_count: ${{needs.file-check.outputs.run_count}}
+      run_count: ${{fromJSON(needs.file-check.outputs.run_count)}}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]
@@ -185,7 +157,7 @@ jobs:
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
       previous-workflow-run-id: ${{ fromJson(needs.file-check.outputs.runId) }}
-      run_count: ${{needs.file-check.outputs.run_count}}
+      run_count: ${{fromJSON(needs.file-check.outputs.run_count)}}
 
   ci-test-limited-result:
     needs: [file-check, ci-test-limited]

--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -145,7 +145,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
-      run_count: ${{fromJSON(needs.file-check.outputs.run_count)}}
+      run_count: ${{fromJson(needs.file-check.outputs.run_count)}}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]
@@ -157,7 +157,7 @@ jobs:
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
       previous-workflow-run-id: ${{ fromJson(needs.file-check.outputs.runId) }}
-      run_count: ${{fromJSON(needs.file-check.outputs.run_count)}}
+      run_count: ${{fromJson(needs.file-check.outputs.run_count)}}
 
   ci-test-limited-result:
     needs: [file-check, ci-test-limited]

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -346,7 +346,7 @@ jobs:
             NODE_ENV: development
         run: |
             cd app/client
-            npx cypress-repeat run -n ${{ github.event.inputs.run_count }} --force \
+            npx cypress-repeat run -n ${{ inputs.run_count }} --force \
                 --spec ${{ env.specs_to_run }} \
                 --config-file "cypress_ci_custom.config.ts"   
 


### PR DESCRIPTION
## Description
We’ve made significant progress and successfully ran a limited set of test files by fixing parameters in the forked repository. I can able to atleast trigger the workflow with slash command and passed right parameter.

The ci-test-limited-with-count.yml workflow now supports running specific test files. However, an issue was identified with one of the parameters. To proceed with testing, the identified issue can be resolved by merging this PR.


Fixes #`34956`  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10351114050>
> Commit: fd17177d71110bf714b5ec4eaf7d2ae683cbdc68
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10351114050&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 12 Aug 2024 11:57:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **Chores**
	- Simplified access to the `run_count` variable in the GitHub Actions workflow, improving readability and potentially enhancing performance.
	- Updated syntax for referencing inputs in Cypress test workflows for better clarity and consistency.
	- Clarified default value handling for `run_count`, ensuring predictable workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->