### PR TITLE
chore: Trigger TBP on pg for scheduled run on release

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -9,11 +9,6 @@ on:
         description: "This is the PR number in case the workflow is being called in a pull request"
         required: false
         type: number
-      is-pg-build:
-        description: "This is a boolean value in case the workflow is being called for a PG build"
-        required: false
-        type: string
-        default: "false"
 
 jobs:
   build-docker:

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -23,7 +23,7 @@ on:
 
   # trigger for pushes to master and pg
   push:
-    branches: [master, pg]
+    branches: [master]
     paths:
       - "app/client/**"
       - "app/server/**"
@@ -58,6 +58,14 @@ jobs:
             echo "tags=" >> $GITHUB_OUTPUT
             echo "matrix=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]" >> $GITHUB_OUTPUT
           fi
+
+  invoke-tbp-workflow-for-pg:
+    needs: [setup]
+    if: github.event_name != 'push' && github.ref == 'refs/heads/release'
+    uses: benc-uk/workflow-dispatch@v1
+    with:
+      workflow: test-build-docker-image.yml
+      inputs: '{ "ref": "pg"}'
 
   server-build:
     needs: [setup]
@@ -100,7 +108,7 @@ jobs:
   ci-test:
     needs: [setup, build-docker-image]
     # Only run if the build step is successful
-    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/pg' )
+    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master')
     name: ci-test
     uses: ./.github/workflows/ci-test-custom-script.yml
     secrets: inherit
@@ -113,17 +121,18 @@ jobs:
   server-unit-tests:
     name: server-unit-tests
     needs: [build-docker-image]
-    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/pg' )
+    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master')
     uses: ./.github/workflows/server-build.yml
     secrets: inherit
     with:
       pr: 0
       skip-tests: false
+      is-pg-build: ${{ github.ref == 'refs/heads/pg' }}
 
   client-unit-tests:
     name: client-unit-tests
     needs: [build-docker-image]
-    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/pg' )
+    if: success() && ( github.event_name != 'push' || github.ref == 'refs/heads/master')
     uses: ./.github/workflows/client-unit-tests.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Description
We want to trigger TBP workflow on pg on a scheduled basis similar to what we have for release branch to be aware of failures on pg branch because of the continuous merges from release. We searched if scheduled job can be triggered for non default branch but that is not possible. With this PR we are adding a job in the workflow to trigger the `workflow_dispatch` event with ref to pg branch. Other options which we may want to explore is [reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows). 

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job for handling PostgreSQL workflows during release events.
- **Changes**
	- Removed the `is-pg-build` parameter from the build workflow.
	- Simplified the CI process by limiting job triggers to the `master` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->