### PR TITLE
chore: Enable netty metrics based on env var

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -67,6 +67,9 @@ public class CommonConfig {
     @Value("${appsmith.micrometer.tracing.detail.enabled:false}")
     private boolean tracingDetail;
 
+    @Value("${appsmith.micrometer.metrics.detail.enabled:false}")
+    private boolean metricsDetail;
+
     private List<String> allowedDomains;
 
     private String mongoDBVersion;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ReactorNettyConfiguration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ReactorNettyConfiguration.java
@@ -1,15 +1,22 @@
 package com.appsmith.server.configurations;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.stereotype.Component;
 
 import java.util.function.Function;
 
+@RequiredArgsConstructor
 @Component
 public class ReactorNettyConfiguration implements WebServerFactoryCustomizer<NettyReactiveWebServerFactory> {
+
+    private final CommonConfig commonConfig;
+
     @Override
     public void customize(NettyReactiveWebServerFactory factory) {
-        factory.addServerCustomizers(httpServer -> httpServer.metrics(true, Function.identity()));
+        if (commonConfig.isTracingDetail()) {
+            factory.addServerCustomizers(httpServer -> httpServer.metrics(true, Function.identity()));
+        }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ReactorNettyConfiguration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ReactorNettyConfiguration.java
@@ -15,7 +15,7 @@ public class ReactorNettyConfiguration implements WebServerFactoryCustomizer<Net
 
     @Override
     public void customize(NettyReactiveWebServerFactory factory) {
-        if (commonConfig.isTracingDetail()) {
+        if (commonConfig.isMetricsDetail()) {
             factory.addServerCustomizers(httpServer -> httpServer.metrics(true, Function.identity()));
         }
     }

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -123,6 +123,7 @@ appsmith.newrelic.micrometer.metrics.application.name=${APPSMITH_NEWRELIC_MICROM
 spring.application.name=${OTEL_SERVICE_NAME:appsmith-anonymous}
 appsmith.micrometer.metrics.enabled=${APPSMITH_MICROMETER_METRICS_ENABLED:false}
 appsmith.micrometer.tracing.detail.enabled=${APPSMITH_ENABLE_TRACING_DETAIL:false}
+appsmith.micrometer.metrics.detail.enabled=${APPSMITH_ENABLE_METRICS_DETAIL:false}
 
 springdoc.api-docs.path=/v3/docs
 springdoc.swagger-ui.path=/v3/swagger


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 563db3aae9a6fae1b3e09fd072654fe849f36588 yet
> <hr>Wed, 04 Sep 2024 06:50:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for detailed metrics collection, enhancing monitoring capabilities.
	- Added a toggle in the application properties to enable or disable detailed metrics via an environment variable.

- **Improvements**
	- Enhanced configurability of server metrics reporting based on the new metrics detail setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->