### PR TITLE
fix: fixed page data DB call getting called twice

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
@@ -201,6 +201,9 @@ public class ConsolidatedAPIServiceCEImpl implements ConsolidatedAPIServiceCE {
         boolean isViewMode = ApplicationMode.PUBLISHED.equals(mode);
 
         /* Fetch default application id if not provided */
+        if (isBlank(basePageId)) {
+            return Mono.when(fetches).thenReturn(consolidatedAPIResponseDTO);
+        }
         Mono<Application> branchedApplicationMonoCached;
         Mono<String> baseApplicationIdMono = Mono.just("");
         if (isViewMode) {
@@ -215,12 +218,9 @@ public class ConsolidatedAPIServiceCEImpl implements ConsolidatedAPIServiceCE {
                 .tap(Micrometer.observation(observationRegistry))
                 .cache();
 
-        Mono<NewPage> branchedPageMonoCached = Mono.empty();
-        if (!isBlank(basePageId)) {
-            branchedPageMonoCached = newPageService
-                    .findByBranchNameAndBasePageIdAndApplicationMode(branchName, basePageId, mode)
-                    .cache();
-        }
+        Mono<NewPage> branchedPageMonoCached = newPageService
+                .findByBranchNameAndBasePageIdAndApplicationMode(branchName, basePageId, mode)
+                .cache();
 
         branchedApplicationMonoCached = baseApplicationIdMono.flatMap(cachedBaseApplicationId -> {
             if (!StringUtils.hasText(cachedBaseApplicationId)) {


### PR DESCRIPTION
## Description
After perf updates made in PR https://github.com/appsmithorg/appsmith/pull/36118/files, Page data DB fetch call was getting triggered twice, one for PAGES_SPAN and one for ACTIONS_SPAN. With this PR, we have replaced that a single Mono which is being cached. 

More details: https://theappsmith.slack.com/archives/C024GUDM0LT/p1725960912325389


Fixes #`Issue Number`  
_or_  
Fixes https://github.com/appsmithorg/appsmith/issues/36243
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10808901838>
> Commit: d36df4cb300653a51d10a09b3315aaa114b68034
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10808901838&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 11 Sep 2024 09:49:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Performance Improvements**
	- Enhanced the page loading process by implementing a caching mechanism for retrieving branched page data, potentially reducing database calls and improving overall application performance.
	- Streamlined the retrieval logic for branched pages, ensuring consistent execution regardless of the base page ID state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->