### PR TITLE
chore: Trigger ok-to-test using commit message

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -122,6 +122,16 @@ jobs:
               else
                 echo "matrix=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
        
+  perform-test-for-tags-in-commit-message:
+      needs: [ parse-tags-from-commit-message ]
+      if: success()
+      uses: ./.github/workflows/pr-cypress.yml
+      secrets: inherit
+      with:
+        tags: ${{ needs.parse-tags-from-commit-message.outputs.tags}}
+        spec: ${{ needs.parse-tags-from-commit-message.outputs.spec}}
+        matrix: ${{ needs.parse-tags-from-commit-message.outputs.matrix}}
+        is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' }}
 
   parse-tags-from-pr-description:
     needs: [ checkTestLabelAndCommit ]
@@ -185,6 +195,7 @@ jobs:
           script: |
             require("write-cypress-status.js")({core, context, github}, "important", process.env.BODY)
 
+
   # Call the workflow to run Cypress tests
   perform-test-for-tags-in-pr-description:
     needs: [ parse-tags-from-pr-description ]
@@ -197,13 +208,4 @@ jobs:
       matrix: ${{ needs.parse-tags-from-pr-description.outputs.matrix}}
       is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' }}
 
-  perform-test-for-tags-in-commit-message:
-    needs: [ parse-tags-from-commit-message ]
-    if: success()
-    uses: ./.github/workflows/pr-cypress.yml
-    secrets: inherit
-    with:
-      tags: ${{ needs.parse-tags-from-commit-message.outputs.tags}}
-      spec: ${{ needs.parse-tags-from-commit-message.outputs.spec}}
-      matrix: ${{ needs.parse-tags-from-commit-message.outputs.matrix}}
-      is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' }}
+  

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -104,9 +104,9 @@ jobs:
         - name: Parse tags from commit message
           id: parseTagsFromCommit
           run: |
-            commit_message="${{ needs.checkTestLabelAndCommit.outputs.commit_message }}"
+            commit_message='${{ needs.checkTestLabelAndCommit.outputs.commit_message }}'
             # Regex to match '/ok-to-test tags=' followed by any text within optional quotes
-            if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*\"([^\"]+)\" ]]; then
+            if [[ '$commit_message' =~ /ok-to-test[[:space:]]+tags=[[:space:]]*\"([^\"]+)\" ]]; then
               tags=${BASH_REMATCH[1]}
               echo "Commit contains /ok-to-test tags= with tags: $tags"
               echo "has_test_spec=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -13,10 +13,11 @@ on:
     types: [ labeled, synchronize ]
 
 jobs:
-  checkTestLabel:
+  checkTestLabelAndCommit:
     runs-on: ubuntu-latest
     outputs:
       ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}
+      commit_contains_test: ${{ steps.checkCommitMessage.outputs.commit_contains_test }}
     steps:
 
       - name: Check PR Label
@@ -36,10 +37,23 @@ jobs:
               console.log("Label 'ok-to-test' is not present");
               core.setOutput("ok_to_test", "false");
             }
-
+      
+      - name: Check Commit Message
+        id: checkCommitMessage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commitMessage = context.payload.pull_request.head.commit.message;
+            if (commitMessage.includes("/ok-to-test tags=")) {
+              console.log("Commit message contains '/ok-to-test tags='");
+              core.setOutput("commit_contains_test", "true");
+            } else {
+              console.log("Commit message does not contain '/ok-to-test tags='");
+              core.setOutput("commit_contains_test", "false");
+            }
   mark-stale:
-    needs: [ checkTestLabel ]
-    if: needs.checkTestLabel.outputs.ok_to_test == 'false'
+    needs: [ checkTestLabelAndCommit ]
+    if: needs.checkTestLabelAndCommit.outputs.ok_to_test == 'false' && needs.checkTestLabelAndCommit.outputs.commit_contains_test == 'false'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -60,9 +74,58 @@ jobs:
           script: |
             require("write-cypress-status.js")({core, context, github}, "warning", process.env.BODY)
 
