### PR TITLE
fix: js library default export to a unique name instead of default key in self

### DIFF
--- a/app/client/src/workers/Evaluation/handlers/__tests__/jsLibrary.test.ts
+++ b/app/client/src/workers/Evaluation/handlers/__tests__/jsLibrary.test.ts
@@ -11,7 +11,17 @@ declare const self: WorkerGlobalScope;
 
 describe("Tests to assert install/uninstall flows", function () {
   beforeAll(() => {
-    self.importScripts = jest.fn(() => {
+    self.importScripts = jest.fn((url: string) => {
+      if (url.includes("jspdf-autotable")) {
+        const defaultVar = function () {};
+
+        defaultVar.Cell = function () {};
+        self.Cell = function () {};
+        self.default = defaultVar;
+
+        return;
+      }
+
       self.lodash = {};
     });
 
@@ -148,6 +158,30 @@ describe("Tests to assert install/uninstall flows", function () {
 
     expect(flatLibrary3).toEqual({
       method: "Hello",
+    });
+  });
+
+  it("should install a library with default export", async function () {
+    const res = await installLibrary({
+      data: {
+        url: "https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.28/dist/jspdf.plugin.autotable.js",
+        takenAccessors: [],
+        takenNamesMap: {},
+      },
+      method: EVAL_WORKER_ASYNC_ACTION.INSTALL_LIBRARY,
+      webworkerTelemetry: {},
+    });
+
+    expect(self.importScripts).toHaveBeenCalled();
+    expect(mod.makeTernDefs).toHaveBeenCalledWith({});
+
+    expect(res).toEqual({
+      accessor: ["jspdf_plugin_autotable_js"],
+      defs: {
+        "!name": "LIB/jspdf_plugin_autotable_js",
+        jspdf_plugin_autotable_js: undefined,
+      },
+      success: true,
     });
   });
 });

--- a/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
+++ b/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
@@ -135,7 +135,7 @@ export async function installLibrary(
 
       if (
         differentiatingKeys.length > 0 &&
-        differentiatingKeys[differentiatingKeys.length - 1] === "default"
+        differentiatingKeys.includes("default")
       ) {
         // Changing default export to library specific name
         const uniqueName = generateUniqueAccessor(
@@ -146,15 +146,15 @@ export async function installLibrary(
 
         // mapping default functionality to library name accessor
         self[uniqueName] = self["default"];
-        // removing default from differentiating keys
-        differentiatingKeys.pop();
         // deleting the reference of default key from the self object
         self["default"] = undefined;
         // mapping all the references of differentiating keys from the self object to the self[uniqueName] key object
         differentiatingKeys.map((key) => {
-          self[uniqueName][key] = self[key];
-          // deleting the references from the self object
-          self[key] = undefined;
+          if (key !== "default") {
+            self[uniqueName][key] = self[key];
+            // deleting the references from the self object
+            self[key] = undefined;
+          }
         });
         // pushing the uniqueName to the accessor array
         accessors.push(uniqueName);

--- a/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
+++ b/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
@@ -133,7 +133,10 @@ export async function installLibrary(
         envKeysBeforeInstallation,
       );
 
-      if (differentiatingKeys[differentiatingKeys.length - 1] === "default") {
+      if (
+        differentiatingKeys.length > 0 &&
+        differentiatingKeys[differentiatingKeys.length - 1] === "default"
+      ) {
         // Changing default export to library specific name
         const uniqueName = generateUniqueAccessor(
           url,
@@ -146,12 +149,12 @@ export async function installLibrary(
         // removing default from differentiating keys
         differentiatingKeys.pop();
         // deleting the reference of default key from the self object
-        delete self["default"];
+        self["default"] = undefined;
         // mapping all the references of differentiating keys from the self object to the self[uniqueName] key object
         differentiatingKeys.map((key) => {
           self[uniqueName][key] = self[key];
           // deleting the references from the self object
-          delete self[key];
+          self[key] = undefined;
         });
         // pushing the uniqueName to the accessor array
         accessors.push(uniqueName);

--- a/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
+++ b/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
@@ -147,13 +147,13 @@ export async function installLibrary(
         // mapping default functionality to library name accessor
         self[uniqueName] = self["default"];
         // deleting the reference of default key from the self object
-        self["default"] = undefined;
+        delete self["default"];
         // mapping all the references of differentiating keys from the self object to the self[uniqueName] key object
         differentiatingKeys.map((key) => {
           if (key !== "default") {
             self[uniqueName][key] = self[key];
             // deleting the references from the self object
-            self[key] = undefined;
+            delete self[key];
           }
         });
         // pushing the uniqueName to the accessor array


### PR DESCRIPTION
## Description
Earlier since some of the libraries one of which is `https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.28/dist/jspdf.plugin.autotable.js` wasn't exporting the functionality to some key, instead it was exporting as default. Hence, after the import of the library the functionality was being set on the default key, which on refresh or on reintializing the application in the store got changed and the inner functions got attached to global object.

This PR fixes this issue and checks if the last accessor is the `default` then it maps all the functionality to a unique name generated from the library url and moves everything to the generated name as done by other libraries.

Fixes #20572
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11011513239>
> Commit: b4c076793f4f28b4b84bfd003e916b70f102c773
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11011513239&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Tue, 24 Sep 2024 10:40:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved handling of library installations, enhancing the management of library exports and default exports.
	- Added a new test case to verify the installation of libraries with default exports.

- **Bug Fixes**
	- Resolved issues related to key differentiation during library installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->