### PR TITLE
fix: width of tooltip box is larger than text on the property panel

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -975,7 +975,7 @@ const PropertyControl = memo((props: Props) => {
                 }
               >
                 <PropertyHelpLabel
-                  className="w-full"
+                  className="fit-content"
                   label={label}
                   theme={props.theme}
                   tooltip={helpText}


### PR DESCRIPTION
#32078 
## Description
>Changes the width of tooltip container from full to fit-content
>Checked it in different screen as well
![Screenshot (274)](https://github.com/user-attachments/assets/eacdd3a5-ab07-460a-9e22-b92d73e3b077)




Fixes #32078   

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the styling of the `PropertyHelpLabel` for a more compact layout within the `PropertyControl` component, improving visual appeal and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->