### PR TITLE
chore: add logs and response when the captcha fails

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GoogleRecaptchaServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GoogleRecaptchaServiceCEImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -14,6 +15,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 public class GoogleRecaptchaServiceCEImpl implements CaptchaServiceCE {
     private final WebClient webClient;
 
@@ -52,11 +54,19 @@ public class GoogleRecaptchaServiceCEImpl implements CaptchaServiceCE {
                         .queryParam("response", recaptchaResponse)
                         .queryParam("secret", googleRecaptchaConfig.getSecretKey())
                         .build())
-                .retrieve()
-                .bodyToMono(String.class)
-                .flatMap(stringBody -> {
+                .exchange()
+                .flatMap(response -> {
+                    if (!response.statusCode().is2xxSuccessful()) {
+                        log.error("Failed to verify recaptcha response. Status code: {}", response.statusCode());
+                    }
+                    return response.bodyToMono(String.class).zipWith(Mono.just(response.statusCode()));
+                })
+                .flatMap(tuple -> {
                     try {
-                        Map<String, Object> response = objectMapper.readValue(stringBody, HashMap.class);
+                        Map<String, Object> response = objectMapper.readValue(tuple.getT1(), HashMap.class);
+                        if (!tuple.getT2().is2xxSuccessful()) {
+                            log.error("Failed to verify recaptcha response. Response: {}", response);
+                        }
                         return Mono.just(response);
                     } catch (JsonProcessingException e) {
                         return Mono.error(new AppsmithException(AppsmithError.JSON_PROCESSING_ERROR, e));


### PR DESCRIPTION
## Description
The PR adds logs to captcha verification flow. We do not collect any information on the captcha failures and this causes issues when we are debugging captcha errors on the users machine. 



## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
