### PR TITLE
chore: Do not mark User testing PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,6 @@ jobs:
         close-issue-message: 'This issue has been closed because of inactivity.'
         close-pr-message: 'This PR has been closed because of inactivity.'
         only-issue-labels: 'Critical'
-        exempt-pr-labels: 'Dont merge,WIP'
+        exempt-pr-labels: 'Dont merge,WIP,User Testing'
         
         


### PR DESCRIPTION
## Description

Adds a new exception on the stale check workflow. If the PR has the flag of "User Testing", it will not mark it as stale.




<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD f27d4ceaf7b36227481c8a11a882c5d5c9fe07ea yet
> <hr>Wed, 21 Aug 2024 08:34:31 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the `User Testing` label to the list of exempt labels, preventing pull requests in user testing from being closed due to inactivity. This enhances workflow management for extended reviews or testing periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->