### PR TITLE
test: replace 3rd party API1 CE

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
@@ -96,7 +96,7 @@ describe(
           force: true,
         })
         .type(
-          "https://www.facebook.com/users/{{Button2.text}}?key=test&val={{Button2.text}}",
+          "http://host.docker.internal:5001/{{Button2.text}}?key=test&val={{Button2.text}}",
           { force: true, parseSpecialCharSequences: false },
         )
         .wait(3000)
@@ -106,7 +106,7 @@ describe(
         .type("{enter}", { parseSpecialCharSequences: true });
 
       cy.validateEvaluatedValue(
-        "https://www.facebook.com/users/Cancel?key=test&val=Cancel",
+        "http://host.docker.internal:5001/Cancel?key=test&val=Cancel",
       );
     });
   },

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
Replacing the 3rd party API with TED API

/ok-to-test tags="@tag.Datasource"




<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11027894410>
> Commit: 0446747b46e74c3ea16b86578cab06fe04346b94
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11027894410&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Wed, 25 Sep 2024 07:37:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->
