### PR TITLE
chore: Revert "feat: telemetry added for current linter (#36400)"

### DIFF
--- a/app/client/src/plugins/Linting/utils/getLintingErrors.ts
+++ b/app/client/src/plugins/Linting/utils/getLintingErrors.ts
@@ -36,8 +36,6 @@ import setters from "workers/Evaluation/setters";
 import { isMemberExpressionNode } from "@shared/ast/src";
 import { generate } from "astring";
 import getInvalidModuleInputsError from "ee/plugins/Linting/utils/getInvalidModuleInputsError";
-import { startAndEndSpanForFn } from "UITelemetry/generateTraces";
-import { objectKeys } from "@appsmith/utils";
 
 const EvaluationScriptPositions: Record<string, Position> = {};
 
@@ -69,7 +67,7 @@ function generateLintingGlobalData(data: Record<string, unknown>) {
 
   libAccessors.forEach((accessor) => (globalData[accessor] = true));
   // Add all supported web apis
-  objectKeys(SUPPORTED_WEB_APIS).forEach(
+  Object.keys(SUPPORTED_WEB_APIS).forEach(
     (apiName) => (globalData[apiName] = true),
   );
 
@@ -197,16 +195,7 @@ export default function getLintingErrors({
   const lintingGlobalData = generateLintingGlobalData(data);
   const lintingOptions = lintOptions(lintingGlobalData);
 
-  startAndEndSpanForFn(
-    "Linter",
-    // adding some metrics to compare the performance changes with eslint
-    {
-      linter: "JSHint",
-      linesOfCodeLinted: originalBinding.split("\n").length,
-      codeSizeInChars: originalBinding.length,
-    },
-    () => jshint(script, lintingOptions),
-  );
+  jshint(script, lintingOptions);
   const sanitizedJSHintErrors = sanitizeJSHintErrors(jshint.errors, scriptPos);
   const jshintErrors: LintError[] = sanitizedJSHintErrors.map((lintError) =>
     convertJsHintErrorToAppsmithLintError(


### PR DESCRIPTION
This reverts commit 6ab9684b737290ebc2476ca959477246d1b3766b.

## Description
PR to revert changes made in telemetry for linter


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/test js

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10936319851>
> Commit: 00ef3209fe35ed23db8aa7df0958f95359eb1363
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10936319851&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Thu, 19 Sep 2024 07:56:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified linting process by removing telemetry-related functionality.
  
- **Bug Fixes**
	- Improved performance and maintainability of the linting process.

- **Refactor**
	- Updated method for retrieving keys from an object to use standard JavaScript functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->