### PR TITLE
ci: use git merge for syncing changes from release

### DIFF
--- a/.github/workflows/sync-release-to-pg.yml
+++ b/.github/workflows/sync-release-to-pg.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Merge release to pg
         id: merge_commits
         run: |
+
+          PG_HEAD=$(git rev-parse pg)
+          RELEASE_HEAD=$(git rev-parse release)
+
+          echo "PG_HEAD=$PG_HEAD"
+          echo "RELEASE_HEAD=$RELEASE_HEAD"
+
           # Checkout the pg branch
           git checkout pg
 

--- a/.github/workflows/sync-release-to-pg.yml
+++ b/.github/workflows/sync-release-to-pg.yml
@@ -16,63 +16,46 @@ jobs:
           ref: release  # Checkout the release branch
 
       - name: Fetch all branches
-        run: git fetch --all
+        run: git fetch pg
 
       - name: Checkout pg branch
         run: git checkout pg
 
-      - name: Get new commits from release
-        id: get_commits
-        run: |
-          # Compare the heads of pg and release
-          PG_HEAD=$(git rev-parse pg)
-          RELEASE_HEAD=$(git rev-parse release)
-
-          echo "PG_HEAD=$PG_HEAD" >> $GITHUB_ENV
-          echo "RELEASE_HEAD=$RELEASE_HEAD" >> $GITHUB_ENV
-
-          # Get new commits on release that are not yet in pg
-          COMMITS=$(git log --reverse --pretty=format:"%H" $PG_HEAD..$RELEASE_HEAD)
-          echo "COMMITS=$COMMITS" >> $GITHUB_ENV
-
-      - name: Merge commits one by one
+      - name: Merge release to pg
         id: merge_commits
         run: |
-          # Initialize an empty list for conflicted commits
-          conflicted_commits=()
+          # Checkout the pg branch
+          git checkout pg
 
-          # Convert the string of commits to an array
-          IFS=' ' read -r -a commit_array <<< "$COMMITS"
+          # Attempt to merge release into pg
+          if ! git merge release; then
+            echo "Merge conflict detected during merge"
 
-          # Loop through each commit
-          for commit in "${commit_array[@]}"; do
-            echo "Attempting to cherry-pick commit $commit"
-            if ! git cherry-pick $commit; then
-              echo "Conflict detected with commit $commit"
-              conflicted_commits+=($commit)
-              git cherry-pick --abort
-            fi
-          done
+            # Capture the conflicting commit SHAs (both HEAD of pg and the merge commit from release)
+            CONFLICTING_COMMIT=$(git log -1 --pretty=format:"%H")
+            echo "CONFLICTING_COMMIT=$CONFLICTING_COMMIT" >> $GITHUB_ENV
 
-          # Save conflicted commits to environment variable
-          echo "CONFLICTED_COMMITS=\"${conflicted_commits[@]}\"" >> $GITHUB_ENV
+            git merge --abort
+            echo "MERGE_CONFLICT=true" >> $GITHUB_ENV
+          else
+            echo "MERGE_CONFLICT=false" >> $GITHUB_ENV
+          fi
 
       - name: Push changes
-        if: success() && steps.merge_commits.outputs.CONFLICTED_COMMITS == ''
+        if: env.MERGE_CONFLICT == 'false'
         run: |
           git push origin pg
 
       - name: Notify on merge conflicts
-        if: failure()
+        if: env.MERGE_CONFLICT == 'true'
         env:
           REPOSITORY_URL: ${{ github.repositoryUrl }}
+          CONFLICTING_COMMIT: ${{ env.CONFLICTING_COMMIT }}
         run: |
           # Prepare the message for Slack
           message="Merge conflict detected while merging release into pg branch. Conflicted commits:\n"
-          for commit in $CONFLICTED_COMMITS; do
-            commit_url="$REPOSITORY_URL/commit/$commit"
-            message+="$commit_url\n"
-          done
+          commit_url="$REPOSITORY_URL/commit/$CONFLICTING_COMMIT"
+          message+="$commit_url\n"
 
           # Send the message to Slack
           # This unwieldy horror of a sed command, converts standard Markdown links to Slack's unwieldy link syntax.


### PR DESCRIPTION
## Description
git merge over cherry-pick with loop by comparing head. 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 087dfe23f63ea4e4dc472c1c048009086976f3d1 yet
> <hr>Tue, 27 Aug 2024 10:22:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined workflow for synchronizing releases to the `pg` branch, enhancing efficiency.
	- Directly merges the `release` branch into the `pg` branch, simplifying the process.
- **Bug Fixes**
	- Improved handling of merge conflicts with clearer notifications and tracking.
- **Chores**
	- Refined the conditions for pushing changes, ensuring operations only occur on successful merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->