### PR TITLE
fix: NPE for policies when `policyMap` is not present

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -109,7 +109,7 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
         if (!CollectionUtils.isEmpty(policies)) {
             return policies;
         }
-        return policyMap == null ? null : Set.copyOf(policyMap.values());
+        return policyMap == null ? Set.of() : Set.copyOf(policyMap.values());
     }
 
     // TODO Abhijeet: Remove this method once we have migrated all the usages of policies to policyMap

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -109,7 +109,7 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
         if (!CollectionUtils.isEmpty(policies)) {
             return policies;
         }
-        return policyMap == null ? Set.of() : Set.copyOf(policyMap.values());
+        return policyMap == null ? null : Set.copyOf(policyMap.values());
     }
 
     // TODO Abhijeet: Remove this method once we have migrated all the usages of policies to policyMap

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/ce/PolicyGeneratorCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/ce/PolicyGeneratorCE.java
@@ -317,6 +317,9 @@ public class PolicyGeneratorCE {
             Set<Policy> policySet,
             Class<? extends BaseDomain> sourceEntity,
             Class<? extends BaseDomain> destinationEntity) {
+        if (policySet == null) {
+            return new HashSet<>();
+        }
         Set<Policy> policies = policySet.stream()
                 .map(policy -> {
                     AclPermission aclPermission =

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -533,7 +533,9 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
         newAction.setUnpublishedAction(action);
 
         Set<Policy> actionCollectionPolicies = new HashSet<>();
-        actionCollection.getPolicies().forEach(policy -> {
+        Set<Policy> existingPolicies =
+                actionCollection.getPolicies() == null ? Set.of() : actionCollection.getPolicies();
+        existingPolicies.forEach(policy -> {
             Policy actionPolicy = Policy.builder()
                     .permission(policy.getPermission())
                     .permissionGroups(policy.getPermissionGroups())

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/UserPermissionUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/UserPermissionUtils.java
@@ -15,7 +15,8 @@ import java.util.Set;
 public class UserPermissionUtils {
     public static boolean validateDomainObjectPermissionExists(
             BaseDomain baseDomain, AclPermission aclPermission, Set<String> permissionGroups) {
-        Optional<Policy> permissionPolicy = baseDomain.getPolicies().stream()
+        Set<Policy> basePolicies = baseDomain.getPolicies() == null ? Set.of() : baseDomain.getPolicies();
+        Optional<Policy> permissionPolicy = basePolicies.stream()
                 .filter(policy -> policy.getPermission().equals(aclPermission.getValue()))
                 .findFirst();
         return permissionPolicy.isPresent()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration025RemoveUnassignPermissionFromUnnecessaryRoles.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration025RemoveUnassignPermissionFromUnnecessaryRoles.java
@@ -14,6 +14,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.appsmith.server.migrations.constants.DeprecatedFieldName.POLICIES;
 import static com.appsmith.server.migrations.constants.FieldName.POLICY_MAP;
@@ -49,7 +50,9 @@ public class Migration025RemoveUnassignPermissionFromUnnecessaryRoles {
 
         mongoTemplate.stream(optimizedQueryForInterestingPermissionGroups, PermissionGroup.class)
                 .forEach(permissionGroup -> {
-                    Optional<Policy> optionalUnassignPolicy = permissionGroup.getPolicies().stream()
+                    Set<Policy> policies =
+                            permissionGroup.getPolicies() == null ? Set.of() : permissionGroup.getPolicies();
+                    Optional<Policy> optionalUnassignPolicy = policies.stream()
                             .filter(policy -> policy.getPermission().equals("unassign:permissionGroups"))
                             .findFirst();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration028TagUserManagementRolesWithoutDefaultDomainTypeAndId.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration028TagUserManagementRolesWithoutDefaultDomainTypeAndId.java
@@ -51,7 +51,8 @@ public class Migration028TagUserManagementRolesWithoutDefaultDomainTypeAndId {
          */
         Set<String> userManagementRoleIds = new HashSet<>();
         existingUsers.forEach(existingUser -> {
-            Optional<Policy> resetPasswordPolicyOptional = existingUser.getPolicies().stream()
+            Set<Policy> policies = existingUser.getPolicies() == null ? new HashSet<>() : existingUser.getPolicies();
+            Optional<Policy> resetPasswordPolicyOptional = policies.stream()
                     .filter(policy1 -> RESET_PASSWORD_USERS.getValue().equals(policy1.getPermission()))
                     .findFirst();
             resetPasswordPolicyOptional.ifPresent(resetPasswordPolicy -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration028TagUserManagementRolesWithoutDefaultDomainTypeAndId.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration028TagUserManagementRolesWithoutDefaultDomainTypeAndId.java
@@ -51,7 +51,7 @@ public class Migration028TagUserManagementRolesWithoutDefaultDomainTypeAndId {
          */
         Set<String> userManagementRoleIds = new HashSet<>();
         existingUsers.forEach(existingUser -> {
-            Set<Policy> policies = existingUser.getPolicies() == null ? new HashSet<>() : existingUser.getPolicies();
+            Set<Policy> policies = existingUser.getPolicies() == null ? Set.of() : existingUser.getPolicies();
             Optional<Policy> resetPasswordPolicyOptional = policies.stream()
                     .filter(policy1 -> RESET_PASSWORD_USERS.getValue().equals(policy1.getPermission()))
                     .findFirst();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration029PopulateDefaultDomainIdInUserManagementRoles.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration029PopulateDefaultDomainIdInUserManagementRoles.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.appsmith.server.acl.AclPermission.RESET_PASSWORD_USERS;
 import static com.appsmith.server.migrations.constants.DeprecatedFieldName.POLICIES;
@@ -51,7 +52,8 @@ public class Migration029PopulateDefaultDomainIdInUserManagementRoles {
         Map<String, String> userManagementRoleIdToUserIdMap = new HashMap<>();
         mongoTemplate.stream(queryExistingUsersWithResetPasswordPolicy, User.class)
                 .forEach(existingUser -> {
-                    Optional<Policy> resetPasswordPolicyOptional = existingUser.getPolicies().stream()
+                    Set<Policy> policies = existingUser.getPolicies() == null ? Set.of() : existingUser.getPolicies();
+                    Optional<Policy> resetPasswordPolicyOptional = policies.stream()
                             .filter(policy1 -> RESET_PASSWORD_USERS.getValue().equals(policy1.getPermission()))
                             .findFirst();
                     resetPasswordPolicyOptional.ifPresent(resetPasswordPolicy -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
@@ -309,7 +309,8 @@ public class PermissionGroupServiceCEImpl extends BaseService<PermissionGroupRep
 
     @Override
     public boolean isEntityAccessible(BaseDomain object, String permission, String permissionGroupId) {
-        return object.getPolicies().stream()
+        Set<Policy> policies = object.getPolicies() == null ? Set.of() : object.getPolicies();
+        return policies.stream()
                 .filter(policy -> policy.getPermission().equals(permission)
                         && policy.getPermissionGroups().contains(permissionGroupId))
                 .findFirst()


### PR DESCRIPTION
## Description

/test all

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10878646145>
> Commit: 5bbb0ad1b7a76a91540f401753dc588b440900d1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10878646145&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 16 Sep 2024 07:32:37 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of policies retrieval methods to prevent null values, ensuring they always return a non-null result.
- **New Features**
	- Enhanced API design with safer handling of collections by returning an empty set when no policies are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->