### PR TITLE
Move Expires-in in Oauth2 and make Second open source contribution

### DIFF
--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/resources/form.json
@@ -119,6 +119,29 @@
           }
         },
         {
+          "label": "Scope(s)",
+          "configProperty": "datasourceConfiguration.authentication.scopeString",
+          "controlType": "INPUT_TEXT",
+          "placeholderText": "e.g. read, write",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Expires In",
+          "configProperty": "datasourceConfiguration.authentication.expiresIn",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
           "label": "Grant type",
           "configProperty": "datasourceConfiguration.authentication.grantType",
           "controlType": "DROP_DOWN",
@@ -213,18 +236,7 @@
             "value": "oAuth2"
           }
         },
-        {
-          "label": "Scope(s)",
-          "configProperty": "datasourceConfiguration.authentication.scopeString",
-          "controlType": "INPUT_TEXT",
-          "placeholderText": "e.g. read, write",
-          "isRequired": false,
-          "hidden": {
-            "path": "datasourceConfiguration.authentication.authenticationType",
-            "comparison": "NOT_EQUALS",
-            "value": "oAuth2"
-          }
-        },
+
         {
           "label": "Authorization URL",
           "configProperty": "datasourceConfiguration.authentication.authorizationUrl",


### PR DESCRIPTION
**Title: ** feat: Enhance Authentication Settings with Optional Fields for Scope and Expiration

**Description: **
This PR addresses the issue of making the "Expires-in" part of the form file and solving the related problem. The following changes have been made:

1. **New Features: **
   - Introduced new optional configuration options for authentication settings in the GraphQL plugin, enhancing flexibility for non-oAuth2 authentication types.
   - Added fields for "Scope(s)" and "Expires In" to allow users to specify scopes and token expiration duration.

2. **Changes: **
   - Restructured the presentation of the "Scope(s)" field in the configuration to improve usability and clarity.

**Fixes: ** #31059

**Implementation Details: **
- **Updated Form File: **
  - Added the "Expires In" field to the form file to allow users to set the token expiration duration.
  - Ensured that the "Scope(s)" and "Expires In" fields are hidden when the authentication type is set to "oAuth2".

- **Code Adjustments: **
  - Modified the relevant components to handle the new fields and their conditions.
  - Updated the logic to ensure the fields are displayed or hidden based on the selected authentication type.

**Testing: **
- Verified that the new fields appear correctly in the form when applicable.
- Ensured that the "Scope(s)" and "Expires In" fields are hidden when "oAuth2" is selected.
- Tested the functionality to confirm that the new fields work as expected and do not introduce any regressions.

**Screenshots: **
![image](https://github.com/user-attachments/assets/9f265cfd-10b2-4e97-8683-358b9e4e3365)


