### PR TITLE
fix: show bindings sub-menu position has been displaced

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
@@ -13,10 +13,7 @@ import { Button } from "@appsmith/ads";
 import { getEntityProperties } from "ee/pages/Editor/Explorer/Entity/getEntityProperties";
 import store from "store";
 import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
-import {
-  APP_SIDEBAR_WIDTH,
-  DEFAULT_EXPLORER_PANE_WIDTH,
-} from "constants/AppConstants";
+import { DEFAULT_EXPLORER_PANE_WIDTH } from "constants/AppConstants";
 import { BOTTOM_BAR_HEIGHT } from "components/BottomBar/constants";
 
 const BindingContainerMaxHeight = 300;
@@ -119,8 +116,7 @@ export function EntityProperties() {
         ref.current.style.top = top - EntityHeight + "px";
         ref.current.style.bottom = "unset";
       }
-      ref.current.style.left =
-        APP_SIDEBAR_WIDTH + DEFAULT_EXPLORER_PANE_WIDTH + "px";
+      ref.current.style.left = DEFAULT_EXPLORER_PANE_WIDTH + "px";
     }
   }, [entityId]);
 


### PR DESCRIPTION
## Description
Issue: Show bindings sub-menu position has been displaced.

This PR addresses issue #36285 by removing the extra space from `left` style property of EntityProperties.tsx as Explorer div has position as relative and entity properties container is inside the Explorer div, so we need to calculate the value of `left` style based on the Explorer div.

Fixes #36285

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the positioning of UI components by removing unnecessary dependencies, which may improve layout consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->