### PR TITLE
fix: Date picker shouldn't appear on top of the date field

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { IntentColors } from "constants/DefaultTheme";
 import type { IRef, Alignment } from "@blueprintjs/core";
-import { ControlGroup, Classes } from "@blueprintjs/core";
+import { ControlGroup, Classes, Position } from "@blueprintjs/core";
 import type { ComponentProps } from "widgets/BaseComponent";
 import { DateInput } from "@blueprintjs/datetime";
 import moment from "moment";
@@ -390,6 +390,11 @@ class DatePickerComponent extends React.Component<
                 usePortal: !this.props.withoutPortal,
                 canEscapeKeyClose: true,
                 portalClassName: `${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`,
+                position: Position.RIGHT,
+                modifiers: {
+                  flip: { enabled: false },
+                  preventOverflow: { enabled: true, boundariesElement: "viewport"},
+                },
                 onClose: this.props.onPopoverClosed,
                 /*
                   Conditional popover props are the popover props that should not be sent to


### PR DESCRIPTION
Fixes: #35794 

Hi @carinanfonseca 

**What's in the pr :** 
- Initially, the date picker was appearing on top of the date field.
- Updated the date picker component by adding props to adjust the popover position to the right.
- Now, the date picker popover consistently appears on the right side of the date field.

**Before :** 

![image](https://github.com/user-attachments/assets/fddf2b00-862c-4882-9ae7-c559c8c58a89)

**After :**

![image](https://github.com/user-attachments/assets/21efef10-0c82-4188-99ea-0763810c4dac)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Date Picker component with improved popover positioning and behavior.
	- The popover now stays within viewport boundaries and does not flip when overflowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->