### PR TITLE
ci: added specs to limited tests [Do Not Merge]

### DIFF
--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,10 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Autocomplete/BracketNotation_AC_spec.ts
+cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
+cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
+cypress/e2e/Regression/ClientSide/Workspace/Workspace_validation_spec.js
+cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
+cypress/e2e/Regression/ClientSide/JSObject/JSObjectMutation_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4909

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 2274cb8c0f8968edc961ccac6b88b8d1b1428638 yet
> <hr>Fri, 16 Aug 2024 10:28:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
