### PR TITLE
test: replaced 3rd apty api in API_On_Load spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
@@ -46,7 +46,7 @@ describe(
     it("2. Shows when API failed to load on page load.", function () {
       cy.fixture("testdata").then(function (dataSet: any) {
         apiPage.CreateAndFillApi(
-          "https://abc.com/" + dataSet.methods,
+          "http://host.docker.internal:5001" + dataSet.methods,
           "PageLoadApi2",
         );
       });
@@ -54,10 +54,7 @@ describe(
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget, {}, [
         "Container3",
       ]);
-      propPane.UpdatePropertyFieldValue(
-        "Table data",
-        `{{PageLoadApi2.data.data}}`,
-      );
+      propPane.UpdatePropertyFieldValue("Table data", `{{PageLoadApi2.data}}`);
       agHelper.RefreshPage();
       debuggerHelper.AssertDebugError(
         'The action "PageLoadApi2" has failed.',

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
replacing 3rd party API with TED api
/ok-to-test tags="@tag.JS"




<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11030794737>
> Commit: ee0ac5c8e34d0bf5c863fb9ef0091678ccec692d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11030794737&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Wed, 25 Sep 2024 10:41:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->
