### PR TITLE
chore: Add cleanup and update stage for tenant at the server restart

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
@@ -1,0 +1,35 @@
+package com.appsmith.server.configurations;
+
+import com.appsmith.server.helpers.CollectionUtils;
+import com.appsmith.server.repositories.CacheableRepositoryHelper;
+import com.appsmith.server.services.TenantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.appsmith.external.models.BaseDomain.policySetToMap;
+
+@Configuration
+@RequiredArgsConstructor
+public class TenantConfig {
+
+    private final TenantService tenantService;
+    private final CacheableRepositoryHelper cacheableRepositoryHelper;
+
+    // Bean to cleanup the cache and update the default tenant policies on every server restart. This will make sure
+    // cache will be updated if we update the tenant via migrations.
+    @Bean
+    public void cleanupAndUpdateRefreshDefaultTenantPolicies() {
+        tenantService
+                .getDefaultTenantId()
+                .flatMap(cacheableRepositoryHelper::evictCachedTenant)
+                .then(tenantService.getDefaultTenant())
+                .flatMap(tenant -> {
+                    if (CollectionUtils.isNullOrEmpty(tenant.getPolicyMap())) {
+                        tenant.setPolicyMap(policySetToMap(tenant.getPolicies()));
+                    }
+                    return tenantService.save(tenant);
+                })
+                .subscribe();
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
@@ -21,7 +21,7 @@ public class TenantConfig implements ApplicationListener<ApplicationStartedEvent
 
     // Method to cleanup the cache and update the default tenant policies if the policyMap is empty. This will make sure
     // cache will be updated if we update the tenant via startup DB migrations.
-    public Mono<Tenant> cleanupAndUpdateRefreshDefaultTenantPolicies() {
+    private Mono<Tenant> cleanupAndUpdateRefreshDefaultTenantPolicies() {
         log.debug("Cleaning up and updating default tenant policies on server startup");
         return tenantService.getDefaultTenant().flatMap(tenant -> {
             if (CollectionUtils.isNullOrEmpty(tenant.getPolicyMap())) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
@@ -2,7 +2,7 @@ package com.appsmith.server.configurations;
 
 import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.helpers.CollectionUtils;
-import com.appsmith.server.services.TenantService;
+import com.appsmith.server.repositories.TenantRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationStartedEvent;
@@ -17,16 +17,16 @@ import static com.appsmith.external.models.BaseDomain.policySetToMap;
 @Slf4j
 public class TenantConfig implements ApplicationListener<ApplicationStartedEvent> {
 
-    private final TenantService tenantService;
+    private final TenantRepository tenantRepository;
 
     // Method to cleanup the cache and update the default tenant policies if the policyMap is empty. This will make sure
     // cache will be updated if we update the tenant via startup DB migrations.
     private Mono<Tenant> cleanupAndUpdateRefreshDefaultTenantPolicies() {
         log.debug("Cleaning up and updating default tenant policies on server startup");
-        return tenantService.getDefaultTenant().flatMap(tenant -> {
+        return tenantRepository.findBySlug("default").flatMap(tenant -> {
             if (CollectionUtils.isNullOrEmpty(tenant.getPolicyMap())) {
                 tenant.setPolicyMap(policySetToMap(tenant.getPolicies()));
-                return tenantService.save(tenant);
+                return this.tenantRepository.save(tenant);
             }
             return Mono.just(tenant);
         });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
@@ -23,6 +23,7 @@ public class TenantConfig implements ApplicationListener<ApplicationStartedEvent
 
     // Method to cleanup the cache and update the default tenant policies if the policyMap is empty. This will make sure
     // cache will be updated if we update the tenant via startup DB migrations.
+    // As we have mocked the TenantService in the tests, we had to manually evict the cache and save the object to DB
     private Mono<Tenant> cleanupAndUpdateRefreshDefaultTenantPolicies() {
         log.debug("Cleaning up and updating default tenant policies on server startup");
         return tenantRepository.findBySlug("default").flatMap(tenant -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
@@ -20,8 +20,8 @@ public class TenantConfig {
     // Bean to cleanup the cache and update the default tenant policies on every server restart. This will make sure
     // cache will be updated if we update the tenant via migrations.
     @Bean
-    public Mono<Void> cleanupAndUpdateRefreshDefaultTenantPolicies() {
-        return tenantService
+    public void cleanupAndUpdateRefreshDefaultTenantPolicies() {
+        tenantService
                 .getDefaultTenantId()
                 .flatMap(cacheableRepositoryHelper::evictCachedTenant)
                 .then(tenantService.getDefaultTenant())
@@ -32,6 +32,6 @@ public class TenantConfig {
                     }
                     return Mono.just(tenant);
                 })
-                .then();
+                .subscribe();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/TenantConfig.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.configurations;
 
+import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
@@ -26,7 +27,7 @@ public class TenantConfig implements ApplicationListener<ApplicationStartedEvent
     // As we have mocked the TenantService in the tests, we had to manually evict the cache and save the object to DB
     private Mono<Tenant> cleanupAndUpdateRefreshDefaultTenantPolicies() {
         log.debug("Cleaning up and updating default tenant policies on server startup");
-        return tenantRepository.findBySlug("default").flatMap(tenant -> {
+        return tenantRepository.findBySlug(FieldName.DEFAULT).flatMap(tenant -> {
             if (CollectionUtils.isNullOrEmpty(tenant.getPolicyMap())) {
                 tenant.setPolicyMap(policySetToMap(tenant.getPolicies()));
                 return cachableRepositoryHelper


### PR DESCRIPTION
## Description
PR to add the cleanup and update default tenant at the server restart. This was required because whenever we update tenant via migrations the result gets reverted because the cached tenant is not getting updated as we generally end up updating only the MongoDB state and not the cached entry. 

/test Sanity
 
### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10471754877>
> Commit: e288cfe1084bdbf2104a656bf60eb9c24708fe77
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10471754877&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 20 Aug 2024 13:01:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a mechanism to refresh tenant policies and manage cache cleanup during server restarts, ensuring accurate policy enforcement for multi-tenant applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->