### PR TITLE
fix: Video2 spec flaky fix

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Video/Video2_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Video/Video2_Spec.ts
@@ -49,34 +49,7 @@ describe(
       agHelper.AssertProperty(widgetLocators.video, "ended", true);
     });
 
-    it("2. Verify Basic Functionality of Video Widget - muted", function () {
-      deployMode.NavigateBacktoEditor();
-      EditorNavigation.SelectEntityByName("Video1", EntityType.Widget);
-      //Validate video for youtube url
-      propPane.TypeTextIntoField("URL", testdata.videoUrl);
-      deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.VIDEO));
-      agHelper.GetNClick(locators._widgetInDeployed(draggableWidgets.VIDEO));
-      agHelper.Sleep(2000);
-      agHelper.GetElement(widgetLocators.iFrame).then(($iframe) => {
-        const doc = $iframe.contents();
-        const video = doc.find(widgetLocators.video);
-        //Check play, mute & unmute, volume buttons
-        cy.wrap(
-          doc.find(widgetLocators.videoWidgetYoutubeLargePlayBtn),
-        ).click();
-        cy.wrap(video).click();
-        agHelper.Sleep(1000);
-        cy.wrap(doc.find(widgetLocators.videoWidgetYoutubeMuteBtn)).click();
-        agHelper.AssertProperty(video, "muted", true);
-        agHelper.AssertProperty(video, "paused", true);
-        cy.wrap(doc.find(widgetLocators.videoWidgetYoutubeVolumeBtn)).type(
-          "{rightarrow}{rightarrow}",
-        );
-        agHelper.AssertProperty(video, "muted", false);
-      });
-    });
-
-    it("3. Verify widget for invalid URL's", function () {
+    it("2. Verify widget for invalid URL's", function () {
       deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("Video1", EntityType.Widget);
       propPane.RemoveText("URL");
@@ -107,7 +80,7 @@ describe(
       });
     });
 
-    it("4. Verify auto play property", function () {
+    it("3. Verify auto play property", function () {
       deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("Video1", EntityType.Widget);
       agHelper.AssertExistingToggleState("Autoplay", "false");
@@ -128,7 +101,7 @@ describe(
       agHelper.AssertProperty(widgetLocators.video, "paused", true);
     });
 
-    it("5. Verify visible property", function () {
+    it("4. Verify visible property", function () {
       deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("Video1", EntityType.Widget);
       agHelper.AssertExistingToggleState("Visible", "true");
@@ -154,7 +127,7 @@ describe(
       );
     });
 
-    it("6. Verify OnPlay, OnPause, OnEnd events are JS convertible", function () {
+    it("5. Verify OnPlay, OnPause, OnEnd events are JS convertible", function () {
       deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("Video1", EntityType.Widget);
       propPane.EnterJSContext(
@@ -193,7 +166,7 @@ describe(
       });
     });
 
-    it("7. Verify video styles", function () {
+    it("6. Verify video styles", function () {
       deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("Video1", EntityType.Widget);
       propPane.MoveToTab("Style");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/Video/Video2_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/Video/Video2_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
RCA: We are using youtube url for `Verify Basic Functionality of Video Widget - muted`. Which leads to flakiness. Also this case needs a human intervention to fulfilled the actual user case.

Solution: Deleted this test as it can be part of manual testing.

Fixes #`36164`  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10766784105>
> Commit: 11d8d952f5e24cc49056532b15da190eefe8ba41
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10766784105&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 09 Sep 2024 05:41:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed a test case for the muted functionality of the Video Widget, streamlining the test suite.
  
- **Chores**
	- Updated the test path in the limited-tests file to prioritize video widget testing over template testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->