### PR TITLE
fix: moved js filter to mongoDB

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -78,6 +78,9 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
     Flux<NewAction> findAllByApplicationIdAndViewMode(
             String applicationId, Boolean viewMode, Optional<AclPermission> permission, Optional<Sort> sort);
 
+    Flux<NewAction> findAllByApplicationIdAndPluginType(
+            String applicationId, Boolean viewMode, AclPermission permission, Sort sort, List<String> pluginTypes);
+
     Flux<ActionViewDTO> getActionsForViewMode(String applicationId);
 
     ActionViewDTO generateActionViewDTO(NewAction action, ActionDTO actionDTO, boolean viewMode);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -735,25 +735,17 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
 
     @Override
     public Flux<NewAction> findAllByApplicationIdAndPluginType(
-            String applicationId, Boolean viewMode, AclPermission permission, Sort sort, List<String> pluginTypes) {
+            String applicationId,
+            Boolean viewMode,
+            AclPermission permission,
+            Sort sort,
+            List<String> excludedPluginTypes) {
         return repository
-                .findByApplicationIdAndPluginType(applicationId, pluginTypes, permission, sort)
+                .findByApplicationIdAndPluginType(applicationId, excludedPluginTypes, permission, sort)
                 .name(VIEW_MODE_FETCH_ACTIONS_FROM_DB)
                 .tap(Micrometer.observation(observationRegistry))
                 // In case of view mode being true, filter out all the actions which haven't been published
-                .flatMap(action -> {
-                    if (Boolean.TRUE.equals(viewMode)) {
-                        // In case we are trying to fetch published actions but this action has not been published, do
-                        // not return
-                        if (action.getPublishedAction() == null) {
-                            return Mono.empty();
-                        }
-                    }
-                    // No need to handle the edge case of unpublished action not being present. This is not possible
-                    // because every created action starts from an unpublishedAction state.
-
-                    return Mono.just(action);
-                })
+                .flatMap(action -> this.filterAction(action, viewMode))
                 .name(VIEW_MODE_FILTER_ACTION)
                 .tap(Micrometer.observation(observationRegistry))
                 .flatMap(this::sanitizeAction)
@@ -767,19 +759,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         return repository
                 .findByApplicationId(applicationId, permission, sort)
                 // In case of view mode being true, filter out all the actions which haven't been published
-                .flatMap(action -> {
-                    if (Boolean.TRUE.equals(viewMode)) {
-                        // In case we are trying to fetch published actions but this action has not been published, do
-                        // not return
-                        if (action.getPublishedAction() == null) {
-                            return Mono.empty();
-                        }
-                    }
-                    // No need to handle the edge case of unpublished action not being present. This is not possible
-                    // because every created action starts from an unpublishedAction state.
-
-                    return Mono.just(action);
-                })
+                .flatMap(action -> this.filterAction(action, viewMode))
                 .flatMap(this::sanitizeAction);
     }
 
@@ -814,18 +794,12 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
             return Flux.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.APPLICATION_ID));
         }
 
-        List<String> pluginTypes = List.of(
-                PluginType.DB.toString(),
-                PluginType.API.toString(),
-                PluginType.SAAS.toString(),
-                PluginType.REMOTE.toString(),
-                PluginType.AI.toString(),
-                PluginType.INTERNAL.toString());
+        List<String> excludedPluginTypes = List.of(PluginType.JS.toString());
 
         // fetch the published actions by applicationId
         // No need to sort the results
         return findAllByApplicationIdAndPluginType(
-                        applicationId, true, actionPermission.getExecutePermission(), null, pluginTypes)
+                        applicationId, true, actionPermission.getExecutePermission(), null, excludedPluginTypes)
                 .name(VIEW_MODE_INITIAL_ACTION)
                 .tap(Micrometer.observation(observationRegistry))
                 .filter(newAction -> !PluginType.JS.equals(newAction.getPluginType()))
@@ -1112,6 +1086,20 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         }
 
         return actionMono;
+    }
+
+    public Mono<NewAction> filterAction(NewAction action, Boolean viewMode) {
+        if (Boolean.TRUE.equals(viewMode)) {
+            // In case we are trying to fetch published actions but this action has not been published, do
+            // not return
+            if (action.getPublishedAction() == null) {
+                return Mono.empty();
+            }
+        }
+        // No need to handle the edge case of unpublished action not being present. This is not possible
+        // because every created action starts from an unpublishedAction state.
+
+        return Mono.just(action);
     }
 
     public Flux<NewAction> addMissingPluginDetailsIntoAllActions(List<NewAction> actionList) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
@@ -37,6 +37,9 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
 
     Flux<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission, Sort sort);
 
+    Flux<NewAction> findByApplicationIdAndPluginType(
+            String applicationId, List<String> pluginTypes, AclPermission aclPermission, Sort sort);
+
     Flux<NewAction> findByApplicationId(
             String applicationId, Optional<AclPermission> aclPermission, Optional<Sort> sort);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -22,7 +22,6 @@ import org.springframework.data.mongodb.core.aggregation.GroupOperation;
 import org.springframework.data.mongodb.core.aggregation.MatchOperation;
 import org.springframework.data.mongodb.core.aggregation.ProjectionOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
