### PR TITLE
fix:inconsistent behavior of widget color across checkbox widgets 24621

### DIFF
--- a/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
+++ b/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
@@ -37,13 +37,32 @@ export class DependencyMapUtils {
       return { success: false, cyclicNode: node, error };
     }
   }
-
+  // this function links childNode to its parent as a dependency for the entire dependencyGraph
   static makeParentsDependOnChildren(dependencyMap: DependencyMap) {
     const dependencies = dependencyMap.rawDependencies;
     for (const [node, deps] of dependencies.entries()) {
       this.makeParentsDependOnChild(dependencyMap, node);
       deps.forEach((dep) => {
         this.makeParentsDependOnChild(dependencyMap, dep);
+      });
+    }
+    return dependencyMap;
+  }
+
+  // this function links childNode to its parent as a dependency for only affectedNodes in the graph
+  static linkAffectedChildNodesToParent(
+    dependencyMap: DependencyMap,
+    affectedSet: Set<string>,
+  ) {
+    const dependencies = dependencyMap.rawDependencies;
+    for (const [node, deps] of dependencies.entries()) {
+      if (affectedSet.has(node)) {
+        DependencyMapUtils.makeParentsDependOnChild(dependencyMap, node);
+      }
+      deps.forEach((dep) => {
+        if (affectedSet.has(dep)) {
+          DependencyMapUtils.makeParentsDependOnChild(dependencyMap, dep);
+        }
       });
     }
     return dependencyMap;

--- a/app/client/src/entities/DependencyMap/__tests__/index.test.ts
+++ b/app/client/src/entities/DependencyMap/__tests__/index.test.ts
@@ -2708,6 +2708,70 @@ describe("Tests for DependencyMapUtils", () => {
       "Api1",
     ]);
   }
