### PR TITLE
chore: Add admin email for installation complete event even if the user opt out of product updates

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -440,8 +440,8 @@ public class UserSignupCEImpl implements UserSignupCE {
                     final String instanceId = tuple.getT1();
                     final String ip = tuple.getT2();
                     log.debug("Installation setup complete.");
-                    String newsletterSignedUpUserEmail = userFromRequest.isSignupForNewsletter() ? user.getEmail() : "";
-                    String newsletterSignedUpUserName = userFromRequest.isSignupForNewsletter() ? user.getName() : "";
+                    String newsletterSignedUpUserEmail = user.getEmail();
+                    String newsletterSignedUpUserName = user.getName();
                     Map<String, Object> analyticsProps = new HashMap<>();
                     analyticsProps.put(DISABLE_TELEMETRY, !userFromRequest.isAllowCollectingAnonymousData());
                     analyticsProps.put(SUBSCRIBE_MARKETING, userFromRequest.isSignupForNewsletter());


### PR DESCRIPTION
## Description
PR to add admin email and domain hash if the user opts out of product updates and track subscription in a separate variable.

Fixes https://github.com/appsmithorg/appsmith/issues/35658

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10613084027>
> Commit: 08ad5157d76f8ced94cc40fdf65f1a94c1697300
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10613084027&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 29 Aug 2024 10:33:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of user information during the newsletter sign-up process, ensuring that user email and name are always captured for analytics.
- **Bug Fixes**
	- Removed conditional logic that previously set user email and name to empty strings if the newsletter was not opted into, enhancing data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->