### PR TITLE
fix: disable anvil snapshots tests

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilModal_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AnvilModal_spec.ts
@@ -134,7 +134,8 @@ describe(
         anvilLocators.anvilWidgetNameSelector("Button2"),
       );
     });
-    it("8. Verify different modal sizes", () => {
+    // TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+    it.skip("8. Verify different modal sizes", () => {
       // select all widgets and delete
       agHelper.PressEscape();
       agHelper.SelectAllWidgets();

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/AppTheming/AnvilAppThemingSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/AppTheming/AnvilAppThemingSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for App Theming`,
   { tags: ["@tag.Anvil"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilButtonWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilButtonWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Button Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxGroupWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxGroupWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Checkbox Group Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCheckboxWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Checkbox Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCurrencyInputWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilCurrencyInputWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Currency Input Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilHeadingWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilHeadingWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Heading Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilIconButtonWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilIconButtonWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Icon Button Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInlineButtonWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInlineButtonWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Inline Button Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInputWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilInputWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Input Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilParagraphWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilParagraphWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Paragraph Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilPhoneInputWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilPhoneInputWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Phone Input Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilRadioGroupWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilRadioGroupWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Radio Group Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilStatsWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilStatsWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Stats Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {
@@ -20,7 +21,7 @@ describe(
     });
 
     it("2. Preview Mode", () => {
-      anvilSnapshot.enterPreviewMode("StatsWidget");
+      anvilSnapshot.enterPreviewMode();
     });
 
     it("3. Deploy Mode", () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilSwitchGroupWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilSwitchGroupWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Switch Group Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilSwitchWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilSwitchWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Switch Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilTableWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilTableWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Table Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilToolbarButtonWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilToolbarButtonWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Toolbar Button Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilZoneSectionWidgetSnapshot_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Anvil/Widgets/AnvilZoneSectionWidgetSnapshot_spec.ts
@@ -4,7 +4,8 @@ import {
   anvilSnapshot,
 } from "../../../../../support/Objects/ObjectsCore";
 
-describe(
+// TODO: Enable when issue(github.com/appsmithorg/appsmith/issues/36419) is solved.
+describe.skip(
   `${ANVIL_EDITOR_TEST}: Anvil tests for Zone and Section Widget`,
   { tags: ["@tag.Anvil", "@tag.Visual"] },
   () => {


### PR DESCRIPTION
## Description
Disable all Anvil snapshot tests. The tests will be enabled after solving the #36419. 

Related thread https://theappsmith.slack.com/archives/C025SE88KNE/p1726721979435589

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10938186194>
> Commit: ee5c8f40eb3873bd9db8d9b7ca4c3519d989a038
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10938186194&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 19 Sep 2024 11:14:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Temporarily skipped multiple test suites for various Anvil widgets due to unresolved issues, preventing potential false negatives in testing.
	- Specific tests affected include those for Modal sizes, App Theming, Button, Checkbox, Currency Input, Heading, Icon Button, Inline Button, Input, Paragraph, Phone Input, Radio Group, Stats, Switch Group, Switch, Table, Toolbar Button, and Zone Section Widgets. 

These adjustments ensure the integrity of the testing process while issues are being addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->