### PR TITLE
test if only when adding a new widget do we compute the entire widget…

### DIFF
--- a/app/client/src/workers/common/DependencyMap/index.ts
+++ b/app/client/src/workers/common/DependencyMap/index.ts
@@ -148,6 +148,7 @@ export const updateDependencyMap = ({
           const allAddedPaths = getAllPaths({
             [fullPropertyPath]: get(unEvalDataTree, fullPropertyPath),
           });
+
           // If a new entity is added, add setter functions to all nodes
           if (entityName === fullPropertyPath) {
             const addedNodes = getEntitySetterFunctions(
@@ -163,8 +164,9 @@ export const updateDependencyMap = ({
             addNodesToDepedencyMapFn(allAddedPaths, false) ||
             didUpdateDependencyMap;
 
+          const isAddingNewWidget = entityName === fullPropertyPath;
           if (isWidgetActionOrJsObject(entity)) {
-            if (!isDynamicLeaf(unEvalDataTree, fullPropertyPath, configTree)) {
+            if (isAddingNewWidget) {
               const entityDependencyMap = getEntityDependencies(
                 entity,
                 configTree[entityName],
@@ -188,21 +190,23 @@ export const updateDependencyMap = ({
                 );
               }
             } else {
-              const entityPathDependencies = getEntityPathDependencies(
-                entity,
-                entityConfig,
-                fullPropertyPath,
-                allKeys,
-              );
-              const { errors: extractDependencyErrors, references } =
-                extractInfoFromBindings(entityPathDependencies, allKeys);
+              if (isDynamicLeaf(unEvalDataTree, fullPropertyPath, configTree)) {
+                const entityPathDependencies = getEntityPathDependencies(
+                  entity,
+                  entityConfig,
+                  fullPropertyPath,
+                  allKeys,
+                );
+                const { errors: extractDependencyErrors, references } =
+                  extractInfoFromBindings(entityPathDependencies, allKeys);
 
-              setDependenciesToDepedencyMapFn(fullPropertyPath, references);
+                setDependenciesToDepedencyMapFn(fullPropertyPath, references);
 
-              didUpdateDependencyMap = true;
-              dataTreeEvalErrors = dataTreeEvalErrors.concat(
-                extractDependencyErrors,
-              );
+                didUpdateDependencyMap = true;
+                dataTreeEvalErrors = dataTreeEvalErrors.concat(
+                  extractDependencyErrors,
+                );
+              }
             }
           }
           break;

--- a/app/client/src/workers/common/DependencyMap/index.ts
+++ b/app/client/src/workers/common/DependencyMap/index.ts
@@ -98,6 +98,15 @@ const setDependenciesToDependencyMap =
     addingAffectedNodesToList(affectedNodes, [node, ...dependencies]);
   };
 
+const excludeNodes = [
+  "version",
+  "parentId",
+  "renderMode",
+  "isMobile",
+  "creatorId",
+  "labelComponentWidth",
+];
+
 export const updateDependencyMap = ({
   configTree,
   dataTreeEvalRef,
@@ -164,9 +173,11 @@ export const updateDependencyMap = ({
             addNodesToDepedencyMapFn(allAddedPaths, false) ||
             didUpdateDependencyMap;
 
-          const isAddingNewWidget = entityName === fullPropertyPath;
           if (isWidgetActionOrJsObject(entity)) {
-            if (isAddingNewWidget) {
+            if (!isDynamicLeaf(unEvalDataTree, fullPropertyPath, configTree)) {
+              if (excludeNodes.some((v) => fullPropertyPath.endsWith(v))) {
+                break;
+              }
               const entityDependencyMap = getEntityDependencies(
                 entity,
                 configTree[entityName],
@@ -190,23 +201,21 @@ export const updateDependencyMap = ({
                 );
               }
             } else {
-              if (isDynamicLeaf(unEvalDataTree, fullPropertyPath, configTree)) {
-                const entityPathDependencies = getEntityPathDependencies(
-                  entity,
-                  entityConfig,
-                  fullPropertyPath,
-                  allKeys,
-                );
-                const { errors: extractDependencyErrors, references } =
-                  extractInfoFromBindings(entityPathDependencies, allKeys);
+              const entityPathDependencies = getEntityPathDependencies(
+                entity,
+                entityConfig,
+                fullPropertyPath,
+                allKeys,
+              );
+              const { errors: extractDependencyErrors, references } =
+                extractInfoFromBindings(entityPathDependencies, allKeys);
 
-                setDependenciesToDepedencyMapFn(fullPropertyPath, references);
+              setDependenciesToDepedencyMapFn(fullPropertyPath, references);
 
-                didUpdateDependencyMap = true;
-                dataTreeEvalErrors = dataTreeEvalErrors.concat(
-                  extractDependencyErrors,
-                );
-              }
+              didUpdateDependencyMap = true;
+              dataTreeEvalErrors = dataTreeEvalErrors.concat(
+                extractDependencyErrors,
+              );
             }
           }
           break;

--- a/app/client/src/workers/common/DependencyMap/index.ts
+++ b/app/client/src/workers/common/DependencyMap/index.ts
@@ -3,7 +3,6 @@ import {
   getAllPaths,
   DataTreeDiffEvent,
   getEntityNameAndPropertyPath,
-  isDynamicLeaf,
 } from "ee/workers/Evaluation/evaluationUtils";
 import type {
   WidgetEntity,
@@ -98,15 +97,6 @@ const setDependenciesToDependencyMap =
     addingAffectedNodesToList(affectedNodes, [node, ...dependencies]);
   };
 
-const excludeNodes = [
-  "version",
-  "parentId",
-  "renderMode",
-  "isMobile",
-  "creatorId",
-  "labelComponentWidth",
-];
-
 export const updateDependencyMap = ({
   configTree,
   dataTreeEvalRef,
@@ -174,10 +164,7 @@ export const updateDependencyMap = ({
             didUpdateDependencyMap;
 
           if (isWidgetActionOrJsObject(entity)) {
-            if (!isDynamicLeaf(unEvalDataTree, fullPropertyPath, configTree)) {
-              if (excludeNodes.some((v) => fullPropertyPath.endsWith(v))) {
-                break;
-              }
+            if (entityName === fullPropertyPath) {
               const entityDependencyMap = getEntityDependencies(
                 entity,
                 configTree[entityName],


### PR DESCRIPTION
… graph

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10848494131>
> Commit: c8eb9f64ba3229c9585d63d9b6b91400d3b6efbb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10848494131&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/OneClickBindingMysql_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/Table_MongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/Table_postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Event_Bindings_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_NestedList_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Nested_EventBindings_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_autocomplete_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_PropertyPane_2_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/currency_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/inline_editing_validations_spec.js
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Fri, 13 Sep 2024 12:54:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a mechanism to exclude specific nodes from dependency processing, enhancing efficiency.
	- Improved handling of widget actions and entity dependencies for better control and clarity.
	- Simplified logic for processing entity dependencies, focusing on direct comparisons for improved clarity.
- **Bug Fixes**
	- Enhanced error handling and streamlined dependency setting logic for improved functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->