### PR TITLE
chore: JSONform - useRegisterFieldValidity remove unused dependency in useEffect

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
@@ -35,18 +35,20 @@ function useRegisterFieldValidity({
      */
     setTimeout(() => {
       try {
-        isValid
-          ? startAndEndSpanForFn("JSONFormWidget.clearErrors", {}, () => {
-              if (error) {
-                clearErrors(fieldName);
-              }
-            })
-          : startAndEndSpanForFn("JSONFormWidget.setError", {}, () => {
-              setError(fieldName, {
-                type: fieldType,
-                message: "Invalid field",
-              });
+        if (isValid) {
+          if (error) {
+            startAndEndSpanForFn("JSONFormWidget.clearErrors", {}, () => {
+              clearErrors(fieldName);
             });
+          }
+        } else {
+          startAndEndSpanForFn("JSONFormWidget.setError", {}, () => {
+            setError(fieldName, {
+              type: fieldType,
+              message: "Invalid field",
+            });
+          });
+        }
       } catch (e) {
         Sentry.captureException(e);
       }

--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
@@ -51,15 +51,7 @@ function useRegisterFieldValidity({
         Sentry.captureException(e);
       }
     }, 0);
-  }, [
-    isValid,
-    fieldName,
-    fieldType,
-    setMetaInternalFieldState,
-    error,
-    clearErrors,
-    setError,
-  ]);
+  }, [isValid, fieldName, fieldType, error, clearErrors, setError]);
 
   useEffect(() => {
     setMetaInternalFieldState((prevState) => {


### PR DESCRIPTION
## Description
Removes unused dependency in `useRegisterFieldValidity` of JSONForm

Introduced in https://github.com/appsmithorg/appsmith/pull/35717

## Automation

/ok-to-test tags="@tag.JSONForm"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10554659505>
> Commit: e59355e8484e4dd0707d6c0b7a13b0b96b2b3507
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10554659505&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JSONForm`
> Spec:
> <hr>Mon, 26 Aug 2024 06:45:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Performance Improvements**
	- Optimized the `useRegisterFieldValidity` function by reducing the number of dependencies in its `useEffect` hook, potentially enhancing performance by minimizing unnecessary updates.

- **Bug Fixes**
	- Streamlined control flow for error handling within the `useRegisterFieldValidity` function to ensure consistent behavior when validating fields and managing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->