### PR TITLE
fix: initial store value fix for query response tab test case

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.test.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.test.tsx
@@ -5,11 +5,10 @@ import configureStore from "redux-mock-store";
 import QueryResponseTab from "./QueryResponseTab";
 import { ENTITY_TYPE } from "ee/entities/AppsmithConsole/utils";
 import type { Action } from "entities/Action";
-import { unitTestBaseMockStore } from "layoutSystems/common/dropTarget/unitTestUtils";
-import { EditorViewMode } from "ee/entities/IDE/constants";
 import { lightTheme } from "selectors/themeSelectors";
 import { ThemeProvider } from "styled-components";
 import { BrowserRouter as Router } from "react-router-dom";
+import { getIDETestState } from "test/factories/AppIDEFactoryUtils";
 
 // Mock store
 const mockStore = configureStore([]);
@@ -32,44 +31,7 @@ const defaultProps = {
   runErrorMessage: "",
 };
 
-const storeData = {
-  ...unitTestBaseMockStore,
-  evaluations: {
-    tree: {},
-  },
-  entities: {
-    plugins: {
-      list: [],
-    },
-    datasources: {
-      structure: {},
-    },
-  },
-  ui: {
-    ...unitTestBaseMockStore.ui,
-    users: {
-      featureFlag: {
-        data: {},
-        overriddenFlags: {},
-      },
-    },
-    ide: {
-      view: EditorViewMode.FullScreen,
-    },
-    debugger: {
-      context: {
-        errorCount: 0,
-      },
-    },
-    queryPane: {
-      debugger: {
-        open: true,
-        responseTabHeight: 200,
-        selectedTab: "response",
-      },
-    },
-  },
-};
+const storeData = getIDETestState({});
 
 describe("QueryResponseTab", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description
 
Initial state value was not having module instance data which cause test failure in EE. This PR address this issue.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/10997712576>
> Commit: 8877729aa15e313bdd6ab552f0658eba8e3211ed
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=10997712576&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 23 Sep 2024 16:17:41 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the test setup for the Query Response Tab to simplify the store data initialization using a factory function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->