### PR TITLE
test: remove redundant select workspace in cypres test

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Workspace/MemberRoles_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Workspace/MemberRoles_Spec.ts
@@ -202,7 +202,6 @@ describe(
       );
       if (CURRENT_REPO === REPO.EE)
         _.adminSettings.EnableGAC(false, true, "home");
-      _.homePage.SelectWorkspace(workspaceId);
       _.homePage.LeaveWorkspace(workspaceId);
     });
   },

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+#cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Workspace/MemberRoles_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,6 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-#cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
-cypress/e2e/Regression/ClientSide/Workspace/MemberRoles_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description

The spec MemberRoles started failing on PG branch(both ce and ee) recently. In this spec the last step, which asserts the user with view permission leaving workspace was failing. `the _.homePage.LeaveWorkspace(workspaceId);` internally calls for `_.homePage.SelectWorkspace(workspaceId);`

## Automation

/ok-to-test tags="@tag.Workspace"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10736154328>
> Commit: c9203b7da718cd2b718cf0fc990c4e4375cf5435
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10736154328&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Workspace`
> Spec:
> <hr>Fri, 06 Sep 2024 10:04:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the test flow for workspace member roles to ensure accurate simulation of user behavior when leaving a workspace.
  
- **Chores**
	- Modified the limited tests configuration to focus on member roles, removing the previous test for template for improved testing relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->