### PR TITLE
feat: disable create js object option in workflows editor

### DIFF
--- a/app/client/src/ce/utils/workflowHelpers.ts
+++ b/app/client/src/ce/utils/workflowHelpers.ts
@@ -1,3 +1,10 @@
 export const useWorkflowOptions = () => {
   return [];
 };
+
+// We don't want to show the create new JS object option if the user is in the workflow editor
+// this is done since worflows runner doesn't support multiple JS objects
+// TODO: Remove this once workflows can support multiple JS objects
+export const checkIfJSObjectCreationAllowed = () => {
+  return false;
+};

--- a/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.test.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.test.ts
@@ -295,4 +295,58 @@ describe("getFilteredAndSortedFileOperations", () => {
       }),
     );
   });
+
+  it("should not show new js object option if disableJSObjectCreation is true", () => {
+    const fileOptions = useFilteredAndSortedFileOperations({
+      query: "new js",
+      allDatasources: [],
+      recentlyUsedDSMap: {},
+      canCreateActions: true,
+      canCreateDatasource: true,
+      disableJSObjectCreation: true,
+    });
+
+    expect(fileOptions.length).toEqual(1);
+    expect(fileOptions[0]).toEqual(
+      expect.objectContaining({
+        title: "New datasource",
+      }),
+    );
+  });
+
+  it("should show new js object option if disableJSObjectCreation is false", () => {
+    const fileOptions = useFilteredAndSortedFileOperations({
+      query: "new js",
+      allDatasources: [],
+      recentlyUsedDSMap: {},
+      canCreateActions: true,
+      canCreateDatasource: true,
+      disableJSObjectCreation: false,
+    });
+
+    expect(fileOptions.length).toEqual(2);
+    expect(fileOptions[0]).toEqual(
+      expect.objectContaining({
+        title: "New JS Object",
+      }),
+    );
+  });
+
+  it("should show new js object option if disableJSObjectCreation is not set", () => {
+    const fileOptions = useFilteredAndSortedFileOperations({
+      query: "new js",
+      allDatasources: [],
+      recentlyUsedDSMap: {},
+      canCreateActions: true,
+      canCreateDatasource: true,
+      disableJSObjectCreation: false,
+    });
+
+    expect(fileOptions.length).toEqual(2);
+    expect(fileOptions[0]).toEqual(
+      expect.objectContaining({
+        title: "New JS Object",
+      }),
+    );
+  });
 });

--- a/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.tsx
@@ -39,6 +39,7 @@ import { useModuleOptions } from "ee/utils/moduleInstanceHelpers";
 import type { ActionParentEntityTypeInterface } from "ee/entities/Engine/actionHelpers";
 import { createNewQueryBasedOnParentEntity } from "ee/actions/helpers";
 import { useWorkflowOptions } from "ee/utils/workflowHelpers";
+import urlBuilder, { EDITOR_TYPE } from "ee/entities/URLRedirect/URLAssembly";
 
 export interface FilterFileOperationsProps {
   canCreateActions: boolean;
@@ -127,8 +128,13 @@ export const useFilteredAndSortedFileOperations = ({
    */
   const actionOps = updateActionOperations(plugins, actionOperations);
 
-  // Add JS Object operation
-  fileOperations.push(actionOps[2]);
+  // We don't want to show the create new JS object option if the user is in the workflow editor
+  // this is done since worflows runner doesn't support multiple JS objects
+  // TODO: Remove this check once workflows can support multiple JS objects
+  if (urlBuilder.getDefaultEditorType() !== EDITOR_TYPE.WORKFLOW) {
+    // Add JS Object operation
+    fileOperations.push(actionOps[2]);
+  }
 
   // Add Module operations
   if (moduleOptions.length > 0) {

--- a/app/client/src/pages/Editor/Explorer/Files/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/index.tsx
@@ -67,7 +67,7 @@ function Files() {
 
   const onCreate = useCallback(() => {
     openMenu(true);
-  }, [dispatch, openMenu]);
+  }, [openMenu]);
 
   const activeActionBaseId = useActiveActionBaseId();
 
@@ -141,7 +141,7 @@ function Files() {
           );
         }
       }),
-    [files, activeActionBaseId, parentEntityId],
+    [files, activeActionBaseId, parentEntityId, parentEntityType],
   );
 
   const handleClick = useCallback(
@@ -161,7 +161,7 @@ function Files() {
         item.redirect(parentEntityId, DatasourceCreateEntryPoints.SUBMENU);
       }
     },
-    [parentEntityId, dispatch],
+    [dispatch, parentEntityId, parentEntityType],
   );
 
   return (


### PR DESCRIPTION
## Description

Workflows is not currently supporting multiple js objects. Hence, we need to disable the option for the workflows editor. 

EE branch: https://github.com/appsmithorg/appsmith-ee/pull/5027

Fixes #32239 

## Automation

/test js

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10686636668>
> Commit: 5cb101fca88fad7d8ddba64ccec99b76fd49674b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10686636668&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Tue, 03 Sep 2024 16:45:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for creating new JavaScript objects, preventing unnecessary additions in the workflow editor.
	- Introduced a function to determine if creating a new JavaScript object is allowed, improving user experience in the workflow editor.
	- Improved responsiveness of the Files component based on the parent entity type, allowing for context-sensitive behavior.

- **Bug Fixes**
	- Addressed limitations in workflow runner support for multiple JavaScript objects.

- **Refactor**
	- Simplified the `onCreate` function's dependencies for improved clarity and functionality.
  
- **Tests**
	- Added new test cases to validate the behavior of JavaScript object creation options based on user settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->