### PR TITLE
fix: Query instance failure caused by missing prepared statement obj

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.tsx
@@ -204,10 +204,10 @@ const QueryResponseTab = (props: Props) => {
 
     const { actionConfiguration } = currentActionConfig;
     const hasPluginSpecifiedTemplates =
-      actionConfiguration.pluginSpecifiedTemplates?.[0]?.value === true;
+      actionConfiguration?.pluginSpecifiedTemplates?.[0]?.value === true;
     // oracle have different key for prepared statements
     const hasPreparedStatement =
-      actionConfiguration.formData?.preparedStatement?.data === true;
+      actionConfiguration?.formData?.preparedStatement?.data === true;
 
     if (error && (hasPluginSpecifiedTemplates || hasPreparedStatement)) {
       showPreparedStatementWarning = true;

--- a/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.tsx
@@ -202,15 +202,14 @@ const QueryResponseTab = (props: Props) => {
       hintMessages = actionResponse.messages;
     }
 
-    const { pluginSpecifiedTemplates } =
-      currentActionConfig.actionConfiguration;
+    const { actionConfiguration } = currentActionConfig;
+    const hasPluginSpecifiedTemplates =
+      actionConfiguration.pluginSpecifiedTemplates?.[0]?.value === true;
+    // oracle have different key for prepared statements
+    const hasPreparedStatement =
+      actionConfiguration.formData?.preparedStatement?.data === true;
 
-    if (
-      error &&
-      pluginSpecifiedTemplates &&
-      pluginSpecifiedTemplates.length > 0 &&
-      pluginSpecifiedTemplates[0].value === true
-    ) {
+    if (error && (hasPluginSpecifiedTemplates || hasPreparedStatement)) {
       showPreparedStatementWarning = true;
     }
   }


### PR DESCRIPTION
## Description

Query instance was breaking because of missing prepared statement obj in the action configuration.

PR caused this issue: https://github.com/appsmithorg/appsmith/pull/36407

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11007670447>
> Commit: 420801e87c807d4b3fda6c47c26df428fd49ea29
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11007670447&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 24 Sep 2024 07:04:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for displaying warnings related to prepared statements, improving user experience by streamlining checks.

- **Bug Fixes**
	- Resolved issues with warning display for prepared statements, ensuring accurate notifications based on user actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->