### PR TITLE
chore: Removes unused feature flag ref

### DIFF
--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -12780,7 +12780,6 @@ export const defaultAppState = {
           ab_ds_binding_enabled: true,
           ask_ai_js: false,
           license_connection_pool_size_enabled: false,
-          release_widgetdiscovery_enabled: false,
           ab_ai_js_function_completion_enabled: true,
           release_workflows_enabled: false,
           license_scim_enabled: false,


### PR DESCRIPTION
## Description
`release_widgetdiscovery_enabled` is not used anymore, hence removing last traces of it.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 73c4d18e912eb07e82c2d22a047c5f470489a5e9 yet
> <hr>Thu, 19 Sep 2024 08:18:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the deprecated `release_widgetdiscovery_enabled` property from the application state, simplifying configuration and improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->