### PR TITLE
TESTING EXTERNAL SCRIPT: external merge request from Contributor

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInput_Part2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInput_Part2_spec.ts
@@ -292,6 +292,9 @@ describe(
 
       agHelper.ClearNType(locators._input, "100");
       agHelper.ValidateToastMessage("Value Changed");
+      agHelper.WaitUntilToastDisappear("Value Changed");
+      agHelper.ClearNType(locators._input, "a");
+      cy.get(locators._toastMsg).should("not.exist");
 
       // onFocus
       propPane.SelectPlatformFunction("onFocus", "Show alert");

--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -411,13 +411,18 @@ class PhoneInputWidget extends BaseInputWidget<
       "value",
       parseIncompletePhoneNumber(formattedValue),
     );
-    this.props.updateWidgetMetaProperty("text", formattedValue, {
-      triggerPropertyName: "onTextChanged",
-      dynamicString: this.props.onTextChanged,
-      event: {
-        type: EventType.ON_TEXT_CHANGE,
-      },
-    });
+    // This regular expression validates that the input:
+    // - Does not start with a whitespace character
+    // - Contains only digits, spaces, parentheses, plus, and minus symbols
+    if (/^(?!\s)[\d\s()+-]*$/.test(value)) {
+      this.props.updateWidgetMetaProperty("text", formattedValue, {
+        triggerPropertyName: "onTextChanged",
+        dynamicString: this.props.onTextChanged,
+        event: {
+          type: EventType.ON_TEXT_CHANGE,
+        },
+      });
+    }
     if (!this.props.isDirty) {
       this.props.updateWidgetMetaProperty("isDirty", true);
     }


### PR DESCRIPTION
## Description
- Shadow PR for https://github.com/appsmithorg/appsmith/pull/34715

Fixes #  

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget, @tag.PhoneInput, @tag.Binding, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10920246066>
> Commit: 659af9dd683faa269cec8d3e429376af185fcf89
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10920246066&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Anvil/AnvilModal_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxGroupWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCurrencyInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilIconButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInlineButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilParagraphWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilPhoneInputWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilStatsWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilSwitchGroupWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilSwitchWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilTableWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilToolbarButtonWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilZoneSectionWidgetSnapshot_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Radio/Radio2_spec.ts
> <li>cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Wed, 18 Sep 2024 11:30:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for the PhoneInput widget to ensure valid input formats.
	- Added a mechanism to confirm the disappearance of toast messages after input changes.

- **Bug Fixes**
	- Improved test robustness by verifying that toast messages are correctly displayed and removed during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->