### PR TITLE
test: fix inline editing spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -3,6 +3,7 @@ const widgetsPage = require("../../../../../locators/Widgets.json");
 import {
   agHelper,
   table as tableHelper,
+  propPane,
 } from "../../../../../support/Objects/ObjectsCore";
 
 describe(
@@ -161,6 +162,9 @@ describe(
     it("6. should check that onsubmit event is available for the columns that are editable", () => {
       cy.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
+      cy.get(commonlocators.changeColType).last().click();
+      cy.get(".t--dropdown-option").children().contains("Plain text").click();
+      propPane.TogglePropertyState("Editable", "Off", "");
       cy.wait(500);
       [
         {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -163,7 +163,10 @@ describe(
       cy.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       cy.get(commonlocators.changeColType).last().click();
-      cy.get(".t--dropdown-option").children().contains("Plain text").click();
+      cy.get(tableHelper._dropdownText)
+        .children()
+        .contains("Plain text")
+        .click();
       propPane.TogglePropertyState("Editable", "Off", "");
       cy.wait(500);
       [

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -169,7 +169,6 @@ describe(
         .contains("Plain text")
         .click();
       propPane.TogglePropertyState("Editable", "Off", "");
-      cy.wait(500);
       [
         {
           columnType: "URL",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -5,6 +5,7 @@ import {
   table as tableHelper,
   propPane,
 } from "../../../../../support/Objects/ObjectsCore";
+import { PROPERTY_SELECTOR } from "../../../../../locators/WidgetLocators";
 
 describe(
   "Table widget inline editing functionality",
@@ -213,8 +214,7 @@ describe(
           .contains(data.columnType)
           .click();
         cy.wait("@updateLayout");
-        cy.wait(500);
-        cy.get(".t--property-control-onsubmit").should(data.expected);
+        cy.get(PROPERTY_SELECTOR.onSubmit).should("not.exist");
       });
 
       cy.get(propPaneBack).click();
@@ -269,8 +269,7 @@ describe(
           .contains(data.columnType)
           .click();
         cy.wait("@updateLayout");
-        cy.wait(500);
-        cy.get(".t--property-control-onsubmit").should(data.expected);
+        cy.get(PROPERTY_SELECTOR.onSubmit).should(data.expected);
       });
     });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -213,7 +213,7 @@ describe(
           .contains(data.columnType)
           .click();
         cy.wait("@updateLayout");
-        cy.get(PROPERTY_SELECTOR.onSubmit).should("not.exist");
+        cy.get(PROPERTY_SELECTOR.onSubmit).should(data.expected);
       });
 
       cy.get(propPaneBack).click();

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
RCA:
Toggle state of the property was going to wrong state, hence with retry test was passing as it would bring back the application to required statee.

Solution:
Updated toggle state in the flaky test to avoid this issue

EE PR: https://github.com/appsmithorg/appsmith-ee/pull/4997

/ok-to-test tags="@tag.Sanity"



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10633979760>
> Commit: b63e5716203e0865ad493b1bc0ab8e952aaa7301
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10633979760&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 30 Aug 2024 14:27:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced inline editing functionality for table widgets, improving interaction and validation in tests.

- **Bug Fixes**
	- Updated limited tests configuration to prioritize inline editing tests over previous specifications.

- **Tests**
	- Improved test coverage for inline editing by adding interactions with dropdowns and property state toggling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->