### PR TITLE
chore: reconnect ds detached from datasource editor part 1

### DIFF
--- a/app/client/src/Datasource/components/ReconnectDatasourceForm.tsx
+++ b/app/client/src/Datasource/components/ReconnectDatasourceForm.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import DatasourceEditor from "pages/Editor/DataSourceEditor";
+
+interface ReconnectDatasourceFormProps {
+  applicationId: string | null;
+  datasourceId: string | null;
+  pageId: string | null;
+}
+
+function ReconnectDatasourceForm(props: ReconnectDatasourceFormProps) {
+  const { applicationId, datasourceId, pageId } = props;
+
+  return (
+    <DatasourceEditor
+      applicationId={applicationId}
+      datasourceId={datasourceId}
+      fromImporting
+      // isInsideReconnectModal: indicates that the datasource form is rendering inside reconnect modal
+      isInsideReconnectModal
+      pageId={pageId}
+    />
+  );
+}
+
+export default ReconnectDatasourceForm;

--- a/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
@@ -39,7 +39,6 @@ import {
   setWorkspaceIdForImport,
 } from "ee/actions/applicationActions";
 import type { Datasource } from "entities/Datasource";
-import DatasourceForm from "../DataSourceEditor";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import { useQuery } from "../utils";
 import ListItemWrapper from "./components/DatasourceListItem";
@@ -76,6 +75,7 @@ import { getApplicationsOfWorkspace } from "ee/selectors/selectedWorkspaceSelect
 import useReconnectModalData from "ee/pages/Editor/gitSync/useReconnectModalData";
 import { resetImportData } from "ee/actions/workspaceActions";
 import { getLoadingTokenForDatasourceId } from "selectors/datasourceSelectors";
+import ReconnectDatasourceForm from "Datasource/components/ReconnectDatasourceForm";
 
 const Section = styled.div`
   display: flex;
@@ -609,12 +609,9 @@ function ReconnectDatasourceModal() {
 
               <DBFormWrapper>
                 {shouldShowDBForm && (
-                  <DatasourceForm
+                  <ReconnectDatasourceForm
                     applicationId={editorId}
                     datasourceId={selectedDatasourceId}
-                    fromImporting
-                    // isInsideReconnectModal: indicates that the datasource form is rendering inside reconnect modal
-                    isInsideReconnectModal
                     pageId={parentEntityId}
                   />
                 )}


### PR DESCRIPTION
## Description
Datasource modularisation - Take out reconnect datasource dependencies out of DatasourceEditor (part 1)


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10577633946>
> Commit: 2f06f3462ae073440b62c9cc7f7ab14a0fc0d1c2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10577633946&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 27 Aug 2024 12:38:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