-  parse-tags:
-    needs: [ checkTestLabel ]
-    if: needs.checkTestLabel.outputs.ok_to_test == 'true'
+  parse-tags-from-commit-message:
+    needs: [ checkTestLabelAndCommit ]
+    if: needs.checkTestLabelAndCommit.outputs.commit_contains_test == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      tags: ${{ steps.parseTagsFromCommit.outputs.tags }}
+      spec: ${{ steps.parseTagsFromCommit.outputs.spec }}
+      matrix: ${{ steps.checkAll.outputs.matrix }}
+    steps:
+      
+        # Checkout the code in the current branch in case the workflow is called because of a branch push event
+        - name: Checkout the head commit of the branch
+          uses: actions/checkout@v4
+          with:
+            repository: appsmithorg/appsmith
+  
+        - name: Parse tags from commit message
+          id: parseTagsFromCommit
+          run: |
+            commit_message=$(git log -1 --pretty=%B)
+            # Regex to match '/ok-to-test tags=' followed by any text within optional quotes
+            if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*["'']?([^"'\n]*)["'']? ]]; then
+              tags=${BASH_REMATCH[1]}
+              echo "Commit contains /ok-to-test tags= with tags: $tags"
+              echo "has_test_spec=true" >> $GITHUB_OUTPUT
+              echo "tags_from_commit=$tags" >> $GITHUB_OUTPUT
+            else
+              echo "No /ok-to-test tags= found in the commit message"
+              echo "has_test_spec=false" >> $GITHUB_OUTPUT
+              echo "tags_from_commit=" >> $GITHUB_OUTPUT
+            fi
+  
+        # In case of a run with all test cases, allocate a larger matrix
+        - name: Check if @tag.All is present in tags
+          id: checkAll
+          run: |
+            if [[ -n "${{ steps.parseTagsFromCommit.outputs.spec }}" ]]; then
+              echo "matrix=[0]" >> $GITHUB_OUTPUT
+            else
+              tags="${{ steps.parseTagsFromCommit.outputs.tags }}"
+              if [[ $tags == "@tag.All" ]]; then
+                echo "matrix=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]" >> $GITHUB_OUTPUT
+              else
+                echo "matrix=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+       
+
+  parse-tags-from-pr-description:
+    needs: [ checkTestLabelAndCommit ]
+    if: needs.checkTestLabelAndCommit.outputs.ok_to_test == 'true' && needs.checkTestLabelAndCommit.outputs.commit_contains_test == 'false'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -123,13 +186,24 @@ jobs:
             require("write-cypress-status.js")({core, context, github}, "important", process.env.BODY)
 
   # Call the workflow to run Cypress tests
-  perform-test:
-    needs: [ parse-tags ]
+  perform-test-for-tags-in-pr-description:
+    needs: [ parse-tags-from-pr-description ]
     if: success()
     uses: ./.github/workflows/pr-cypress.yml
     secrets: inherit
     with:
-      tags: ${{ needs.parse-tags.outputs.tags}}
-      spec: ${{ needs.parse-tags.outputs.spec}}
-      matrix: ${{ needs.parse-tags.outputs.matrix}}
+      tags: ${{ needs.parse-tags-from-pr-description.outputs.tags}}
+      spec: ${{ needs.parse-tags-from-pr-description.outputs.spec}}
+      matrix: ${{ needs.parse-tags-from-pr-description.outputs.matrix}}
+      is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' }}
+
+  perform-test-for-tags-in-commit-message:
+    needs: [ parse-tags-from-commit-message ]
+    if: success()
+    uses: ./.github/workflows/pr-cypress.yml
+    secrets: inherit
+    with:
+      tags: ${{ needs.parse-tags-from-commit-message.outputs.tags}}
+      spec: ${{ needs.parse-tags-from-commit-message.outputs.spec}}
+      matrix: ${{ needs.parse-tags-from-commit-message.outputs.matrix}}
       is-pg-build: ${{ github.event.pull_request.base.ref == 'pg' }}

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check Commit Message
         id: checkCommitMessage
         run: |
-          commit_message=$(git log -1 --pretty=%B)
+          commit_message=$(git log -1 --skip=1 --pretty=%B)
           # Print the commit message for debugging
           echo "Commit Message: $commit_message" 
           if [[ "$commit_message" == *"/ok-to-test tags="* ]]; then

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           commit_message=$(git log -1 --pretty=%B)
           # Print the commit message for debugging
-          echo "Commit Message: $commitMessage"
+          echo "Commit Message: $commit_message" 
           if [[ "$commit_message" == *"/ok-to-test tags="* ]]; then
             echo "Commit message contains '/ok-to-test tags='"
             echo "commit_contains_test=true" >> $GITHUB_ENV

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   checkTestLabelAndCommit:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     outputs:
       ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}
       commit_contains_test: ${{ steps.checkCommitMessage.outputs.commit_contains_test }}
@@ -37,20 +40,25 @@ jobs:
               console.log("Label 'ok-to-test' is not present");
               core.setOutput("ok_to_test", "false");
             }
