### PR TITLE
fix: bug when editing a row the selected row doesn't change UI accordingly

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_4_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_4_spec.js
@@ -1,0 +1,24 @@
+import { agHelper, table } from "../../../../../support/Objects/ObjectsCore";
+
+describe(
+  "Table widget inline editing functionality",
+  { tags: ["@tag.Widget", "@tag.Table"] },
+  () => {
+    afterEach(() => {
+      agHelper.SaveLocalStorageCache();
+    });
+
+    beforeEach(() => {
+      agHelper.RestoreLocalStorageCache();
+      agHelper.AddDsl("Table/InlineEditingDSL");
+    });
+
+    it("1. When editing a row, the selected row should change the UI accordingly ", () => {
+      cy.openPropertyPane("tablewidgetv2");
+      table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
+      cy.editColumn("EditActions1");
+      cy.editTableCell(0, 1);
+      cy.enterTableCellValue(0, 1, "NewValue");
+    });
+  },
+);

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -2600,6 +2600,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
         ...this.props.columnEditableCellValue,
         [alias]: value,
       });
+      pushBatchMetaUpdates("selectedRowIndex", rowIndex);
 
       /*
        * We need to clear the selectedRowIndex and selectedRowIndices


### PR DESCRIPTION
## Description:

When a column is editable, you can select a row and then click edit icon of another row, but selected row does not change.
Expected: the new current editing row has to shown as selected row both programatically and in the UI.

> I have raised this PR to fix the `Bug when editing a row the selected row doesnt change accordingly`

## [Issue Link](https://github.com/appsmithorg/appsmith/issues/35792)

## Screenshots:
### Before resoving bug:
![image](https://github.com/user-attachments/assets/c455dcde-20a0-4aa8-9073-30eb613fad5a)

### After resoving bug:
![image](https://github.com/user-attachments/assets/b9f628ba-2f88-47af-840d-b9316c53af6f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automated tests for the inline editing functionality of the table widget, ensuring a reliable user experience.
	- Enhanced state management for the table widget to consistently track the selected row index during edits, improving interactivity.

- **Bug Fixes**
	- Improved UI responsiveness when editing table rows, ensuring that changes reflect accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->