### PR TITLE
chore: caddy: enable logging of static file requests

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -76,7 +76,7 @@ parts.push(`
   # skip logs for health check
   skip_log /api/v1/health
 
-  # skip logs for js map files
+  # skip logs for sourcemap files
   @mapfiles {
     path_regexp mapfiles ^/static/js.*\.map$
   }

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -74,13 +74,13 @@ parts.push(`
   }
 
   # skip logs for health check
-	skip_log /api/v1/health
+  skip_log /api/v1/health
 
-	# skip logs for js map files
-	@mapfiles {
-		path_regexp mapfiles ^/static/js.*\.map$
-	}
-	skip_log @mapfiles
+  # skip logs for js map files
+  @mapfiles {
+    path_regexp mapfiles ^/static/js.*\.map$
+  }
+  skip_log @mapfiles
 
   # The internal request ID header should never be accepted from an incoming request.
   request_header -X-Appsmith-Request-Id

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -110,7 +110,6 @@ parts.push(`
   @file file
   handle @file {
     import file_server
-    skip_log
   }
 
   handle /static/* {

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -72,7 +72,15 @@ parts.push(`
   log {
     output stdout
   }
-  skip_log /api/v1/health
+
+  # skip logs for health check
+	skip_log /api/v1/health
+
+	# skip logs for js map files
+	@mapfiles {
+		path_regexp mapfiles ^/static/js.*\.map$
+	}
+	skip_log @mapfiles
 
   # The internal request ID header should never be accepted from an incoming request.
   request_header -X-Appsmith-Request-Id

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -77,10 +77,10 @@ parts.push(`
   skip_log /api/v1/health
 
   # skip logs for sourcemap files
-  @mapfiles {
-    path_regexp mapfiles ^/static/js.*\.map$
+  @source-map-files {
+    path_regexp ^.*\.(js|css)\.map$
   }
-  skip_log @mapfiles
+  skip_log @source-map-files
 
   # The internal request ID header should never be accepted from an incoming request.
   request_header -X-Appsmith-Request-Id


### PR DESCRIPTION
## Description
- Enable logs of static file requests in caddy.
- Skip logging for CSS and JS source map files. These files are inconsequential for page rendering and therefore not worth tracking, as they only pollute the log files.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11016033178>
> Commit: 97cfe307355f159a9cb80295fb566c406ffc056a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11016033178&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 25 Sep 2024 05:08:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging configurations to improve performance by skipping logs for health check requests and JavaScript map files.

- **Bug Fixes**
	- Adjusted existing logging behavior for file handling to ensure more accurate log processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->