### PR TITLE
fix: table row selection using image cell

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/ImageCell.test.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/ImageCell.test.tsx
@@ -1,0 +1,39 @@
+import { ImageCell } from "./ImageCell";
+import { render, fireEvent } from "@testing-library/react";
+import React from "react";
+import {
+  CompactModeTypes,
+  CellAlignmentTypes,
+  VerticalAlignmentTypes,
+} from "../Constants";
+
+describe("Test on ImageCell component", () => {
+  it("test to check if the click even is getting propogated for image cell", () => {
+    const props = {
+      allowCellWrapping: true,
+      cellBackground: "red",
+      compactMode: CompactModeTypes.DEFAULT,
+      fontStyle: "bold",
+      horizontalAlignment: CellAlignmentTypes.LEFT,
+      isCellDisabled: false,
+      isCellVisible: true,
+      isHidden: false,
+      onClick: jest.fn(),
+      textColor: "black",
+      textSize: "large",
+      value: "https://randomuser.me/api/portraits/men/2.jpg",
+      verticalAlignment: VerticalAlignmentTypes.CENTER,
+    };
+    const outerFunction = jest.fn();
+    const { container } = render(
+      <div onClick={outerFunction}>
+        <ImageCell {...props} />
+      </div>,
+    );
+    const imageCell = container.getElementsByClassName("image-cell")[0];
+    expect(imageCell).toBeInTheDocument;
+    fireEvent.click(imageCell);
+    expect(props.onClick).toHaveBeenCalled();
+    expect(outerFunction).toHaveBeenCalled();
+  });
+});

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/ImageCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/ImageCell.tsx
@@ -110,7 +110,6 @@ export function ImageCell(props: renderImageType) {
               className="image-cell-wrapper"
               key={index}
               onClick={(e) => {
-                e.stopPropagation();
                 onClick();
               }}
             >


### PR DESCRIPTION
fixes issue: [16110](https://github.com/appsmithorg/appsmith/issues/16110)

fixed the issue with the selection of row using image column cell

After the fix the user is able to select the table row by clicking on the image type column cell.

video:

https://github.com/user-attachments/assets/77512908-7e82-4dd5-b5bc-e1fd08416988





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `ImageCell` component to allow click events to propagate to parent components, improving interaction capabilities.
  
- **Tests**
	- Introduced a new test suite for the `ImageCell` component to verify click event propagation and ensure reliable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->