### PR TITLE
chore: fix this.rootSpan undefined bug in PageLoadInstrumentation

### DIFF
--- a/app/client/src/UITelemetry/PageLoadInstrumentation.ts
+++ b/app/client/src/UITelemetry/PageLoadInstrumentation.ts
@@ -49,12 +49,12 @@ export class PageLoadInstrumentation extends InstrumentationBase {
     // Leaving it empty as it is done by other OpenTelemetry instrumentation classes
   }
 
-  enable(): void {
+  enable = () => {
     // Register connection change listener
-    this.addConnectionAttributes.call(this);
+    this.addConnectionAttributes();
 
     // Add device attributes to the root span
-    this.addDeviceAttributes.call(this);
+    this.addDeviceAttributes();
 
     // Listen for LCP and FCP events
     // reportAllChanges: true will report all LCP and FCP events
@@ -69,7 +69,7 @@ export class PageLoadInstrumentation extends InstrumentationBase {
       // If PerformanceObserver is not available, fallback to polling
       this.pollResourceTimingEntries();
     }
-  }
+  };
 
   private addDeviceAttributes() {
     this.rootSpan.setAttributes({

--- a/app/client/src/UITelemetry/PageLoadInstrumentation.ts
+++ b/app/client/src/UITelemetry/PageLoadInstrumentation.ts
@@ -41,15 +41,12 @@ export class PageLoadInstrumentation extends InstrumentationBase {
     this.ignoreResourceUrls = ignoreResourceUrls;
     // Start the root span for the page load
     this.rootSpan = startRootSpan("PAGE_LOAD", {}, 0);
+
+    // Initialize the instrumentation after starting the root span
+    this.init();
   }
 
   init() {
-    // init method is present in the base class and needs to be implemented
-    // This is method is never called by the OpenTelemetry SDK
-    // Leaving it empty as it is done by other OpenTelemetry instrumentation classes
-  }
-
-  enable = () => {
     // Register connection change listener
     this.addConnectionAttributes();
 
@@ -69,7 +66,12 @@ export class PageLoadInstrumentation extends InstrumentationBase {
       // If PerformanceObserver is not available, fallback to polling
       this.pollResourceTimingEntries();
     }
-  };
+  }
+
+  enable() {
+    // enable method is present in the base class and needs to be implemented
+    // Leaving it empty as there is no need to do anything here
+  }
 
   private addDeviceAttributes() {
     this.rootSpan.setAttributes({

--- a/app/client/src/UITelemetry/PageLoadInstrumentation.ts
+++ b/app/client/src/UITelemetry/PageLoadInstrumentation.ts
@@ -51,10 +51,10 @@ export class PageLoadInstrumentation extends InstrumentationBase {
 
   enable(): void {
     // Register connection change listener
-    this.addConnectionAttributes();
+    this.addConnectionAttributes.call(this);
 
     // Add device attributes to the root span
-    this.addDeviceAttributes();
+    this.addDeviceAttributes.call(this);
 
     // Listen for LCP and FCP events
     // reportAllChanges: true will report all LCP and FCP events


### PR DESCRIPTION
## Description
Fix this context in the enable method
this.rootSpan is undefined in the fn this.addDeviceAttributes

The issue occurs because this.rootSpan is undefined when the enable method is called. This PR resolves the issue by converting the enable method to an arrow function, ensuring that the this value is preserved from its lexical scope.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10960896859>
> Commit: d40ebc114f47e6ee1748748f3ec18a3dcc7e685f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10960896859&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 20 Sep 2024 14:53:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced page load instrumentation with improved initialization logic.
	- Added a new `enable` method for future functionality.

- **Bug Fixes**
	- Streamlined the initialization process for better performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->