### PR TITLE
fix: added the method to sort the workspace after fetching them.

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/WorkspaceControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/WorkspaceControllerCE.java
@@ -110,7 +110,7 @@ public class WorkspaceControllerCE {
     @GetMapping("/home")
     public Mono<ResponseDTO<List<Workspace>>> workspacesForHome() {
         return userWorkspaceService
-                .getUserWorkspacesByRecentlyUsedOrder()
+                .getUserWorkspaceInAlphabeticalOrder()
                 .map(workspaces -> new ResponseDTO<>(HttpStatus.OK.value(), workspaces, null));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCE.java
@@ -25,4 +25,6 @@ public interface UserWorkspaceServiceCE {
     Boolean isLastAdminRoleEntity(PermissionGroup permissionGroup);
 
     Mono<List<Workspace>> getUserWorkspacesByRecentlyUsedOrder();
+
+    Mono<List<Workspace>> getUserWorkspaceInAlphabeticalOrder();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserWorkspaceServiceCEImpl.java
@@ -423,23 +423,9 @@ public class UserWorkspaceServiceCEImpl implements UserWorkspaceServiceCE {
      */
     @Override
     public Mono<List<Workspace>> getUserWorkspaceInAlphabeticalOrder() {
-        Mono<List<String>> workspaceIdsMono = userDataService
-                .getForCurrentUser()
-                .defaultIfEmpty(new UserData())
-                .map(userData -> {
-                    if (userData.getRecentlyUsedEntityIds() == null) {
-                        return Collections.emptyList();
-                    }
-                    return userData.getRecentlyUsedEntityIds().stream()
-                            .map(RecentlyUsedEntityDTO::getWorkspaceId)
-                            .collect(Collectors.toList());
-                });
-
-        return workspaceIdsMono.flatMap(workspaceIds -> workspaceService
-                .getAll(workspacePermission.getReadPermission())
-                // Sort by workspace names alphabetically
-                .sort(Comparator.comparing(workspace -> workspace.getName().toLowerCase()))
-                // Collect to list to keep the order of the workspaces
-                .collectList());
+        return workspaceService
+            .getAll(workspacePermission.getReadPermission())
+            .sort(Comparator.comparing(workspace -> workspace.getName().toLowerCase()))
+            .collectList();
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserWorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserWorkspaceServiceTest.java
@@ -375,4 +375,31 @@ public class UserWorkspaceServiceTest {
                 .cleanPermissionGroupCacheForUsers(List.of(api_user.getId(), test_user.getId()))
                 .block();
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void getUserWorkspaceInAlphabeticalOrder_WhenUserHasWorkspaces_ReturnsWorkspacesSortedAlphabetically() {
+        // Arrange: Create multiple workspaces with different names
+        String[] workspaceNames = {"Zebra Workspace", "Alpha Workspace", "Beta Workspace"};
+
+        for (String name : workspaceNames) {
+            Workspace workspace = new Workspace();
+            workspace.setName(name);
+            workspaceRepository.save(workspace).block();
+        }
+
+        // Act: Call the method to get the user's workspaces in alphabetical order
+        Mono<List<Workspace>> workspacesMono = userWorkspaceService.getUserWorkspaceInAlphabeticalOrder();
+
+        // Assert: Verify the workspaces are returned in alphabetical order
+        StepVerifier.create(workspacesMono)
+                .assertNext(workspaces -> {
+                    assertThat(workspaces).isNotNull();
+                    assertThat(workspaces).hasSize(3);
+                    assertThat(workspaces.get(0).getName()).isEqualTo("Alpha Workspace");
+                    assertThat(workspaces.get(1).getName()).isEqualTo("Beta Workspace");
+                    assertThat(workspaces.get(2).getName()).isEqualTo("Zebra Workspace");
+                })
+                .verifyComplete();
+    }
 }


### PR DESCRIPTION
**Description:**
Currently, workspaces on sidebar and apps are sorted in order of last edited. We should sort them in alphabetical order

fixes: [#31108](https://github.com/appsmithorg/appsmith/issues/31108)

**updates in Pr:**
1.added a new service which return workspaces of the user in alphabetical order along with its interface
2.added this service call in controller.
3.added the test case for this changes.

**snapshot:**
![image](https://github.com/user-attachments/assets/8d5d345c-dbe6-4e5d-ba83-8dde7eef82a7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspaces are now displayed in alphabetical order instead of by recently used, enhancing organization and accessibility for users.

- **Bug Fixes**
  - Improved retrieval method for user workspaces to ensure accurate alphabetical sorting.

- **Tests**
  - Added tests to validate the new alphabetical sorting functionality for user workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->