### PR TITLE
test: fix failing table filter spec by rearranging steps.

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter1_1_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter1_1_Spec.ts
@@ -143,10 +143,10 @@ describe(
     });
 
     it("11. Verify table search includes label and value for table with select column type", () => {
+      deployMode.NavigateBacktoEditor();
       // This flag is turned on to allow the label show in the table select cell content
       // when this feature is turned on fully, this flag will be removed
       featureFlagIntercept({ release_table_cell_label_value_enabled: true });
-      deployMode.NavigateBacktoEditor();
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       propPane.EnterJSContext("Table data", demoTableDataForSelect);
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter1_1_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter1_1_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
In the spec, feature flag intercept is interfering with navigating back to editor flow.
Since we need FF in the editor, this PR rearranges these steps.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/10845920958>
> Commit: c7de064cd6c262f969270be226a135371985646e
> Workflow: `PR Automation test suite`
> Tags: `@tag.Table`
> Spec: ``
> <hr>Fri, 13 Sep 2024 08:40:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved test flow for the Table V2 component by repositioning navigation actions, enhancing clarity and context.
  
- **Chores**
	- Updated the configuration for limited tests to focus on the Table V2 widget's filtering functionality instead of template-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->