### PR TITLE
chore: add custom serialiser and deserialiser to handle null values in the page DSL

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectDeserializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectDeserializer.java
@@ -2,16 +2,14 @@ package com.appsmith.external.converters;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
@@ -20,60 +18,7 @@ public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
         super(t);
     }
 
-    public JSONObject deserialize(JsonParser jsonParser, DeserializationContext context)
-            throws IOException, JsonProcessingException {
-        // Use Jackson to read a generic Object and then handle type casting appropriately
-        /*Object parsed = jsonParser.readValueAs(Object.class);
-        return handleParsedObject(parsed);*/
-        ObjectCodec codec = jsonParser.getCodec();
-        JsonNode node = codec.readTree(jsonParser);
-
-        // Convert JsonNode to LinkedHashMap to avoid the cast exception
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> map = mapper.convertValue(node, LinkedHashMap.class);
-
-        // Return the map wrapped in a JSONObject
-        return new JSONObject(map);
-    }
-
-    private JSONObject handleParsedObject(Object parsed) {
-        if (parsed instanceof Map) {
-            return convertMapToJSONObject((Map<String, Object>) parsed); // Handle objects
-        } else if (parsed instanceof JSONArray) {
-            throw new IllegalStateException("Expected JSONObject but found JSONArray");
-        } else {
-            throw new IllegalStateException("Unexpected JSON structure");
-        }
-    }
-
-    private JSONObject convertMapToJSONObject(Map<String, Object> map) {
-        JSONObject jsonObject = new JSONObject();
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            Object value = entry.getValue();
-
-            if (value instanceof Map) {
-                value = convertMapToJSONObject((Map<String, Object>) value); // Handle nested objects
-            } else if (value instanceof Iterable) {
-                value = convertIterableToJSONArray((Iterable<?>) value); // Handle arrays
-            }
-            // No need to cast anything further here, we preserve original types
-            jsonObject.put(entry.getKey(), value);
-        }
-        return jsonObject;
-    }
-
-    private JSONArray convertIterableToJSONArray(Iterable<?> iterable) {
-        JSONArray jsonArray = new JSONArray();
-        for (Object element : iterable) {
-            if (element instanceof Map) {
-                element = convertMapToJSONObject((Map<String, Object>) element); // Handle nested objects in arrays
-            }
-            jsonArray.add(element); // Preserve original element type
-        }
-        return jsonArray;
-    }
-
-    /*public JSONObject deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+    public JSONObject deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException, JsonProcessingException {
         JsonNode node = jsonParser.getCodec().readTree(jsonParser);
         return processJsonNode(node);
@@ -141,5 +86,5 @@ public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
             // For other cases (like strings or non-standard types), we fallback to asText()
             return node.asText();
         }
-    }*/
+    }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectDeserializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectDeserializer.java
@@ -1,0 +1,90 @@
+package com.appsmith.external.converters;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
+
+    public JSONObjectDeserializer(Class<JSONObject> t) {
+        super(t);
+    }
+
+    public JSONObject deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException, JsonProcessingException {
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        return processJsonNode(node);
+    }
+
+    private JSONObject processJsonNode(JsonNode node) {
+        JSONObject jsonObject = new JSONObject();
+
+        // Iterate over the fields in the JSON object
+        Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> field = fields.next();
+            String fieldName = field.getKey();
+            JsonNode fieldValue = field.getValue();
+
+            // Handle the different types of values
+            if (fieldValue.isObject()) {
+                // Recursively process nested JSONObject
+                jsonObject.put(fieldName, processJsonNode(fieldValue));
+            } else if (fieldValue.isArray()) {
+                // Process arrays
+                jsonObject.put(fieldName, processJsonArray(fieldValue));
+            } else if (fieldValue.isNull()) {
+                // Handle null values explicitly
+                jsonObject.put(fieldName, null);
+            } else {
+                // Handle primitive types (string, number, boolean)
+                jsonObject.put(fieldName, getPrimitiveValue(fieldValue));
+            }
+        }
+        return jsonObject;
+    }
+
+    private Object processJsonArray(JsonNode arrayNode) {
+        JSONArray jsonArray = new JSONArray();
+        for (JsonNode element : arrayNode) {
+            if (element.isObject()) {
+                // Recursively process nested objects in arrays
+                jsonArray.add(processJsonNode(element));
+            } else if (element.isArray()) {
+                // Recursively process nested arrays
+                jsonArray.add(processJsonArray(element));
+            } else if (element.isNull()) {
+                // Add null values to the array
+                jsonArray.add(null);
+            } else {
+                // Handle primitive types in arrays
+                jsonArray.add(getPrimitiveValue(element));
+            }
+        }
+        return jsonArray;
+    }
+
+    // Determine the appropriate type of the primitive value and return it
+    private Object getPrimitiveValue(JsonNode node) {
+        if (node.isInt()) {
+            return node.asInt();
+        } else if (node.isLong()) {
+            return node.asLong();
+        } else if (node.isDouble()) {
+            return node.asDouble();
+        } else if (node.isBoolean()) {
+            return node.asBoolean();
+        } else {
+            // For other cases (like strings or non-standard types), we fallback to asText()
+            return node.asText();
+        }
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectDeserializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectDeserializer.java
@@ -2,14 +2,16 @@ package com.appsmith.external.converters;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.io.IOException;
-import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
@@ -18,7 +20,60 @@ public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
         super(t);
     }
 
