### PR TITLE
fix:icon align when  datatype is of image

### DIFF
--- a/app/client/src/widgets/BaseInputWidget/component/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/component/index.tsx
@@ -523,6 +523,12 @@ class BaseInputComponent extends React.Component<
     const locale = this.props.shouldUseLocale ? getLocale() : undefined;
     const leftIcon = this.getLeftIcon();
     const conditionalProps: Record<string, number> = {};
+    const ICON_ALIGN_RIGHT = 'right';
+    const rightElement = (
+      this.props.iconAlign === ICON_ALIGN_RIGHT && this.props.iconName
+        ? <Tag icon={this.props.iconName} />
+        : undefined
+    );
 
     if (!isNil(this.props.maxNum)) {
       conditionalProps.max = this.props.maxNum;
@@ -558,6 +564,7 @@ class BaseInputComponent extends React.Component<
         onKeyUp={this.onKeyUp}
         onValueChange={this.onNumberChange}
         placeholder={this.props.placeholder}
+        rightElement={rightElement}
         stepSize={this.props.stepSize}
         value={this.props.value}
         {...conditionalProps}


### PR DESCRIPTION
### Description


### [Bug Link](https://github.com/appsmithorg/appsmith/issues/35549)

I have raised this PR In-order to fix `alignment` of the `icon` in `input component` when `datatype` is selected as `number`  and position is selected as `right`

### screenshot
### Before issue is resolved , icon dissapears
![Screenshot_from_2024-08-14_14-24-33](/uploads/2792048f210d33d08d596e4da38fe368/Screenshot_from_2024-08-14_14-24-33.png)

### After the issue is resolved
![Screenshot_from_2024-08-14_14-25-29](/uploads/ccffa429230599be7f165d9e532ad258/Screenshot_from_2024-08-14_14-25-29.png)

### Cypress Testing 

![Screenshot_from_2024-08-14_14-17-13](/uploads/457b89a02025c07291bf5a4254474ae7/Screenshot_from_2024-08-14_14-17-13.png)

### Cypress Testing video
![Inputv2_Icon_Align_Spec.js](/uploads/6383603e8437ac826a96a6865eaa8e8e/Inputv2_Icon_Align_Spec.js.mp4)