### PR TITLE
perf: JSONForm widget optimise calling of clear errors

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.test.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import { FormProvider, useForm } from "react-hook-form";
 
 import { FormContextProvider } from "../FormContext";
@@ -25,7 +25,174 @@ const initialFieldState = {
   },
 };
 
-describe("useRegisterFieldInvalid", () => {
+describe("useRegisterFieldInvalid - setMetaInternalFieldState", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    jest.runAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("calls clearErrors when isValid is true and error is present", () => {
+    const mocksetMetaInternalFieldState = jest.fn();
+    const mockClearErrors = jest.fn();
+    const mockSetError = jest.fn();
+    const mockGetFieldState = jest
+      .fn()
+      .mockReturnValue({ error: { message: "Some error" } });
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      const methods = useForm();
+
+      return (
+        <FormContextProvider
+          executeAction={jest.fn}
+          renderMode="CANVAS"
+          setMetaInternalFieldState={mocksetMetaInternalFieldState}
+          updateFormData={jest.fn}
+          updateWidgetMetaProperty={jest.fn}
+          updateWidgetProperty={jest.fn}
+        >
+          <FormProvider
+            {...methods}
+            clearErrors={mockClearErrors}
+            getFieldState={mockGetFieldState}
+            setError={mockSetError}
+          >
+            {children}
+          </FormProvider>
+        </FormContextProvider>
+      );
+    }
+
+    const fieldName = "testField";
+
+    act(() => {
+      renderHook(
+        () =>
+          useRegisterFieldValidity({
+            isValid: true,
+            fieldName,
+            fieldType: FieldType.TEXT_INPUT,
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+
+      jest.runAllTimers();
+    });
+
+    expect(mockClearErrors).toBeCalledWith(fieldName);
+    expect(mockSetError).not.toBeCalled();
+  });
+
+  it("does not call clearErrors when isValid is false", () => {
+    const mocksetMetaInternalFieldState = jest.fn();
+    const mockClearErrors = jest.fn();
+    const mockSetError = jest.fn();
+    const mockGetFieldState = jest
+      .fn()
+      .mockReturnValue({ error: { message: "Some error" } });
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      const methods = useForm();
+
+      return (
+        <FormContextProvider
+          executeAction={jest.fn}
+          renderMode="CANVAS"
+          setMetaInternalFieldState={mocksetMetaInternalFieldState}
+          updateFormData={jest.fn}
+          updateWidgetMetaProperty={jest.fn}
+          updateWidgetProperty={jest.fn}
+        >
+          <FormProvider
+            {...methods}
+            clearErrors={mockClearErrors}
+            getFieldState={mockGetFieldState}
+            setError={mockSetError}
+          >
+            {children}
+          </FormProvider>
+        </FormContextProvider>
+      );
+    }
+
+    const fieldName = "testField";
+    act(() => {
+      renderHook(
+        () =>
+          useRegisterFieldValidity({
+            isValid: false,
+            fieldName,
+            fieldType: FieldType.TEXT_INPUT,
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+      jest.runAllTimers();
+    });
+
+    expect(mockClearErrors).not.toBeCalled();
+  });
+
+  it("does not call clearErrors when there is no existing error", () => {
+    const mocksetMetaInternalFieldState = jest.fn();
+    const mockClearErrors = jest.fn();
+    const mockSetError = jest.fn();
+    const mockGetFieldState = jest.fn().mockReturnValue({ error: null });
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      const methods = useForm();
+
+      return (
+        <FormContextProvider
+          executeAction={jest.fn}
+          renderMode="CANVAS"
+          setMetaInternalFieldState={mocksetMetaInternalFieldState}
+          updateFormData={jest.fn}
+          updateWidgetMetaProperty={jest.fn}
+          updateWidgetProperty={jest.fn}
+        >
+          <FormProvider
+            {...methods}
+            clearErrors={mockClearErrors}
+            getFieldState={mockGetFieldState}
+            setError={mockSetError}
+          >
+            {children}
+          </FormProvider>
+        </FormContextProvider>
+      );
+    }
+
+    const fieldName = "testField";
+
+    act(() => {
+      renderHook(
+        () =>
+          useRegisterFieldValidity({
+            isValid: true,
+            fieldName,
+            fieldType: FieldType.TEXT_INPUT,
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+
+      jest.runAllTimers();
+    });
+
+    expect(mockClearErrors).not.toBeCalled();
+    expect(mockSetError).not.toBeCalled();
+  });
+
   it("updates fieldState and error state with the updated isValid value", () => {
     const mocksetMetaInternalFieldState = jest.fn();
     // TODO: Fix this the next time the file is edited

--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
@@ -51,16 +51,6 @@ function useRegisterFieldValidity({
         Sentry.captureException(e);
       }
     }, 0);
-
-    setMetaInternalFieldState((prevState) => {
-      const metaInternalFieldState = klona(prevState.metaInternalFieldState);
-      set(metaInternalFieldState, `${fieldName}.isValid`, isValid);
-
-      return {
-        ...prevState,
-        metaInternalFieldState,
-      };
-    });
   }, [
     isValid,
     fieldName,
@@ -70,6 +60,18 @@ function useRegisterFieldValidity({
     clearErrors,
     setError,
   ]);
+
+  useEffect(() => {
+    setMetaInternalFieldState((prevState) => {
+      const metaInternalFieldState = klona(prevState.metaInternalFieldState);
+      set(metaInternalFieldState, `${fieldName}.isValid`, isValid);
+
+      return {
+        ...prevState,
+        metaInternalFieldState,
+      };
+    });
+  }, [fieldName, isValid, setMetaInternalFieldState]);
 }
 
 export default useRegisterFieldValidity;

--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
@@ -23,8 +23,9 @@ function useRegisterFieldValidity({
   fieldType,
   isValid,
 }: UseRegisterFieldValidityProps) {
-  const { clearErrors, setError } = useFormContext();
+  const { clearErrors, getFieldState, setError } = useFormContext();
   const { setMetaInternalFieldState } = useContext(FormContext);
+  const { error } = getFieldState(fieldName);
 
   useEffect(() => {
     /**
@@ -36,7 +37,9 @@ function useRegisterFieldValidity({
       try {
         isValid
           ? startAndEndSpanForFn("JSONFormWidget.clearErrors", {}, () => {
-              clearErrors(fieldName);
+              if (error) {
+                clearErrors(fieldName);
+              }
             })
           : startAndEndSpanForFn("JSONFormWidget.setError", {}, () => {
               setError(fieldName, {
@@ -58,7 +61,15 @@ function useRegisterFieldValidity({
         metaInternalFieldState,
       };
     });
-  }, [isValid, fieldName, fieldType]);
+  }, [
+    isValid,
+    fieldName,
+    fieldType,
+    setMetaInternalFieldState,
+    error,
+    clearErrors,
+    setError,
+  ]);
 }
 
 export default useRegisterFieldValidity;


### PR DESCRIPTION
## Description
During on page load for a jsonForm widget, the `clearErrors` method was getting called even if there wasn't any error to clear. This led to significant number of this function execution for a large scale application

For more info - https://theappsmith.slack.com/archives/C024GUDM0LT/p1723206363693759

Fixes https://github.com/appsmithorg/appsmith/issues/35739

## Automation

/ok-to-test tags="@tag.JSONForm"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10440802784>
> Commit: 8f449b75c15bd57a65ca75c5b7cffc7417f645c5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10440802784&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JSONForm`
> Spec:
> <hr>Sun, 18 Aug 2024 13:21:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved error handling in form validation to ensure errors are cleared only when necessary.
  
- **Bug Fixes**
	- Enhanced logic for retrieving current error states to provide a more robust user experience when filling out forms.

- **Tests**
	- Expanded test coverage for form validation logic, including various scenarios to ensure correct behavior under different conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->