### PR TITLE
fix: Duplicate page name error does not disappear on navigating to oth…

### DIFF
--- a/app/client/src/pages/Editor/AppSettingsPane/AppSettings/PageSettings.tsx
+++ b/app/client/src/pages/Editor/AppSettingsPane/AppSettings/PageSettings.tsx
@@ -126,6 +126,10 @@ function PageSettings(props: { page: Page }) {
     }
   }, [isUpdatingEntity]);
 
+  useEffect(() => {
+    setIsPageNameValid("");
+  }, [page]);
+
   const savePageName = useCallback(() => {
     if (!canManagePages || !!isPageNameValid || page.pageName === pageName)
       return;


### PR DESCRIPTION
## Description
**Issue**: Duplicate page name error does not disappear on navigating to other pages

In this PR , I have performed side effects on the **isPageNameValid** state using useEffect hook, and after this the  correctly updated upon page navigation.

**previously page navigating behaviour**
[fbfb8115-c979-44da-833f-8b705c807e24.webm](https://github.com/user-attachments/assets/8b5b32d7-508d-47c8-9b4b-b10b3526aa3b)

**currently page navigating behaviour**
[Screencast from 10-09-24 04:58:15 PM IST.webm](https://github.com/user-attachments/assets/c16313ed-88ff-4a92-80ba-14bcc0771ff6)


Fixes #35949   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved responsiveness of the page settings by resetting validation messages when the page prop changes.

- **Bug Fixes**
	- Enhanced user experience by preventing stale validation messages when switching between different pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->