### PR TITLE
fix: Fixed flaky fork template test case

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Templates/Fork_Template_To_App_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Templates/Fork_Template_To_App_spec.ts
@@ -15,17 +15,14 @@ describe(
     it("1. Fork a template to the current app + Bug 17477", () => {
       PageList.AddNewPage("Add page from template");
       agHelper.AssertElementVisibility(template.templateDialogBox);
-      agHelper.GetNClick("//h1[text()='Applicant Tracker-test']");
+      agHelper.GetNClick(template.templateCard, 0, true);
       agHelper.FailIfErrorToast("INTERNAL_SERVER_ERROR");
       agHelper.GetNClick(template.templateViewForkButton);
       agHelper.WaitUntilToastDisappear("template added successfully");
       assertHelper.AssertNetworkStatus("updateLayout");
-      // [Bug]: Getting 'Resource not found' error on deploying template #17477
+      PageList.AddNewPage("Generate page with data");
       deployMode.DeployApp();
-      agHelper.GetNClickByContains(
-        ".t--page-switch-tab",
-        "1 Track Applications",
-      );
+      agHelper.GetNClick(locators._deployedPage, 0, true);
       deployMode.NavigateBacktoEditor();
       homePage.NavigateToHome();
       agHelper.WaitUntilAllToastsDisappear();
@@ -35,14 +32,13 @@ describe(
       homePage.CreateNewApplication();
       PageList.AddNewPage("Add page from template");
       agHelper.AssertElementVisibility(template.templateDialogBox);
-      agHelper.GetNClick("//h1[text()='Applicant Tracker-test']");
+      agHelper.GetNClick(template.templateCard, 0, true);
       agHelper.FailIfErrorToast(
         "Internal server error while processing request",
       );
       assertHelper.AssertNetworkStatus("getTemplatePages");
       agHelper.CheckUncheck(template.selectAllPages, false);
       agHelper.GetNClick(template.selectCheckbox, 1);
-      // [Bug]: On forking selected pages from a template, resource not found error is shown #17270
       agHelper.GetNClick(template.templateViewForkButton);
       agHelper.AssertElementAbsence(
         locators._visibleTextSpan("Setting up the template"),

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_To_App_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_To_App_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
Root Cause Analysis (RCA):
The issue stemmed from the use of hardcoded templates in our tests, which introduced inherent flakiness. This approach caused intermittent failures, particularly when the hardcoded template was not available or had changed.

Solution:
I have resolved this by implementing dynamic locators that select the first available template during the test execution. This ensures greater stability and reduces flakiness. The only scenario where this approach could fail is if no templates are available, which would be a product-level blocker rather than a test issue.


Fixes #`36199`  

## Automation

/ok-to-test tags="@tag.Templates"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10775279036>
> Commit: be8fc879c21fa90b7083e52d4cde52439f8f5546
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10775279036&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Templates`
> Spec:
> <hr>Mon, 09 Sep 2024 14:51:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of the template forking test by updating element selectors and streamlining navigation steps.
	- Enhanced test coverage by adding a step for generating a page with data.

- **Chores**
	- Renamed test specification file to better reflect its focus on application-level testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->