### PR TITLE
fix: postgres plugin blocking call

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -654,15 +654,11 @@ public class PostgresPlugin extends BasePlugin {
                         e.getMessage()));
             }
 
-            return connectionPoolConfig
-                    .getMaxConnectionPoolSize()
-                    .flatMap(maxPoolSize -> {
-                        return Mono.fromCallable(() -> {
-                            log.debug("Connecting to Postgres db");
-                            return createConnectionPool(datasourceConfiguration, maxPoolSize);
-                        });
+            return connectionPoolConfig.getMaxConnectionPoolSize().flatMap(maxPoolSize -> Mono.fromCallable(() -> {
+                        log.debug("Connecting to Postgres db");
+                        return createConnectionPool(datasourceConfiguration, maxPoolSize);
                     })
-                    .subscribeOn(scheduler);
+                    .subscribeOn(scheduler));
         }
 
         @Override

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -655,7 +655,7 @@ public class PostgresPlugin extends BasePlugin {
             }
 
             return connectionPoolConfig.getMaxConnectionPoolSize().flatMap(maxPoolSize -> Mono.fromCallable(() -> {
-                        log.debug("Connecting to Postgres db");
+                        log.info("Connecting to Postgres db");
                         return createConnectionPool(datasourceConfiguration, maxPoolSize);
                     })
                     .subscribeOn(scheduler));


### PR DESCRIPTION
## Description
This PR resolves the blockhound callout `Blocking call! java.io.FileInputStream#readBytes` in the /v1/actions/execute (POST) API call when used with Postgres Plugin. 
This blocking call was present in the PostgresPlugin.java

Fixes #36008   

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10666128697>
> Commit: 9224297c20722ebd5b2891e9e2f306f75e78ed1b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10666128697&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 02 Sep 2024 11:40:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved the readability and conciseness of the connection pool creation logic in the Postgres plugin, enhancing maintainability without affecting functionality.
	- Updated logging level from debug to info for better clarity on log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->