### PR TITLE
feat: added properties for executeAction mixpanel event (#35291)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
@@ -153,6 +153,7 @@ public class FieldNameCE {
     public static final String ACTION_EXECUTION_TIME = "actionExecutionTime";
     public static final String ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP = "actionExecutionRequestParamsValueMap";
     public static final String ACTION_EXECUTION_INVERT_PARAMETER_MAP = "actionExecutionInvertParameterMap";
+    public static final String ACTION_EXECUTION_RAW_QUERY = "rawQuery";
     public static final String WEBSITE = "website";
     public static final String TEMPLATE_APPLICATION_NAME = "templateAppName";
     public static final String SOURCE = "source";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
@@ -153,7 +153,7 @@ public class FieldNameCE {
     public static final String ACTION_EXECUTION_TIME = "actionExecutionTime";
     public static final String ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP = "actionExecutionRequestParamsValueMap";
     public static final String ACTION_EXECUTION_INVERT_PARAMETER_MAP = "actionExecutionInvertParameterMap";
-    public static final String ACTION_EXECUTION_RAW_QUERY = "rawQuery";
+    public static final String ACTION_CONFIGURATION = "actionConfiguration";
     public static final String WEBSITE = "website";
     public static final String TEMPLATE_APPLICATION_NAME = "templateAppName";
     public static final String SOURCE = "source";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/FieldNameCE.java
@@ -151,6 +151,8 @@ public class FieldNameCE {
     public static final String ACTION_EXECUTION_REQUEST_PARAMS_COUNT = "actionExecutionRequestParamsCount";
     public static final String ACTION_EXECUTION_RESULT = "actionExecutionResult";
     public static final String ACTION_EXECUTION_TIME = "actionExecutionTime";
+    public static final String ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP = "actionExecutionRequestParamsValueMap";
+    public static final String ACTION_EXECUTION_INVERT_PARAMETER_MAP = "actionExecutionInvertParameterMap";
     public static final String WEBSITE = "website";
     public static final String TEMPLATE_APPLICATION_NAME = "templateAppName";
     public static final String SOURCE = "source";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -208,9 +208,6 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
             final String hashedUserId = hash(userId);
             // Remove params map and request key properties, if it's self-hosted as it contains user's evaluated params
             analyticsProperties.remove("request");
-            if (analyticsProperties.containsKey(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP)) {
-                analyticsProperties.remove(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP);
-            }
             for (final Map.Entry<String, Object> entry : analyticsProperties.entrySet()) {
                 if (userId.equals(entry.getValue())) {
                     analyticsProperties.put(entry.getKey(), hashedUserId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -206,7 +206,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
         // Hash usernames at all places for self-hosted instance
         if (shouldHashUserId(event, userId, hashUserId, commonConfig.isCloudHosting())) {
             final String hashedUserId = hash(userId);
-            // Remove params map and request key properties, if it's self-hosted as it contains user's evaluated params
+            // Remove request key, if it's self-hosted as it contains user's evaluated params
             analyticsProperties.remove("request");
             for (final Map.Entry<String, Object> entry : analyticsProperties.entrySet()) {
                 if (userId.equals(entry.getValue())) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -207,6 +207,10 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
         if (shouldHashUserId(event, userId, hashUserId, commonConfig.isCloudHosting())) {
             final String hashedUserId = hash(userId);
             analyticsProperties.remove("request");
+            // Remove params map key property if it's self-hosted
+            if (analyticsProperties.containsKey(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP)) {
+                analyticsProperties.remove(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP);
+            }
             for (final Map.Entry<String, Object> entry : analyticsProperties.entrySet()) {
                 if (userId.equals(entry.getValue())) {
                     analyticsProperties.put(entry.getKey(), hashedUserId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -206,8 +206,8 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
         // Hash usernames at all places for self-hosted instance
         if (shouldHashUserId(event, userId, hashUserId, commonConfig.isCloudHosting())) {
             final String hashedUserId = hash(userId);
+            // Remove params map and request key properties, if it's self-hosted as it contains user's evaluated params
             analyticsProperties.remove("request");
-            // Remove params map key property if it's self-hosted
             if (analyticsProperties.containsKey(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP)) {
                 analyticsProperties.remove(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP);
             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ActionExecutionSolutionImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ActionExecutionSolutionImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.solutions;
 
 import com.appsmith.server.applications.base.ApplicationService;
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
 import com.appsmith.server.helpers.PluginExecutorHelper;
@@ -38,7 +39,8 @@ public class ActionExecutionSolutionImpl extends ActionExecutionSolutionCEImpl i
             DatasourceStorageService datasourceStorageService,
             EnvironmentPermission environmentPermission,
             ConfigService configService,
-            TenantService tenantService) {
+            TenantService tenantService,
+            CommonConfig commonConfig) {
         super(
                 newActionService,
                 actionPermission,
@@ -57,6 +59,7 @@ public class ActionExecutionSolutionImpl extends ActionExecutionSolutionCEImpl i
                 datasourceStorageService,
                 environmentPermission,
                 configService,
-                tenantService);
+                tenantService,
+                commonConfig);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -789,6 +789,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                     final DatasourceStorage datasourceStorage = tuple.getT2();
                     final PluginExecutor pluginExecutor = tuple.getT3();
                     final Plugin plugin = tuple.getT4();
+                    final String rawQuery = actionDTO.getActionConfiguration().getBody();
 
                     log.debug(
                             "[{}]Execute Action called in Page {}, for action id : {}  action name : {}",
@@ -824,7 +825,12 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                                         timeElapsed);
 
                                 return sendExecuteAnalyticsEvent(
-                                                actionDTO, datasourceStorage, executeActionDTO, result, timeElapsed)
+                                                actionDTO,
+                                                datasourceStorage,
+                                                executeActionDTO,
+                                                result,
+                                                timeElapsed,
+                                                rawQuery)
                                         .thenReturn(result);
                             });
                 });
@@ -925,7 +931,8 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
             DatasourceStorage datasourceStorage,
             ExecuteActionDTO executeActionDto,
             ActionExecutionResult actionExecutionResult,
-            Long timeElapsed) {
+            Long timeElapsed,
+            String rawQuery) {
 
         if (!isSendExecuteAnalyticsEvent()) {
             return Mono.empty();
@@ -1113,8 +1120,14 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                     } else {
                         eventData.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS, REDACTED_DATA);
                     }
+                    if (executeActionDto != null) {
+                        data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP, executeActionDto.getParams());
+                        data.put(
+                                FieldName.ACTION_EXECUTION_INVERT_PARAMETER_MAP,
+                                executeActionDto.getInvertParameterMap());
+                    }
+                    data.put("rawQuery", rawQuery);
                     data.put(FieldName.EVENT_DATA, eventData);
-
                     return analyticsService
                             .sendObjectEvent(AnalyticsEvents.EXECUTE_ACTION, actionDTO, data)
                             .thenReturn(request);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -1126,7 +1126,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                                 FieldName.ACTION_EXECUTION_INVERT_PARAMETER_MAP,
                                 executeActionDto.getInvertParameterMap());
                     }
-                    data.put("rawQuery", rawQuery);
+                    data.put(FieldName.ACTION_EXECUTION_RAW_QUERY, rawQuery);
                     data.put(FieldName.EVENT_DATA, eventData);
                     return analyticsService
                             .sendObjectEvent(AnalyticsEvents.EXECUTE_ACTION, actionDTO, data)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -1135,7 +1135,10 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                         eventData.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS, REDACTED_DATA);
                     }
                     if (executeActionDto != null) {
-                        data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP, executeActionDto.getParams());
+                        if (commonConfig.isCloudHosting()) {
+                            // Only send this parameter if cloud hosting is true as it contains user's evaluated params
+                            data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP, executeActionDto.getParams());
+                        }
                         data.put(
                                 FieldName.ACTION_EXECUTION_INVERT_PARAMETER_MAP,
                                 executeActionDto.getInvertParameterMap());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -8,6 +8,7 @@ import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.Param;
 import com.appsmith.server.applications.base.ApplicationService;
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
@@ -128,6 +129,9 @@ class ActionExecutionSolutionCEImplTest {
     @SpyBean
     TenantService tenantService;
 
+    @MockBean
+    CommonConfig commonConfig;
+
     @Autowired
     EnvironmentPermission environmentPermission;
 
@@ -157,7 +161,8 @@ class ActionExecutionSolutionCEImplTest {
                 datasourceStorageService,
                 environmentPermission,
                 configService,
-                tenantService);
+                tenantService,
+                commonConfig);
 
         ObservationRegistry.ObservationConfig mockObservationConfig =
                 Mockito.mock(ObservationRegistry.ObservationConfig.class);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -129,7 +129,7 @@ class ActionExecutionSolutionCEImplTest {
     @SpyBean
     TenantService tenantService;
 
-    @MockBean
+    @SpyBean
     CommonConfig commonConfig;
 
     @Autowired


### PR DESCRIPTION
## Description
This PR adds new properties to the `Execute Action` mixpanel event so that we can measure the following:
- How many users are progressing through their app building journey
- Are we noticing patterns of what order users are building out this functionality
- What stage do users get to before they get stuck, or lost

New Properties added are: 
- ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP
- ACTION_EXECUTION_INVERT_PARAMETER_MAP
- ACTION_EXECUTION_RAW_QUERY

Fixes #35291 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10372829069>
> Commit: e8d8a02d38c9306eebef201a84a3570db9cd572d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10372829069&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 13 Aug 2024 16:11:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new constants for action execution parameters, enhancing clarity and maintainability.
	- Added the capability to log raw action configurations in analytics events for improved tracking of action executions.

- **Improvements**
	- Enhanced analytics data handling by conditionally managing properties based on the hosting environment, ensuring better data privacy for self-hosted applications.
	- Expanded functionality of action execution by integrating new configuration options, improving overall performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->