### PR TITLE
fix: Remove Gsheets unauth method

### DIFF
--- a/app/client/cypress/e2e/GSheet/AllAccess_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/AllAccess_Spec.ts
@@ -15,7 +15,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-all";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet";
-describe(
+describe.skip(
   "GSheet-Functional Tests With All Access",
   { tags: ["@tag.Datasource", "@tag.GSheet"] },
   function () {

--- a/app/client/cypress/e2e/GSheet/GsheetMisc_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/GsheetMisc_Spec.ts
@@ -21,7 +21,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-all";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet";
-describe(
+describe.skip(
   "GSheet Miscellaneous Tests",
   { tags: ["@tag.Datasource", "@tag.GSheet"] },
   function () {

--- a/app/client/cypress/e2e/GSheet/ReadNWrite_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/ReadNWrite_Access_Spec.ts
@@ -11,7 +11,7 @@ import {
   appSettings,
 } from "../../support/Objects/ObjectsCore";
 
-describe(
+describe.skip(
   "GSheet-Functional Tests With Read/Write Access",
   { tags: ["@tag.Datasource", "@tag.GSheet"] },
   function () {

--- a/app/client/cypress/e2e/GSheet/ReadOnly_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/ReadOnly_Access_Spec.ts
@@ -11,7 +11,7 @@ import {
   appSettings,
 } from "../../support/Objects/ObjectsCore";
 
-describe(
+describe.skip(
   "GSheet-Functional Tests With Read Access",
   { tags: ["@tag.Datasource", "@tag.GSheet"] },
   function () {

--- a/app/client/cypress/e2e/GSheet/WidgetBinding_AllAccess_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/WidgetBinding_AllAccess_Spec.ts
@@ -21,7 +21,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-all";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet";
-describes.skip(
+describe.skip(
   "GSheet-widget binding",
   { tags: ["@tag.Datasource", "@tag.GSheet"] },
   function () {

--- a/app/client/cypress/e2e/GSheet/WidgetBinding_AllAccess_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/WidgetBinding_AllAccess_Spec.ts
@@ -21,7 +21,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-all";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet";
-describe(
+describes.skip(
   "GSheet-widget binding",
   { tags: ["@tag.Datasource", "@tag.GSheet"] },
   function () {

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/GoogleSheets_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/GoogleSheets_spec.ts
@@ -20,9 +20,11 @@ describe(
       dataSources.CreatePlugIn("Google Sheets");
       VerifyFunctionDropdown([
         "Read / Write / Delete | Selected google sheets",
-        "Read / Write / Delete | All google sheets",
-        "Read / Write | All google sheets",
-        "Read | All google sheets",
+        // Hiding below methods as they are not authorized at this state
+        
+        // "Read / Write / Delete | All google sheets",
+        // "Read / Write | All google sheets",
+        // "Read | All google sheets",
       ]);
       dataSources.SaveDSFromDialog(false);
     });

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/GoogleSheets_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/GoogleSheets_spec.ts
@@ -21,7 +21,6 @@ describe(
       VerifyFunctionDropdown([
         "Read / Write / Delete | Selected google sheets",
         // Hiding below methods as they are not authorized at this state
-        
         // "Read / Write / Delete | All google sheets",
         // "Read / Write | All google sheets",
         // "Read | All google sheets",

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/GoogleSheets_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/GoogleSheets_spec.ts
@@ -32,8 +32,6 @@ describe(
       agHelper.GetNClick(dataSources._gsScopeDropdown);
       cy.get(dataSources._gsScopeOptions).then(function ($ele) {
         expect($ele.eq(0).text()).to.be.oneOf(scopeOptions);
-        expect($ele.eq(1).text()).to.be.oneOf(scopeOptions);
-        expect($ele.eq(2).text()).to.be.oneOf(scopeOptions);
       });
       agHelper.GetNClick(dataSources._gsScopeDropdown);
     }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
@@ -38,18 +38,6 @@
             {
               "label": "Read / Write / Delete | Selected google sheets",
               "value": "https://www.googleapis.com/auth/drive.file"
-            },
-            {
-              "label": "Read / Write / Delete | All google sheets",
-              "value": "https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive"
-            },
-            {
-              "label": "Read / Write | All google sheets",
-              "value": "https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive.readonly"
-            },
-            {
-              "label": "Read | All google sheets",
-              "value": "https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/drive.readonly"
             }
           ],
           "initialValue": "https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive",


### PR DESCRIPTION
## Description

This PR temporarily removes the unauthorised Google Sheets method to ensure users are only shown methods that would work and avoid causing confusion. 
- The feature flag wasn't used here as the form JSON config's method field does not support hidden fields using feature flag and we avoided writing a logic specifically to remove the field from JSON before sending it as once the other methods get authorised again, we won't need the feature flag again

Fixes #35523

## Automation

/test gsheet

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10789501829>
> Commit: 040643a4d4ed4f2467a0af5733f4015a92d74e26
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10789501829&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.GSheet`
> Spec:
> <hr>Tue, 10 Sep 2024 09:37:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Simplified authorization options for Google Sheets integration, now limited to read and write access for selected sheets only.

- **Bug Fixes**
	- Updated integration tests to reflect the removal of outdated Google Sheets permission options, ensuring tests align with current authorization constraints.

- **Tests**
	- Temporarily skipped multiple test suites related to Google Sheets functionality to streamline testing and focus on relevant tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->