### PR TITLE
Resolve the Use APPSMITH_LOG_DIR for writing logs of backup command #32666

### DIFF
--- a/deploy/docker/fs/opt/appsmith/utils/bin/constants.js
+++ b/deploy/docker/fs/opt/appsmith/utils/bin/constants.js
@@ -5,7 +5,9 @@ const RESTORE_PATH = "/appsmith-stacks/data/restore"
 
 const DUMP_FILE_NAME = "appsmith-data.archive"
 
-const APPSMITHCTL_LOG_PATH = "/appsmith-stacks/logs/appsmithctl"
+const APPSMITH_LOG_DIR = process.env.APPSMITH_LOG_DIR || "/appsmith-stacks/logs";
+const APPSMITHCTL_LOG_PATH = `${APPSMITH_LOG_DIR}/appsmithctl`;
+
 
 const LAST_ERROR_MAIL_TS = "/appsmith-stacks/data/backup/last-error-mail-ts"
 


### PR DESCRIPTION
## Resolve the Use APPSMITH_LOG_DIR for writing logs of backup command 
 PR: https://github.com/appsmithorg/appsmith/issues/32666

## Description Resolve the Issue:

### 1. **Understand the Problem:**
   The `appsmithctl` backup/restore commands are not using the environment variable `APPSMITH_LOG_DIR` to write logs. Instead, they are writing logs to a hardcoded path (`/appsmith-stacks/logs/appsmithctl`).

### 2. **Locate the Relevant Code:**
   According to the issue description, the hardcoded log path can be found in:

   - File: `appsmith/deploy/docker/fs/opt/appsmith/utils/bin/constants.js`
   - Line 8:
     ```javascript
     const APPSMITHCTL_LOG_PATH = "/appsmith-stacks/logs/appsmithctl";
     ```

### 3. **Modify the Code to Use `APPSMITH_LOG_DIR`:**
   modify the code to dynamically use the value of the `APPSMITH_LOG_DIR` environment variable. Here's an approach to update the log path:

   - Replace the hardcoded log path with a value that reads from `APPSMITH_LOG_DIR`:
     ```javascript
     const APPSMITH_LOG_DIR = process.env.APPSMITH_LOG_DIR || "/appsmith-stacks/logs";
     const APPSMITHCTL_LOG_PATH = `${APPSMITH_LOG_DIR}/appsmithctl`;
     ```

   This way, the `APPSMITH_LOG_DIR` environment variable will be respected. If `APPSMITH_LOG_DIR` is not set, it will default to `/appsmith-stacks/logs`.



Fixes #32666   

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configurable log directory for Appsmith, allowing users to customize the logging path via an environment variable.
  
- **Improvements**
	- Enhanced the logging system's flexibility by dynamically setting the log path based on the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->