### PR TITLE
test: updated tests for checkboxgroup

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
@@ -77,8 +77,6 @@ describe(
     it("3. handleSelectAllChange: unchecked", function () {
       const selectAllSelector = formWidgetsPage.selectAllCheckboxControl;
       const uncheckedOptionInputs = `${formWidgetsPage.checkboxGroupOptionInputs} input:not(:checked)`;
-      // Deselect all
-      cy.get(selectAllSelector).click();
       // Should get 2 unchecked option inputs
       cy.get(uncheckedOptionInputs).should("have.length", 2);
       //handleSelectAllChange: checked", function () {

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,6 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup2_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
RCA:
Test was failing after removing retry, the issue was it was clicking on a checkbox which was not required.
the retry actually was bringing back the system to right state by clicking again.

Solution:
We removed the step that was unnecessary in this case which resolved the issue
EE: https://github.com/appsmithorg/appsmith-ee/pull/4992

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10616697878>
> Commit: e599c6d0149814c38049aaba7828465361d8f43b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10616697878&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 29 Aug 2024 14:33:59 UTC
<!-- end of auto-generated comment: Cypress test results  -->
