### PR TITLE
fix: file picker thumbnail when moving back to the widget

### DIFF
--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.test.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.test.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { ThemeProvider } from "styled-components";
+import { createMemoryHistory, History } from "history";
+import { Router } from "react-router-dom";
+
+import "@testing-library/jest-dom";
+
+import FilePickerWidget from "./";
+import type { FilePickerWidgetProps } from "widgets/FilepickerWidget/widget";
+import FileDataTypes from "widgets/FilepickerWidget/widget/FileDataTypes";
+import { lightTheme } from "selectors/themeSelectors";
+
+const mockFileWidgetprops: FilePickerWidgetProps = {
+  allowedFileTypes: ["image/*", "application/pdf", "video/*"],
+  label: "File",
+  maxNumFiles: 5,
+  maxFileSize: 8800,
+  selectedFiles: [
+    {
+      name: "test.png",
+      type: "image/jpeg",
+      data: "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+    },
+    {
+      name: "pic.png",
+      type: "image/png",
+      data: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+    },
+    {
+      name: "samplepdf.pdf",
+      type: "application/pdf",
+      data: "data:application/pdf;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+    },
+    {
+      name: "example_video.mp4",
+      type: "video/webm",
+      data: "data:video/webm;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
+    },
+  ],
+  onFilesSelected: "Files selected",
+  fileDataType: FileDataTypes.Base64,
+  isRequired: true,
+  widgetId: "Widget1",
+  type: "",
+  widgetName: "File Picker 1",
+  renderMode: "CANVAS",
+  updateWidgetMetaProperty: jest.fn(),
+  backgroundColor: "#FAFAFA",
+  borderRadius: "2px",
+
+  version: 0,
+  parentColumnSpace: 0,
+  parentRowSpace: 0,
+  leftColumn: 0,
+  rightColumn: 0,
+  topRow: 0,
+  bottomRow: 0,
+  isLoading: false,
+};
+
+describe("<FilePickerWidget />", () => {
+  const initialState = {
+    ui: {
+      appSettingsPane: {
+        isOpen: false,
+      },
+      widgetDragResize: {
+        lastSelectedWidget: "Widget1",
+        selectedWidgets: ["Widget1"],
+      },
+      users: {
+        featureFlag: {
+          data: {},
+        },
+      },
+      propertyPane: {
+        isVisible: true,
+        widgetId: "Widget1",
+      },
+      debugger: {
+        errors: {},
+      },
+      editor: {
+        isPreviewMode: false,
+      },
+      widgetReflow: {
+        enableReflow: true,
+      },
+      autoHeightUI: {
+        isAutoHeightWithLimitsChanging: false,
+      },
+      mainCanvas: {
+        width: 1159,
+      },
+      canvasSelection: {
+        isDraggingForSelection: false,
+      },
+    },
+    entities: { canvasWidgets: {}, app: { mode: "canvas" } },
+  };
+
+  const renderFilePickerWidget = (
+    props: FilePickerWidgetProps,
+    history: History<unknown>,
+  ) => {
+    const store = configureStore()(initialState);
+    return render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <Router history={history}>
+            <FilePickerWidget borderRadius="5px" {...props} />
+          </Router>
+        </ThemeProvider>
+      </Provider>,
+    );
+  };
+
+  it("should render thumbnail correctly even if we move from the canvas and coming back to the widget", async () => {
+    const history = createMemoryHistory();
+    history.push("/edit/widgets");
+
+    renderFilePickerWidget(mockFileWidgetprops, history);
+
+    const filePickerOpenerBtn = screen.getByText("4 files selected");
+    fireEvent.click(filePickerOpenerBtn);
+
+    await waitFor(() => {
+      const filesWithThumbnail = screen.getAllByRole("listitem");
+      expect(filesWithThumbnail).toHaveLength(4);
+    });
+
+    // Simulate navigating away from canvas
+    history.push("/edit/queries");
+
+    // Simulate navigating back to the widget
+    history.push("/edit/widgets");
+
+    // Verify that thumbnails are still present
+    await waitFor(() => {
+      const filesWithThumbnail = screen.getAllByRole("listitem");
+      filesWithThumbnail.forEach((element) => {
+        const thumbnail = element.querySelector(".uppy-Dashboard-Item-preview");
+        const thumbnailImg = thumbnail?.firstChild;
+        expect(thumbnailImg).toHaveClass(
+          "uppy-Dashboard-Item-previewInnerWrap",
+        );
+      });
+      expect(filesWithThumbnail).toHaveLength(4);
+    });
+  });
+});

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -742,16 +742,23 @@ class FilePickerWidget extends BaseWidget<
     // TODO: Fix this the next time the file is edited
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.props.selectedFiles?.forEach((fileItem: any) => {
-      uppy.addFile({
+      const file = {
         name: fileItem.name,
         type: fileItem.type,
+        preview: "",
         data: new Blob([fileItem.data]),
         meta: {
           // Adding this flag to distinguish a file in the files-added event
           isInitializing: true,
         },
-      });
+      };
+
+      if (fileItem.type.startsWith("image/")) {
+        file.preview = fileItem.data;
+      }
+      uppy.addFile(file);
     });
+
   }
 
   async componentDidMount() {


### PR DESCRIPTION
### PR Description: 
- Issue fixed: https://github.com/appsmithorg/appsmith/issues/17661
- Description: File picker was not able to persist the thumbnail for the image files.
- File changes in PR: 
  - Fixed the thumbnail generation while `initializeSelectedFiles` method in the widget and added in to the preview to render thumbnail correctly.
  - Added the unit test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved file handling in the FilePickerWidget, enabling image previews for files of type "image/".
	
- **Tests**
	- Added a comprehensive suite of unit tests for the FilePickerWidget to validate rendering and functionality, ensuring reliability across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->