### PR TITLE
feat: Action redesign: Updating the config for Google AI plugin to use sections and zones format

### DIFF
--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/editor/generate.json
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/editor/generate.json
@@ -1,77 +1,89 @@
 {
+  "controlType": "SECTION_V2",
   "identifier": "CHAT",
-  "controlType": "SECTION",
   "conditionals": {
     "show": "{{actionConfiguration.formData.command.data === 'GENERATE_CONTENT'}}"
   },
   "children": [
     {
-      "label": "Models",
-      "tooltipText": "Select the model for content generation",
-      "subtitle": "ID of the model to use.",
-      "isRequired": true,
-      "propertyName": "generate_content_model_id",
-      "configProperty": "actionConfiguration.formData.generateContentModel.data",
-      "controlType": "DROP_DOWN",
-      "initialValue": "",
-      "options": [],
-      "placeholderText": "All models will be fetched.",
-      "fetchOptionsConditionally": true,
-      "setFirstOptionAsDefault": true,
-      "alternateViewTypes": ["json"],
-      "conditionals": {
-        "enable": "{{true}}",
-        "fetchDynamicValues": {
-          "condition": "{{actionConfiguration.formData.command.data === 'GENERATE_CONTENT'}}",
-          "config": {
-            "params": {
-              "requestType": "GENERATE_CONTENT_MODELS",
-              "displayType": "DROP_DOWN"
+      "controlType": "DOUBLE_COLUMN_ZONE",
+      "identifier": "CHAT-Z1",
+      "children": [
+        {
+          "label": "Models",
+          "tooltipText": "Select the model for content generation",
+          "subtitle": "ID of the model to use.",
+          "isRequired": true,
+          "propertyName": "generate_content_model_id",
+          "configProperty": "actionConfiguration.formData.generateContentModel.data",
+          "controlType": "DROP_DOWN",
+          "initialValue": "",
+          "options": [],
+          "placeholderText": "All models will be fetched.",
+          "fetchOptionsConditionally": true,
+          "setFirstOptionAsDefault": true,
+          "alternateViewTypes": ["json"],
+          "conditionals": {
+            "enable": "{{true}}",
+            "fetchDynamicValues": {
+              "condition": "{{actionConfiguration.formData.command.data === 'GENERATE_CONTENT'}}",
+              "config": {
+                "params": {
+                  "requestType": "GENERATE_CONTENT_MODELS",
+                  "displayType": "DROP_DOWN"
+                }
+              }
             }
           }
         }
-      }
+      ]
     },
     {
-      "label": "Messages",
-      "tooltipText": "Ask a question",
-      "subtitle": "A list of messages to generate the content",
-      "propertyName": "messages",
-      "isRequired": true,
-      "configProperty": "actionConfiguration.formData.messages.data",
-      "controlType": "ARRAY_FIELD",
-      "addMoreButtonLabel": "Add message",
-      "alternateViewTypes": ["json"],
-      "schema": [
+      "controlType": "SINGLE_COLUMN_ZONE",
+      "identifier": "CHAT-Z2",
+      "children": [
         {
-          "label": "Role",
-          "key": "role",
-          "controlType": "DROP_DOWN",
-          "initialValue": "user",
-          "options": [
+          "label": "Messages",
+          "tooltipText": "Ask a question",
+          "subtitle": "A list of messages to generate the content",
+          "propertyName": "messages",
+          "isRequired": true,
+          "configProperty": "actionConfiguration.formData.messages.data",
+          "controlType": "ARRAY_FIELD",
+          "addMoreButtonLabel": "Add message",
+          "alternateViewTypes": ["json"],
+          "schema": [
             {
-              "label": "User",
-              "value": "user"
+              "label": "Role",
+              "key": "role",
+              "controlType": "DROP_DOWN",
+              "initialValue": "user",
+              "options": [
+                {
+                  "label": "User",
+                  "value": "user"
+                }
+              ]
+            },
+            {
+              "label": "Type",
+              "key": "type",
+              "controlType": "DROP_DOWN",
+              "initialValue": "text",
+              "options": [
+                {
+                  "label": "Text",
+                  "value": "text"
+                }
+              ]
+            },
+            {
+              "label": "Content",
+              "key": "content",
+              "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+              "placeholderText": "{{ UserInput.text }}"
             }
           ]
-        },
-        {
-          "label": "Type",
-          "key": "type",
-          "controlType": "DROP_DOWN",
-          "initialValue": "text",
-          "options": [
-            {
-              "label": "Text",
-              "value": "text"
-            }
-          ]
-        },
-        {
-          "label": "Content",
-          "key": "content",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
-          "placeholderText": "{{ UserInput.text }}"
         }
       ]
     }

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/editor/root.json
@@ -1,20 +1,26 @@
 {
   "editor": [
     {
-      "controlType": "SECTION",
+      "controlType": "SECTION_V2",
       "identifier": "SELECTOR",
       "children": [
         {
-          "label": "Command",
-          "description": "Choose the method you would like to use",
-          "configProperty": "actionConfiguration.formData.command.data",
-          "controlType": "DROP_DOWN",
-          "isRequired": true,
-          "initialValue": "GENERATE_CONTENT",
-          "options": [
+          "controlType": "DOUBLE_COLUMN_ZONE",
+          "identifier": "SELECTOR-Z1",
+          "children": [
             {
-              "label": "Generate Content",
-              "value": "GENERATE_CONTENT"
+              "label": "Command",
+              "description": "Choose the method you would like to use",
+              "configProperty": "actionConfiguration.formData.command.data",
+              "controlType": "DROP_DOWN",
+              "isRequired": true,
+              "initialValue": "GENERATE_CONTENT",
+              "options": [
+                {
+                  "label": "Generate Content",
+                  "value": "GENERATE_CONTENT"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Description

Action redesign: Updating the config for Google AI plugin to use sections and zones format

Fixes [#35493](https://github.com/appsmithorg/appsmith/issues/35493)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10700147940>
> Commit: dda8cee018765fc2827d3bfed214057dda73c692
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10700147940&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 04 Sep 2024 13:18:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced chat interface with improved control organization through the introduction of `DOUBLE_COLUMN_ZONE` and `SINGLE_COLUMN_ZONE`.
	- Upgraded section functionality with `SECTION_V2` for better usability and clarity.
	- More structured layout for dropdown controls, allowing for easier navigation and interaction.

- **Bug Fixes**
	- Resolved layout issues by restructuring child elements for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->