### PR TITLE
fix: updateWithoutPermission updates user instead of saving it

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.services.ce;
 
-import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.external.helpers.EncryptionHelper;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.configurations.CommonConfig;
@@ -576,8 +575,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
             userUpdate.setPassword(passwordEncoder.encode(userUpdate.getPassword()));
         }
 
-        AppsmithBeanUtils.copyNewFieldValuesIntoOldObject(userUpdate, existingUser);
-        return repository.save(existingUser);
+        return repository.updateById(existingUser.getId(), userUpdate, null);
     }
 
     private boolean validateName(String name) {
@@ -603,6 +601,8 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                 return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.NAME));
             }
             updates.setName(inputName);
+            // Set policies to null to avoid overriding them.
+            updates.setPolicies(null);
             updatedUserMono = sessionUserService
                     .getCurrentUser()
                     .flatMap(user -> updateWithoutPermission(user.getId(), updates)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -39,6 +39,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.DirtiesContext;
@@ -747,5 +750,39 @@ public class UserServiceTest {
                     assertEquals("New use case", userData.getUseCase());
                 })
                 .verifyComplete();
+    }
+
+    private <I> Mono<I> runAs(Mono<I> input, User user, String password) {
+        log.info("Running as user: {}", user.getEmail());
+        return input.contextWrite((ctx) -> {
+            SecurityContext securityContext = new SecurityContextImpl(
+                    new UsernamePasswordAuthenticationToken(user, password, user.getAuthorities()));
+            return ctx.put(SecurityContext.class, Mono.just(securityContext));
+        });
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testUpdateName_shouldNotUpdatePolicies() {
+        String testName = "testUpdateName_shouldNotUpdatePolicies";
+        User user = new User();
+        user.setEmail(testName + "@test.com");
+        user.setPassword(testName);
+        User createdUser = userService.create(user).block();
+        Set<Policy> policies = createdUser.getPolicies();
+
+        assertThat(createdUser.getName()).isNull();
+        assertThat(createdUser.getPolicies()).isNotEmpty();
+
+        UserUpdateDTO updateUser = new UserUpdateDTO();
+        updateUser.setName("Test Name");
+
+        User userUpdatedPostNameUpdate = runAs(userService.updateCurrentUser(updateUser, null), createdUser, testName)
+                .block();
+
+        assertThat(userUpdatedPostNameUpdate.getName()).isEqualTo("Test Name");
+        userUpdatedPostNameUpdate.getPolicies().forEach(policy -> {
+            assertThat(policies).contains(policy);
+        });
     }
 }


### PR DESCRIPTION
## Description
> UserService$updateWithoutPermission will now update the user instead of saving it.

Fixes https://github.com/appsmithorg/appsmith/issues/36063

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10786655302>
> Commit: 0eb7f18762d51529822907df7e5f3f6129e3286f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10786655302&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 10 Sep 2024 06:20:46 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced user update functionality for more efficient processing.
	- Added a mechanism to ensure user policies remain unchanged during updates.

- **Bug Fixes**
	- Implemented tests to verify that user name updates do not affect associated policies.

- **Tests**
	- Introduced new test methods to validate user update scenarios within the correct security context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->