### PR TITLE
chore: fix zone dotted highlight is not showing up on new anvil apps 

### DIFF
--- a/app/client/cypress.config.ts
+++ b/app/client/cypress.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     openMode: 0,
   },
   e2e: {
-    baseUrl: "https://release.app.appsmith.com/",
+    baseUrl: "https://dev.appsmith.com/",
     env: {
       USERNAME: "xxxx",
       PASSWORD: "xxx",

--- a/app/client/cypress.config.ts
+++ b/app/client/cypress.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     openMode: 0,
   },
   e2e: {
-    baseUrl: "https://dev.appsmith.com/",
+    baseUrl: "https://release.app.appsmith.com/",
     env: {
       USERNAME: "xxxx",
       PASSWORD: "xxx",

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilSpaceDistribution_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilSpaceDistribution_spec.ts
@@ -175,7 +175,8 @@ describe(
       );
 
       const zone1Selector = anvilLocators.anvilWidgetNameSelector("Zone1");
-      const section1Selector = anvilLocators.anvilWidgetNameSelector("Section1");
+      const section1Selector =
+        anvilLocators.anvilWidgetNameSelector("Section1");
 
       anvilLayout.sections.mouseDownSpaceDistributionHandle("Section1", 1);
       // outline color of zone while distributing space should be transparent

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilSpaceDistribution_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilSpaceDistribution_spec.ts
@@ -175,26 +175,20 @@ describe(
       );
 
       const zone1Selector = anvilLocators.anvilWidgetNameSelector("Zone1");
+      const section1Selector = anvilLocators.anvilWidgetNameSelector("Section1");
+
       anvilLayout.sections.mouseDownSpaceDistributionHandle("Section1", 1);
       // outline color of zone while distributing space should be transparent
       cy.get(zone1Selector).should(
         "have.css",
         "outline-color",
-        "rgba(0, 0, 0, 0)",
+        "transparent",
       );
-      anvilLayout.sections.mouseUpSpaceDistributionHandle("Section1", 1);
-      // select zone1
-      agHelper.GetNClick(zone1Selector);
-      // go to style tab
-      propPane.MoveToTab("Style");
-      // toggle visual separation off on property pane
-      propPane.TogglePropertyState("Visual Separation", "Off");
-      anvilLayout.sections.mouseDownSpaceDistributionHandle("Section1", 1);
-      // outline color of background less zone while distributing space should not be transparent
-      cy.get(zone1Selector).should(
+      // outline color of section while distributing space should not be transparent
+      cy.get(section1Selector).should(
         "not.have.css",
         "outline-color",
-        "rgba(0, 0, 0, 0)",
+        "transparent",
       );
     });
   },

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilSpaceDistribution_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilSpaceDistribution_spec.ts
@@ -182,7 +182,7 @@ describe(
       cy.get(zone1Selector).should(
         "have.css",
         "outline-color",
-        "transparent",
+        "rgba(0, 0, 0, 0)",
       );
       // outline color of section while distributing space should not be transparent
       cy.get(section1Selector).should(

--- a/app/client/src/layoutSystems/anvil/common/hooks/useWidgetBorderStyles.ts
+++ b/app/client/src/layoutSystems/anvil/common/hooks/useWidgetBorderStyles.ts
@@ -10,11 +10,7 @@ import { useSelector } from "react-redux";
 import { combinedPreviewModeSelector } from "selectors/editorSelectors";
 import { isWidgetFocused, isWidgetSelected } from "selectors/widgetSelectors";
 
-export function useWidgetBorderStyles(
-  widgetId: string,
-  widgetType: string,
-  elevatedBackground?: boolean,
-) {
+export function useWidgetBorderStyles(widgetId: string, widgetType: string) {
   /** Selectors */
   const isFocused = useSelector(isWidgetFocused(widgetId));
   const isSelected = useSelector(isWidgetSelected(widgetId));
@@ -44,14 +40,13 @@ export function useWidgetBorderStyles(
   if (isPreviewMode) {
     return {};
   }
-  const isZoneDistributingSpace =
-    widgetsEffectedBySpaceDistribution.zones.includes(widgetId);
-  // If the widget is a zone and is distributing space and has no elevated background
-  const isZoneNotElevated = isZoneDistributingSpace && !elevatedBackground;
+
+  const isSectionDistributingSpace =
+    widgetsEffectedBySpaceDistribution.section == widgetId;
   // Show the border if the widget has widgets being dragged or redistributed inside it
   const showDraggedOnBorder =
     (highlightShown && highlightShown.canvasId === widgetId) ||
-    isZoneNotElevated;
+    isSectionDistributingSpace;
 
   const onCanvasUI = WidgetFactory.getConfig(widgetType)?.onCanvasUI;
 

--- a/app/client/src/layoutSystems/anvil/editor/AnvilEditorFlexComponent.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilEditorFlexComponent.tsx
@@ -47,7 +47,6 @@ export const AnvilEditorFlexComponent = (props: AnvilFlexComponentProps) => {
     props.widgetName,
     props.isVisible,
     props.widgetType,
-    !!props.elevatedBackground,
     ref,
   );
   useAnvilWidgetDrag(props.widgetId, props.widgetType, props.layoutId, ref);

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/selectors.ts
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/selectors.ts
@@ -4,7 +4,10 @@ import { EVAL_ERROR_PATH } from "utils/DynamicBindingUtils";
 import get from "lodash/get";
 import { createSelector } from "reselect";
 import { getIsDragging } from "selectors/widgetDragSelectors";
-import { getAnvilHighlightShown } from "layoutSystems/anvil/integrations/selectors";
+import {
+  getAnvilHighlightShown,
+  getAnvilSpaceDistributionStatus,
+} from "layoutSystems/anvil/integrations/selectors";
 import { isWidgetFocused, isWidgetSelected } from "selectors/widgetSelectors";
 import { isEditOnlyModeSelector } from "selectors/editorSelectors";
 
@@ -58,25 +61,33 @@ export function shouldSelectOrFocus(widgetId: string) {
     getAnvilHighlightShown,
     isWidgetSelected(widgetId),
     isWidgetFocused(widgetId),
+    getAnvilSpaceDistributionStatus,
     (
       isEditorOpen,
       isDragging,
       highlightShown,
       isWidgetSelected,
       isWidgetFocused,
+      isDistributingSpace,
     ) => {
       const baseCondition = isEditorOpen && !isDragging;
-
       let onCanvasUIState: NameComponentStates = "none";
       if (baseCondition) {
         if (isWidgetSelected) onCanvasUIState = "select";
+
+        // when dragging the resizing handle, the action also makes
+        // the widget selected but we want to show it as focused while distributing space
+        if (isWidgetSelected && isDistributingSpace) onCanvasUIState = "focus";
+
         // A widget can be focused and selected at the same time.
         // I'm not sure if these should be mutually exclusive states.
         if (isWidgetFocused && !isWidgetSelected) onCanvasUIState = "focus";
       }
+
       if (highlightShown && highlightShown.canvasId === widgetId) {
         onCanvasUIState = "focus";
       }
+
       return onCanvasUIState;
     },
   );

--- a/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/selectors.ts
+++ b/app/client/src/layoutSystems/anvil/editor/AnvilWidgetName/selectors.ts
@@ -4,10 +4,7 @@ import { EVAL_ERROR_PATH } from "utils/DynamicBindingUtils";
 import get from "lodash/get";
 import { createSelector } from "reselect";
 import { getIsDragging } from "selectors/widgetDragSelectors";
-import {
-  getAnvilHighlightShown,
-  getAnvilSpaceDistributionStatus,
-} from "layoutSystems/anvil/integrations/selectors";
+import { getAnvilHighlightShown } from "layoutSystems/anvil/integrations/selectors";
 import { isWidgetFocused, isWidgetSelected } from "selectors/widgetSelectors";
 import { isEditOnlyModeSelector } from "selectors/editorSelectors";
 
@@ -61,16 +58,15 @@ export function shouldSelectOrFocus(widgetId: string) {
     getAnvilHighlightShown,
     isWidgetSelected(widgetId),
     isWidgetFocused(widgetId),
-    getAnvilSpaceDistributionStatus,
     (
       isEditorOpen,
       isDragging,
       highlightShown,
       isWidgetSelected,
       isWidgetFocused,
-      isDistributingSpace,
     ) => {
-      const baseCondition = isEditorOpen && !isDragging && !isDistributingSpace;
+      const baseCondition = isEditorOpen && !isDragging;
+
       let onCanvasUIState: NameComponentStates = "none";
       if (baseCondition) {
         if (isWidgetSelected) onCanvasUIState = "select";

--- a/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetStyles.ts
+++ b/app/client/src/layoutSystems/anvil/editor/hooks/useAnvilWidgetStyles.ts
@@ -11,7 +11,6 @@ export const useAnvilWidgetStyles = (
   widgetName: string,
   isVisible = true,
   widgetType: string,
-  elevatedBackground: boolean,
   ref: React.RefObject<HTMLDivElement>, // Ref object to reference the AnvilFlexComponent
 ) => {
   // Selectors to determine whether the widget is selected or dragging
@@ -20,11 +19,7 @@ export const useAnvilWidgetStyles = (
     (state: AppState) => state.ui.widgetDragResize.isDragging,
   );
   // Get widget border styles using useWidgetBorderStyles
-  const widgetBorderStyles = useWidgetBorderStyles(
-    widgetId,
-    widgetType,
-    elevatedBackground,
-  );
+  const widgetBorderStyles = useWidgetBorderStyles(widgetId, widgetType);
 
   // Effect hook to apply widget border styles to the widget
   useEffect(() => {


### PR DESCRIPTION
Fixes #35231

/ok-to-test tags="@tag.Anvil"

Before:
![CleanShot 2024-08-20 at 16 52 13](https://github.com/user-attachments/assets/bcc40ba9-0e8f-40c0-a38d-b22983932dc4)

After:
![CleanShot 2024-08-20 at 16 52 31](https://github.com/user-attachments/assets/1a5d3533-72e3-474a-8ad9-4af69dd4ae86)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved widget border style handling by simplifying parameters and logic.
	- Enhanced visual consistency by removing the `elevatedBackground` consideration from various components.
	- Refined test logic to focus on section properties during space distribution.
- **Bug Fixes**
	- Addressed potential inconsistencies in widget appearance related to background elevation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10503394684>
> Commit: 574aab588e35fc90e59720010e2b8a249bf824ed
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10503394684&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Anvil
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxGroupWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCurrencyInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilHeadingWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilIconButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInlineButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilParagraphWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilPhoneInputWidgetSnapshot_spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Thu, 22 Aug 2024 07:30:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->
