### PR TITLE
chore: removed value from actionExecutionRequestParamsValueMap

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -1151,10 +1151,10 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                         eventData.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS, REDACTED_DATA);
                     }
                     if (executeActionDto != null) {
-                        if (commonConfig.isCloudHosting()) {
-                            // Only send this parameter if cloud hosting is true as it contains user's evaluated params
-                            data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP, executeActionDto.getParams());
-                        }
+                        // Remove the value from the executeActionDto.params before sending to mixpanel as it contains
+                        // user submitted data
+                        executeActionDto.getParams().forEach(param -> param.setValue(REDACTED_DATA));
+                        data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP, executeActionDto.getParams());
                         data.put(
                                 FieldName.ACTION_EXECUTION_INVERT_PARAMETER_MAP,
                                 executeActionDto.getInvertParameterMap());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -1153,7 +1153,9 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                     if (executeActionDto != null) {
                         // Remove the value from the executeActionDto.params before sending to mixpanel as it contains
                         // user submitted data
-                        executeActionDto.getParams().forEach(param -> param.setValue(REDACTED_DATA));
+                        if (executeActionDto.getParams() != null) {
+                            executeActionDto.getParams().forEach(param -> param.setValue(REDACTED_DATA));
+                        }
                         data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP, executeActionDto.getParams());
                         data.put(
                                 FieldName.ACTION_EXECUTION_INVERT_PARAMETER_MAP,


### PR DESCRIPTION
## Description
> This PR removes the `value` data from the `actionExecutionRequestParamsValueMap` field as it contains user data. It also adds the `actionExecutionRequestParamsValueMap` now for all types of users since the private data is not captured.
Fixes #35904

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10620985550>
> Commit: 92640e13cd5f3486131ea34754ce5634ca5b8fc0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10620985550&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 29 Aug 2024 19:17:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced data privacy by consistently redacting sensitive user-submitted data in analytics events.
- **Bug Fixes**
	- Removed conditional logic that previously limited parameter inclusion based on hosting environment, ensuring all necessary data is sent without sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->