### PR TITLE
chore: filter smartlook urls from tracing assets in page load instrumentation

### DIFF
--- a/app/client/src/UITelemetry/auto-otel-web.ts
+++ b/app/client/src/UITelemetry/auto-otel-web.ts
@@ -36,6 +36,10 @@ const {
   otlpServiceName,
 } = newRelic;
 
+// This base domain is used to filter out the Smartlook requests from the browser agent
+// There are some requests made to subdomains of smartlook.cloud which will also be filtered out
+const smartlookBaseDomain = "smartlook.cloud";
+
 const tracerProvider = new WebTracerProvider({
   resource: new Resource({
     [SEMRESATTRS_SERVICE_NAME]: otlpServiceName,
@@ -125,7 +129,11 @@ registerInstrumentations({
   meterProvider,
   instrumentations: [
     new PageLoadInstrumentation({
-      ignoreResourceUrls: [browserAgentEndpoint, otlpEndpoint],
+      ignoreResourceUrls: [
+        browserAgentEndpoint,
+        otlpEndpoint,
+        smartlookBaseDomain,
+      ],
     }),
   ],
 });


### PR DESCRIPTION
## Description
Filter smartlook urls from page load instrumentation. These api calls need not be tracked to measure page load performance.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10446808927>
> Commit: c81e741f9dcb071f0961903e806e60260a744677
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10446808927&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 19 Aug 2024 04:16:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved telemetry data accuracy by filtering out requests to Smartlook subdomains.

- **Bug Fixes**
	- Enhanced resource URL handling to exclude specific domains, reducing noise in telemetry reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->