### PR TITLE
Fix/select label key function

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select2_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Select/Select2_Spec.ts
@@ -305,5 +305,26 @@ describe(
         1,
       );
     });
+
+    it("10. Validate using function inside label key works correctly", () => {
+      deployMode.NavigateBacktoEditor();
+      EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
+      propPane.ToggleJSMode("Label key", true);
+      propPane.UpdatePropertyFieldValue("Label key", "{{(() => 'name')()}}");
+      agHelper.SelectDropDown("Blue");
+      agHelper.ReadSelectedDropDownValue().then(($selectedValue) => {
+        expect($selectedValue).to.eq("Blue");
+      });
+    });
+
+    it("11. Validate using function inside value key works correctly", () => {
+      EditorNavigation.SelectEntityByName("Select1", EntityType.Widget);
+      propPane.ToggleJSMode("Value key", true);
+      propPane.UpdatePropertyFieldValue("Value key", "{{(() => 'code')()}}");
+      agHelper.SelectDropDown("Blue");
+      agHelper.ReadSelectedDropDownValue().then(($selectedValue) => {
+        expect($selectedValue).to.eq("Blue");
+      });
+    });
   },
 );

--- a/app/client/src/widgets/SelectWidget/widget/derived.js
+++ b/app/client/src/widgets/SelectWidget/widget/derived.js
@@ -8,13 +8,13 @@ export default {
     if (typeof props.optionLabel === "string") {
       labels = sourceData.map((d) => d[props.optionLabel]);
     } else if (_.isArray(props.optionLabel)) {
-      labels = props.optionLabel;
+      labels = sourceData.map((d, i) => d[props.optionLabel[i]]);
     }
 
     if (typeof props.optionValue === "string") {
       values = sourceData.map((d) => d[props.optionValue]);
     } else if (_.isArray(props.optionValue)) {
-      values = props.optionValue;
+      values = sourceData.map((d, i) => d[props.optionValue[i]]);
     }
 
     return sourceData.map((d, i) => ({


### PR DESCRIPTION
## Description
**Problem**
When the Select widget's labelKey or valueKey properties are switched to JS mode, passing a function that returns a string as the key causes the dropdown options to break. Instead of correctly mapping the labels and values, the options are incorrectly returned as an array of the key itself.

**Root Cause**
The issue lies in the `getOptions` function in derived.js. The logic that computes the select options based on the labelKey and valueKey was not handling cases where these properties are functions that return arrays. Instead of mapping through the source data and returning the corresponding values for each key, the function was mistakenly returning the entire array.

**Solution**
The `getOptions` function in derived.js has been updated to correctly handle cases where labelKey or valueKey are arrays. The function now maps through the sourceData and computes the correct labels and values based on the provided properties, ensuring that the dropdown options are displayed as expected.



Fixes #35269

## Automation

/ok-to-test tags="@tag.Sanity, @tag.Select, @tag.Widget, @tag.Binding"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
