### PR TITLE
fix: disable loading button

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Button/src/Button.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Button/src/Button.tsx
@@ -63,7 +63,7 @@ const _Button = (props: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
       data-loading={isLoading ? "" : undefined}
       data-size={Boolean(size) ? size : undefined}
       data-variant={variant}
-      isDisabled={isDisabled}
+      isDisabled={isDisabled || isLoading}
       ref={ref}
       {...rest}
     >

--- a/app/client/packages/design-system/widgets/src/components/Button/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Button/src/styles.module.css
@@ -99,6 +99,9 @@
   */
   &[data-disabled] {
     cursor: not-allowed;
+  }
+
+  &[data-disabled]:not([data-loading]) {
     opacity: var(--opacity-disabled);
   }
 

--- a/app/client/packages/design-system/widgets/src/components/Button/tests/Button.test.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Button/tests/Button.test.tsx
@@ -32,6 +32,7 @@ describe("@appsmith/wds/Button", () => {
   it("sets data-loading attribute and icon based on loading prop", () => {
     render(<Button isLoading />);
     expect(screen.getByRole("button")).toHaveAttribute("data-loading");
+    expect(screen.getByRole("button")).toBeDisabled();
 
     // eslint-disable-next-line testing-library/no-node-access
     const icon = screen.getByRole("button").querySelector("[data-icon]");


### PR DESCRIPTION
## Description
set `disabled` attr is `isLoading` prop set to true

Fixes #36129

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10773619804>
> Commit: 5770ec2e7081f3e3d41888c18f1dbf57012270a5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10773619804&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 09 Sep 2024 14:05:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced button functionality to disable during loading states, improving user interaction and preventing errors.
	- Introduced distinct visual styles for disabled buttons, enhancing clarity on button states.

- **Bug Fixes**
	- Updated tests to ensure buttons are correctly disabled when in a loading state, improving test coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->