### PR TITLE
CI: Added screenshot for cypress failure

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -372,6 +372,13 @@ jobs:
           path: ${{ github.workspace }}/app/client/cypress/cypress-logs
           overwrite: true
 
+      # Upload the screenshots as artifacts if there's a failure
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots-${{ matrix.job }}
+          path: ${{ github.workspace }}/app/client/cypress/screenshots/
+
       - name: Collect CI container logs
         if: failure()
         working-directory: "."


### PR DESCRIPTION
Added screenshot archival for cypress failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new step in the CI workflow to upload screenshots as artifacts when Cypress tests fail, enhancing debugging capabilities.
  
- **Bug Fixes**
	- Improved the overall functionality of the CI process by providing immediate access to visual evidence of test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->