+
+      # Checkout the code in the current branch in case the workflow is called because of a branch push event
+      - name: Checkout the head commit of the branch
+        uses: actions/checkout@v4
+        with:
+          repository: appsmithorg/appsmith
       
       - name: Check Commit Message
         id: checkCommitMessage
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const commitMessage = context.payload.pull_request.head.commit.message;
-            if (commitMessage.includes("/ok-to-test tags=")) {
-              console.log("Commit message contains '/ok-to-test tags='");
-              core.setOutput("commit_contains_test", "true");
-            } else {
-              console.log("Commit message does not contain '/ok-to-test tags='");
-              core.setOutput("commit_contains_test", "false");
-            }
+        run: |
+          commit_message=$(git log -1 --pretty=%B)
+          if [[ "$commit_message" == *"/ok-to-test tags="* ]]; then
+            echo "Commit message contains '/ok-to-test tags='"
+            echo "commit_contains_test=true" >> $GITHUB_ENV
+          else
+            echo "Commit message does not contain '/ok-to-test tags='"
+            echo "commit_contains_test=false" >> $GITHUB_ENV
+          fi
+
   mark-stale:
     needs: [ checkTestLabelAndCommit ]
     if: needs.checkTestLabelAndCommit.outputs.ok_to_test == 'false' && needs.checkTestLabelAndCommit.outputs.commit_contains_test == 'false'

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -128,8 +128,9 @@ jobs:
               if [[ $tags == "@tag.All" ]]; then
                 echo "matrix=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]" >> $GITHUB_OUTPUT
               else
-                echo "matrix=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
-       
+                echo "matrix=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]" >> $GITHUB_OUTPUT
+              fi
+            fi
   perform-test-for-tags-in-commit-message:
       needs: [ parse-tags-from-commit-message ]
       if: success()

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -42,10 +42,11 @@ jobs:
             }
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
-      - name: Checkout the head commit of the branch
+      - name: Checkout PR
         uses: actions/checkout@v4
         with:
-          repository: appsmithorg/appsmith
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       
       - name: Check Commit Message
         id: checkCommitMessage

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}
       commit_contains_test: ${{ steps.checkCommitMessage.outputs.commit_contains_test }}
+      commit_message: ${{ steps.checkCommitMessage.outputs.commit_message }}
     steps:
 
       - name: Check PR Label
@@ -100,18 +101,12 @@ jobs:
       matrix: ${{ steps.checkAll.outputs.matrix }}
     steps:
       
-        # Checkout the code in the current branch in case the workflow is called because of a branch push event
-        - name: Checkout the head commit of the branch
-          uses: actions/checkout@v4
-          with:
-            repository: appsmithorg/appsmith
-  
         - name: Parse tags from commit message
           id: parseTagsFromCommit
           run: |
-            commit_message=$(git log -1 --pretty=%B)
+            commit_message="${{ needs.job1-set-output.outputs.commit_message }}"
             # Regex to match '/ok-to-test tags=' followed by any text within optional quotes
