### PR TITLE
chore: use translate to center the resize handle

### DIFF
--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/SpaceDistributionHandle.tsx
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/SpaceDistributionHandle.tsx
@@ -29,6 +29,9 @@ const StyledSpaceDistributionHandle = styled.div<{ left: number }>`
   pointer-events: all;
   z-index: 1000;
   left: ${({ left }) => left}px;
+  // Note: we are using translateX to center the handle instead of adjusting left property
+  // (by subtracting half of the width of the handle) because translate is better with interpolating the sub-pixel values (pixel snapping issue)
+  transform: translateX(-50%);
   &:hover {
     background: var(--space-distribution-handle-bg);
   }
@@ -64,12 +67,8 @@ const updateDistributionHandlePosition = (
       // Calculate the midpoint between zones by subtracting half of the zoneGap from the offsetLeft
       const midPointBetweenZones = offsetLeft - zoneGap / 2;
 
-      // Calculate the left position of the handle, adjusting for its width
-      const handleWidthAdjustedLeft =
-        midPointBetweenZones - SpaceDistributorHandleDimensions.width / 2;
-
       // Set the left position of the handle element using its reference
-      ref.current.style.left = handleWidthAdjustedLeft + "px";
+      ref.current.style.left = midPointBetweenZones + "px";
     }
   }
 };
@@ -95,8 +94,7 @@ export const SpaceDistributionHandle = ({
   const isCurrentHandleDistributingSpace = useRef(false);
 
   // Calculate the left position of the distribution handle
-  const leftPositionOfHandle =
-    left - (SpaceDistributorHandleDimensions.width + zoneGap) * 0.5;
+  const leftPositionOfHandle = left - zoneGap * 0.5;
 
   // Destructure the parent zones array of zone ids
   const [leftZone, rightZone] = parentZones;

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/spaceDistributionEditorUtils.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/spaceDistributionEditorUtils.ts
@@ -56,6 +56,7 @@ const getElementsBoundingBoxValue = (ele: HTMLElement) => {
 export const getAnvilZoneBoundaryOffset = (zoneId: string) => {
   const zoneDom = document.getElementById(getAnvilWidgetDOMId(zoneId));
   if (zoneDom) {
+    // (TODO: Anvil): Why is 2 added here?
     return getElementsBoundingBoxValue(zoneDom) + 2;
   }
   return 0;

--- a/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/spaceDistributionEditorUtils.ts
+++ b/app/client/src/layoutSystems/anvil/sectionSpaceDistributor/utils/spaceDistributionEditorUtils.ts
@@ -56,7 +56,6 @@ const getElementsBoundingBoxValue = (ele: HTMLElement) => {
 export const getAnvilZoneBoundaryOffset = (zoneId: string) => {
   const zoneDom = document.getElementById(getAnvilWidgetDOMId(zoneId));
   if (zoneDom) {
-    // (TODO: Anvil): Why is 2 added here?
     return getElementsBoundingBoxValue(zoneDom) + 2;
   }
   return 0;


### PR DESCRIPTION
Fixes #35232

Because of how sub-pixels are handled in browsers, the resize handle was previously looking more inclined towards right. By using translate instead adjusting the width in left property, the issue seems to be resolved.

Before:
<img width="65" alt="CleanShot 2024-08-13 at 17 08 47@2x" src="https://github.com/user-attachments/assets/04f65b6a-6ef6-435f-91ea-3ebf1c12e7ab">

After:
<img width="71" alt="CleanShot 2024-08-13 at 17 08 00@2x" src="https://github.com/user-attachments/assets/bc29017c-c12c-49ee-a14e-270f33b3a6a6">



</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced positioning logic for the space distribution handle, simplifying the alignment process and potentially improving rendering behavior. 

- **Documentation**
	- Added comments to clarify the rationale behind adjustments in the positioning logic and highlight the benefits of using `translateX` for centering. 

- **Bug Fixes**
	- Resolved potential pixel snapping issues related to the handle's positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 801900efe8c65439e1b82db3fb309dcd59e461a3 yet
> <hr>Tue, 13 Aug 2024 12:05:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->
