### PR TITLE
chore: Add adhoc image builder

### DIFF
--- a/.github/workflows/ad-hoc-docker-image.yml
+++ b/.github/workflows/ad-hoc-docker-image.yml
@@ -1,0 +1,113 @@
+name: Ad-hoc Docker Image
+
+on:
+  # This line enables manual triggering of this workflow.
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to build image out of
+        required: false
+        type: string
+        default: master
+      tag:
+        description: Tag to use for image
+        required: false
+        type: string
+        default: ad-hoc
+
+jobs:
+  server-build:
+    name: server-build
+    uses: ./.github/workflows/server-build.yml
+    secrets: inherit
+    with:
+      branch: ${{ inputs.branch }}
+      skip-tests: true
+
+  client-build:
+    name: client-build
+    uses: ./.github/workflows/client-build.yml
+    secrets: inherit
+    with:
+      branch: ${{ inputs.branch }}
+
+  rts-build:
+    name: rts-build
+    uses: ./.github/workflows/rts-build.yml
+    secrets: inherit
+    with:
+      branch: ${{ inputs.branch }}
+
+  package:
+    needs: [server-build, client-build, rts-build]
+    runs-on: ubuntu-latest
+    # Set permissions since we're using OIDC token authentication between Depot and GitHub
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      # Check out the specified branch in case this workflow is called by another workflow
+      - name: Checkout the specified branch
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          ref: ${{ inputs.branch }}
+
+      - name: Download the react build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: client-build
+          path: app/client
+
+      - name: Unpack the client build artifact
+        if: steps.run_result.outputs.run_result != 'success'
+        run: |
+          mkdir -p app/client/build
+          tar -xvf app/client/build.tar -C app/client/build
+
+      - name: Download the server build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: server-build
+          path: app/server/dist
+
+      - name: Download the rts build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rts-dist
+          path: app/client/packages/rts/dist
+
+      - name: Untar the rts folder
+        run: |
+          tar -xvf app/client/packages/rts/dist/rts-dist.tar -C app/client/packages/rts/
+          echo "Cleaning up the tar files"
+          rm app/client/packages/rts/dist/rts-dist.tar
+
+      - name: Generate info.json
+        run: |
+          if [[ -f scripts/generate_info_json.sh ]]; then
+            scripts/generate_info_json.sh
+          fi
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push environment specific image to Docker Hub
+        if: success()
+        uses: depot/build-push-action@v1
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64,linux/amd64
+          build-args: |
+            APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
+            BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:nightly
+          tags: |
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:${{ inputs.tag }}


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for manual triggering of Docker image builds and pushes.
	- Users can specify branch and tag inputs, defaulting to `master` and `ad-hoc`.
	- Enhanced CI/CD capabilities by supporting multi-platform Docker image creation.

- **Improvements**
	- Streamlined the building and deployment process for Docker images with automated jobs and secure access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->