### PR TITLE
Added function to entrypoint.sh to create the HeapDumpPath if it is d…

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -469,12 +469,12 @@ init_loading_pages(){
   "$_APPSMITH_CADDY" start --config "$TMP/Caddyfile"
 }
 
-function create_heap_dump_path(
+function create_heap_dump_path() {
   if [[ "$(echo $APPSMITH_JAVA_ARGS | grep HeapDumpPath)" ]];then
     heap_dump_path="$(echo $APPSMITH_JAVA_ARGS | awk -FHeapDumpPath= '{print $2}' | cut -f 1 -d " ")"
     mkdir  -p "$heap_dump_path"
   fi
-)
+}
 
 function setup_auto_heal(){
    if [[ ${APPSMITH_AUTO_HEAL-} = 1 ]]; then

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -469,6 +469,13 @@ init_loading_pages(){
   "$_APPSMITH_CADDY" start --config "$TMP/Caddyfile"
 }
 
+function create_heap_dump_path(
+  if [[ "$(echo $APPSMITH_JAVA_ARGS | grep HeapDumpPath)" ]];then
+    heap_dump_path="$(echo $APPSMITH_JAVA_ARGS | awk -FHeapDumpPath= '{print $2}' | cut -f 1 -d " ")"
+    mkdir  -p "$heap_dump_path"
+  fi
+)
+
 function setup_auto_heal(){
    if [[ ${APPSMITH_AUTO_HEAL-} = 1 ]]; then
      # By default APPSMITH_AUTO_HEAL=0
@@ -527,6 +534,8 @@ mkdir -p /appsmith-stacks/data/{backup,restore} /appsmith-stacks/ssl
 # Create sub-directory to store services log in the container mounting folder
 export APPSMITH_LOG_DIR="${APPSMITH_LOG_DIR:-/appsmith-stacks/logs}"
 mkdir -p "$APPSMITH_LOG_DIR"/{supervisor,backend,cron,editor,rts,mongodb,redis,postgres,appsmithctl}
+
+create_heap_dump_path
 
 setup_auto_heal
 capture_infra_details


### PR DESCRIPTION
…efined in APPSMITH_JAVA_ARGS

## Description
Simple function to create the necessary directory for HeapDumpPath as defined in APPSMITH_JAVA_ARGS

This is so the proper directory exists to do preStop heap dumps

Fixes #35637r  

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 59262ddfacf8fff569f7fde6258015d8249a1bcd yet
> <hr>Mon, 12 Aug 2024 18:21:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced automatic creation of a heap dump directory based on specified Java arguments, enhancing debugging and performance monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->