### PR TITLE
fix: bug invalid button label on the button in table widget #17940

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
@@ -260,7 +260,7 @@ export const getPropertyValue = (
   if (value && isObject(value) && !Array.isArray(value)) {
     return value;
   }
-  if (value && Array.isArray(value) && value[index]) {
+  if (value && Array.isArray(value) && (value[index] || value[index] === "")) {
     // TODO: Fix this the next time the file is edited
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const getValueForSourceData = (value: any, index: number) => {


### PR DESCRIPTION
## Description:

As a user of the Appsmith platform, 

I want the button label in the Table widget to handle arrays of strings with empty strings correctly, 

so that no invalid labels are shown on the buttons. Will show the default value.

> I have raised this PR to fix the `Invalid button label on the button in the table widget when we give empty string`

## [Issue Link](https://github.com/appsmithorg/appsmith/issues/17940)

## Screenshots:
### Before resoving bug:
![image](https://github.com/user-attachments/assets/c3e7d937-2dde-4156-9773-96c0038a9ab0)

### After resoving bug:
![Screenshot from 2024-08-30 09-28-14](https://github.com/user-attachments/assets/4cbc1550-2f32-4ab6-a1dc-e8c49e36496b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of array values in the Table Widget, allowing empty strings to be returned as valid values. This enhances data processing accuracy when dealing with arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->