### PR TITLE
fix: Browser scale factor

### DIFF
--- a/app/client/cypress/plugins/index.js
+++ b/app/client/cypress/plugins/index.js
@@ -95,6 +95,40 @@ module.exports = async (on, config) => {
       launchOptions.preferences.resizable = false;
       return launchOptions;
     }
+
+    if (browser.name === "chrome" && browser.isHeadless) {
+      const video = path.join(
+        "cypress",
+        "fixtures",
+        "Videos",
+        "webCamVideo.y4m",
+      );
+      launchOptions.args.push("--disable-dev-shm-usage");
+      launchOptions.args.push("--window-size=1400,1100");
+      launchOptions.args.push("--use-fake-ui-for-media-stream");
+      launchOptions.args.push("--use-fake-device-for-media-stream");
+      //Stream default video source for camera & code scanner
+      launchOptions.args.push(`--use-file-for-fake-video-capture=${video}`);
+      launchOptions.args.push('--force-device-scale-factor=1');
+      return launchOptions;
+    }
+
+    if (browser.name === "chromium" && browser.isHeadless) {
+      const video = path.join(
+        "cypress",
+        "fixtures",
+        "Videos",
+        "webCamVideo.y4m",
+      );
+      launchOptions.args.push("--disable-dev-shm-usage");
+      launchOptions.args.push("--window-size=1400,1100");
+      launchOptions.args.push("--use-fake-ui-for-media-stream");
+      launchOptions.args.push("--use-fake-device-for-media-stream");
+      //Stream default video source for camera & code scanner
+      launchOptions.args.push(`--use-file-for-fake-video-capture=${video}`);
+      launchOptions.args.push('--force-device-scale-factor=1');
+      return launchOptions;
+    }
   });
   // module.exports = (on, config) => {
   //   on("after:spec", (spec, results) => {


### PR DESCRIPTION
## Description
Added --force-device-scale-factor=1 for making scale view to same as given server in docker.


Fixes #`35763`  

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10466280072>
> Commit: e4c72a52c9461851eb0cc3842fed3f2e9d55a537
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10466280072&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_All_Verb_spec.js
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Binary_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Tue, 20 Aug 2024 07:11:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Cypress testing framework with improved configurations for headless Chrome and Chromium.
	- Introduced conditional logic for customized launch options, improving testing fidelity for media device interactions.
  
- **Bug Fixes**
	- Resolved issues related to media device simulation in headless testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->