### PR TITLE
test: Fix mockdb flaky test case

### DIFF
--- a/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
@@ -74,49 +74,7 @@ describe(
 
         assertHelper.AssertNetworkStatus("@trigger");
         dataSources.ValidateNSelectDropdown("Command", "Find document(s)");
-        agHelper.Sleep(2000); //for movies collection to load & populate in dropdown
-        dataSources.ValidateNSelectDropdown("Collection", "movies");
-        dataSources.RunQueryNVerifyResponseViews(1, false);
-        AppSidebar.navigate(AppSidebarButton.Data);
-        dataSources
-          .getDatasourceListItemDescription(mockDBName)
-          .then(($queryCount) =>
-            expect($queryCount).to.eq("1 queries in this app"),
-          );
-
-        entityExplorer.CreateNewDsQuery(mockDBName);
-        dataSources.ValidateNSelectDropdown("Command", "Find document(s)");
-        dataSources.ValidateNSelectDropdown("Collection", "movies");
-        dataSources.RunQueryNVerifyResponseViews(1, false);
-        AppSidebar.navigate(AppSidebarButton.Data);
-        dataSources
-          .getDatasourceListItemDescription(mockDBName)
-          .then(($queryCount) =>
-            expect($queryCount).to.eq("2 queries in this app"),
-          );
       });
-    });
-
-    afterEach(() => {
-      AppSidebar.navigate(AppSidebarButton.Editor);
-      PageLeftPane.switchSegment(PagePaneSegment.Queries);
-      entityExplorer.ActionContextMenuByEntityName({
-        entityNameinLeftSidebar: "Query1",
-        action: "Delete",
-        entityType: entityItems.Query,
-      });
-      entityExplorer.ActionContextMenuByEntityName({
-        entityNameinLeftSidebar: "Query2",
-        action: "Delete",
-        entityType: entityItems.Query,
-      });
-      AppSidebar.navigate(AppSidebarButton.Data);
-      dataSources
-        .getDatasourceListItemDescription(dsName)
-        .then(($queryCount) =>
-          expect($queryCount).to.eq("No queries in this app"),
-        );
-      dataSources.DeleteDatasourceFromWithinDS(dsName);
     });
   },
 );

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
Fix the flaky test case with latest update.

**Problem :** Whenever the Mock DBs are getting corrupted, we see flaky behaviours.
As per the solution, we are running reset script every day. We can not increase the frequency as in a day time lot of testing pipelines are running it. Most of the time we see failure at two places, 
1. Query from Mock Mongo DB
2. Failure in afterEach run.

**Solution:** We need to remove flaky test cases part.
1. For mongo DB case, test till here so we can test connection at least as mentioned by one of developer. `dataSources.ValidateNSelectDropdown("Command", "Find document(s)");`. 
2. Remove afterEach code as it is actually no required as we use new setup for each new run. 

**Relevant threads:**
1. https://theappsmith.slack.com/archives/C0134BAVDB4/p1724317643564089?thread_ts=1724216243.067959&cid=C0134BAVDB4
2. https://theappsmith.slack.com/archives/C02GAUE9P5H/p1712038530288709?thread_ts=1712020398.128169&cid=C02GAUE9P5H

Fixes #`35136`  


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10633737589>
> Commit: 660b710bde7ca5c2d3998d86ce15753ac7c4c2bf
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10633737589&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 30 Aug 2024 14:07:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Streamlined test cases for mock database validations, improving performance and efficiency.
	- Removed unnecessary cleanup operations post-test execution, simplifying the testing process.

- **Chores**
	- Updated the test specification path to prioritize sanity testing of mock databases over regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->