### PR TITLE
feat: #11566 filter toolbar buttons RTE widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_4_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_4_spec.ts
@@ -1,0 +1,20 @@
+import { agHelper, propPane } from "../../../../../support/Objects/ObjectsCore";
+import EditorNavigation, {
+  EntityType,
+} from "../../../../../support/Pages/EditorNavigation";
+
+describe(
+  "Rich Text Editor widget Tests",
+  { tags: ["@tag.Widget", "@tag.TextEditor"] },
+  function () {
+    before(() => {
+      agHelper.AddDsl("richTextEditorDsl");
+      EditorNavigation.SelectEntityByName("RichTextEditor1", EntityType.Widget);
+    });
+
+    it("1. Verify updating disable plugin types updates toolbar buttons in widget", function () {
+      propPane.EnterJSContext("Disabled plugin types", `["bold"]`);
+      cy.get('[data-mce-name="bold"]').should("not.exist");
+    });
+  },
+);

--- a/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
@@ -331,6 +331,56 @@ class RichTextEditorWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          {
+            propertyName: "disablePluginTypes",
+            helpText: "Disables plugins from RTE",
+            label: "Disabled plugin types",
+            controlType: "DROP_DOWN",
+            isMultiSelect: true,
+            placeholderText: "Select plugin types",
+            options: [
+              { label: "Insert File", value: "insertfile" },
+              { label: "Undo", value: "undo" },
+              { label: "Redo", value: "redo" },
+              { label: "Blocks", value: "blocks" },
+              { label: "Bold", value: "bold" },
+              { label: "Italic", value: "italic" },
+              { label: "Underline", value: "underline" },
+              { label: "Backcolor", value: "backcolor" },
+              { label: "Forecolor", value: "forecolor" },
+              { label: "Lineheight", value: "lineheight" },
+              { label: "Align Left", value: "alignleft" },
+              { label: "Align Center", value: "aligncenter" },
+              { label: "Align Right", value: "alignright" },
+              { label: "Align Justify", value: "alignjustify" },
+              { label: "Bullist", value: "bullist" },
+              { label: "Numlist", value: "numlist" },
+              { label: "Outdent", value: "outdent" },
+              { label: "Indent", value: "indent" },
+              { label: "Link", value: "link" },
+              { label: "Image", value: "image" },
+              { label: "Remove Format", value: "removeformat" },
+              { label: "Table", value: "table" },
+              { label: "Print", value: "print" },
+              { label: "Preview", value: "preview" },
+              { label: "Media", value: "media" },
+              { label: "Emoticons", value: "emoticons" },
+              { label: "Code", value: "code" },
+              { label: "Help", value: "help" },
+            ],
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.ARRAY,
+              params: {
+                unique: true,
+                children: {
+                  type: ValidationTypes.TEXT,
+                },
+              },
+            },
+          },
         ],
       },
 
@@ -543,6 +593,7 @@ class RichTextEditorWidget extends BaseWidget<
           borderRadius={this.props.borderRadius}
           boxShadow={this.props.boxShadow}
           compactMode={isCompactMode(componentHeight)}
+          disablePluginTypes={this.props.disablePluginTypes}
           isDisabled={this.props.isDisabled}
           isDynamicHeightEnabled={isAutoHeightEnabledForWidget(this.props)}
           isMarkdown={this.props.inputType === RTEFormats.MARKDOWN}
@@ -589,6 +640,7 @@ export interface RichTextEditorWidgetProps extends WidgetProps {
   labelStyle?: string;
   isDirty: boolean;
   labelComponentWidth?: number;
+  disablePluginTypes: string[];
 }
 
 export default RichTextEditorWidget;


### PR DESCRIPTION
#11566 
- Added the `disablePluginTypes` prop to the `RichTextEditorComponent` to allow filtering of toolbar buttons.
- Implemented the `filterToolbarConfig` function to dynamically filter toolbar items based on the disabled plugins.
- Updated the `RichTextEditorWidget` to include the `disablePluginTypes` property with a dropdown for selecting plugins to disable.
- Passed the `disablePluginTypes` prop from the widget to the component to apply the toolbar filtering.


https://github.com/user-attachments/assets/270e6831-6681-4978-bf08-182393281ad6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `disablePluginTypes` property in the Rich Text Editor, allowing users to specify which plugins to disable in the toolbar.
	- Enhanced widget configuration with a dropdown for selecting disabled plugins, improving customization options.

- **Bug Fixes**
	- Improved rendering logic to ensure the editor updates correctly when plugin types are disabled.

- **Tests**
	- Added automated tests for the Rich Text Editor widget to verify functionality related to disabled plugin types, enhancing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->