### PR TITLE
chore: Make sure each container / pod has its own stdout log files

### DIFF
--- a/deploy/docker/fs/etc/supervisor/supervisord.conf
+++ b/deploy/docker/fs/etc/supervisor/supervisord.conf
@@ -39,3 +39,5 @@ command = python3 -m supervisor.appsmith_supervisor_stdout
 buffer_size = 10000
 events = PROCESS_LOG
 result_handler = supervisor.appsmith_supervisor_stdout:event_handler
+stdout_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/access-supervisor-%(ENV_HOSTNAME)s.log
+stderr_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/error-supervisor-%(ENV_HOSTNAME)s.log

--- a/deploy/docker/fs/etc/supervisor/supervisord.conf
+++ b/deploy/docker/fs/etc/supervisor/supervisord.conf
@@ -40,4 +40,7 @@ buffer_size = 10000
 events = PROCESS_LOG
 result_handler = supervisor.appsmith_supervisor_stdout:event_handler
 stdout_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/access-supervisor-%(ENV_HOSTNAME)s.log
-stderr_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/error-supervisor-%(ENV_HOSTNAME)s.log
+stderr_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/error-supervisor-%(ENV_HOSTNAME)s.logstdout_logfile_maxbytes=10MB
+stderr_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stderr_logfile_backups=10

--- a/deploy/docker/fs/etc/supervisor/supervisord.conf
+++ b/deploy/docker/fs/etc/supervisor/supervisord.conf
@@ -40,7 +40,8 @@ buffer_size = 10000
 events = PROCESS_LOG
 result_handler = supervisor.appsmith_supervisor_stdout:event_handler
 stdout_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/access-supervisor-%(ENV_HOSTNAME)s.log
-stderr_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/error-supervisor-%(ENV_HOSTNAME)s.logstdout_logfile_maxbytes=10MB
+stderr_logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/error-supervisor-%(ENV_HOSTNAME)s.log
+stdout_logfile_maxbytes=10MB
 stderr_logfile_maxbytes=10MB
 stdout_logfile_backups=10
 stderr_logfile_backups=10


### PR DESCRIPTION
## Description
Log files from stdout, when undefined were defaulting to the supervisord child dir random fd paths. These files got deleted on supervisor process restarts, which meant that successive rollouts would always end up with stale file handles. We're now providing a deterministic path for these logs as well, rolled over and backed up similar to other files.

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 5f990084b6866392c79e237753048dd1a6e984df yet
> <hr>Mon, 09 Sep 2024 16:07:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities for better monitoring and management of log files.
	- Introduced dynamic paths for log files based on environment variables.
	- Added log file size management and backup retention settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->