-import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.appsmith.external.constants.spans.ce.ActionSpanCE.VIEW_MODE_FETCH_ACTIONS_FROM_DB_QUERY;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.group;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.match;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregation;
@@ -52,9 +50,7 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
         return queryBuilder()
                 .criteria(getCriterionForFindByApplicationId(applicationId))
                 .permission(aclPermission)
-                .all()
-                .name(VIEW_MODE_FETCH_ACTIONS_FROM_DB_QUERY)
-                .tap(Micrometer.observation(observationRegistry));
+                .all();
     }
 
     @Override
@@ -204,6 +200,25 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     protected BridgeQuery<NewAction> getCriterionForFindByApplicationId(String applicationId) {
         return Bridge.equal(NewAction.Fields.applicationId, applicationId);
+    }
+
+    @Override
+    public Flux<NewAction> findByApplicationIdAndPluginType(
+            String applicationId, List<String> pluginTypes, AclPermission aclPermission, Sort sort) {
+        return queryBuilder()
+                .criteria(getCriterionForFindByApplicationIdAndPluginType(applicationId, pluginTypes))
+                .permission(aclPermission)
+                .sort(sort)
+                .all();
+    }
+
+    protected BridgeQuery<NewAction> getCriterionForFindByApplicationIdAndPluginType(
+            String applicationId, List<String> pluginTypes) {
+        final BridgeQuery<NewAction> q = getCriterionForFindByApplicationId(applicationId);
+        q.and(Bridge.or(
+                Bridge.in(NewAction.Fields.pluginType, pluginTypes), Bridge.isNull(NewAction.Fields.pluginType)));
+
+        return q;
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -204,19 +204,20 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
 
     @Override
     public Flux<NewAction> findByApplicationIdAndPluginType(
-            String applicationId, List<String> pluginTypes, AclPermission aclPermission, Sort sort) {
+            String applicationId, List<String> excludedPluginTypes, AclPermission aclPermission, Sort sort) {
         return queryBuilder()
-                .criteria(getCriterionForFindByApplicationIdAndPluginType(applicationId, pluginTypes))
+                .criteria(getCriterionForFindByApplicationIdAndPluginType(applicationId, excludedPluginTypes))
                 .permission(aclPermission)
                 .sort(sort)
                 .all();
     }
 
     protected BridgeQuery<NewAction> getCriterionForFindByApplicationIdAndPluginType(
-            String applicationId, List<String> pluginTypes) {
+            String applicationId, List<String> excludedPluginTypes) {
         final BridgeQuery<NewAction> q = getCriterionForFindByApplicationId(applicationId);
         q.and(Bridge.or(
-                Bridge.in(NewAction.Fields.pluginType, pluginTypes), Bridge.isNull(NewAction.Fields.pluginType)));
+                Bridge.notIn(NewAction.Fields.pluginType, excludedPluginTypes),
+                Bridge.isNull(NewAction.Fields.pluginType)));
 
         return q;
     }


### PR DESCRIPTION
## Description
This PR adds an improvement to the actions part of the consolidated view API, where by it moves the filtering that we do to check if the action of pluginType JSObject has been moved to MongoDB. This way the mongoDB query that we do contains pluginTypes to include and we won't have to do additional filtering at the code layer, there by saving some time that is spend on further filtering and sanitising each action. 

Here are some of the observations for before and after making this change:

### Case 1:
Before (Total consolidated view api duration ~ 1.72s)
Actions span totally took ~ 1.12s
<img width="1171" alt="Screenshot 2024-08-22 at 9 26 15 PM" src="https://github.com/user-attachments/assets/2dc69e4f-619a-4b86-9e9b-f1aede63d868">

After (Total consolidated view api duration ~ 1.72s)
Actions span totally took ~ 566ms
<img width="1180" alt="Screenshot 2024-08-22 at 9 33 16 PM" src="https://github.com/user-attachments/assets/2947da7e-34ae-4933-9adf-7f7433c89c4e">


### Case 2:
Before (Total consolidated view api duration ~ 2.66s)
Actions span totally took ~ 1.67s
<img width="1170" alt="Screenshot 2024-08-22 at 9 34 05 PM" src="https://github.com/user-attachments/assets/27b046d9-c066-4282-92c3-d1053b820d33">


After (Total consolidated view api duration ~ 2.88s)
Actions span totally took ~ 935ms
<img width="1180" alt="Screenshot 2024-08-22 at 9 34 28 PM" src="https://github.com/user-attachments/assets/6bf3c47a-27a3-497d-b4ee-debdd5e6f25e">

Note: These numbers are obtained by testing the app with many actions and js objects [Xolair App]

Fixes #`Issue Number`  
_or_  
Fixes [`Issue URL`](https://github.com/appsmithorg/appsmith/issues/35815)
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10522148136>
> Commit: f0cf9b23c1ca80eb652c5e3a5e3502fdb4dcab59
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10522148136&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Fri, 23 Aug 2024 08:34:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced enhanced action retrieval capabilities based on specific plugin types, allowing for more tailored responses.
  - Added new methods to filter actions by application ID and plugin type, improving granularity in action queries.

- **Bug Fixes**
  - Updated existing action retrieval methods to support additional filtering options, improving the accuracy of returned results.

- **Chores**
  - Streamlined query logic in the repository to enhance performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->