### PR TITLE
test: updated test with intercept

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetEditorPropertyPane_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetEditorPropertyPane_spec.ts
@@ -1,9 +1,15 @@
 import {
   agHelper,
+  assertHelper,
   deployMode,
   entityExplorer,
+  locators,
   propPane,
 } from "../../../../../support/Objects/ObjectsCore";
+import {
+  PageLeftPane,
+  PagePaneSegment,
+} from "../../../../../support/Pages/EditorNavigation";
 
 describe(
   "Custom widget Tests",
@@ -26,6 +32,9 @@ describe(
     };
 
     it("shoud check that default model changes are converyed to custom component", () => {
+      agHelper.AssertElementExist(locators._widgetInDeployed("customwidget"));
+      cy.intercept("https://api.segment.io/v1/b").as("widgetLoad");
+      assertHelper.WaitForNetworkCall("widgetLoad");
       getIframeBody().find(".tip-container").should("exist");
 
       agHelper.GetElement(".t--text-widget-container").should("have.text", "");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetEditorPropertyPane_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/Custom/CustomWidgetEditorPropertyPane_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
RCA:
Widget was not loading as a result test is flaky

Solution:
Adding an intercept to make sure the widget is loaded

EE PR: https://github.com/appsmithorg/appsmith-ee/pull/5020


<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 125780e27b5b8d4898fc7d48e8f9f5a8d92d0138 yet
> <hr>Wed, 04 Sep 2024 07:15:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->
