### PR TITLE
chore: Added threads to logging

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -31,7 +31,7 @@ appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:150}
 logging.level.root=info
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
-logging.pattern.console=[%d{ISO8601, UTC}] requestId=%X{X-Appsmith-Request-Id} userEmail=%X{userEmail} traceId=%X{traceId} spanId=%X{spanId} - %m%n
+logging.pattern.console=[%d{ISO8601, UTC}] [%t] requestId=%X{X-Appsmith-Request-Id} userEmail=%X{userEmail} traceId=%X{traceId} spanId=%X{spanId} - %m%n
 
 #Spring security
 spring.security.oauth2.client.registration.google.client-id=${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:missing_value_sentinel}


### PR DESCRIPTION
## Description
- Added thread in the logs, now an method running on threads would be visible.
for e.g. 
`[2024-09-02 06:56:16,840] [boundedElastic-2] requestId= userEmail= traceId= spanId= - Adding manage workspace policy map indices` 
The second brackets hold the thread on which this logging was run, the thread utilised is same as the one in which process is running.

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
