### PR TITLE
chore: Fix Oauth2Type (de)serialization issue

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/OauthTypeConverter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/OauthTypeConverter.java
@@ -1,0 +1,32 @@
+package com.appsmith.external.converters;
+
+import com.appsmith.external.models.OAuth2;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class OauthTypeConverter {
+    public static class OauthTypeSerializer extends com.fasterxml.jackson.databind.JsonSerializer<OAuth2.Type> {
+        @Override
+        public void serialize(OAuth2.Type type, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+                throws IOException {
+            jsonGenerator.writeString(type.name().toLowerCase());
+        }
+    }
+
+    public static class OauthTypeDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer<OAuth2.Type> {
+        @Override
+        public OAuth2.Type deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            String value = deserializationContext.readValue(jsonParser, String.class);
+            if (value == null) {
+                return null;
+            }
+            value = value.toUpperCase();
+            return OAuth2.Type.valueOf(value);
+        }
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -1,12 +1,17 @@
 package com.appsmith.external.models;
 
 import com.appsmith.external.annotations.encryption.Encrypted;
+import com.appsmith.external.constants.Authentication;
+import com.appsmith.external.converters.OauthTypeConverter;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.helpers.CustomJsonType;
 import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Views;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -32,10 +37,9 @@ import java.util.stream.Collectors;
 public class OAuth2 extends AuthenticationDTO {
 
     public enum Type {
-        // We are facing issues in the release DB where the object is not respecting the JsonProperty annotation
-        // @JsonProperty(Authentication.CLIENT_CREDENTIALS)
+        @JsonProperty(Authentication.CLIENT_CREDENTIALS)
         CLIENT_CREDENTIALS,
-        // @JsonProperty(Authentication.AUTHORIZATION_CODE)
+        @JsonProperty(Authentication.AUTHORIZATION_CODE)
         AUTHORIZATION_CODE
     }
 
@@ -44,7 +48,10 @@ public class OAuth2 extends AuthenticationDTO {
         BODY
     }
 
+    // Adding a custom (de)serializer to support migrated data from MongoDB
     @JsonView({Views.Public.class, FromRequest.class})
+    @JsonSerialize(using = OauthTypeConverter.OauthTypeSerializer.class)
+    @JsonDeserialize(using = OauthTypeConverter.OauthTypeDeserializer.class)
     Type grantType;
 
     // Send tokens as query params if false


### PR DESCRIPTION
## Description
With `@JsonProperty` we expect the fields to respect during (de)serialisation, but as per current values stored in MongoDB these are saved as per enum constants and not with the JsonProperty. Now on pg hibernate do follow all the annotation from Jackson and hence the de-serialization is failing there. To fix this we are introducing a custom (de)serialiser. 

Fixes https://github.com/appsmithorg/appsmith/issues/35764, https://github.com/appsmithorg/appsmith/issues/35818

/test datasource,sanity,fork,importExport,git,GSheet

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10495391384>
> Commit: fceea9b23aa40326a0bfdbc0f1b34b89ae713b30
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10495391384&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.Sanity, @tag.Fork, @tag.ImportExport, @tag.Git, @tag.GSheet`
> Spec:
> <hr>Wed, 21 Aug 2024 20:19:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
