### PR TITLE
fix:updated mustache method correctly identify the query properly whe…

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
@@ -561,7 +561,7 @@ public class MustacheHelper {
         Map<String, String> replaceParamsMap = mustacheSet.stream()
                 .map(mustacheToken -> mustacheToken.getValue())
                 .distinct()
-                .collect(Collectors.toMap(k -> k, v -> placeholder));
+                .collect(Collectors.toMap(k -> "{{" + k + "}}", v -> placeholder));
 
         // Replace the mustaches with the values mapped to each mustache in replaceParamsMap
         ActionConfiguration updatedActionConfiguration = renderFieldValues(actionConfiguration, replaceParamsMap);

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
@@ -24,6 +24,7 @@ import static com.appsmith.external.helpers.MustacheHelper.render;
 import static com.appsmith.external.helpers.MustacheHelper.renderFieldValues;
 import static com.appsmith.external.helpers.MustacheHelper.tokenize;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings(
         // Disabling this so we may use `Arrays.asList` with single argument, which is easier to refactor, just for
@@ -68,6 +69,16 @@ public class MustacheHelperTest {
         checkTokens("{{A}}", Arrays.asList(new MustacheBindingToken("{{A}}", 0, true)));
         checkKeys("{{A}}", Set.of(new MustacheBindingToken("A", 2, false)));
         checkKeys("{{A + B / C}}", Set.of(new MustacheBindingToken("A + B / C", 2, false)));
+    }
+
+    @Test
+    public void testReplaceMustacheUsingPatterns() {
+        String inputQuery = "content";
+        List<MustacheBindingToken> mustacheBindings = Arrays.asList(new MustacheBindingToken());
+        String result = MustacheHelper.replaceMustacheWithPlaceholder(inputQuery, mustacheBindings);
+
+        String expectedOutput = "{{\"content\"}}";
+        assertEquals(expectedOutput, result);
     }
 
     @Test


### PR DESCRIPTION
**Description:**
 When attempting to use a regex value in a MongoDB query to find records, the regex expression is misinterpreted, resulting in no records being returned. Specifically:
Using the $in clause with a simple array of strings successfully returns records.
Replacing a string (e.g., "chip") with a JavaScript expression or including slashes in the regex expression results in no records found.

**fixes:** [#17240](https://github.com/appsmithorg/appsmith/issues/17240)

**updates in PR:**
1.updated the mustache method in backend for mongodb , to currently identify the query content and pass to other methods, to get the proper result as excepted.
2.written a test case for the updated code.

**snapshots:**
![Screenshot from 2024-08-12 16-07-56](https://github.com/user-attachments/assets/870adf53-2d06-4da7-8c8f-3736dc6b3a44)
![Screenshot from 2024-08-23 10-13-35](https://github.com/user-attachments/assets/650c0b6e-d856-44f4-8a95-1e65f369bc2e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved processing of mustache tokens for enhanced template rendering by wrapping token values in double curly braces.

- **Tests**
  - Added a new test to validate the functionality of mustache pattern replacements, ensuring accurate output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->