### PR TITLE
hotfix: JSONForm infinite re-rendering when field validation is set

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.test.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.test.tsx
@@ -193,6 +193,56 @@ describe("useRegisterFieldInvalid - setMetaInternalFieldState", () => {
     expect(mockSetError).not.toBeCalled();
   });
 
+  it("calls setError when isValid is false and error is not present", () => {
+    const mocksetMetaInternalFieldState = jest.fn();
+    const mockClearErrors = jest.fn();
+    const mockSetError = jest.fn();
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      const methods = useForm();
+
+      return (
+        <FormContextProvider
+          executeAction={jest.fn}
+          renderMode="CANVAS"
+          setMetaInternalFieldState={mocksetMetaInternalFieldState}
+          updateFormData={jest.fn}
+          updateWidgetMetaProperty={jest.fn}
+          updateWidgetProperty={jest.fn}
+        >
+          <FormProvider
+            {...methods}
+            clearErrors={mockClearErrors}
+            setError={mockSetError}
+          >
+            {children}
+          </FormProvider>
+        </FormContextProvider>
+      );
+    }
+
+    const fieldName = "testField";
+
+    act(() => {
+      renderHook(
+        () =>
+          useRegisterFieldValidity({
+            isValid: false,
+            fieldName,
+            fieldType: FieldType.TEXT_INPUT,
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+    });
+
+    jest.runAllTimers();
+
+    expect(mockSetError).toBeCalledTimes(1);
+    expect(mockClearErrors).not.toBeCalledWith(fieldName);
+  });
+
   it("updates fieldState and error state with the updated isValid value", () => {
     const mocksetMetaInternalFieldState = jest.fn();
     // TODO: Fix this the next time the file is edited

--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
@@ -42,12 +42,14 @@ function useRegisterFieldValidity({
             });
           }
         } else {
-          startAndEndSpanForFn("JSONFormWidget.setError", {}, () => {
-            setError(fieldName, {
-              type: fieldType,
-              message: "Invalid field",
+          if (!error) {
+            startAndEndSpanForFn("JSONFormWidget.setError", {}, () => {
+              setError(fieldName, {
+                type: fieldType,
+                message: "Invalid field",
+              });
             });
-          });
+          }
         }
       } catch (e) {
         Sentry.captureException(e);


### PR DESCRIPTION
## Description
Cherry pick https://github.com/appsmithorg/appsmith/commit/827f22e4872cdf7ca5066a9a1958993fe10f34f7
Thread https://theappsmith.slack.com/archives/C02GAUE9P5H/p1724998475904939
current version - v1.38

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling logic in the form validation process to prevent unnecessary error reporting.
  
- **Tests**
	- Added a new test case for the `useRegisterFieldValidity` hook to enhance coverage and ensure proper behavior when the field is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->