### PR TITLE
fix: hide datepicker clear button when date cell set to required

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -400,7 +400,7 @@ class DatePickerComponent extends React.Component<
                 ...this.getConditionalPopoverProps(this.props),
               }}
               shortcuts={this.props.shortcuts}
-              showActionsBar
+              showActionsBar={this.props.showActionsBar}
               timePrecision={
                 this.props.timePrecision === TimePrecision.NONE
                   ? undefined
@@ -522,6 +522,7 @@ interface DatePickerComponentProps extends ComponentProps {
   isPopoverOpen?: boolean;
   onDateOutOfRange?: () => void;
   isRequired?: boolean;
+  showActionsBar?: boolean;
 }
 
 interface DatePickerComponentState {

--- a/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
@@ -702,6 +702,7 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
         onFocus={this.onFocus}
         selectedDate={this.props.value}
         shortcuts={this.props.shortcuts}
+        showActionsBar={!this.props.isRequired}
         timePrecision={this.props.timePrecision}
         widgetId={this.props.widgetId}
       />


### PR DESCRIPTION
## Description
**Issue**: When the date cell is set to required, the date picker shouldn't show the clear button

In this PR , I have integrated the **showActionBar** prop into the **DatePickerComponent** and toggle its value based on the required property. This approach ensures that the "Clear" button is hidden when the date field is marked as required, preventing users from clearing a mandatory date field.

**Previously Date picker behaviour**
[Screencast from 03-09-24 12:42:48 PM IST.webm](https://github.com/user-attachments/assets/bb8e9669-3ff6-4f7b-ab7f-98090bdfd59b)

**currently Date picket behaviour**
[Screencast from 03-09-24 12:45:48 PM IST.webm](https://github.com/user-attachments/assets/fff5493b-64e0-48f0-8eca-0c068c6fb0bb)

Fixes
 #35793 

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable `showActionsBar` property in the DatePicker component, enhancing flexibility in user interactions.
	- The visibility of the actions bar is now conditionally based on whether the date picker is marked as required, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->