### PR TITLE
chore: stability pr for changes

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -93,7 +94,9 @@ public class CommonGitFileUtilsCE {
 
         // Save application to git repo
         try {
-            return fileUtils.saveApplicationToGitRepo(baseRepoSuffix, artifactGitReference, branchName);
+            return fileUtils
+                    .saveApplicationToGitRepo(baseRepoSuffix, artifactGitReference, branchName)
+                    .subscribeOn(Schedulers.boundedElastic());
         } catch (IOException | GitAPIException e) {
             log.error("Error occurred while saving files to local git repo: ", e);
             throw Exceptions.propagate(e);


### PR DESCRIPTION
## Description
- Changes to put blocking calls on the bounded elastic thread.
- This Pr has changes to test.
- commit
- Status
- branch
- delete branch
- List branch 
- checkout
- checkout remote
- merge status
- merge

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10628395436>
> Commit: af76a9714ce4b28192220131c0a494c849bcf836
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10628395436&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Fri, 30 Aug 2024 07:29:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved performance and responsiveness when saving applications to Git repositories by optimizing the execution flow.
	- Enhanced clarity and control in the application push process to Git, ensuring better maintainability.

- **Bug Fixes**
	- Addressed potential threading issues by ensuring operations run on the appropriate scheduler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->