### PR TITLE
chore: add telemetry for current linter

### DIFF
--- a/app/client/src/plugins/Linting/handlers/lintService.ts
+++ b/app/client/src/plugins/Linting/handlers/lintService.ts
@@ -9,6 +9,7 @@ import { PathUtils } from "plugins/Linting/utils/pathUtils";
 import { extractReferencesFromPath } from "ee/plugins/Linting/utils/getEntityDependencies";
 import { groupDifferencesByType } from "plugins/Linting/utils/groupDifferencesByType";
 import type {
+  LintRequest,
   LintTreeRequestPayload,
   LintTreeResponse,
 } from "plugins/Linting/types";
@@ -39,7 +40,8 @@ class LintService {
     }
   }
 
-  lintTree = (payload: LintTreeRequestPayload) => {
+  lintTree = (lintRequest: LintRequest<LintTreeRequestPayload>) => {
+    const { data: payload, webworkerTelemetry } = lintRequest;
     const {
       cloudHosting,
       configTree,
@@ -78,6 +80,7 @@ class LintService {
       errors: {},
       lintedJSPaths: [],
       jsPropertiesState,
+      webworkerTelemetry,
     };
 
     try {
@@ -87,12 +90,13 @@ class LintService {
         jsPropertiesState,
         cloudHosting,
         asyncJSFunctionsInDataFields,
-
+        webworkerTelemetry,
         configTree,
       });
 
       lintTreeResponse.errors = lintErrors;
       lintTreeResponse.lintedJSPaths = lintedJSPaths;
+      lintTreeResponse.webworkerTelemetry = webworkerTelemetry;
     } catch (e) {}
 
     return lintTreeResponse;

--- a/app/client/src/plugins/Linting/handlers/setupLinkingWorkerEnv.ts
+++ b/app/client/src/plugins/Linting/handlers/setupLinkingWorkerEnv.ts
@@ -1,6 +1,9 @@
 import type { FeatureFlags } from "ee/entities/FeatureFlag";
 import { WorkerEnv } from "workers/Evaluation/handlers/workerEnv";
+import type { LintRequest } from "../types";
 
-export const setupLintingWorkerEnv = (featureFlags: FeatureFlags) => {
+export const setupLintingWorkerEnv = ({
+  data: featureFlags,
+}: LintRequest<FeatureFlags>) => {
   WorkerEnv.setFeatureFlags(featureFlags);
 };

--- a/app/client/src/plugins/Linting/handlers/updateJSLibraryGlobals.ts
+++ b/app/client/src/plugins/Linting/handlers/updateJSLibraryGlobals.ts
@@ -1,9 +1,11 @@
-import type { updateJSLibraryProps } from "plugins/Linting/types";
+import type { LintRequest, updateJSLibraryProps } from "plugins/Linting/types";
 import { isEqual } from "lodash";
 import { JSLibraries, JSLibraryAccessor } from "workers/common/JSLibrary";
 import { resetJSLibraries } from "workers/common/JSLibrary/resetJSLibraries";
 
-export function updateJSLibraryGlobals(data: updateJSLibraryProps) {
+export function updateJSLibraryGlobals({
+  data,
+}: LintRequest<updateJSLibraryProps>) {
   const { add, libs } = data;
 
   if (add) {

--- a/app/client/src/plugins/Linting/lintTree.ts
+++ b/app/client/src/plugins/Linting/lintTree.ts
@@ -21,6 +21,7 @@ export function getLintErrorsFromTree({
   jsPropertiesState,
   pathsToLint,
   unEvalTree,
+  webworkerTelemetry,
 }: getLintErrorsFromTreeProps): getLintErrorsFromTreeResponse {
   const lintTreeErrors: LintErrorsStore = {};
   const lintedJSPaths = new Set<string>();
@@ -47,6 +48,7 @@ export function getLintErrorsFromTree({
       entity,
       fullPropertyPath: bindingPath,
       globalData: globalData.getGlobalData(false),
+      webworkerTelemetry,
     });
 
     set(lintTreeErrors, `["${bindingPath}"]`, lintErrors);
@@ -67,6 +69,7 @@ export function getLintErrorsFromTree({
       userScript: unEvalPropertyValue,
       entity,
       globalData: globalData.getGlobalData(true),
+      webworkerTelemetry,
     });
 
     set(lintTreeErrors, `["${triggerPath}"]`, lintErrors);
@@ -87,6 +90,7 @@ export function getLintErrorsFromTree({
         const jsObjectBodyLintErrors = lintJSObjectBody(
           jsObjectName,
           globalData.getGlobalData(true),
+          webworkerTelemetry,
         );
 
         set(lintTreeErrors, jsObjectBodyPath, jsObjectBodyLintErrors);
@@ -96,6 +100,7 @@ export function getLintErrorsFromTree({
           jsObjectPath,
           jsObjectState,
           asyncJSFunctionsInDataFields,
+          webworkerTelemetry,
         );
         const currentLintErrorsInBody = get(
           lintTreeErrors,

--- a/app/client/src/plugins/Linting/linters/worker.ts
+++ b/app/client/src/plugins/Linting/linters/worker.ts
@@ -1,17 +1,29 @@
 import type { TMessage } from "utils/MessageUtil";
 import { MessageType } from "utils/MessageUtil";
 import { WorkerMessenger } from "workers/Evaluation/fns/utils/Messenger";
-import type { LintRequest } from "../types";
+import type {
+  LintRequest,
+  LintTreeRequestPayload,
+  updateJSLibraryProps,
+} from "../types";
 import { handlerMap } from "../handlers";
+import type { FeatureFlags } from "ee/entities/FeatureFlag";
 
-export function messageListener(e: MessageEvent<TMessage<LintRequest>>) {
+// The messageListener can have either of these three types
+type LinterFunctionPayload = LintTreeRequestPayload &
+  FeatureFlags &
+  updateJSLibraryProps;
+
+export function messageListener(
+  e: MessageEvent<TMessage<LintRequest<LinterFunctionPayload>>>,
+) {
   const { messageType } = e.data;
 
   if (messageType !== MessageType.REQUEST) return;
 
   const startTime = Date.now();
   const { body, messageId } = e.data;
-  const { data, method } = body;
+  const { method } = body;
 
   if (!method) return;
 
@@ -19,7 +31,7 @@ export function messageListener(e: MessageEvent<TMessage<LintRequest>>) {
 
   if (typeof messageHandler !== "function") return;
 
-  const responseData = messageHandler(data);
+  const responseData = messageHandler(body);
 
   if (!responseData) return;
 

--- a/app/client/src/plugins/Linting/tests/getLintingErrors.test.ts
+++ b/app/client/src/plugins/Linting/tests/getLintingErrors.test.ts
@@ -2,6 +2,8 @@ import { getScriptType } from "workers/Evaluation/evaluate";
 import { CustomLintErrorCode } from "../constants";
 import getLintingErrors from "../utils/getLintingErrors";
 
+const webworkerTelemetry = {};
+
 describe("getLintingErrors", () => {
   describe("1. Verify lint errors are not shown for supported window APIs", () => {
     const data = {};
@@ -17,6 +19,7 @@ describe("getLintingErrors", () => {
         originalBinding,
         script,
         scriptType,
+        webworkerTelemetry,
       });
 
       expect(Array.isArray(lintErrors)).toBe(true);
@@ -29,6 +32,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, true);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         originalBinding,
         script,
@@ -45,6 +49,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, true);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         originalBinding,
         script,
@@ -65,6 +70,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, true);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         originalBinding,
         script,
@@ -80,6 +86,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, true);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         originalBinding,
         script,
@@ -95,6 +102,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, true);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         originalBinding,
         script,
@@ -128,6 +136,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, false);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         options,
         originalBinding,
@@ -150,6 +159,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, false);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         options,
         originalBinding,
@@ -172,6 +182,7 @@ describe("getLintingErrors", () => {
       const scriptType = getScriptType(false, false);
 
       const lintErrors = getLintingErrors({
+        webworkerTelemetry,
         data,
         options,
         originalBinding,

--- a/app/client/src/plugins/Linting/types.ts
+++ b/app/client/src/plugins/Linting/types.ts
@@ -11,6 +11,10 @@ import type {
 import type { DependencyMap } from "utils/DynamicBindingUtils";
 import type { TJSPropertiesState } from "workers/Evaluation/JSObject/jsPropertiesState";
 import type { JSLibrary } from "workers/common/JSLibrary";
+import type { WebworkerSpanData } from "UITelemetry/generateWebWorkerTraces";
+import type { SpanAttributes } from "UITelemetry/generateTraces";
+
+export type WebworkerTelemetryAttribute = WebworkerSpanData | SpanAttributes;
 
 export enum LINT_WORKER_ACTIONS {
   LINT_TREE = "LINT_TREE",
@@ -21,6 +25,7 @@ export interface LintTreeResponse {
   errors: LintErrorsStore;
   lintedJSPaths: string[];
   jsPropertiesState: TJSPropertiesState;
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>;
 }
 
 export interface LintTreeRequestPayload {
@@ -30,11 +35,10 @@ export interface LintTreeRequestPayload {
   forceLinting?: boolean;
 }
 
-export interface LintRequest {
-  // TODO: Fix this the next time the file is edited
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any;
+export interface LintRequest<T> {
+  data: T;
   method: LINT_WORKER_ACTIONS;
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>;
 }
 
 export interface LintTreeSagaRequestData {
@@ -46,12 +50,14 @@ export interface lintTriggerPathProps {
   userScript: string;
   entity: DataTreeEntity;
   globalData: ReturnType<typeof createEvaluationContext>;
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>;
 }
 export interface lintBindingPathProps {
   dynamicBinding: string;
   entity: DataTreeEntity;
   fullPropertyPath: string;
   globalData: ReturnType<typeof createEvaluationContext>;
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>;
 }
 export interface getLintingErrorsProps {
   script: string;
@@ -62,6 +68,7 @@ export interface getLintingErrorsProps {
   options?: {
     isJsObject: boolean;
   };
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>;
 }
 
 export interface getLintErrorsFromTreeProps {
@@ -71,6 +78,7 @@ export interface getLintErrorsFromTreeProps {
   cloudHosting: boolean;
   asyncJSFunctionsInDataFields: DependencyMap;
   configTree: ConfigTree;
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>;
 }
 
 export interface getLintErrorsFromTreeResponse {

--- a/app/client/src/plugins/Linting/utils/getLintingErrors.ts
+++ b/app/client/src/plugins/Linting/utils/getLintingErrors.ts
@@ -36,8 +36,8 @@ import setters from "workers/Evaluation/setters";
 import { isMemberExpressionNode } from "@shared/ast/src";
 import { generate } from "astring";
 import getInvalidModuleInputsError from "ee/plugins/Linting/utils/getInvalidModuleInputsError";
-import { startAndEndSpanForFn } from "UITelemetry/generateTraces";
 import { objectKeys } from "@appsmith/utils";
+import { profileFn } from "UITelemetry/generateWebWorkerTraces";
 
 const EvaluationScriptPositions: Record<string, Position> = {};
 
@@ -192,12 +192,13 @@ export default function getLintingErrors({
   originalBinding,
   script,
   scriptType,
+  webworkerTelemetry,
 }: getLintingErrorsProps): LintError[] {
   const scriptPos = getEvaluationScriptPosition(scriptType);
   const lintingGlobalData = generateLintingGlobalData(data);
   const lintingOptions = lintOptions(lintingGlobalData);
 
-  startAndEndSpanForFn(
+  profileFn(
     "Linter",
     // adding some metrics to compare the performance changes with eslint
     {
@@ -205,6 +206,7 @@ export default function getLintingErrors({
       linesOfCodeLinted: originalBinding.split("\n").length,
       codeSizeInChars: originalBinding.length,
     },
+    webworkerTelemetry,
     () => jshint(script, lintingOptions),
   );
   const sanitizedJSHintErrors = sanitizeJSHintErrors(jshint.errors, scriptPos);

--- a/app/client/src/plugins/Linting/utils/lintBindingPath.ts
+++ b/app/client/src/plugins/Linting/utils/lintBindingPath.ts
@@ -11,6 +11,7 @@ export default function lintBindingPath({
   entity,
   fullPropertyPath,
   globalData,
+  webworkerTelemetry,
 }: lintBindingPathProps) {
   let lintErrors: LintError[] = [];
   const { propertyPath } = getEntityNameAndPropertyPath(fullPropertyPath);
@@ -37,6 +38,7 @@ export default function lintBindingPath({
           data: globalData,
           originalBinding,
           scriptType,
+          webworkerTelemetry,
         });
 
         lintErrors = lintErrors.concat(lintErrorsFromSnippet);

--- a/app/client/src/plugins/Linting/utils/lintJSObjectBody.ts
+++ b/app/client/src/plugins/Linting/utils/lintJSObjectBody.ts
@@ -11,10 +11,12 @@ import {
 import { Severity } from "entities/AppsmithConsole";
 import { getJSToLint } from "./getJSToLint";
 import getLintingErrors from "./getLintingErrors";
+import type { WebworkerTelemetryAttribute } from "../types";
 
 export default function lintJSObjectBody(
   jsObjectName: string,
   globalData: DataTree,
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>,
 ): LintError[] {
   const jsObject = globalData[jsObjectName];
   const rawJSObjectbody = (jsObject as unknown as JSActionEntity).body;
@@ -50,5 +52,6 @@ export default function lintJSObjectBody(
     data: globalData,
     originalBinding: jsbodyToLint,
     scriptType,
+    webworkerTelemetry,
   });
 }

--- a/app/client/src/plugins/Linting/utils/lintJSObjectProperty.ts
+++ b/app/client/src/plugins/Linting/utils/lintJSObjectProperty.ts
@@ -11,11 +11,13 @@ import { globalData } from "../globalData";
 import getLintSeverity from "./getLintSeverity";
 import lintJSProperty from "./lintJSProperty";
 import { isEmpty } from "lodash";
+import type { WebworkerTelemetryAttribute } from "../types";
 
 export default function lintJSObjectProperty(
   jsPropertyFullName: string,
   jsObjectState: Record<string, TJSpropertyState>,
   asyncJSFunctionsInDataFields: DependencyMap,
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>,
 ) {
   let lintErrors: LintError[] = [];
   const { propertyPath: jsPropertyName } =
@@ -29,6 +31,7 @@ export default function lintJSObjectProperty(
     jsPropertyFullName,
     jsPropertyState,
     globalData.getGlobalData(!isAsyncJSFunctionBoundToSyncField),
+    webworkerTelemetry,
   );
 
   lintErrors = lintErrors.concat(jsPropertyLintErrors);

--- a/app/client/src/plugins/Linting/utils/lintJSProperty.ts
+++ b/app/client/src/plugins/Linting/utils/lintJSProperty.ts
@@ -8,11 +8,13 @@ import {
 } from "workers/Evaluation/evaluate";
 import type { TJSpropertyState } from "workers/Evaluation/JSObject/jsPropertiesState";
 import getLintingErrors from "./getLintingErrors";
+import type { WebworkerTelemetryAttribute } from "../types";
 
 export default function lintJSProperty(
   jsPropertyFullName: string,
   jsPropertyState: TJSpropertyState,
   globalData: DataTree,
+  webworkerTelemetry: Record<string, WebworkerTelemetryAttribute>,
 ): LintError[] {
   if (isNil(jsPropertyState)) {
     return [];
@@ -29,6 +31,7 @@ export default function lintJSProperty(
     originalBinding: jsPropertyState.value,
     scriptType,
     options: { isJsObject: true },
+    webworkerTelemetry,
   });
   const refinedErrors = propLintErrors.map((lintError) => {
     return {

--- a/app/client/src/plugins/Linting/utils/lintTriggerPath.ts
+++ b/app/client/src/plugins/Linting/utils/lintTriggerPath.ts
@@ -10,6 +10,7 @@ export default function lintTriggerPath({
   entity,
   globalData,
   userScript,
+  webworkerTelemetry,
 }: lintTriggerPathProps) {
   const { jsSnippets } = getDynamicBindings(userScript, entity);
   const script = getScriptToEval(jsSnippets[0], EvaluationScriptType.TRIGGERS);
@@ -19,5 +20,6 @@ export default function lintTriggerPath({
     data: globalData,
     originalBinding: jsSnippets[0],
     scriptType: EvaluationScriptType.TRIGGERS,
+    webworkerTelemetry,
   });
 }


### PR DESCRIPTION
## Description
As the first step of replacing jshint with eslint, we need to add telemetry to the current linter to track the performance for the same and cross verify it with eslint once the replacement is done. Since linter works in a worker thread, the normal span functions do not work and we need to use the `webworkerTelemetry` object to collect all the metrics when the worker is doing its job and at the end pass it off to the main thread for the metrics to be deployed.


note: this PR does not change any functionality of the system, just adds telemetry for the linter and the tooling to add metrics to any other linter functions easier.


Fixes #36331 

## Automation

/test sanity js 

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10943427984>
> Commit: 0da7c9d57dda7b3ddbc6bad0d78217080fb2bf6c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10943427984&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.JS`
> Spec:
> <hr>Thu, 19 Sep 2024 15:32:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced linting functionality with integrated telemetry tracking for performance metrics.
	- Improved monitoring of linting operations, including lines of code and character size.
	- Expanded capabilities to handle structured linting requests with additional telemetry data.

- **Bug Fixes**
	- Updated method for obtaining keys from the `SUPPORTED_WEB_APIS` for better consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->