### PR TITLE
chore: add isVisible in default values in wds widgets

### DIFF
--- a/app/client/src/components/propertyControls/BaseControl.tsx
+++ b/app/client/src/components/propertyControls/BaseControl.tsx
@@ -16,12 +16,14 @@ export type ControlMethods = Record<
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 class BaseControl<P extends ControlProps, S = {}> extends Component<P, S> {
-  shoudUpdateProperty(propertyValue: unknown) {
-    return !(
-      (this.props.propertyValue === undefined &&
-        propertyValue === this.props.defaultValue) ||
-      !(this.props.propertyValue !== propertyValue)
-    );
+  shoudUpdateProperty(newValue: unknown) {
+    const { defaultValue, propertyValue: oldValue } = this.props;
+
+    if (oldValue === undefined && newValue === defaultValue) return false;
+
+    if (newValue === oldValue) return false;
+
+    return true;
   }
 
   updateProperty(

--- a/app/client/src/components/propertyControls/BaseControl.tsx
+++ b/app/client/src/components/propertyControls/BaseControl.tsx
@@ -34,7 +34,7 @@ class BaseControl<P extends ControlProps, S = {}> extends Component<P, S> {
     isUpdatedViaKeyboard?: boolean,
   ) {
     if (
-      this.shoudUpdateProperty(propertyValue) &&
+      this.shouldUpdateProperty(propertyValue) &&
       this.props.onPropertyChange
     ) {
       this.props.onPropertyChange(

--- a/app/client/src/components/propertyControls/BaseControl.tsx
+++ b/app/client/src/components/propertyControls/BaseControl.tsx
@@ -16,7 +16,7 @@ export type ControlMethods = Record<
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 class BaseControl<P extends ControlProps, S = {}> extends Component<P, S> {
-  shoudUpdateProperty(newValue: unknown) {
+  shouldUpdateProperty(newValue: unknown) {
     const { defaultValue, propertyValue: oldValue } = this.props;
 
     if (oldValue === undefined && newValue === defaultValue) return false;
@@ -59,7 +59,7 @@ class BaseControl<P extends ControlProps, S = {}> extends Component<P, S> {
     if (this.props.onBatchUpdateWithAssociatedUpdates) {
       this.props.onBatchUpdateWithAssociatedUpdates(
         updates.filter(({ propertyValue }) =>
-          this.shoudUpdateProperty(propertyValue),
+          this.shouldUpdateProperty(propertyValue),
         ),
       );
     }

--- a/app/client/src/widgets/anvil/SectionWidget/widget/config/autocompleteConfig.ts
+++ b/app/client/src/widgets/anvil/SectionWidget/widget/config/autocompleteConfig.ts
@@ -1,0 +1,5 @@
+import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
+
+export const autocompleteConfig = {
+  isVisible: DefaultAutocompleteDefinitions.isVisible,
+};

--- a/app/client/src/widgets/anvil/SectionWidget/widget/config/defaultConfig.ts
+++ b/app/client/src/widgets/anvil/SectionWidget/widget/config/defaultConfig.ts
@@ -19,6 +19,7 @@ export const defaultConfig: WidgetDefaultProps = {
   version: 1,
   widgetName: "Section",
   zoneCount: 1,
+  isVisible: true,
   blueprint: {
     operations: [
       {

--- a/app/client/src/widgets/anvil/SectionWidget/widget/config/index.ts
+++ b/app/client/src/widgets/anvil/SectionWidget/widget/config/index.ts
@@ -4,6 +4,7 @@ import { defaultConfig } from "./defaultConfig";
 import { propertyPaneContent } from "./propertyPaneContent";
 import { propertyPaneStyle } from "./propertyPaneStyle";
 import { methodsConfig } from "./methodsConfig";
+import { autocompleteConfig } from "./autocompleteConfig";
 
 export {
   anvilConfig,
@@ -12,4 +13,5 @@ export {
   propertyPaneContent,
   propertyPaneStyle,
   methodsConfig,
+  autocompleteConfig,
 };

--- a/app/client/src/widgets/anvil/SectionWidget/widget/index.tsx
+++ b/app/client/src/widgets/anvil/SectionWidget/widget/index.tsx
@@ -16,6 +16,7 @@ import {
   propertyPaneContent,
   propertyPaneStyle,
   methodsConfig,
+  autocompleteConfig,
 } from "./config";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import type { LayoutProps } from "layoutSystems/anvil/utils/anvilTypes";
@@ -33,7 +34,6 @@ import type {
 } from "layoutSystems/anvil/utils/paste/types";
 import { call } from "redux-saga/effects";
 import { pasteWidgetsInSection } from "layoutSystems/anvil/utils/paste/sectionPasteUtils";
-import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
 
 class SectionWidget extends BaseWidget<SectionWidgetProps, WidgetState> {
   static type = anvilWidgets.SECTION_WIDGET;
@@ -58,9 +58,7 @@ class SectionWidget extends BaseWidget<SectionWidgetProps, WidgetState> {
   }
 
   static getAutocompleteDefinitions(): AutocompletionDefinitions {
-    return {
-      isVisible: DefaultAutocompleteDefinitions.isVisible,
-    };
+    return autocompleteConfig;
   }
 
   static getSetterConfig(): SetterConfig | null {

--- a/app/client/src/widgets/anvil/ZoneWidget/widget/config/autocompleteConfig.ts
+++ b/app/client/src/widgets/anvil/ZoneWidget/widget/config/autocompleteConfig.ts
@@ -1,0 +1,5 @@
+import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
+
+export const autocompleteConfig = {
+  isVisible: DefaultAutocompleteDefinitions.isVisible,
+};

--- a/app/client/src/widgets/anvil/ZoneWidget/widget/config/defaultConfig.ts
+++ b/app/client/src/widgets/anvil/ZoneWidget/widget/config/defaultConfig.ts
@@ -22,6 +22,7 @@ export const defaultConfig: WidgetDefaultProps = {
   rows: 0,
   version: 1,
   widgetName: "Zone",
+  isVisible: true,
   blueprint: {
     operations: [
       {

--- a/app/client/src/widgets/anvil/ZoneWidget/widget/config/index.ts
+++ b/app/client/src/widgets/anvil/ZoneWidget/widget/config/index.ts
@@ -4,6 +4,7 @@ import { defaultConfig } from "./defaultConfig";
 import { propertyPaneContent } from "./propertyPaneContent";
 import { propertyPaneStyle } from "./propertyPaneStyle";
 import { methodsConfig } from "./methodsConfig";
+import { autocompleteConfig } from "./autocompleteConfig";
 
 export {
   anvilConfig,
@@ -12,4 +13,5 @@ export {
   propertyPaneContent,
   propertyPaneStyle,
   methodsConfig,
+  autocompleteConfig,
 };

--- a/app/client/src/widgets/anvil/ZoneWidget/widget/index.tsx
+++ b/app/client/src/widgets/anvil/ZoneWidget/widget/index.tsx
@@ -16,6 +16,7 @@ import {
   propertyPaneContent,
   propertyPaneStyle,
   methodsConfig,
+  autocompleteConfig,
 } from "./config";
 import BaseWidget from "widgets/BaseWidget";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
@@ -33,7 +34,6 @@ import type {
 import { call } from "redux-saga/effects";
 import { pasteWidgetsInZone } from "layoutSystems/anvil/utils/paste/zonePasteUtils";
 import { SectionColumns } from "layoutSystems/anvil/sectionSpaceDistributor/constants";
-import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
 
 class ZoneWidget extends BaseWidget<ZoneWidgetProps, WidgetState> {
   static type = anvilWidgets.ZONE_WIDGET;
@@ -62,9 +62,7 @@ class ZoneWidget extends BaseWidget<ZoneWidgetProps, WidgetState> {
   }
 
   static getAutocompleteDefinitions(): AutocompletionDefinitions {
-    return {
-      isVisible: DefaultAutocompleteDefinitions.isVisible,
-    };
+    return autocompleteConfig;
   }
 
   static getSetterConfig(): SetterConfig | null {

--- a/app/client/src/widgets/wds/WDSBaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSBaseInputWidget/widget/index.tsx
@@ -37,6 +37,7 @@ class WDSBaseInputWidget<
       isRequired: false,
       isReadOnly: false,
       isDisabled: false,
+      isVisible: true,
       animateLoading: true,
       responsiveBehavior: ResponsiveBehavior.Fill,
     } as unknown as WidgetDefaultProps;

--- a/app/client/src/widgets/wds/WDSCheckboxWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSCheckboxWidget/config/defaultsConfig.ts
@@ -8,6 +8,7 @@ export const defaultsConfig = {
   version: 1,
   isDisabled: false,
   isRequired: false,
+  isVisible: true,
   animateLoading: true,
   responsiveBehavior: ResponsiveBehavior.Fill,
 } as unknown as WidgetDefaultProps;

--- a/app/client/src/widgets/wds/WDSParagraphWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSParagraphWidget/config/defaultsConfig.ts
@@ -15,6 +15,7 @@ export const defaultsConfig = {
   shouldTruncate: false,
   version: 1,
   animateLoading: true,
+  isVisible: true,
   responsiveBehavior: ResponsiveBehavior.Fill,
   blueprint: {
     operations: [

--- a/app/client/src/widgets/wds/WDSRadioGroupWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSRadioGroupWidget/config/defaultsConfig.ts
@@ -12,6 +12,7 @@ export const defaultsConfig = {
   defaultOptionValue: "L",
   isRequired: false,
   isDisabled: false,
+  isVisible: true,
   isInline: true,
   widgetName: "RadioGroup",
   orientation: "vertical",

--- a/app/client/src/widgets/wds/WDSSwitchWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSSwitchWidget/config/defaultsConfig.ts
@@ -8,6 +8,7 @@ export const defaultsConfig = {
   labelPosition: "start",
   version: 1,
   isDisabled: false,
+  isVisible: true,
   animateLoading: true,
   responsiveBehavior: ResponsiveBehavior.Fill,
 } as unknown as WidgetDefaultProps;

--- a/app/client/src/widgets/wds/WDSTableWidget/config/defaultsConfig.ts
+++ b/app/client/src/widgets/wds/WDSTableWidget/config/defaultsConfig.ts
@@ -42,6 +42,7 @@ export const defaultsConfig = {
   buttonLabel: "Action",
   buttonColor: "accent",
   buttonVariant: "filled",
+  isVisible: true,
   blueprint: {
     operations: [
       {


### PR DESCRIPTION
Fixes #35317
Fixes #35319
Fixes #35272

/ok-to-test tags="@tag.Anvil"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `autocompleteConfig` to manage visibility of autocomplete features consistently across the application.
  - Added `isVisible` property to `defaultConfig` for better control over widget visibility.

- **Improvements**
  - Simplified logic in the `shouldUpdateProperty` method for enhanced clarity and efficiency.
  - Updated `getAutocompleteDefinitions` methods to utilize the new `autocompleteConfig`, streamlining autocomplete handling.

- **Modifications**
  - Expanded export capabilities of configuration modules, including the new `autocompleteConfig` across multiple widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10368473517>
> Commit: 362f2af4cd0370aefe57c0004102d25c9b10ad33
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10368473517&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Anvil
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxGroupWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCurrencyInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilHeadingWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilIconButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInlineButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilParagraphWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilPhoneInputWidgetSnapshot_spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Tue, 13 Aug 2024 11:27:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->