+  describe("linkAffectedChildNodesToParent", () => {
+    const createSomeDependencyMap = () => {
+      const dependencyMap = new DependencyMap();
+      dependencyMap.addNodes({
+        tableWidget: true,
+        apiData: true,
+        "tableWidget.tableData": true,
+        "apiData.data": true,
+        "apiData.allData": true,
+        "apiData.allData.paginatedData": true,
+      });
+      dependencyMap.addDependency("tableWidget", ["tableWidget.tableData"]);
+      return dependencyMap;
+    };
+
+    test("should link child node to its parentNode as a dependant", () => {
+      const dependencyMap = createSomeDependencyMap();
+      dependencyMap.addDependency("tableWidget.tableData", ["apiData.data"]);
+      // although "apiData.data" was attached as a dependency to "tableWidget.tableData", it's parent "apiData" also needs to be linked to "apiData.data"
+      expect(dependencyMap.rawDependencies.get("apiData")).toEqual(undefined);
+      const affectedNodes = new Set(["apiData.data"]);
+      DependencyMapUtils.linkAffectedChildNodesToParent(
+        dependencyMap,
+        affectedNodes,
+      );
+      // after linkAffectedChildNodesToParent execution "apiData" does get linked to "apiData.data"
+      expect(dependencyMap.rawDependencies.get("apiData")).toEqual(
+        new Set(["apiData.data"]),
+      );
+    });
+    test("should not link child node to its parentNode as a dependant when the child node is not affected ", () => {
+      const dependencyMap = createSomeDependencyMap();
+      dependencyMap.addDependency("tableWidget.tableData", ["apiData.data"]);
+      // although "apiData.data" was attached as a dependency to "tableWidget.tableData", it's parent "apiData" also needs to be linked to "apiData.data"
+      expect(dependencyMap.rawDependencies.get("apiData")).toEqual(undefined);
+      const emptyAffectedNodes = new Set([]);
+      DependencyMapUtils.linkAffectedChildNodesToParent(
+        dependencyMap,
+        emptyAffectedNodes,
+      );
+      expect(dependencyMap.rawDependencies.get("apiData")).toEqual(undefined);
+    });
+
+    test("should link child node to its grand parent node as a dependant", () => {
+      const dependencyMap = createSomeDependencyMap();
+      dependencyMap.addDependency("tableWidget.tableData", [
+        "apiData.allData.paginatedData",
+      ]);
+      expect(dependencyMap.rawDependencies.get("apiData")).toEqual(undefined);
+      const affectedNodes = new Set(["apiData.allData.paginatedData"]);
+
+      DependencyMapUtils.linkAffectedChildNodesToParent(
+        dependencyMap,
+        affectedNodes,
+      );
+      // after linkAffectedChildNodesToParent execution "apiData.allData.paginatedData" get linked to "apiData.data" and its parent "apiData.data" gets linked to "apiData"
+      expect(dependencyMap.getDirectDependencies("apiData")).toEqual([
+        "apiData.allData",
+      ]);
+      expect(dependencyMap.getDirectDependencies("apiData.allData")).toEqual([
+        "apiData.allData.paginatedData",
+      ]);
+    });
+  });
   describe("makeParentsDependOnChild", () => {
     const createSomeDependencyMap = () => {
       const dependencyMap = new DependencyMap();

--- a/app/client/src/workers/common/DependencyMap/index.ts
+++ b/app/client/src/workers/common/DependencyMap/index.ts
@@ -29,6 +29,7 @@ import {
 } from "ee/workers/Evaluation/Actions";
 import { isWidgetActionOrJsObject } from "ee/entities/DataTree/utils";
 import { getValidEntityType } from "workers/common/DataTreeEvaluator/utils";
+import type DependencyMap from "entities/DependencyMap";
 
 export function createDependencyMap(
   dataTreeEvalRef: DataTreeEvaluator,
@@ -72,6 +73,30 @@ export function createDependencyMap(
     inverseDependencies: dependencyMap.inverseDependencies,
   };
 }
+const addingAffectedNodesToList = (
+  affectedNodes: Set<string>,
+  addedNodes: string[],
+) => {
+  addedNodes.forEach((v) => affectedNodes.add(v));
+};
+
+const addNodesToDependencyMap =
+  (affectedNodes: Set<string>, dependencyMap: DependencyMap) =>
+  (addedNodes: Record<string, true>, strict?: boolean) => {
+    const didUpdateDep = dependencyMap.addNodes(addedNodes, strict);
+    if (didUpdateDep) {
+      addingAffectedNodesToList(affectedNodes, Object.keys(addedNodes));
+    }
+    return didUpdateDep;
+  };
+
+const setDependenciesToDependencyMap =
+  (affectedNodes: Set<string>, dependencyMap: DependencyMap) =>
+  (node: string, dependencies: string[]) => {
+    dependencyMap.addDependency(node, dependencies);
+
+    addingAffectedNodesToList(affectedNodes, [node, ...dependencies]);
+  };
 
 export const updateDependencyMap = ({
   configTree,
@@ -91,7 +116,15 @@ export const updateDependencyMap = ({
   const { allKeys, dependencyMap, oldConfigTree, oldUnEvalTree } =
     dataTreeEvalRef;
   let { errors: dataTreeEvalErrors } = dataTreeEvalRef;
-
+  const affectedNodes: Set<string> = new Set();
+  const addNodesToDepedencyMapFn = addNodesToDependencyMap(
+    affectedNodes,
+    dependencyMap,
+  );
+  const setDependenciesToDepedencyMapFn = setDependenciesToDependencyMap(
+    affectedNodes,
+    dependencyMap,
+  );
   translatedDiffs.forEach((dataTreeDiff) => {
     const {
       event,
@@ -117,15 +150,18 @@ export const updateDependencyMap = ({
           });
           // If a new entity is added, add setter functions to all nodes
           if (entityName === fullPropertyPath) {
-            const didUpdateDep = dependencyMap.addNodes(
-              getEntitySetterFunctions(entityConfig, entityName, entity),
+            const addedNodes = getEntitySetterFunctions(
+              entityConfig,
+              entityName,
+              entity,
             );
-            if (didUpdateDep) didUpdateDependencyMap = true;
+            didUpdateDependencyMap =
+              addNodesToDepedencyMapFn(addedNodes) || didUpdateDependencyMap;
           }
 
-          const didUpdateDep = dependencyMap.addNodes(allAddedPaths, false);
-
-          if (didUpdateDep) didUpdateDependencyMap = true;
+          didUpdateDependencyMap =
+            addNodesToDepedencyMapFn(allAddedPaths, false) ||
+            didUpdateDependencyMap;
 
           if (isWidgetActionOrJsObject(entity)) {
             if (!isDynamicLeaf(unEvalDataTree, fullPropertyPath, configTree)) {
@@ -141,7 +177,9 @@ export const updateDependencyMap = ({
                   ([path, pathDependencies]) => {
                     const { errors: extractDependencyErrors, references } =
                       extractInfoFromBindings(pathDependencies, allKeys);
-                    dependencyMap.addDependency(path, references);
+
+                    setDependenciesToDepedencyMapFn(path, references);
+
                     didUpdateDependencyMap = true;
                     dataTreeEvalErrors = dataTreeEvalErrors.concat(
                       extractDependencyErrors,
@@ -158,7 +196,9 @@ export const updateDependencyMap = ({
               );
               const { errors: extractDependencyErrors, references } =
                 extractInfoFromBindings(entityPathDependencies, allKeys);
-              dependencyMap.addDependency(fullPropertyPath, references);
+
+              setDependenciesToDepedencyMapFn(fullPropertyPath, references);
+
               didUpdateDependencyMap = true;
               dataTreeEvalErrors = dataTreeEvalErrors.concat(
                 extractDependencyErrors,
@@ -218,7 +258,8 @@ export const updateDependencyMap = ({
             );
             const { errors: extractDependencyErrors, references } =
               extractInfoFromBindings(entityPathDependencies, allKeys);
-            dependencyMap.addDependency(fullPropertyPath, references);
+            setDependenciesToDepedencyMapFn(fullPropertyPath, references);
+
             didUpdateDependencyMap = true;
             dataTreeEvalErrors = dataTreeEvalErrors.concat(
               extractDependencyErrors,
@@ -237,7 +278,10 @@ export const updateDependencyMap = ({
   const updateChangedDependenciesStart = performance.now();
 
   if (didUpdateDependencyMap) {
-    DependencyMapUtils.makeParentsDependOnChildren(dependencyMap);
+    DependencyMapUtils.linkAffectedChildNodesToParent(
+      dependencyMap,
+      affectedNodes,
+    );
     dataTreeEvalRef.sortedDependencies = dataTreeEvalRef.sortDependencies(
       dependencyMap,
       translatedDiffs,


### PR DESCRIPTION
[Issue - 24621](https://github.com/appsmithorg/appsmith/issues/24621)

#### Description
- updated default color of CheckboxGroup to match all other widgets
- added jest unit test cases for the same

#### Screenshots
![image](https://github.com/user-attachments/assets/24d96676-6aae-4403-b7d7-e8e45ab76f27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a default background color for the `CheckboxGroupWidget` when the `accentColor` prop is not specified, enhancing UI consistency.
  
- **Bug Fixes**
  - Added tests to verify the component's behavior with an empty `accentColor`, ensuring it defaults to the predefined background color. 

- **Tests**
  - Enhanced the test suite for the `CheckboxGroupWidget` to improve coverage and reliability of the component's styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->