-            if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*["'']?([^"'\n]*)["'']? ]]; then
+            if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*['"]?([^"'\n]*)['"]? ]]; then
               tags=${BASH_REMATCH[1]}
               echo "Commit contains /ok-to-test tags= with tags: $tags"
               echo "has_test_spec=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           commit_message=$(git log -1 --pretty=%B)
           # Print the commit message for debugging
-          echo "Commit Message: $commit_message" 
+          echo "commit_message=$commit_message" >> $GITHUB_OUTPUT
           if [[ "$commit_message" == *"/ok-to-test tags="* ]]; then
             echo "Commit message contains '/ok-to-test tags='"
             echo "commit_contains_test=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -106,7 +106,7 @@ jobs:
           run: |
             commit_message="${{ needs.job1-set-output.outputs.commit_message }}"
             # Regex to match '/ok-to-test tags=' followed by any text within optional quotes
-            if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*['"]?([^"'\n]*)['"]? ]]; then
+            if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*\"([^\"]+)\" ]]; then
               tags=${BASH_REMATCH[1]}
               echo "Commit contains /ok-to-test tags= with tags: $tags"
               echo "has_test_spec=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -110,11 +110,11 @@ jobs:
               tags=${BASH_REMATCH[1]}
               echo "Commit contains /ok-to-test tags= with tags: $tags"
               echo "has_test_spec=true" >> $GITHUB_OUTPUT
-              echo "tags_from_commit=$tags" >> $GITHUB_OUTPUT
+              echo "spec=$tags" >> $GITHUB_OUTPUT
             else
               echo "No /ok-to-test tags= found in the commit message"
               echo "has_test_spec=false" >> $GITHUB_OUTPUT
-              echo "tags_from_commit=" >> $GITHUB_OUTPUT
+              echo "spec=" >> $GITHUB_OUTPUT
             fi
   
         # In case of a run with all test cases, allocate a larger matrix

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -104,7 +104,7 @@ jobs:
         - name: Parse tags from commit message
           id: parseTagsFromCommit
           run: |
-            commit_message="${{ needs.job1-set-output.outputs.commit_message }}"
+            commit_message="${{ needs.checkTestLabelAndCommit.outputs.commit_message }}"
             # Regex to match '/ok-to-test tags=' followed by any text within optional quotes
             if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*\"([^\"]+)\" ]]; then
               tags=${BASH_REMATCH[1]}

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -46,11 +46,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: appsmithorg/appsmith
+          ref: ${{ github.event.pull_request.head.sha }}
      
       - name: Check Commit Message
         id: checkCommitMessage
         run: |
-          commit_message=$(git log -1 --skip=1 --pretty=%B)
+          commit_message=$(git log -1 --pretty=%B)
           # Print the commit message for debugging
           echo "Commit Message: $commit_message" 
           if [[ "$commit_message" == *"/ok-to-test tags="* ]]; then

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -51,6 +51,8 @@ jobs:
         id: checkCommitMessage
         run: |
           commit_message=$(git log -1 --pretty=%B)
+          # Print the commit message for debugging
+          echo "Commit Message: $commitMessage"
           if [[ "$commit_message" == *"/ok-to-test tags="* ]]; then
             echo "Commit message contains '/ok-to-test tags='"
             echo "commit_contains_test=true" >> $GITHUB_ENV

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -110,11 +110,11 @@ jobs:
               tags=${BASH_REMATCH[1]}
               echo "Commit contains /ok-to-test tags= with tags: $tags"
               echo "has_test_spec=true" >> $GITHUB_OUTPUT
-              echo "spec=$tags" >> $GITHUB_OUTPUT
+              echo "tags=$tags" >> $GITHUB_OUTPUT
             else
               echo "No /ok-to-test tags= found in the commit message"
               echo "has_test_spec=false" >> $GITHUB_OUTPUT
-              echo "spec=" >> $GITHUB_OUTPUT
+              echo "tags=" >> $GITHUB_OUTPUT
             fi
   
         # In case of a run with all test cases, allocate a larger matrix
@@ -203,7 +203,6 @@ jobs:
         with:
           script: |
             require("write-cypress-status.js")({core, context, github}, "important", process.env.BODY)
-
 
   # Call the workflow to run Cypress tests
   perform-test-for-tags-in-pr-description:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -42,12 +42,11 @@ jobs:
             }
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
-      - name: Checkout PR
+      - name: Checkout the head commit of the branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      
+          repository: appsmithorg/appsmith
+     
       - name: Check Commit Message
         id: checkCommitMessage
         run: |
@@ -56,10 +55,12 @@ jobs:
           echo "Commit Message: $commit_message" 
           if [[ "$commit_message" == *"/ok-to-test tags="* ]]; then
             echo "Commit message contains '/ok-to-test tags='"
-            echo "commit_contains_test=true" >> $GITHUB_ENV
+            echo "commit_contains_test=true" >> $GITHUB_OUTPUT
+            echo "commit_contains_test: $commit_contains_test"
           else
             echo "Commit message does not contain '/ok-to-test tags='"
-            echo "commit_contains_test=false" >> $GITHUB_ENV
+            echo "commit_contains_test=false" >> $GITHUB_OUTPUT
+            echo "commit_contains_test: $commit_contains_test"
           fi
 
   mark-stale:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -106,7 +106,7 @@ jobs:
           run: |
             commit_message='${{ needs.checkTestLabelAndCommit.outputs.commit_message }}'
             # Regex to match '/ok-to-test tags=' followed by any text within optional quotes
-            if [[ '$commit_message' =~ /ok-to-test[[:space:]]+tags=[[:space:]]*\"([^\"]+)\" ]]; then
+            if [[ "$commit_message" =~ /ok-to-test[[:space:]]+tags=[[:space:]]*\"([^\"]+)\" ]]; then
               tags=${BASH_REMATCH[1]}
               echo "Commit contains /ok-to-test tags= with tags: $tags"
               echo "has_test_spec=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -16,7 +16,7 @@ on:
         description: "This is a boolean value in case the workflow is being called for a PG build"
         required: false
         type: string
-        default: "false"
+        default: false
 
 jobs:
   server-build:


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10987878815>
> Commit: 68a55c0e31a3dc24f96656d65697b35414cf1d7d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10987878815&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Mon, 23 Sep 2024 05:19:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
