### PR TITLE
fix: IDE Header Height usage

### DIFF
--- a/app/client/src/pages/Editor/EditorName/components.ts
+++ b/app/client/src/pages/Editor/EditorName/components.ts
@@ -7,25 +7,30 @@ import { IDE_HEADER_HEIGHT } from "IDE";
 export const Container = styled.div`
   display: flex;
   cursor: pointer;
+
   &:hover {
     background-color: var(--ads-v2-color-bg-subtle);
   }
+
   & .${Classes.EDITABLE_TEXT} {
-    height: ${IDE_HEADER_HEIGHT} !important;
+    height: ${IDE_HEADER_HEIGHT}px !important;
     display: block;
     cursor: pointer;
   }
+
   &&&& .${Classes.EDITABLE_TEXT}, &&&& .${Classes.EDITABLE_TEXT_EDITING} {
     padding: 0;
     width: 100%;
   }
+
   &&&& .${Classes.EDITABLE_TEXT_CONTENT}, &&&& .${Classes.EDITABLE_TEXT_INPUT} {
     display: block;
     ${getTypographyByKey("h5")};
-    line-height: ${IDE_HEADER_HEIGHT} !important;
+    line-height: ${IDE_HEADER_HEIGHT}px !important;
     padding: 0 ${(props) => props.theme.spaces[2]}px;
-    height: ${IDE_HEADER_HEIGHT} !important;
+    height: ${IDE_HEADER_HEIGHT}px !important;
   }
+
   &&&& .${Classes.EDITABLE_TEXT_INPUT} {
     margin-right: 20px;
   }


### PR DESCRIPTION
## Description

Fixes incorrect usage of IDE Header Height which caused bug in the Menu location

Fixes #36284 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10843283682>
> Commit: 0868d06021b2cf16bd7c7172068cf476d26c3a6f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10843283682&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Fri, 13 Sep 2024 05:28:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced CSS properties for better rendering consistency across browsers in the Editor component.
	- Improved formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->