### PR TITLE
perf: JSONForm infinite re-rendering when field validation is set

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.test.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.test.tsx
@@ -193,6 +193,56 @@ describe("useRegisterFieldInvalid - setMetaInternalFieldState", () => {
     expect(mockSetError).not.toBeCalled();
   });
 
+  it("calls setError when isValid is false and error is not present", () => {
+    const mocksetMetaInternalFieldState = jest.fn();
+    const mockClearErrors = jest.fn();
+    const mockSetError = jest.fn();
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      const methods = useForm();
+
+      return (
+        <FormContextProvider
+          executeAction={jest.fn}
+          renderMode="CANVAS"
+          setMetaInternalFieldState={mocksetMetaInternalFieldState}
+          updateFormData={jest.fn}
+          updateWidgetMetaProperty={jest.fn}
+          updateWidgetProperty={jest.fn}
+        >
+          <FormProvider
+            {...methods}
+            clearErrors={mockClearErrors}
+            setError={mockSetError}
+          >
+            {children}
+          </FormProvider>
+        </FormContextProvider>
+      );
+    }
+
+    const fieldName = "testField";
+
+    act(() => {
+      renderHook(
+        () =>
+          useRegisterFieldValidity({
+            isValid: false,
+            fieldName,
+            fieldType: FieldType.TEXT_INPUT,
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+    });
+
+    jest.runAllTimers();
+
+    expect(mockSetError).toBeCalledTimes(1);
+    expect(mockClearErrors).not.toBeCalledWith(fieldName);
+  });
+
   it("updates fieldState and error state with the updated isValid value", () => {
     const mocksetMetaInternalFieldState = jest.fn();
     // TODO: Fix this the next time the file is edited

--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
@@ -42,12 +42,14 @@ function useRegisterFieldValidity({
             });
           }
         } else {
-          startAndEndSpanForFn("JSONFormWidget.setError", {}, () => {
-            setError(fieldName, {
-              type: fieldType,
-              message: "Invalid field",
+          if (!error) {
+            startAndEndSpanForFn("JSONFormWidget.setError", {}, () => {
+              setError(fieldName, {
+                type: fieldType,
+                message: "Invalid field",
+              });
             });
-          });
+          }
         }
       } catch (e) {
         Sentry.captureException(e);


### PR DESCRIPTION
## Description
The setError function updates the state and the effect is also dependant on the state which triggers re-render. This is a classic case of re-rendering due to self state dependency and is fixed with a check if the error is present for a particular field then it doesn't need to set again

Fixes https://github.com/appsmithorg/appsmith/issues/35995

## Automation

/ok-to-test tags="@tag.JSONForm"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10627924838>
> Commit: 1d5dec675abd788931aab462832455fbce250df3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10627924838&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JSONForm`
> Spec:
> <hr>Fri, 30 Aug 2024 06:50:40 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling logic in the form validation process to improve efficiency and correctness.
  
- **Tests**
	- Added a new test case to validate the behavior of the form validation hook when encountering invalid field states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->