### PR TITLE
chore: change the isResourceUpdated implementation to check if the resourceType is present or not

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/ModifiedResources.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/ModifiedResources.java
@@ -33,9 +33,9 @@ public class ModifiedResources {
      */
     public boolean isResourceUpdated(String resourceType, String resourceName) {
         return StringUtils.isEmpty(resourceType)
-                || isAllModified
-                || (!CollectionUtils.isEmpty(modifiedResourceMap.get(resourceType))
-                        && modifiedResourceMap.get(resourceType).contains(resourceName));
+                && (isAllModified
+                        || (!CollectionUtils.isEmpty(modifiedResourceMap.get(resourceType))
+                                && modifiedResourceMap.get(resourceType).contains(resourceName)));
     }
 
     /**

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/ModifiedResources.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/ModifiedResources.java
@@ -1,6 +1,7 @@
 package com.appsmith.external.dtos;
 
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 import java.util.HashSet;
@@ -31,7 +32,8 @@ public class ModifiedResources {
      * @return true if modified, false otherwise
      */
     public boolean isResourceUpdated(String resourceType, String resourceName) {
-        return isAllModified
+        return StringUtils.isEmpty(resourceType)
+                || isAllModified
                 || (!CollectionUtils.isEmpty(modifiedResourceMap.get(resourceType))
                         && modifiedResourceMap.get(resourceType).contains(resourceName));
     }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/ModifiedResources.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/ModifiedResources.java
@@ -32,7 +32,7 @@ public class ModifiedResources {
      * @return true if modified, false otherwise
      */
     public boolean isResourceUpdated(String resourceType, String resourceName) {
-        return StringUtils.isEmpty(resourceType)
+        return StringUtils.isNotEmpty(resourceType)
                 && (isAllModified
                         || (!CollectionUtils.isEmpty(modifiedResourceMap.get(resourceType))
                                 && modifiedResourceMap.get(resourceType).contains(resourceName)));

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/dtos/ModifiedResourcesTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/dtos/ModifiedResourcesTest.java
@@ -15,24 +15,30 @@ public class ModifiedResourcesTest {
 
         // should be true when no the flag is not set
         assertThat(modifiedResources.isResourceUpdated("any", "any")).isFalse();
+        assertThat(modifiedResources.isResourceUpdated(null, "any")).isFalse();
 
         modifiedResources.setAllModified(false);
         assertThat(modifiedResources.isResourceUpdated("any", "any")).isFalse();
+        assertThat(modifiedResources.isResourceUpdated(null, "any")).isFalse();
 
         modifiedResources.setAllModified(true);
         assertThat(modifiedResources.isResourceUpdated("any", "any")).isTrue();
+        assertThat(modifiedResources.isResourceUpdated(null, "any")).isFalse();
 
         modifiedResources.setAllModified(false);
         modifiedResources.setModifiedResourceMap(Map.of());
         assertThat(modifiedResources.isResourceUpdated("any", "any")).isFalse();
+        assertThat(modifiedResources.isResourceUpdated(null, "any")).isFalse();
 
         modifiedResources.setAllModified(false);
         modifiedResources.setModifiedResourceMap(Map.of("any", Set.of()));
         assertThat(modifiedResources.isResourceUpdated("any", "any")).isFalse();
+        assertThat(modifiedResources.isResourceUpdated(null, "any")).isFalse();
 
         modifiedResources.setAllModified(false);
         modifiedResources.setModifiedResourceMap(Map.of("PAGE", Set.of("home")));
         assertThat(modifiedResources.isResourceUpdated("PAGE", "home")).isTrue();
+        assertThat(modifiedResources.isResourceUpdated(null, "any")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Description
> This code change aims to change the implementation of `isResourceUpdated` method in `ModifiedResources`. This change will take into account whether the `resourceType` is present or not. 


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.ImportExport,@tag.Git,@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10465647668>
> Commit: 6c751da6f373c3b373dfa45940ef70b9496f32e5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10465647668&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.ImportExport,@tag.Git,@tag.Sanity`
> Spec:
> <hr>Tue, 20 Aug 2024 05:34:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced resource update detection logic to improve accuracy in determining if resources have been modified based on the provided resource type.
  
- **Bug Fixes**
  - Adjusted conditions under which resources are considered updated, potentially resolving inconsistencies in previous behavior.
  
- **Tests**
  - Improved test coverage for the resource update detection logic by adding assertions for handling null inputs, ensuring robustness against edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->