-    public JSONObject deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+    public JSONObject deserialize(JsonParser jsonParser, DeserializationContext context)
+            throws IOException, JsonProcessingException {
+        // Use Jackson to read a generic Object and then handle type casting appropriately
+        /*Object parsed = jsonParser.readValueAs(Object.class);
+        return handleParsedObject(parsed);*/
+        ObjectCodec codec = jsonParser.getCodec();
+        JsonNode node = codec.readTree(jsonParser);
+
+        // Convert JsonNode to LinkedHashMap to avoid the cast exception
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> map = mapper.convertValue(node, LinkedHashMap.class);
+
+        // Return the map wrapped in a JSONObject
+        return new JSONObject(map);
+    }
+
+    private JSONObject handleParsedObject(Object parsed) {
+        if (parsed instanceof Map) {
+            return convertMapToJSONObject((Map<String, Object>) parsed); // Handle objects
+        } else if (parsed instanceof JSONArray) {
+            throw new IllegalStateException("Expected JSONObject but found JSONArray");
+        } else {
+            throw new IllegalStateException("Unexpected JSON structure");
+        }
+    }
+
+    private JSONObject convertMapToJSONObject(Map<String, Object> map) {
+        JSONObject jsonObject = new JSONObject();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            Object value = entry.getValue();
+
+            if (value instanceof Map) {
+                value = convertMapToJSONObject((Map<String, Object>) value); // Handle nested objects
+            } else if (value instanceof Iterable) {
+                value = convertIterableToJSONArray((Iterable<?>) value); // Handle arrays
+            }
+            // No need to cast anything further here, we preserve original types
+            jsonObject.put(entry.getKey(), value);
+        }
+        return jsonObject;
+    }
+
+    private JSONArray convertIterableToJSONArray(Iterable<?> iterable) {
+        JSONArray jsonArray = new JSONArray();
+        for (Object element : iterable) {
+            if (element instanceof Map) {
+                element = convertMapToJSONObject((Map<String, Object>) element); // Handle nested objects in arrays
+            }
+            jsonArray.add(element); // Preserve original element type
+        }
+        return jsonArray;
+    }
+
+    /*public JSONObject deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException, JsonProcessingException {
         JsonNode node = jsonParser.getCodec().readTree(jsonParser);
         return processJsonNode(node);
@@ -86,5 +141,5 @@ public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
             // For other cases (like strings or non-standard types), we fallback to asText()
             return node.asText();
         }
-    }
+    }*/
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectSerializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectSerializer.java
@@ -1,0 +1,64 @@
+package com.appsmith.external.converters;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import net.minidev.json.JSONObject;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class JSONObjectSerializer extends StdSerializer<JSONObject> {
+
+    public JSONObjectSerializer(Class<JSONObject> t) {
+        super(t);
+    }
+
+    public void serialize(JSONObject value, JsonGenerator jsonGenerator, SerializerProvider serializers)
+            throws IOException {
+        if (value == null) {
+            jsonGenerator.writeNull();
+        } else {
+            jsonGenerator.writeStartObject();
+            for (Map.Entry<String, Object> entry : value.entrySet()) {
+                String key = entry.getKey();
+                Object nestedValue = entry.getValue();
+
+                // Write the field name
+                jsonGenerator.writeFieldName(key);
+
+                // Handle different value types
+                if (nestedValue instanceof JSONObject) {
+                    // Recursively serialize nested JSONObject
+                    serialize((JSONObject) nestedValue, jsonGenerator, serializers);
+                } else if (nestedValue instanceof List<?>) {
+                    // Handle List of values or JSONObjects
+                    jsonGenerator.writeStartArray();
+                    for (Object item : (List<?>) nestedValue) {
+                        if (item instanceof JSONObject) {
+                            serialize((JSONObject) item, jsonGenerator, serializers);
+                        } else {
+                            // Handle values in the array
+                            if (item == null) {
+                                jsonGenerator.writeNull();
+                            } else {
+                                jsonGenerator.writeObject(item);
+                            }
+                        }
+                    }
+                    jsonGenerator.writeEndArray();
+                } else {
+                    // Handle simple data types, including null values
+                    if (nestedValue == null) {
+                        // Explicitly write null value
+                        jsonGenerator.writeNull();
+                    } else {
+                        jsonGenerator.writeObject(nestedValue);
+                    }
+                }
+            }
+            jsonGenerator.writeEndObject();
+        }
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectSerializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectSerializer.java
@@ -3,10 +3,11 @@ package com.appsmith.external.converters;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 public class JSONObjectSerializer extends StdSerializer<JSONObject> {
 
@@ -15,37 +16,6 @@ public class JSONObjectSerializer extends StdSerializer<JSONObject> {
     }
 
     public void serialize(JSONObject value, JsonGenerator jsonGenerator, SerializerProvider serializers)
-            throws IOException {
-        jsonGenerator.writeStartObject();
-
-        for (String key : value.keySet()) {
-            Object obj = value.get(key);
-            if (obj == null) {
-                jsonGenerator.writeNullField(key);
-            } else if (obj instanceof JSONObject) {
-                jsonGenerator.writeFieldName(key);
-                serialize((JSONObject) obj, jsonGenerator, serializers);
-            } else if (obj instanceof JSONArray) {
-                jsonGenerator.writeArrayFieldStart(key);
-                for (Object element : (JSONArray) obj) {
-                    if (element == null) {
-                        jsonGenerator.writeNull();
-                    } else if (element instanceof JSONObject) {
-                        serialize((JSONObject) element, jsonGenerator, serializers);
-                    } else {
-                        jsonGenerator.writeObject(element);
-                    }
-                }
-                jsonGenerator.writeEndArray();
-            } else {
-                jsonGenerator.writeObjectField(key, obj); // Preserve original type
-            }
-        }
-
-        jsonGenerator.writeEndObject();
-    }
-
-    /*public void serialize(JSONObject value, JsonGenerator jsonGenerator, SerializerProvider serializers)
             throws IOException {
         if (value == null) {
             jsonGenerator.writeNull();
@@ -90,5 +60,5 @@ public class JSONObjectSerializer extends StdSerializer<JSONObject> {
             }
             jsonGenerator.writeEndObject();
         }
-    }*/
+    }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectSerializer.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/converters/JSONObjectSerializer.java
@@ -3,11 +3,10 @@ package com.appsmith.external.converters;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 public class JSONObjectSerializer extends StdSerializer<JSONObject> {
 
@@ -16,6 +15,37 @@ public class JSONObjectSerializer extends StdSerializer<JSONObject> {
     }
 
     public void serialize(JSONObject value, JsonGenerator jsonGenerator, SerializerProvider serializers)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+
+        for (String key : value.keySet()) {
+            Object obj = value.get(key);
+            if (obj == null) {
+                jsonGenerator.writeNullField(key);
+            } else if (obj instanceof JSONObject) {
+                jsonGenerator.writeFieldName(key);
+                serialize((JSONObject) obj, jsonGenerator, serializers);
+            } else if (obj instanceof JSONArray) {
+                jsonGenerator.writeArrayFieldStart(key);
+                for (Object element : (JSONArray) obj) {
+                    if (element == null) {
+                        jsonGenerator.writeNull();
+                    } else if (element instanceof JSONObject) {
+                        serialize((JSONObject) element, jsonGenerator, serializers);
+                    } else {
+                        jsonGenerator.writeObject(element);
+                    }
+                }
+                jsonGenerator.writeEndArray();
+            } else {
+                jsonGenerator.writeObjectField(key, obj); // Preserve original type
+            }
+        }
+
+        jsonGenerator.writeEndObject();
+    }
+
+    /*public void serialize(JSONObject value, JsonGenerator jsonGenerator, SerializerProvider serializers)
             throws IOException {
         if (value == null) {
             jsonGenerator.writeNull();
@@ -60,5 +90,5 @@ public class JSONObjectSerializer extends StdSerializer<JSONObject> {
             }
             jsonGenerator.writeEndObject();
         }
-    }
+    }*/
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/JsonForDatabase.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/JsonForDatabase.java
@@ -1,6 +1,8 @@
 package com.appsmith.external.helpers;
 
 import com.appsmith.external.annotations.encryption.Encrypted;
+import com.appsmith.external.converters.JSONObjectDeserializer;
+import com.appsmith.external.converters.JSONObjectSerializer;
 import com.appsmith.external.views.Views;
 import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -11,9 +13,11 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.Converter;
 import com.fasterxml.jackson.databind.util.StdConverter;
 import jakarta.persistence.Transient;
+import net.minidev.json.JSONObject;
 
 /**
  * Owner of ObjectMapper configuration designed for serialization/deserialization of objects into/from the database.
@@ -49,6 +53,12 @@ public final class JsonForDatabase {
         // If at all we decide to change this to `false`, it _has_ to be treated as debt, and paid off by changing it
         // back to `true`.
         om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        // Custom serializer module for JSONObject of page DSL
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(JSONObject.class, new JSONObjectSerializer(JSONObject.class));
+        module.addDeserializer(JSONObject.class, new JSONObjectDeserializer(JSONObject.class));
+        om.registerModule(module);
 
         om.setVisibility(om.getSerializationConfig()
                 .getDefaultVisibilityChecker()

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/converter/JSONObjectDeserializerTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/converter/JSONObjectDeserializerTest.java
@@ -2,13 +2,14 @@ package com.appsmith.external.converter;
 
 import com.appsmith.external.helpers.JsonForDatabase;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JSONObjectDeserializerTest {
 
@@ -16,97 +17,72 @@ public class JSONObjectDeserializerTest {
         return JsonForDatabase.create();
     }
 
-    @Test
-    void testDeserializeSimpleObject() throws Exception {
-        String json = "{\"intField\": 123, \"stringField\": \"test\", \"booleanField\": true, \"doubleField\": 45.67}";
-
-        ObjectMapper objectMapper = getObjectMapper();
-        JSONObject result = objectMapper.readValue(json, JSONObject.class);
-
-        assertNotNull(result);
-        assertEquals(123, result.getAsNumber("intField"));
-        assertEquals("test", result.getAsString("stringField"));
-        assertEquals(true, result.get("booleanField"));
-        assertEquals(45.67, result.getAsNumber("doubleField"));
+    public static class Widget {
+        public String widgetName;
+        public Integer rightColumn;
+        public String backgroundColor;
+        public Integer snapColumns;
+        public Boolean detachFromLayout;
+        public String widgetId;
+        public Integer topRow;
+        public Integer bottomRow;
+        public String containerStyle;
+        public Integer snapRows;
+        public Integer parentRowSpace;
+        public String type;
+        public Boolean canExtend;
+        public Integer version;
+        public Integer minHeight;
+        public Integer parentColumnSpace;
+        public Map<String, Object> children; // Changed type to Map to avoid cast exception
     }
 
     @Test
-    void testDeserializeObjectWithNullValue() throws Exception {
-        String json = "{\"stringField\": \"test\", \"nullField\": null}";
-
-        ObjectMapper objectMapper = getObjectMapper();
-        JSONObject result = objectMapper.readValue(json, JSONObject.class);
-
-        assertNotNull(result);
-        assertEquals("test", result.getAsString("stringField"));
-        assertNull(result.get("nullField"));
-    }
-
-    @Test
-    void testDeserializeNestedObject() throws Exception {
-        String json = "{\"nestedObject\": {\"innerField\": 42, \"innerString\": \"innerValue\"}}";
-
-        ObjectMapper objectMapper = getObjectMapper();
-        JSONObject result = objectMapper.readValue(json, JSONObject.class);
-
-        assertNotNull(result);
-        JSONObject nestedObject = (JSONObject) result.get("nestedObject");
-        assertNotNull(nestedObject);
-        assertEquals(42, nestedObject.getAsNumber("innerField"));
-        assertEquals("innerValue", nestedObject.getAsString("innerString"));
-    }
-
-    @Test
-    void testDeserializeArray() throws Exception {
-        String json = "{\"arrayField\": [1, \"two\", true, null]}";
-
-        ObjectMapper objectMapper = getObjectMapper();
-        JSONObject result = objectMapper.readValue(json, JSONObject.class);
-
-        assertNotNull(result);
-        JSONArray array = (JSONArray) result.get("arrayField");
-
-        assertNotNull(array);
-        assertEquals(4, array.size());
-        assertEquals(1, array.get(0));
-        assertEquals("two", array.get(1));
-        assertEquals(true, array.get(2));
-        assertNull(array.get(3));
-    }
-
-    @Test
-    void testDeserializeComplexObject() throws Exception {
-        String json = "{\n" + "  \"intField\": 10,\n"
-                + "  \"stringField\": \"hello\",\n"
-                + "  \"booleanField\": false,\n"
-                + "  \"nestedObject\": {\n"
-                + "    \"innerInt\": 5,\n"
-                + "    \"innerArray\": [1, 2, 3],\n"
-                + "    \"innerObject\": {\"innerKey\": \"innerValue\"}\n"
-                + "  }\n"
+    public void testDeserializeWithNullValues() throws IOException {
+        // Sample JSON with null values
+        String jsonWithNulls = "{\n" + "  \"widgetName\": \"MainContainer\",\n"
+                + "  \"rightColumn\": 4896,\n"
+                + "  \"backgroundColor\": null,\n"
+                + "  \"snapColumns\": 64,\n"
+                + "  \"detachFromLayout\": true,\n"
+                + "  \"widgetId\": \"0\",\n"
+                + "  \"topRow\": 0,\n"
+                + "  \"bottomRow\": 680,\n"
+                + "  \"containerStyle\": \"none\",\n"
+                + "  \"snapRows\": 124,\n"
+                + "  \"parentRowSpace\": 1,\n"
+                + "  \"type\": \"CANVAS_WIDGET\",\n"
+                + "  \"canExtend\": true,\n"
+                + "  \"version\": 90,\n"
+                + "  \"minHeight\": 1292,\n"
+                + "  \"parentColumnSpace\": null\n"
                 + "}";
 
+        // Configure ObjectMapper with the custom deserializer
         ObjectMapper objectMapper = getObjectMapper();
-        JSONObject result = objectMapper.readValue(json, JSONObject.class);
+        // Register your custom deserializer here if necessary
+        // e.g., objectMapper.registerModule(customModule);
 
-        assertNotNull(result);
-        assertEquals(10, result.getAsNumber("intField"));
-        assertEquals("hello", result.getAsString("stringField"));
-        assertEquals(false, result.get("booleanField"));
+        // Deserialize JSON into Widget object
+        JSONObjectDeserializerTest.Widget widget =
+                objectMapper.readValue(jsonWithNulls, JSONObjectDeserializerTest.Widget.class);
 
-        JSONObject nestedObject = (JSONObject) result.get("nestedObject");
-        assertNotNull(nestedObject);
-        assertEquals(5, nestedObject.getAsNumber("innerInt"));
-
-        JSONArray innerArray = (JSONArray) nestedObject.get("innerArray");
-        assertNotNull(innerArray);
-        assertEquals(3, innerArray.size());
-        assertEquals(1, innerArray.get(0));
-        assertEquals(2, innerArray.get(1));
-        assertEquals(3, innerArray.get(2));
-
-        JSONObject innerObject = (JSONObject) nestedObject.get("innerObject");
-        assertNotNull(innerObject);
-        assertEquals("innerValue", innerObject.getAsString("innerKey"));
+        // Assert deserialized values including null fields
+        assertEquals("MainContainer", widget.widgetName);
+        assertEquals(4896, widget.rightColumn);
+        assertNull(widget.backgroundColor); // Assert null field
+        assertEquals(64, widget.snapColumns);
+        assertTrue(widget.detachFromLayout);
+        assertEquals("0", widget.widgetId);
+        assertEquals(0, widget.topRow);
+        assertEquals(680, widget.bottomRow);
+        assertEquals("none", widget.containerStyle);
+        assertEquals(124, widget.snapRows);
+        assertEquals(1, widget.parentRowSpace);
+        assertEquals("CANVAS_WIDGET", widget.type);
+        assertTrue(widget.canExtend);
+        assertEquals(90, widget.version);
+        assertEquals(1292, widget.minHeight);
+        assertNull(widget.parentColumnSpace); // Assert null field
     }
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/converter/JSONObjectDeserializerTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/converter/JSONObjectDeserializerTest.java
@@ -1,0 +1,112 @@
+package com.appsmith.external.converter;
+
+import com.appsmith.external.helpers.JsonForDatabase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class JSONObjectDeserializerTest {
+
+    private ObjectMapper getObjectMapper() {
+        return JsonForDatabase.create();
+    }
+
+    @Test
+    void testDeserializeSimpleObject() throws Exception {
+        String json = "{\"intField\": 123, \"stringField\": \"test\", \"booleanField\": true, \"doubleField\": 45.67}";
+
+        ObjectMapper objectMapper = getObjectMapper();
+        JSONObject result = objectMapper.readValue(json, JSONObject.class);
+
+        assertNotNull(result);
+        assertEquals(123, result.getAsNumber("intField"));
+        assertEquals("test", result.getAsString("stringField"));
+        assertEquals(true, result.get("booleanField"));
+        assertEquals(45.67, result.getAsNumber("doubleField"));
+    }
+
+    @Test
+    void testDeserializeObjectWithNullValue() throws Exception {
+        String json = "{\"stringField\": \"test\", \"nullField\": null}";
+
+        ObjectMapper objectMapper = getObjectMapper();
+        JSONObject result = objectMapper.readValue(json, JSONObject.class);
+
+        assertNotNull(result);
+        assertEquals("test", result.getAsString("stringField"));
+        assertNull(result.get("nullField"));
+    }
+
+    @Test
+    void testDeserializeNestedObject() throws Exception {
+        String json = "{\"nestedObject\": {\"innerField\": 42, \"innerString\": \"innerValue\"}}";
+
+        ObjectMapper objectMapper = getObjectMapper();
+        JSONObject result = objectMapper.readValue(json, JSONObject.class);
+
+        assertNotNull(result);
+        JSONObject nestedObject = (JSONObject) result.get("nestedObject");
+        assertNotNull(nestedObject);
+        assertEquals(42, nestedObject.getAsNumber("innerField"));
+        assertEquals("innerValue", nestedObject.getAsString("innerString"));
+    }
+
+    @Test
+    void testDeserializeArray() throws Exception {
+        String json = "{\"arrayField\": [1, \"two\", true, null]}";
+
+        ObjectMapper objectMapper = getObjectMapper();
+        JSONObject result = objectMapper.readValue(json, JSONObject.class);
+
+        assertNotNull(result);
+        JSONArray array = (JSONArray) result.get("arrayField");
+
+        assertNotNull(array);
+        assertEquals(4, array.size());
+        assertEquals(1, array.get(0));
+        assertEquals("two", array.get(1));
+        assertEquals(true, array.get(2));
+        assertNull(array.get(3));
+    }
+
+    @Test
+    void testDeserializeComplexObject() throws Exception {
+        String json = "{\n" + "  \"intField\": 10,\n"
+                + "  \"stringField\": \"hello\",\n"
+                + "  \"booleanField\": false,\n"
+                + "  \"nestedObject\": {\n"
+                + "    \"innerInt\": 5,\n"
+                + "    \"innerArray\": [1, 2, 3],\n"
+                + "    \"innerObject\": {\"innerKey\": \"innerValue\"}\n"
+                + "  }\n"
+                + "}";
+
+        ObjectMapper objectMapper = getObjectMapper();
+        JSONObject result = objectMapper.readValue(json, JSONObject.class);
+
+        assertNotNull(result);
+        assertEquals(10, result.getAsNumber("intField"));
+        assertEquals("hello", result.getAsString("stringField"));
+        assertEquals(false, result.get("booleanField"));
+
+        JSONObject nestedObject = (JSONObject) result.get("nestedObject");
+        assertNotNull(nestedObject);
+        assertEquals(5, nestedObject.getAsNumber("innerInt"));
+
+        JSONArray innerArray = (JSONArray) nestedObject.get("innerArray");
+        assertNotNull(innerArray);
+        assertEquals(3, innerArray.size());
+        assertEquals(1, innerArray.get(0));
+        assertEquals(2, innerArray.get(1));
+        assertEquals(3, innerArray.get(2));
+
+        JSONObject innerObject = (JSONObject) nestedObject.get("innerObject");
+        assertNotNull(innerObject);
+        assertEquals("innerValue", innerObject.getAsString("innerKey"));
+    }
+}

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/converter/JSONObjectSerializerTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/converter/JSONObjectSerializerTest.java
@@ -1,0 +1,105 @@
+package com.appsmith.external.converter;
+
+import com.appsmith.external.helpers.JsonForDatabase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JSONObjectSerializerTest {
+    private ObjectMapper getObjectMapper() {
+        return JsonForDatabase.create();
+    }
+
+    @Test
+    void testSerializeSimpleObject() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("intField", 123);
+        jsonObject.put("stringField", "test");
+        jsonObject.put("booleanField", true);
+        jsonObject.put("doubleField", 45.67);
+
+        ObjectMapper objectMapper = getObjectMapper();
+        String result = objectMapper.writeValueAsString(jsonObject);
+
+        assertTrue(result.contains("\"intField\":123"));
+        assertTrue(result.contains("\"stringField\":\"test\""));
+        assertTrue(result.contains("\"booleanField\":true"));
+        assertTrue(result.contains("\"doubleField\":45.67"));
+    }
+
+    @Test
+    void testSerializeObjectWithNullValue() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("stringField", "test");
+        jsonObject.put("nullField", null);
+
+        ObjectMapper objectMapper = getObjectMapper();
+        String result = objectMapper.writeValueAsString(jsonObject);
+
+        assertTrue(result.contains("\"stringField\":\"test\""));
+        assertTrue(result.contains("\"nullField\":null"));
+    }
+
+    @Test
+    void testSerializeNestedObject() throws Exception {
+        JSONObject nestedObject = new JSONObject();
+        nestedObject.put("innerField", 42);
+        nestedObject.put("innerString", "innerValue");
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("nestedObject", nestedObject);
+
+        ObjectMapper objectMapper = getObjectMapper();
+        String result = objectMapper.writeValueAsString(jsonObject);
+
+        assertTrue(result.contains("\"nestedObject\""));
+        assertTrue(result.contains("\"innerField\":42"));
+        assertTrue(result.contains("\"innerString\":\"innerValue\""));
+    }
+
+    @Test
+    void testSerializeArray() throws Exception {
+        JSONArray array = new JSONArray();
+        array.add(1);
+        array.add("two");
+        array.add(true);
+        array.add(null);
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("arrayField", array);
+
+        ObjectMapper objectMapper = getObjectMapper();
+        String result = objectMapper.writeValueAsString(jsonObject);
+
+        assertTrue(result.contains("\"arrayField\":[1,\"two\",true,null]"));
+    }
+
+    @Test
+    void testSerializeComplexObject() throws Exception {
+        JSONObject nestedObject = new JSONObject();
+        nestedObject.put("innerInt", 5);
+        nestedObject.put(
+                "innerArray", new JSONArray().appendElement(1).appendElement(2).appendElement(3));
+        nestedObject.put("innerObject", new JSONObject().appendField("innerKey", "innerValue"));
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("intField", 10);
+        jsonObject.put("stringField", "hello");
+        jsonObject.put("booleanField", false);
+        jsonObject.put("nestedObject", nestedObject);
+
+        ObjectMapper objectMapper = getObjectMapper();
+        String result = objectMapper.writeValueAsString(jsonObject);
+
+        assertTrue(result.contains("\"intField\":10"));
+        assertTrue(result.contains("\"stringField\":\"hello\""));
+        assertTrue(result.contains("\"booleanField\":false"));
+        assertTrue(result.contains("\"nestedObject\""));
+        assertTrue(result.contains("\"innerInt\":5"));
+        assertTrue(result.contains("\"innerArray\":[1,2,3]"));
+        assertTrue(result.contains("\"innerKey\":\"innerValue\""));
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -65,7 +65,6 @@ import reactor.util.function.Tuple2;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1044,15 +1043,18 @@ class LayoutActionServiceTest {
                     // verify that the layout of each page has been updated
                     JSONObject dsl1 = objects.getT1().getLayouts().get(0).getDsl();
                     JSONObject dsl2 = objects.getT2().getLayouts().get(0).getDsl();
-                    ArrayList<LinkedHashMap> childArray1 = (ArrayList) dsl1.get("children");
-                    ArrayList<LinkedHashMap> childArray2 = (ArrayList) dsl2.get("children");
+                    JSONArray childArray1 = (JSONArray) dsl1.get("children");
+                    JSONArray childArray2 = (JSONArray) dsl2.get("children");
 
                     assertEquals(1, childArray1.size());
                     assertEquals(1, childArray2.size());
 
-                    LinkedHashMap<String, String> widget1 = childArray1.get(0);
-                    LinkedHashMap<String, String> widget2 = childArray2.get(0);
-                    List<String> widgetNames = List.of(widget1.get("widgetName"), widget2.get("widgetName"));
+                    JSONObject child1 = (JSONObject) childArray1.get(0);
+                    JSONObject child2 = (JSONObject) childArray2.get(0);
+
+                    List<String> widgetNames = List.of(
+                            child1.get("widgetName").toString(),
+                            child2.get("widgetName").toString());
                     assertThat(widgetNames).contains("Layout1", "Layout2");
                 })
                 .verifyComplete();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -1281,7 +1281,7 @@ class LayoutActionServiceTest {
         assertNotNull(createdAction);
         assertThat(createdAction.getErrorReports()).isNull();
 
-        // since the dependency has been introduced, calling updateLayout will return a LayoutDTO with a populated
+        // since the dependency has been introduced calling updateLayout will return a LayoutDTO with a populated
         // layoutOnLoadActionErrors
         assertNotNull(firstLayout);
         assertEquals(1, firstLayout.getLayoutOnLoadActionErrors().size());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -1281,7 +1281,7 @@ class LayoutActionServiceTest {
         assertNotNull(createdAction);
         assertThat(createdAction.getErrorReports()).isNull();
 
-        // since the dependency has been introduced calling updateLayout will return a LayoutDTO with a populated
+        // since the dependency has been introduced, calling updateLayout will return a LayoutDTO with a populated
         // layoutOnLoadActionErrors
         assertNotNull(firstLayout);
         assertEquals(1, firstLayout.getLayoutOnLoadActionErrors().size());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
@@ -49,6 +49,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -74,6 +75,8 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ExtendWith(AfterAllCleanUpExtension.class)
+@TestPropertySource(
+        properties = "spring.aop.auto=false") // for turning off the aop,the aop and spybean don't work well together
 public class ConsolidatedAPIServiceImplTest {
 
     @Autowired

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
@@ -49,7 +49,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -75,8 +74,6 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ExtendWith(AfterAllCleanUpExtension.class)
-@TestPropertySource(
-        properties = "spring.aop.auto=false") // for turning off the aop,the aop and spybean don't work well together
 public class ConsolidatedAPIServiceImplTest {
 
     @Autowired

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
@@ -49,6 +49,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -74,6 +75,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ExtendWith(AfterAllCleanUpExtension.class)
+@TestPropertySource(properties = "spring.aop.auto=false")
 public class ConsolidatedAPIServiceImplTest {
 
     @Autowired


### PR DESCRIPTION
## Description

This adds a custom serialiser and deserialiser to handle null values in the page DSL. The DSL object can have properties with null values and the object mapper used for the `jsonb` or the `CustomJsonType` had a custom implementation of object mapper which by default does not allow null values to persist to db. 
This change has added a new serialiser and deserialiser that is registered with created object mapper to include null values.
This is applied only for the `JSONObject` type attribute as of now.



## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10935288236>
> Commit: 01304913e4580887305a1bbeac534fee249fdf3f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10935288236&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Thu, 19 Sep 2024 06:22:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
