### PR TITLE
test: fix test in airgap for canvas context prop

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
@@ -117,9 +117,15 @@ describe("Canvas context Property Pane", { tags: ["@tag.IDE"] }, function () {
     propertySectionState = {
       basic: false,
       general: true,
-      validation: false,
-      formsettings: true,
     };
+
+    if (!Cypress.env("AIRGAPPED")) {
+      propertySectionState = {
+        ...propertySectionState,
+        validation: false,
+        formsettings: true,
+      };
+    }
 
     verifyPropertyPaneContext(
       () => {

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/IDE/Canvas_Context_Property_Pane_1_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
This test spec was working fine on EE/CE this fix will handle scenario in airgap environment

/ok-to-test tags="@tag.Sanity"



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11026655789>
> Commit: f120b71d43a06123060ccfc3fcc0b3feb7b72d71
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11026655789&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 25 Sep 2024 05:41:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->
