### PR TITLE
test: shadow PR for 36378

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
@@ -13,6 +13,8 @@ import { Button } from "@appsmith/ads";
 import { getEntityProperties } from "ee/pages/Editor/Explorer/Entity/getEntityProperties";
 import store from "store";
 import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
+import { getIDEViewMode } from "selectors/ideSelectors";
+import { EditorViewMode } from "ee/entities/IDE/constants";
 import { DEFAULT_EXPLORER_PANE_WIDTH } from "constants/AppConstants";
 import { BOTTOM_BAR_HEIGHT } from "components/BottomBar/constants";
 
@@ -43,6 +45,8 @@ export function EntityProperties() {
   const selectedWidgetId = useSelector(
     (state: AppState) => state.ui.widgetDragResize.lastSelectedWidget,
   );
+
+  const ideViewMode = useSelector(getIDEViewMode);
 
   useEffect(() => {
     document.addEventListener("click", handleOutsideClick);
@@ -123,7 +127,10 @@ export function EntityProperties() {
         ref.current.style.bottom = "unset";
       }
 
-      ref.current.style.left = DEFAULT_EXPLORER_PANE_WIDTH + "px";
+      ref.current.style.left =
+        ideViewMode === EditorViewMode.SplitScreen
+          ? "100%"
+          : DEFAULT_EXPLORER_PANE_WIDTH + "px";
     }
   }, [entityId]);
 


### PR DESCRIPTION
## Description
Show bindings menu does not appear in split mode.

This PR addresses issue https://github.com/appsmithorg/appsmith/issues/35775 by updating left style property appropriately based on the editor view mode (split screen/full screen).

Fixes https://github.com/appsmithorg/appsmith/issues/35775

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
