### PR TITLE
fix: Intercom setting anonymous user a common user id

### DIFF
--- a/app/client/src/utils/bootIntercom.ts
+++ b/app/client/src/utils/bootIntercom.ts
@@ -1,15 +1,18 @@
-import type { User } from "constants/userConstants";
+import { ANONYMOUS_USERNAME, type User } from "constants/userConstants";
 import { getAppsmithConfigs } from "ee/configs";
 import { sha256 } from "js-sha256";
 import { getLicenseKey } from "ee/utils/licenseHelpers";
 
 const { appVersion, cloudHosting, intercomAppID } = getAppsmithConfigs();
 
-export default function bootIntercom(user?: User) {
+export default function bootIntercom(user: User) {
   if (intercomAppID && window.Intercom) {
-    let { email, username } = user || {};
-    let name;
-    if (!cloudHosting) {
+    let name = user.name;
+    let email: string | undefined = user.email;
+    let username =
+      user.username === ANONYMOUS_USERNAME ? undefined : user.username;
+    if (!cloudHosting && username) {
+      // We are hiding their information when self-hosted
       username = sha256(username || "");
       // keep email undefined so that users are prompted to enter it when they reach out on intercom
       email = undefined;

--- a/app/client/src/utils/bootIntercom.ts
+++ b/app/client/src/utils/bootIntercom.ts
@@ -5,12 +5,12 @@ import { getLicenseKey } from "ee/utils/licenseHelpers";
 
 const { appVersion, cloudHosting, intercomAppID } = getAppsmithConfigs();
 
-export default function bootIntercom(user: User) {
+export default function bootIntercom(user?: User) {
   if (intercomAppID && window.Intercom) {
-    let name = user.name;
-    let email: string | undefined = user.email;
+    let name: string | undefined = user?.name;
+    let email: string | undefined = user?.email;
     let username =
-      user.username === ANONYMOUS_USERNAME ? undefined : user.username;
+      user?.username === ANONYMOUS_USERNAME ? undefined : user?.username;
     if (!cloudHosting && username) {
       // We are hiding their information when self-hosted
       username = sha256(username || "");


### PR DESCRIPTION
## Description

Avoids setting the `user_id` field in intercom when the user is not logged in

Fixes https://github.com/appsmithorg/appsmith-ee/issues/5003


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10631847104>
> Commit: 1eaad316f8da84f0e99b92842f1dddc177d252c5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10631847104&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 30 Aug 2024 11:52:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user information handling for improved privacy in the application.
	- Anonymous users will no longer have their usernames processed, ensuring greater data protection.

- **Bug Fixes**
	- Refined logic for extracting user information to prevent exposure of sensitive data. 

- **Documentation**
	- Updated comments and documentation to reflect changes in user data handling and privacy measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->