### PR TITLE
fix: Inline editing flaky test fix

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -17,10 +17,6 @@ describe(
   "Table widget inline editing functionality",
   { tags: ["@tag.Widget", "@tag.Table"] },
   () => {
-    afterEach(() => {
-      agHelper.SaveLocalStorageCache();
-    });
-
     beforeEach(() => {
       agHelper.RestoreLocalStorageCache();
       agHelper.AddDsl("Table/InlineEditingDSL");
@@ -161,6 +157,7 @@ describe(
     });
 
     it("7. should check if updatedRowIndex is getting updated for multi row update mode", () => {
+      agHelper.AddDsl("Table/InlineEditingDSL");
       cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
       cy.get(".t--widget-textwidget").should("exist");
       cy.updateCodeInput(

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -50,22 +50,16 @@ describe(
       cy.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editTableCell(0, 0);
-      cy.get(
-        widgetsPage.firstEditInput,
-      ).should("not.be.disabled");
+      cy.get(widgetsPage.firstEditInput).should("not.be.disabled");
     });
 
     it("3. should check that inline editing works with text wrapping enabled", () => {
       cy.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editColumn("step");
-      cy.get(widgetsPage.cellControlSwitch)
-        .first()
-        .click({ force: true });
+      cy.get(widgetsPage.cellControlSwitch).first().click({ force: true });
       cy.editTableCell(0, 0);
-      cy.get(
-        widgetsPage.firstEditInput,
-      ).should("not.be.disabled");
+      cy.get(widgetsPage.firstEditInput).should("not.be.disabled");
     });
 
     it("4. should check that cell column height doesn't grow taller when text wrapping is disabled", () => {
@@ -114,14 +108,13 @@ describe(
     it("6. should check if updatedRowIndex is getting updated for single row update mode", () => {
       cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
       cy.get(publish.textWidget).should("exist");
-      cy.updateCodeInput(
-        PROPERTY_SELECTOR.text,
-        `{{Table1.updatedRowIndex}}`,
-      );
+      cy.updateCodeInput(PROPERTY_SELECTOR.text, `{{Table1.updatedRowIndex}}`);
 
       cy.dragAndDropToCanvas("buttonwidget", { x: 300, y: 300 });
       cy.get(widgetsPage.widgetBtn).should("exist");
-      cy.get(PROPERTY_SELECTOR.onClick).find(PROPERTY_SELECTOR.jsToggle).click();
+      cy.get(PROPERTY_SELECTOR.onClick)
+        .find(PROPERTY_SELECTOR.jsToggle)
+        .click();
       cy.updateCodeInput(widgetsPage.propertyControlLabel, "Reset");
       cy.updateCodeInput(
         PROPERTY_SELECTOR.onClick,
@@ -165,13 +158,12 @@ describe(
       table.AddSampleTableData();
       cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
       cy.get(publish.textWidget).should("exist");
-      cy.updateCodeInput(
-        PROPERTY_SELECTOR.text,
-        `{{Table1.updatedRowIndex}}`,
-      );
+      cy.updateCodeInput(PROPERTY_SELECTOR.text, `{{Table1.updatedRowIndex}}`);
       cy.dragAndDropToCanvas("buttonwidget", { x: 300, y: 300 });
       cy.get(widgetsPage.widgetBtn).should("exist");
-      cy.get(PROPERTY_SELECTOR.onClick).find(PROPERTY_SELECTOR.jsToggle).click();
+      cy.get(PROPERTY_SELECTOR.onClick)
+        .find(PROPERTY_SELECTOR.jsToggle)
+        .click();
       cy.updateCodeInput(widgetsPage.propertyControlLabel, "Reset");
       propPane.EnterJSContext(
         "onClick",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -18,7 +18,12 @@ describe(
   "Table widget inline editing functionality",
   { tags: ["@tag.Widget", "@tag.Table"] },
   () => {
+    afterEach(() => {
+      agHelper.SaveLocalStorageCache();
+    });
+
     beforeEach(() => {
+      agHelper.RestoreLocalStorageCache();
       agHelper.AddDsl("Table/InlineEditingDSL");
     });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -12,6 +12,7 @@ import {
   draggableWidgets,
 } from "../../../../../support/Objects/ObjectsCore";
 import { PROPERTY_SELECTOR } from "../../../../../locators/WidgetLocators";
+import PageList from "../../../../../support/Pages/PageList";
 
 describe(
   "Table widget inline editing functionality",
@@ -156,6 +157,9 @@ describe(
     });
 
     it("7. should check if updatedRowIndex is getting updated for multi row update mode", () => {
+      PageList.AddNewPage("New blank page");
+      cy.dragAndDropToCanvas("tablewidgetv2", { x: 350, y: 500 });
+      table.AddSampleTableData();
       cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
       cy.get(".t--widget-textwidget").should("exist");
       cy.updateCodeInput(
@@ -166,10 +170,13 @@ describe(
       cy.get(".t--widget-buttonwidget").should("exist");
       cy.get(PROPERTY_SELECTOR.onClick).find(".t--js-toggle").click();
       cy.updateCodeInput(".t--property-control-label", "Reset");
-      cy.updateCodeInput(
-        PROPERTY_SELECTOR.onClick,
-        `{{resetWidget("Table1",true)}}`,
+      propPane.EnterJSContext(
+        "onClick",
+        '{{resetWidget("Table1",true)}}',
+        true,
+        false,
       );
+
       agHelper.ClickOutside();
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -10,7 +10,6 @@ import {
   propPane,
   table,
   draggableWidgets,
-  assertHelper,
 } from "../../../../../support/Objects/ObjectsCore";
 import { PROPERTY_SELECTOR } from "../../../../../locators/WidgetLocators";
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -182,7 +182,6 @@ describe(
         false,
       );
 
-      agHelper.ClickOutside();
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       agHelper.GetNClick(table._updateMode("Multi"), 0, false, 1000);

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -6,13 +6,12 @@ const commonlocators = require("../../../../../locators/commonlocators.json");
 const widgetsPage = require("../../../../../locators/Widgets.json");
 import {
   agHelper,
-  entityExplorer,
   propPane,
   table,
-  draggableWidgets,
 } from "../../../../../support/Objects/ObjectsCore";
 import { PROPERTY_SELECTOR } from "../../../../../locators/WidgetLocators";
 import PageList from "../../../../../support/Pages/PageList";
+const publish = require("../../../../../locators/publishWidgetspage.json");
 
 describe(
   "Table widget inline editing functionality",
@@ -31,8 +30,7 @@ describe(
       cy.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editColumn("EditActions1");
-      cy.get(".t--property-pane-section-collapse-savebutton").click();
-      //cy.get(".t--property-pane-section-collapse-discardbutton").click();
+      cy.get(widgetsPage.propertyPaneSaveButton).click();
       cy.getAlert("onDiscard", "discarded!!");
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "NewValue");
@@ -53,7 +51,7 @@ describe(
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editTableCell(0, 0);
       cy.get(
-        "[data-colindex=0][data-rowindex=0] .t--inlined-cell-editor input.bp3-input",
+        widgetsPage.firstEditInput,
       ).should("not.be.disabled");
     });
 
@@ -61,12 +59,12 @@ describe(
       cy.openPropertyPane("tablewidgetv2");
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       cy.editColumn("step");
-      cy.get(".t--property-control-cellwrapping .ads-v2-switch")
+      cy.get(widgetsPage.cellControlSwitch)
         .first()
         .click({ force: true });
       cy.editTableCell(0, 0);
       cy.get(
-        "[data-colindex=0][data-rowindex=0] .t--inlined-cell-editor input.bp3-input",
+        widgetsPage.firstEditInput,
       ).should("not.be.disabled");
     });
 
@@ -115,16 +113,16 @@ describe(
 
     it("6. should check if updatedRowIndex is getting updated for single row update mode", () => {
       cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
-      cy.get(".t--widget-textwidget").should("exist");
+      cy.get(publish.textWidget).should("exist");
       cy.updateCodeInput(
-        ".t--property-control-text",
+        PROPERTY_SELECTOR.text,
         `{{Table1.updatedRowIndex}}`,
       );
 
       cy.dragAndDropToCanvas("buttonwidget", { x: 300, y: 300 });
-      cy.get(".t--widget-buttonwidget").should("exist");
-      cy.get(PROPERTY_SELECTOR.onClick).find(".t--js-toggle").click();
-      cy.updateCodeInput(".t--property-control-label", "Reset");
+      cy.get(widgetsPage.widgetBtn).should("exist");
+      cy.get(PROPERTY_SELECTOR.onClick).find(PROPERTY_SELECTOR.jsToggle).click();
+      cy.updateCodeInput(widgetsPage.propertyControlLabel, "Reset");
       cy.updateCodeInput(
         PROPERTY_SELECTOR.onClick,
         `{{resetWidget("Table1",true)}}`,
@@ -166,15 +164,15 @@ describe(
       cy.dragAndDropToCanvas("tablewidgetv2", { x: 350, y: 500 });
       table.AddSampleTableData();
       cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
-      cy.get(".t--widget-textwidget").should("exist");
+      cy.get(publish.textWidget).should("exist");
       cy.updateCodeInput(
-        ".t--property-control-text",
+        PROPERTY_SELECTOR.text,
         `{{Table1.updatedRowIndex}}`,
       );
       cy.dragAndDropToCanvas("buttonwidget", { x: 300, y: 300 });
-      cy.get(".t--widget-buttonwidget").should("exist");
-      cy.get(PROPERTY_SELECTOR.onClick).find(".t--js-toggle").click();
-      cy.updateCodeInput(".t--property-control-label", "Reset");
+      cy.get(widgetsPage.widgetBtn).should("exist");
+      cy.get(PROPERTY_SELECTOR.onClick).find(PROPERTY_SELECTOR.jsToggle).click();
+      cy.updateCodeInput(widgetsPage.propertyControlLabel, "Reset");
       propPane.EnterJSContext(
         "onClick",
         '{{resetWidget("Table1",true)}}',

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
@@ -10,6 +10,7 @@ import {
   propPane,
   table,
   draggableWidgets,
+  assertHelper,
 } from "../../../../../support/Objects/ObjectsCore";
 import { PROPERTY_SELECTOR } from "../../../../../locators/WidgetLocators";
 
@@ -18,7 +19,6 @@ describe(
   { tags: ["@tag.Widget", "@tag.Table"] },
   () => {
     beforeEach(() => {
-      agHelper.RestoreLocalStorageCache();
       agHelper.AddDsl("Table/InlineEditingDSL");
     });
 
@@ -157,7 +157,6 @@ describe(
     });
 
     it("7. should check if updatedRowIndex is getting updated for multi row update mode", () => {
-      agHelper.AddDsl("Table/InlineEditingDSL");
       cy.dragAndDropToCanvas("textwidget", { x: 400, y: 400 });
       cy.get(".t--widget-textwidget").should("exist");
       cy.updateCodeInput(
@@ -172,7 +171,7 @@ describe(
         PROPERTY_SELECTOR.onClick,
         `{{resetWidget("Table1",true)}}`,
       );
-
+      agHelper.ClickOutside();
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       table.toggleColumnEditableViaColSettingsPane("step", "v2", true, true);
       agHelper.GetNClick(table._updateMode("Multi"), 0, false, 1000);

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/locators/WidgetLocators.ts
+++ b/app/client/cypress/locators/WidgetLocators.ts
@@ -61,6 +61,7 @@ export const PROPERTY_SELECTOR = {
   TextFieldName: "Text",
   tableData: ".t--property-control-tabledata",
   tableColumnNames: '[data-rbd-draggable-id] input[type="text"]',
+  jsToggle : '.t--js-toggle',
 };
 
 export const WIDGETSKIT = {

--- a/app/client/cypress/locators/Widgets.json
+++ b/app/client/cypress/locators/Widgets.json
@@ -230,5 +230,9 @@
   "showResult": ".t--property-control-showresult input[type='checkbox']",
   "infiniteLoading": ".t--property-control-infiniteloading input[type='checkbox']",
   "counterclockwise": ".t--property-control-counterclockwise input[type='checkbox']",
-  "serversideFilteringInput": ".t--property-control-serversidefiltering input[type='checkbox']"
+  "serversideFilteringInput": ".t--property-control-serversidefiltering input[type='checkbox']",
+  "propertyPaneSaveButton": ".t--property-pane-section-collapse-savebutton",
+  "firstEditInput":"[data-colindex=0][data-rowindex=0] .t--inlined-cell-editor input.bp3-input",
+  "cellControlSwitch" : ".t--property-control-cellwrapping .ads-v2-switch",
+  "propertyControlLabel" : ".t--property-control-label"
 }


### PR DESCRIPTION
## Description

EE PR: [Appsmith EE Pull Request #5158](https://github.com/appsmithorg/appsmith-ee/pull/5158)

Root Cause Analysis (RCA):
The `updateCodeInput` function was identified as a source of flakiness due to improper execution. Additionally, the `SaveLocalStorageCache` caused issues by retaining the reset button after the 6th test case, resulting in a duplicate button in the 7th test case, which led to test failures.

Solution:
Replaced `updateCodeInput` with `EnterJSContext` from `agHelper` for more reliable execution. For the second flaky step, a new page was created, and a table with relevant data was added. This resolved the issue without requiring significant changes to the test case or workflow.

Fixes #`36365`  

## Automation

/ok-to-test tags="@tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10940196158>
> Commit: 32d1be4c3dfe54bf8a0f8e9f54b20d2845c86407
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10940196158&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.ImportExport`
> Spec:
> <hr>Thu, 19 Sep 2024 12:01:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the inline editing test suite for the table widget to improve state management between tests.

- **New Features**
	- Updated the limited tests to focus on inline editing functionality, enhancing testing priorities for the Table V2 widget.
	- Introduced new properties in the widget locators to enhance UI interactions, including selectors for various controls and elements within the property pane and cell editing functionalities.
	- Added a new JavaScript toggle selector to facilitate interactions in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->