### PR TITLE
fix: Pencil icon appearing in application name

### DIFF
--- a/app/client/packages/design-system/ads-old/src/EditableTextSubComponent/index.tsx
+++ b/app/client/packages/design-system/ads-old/src/EditableTextSubComponent/index.tsx
@@ -254,7 +254,7 @@ export const EditableTextSubComponent = React.forwardRef(
           {savingState === SavingState.STARTED ? (
             <Spinner size="md" />
           ) : value && !props.hideEditIcon && iconName ? (
-            <Icon name={iconName} size="md" />
+            <Icon className="cursor-pointer" name={iconName} size="md" />
           ) : null}
         </TextContainer>
         {isEditing && !!isInvalid ? (

--- a/app/client/src/pages/Editor/EditorName/EditableName.tsx
+++ b/app/client/src/pages/Editor/EditorName/EditableName.tsx
@@ -22,6 +22,7 @@ export type EditableAppNameProps = CommonComponentProps & {
   onBlur?: (value: string) => void;
   isEditingDefault?: boolean;
   inputValidation?: (value: string) => string | boolean;
+  hideEditIcon?: boolean;
   fill?: boolean;
   isError?: boolean;
   isEditing: boolean;

--- a/app/client/src/pages/Editor/EditorName/index.tsx
+++ b/app/client/src/pages/Editor/EditorName/index.tsx
@@ -123,6 +123,7 @@ export function EditorName(props: EditorNameProps) {
               defaultValue={defaultValue}
               editInteractionKind={props.editInteractionKind}
               fill={props.fill}
+              hideEditIcon
               inputValidation={inputValidation}
               isEditing={isEditing}
               isEditingDefault={isEditingDefault}


### PR DESCRIPTION
## Description

PR address below issues
1. Edit icon appearing next to application name
2. No cursor pointer for edit icon

Fixes #35878

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10562542656>
> Commit: 31ab617cdc5c37fa1fce7ecadd08a4250e9d373a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10562542656&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 26 Aug 2024 19:15:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `EditableTextSubComponent` by making the icon interactive with a cursor pointer style.
	- Introduced an optional `hideEditIcon` property for the `EditableAppNameProps`, allowing for conditional visibility of the edit icon.
	- Updated the `EditorName` component to accept the new `hideEditIcon` prop for improved customization.

- **Improvements**
	- Improved user interface flexibility and customization options for editing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->