### PR TITLE
chore: Add server artifacts for pg and mongodb for github release wor…

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -247,6 +247,12 @@ jobs:
         run: |
           scripts/generate_info_json.sh
 
+      - name: Place server artifacts-es
+        run: |
+          if [[ -f scripts/prepare_server_artifacts.sh ]]; then
+            scripts/prepare_server_artifacts.sh
+          fi
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
…kflow (#36516)

## Description
We recently updated the build process where going forward we will be placing server artifacts under opt/appsmith/server directory which should contain both MongoDB and Postgres specific artifacts under opt/appsmith/server/mongo and opt/appsmith/server/pg
PR for ref: https://github.com/appsmithorg/appsmith/pull/36424   

With this PR we are updating the github-releases script to add the server jars at specific locations.

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
