### PR TITLE
fix: consolidated api test file split to ce

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.appsmith.server.services;
+package com.appsmith.server.services.ce;
 
 import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.Datasource;
@@ -32,6 +32,14 @@ import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.NewPageRepository;
+import com.appsmith.server.services.ApplicationPageService;
+import com.appsmith.server.services.ConsolidatedAPIService;
+import com.appsmith.server.services.MockDataService;
+import com.appsmith.server.services.ProductAlertService;
+import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.services.TenantService;
+import com.appsmith.server.services.UserDataService;
+import com.appsmith.server.services.UserService;
 import com.appsmith.server.themes.base.ThemeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## Description
Split ConsolidatedAPIServiceImplTest file to CE as we need to write modules related tests in EE.

EE Test PR: https://github.com/appsmithorg/appsmith-ee/pull/5140

Fixes #36276 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10872195570>
> Commit: fe51aaa8aa141cbbfc4c04d39422e1bcca01868c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10872195570&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Sun, 15 Sep 2024 15:46:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- The package structure for the test class has been reorganized to better categorize services.
  
- **Tests**
	- Enhanced test functionality by incorporating additional service imports, potentially improving test coverage and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->