### PR TITLE
fix: mongo schema collections order of mongo plugin

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -912,6 +912,7 @@ public class MongoPlugin extends BasePlugin {
                         }
                         return true;
                     })
+                    .sort((collectionName1, collectionName2) -> collectionName1.compareToIgnoreCase(collectionName2))
                     .flatMap(collectionName -> {
                         final ArrayList<DatasourceStructure.Column> columns = new ArrayList<>();
                         final ArrayList<DatasourceStructure.Template> templates = new ArrayList<>();

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginQueriesTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginQueriesTest.java
@@ -656,6 +656,26 @@ public class MongoPluginQueriesTest {
     }
 
     @Test
+    public void testStructure_should_return_collections_in_order() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        Mono<DatasourceStructure> structureMono = pluginExecutor
+                .datasourceCreate(dsConfig)
+                .flatMap(connection -> pluginExecutor.getStructure(connection, dsConfig, null));
+
+        StepVerifier.create(structureMono)
+                .assertNext(structure -> {
+                    assertNotNull(structure);
+                    assertEquals(3, structure.getTables().size());
+
+                    // Check that the tables are sorted in ascending order
+                    assertEquals("address", structure.getTables().get(0).getName());
+                    assertEquals("teams", structure.getTables().get(1).getName());
+                    assertEquals("users", structure.getTables().get(2).getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
     public void testCountCommand() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         Mono<MongoClient> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);


### PR DESCRIPTION
### PR Description: 
- **File changes in the PR**:
  - Integrated the sorting feature to the mongo collections.
  - Added the unit test for sorting.

Fixes https://github.com/appsmithorg/appsmith/issues/35842

- **Snapshots**:
  
  **Before resolving bug:**
  
  ![image](https://github.com/user-attachments/assets/34c04ebc-e81b-480c-9a54-1b643b68ffb2)
  
  **After resolving bug:**
  
  ![image](https://github.com/user-attachments/assets/fd7155e1-e261-491a-b912-7d482b8a9386)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the MongoDB plugin to return collection names in a case-insensitive sorted order, improving predictability and user experience.
  
- **Tests**
	- Added a new test to validate that collections returned by the plugin are sorted correctly, ensuring consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->