### PR TITLE
fix: Action redesign/remove container query

### DIFF
--- a/app/client/src/components/formControls/DynamicTextFieldControl.tsx
+++ b/app/client/src/components/formControls/DynamicTextFieldControl.tsx
@@ -65,7 +65,7 @@ class DynamicTextControl extends BaseControl<
 
     return (
       <Wrapper
-        className={`t--${configProperty} dynamic-text-feild-control`}
+        className={`t--${configProperty} dynamic-text-field-control`}
         fullWidth={isActionRedesignEnabled}
       >
         <DynamicTextField

--- a/app/client/src/components/formControls/DynamicTextFieldControl.tsx
+++ b/app/client/src/components/formControls/DynamicTextFieldControl.tsx
@@ -65,7 +65,7 @@ class DynamicTextControl extends BaseControl<
 
     return (
       <Wrapper
-        className={`t--${configProperty}`}
+        className={`t--${configProperty} dynamic-text-feild-control`}
         fullWidth={isActionRedesignEnabled}
       >
         <DynamicTextField

--- a/app/client/src/components/formControls/FieldArrayControl.tsx
+++ b/app/client/src/components/formControls/FieldArrayControl.tsx
@@ -100,6 +100,7 @@ function NestedComponents(props: any) {
               <CenteredIconButton
                 alignSelf={"start"}
                 data-testid={`t--where-clause-delete-[${index}]`}
+                isIconButton
                 kind="tertiary"
                 onClick={(e: React.MouseEvent) => {
                   e.stopPropagation();

--- a/app/client/src/pages/Editor/ActionForm/Section/styles.module.css
+++ b/app/client/src/pages/Editor/ActionForm/Section/styles.module.css
@@ -5,7 +5,6 @@
   width: 100%;
   max-width: 800px;
   justify-content: center;
-  container: uqi-section / inline-size;
 
   &[data-standalone="false"] {
     padding-block: var(--ads-v2-spaces-6);

--- a/app/client/src/pages/Editor/ActionForm/Zone/styles.module.css
+++ b/app/client/src/pages/Editor/ActionForm/Zone/styles.module.css
@@ -5,7 +5,7 @@
   box-sizing: border-box;
 
   &[data-layout="double_column"] {
-    grid-template-columns: repeat(2, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   }
 
   &[data-layout="single_column"] {
@@ -48,10 +48,4 @@
     }
   }
   /* Removable section ends here */
-}
-
-@container uqi-section (max-width: 531px) {
-  .zone[data-layout="double_column"] {
-    grid-template-columns: 1fr;
-  }
 }

--- a/app/client/src/pages/Editor/ActionForm/Zone/styles.module.css
+++ b/app/client/src/pages/Editor/ActionForm/Zone/styles.module.css
@@ -47,5 +47,15 @@
       }
     }
   }
+
+  /* Remove when code editor min width is resolved in DynamicTextFeildControl */
+  & :global(.dynamic-text-feild-control) {
+    min-width: 260px;
+  }
+
+  /* reset ads select min width */
+  & :global(.ads-v2-select > .rc-select-selector) {
+    min-width: unset;
+  }
   /* Removable section ends here */
 }

--- a/app/client/src/pages/Editor/ActionForm/Zone/styles.module.css
+++ b/app/client/src/pages/Editor/ActionForm/Zone/styles.module.css
@@ -49,7 +49,7 @@
   }
 
   /* Remove when code editor min width is resolved in DynamicTextFeildControl */
-  & :global(.dynamic-text-feild-control) {
+  & :global(.dynamic-text-field-control) {
     min-width: 260px;
   }
 


### PR DESCRIPTION
## Description

PR addresses below issues,
1. Query was not scrollable when code editor field dynamically increase height. This was caused by the container property in Section. Container will ignore absolute positioned elements dynamic heights.
2. Fixed code editor field min-width while resizing
3. Fixed ads select feild min-width while resizing.

Fixes #36000
Fixes #35901

## Automation

/ok-to-test tags="@tag.Sanity, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10631460963>
> Commit: 9d9fe7691113f36ecf4172972ae31a69c059a8f4
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10631460963&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.IDE`
> Spec:
> <hr>Fri, 30 Aug 2024 11:24:13 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced styling for the dynamic text field control, improving visual consistency.
	- Introduced a flexible grid layout for better responsiveness across different screen sizes.

- **Bug Fixes**
	- Addressed layout issues with minimum width adjustments for dynamic text fields and advertisement selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->