### PR TITLE
test: fix for Context property pane 1

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
@@ -211,12 +211,14 @@ function verifyPropertyPaneSectionState(propertySectionState) {
   for (const [sectionName, shouldSectionOpen] of Object.entries(
     propertySectionState,
   )) {
-    cy.get("body").then(($body) => {
-      const isSectionOpen =
-        $body.find(`${propertySectionClass(sectionName)} .t--chevron-icon`)
-          .length > 0;
-      expect(isSectionOpen).to.equal(shouldSectionOpen);
-    });
+    cy.get(`${propertySectionClass(sectionName)}`)
+      .siblings(".bp3-collapse")
+      .find(".bp3-collapse-body")
+      .invoke("attr", "aria-hidden")
+      .then((isSectionOpen) => {
+        const expectedValue = shouldSectionOpen ? "false" : "true"; // Convert boolean to aria-hidden value
+        expect(isSectionOpen).to.equal(expectedValue);
+      });
   }
 }
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
EE PR: https://github.com/appsmithorg/appsmith-ee/pull/5159

RCA:
The property section related validations were not working

Solution:

Enhanced verification of property pane section visibility using accessibility attributes.
Introduced new UI interaction properties for managing collapsible sections.

/ok-to-test tags="@tag.IDE"


