### PR TITLE
chore: Remove pg build input for build docker as not needed anymore

### DIFF
--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -62,7 +62,6 @@ jobs:
     secrets: inherit
     with:
       pr: ${{ github.event.number }}
-      is-pg-build: ${{ inputs.is-pg-build }}
 
   ci-test:
     needs: [build-docker-image]


### PR DESCRIPTION
## Description
We removed is-pg-build input for `.github/workflows/build-docker-image.yml` via [commit](https://github.com/appsmithorg/appsmith/commit/115ed5af41693a6a600c7ecc7f3661ee26036e17#diff-5b40193e09025fd041de92d38c976d0b469e3ee85bef45a71d05d8b5078b1ee8L12) as this is not being used anywhere in that workflow. This PR makes sure to remove the references in other workflows. 

Ref : https://theappsmith.slack.com/archives/CGBPVEJ5C/p1726808452890429

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/10953584231>
> Commit: c1d45caaf36cf0b619278fd0f3f98b0617d41d97
> Workflow: `PR Automation test suite`
> Tags: `@tag.Sanity`
> Spec: ``
> <hr>Fri, 20 Sep 2024 05:14:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the GitHub Actions workflow by removing the unnecessary `is-pg-build` input parameter from the `build-docker-image` job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->