### PR TITLE
chore: Return failure results

### DIFF
--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -349,7 +349,12 @@ jobs:
             npx cypress-repeat-pro run -n ${{ inputs.run_count }} --force \
                 --spec ${{ env.specs_to_run }} \
                 --config-file "cypress_ci_custom.config.ts"
-            cat cy-repeat-summary.txt       
+            cat cy-repeat-summary.txt  
+            # Check if "Total Failed: 0" is present
+            if ! grep -q "Total Failed: 0" cy-repeat-summary.txt; then
+              echo "Tests failed, failing the GitHub Action."
+              exit 1  # Fails the step if tests failed
+            fi     
 
       - name: Trim number of cypress log files
         if: failure()


### PR DESCRIPTION
## Description

**Problem:** When running Cypress tests multiple times with the cypress-repeat-pro --force option, we only see success messages. This is because the `--force` option may override or mask failures, leading to misleading results.

**Solution:** To address this, we have added a step to check for specific failure indicators in the test summary file. If the summary indicates that there were any failed tests (i.e., `Total Failed: 0` is not present), the GitHub Action step will fail. This ensures that failures are properly highlighted and reported in the PR comments.


Fixes #`36232`  

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
