### PR TITLE
TESTING EXTERNAL SCRIPT: external merge request from Contributor

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
@@ -2,6 +2,7 @@ import {
   agHelper,
   apiPage,
   assertHelper,
+  dataManager,
   deployMode,
   entityItems,
   jsEditor,
@@ -128,8 +129,8 @@ describe(
       agHelper.AddDsl("multiPartFormDataDsl");
 
       apiPage.CreateAndFillApi(
-        "https://api.cloudinary.com/v1_1/appsmithautomationcloud/image/upload?upload_preset=fbbhg4xu",
-        "CloudinaryUploadApi",
+        dataManager.dsValues[dataManager.defaultEnviorment].multipartAPI,
+        "MultipartAPI",
         30000,
         "POST",
       );
@@ -145,7 +146,7 @@ describe(
             myVar1: [],
             myVar2: {},
             upload: async () => {
-                await CloudinaryUploadApi.run().then(()=> showAlert('Image uploaded to Cloudinary successfully', 'success')).catch(err => showAlert(err.message, 'error'));
+                await MultipartAPI.run().then(()=> showAlert('Image uploaded to multipart successfully', 'success')).catch(err => showAlert(err.message, 'error'));
                 await resetWidget('FilePicker1', true);
             }
         }`,
@@ -161,15 +162,9 @@ describe(
       propPane.EnterJSContext("onFilesSelected", `{{JSObject1.upload()}}`);
 
       EditorNavigation.SelectEntityByName("Image1", EntityType.Widget);
-      propPane.UpdatePropertyFieldValue(
-        "Image",
-        "{{CloudinaryUploadApi.data.url}}",
-      );
+      propPane.UpdatePropertyFieldValue("Image", "{{MultipartAPI.data.url}}");
 
-      EditorNavigation.SelectEntityByName(
-        "CloudinaryUploadApi",
-        EntityType.Api,
-      );
+      EditorNavigation.SelectEntityByName("MultipartAPI", EntityType.Api);
 
       apiPage.ToggleOnPageLoadRun(false); //Bug 12476
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
@@ -177,9 +172,7 @@ describe(
       agHelper.ClickButton("Select Files");
       agHelper.UploadFile(imageNameToUpload);
       assertHelper.AssertNetworkExecutionSuccess("@postExecute"); //validating Cloudinary api call
-      agHelper.ValidateToastMessage(
-        "Image uploaded to Cloudinary successfully",
-      );
+      agHelper.ValidateToastMessage("Image uploaded to multipart successfully");
       agHelper.Sleep();
       cy.xpath(apiPage._imageSrc)
         .find("img")
@@ -191,32 +184,6 @@ describe(
         });
       agHelper.AssertElementVisibility(locators._buttonByText("Select Files")); //verifying if reset!
       deployMode.NavigateBacktoEditor();
-    });
-
-    it("8. Checks MultiPart form data for a Array Type upload results in API error", () => {
-      const imageNameToUpload = "AAAFlowerVase.jpeg";
-      EditorNavigation.SelectEntityByName(
-        "CloudinaryUploadApi",
-        EntityType.Api,
-      );
-      apiPage.EnterBodyFormData(
-        "MULTIPART_FORM_DATA",
-        "file",
-        "{{FilePicker1.files[0]}}",
-        "Array",
-        true,
-      );
-      EditorNavigation.SelectEntityByName("FilePicker1", EntityType.Widget);
-      agHelper.ClickButton("Select Files");
-      agHelper.UploadFile(imageNameToUpload);
-      assertHelper.AssertNetworkExecutionSuccess("@postExecute", false);
-
-      deployMode.DeployApp(locators._buttonByText("Select Files"));
-      agHelper.ClickButton("Select Files");
-      agHelper.UploadFile(imageNameToUpload);
-      assertHelper.AssertNetworkExecutionSuccess("@postExecute", false);
-      agHelper.ValidateToastMessage("CloudinaryUploadApi failed to execute");
-      agHelper.AssertElementVisibility(locators._buttonByText("Select Files")); //verifying if reset in case of failure!
     });
   },
 );

--- a/app/client/cypress/support/Objects/DataManager.ts
+++ b/app/client/cypress/support/Objects/DataManager.ts
@@ -80,6 +80,8 @@ export class DataManager {
         "http://host.docker.internal:5001/v1/mock-api-object?records=10",
       echoApiUrl: "http://host.docker.internal:5001/v1/mock-api/echo",
       randomCatfactUrl: "http://host.docker.internal:5001/v1/catfact/random",
+      multipartAPI:
+        "http://host.docker.internal:5001/v1/mock-api/echo-multipart",
       randomTrumpApi:
         "http://host.docker.internal:5001/v1/whatdoestrumpthink/random",
       mockHttpCodeUrl: "http://host.docker.internal:5001/v1/mock-http-codes/",
@@ -179,6 +181,8 @@ export class DataManager {
       mockApiUrl: "http://host.docker.internal:5001/v1/mock-api?records=10",
       echoApiUrl: "http://host.docker.internal:5001/v1/mock-api/echo",
       randomCatfactUrl: "http://host.docker.internal:5001/v1/catfact/random",
+      multipartAPI:
+        "http://host.docker.internal:5001/v1/mock-api/echo-multipart",
       mockHttpCodeUrl: "http://host.docker.internal:5001/v1/mock-http-codes/",
       AirtableBaseForME: "appubHrVbovcudwN6",
       AirtableTableForME: "tblsFCQSskVFf7xNd",

--- a/app/client/cypress/support/Pages/ApiPage.ts
+++ b/app/client/cypress/support/Pages/ApiPage.ts
@@ -303,7 +303,7 @@ export class ApiPage {
       | "RAW",
   ) {
     this.agHelper.GetNClick(this._bodyTypeSelect);
-    cy.xpath(this._bodyTypeToSelect(subTabName)).should("be.visible").click();
+    this.agHelper.GetNClick(this._bodyTypeToSelect(subTabName));
   }
 
   AssertRightPaneSelectedTab(tabName: RightPaneTabs) {


### PR DESCRIPTION

## Description
- Shadow PR for https://github.com/appsmithorg/appsmith/pull/35413

Fixes #28190  

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=@tag.All

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Invalid tags. Please use `/ok-to-test tags="@tag.All"` or `/test all` in the PR body to run all tests.
> [Tags documentation](https://www.notion.so/appsmith/7c0fc64d4efb4afebf53348cd6252918).
> [List of valid tags](https://github.com/appsmithorg/appsmith/blob/release/app/client/cypress/tags.js).
> <hr>Wed, 28 Aug 2024 14:21:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data handling in the datasource trigger functionality for improved clarity and structure.
	- Implemented sorting of returned entities based on labels for consistent data presentation.

- **Tests**
	- Added a new test to validate the order of collections returned by the datasource trigger, ensuring robustness and reliability of the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->