### PR TITLE
chore: add uuid supported path

### DIFF
--- a/app/client/src/ce/pages/Editor/Explorer/helpers.tsx
+++ b/app/client/src/ce/pages/Editor/Explorer/helpers.tsx
@@ -7,7 +7,9 @@ import {
   DATA_SOURCES_EDITOR_ID_PATH,
   matchBuilderPath,
   matchViewerPath,
-  BUILDER_VIEWER_PATH_PREFIX,
+  VIEWER_PATH,
+  VIEWER_CUSTOM_PATH,
+  VIEWER_PATH_DEPRECATED,
 } from "constants/routes";
 
 import {
@@ -80,11 +82,7 @@ export const getActionIdFromURL = () => {
 };
 
 export function getAppViewerPageIdFromPath(path: string): string | null {
-  const regexes = [
-    `${BUILDER_VIEWER_PATH_PREFIX}:applicationSlug/:pageSlug(.*\\-):basePageId`, // VIEWER_PATH
-    `${BUILDER_VIEWER_PATH_PREFIX}:customSlug(.*\\-):basePageId`, // VIEWER_CUSTOM_PATH
-    `/applications/:baseApplicationId/pages/:basePageId`, // VIEWER_PATH_DEPRECATED
-  ];
+  const regexes = [VIEWER_PATH, VIEWER_CUSTOM_PATH, VIEWER_PATH_DEPRECATED];
   for (const regex of regexes) {
     const match = matchPath<{ basePageId: string }>(path, { path: regex });
     if (match?.params.basePageId) {


### PR DESCRIPTION
## Description
Use the path variable from routes that supports both mongo object ids and UUIDs of pg. 


Fixes 
## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10787501214>
> Commit: 66cf4fc1ff353111b1557f0967bb9cb0fe1fbbce
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10787501214&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 10 Sep 2024 08:19:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new constants for viewer paths to enhance clarity in path matching.
- **Refactor**
	- Simplified logic for extracting base page IDs by replacing the old constant with more descriptive ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->