### PR TITLE
chore: Fix table columns when hidden are not greyed out in preview mode

### DIFF
--- a/app/client/src/widgets/wds/WDSTableWidget/component/styles.module.css
+++ b/app/client/src/widgets/wds/WDSTableWidget/component/styles.module.css
@@ -78,7 +78,7 @@
     border-block-end: var(--border-width-1) solid var(--color-bd);
   }
 
-  & thead [role="columnheader"]:is([aria-hidden]) {
+  & thead [role="columnheader"][aria-hidden] {
     opacity: var(--opacity-disabled);
   }
 
@@ -155,7 +155,7 @@
     background-color: var(--color-bg-elevation-3);
   }
 
-  & [role="cell"]:is([aria-hidden]) {
+  & [role="cell"][aria-hidden] {
     opacity: var(--opacity-disabled);
   }
 

--- a/app/client/src/widgets/wds/WDSTableWidget/component/styles.module.css
+++ b/app/client/src/widgets/wds/WDSTableWidget/component/styles.module.css
@@ -78,6 +78,10 @@
     border-block-end: var(--border-width-1) solid var(--color-bd);
   }
 
+  & thead [role="columnheader"]:is([aria-hidden]) {
+    opacity: var(--opacity-disabled);
+  }
+
   &[data-variant="default"] thead [role="columnheader"] {
     border-inline-end: var(--border-width-1) solid var(--color-bd);
   }
@@ -149,6 +153,10 @@
   & [role="cell"] {
     position: relative;
     background-color: var(--color-bg-elevation-3);
+  }
+
+  & [role="cell"]:is([aria-hidden]) {
+    opacity: var(--opacity-disabled);
   }
 
   & [role="row"][aria-checked="true"] [role="cell"] {


### PR DESCRIPTION
Fixes #34852

Grey out the header cells and row cells when the column is set invisible.

Before: 
![CleanShot 2024-08-16 at 16 28 01](https://github.com/user-attachments/assets/75076e7e-4ed6-444c-93c7-ada724888e45)

After:
![CleanShot 2024-08-16 at 16 28 15](https://github.com/user-attachments/assets/62e99c81-5114-4fd3-bd50-173140606f62)

/ok-to-test tags="@tag.Widget"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10422331593>
> Commit: 045a3e723cc3783c40b191613eb253a4e4ab1366
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10422331593&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Fri, 16 Aug 2024 16:28:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the visual feedback for users interacting with the `WDSTableWidget` by improving opacity styles for disabled table headers and cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->