### PR TITLE
Do not merge Cypres config update

### DIFF
--- a/app/client/cypress.config.ts
+++ b/app/client/cypress.config.ts
@@ -40,6 +40,6 @@ export default defineConfig({
     testIsolation: false,
     excludeSpecPattern: "cypress/e2e/**/spec_utility.ts",
     screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
-    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
+   // trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
   },
 });

--- a/app/client/cypress.config.ts
+++ b/app/client/cypress.config.ts
@@ -39,5 +39,7 @@ export default defineConfig({
     specPattern: "cypress/e2e/**/*.{js,ts}",
     testIsolation: false,
     excludeSpecPattern: "cypress/e2e/**/spec_utility.ts",
+    screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
+    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
   },
 });

--- a/app/client/cypress/plugins/index.js
+++ b/app/client/cypress/plugins/index.js
@@ -55,6 +55,10 @@ module.exports = async (on, config) => {
 
   on("file:preprocessor", tagify(config));
   addMatchImageSnapshotPlugin(on, config);
+  return {
+    ...config,
+    screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
+  };
 
   on("before:browser:launch", (browser = {}, launchOptions) => {
     /*

--- a/app/client/cypress_ci.config.ts
+++ b/app/client/cypress_ci.config.ts
@@ -37,5 +37,7 @@ export default defineConfig({
       "cypress/e2e/Regression/ClientSide/CommunityTemplate/*",
       "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
     ],
+    screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
+    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
   },
 });

--- a/app/client/cypress_ci.config.ts
+++ b/app/client/cypress_ci.config.ts
@@ -38,6 +38,6 @@ export default defineConfig({
       "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
     ],
     screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
-    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
+   // trashAssetsBeforeRuns: false, // Optionally delete previous snapshots before new runs
   },
 });

--- a/app/client/cypress_ci_custom.config.ts
+++ b/app/client/cypress_ci_custom.config.ts
@@ -67,6 +67,6 @@ export default defineConfig({
       "cypress/e2e/Sanity/Datasources/MsSQL_Basic_Spec.ts",
     ],
     screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
-    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
+    //trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
   },
 });

--- a/app/client/cypress_ci_custom.config.ts
+++ b/app/client/cypress_ci_custom.config.ts
@@ -66,5 +66,7 @@ export default defineConfig({
       "cypress/e2e/Regression/ClientSide/Widgets/Others/MapWidget_Spec.ts",
       "cypress/e2e/Sanity/Datasources/MsSQL_Basic_Spec.ts",
     ],
+    screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
+    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
   },
 });

--- a/app/client/cypress_ci_hosted.config.ts
+++ b/app/client/cypress_ci_hosted.config.ts
@@ -59,6 +59,6 @@ export default defineConfig({
     testIsolation: false,
     excludeSpecPattern: ["cypress/e2e/**/spec_utility.ts"],
     screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
-    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
+    //trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
   },
 });

--- a/app/client/cypress_ci_hosted.config.ts
+++ b/app/client/cypress_ci_hosted.config.ts
@@ -58,5 +58,7 @@ export default defineConfig({
     ],
     testIsolation: false,
     excludeSpecPattern: ["cypress/e2e/**/spec_utility.ts"],
+    screenshotsFolder: 'cypress/snapshots', // Define the directory for snapshots
+    trashAssetsBeforeRuns: true, // Optionally delete previous snapshots before new runs
   },
 });


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10545190317>
> Commit: 8fdf3f975b1475993d757847a2775346e54090f4
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10545190317&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/10545190317" target="_blank">workflow here</a>.
> <hr>Sun, 25 Aug 2024 13:55:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced customizable directory for storing screenshots during test runs, improving organization.
  - Added option to automatically delete previous snapshots before new test runs, ensuring a clean testing environment.

These enhancements provide users with better control over test output management, streamlining the testing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->