### PR TITLE
ci: sync release changes to pg

### DIFF
--- a/.github/workflows/sync-release-to-pg.yml
+++ b/.github/workflows/sync-release-to-pg.yml
@@ -55,7 +55,7 @@ jobs:
           git push origin pg
 
       - name: Notify on merge conflicts
-        if: steps.merge_commits.outputs.CONFLICTED_COMMITS != ''
+        if: failure()
         env:
           REPOSITORY_URL: ${{ github.repositoryUrl }}
         run: |


### PR DESCRIPTION
## Description
Change the boolean flag for the ci job to capture success or failure

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10572876956>
> Commit: 4f3986f053850edb0298934b6f59c398a8708416
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10572876956&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 27 Aug 2024 06:45:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced notification system for GitHub Actions to alert on any job failures, improving awareness of issues during workflows.
- **Refactor**
	- Modified conditions in the workflow to broaden the criteria for triggering notifications, ensuring timely alerts for various failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->