### PR TITLE
chore(deps): Upgrade path-to-regexp from 6.2.0 to 6.3.0 

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -163,7 +163,7 @@
     "node-forge": "^1.3.0",
     "normalizr": "^3.3.0",
     "object-hash": "^3.0.0",
-    "path-to-regexp": "^6.2.0",
+    "path-to-regexp": "^6.3.0",
     "popper.js": "^1.15.0",
     "prismjs": "^1.27.0",
     "proxy-memoize": "^1.2.0",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -13391,7 +13391,7 @@ __metadata:
     node-forge: ^1.3.0
     normalizr: ^3.3.0
     object-hash: ^3.0.0
-    path-to-regexp: ^6.2.0
+    path-to-regexp: ^6.3.0
     pg: ^8.11.3
     plop: ^3.1.1
     popper.js: ^1.15.0
@@ -27112,10 +27112,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "path-to-regexp@npm:6.2.0"
-  checksum: a6aca74d2d6e2e7594d812f653cf85e9cb5054d3a8d80f099722a44ef6ad22639b02078e5ea83d11db16321c3e4359e3f1ab0274fa78dad0754a6e53f630b0fc
+"path-to-regexp@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: eca78602e6434a1b6799d511d375ec044e8d7e28f5a48aa5c28d57d8152fb52f3fc62fb1cfc5dfa2198e1f041c2a82ed14043d75740a2fe60e91b5089a153250
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Shadow PR: https://github.com/appsmithorg/appsmith/pull/36292

Bumps [path-to-regexp](https://github.com/pillarjs/path-to-regexp) from 6.2.0 to 6.3.0.
- [Release notes](https://github.com/pillarjs/path-to-regexp/releases)
- [Changelog](https://github.com/pillarjs/path-to-regexp/blob/master/History.md)
- [Commits](https://github.com/pillarjs/path-to-regexp/compare/v6.2.0...v6.3.0)

---
updated-dependencies:
- dependency-name: path-to-regexp dependency-type: direct:production ...




## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10843361029>
> Commit: a3536c944cdb766a47f038d271bcafbdef4132cf
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10843361029&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 13 Sep 2024 05:35:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `path-to-regexp` package to version 6.3.0, which may enhance performance and introduce new features for improved URL path matching and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->