### PR TITLE
fix: Widget Overflow and Show Binding issue

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
@@ -16,6 +16,10 @@ import { Button } from "@appsmith/ads";
 import { getEntityProperties } from "ee/pages/Editor/Explorer/Entity/getEntityProperties";
 import store from "store";
 import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
+import {
+  APP_SIDEBAR_WIDTH,
+  DEFAULT_EXPLORER_PANE_WIDTH,
+} from "../../../../constants/AppConstants";
 
 const BindingContainerMaxHeight = 300;
 const EntityHeight = 36;
@@ -127,7 +131,8 @@ export function EntityProperties() {
         ref.current.style.top = top - EntityHeight + "px";
         ref.current.style.bottom = "unset";
       }
-      ref.current.style.left = "100%";
+      ref.current.style.left =
+        APP_SIDEBAR_WIDTH + DEFAULT_EXPLORER_PANE_WIDTH + "px";
     }
   }, [entityId]);
 

--- a/app/client/src/pages/Editor/IDE/EditorPane/Explorer.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/Explorer.tsx
@@ -15,7 +15,6 @@ import {
   BUILDER_PATH,
   BUILDER_PATH_DEPRECATED,
 } from "ee/constants/routes/appRoutes";
-import EntityProperties from "pages/Editor/Explorer/Entity/EntityProperties";
 import SegmentedHeader from "./components/SegmentedHeader";
 import { useSelector } from "react-redux";
 import { getIDEViewMode } from "selectors/ideSelectors";
@@ -34,6 +33,7 @@ const EditorPaneExplorer = () => {
       }
       className="relative ide-editor-left-pane__content"
       flexDirection="column"
+      overflow="hidden"
       width={
         ideViewMode === EditorViewMode.FullScreen
           ? DEFAULT_EXPLORER_PANE_WIDTH
@@ -41,9 +41,6 @@ const EditorPaneExplorer = () => {
       }
     >
       <SegmentedHeader />
-      {/** Entity Properties component is needed to render
-       the Bindings popover in the context menu. Will be removed eventually **/}
-      <EntityProperties />
       <Switch>
         <SentryRoute
           component={JSExplorer}

--- a/app/client/src/pages/Editor/IDE/EditorPane/index.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/index.tsx
@@ -6,6 +6,7 @@ import Editor from "./Editor";
 import { useSelector } from "react-redux";
 import { getIDEViewMode } from "selectors/ideSelectors";
 import { EditorViewMode } from "ee/entities/IDE/constants";
+import EntityProperties from "pages/Editor/Explorer/Entity/EntityProperties";
 
 const EditorPane = () => {
   const width = useEditorPaneWidth();
@@ -27,6 +28,10 @@ const EditorPane = () => {
       height="100%"
       width={width}
     >
+      {/** Entity Properties component is necessary to render
+       the Bindings popover in the context menu.
+       Will be removed eventually **/}
+      <EntityProperties />
       <EditorPaneExplorer />
       <Editor />
     </Flex>


### PR DESCRIPTION
## Description

Fix side effect introduced in #35611 that caused the widget pane to not be scrollable and extend beyond the IDE
Also fixes the show bindings issue not rendering correctly


Fixes #35584

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10364931153>
> Commit: db587d1622bac1312da463a3f747c1b2bdf5763d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10364931153&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Tue, 13 Aug 2024 07:11:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
