### PR TITLE
fix: Default invalid sheet method value in Gsheet datasource

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
@@ -40,7 +40,7 @@
               "value": "https://www.googleapis.com/auth/drive.file"
             }
           ],
-          "initialValue": "https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive",
+          "initialValue": "https://www.googleapis.com/auth/drive.file",
           "customStyles": {
             "width": "340px"
           }


### PR DESCRIPTION
## Description

The default value for gsheet method didn't match with the available method in the list and hence showed unexpected result. This change updates the default value to match the available option. 

Fixes https://github.com/appsmithorg/appsmith/issues/36263

## Automation

/test gsheet

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10824475544>
> Commit: 13c28b223a01a98d91aafbccc481050b970cb856
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10824475544&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.GSheet`
> Spec:
> <hr>Thu, 12 Sep 2024 05:17:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security for the Google Sheets plugin by restricting access permissions.
	- Updated the plugin to allow access only to files created or opened by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->