### PR TITLE
test: replace 3rd party API

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
@@ -7,7 +7,7 @@ import EditorNavigation, {
 describe("Api Error Debugger", { tags: ["@tag.IDE"] }, () => {
   before(() => {
     // Create api that causes an error
-    _.apiPage.CreateAndFillApi("https://fakeapi/user");
+    _.apiPage.CreateAndFillApi("http://host.docker.internal:500");
   });
   it("it shows error message", () => {
     _.apiPage.RunAPI(false);

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/OtherUIFeatures/ApiError_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
replacing 3rd party API with TED

/ok-to-test tags="@tag.IDE"




<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11030796227>
> Commit: 1630d9bcbbc8a332dd80248b04d6f17a2ec9c411
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11030796227&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Wed, 25 Sep 2024 10:35:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->
