### PR TITLE
fix: View mode canvas margin

### DIFF
--- a/app/client/src/pages/AppViewer/AppPage/AppPage.tsx
+++ b/app/client/src/pages/AppViewer/AppPage/AppPage.tsx
@@ -34,7 +34,7 @@ export function AppPage(props: AppPageProps) {
   }, [isAnvilLayout, canvasWidth]);
 
   const pageViewWrapperRef = useRef<HTMLDivElement>(null);
-  useCanvasWidthAutoResize({ ref: pageViewWrapperRef, sidebarWidth });
+  useCanvasWidthAutoResize({ ref: pageViewWrapperRef });
 
   useEffect(() => {
     AnalyticsUtil.logEvent("PAGE_LOAD", {


### PR DESCRIPTION
## Description

Removes the extra margin added in the View Mode when Navigation is as Sidebar. It was noticed that the width of the sidebar was already accounted for and was reduced from the available width unnecessarily

Fixes #35618

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run:
<https://github.com/appsmithorg/appsmith/actions/runs/10349675002>
> Commit: 9778e836c9c8b13e4f6f0971ff36407f452b5d08
> <a
href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10349675002&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 12 Aug 2024 10:18:59 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
- Enhanced the auto-resizing behavior of the app's canvas by streamlining the parameters used in the resizing hook, potentially improving performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
