### PR TITLE
chore: Enable capturing metrics at higher freq

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
@@ -1,53 +1,20 @@
 package com.appsmith.server;
 
-import com.appsmith.server.annotations.ConditionalOnMicrometerMetricsEnabled;
 import com.appsmith.server.configurations.ProjectProperties;
-import io.micrometer.core.aop.TimedAspect;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.observation.aop.ObservedAspect;
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
-import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.metrics.Aggregation;
-import io.opentelemetry.sdk.metrics.InstrumentType;
-import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
-import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
-import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-import io.opentelemetry.sdk.resources.Resource;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
-
-import java.time.Duration;
 
 @SpringBootApplication
 @ComponentScan({"com.appsmith"})
 @EnableScheduling
 @Slf4j
 public class ServerApplication {
-    public static final String NEW_RELIC_MICROMETER_METRICS_ENDPOINT = "https://otlp.nr-data.net:4317";
-    public static final String API_KEY = "api-key";
-    public static final String SERVICE_NAME_KEY = "service.name";
-    public static final String INSTRUMENTATION_PROVIDER_KEY = "instrumentation.provider";
-    public static final String MICROMETER = "micrometer";
-    public static final int MICROMETER_COLLECTION_INTERVAL_SECONDS = 60;
 
     private final ProjectProperties projectProperties;
-
-    @Value("${appsmith.newrelic.micrometer.metrics.application.name}")
-    private String newRelicApplicationName;
-
-    @Value("${appsmith.newrelic.licensekey}")
-    private String newRelicKey;
 
     public ServerApplication(ProjectProperties projectProperties) {
         this.projectProperties = projectProperties;
@@ -64,56 +31,5 @@ public class ServerApplication {
         String version = projectProperties.getVersion();
         String commitId = projectProperties.getCommitSha();
         log.info("Application started with build version {}, and commitSha {}", version, commitId);
-    }
-
-    @Bean
-    @ConditionalOnMicrometerMetricsEnabled
-    public TimedAspect timedAspect(MeterRegistry registry) {
-        return new TimedAspect(registry);
-    }
-
-    @Bean
-    @ConditionalOnMicrometerMetricsEnabled
-    public MeterRegistry meterRegistry(OpenTelemetry openTelemetry) {
-        return OpenTelemetryMeterRegistry.builder(openTelemetry).build();
-    }
-
-    @Bean
-    @ConditionalOnMicrometerMetricsEnabled
-    public OpenTelemetry openTelemetry() {
-        return OpenTelemetrySdk.builder()
-                .setMeterProvider(SdkMeterProvider.builder()
-                        .setResource(Resource.getDefault().toBuilder()
-                                .put(SERVICE_NAME_KEY, newRelicApplicationName)
-                                // Include instrumentation.provider=micrometer to enable micrometer metrics
-                                // experience in New Relic
-                                .put(INSTRUMENTATION_PROVIDER_KEY, MICROMETER)
-                                .build())
-                        .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder()
-                                        .setEndpoint(NEW_RELIC_MICROMETER_METRICS_ENDPOINT)
-                                        .addHeader(API_KEY, newRelicKey)
-                                        // IMPORTANT: New Relic requires metrics to be delta temporality
-
-                                        .setAggregationTemporalitySelector(
-                                                AggregationTemporalitySelector.deltaPreferred())
-                                        // Use exponential histogram aggregation for histogram instruments
-                                        // to
-                                        // produce better data and compression
-                                        .setDefaultAggregationSelector(DefaultAggregationSelector.getDefault()
-                                                .with(
-                                                        InstrumentType.HISTOGRAM,
-                                                        Aggregation.base2ExponentialBucketHistogram()))
-                                        .build())
-                                // Match default micrometer collection interval of 60 seconds
-                                .setInterval(Duration.ofSeconds(MICROMETER_COLLECTION_INTERVAL_SECONDS))
-                                .build())
-                        .build())
-                .build();
-    }
-
-    @Bean
-    @ConditionalOnExpression("${logging.verbose.enabled}")
-    ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
-        return new ObservedAspect(observationRegistry);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -70,6 +70,9 @@ public class CommonConfig {
     @Value("${appsmith.micrometer.metrics.detail.enabled:false}")
     private boolean metricsDetail;
 
+    @Value("${appsmith.micrometer.metrics.interval.millis:60000}")
+    private int metricsIntervalMillis;
+
     private List<String> allowedDomains;
 
     private String mongoDBVersion;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
@@ -33,6 +33,7 @@ public class MetricsConfig {
 
     public static final String NEW_RELIC_MICROMETER_METRICS_ENDPOINT = "https://otlp.nr-data.net:4317";
     public static final String API_KEY = "api-key";
+    public static final String CONTAINER_NAME_KEY = "container.name";
     public static final String SERVICE_NAME_KEY = "service.name";
     public static final String INSTRUMENTATION_PROVIDER_KEY = "instrumentation.provider";
     public static final String MICROMETER = "micrometer";
@@ -77,7 +78,7 @@ public class MetricsConfig {
                                 // Include instrumentation.provider=micrometer to enable micrometer metrics
                                 // experience in New Relic
                                 .put(INSTRUMENTATION_PROVIDER_KEY, MICROMETER)
-                                .put("container.name", newRelicContainerName)
+                                .put(CONTAINER_NAME_KEY, newRelicContainerName)
                                 .build())
                         .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder()
                                         .setEndpoint(NEW_RELIC_MICROMETER_METRICS_ENDPOINT)
@@ -87,8 +88,7 @@ public class MetricsConfig {
                                         .setAggregationTemporalitySelector(
                                                 AggregationTemporalitySelector.deltaPreferred())
                                         // Use exponential histogram aggregation for histogram instruments
-                                        // to
-                                        // produce better data and compression
+                                        // to produce better data and compression
                                         .setDefaultAggregationSelector(DefaultAggregationSelector.getDefault()
                                                 .with(
                                                         InstrumentType.HISTOGRAM,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
@@ -33,6 +33,8 @@ public class MetricsConfig {
 
     public static final String NEW_RELIC_MICROMETER_METRICS_ENDPOINT = "https://otlp.nr-data.net:4317";
     public static final String API_KEY = "api-key";
+    public static final String CONTAINER_NAME_KEY = "container.name";
+
     public static final String SERVICE_NAME_KEY = "service.name";
     public static final String INSTRUMENTATION_PROVIDER_KEY = "instrumentation.provider";
     public static final String MICROMETER = "micrometer";
@@ -70,7 +72,7 @@ public class MetricsConfig {
                                 // Include instrumentation.provider=micrometer to enable micrometer metrics
                                 // experience in New Relic
                                 .put(INSTRUMENTATION_PROVIDER_KEY, MICROMETER)
-                                .put("container.name", newRelicContainerName)
+                                .put(CONTAINER_NAME_KEY, newRelicContainerName)
                                 .build())
                         .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder()
                                         .setEndpoint(NEW_RELIC_MICROMETER_METRICS_ENDPOINT)
@@ -80,8 +82,7 @@ public class MetricsConfig {
                                         .setAggregationTemporalitySelector(
                                                 AggregationTemporalitySelector.deltaPreferred())
                                         // Use exponential histogram aggregation for histogram instruments
-                                        // to
-                                        // produce better data and compression
+                                        // to produce better data and compression
                                         .setDefaultAggregationSelector(DefaultAggregationSelector.getDefault()
                                                 .with(
                                                         InstrumentType.HISTOGRAM,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
@@ -1,0 +1,109 @@
+package com.appsmith.server.configurations;
+
+import com.appsmith.server.annotations.ConditionalOnMicrometerMetricsEnabled;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservedAspect;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * This configuration file configures beans as required by NewRelic
+ */
+@RequiredArgsConstructor
+@Configuration
+public class MetricsConfig {
+
+    public static final String NEW_RELIC_MICROMETER_METRICS_ENDPOINT = "https://otlp.nr-data.net:4317";
+    public static final String API_KEY = "api-key";
+    public static final String SERVICE_NAME_KEY = "service.name";
+    public static final String INSTRUMENTATION_PROVIDER_KEY = "instrumentation.provider";
+    public static final String MICROMETER = "micrometer";
+
+    @Value("${appsmith.newrelic.micrometer.metrics.application.name}")
+    private String newRelicApplicationName;
+
+    @Value("${appsmith.newrelic.licensekey}")
+    private String newRelicKey;
+
+    @Value("${appsmith.newrelic.micrometer.metrics.container.name}")
+    private String newRelicContainerName;
+
+    private final CommonConfig commonConfig;
+
+    private int getMetricsInterval() {
+        if (commonConfig.isMetricsDetail()) {
+            return 1;
+        }
+        return 60;
+    }
+
+    @Bean
+    @ConditionalOnMicrometerMetricsEnabled
+    public TimedAspect timedAspect(MeterRegistry registry) {
+        return new TimedAspect(registry);
+    }
+
+    @Bean
+    @ConditionalOnMicrometerMetricsEnabled
+    public MeterRegistry meterRegistry(OpenTelemetry openTelemetry) {
+        return OpenTelemetryMeterRegistry.builder(openTelemetry).build();
+    }
+
+    @Bean
+    @ConditionalOnMicrometerMetricsEnabled
+    public OpenTelemetry openTelemetry() {
+        return OpenTelemetrySdk.builder()
+                .setMeterProvider(SdkMeterProvider.builder()
+                        .setResource(Resource.getDefault().toBuilder()
+                                .put(SERVICE_NAME_KEY, newRelicApplicationName)
+                                // Include instrumentation.provider=micrometer to enable micrometer metrics
+                                // experience in New Relic
+                                .put(INSTRUMENTATION_PROVIDER_KEY, MICROMETER)
+                                .put("container.name", newRelicContainerName)
+                                .build())
+                        .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder()
+                                        .setEndpoint(NEW_RELIC_MICROMETER_METRICS_ENDPOINT)
+                                        .addHeader(API_KEY, newRelicKey)
+                                        // IMPORTANT: New Relic requires metrics to be delta temporality
+
+                                        .setAggregationTemporalitySelector(
+                                                AggregationTemporalitySelector.deltaPreferred())
+                                        // Use exponential histogram aggregation for histogram instruments
+                                        // to
+                                        // produce better data and compression
+                                        .setDefaultAggregationSelector(DefaultAggregationSelector.getDefault()
+                                                .with(
+                                                        InstrumentType.HISTOGRAM,
+                                                        Aggregation.base2ExponentialBucketHistogram()))
+                                        .build())
+                                // Match default micrometer collection interval of 60 seconds
+                                .setInterval(Duration.ofSeconds(getMetricsInterval()))
+                                .build())
+                        .build())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnExpression("${logging.verbose.enabled}")
+    ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
+        return new ObservedAspect(observationRegistry);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MetricsConfig.java
@@ -64,34 +64,34 @@ public class MetricsConfig {
     @ConditionalOnMicrometerMetricsEnabled
     public OpenTelemetry openTelemetry() {
         return OpenTelemetrySdk.builder()
-            .setMeterProvider(SdkMeterProvider.builder()
-                .setResource(Resource.getDefault().toBuilder()
-                    .put(SERVICE_NAME_KEY, newRelicApplicationName)
-                    // Include instrumentation.provider=micrometer to enable micrometer metrics
-                    // experience in New Relic
-                    .put(INSTRUMENTATION_PROVIDER_KEY, MICROMETER)
-                    .put("container.name", newRelicContainerName)
-                    .build())
-                .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder()
-                        .setEndpoint(NEW_RELIC_MICROMETER_METRICS_ENDPOINT)
-                        .addHeader(API_KEY, newRelicKey)
-                        // IMPORTANT: New Relic requires metrics to be delta temporality
+                .setMeterProvider(SdkMeterProvider.builder()
+                        .setResource(Resource.getDefault().toBuilder()
+                                .put(SERVICE_NAME_KEY, newRelicApplicationName)
+                                // Include instrumentation.provider=micrometer to enable micrometer metrics
+                                // experience in New Relic
+                                .put(INSTRUMENTATION_PROVIDER_KEY, MICROMETER)
+                                .put("container.name", newRelicContainerName)
+                                .build())
+                        .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder()
+                                        .setEndpoint(NEW_RELIC_MICROMETER_METRICS_ENDPOINT)
+                                        .addHeader(API_KEY, newRelicKey)
+                                        // IMPORTANT: New Relic requires metrics to be delta temporality
 
-                        .setAggregationTemporalitySelector(
-                            AggregationTemporalitySelector.deltaPreferred())
-                        // Use exponential histogram aggregation for histogram instruments
-                        // to
-                        // produce better data and compression
-                        .setDefaultAggregationSelector(DefaultAggregationSelector.getDefault()
-                            .with(
-                                InstrumentType.HISTOGRAM,
-                                Aggregation.base2ExponentialBucketHistogram()))
+                                        .setAggregationTemporalitySelector(
+                                                AggregationTemporalitySelector.deltaPreferred())
+                                        // Use exponential histogram aggregation for histogram instruments
+                                        // to
+                                        // produce better data and compression
+                                        .setDefaultAggregationSelector(DefaultAggregationSelector.getDefault()
+                                                .with(
+                                                        InstrumentType.HISTOGRAM,
+                                                        Aggregation.base2ExponentialBucketHistogram()))
+                                        .build())
+                                // Match default micrometer collection interval of 60 seconds
+                                .setInterval(Duration.ofMillis(commonConfig.getMetricsIntervalMillis()))
+                                .build())
                         .build())
-                    // Match default micrometer collection interval of 60 seconds
-                    .setInterval(Duration.ofMillis(commonConfig.getMetricsIntervalMillis()))
-                    .build())
-                .build())
-            .build();
+                .build();
     }
 
     @Bean

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -119,6 +119,7 @@ appsmith.index.lock.file.time=${APPSMITH_INDEX_LOCK_FILE_TIME:300}
 
 # NewRelic and Micrometer related configs
 appsmith.newrelic.licensekey=${APPSMITH_NEW_RELIC_OTLP_LICENSE_KEY:}
+appsmith.newrelic.micrometer.metrics.container.name=${NEW_RELIC_METADATA_KUBERNETES_POD_NAME:appsmith-0}
 appsmith.newrelic.micrometer.metrics.application.name=${APPSMITH_NEWRELIC_MICROMETER_SERVICE_NAME:}
 spring.application.name=${OTEL_SERVICE_NAME:appsmith-anonymous}
 appsmith.micrometer.metrics.enabled=${APPSMITH_MICROMETER_METRICS_ENABLED:false}

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -125,6 +125,7 @@ spring.application.name=${OTEL_SERVICE_NAME:appsmith-anonymous}
 appsmith.micrometer.metrics.enabled=${APPSMITH_MICROMETER_METRICS_ENABLED:false}
 appsmith.micrometer.tracing.detail.enabled=${APPSMITH_ENABLE_TRACING_DETAIL:false}
 appsmith.micrometer.metrics.detail.enabled=${APPSMITH_ENABLE_METRICS_DETAIL:false}
+appsmith.micrometer.metrics.interval.millis=${APPSMITH_METRICS_INTERVAL_MILLIS:60000}
 
 springdoc.api-docs.path=/v3/docs
 springdoc.swagger-ui.path=/v3/swagger


### PR DESCRIPTION
## Description
Make it so that metrics are controlled by environment variables to be higher in number, and distinguished by origin container name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new configuration class for metrics collection, enhancing integration with New Relic.
	- Added support for specifying the Kubernetes pod name in the application properties for better instance identification.
	- Added a new configuration property to specify the interval for metrics collection.

- **Bug Fixes**
	- Removed deprecated metrics-related components and constants to streamline monitoring functionality.

- **Refactor**
	- Significant refactoring of monitoring capabilities, removing dependencies on Micrometer and OpenTelemetry.

- **Documentation**
	- Updated application properties to include new configuration options for New Relic metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 0bc82c5fa8e95ec0d0224ca80bf7dad37879a44a yet
> <hr>Thu, 05 Sep 2024 13:59:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->
