### PR TITLE
chore: Un commented yarn cache

### DIFF
--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -209,14 +209,14 @@ jobs:
       # actions/setup-node@v4 doesn’t work properly with Yarn 3
       # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
       # Restoring the cache manually instead
-      # - name: Restore Yarn cache
-      #   if: steps.run_result.outputs.run_result != 'success'
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: |
-      #       app/client/.yarn/cache
-      #       app/client/node_modules/.cache/webpack/
-      #     key: v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+      - name: Restore Yarn cache
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/client/.yarn/cache
+            app/client/node_modules/.cache/webpack/
+          key: v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
 
       # Install all the dependencies
       - name: Install dependencies


### PR DESCRIPTION
## Description
Having seen memory failure in EE repo for the yarn install. This same steps works fine in CE.


Fixes #`35667`  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10369580919>
> Commit: 29e0b8dbbd06ba6068af3484d466a57206e81c3d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10369580919&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 13 Aug 2024 12:37:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Restored the Yarn cache during workflow execution in case of failure, improving build efficiency.

- **Chores**
	- Updated GitHub Actions workflow to enhance caching mechanism for better performance in CI processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->