### PR TITLE
feat: telemetry added for current linter

### DIFF
--- a/app/client/src/plugins/Linting/utils/getLintingErrors.ts
+++ b/app/client/src/plugins/Linting/utils/getLintingErrors.ts
@@ -36,6 +36,8 @@ import setters from "workers/Evaluation/setters";
 import { isMemberExpressionNode } from "@shared/ast/src";
 import { generate } from "astring";
 import getInvalidModuleInputsError from "ee/plugins/Linting/utils/getInvalidModuleInputsError";
+import { startAndEndSpanForFn } from "UITelemetry/generateTraces";
+import { objectKeys } from "@appsmith/utils";
 
 const EvaluationScriptPositions: Record<string, Position> = {};
 
@@ -65,7 +67,7 @@ function generateLintingGlobalData(data: Record<string, unknown>) {
   );
   libAccessors.forEach((accessor) => (globalData[accessor] = true));
   // Add all supported web apis
-  Object.keys(SUPPORTED_WEB_APIS).forEach(
+  objectKeys(SUPPORTED_WEB_APIS).forEach(
     (apiName) => (globalData[apiName] = true),
   );
   return globalData;
@@ -185,7 +187,16 @@ export default function getLintingErrors({
   const lintingGlobalData = generateLintingGlobalData(data);
   const lintingOptions = lintOptions(lintingGlobalData);
 
-  jshint(script, lintingOptions);
+  startAndEndSpanForFn(
+    "Linter",
+    // adding some metrics to compare the performance changes with eslint
+    {
+      linter: "JSHint",
+      linesOfCodeLinted: originalBinding.split("\n").length,
+      codeSizeInChars: originalBinding.length,
+    },
+    () => jshint(script, lintingOptions),
+  );
   const sanitizedJSHintErrors = sanitizeJSHintErrors(jshint.errors, scriptPos);
   const jshintErrors: LintError[] = sanitizedJSHintErrors.map((lintError) =>
     convertJsHintErrorToAppsmithLintError(


### PR DESCRIPTION
## Description
As the first step of replacing jshint with eslint, we need to add telemetry to the current linter to track the performance for the same and cross verify it with eslint once the replacement is done


Fixes #36331 

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10926988067>
> Commit: fd5272b96dfe3ee1105a85eba8f766379a125669
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10926988067&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 18 Sep 2024 17:42:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced linting process with performance tracking metrics.
	- Integrated telemetry to monitor the number of lines of code linted and code size.
	- Improved method for retrieving object keys for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->