### PR TITLE
fix: bug added placeholder text for the select column type's option property

### DIFF
--- a/app/client/src/components/propertyControls/TableComputeValue.tsx
+++ b/app/client/src/components/propertyControls/TableComputeValue.tsx
@@ -98,7 +98,9 @@ function InputText(props: InputTextProp) {
   );
 }
 
-class ComputeTablePropertyControlV2 extends BaseControl<ComputeTablePropertyControlPropsV2> {
+class ComputeTablePropertyControlV2 extends BaseControl<
+  ComputeTablePropertyControlPropsV2 & { placeholderText: string }
+> {
   static getBindingPrefix(tableName: string) {
     return `{{${tableName}.processedTableData.map((currentRow, currentIndex) => ( `;
   }
@@ -113,6 +115,7 @@ class ComputeTablePropertyControlV2 extends BaseControl<ComputeTablePropertyCont
       label,
       propertyValue,
       theme,
+      placeholderText,
     } = this.props;
     const tableName = this.props.widgetProperties.widgetName;
     const value =
@@ -153,6 +156,7 @@ class ComputeTablePropertyControlV2 extends BaseControl<ComputeTablePropertyCont
         onChange={this.onTextChange}
         theme={theme}
         value={value}
+        placeholder={placeholderText}
       />
     );
   }

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Select.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Select.ts
@@ -18,6 +18,16 @@ export default {
     {
       propertyName: "selectOptions",
       helpText: "Options to be shown on the select dropdown",
+      placeholderText: `[
+        {
+          label: "label1",
+          value: "1",
+        },
+        {
+          label: "label2",
+          value: "2",
+        },
+      ]`,
       label: "Options",
       controlType: "TABLE_COMPUTE_VALUE",
       isJSConvertible: false,


### PR DESCRIPTION
## Description:

Currently, the option property of select column type for table widget does not contain placeholder text. A placeholder text will help the users to understand the format.


> I have raised this PR to fix the `bug added placeholder text for the select column type's option property`

## [Issue Link](https://github.com/appsmithorg/appsmith/issues/18059)
## Screenshots:
### Before resoving bug:
![image](https://github.com/user-attachments/assets/ab0bcc9f-bcb3-4be6-b92a-7ec115be263c)

### After resoving bug:
![image](https://github.com/user-attachments/assets/df8c3cc7-00b4-450c-9c30-98d223077546)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `placeholderText` property for input fields, enhancing user experience with placeholder values.
	- Added a `placeholderText` property to the select dropdown configuration, providing clear examples for expected input format.

- **Documentation**
	- Improved documentation for `selectOptions` to illustrate the expected structure of options in the dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->