### PR TITLE
fix: Colorpicker empty color value regression

### DIFF
--- a/app/client/src/components/propertyControls/ColorPickerComponentV2.tsx
+++ b/app/client/src/components/propertyControls/ColorPickerComponentV2.tsx
@@ -546,9 +546,7 @@ const ColorPickerComponent = React.forwardRef(
 
     const handleChangeColor = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
-        const value = event.target.value;
-
-        if (!value) return;
+        const value = event.target.value || "";
 
         if (isValidColor(value)) {
           debouncedOnChange(value, true);


### PR DESCRIPTION
/ok-to-test tags="@tag.All"

This PR fixes a regression that was added by #36119

<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10736250400>
> Commit: 11ba202fd998ef3b403ca95ed6da0e1d1afe958f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10736250400&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/OnLoadTests/ExecuteAction_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Fri, 06 Sep 2024 11:05:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved color input handling to ensure that empty values are processed correctly, enhancing color validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->