### PR TITLE
chore: Running on failure only (reverting to original)

### DIFF
--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -362,7 +362,7 @@ jobs:
             cat "$FAILURE_FLAG_FILE"
             
       - name: Trim number of cypress log files
-        if: always()
+        if: failure()
         run: |
           find ${{ github.workspace }}/app/client/cypress/cypress-logs -name '*.json' -type f | tail -n +11 | xargs -I {} rm -- {}
 


### PR DESCRIPTION
## Description
Reverting to previous version as this steps specifically run for failure.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10848068018>
> Commit: d646576aa20499b099adbf6f0479ff3b8363e41c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10848068018&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.ImportExport`
> Spec:
> <hr>Fri, 13 Sep 2024 11:26:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow conditions to trim Cypress log files only on job failures, improving log management for successful runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->