### PR TITLE
chore: create appsmith schema for the pg branch with user and password

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -466,9 +466,7 @@ init_postgres() {
     echo "Connecting to PostgreSQL at $DB_HOST:$DB_PORT with user $DB_USER"
 
     # Create the appsmith schema if it does not exist
-    PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME <<EOF
-    CREATE SCHEMA IF NOT EXISTS appsmith;
-  EOF
+    PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -c "CREATE SCHEMA IF NOT EXISTS appsmith;"
 
     if [ $? -eq 0 ]; then
       echo "Schema 'appsmith' created or already exists."

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -436,50 +436,46 @@ init_postgres() {
   fi
 
   # Create the appsmith schema
-  init_postgres() {
-    echo "Initializing PostgreSQL..."
+  echo "Initializing PostgreSQL..."
 
-    # Check if APPSMITH_DB_URL is a PostgreSQL URL
-    if [[ -n "$APPSMITH_DB_URL" && "$APPSMITH_DB_URL" == postgres*://* ]]; then
-      echo "APPSMITH_DB_URL is a valid PostgreSQL URL."
+  # Check if APPSMITH_DB_URL is a PostgreSQL URL
+  if [[ -n "$APPSMITH_DB_URL" && "$APPSMITH_DB_URL" == postgres*://* ]]; then
+    echo "APPSMITH_DB_URL is a valid PostgreSQL URL."
+    # Extract username, password, host, port, and database name from APPSMITH_DB_URL
+    DB_USER=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://\([^:]*\):.*#\1#p')
+    DB_PASSWORD=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^:]*:\([^@]*\)@.*#\1#p')
+    DB_HOST=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^@]*@\([^:]*\):.*#\1#p')
+    DB_PORT=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^@]*@[^:]*:\([^/]*\)/.*#\1#p')
+    DB_NAME=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^@]*@[^/]*/\([^?]*\).*#\1#p')
 
-      # Extract username, password, host, port, and database name from APPSMITH_DB_URL
-      DB_USER=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://\([^:]*\):.*#\1#p')
-      DB_PASSWORD=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^:]*:\([^@]*\)@.*#\1#p')
-      DB_HOST=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^@]*@\([^:]*\):.*#\1#p')
-      DB_PORT=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^@]*@[^:]*:\([^/]*\)/.*#\1#p')
-      DB_NAME=$(echo "$APPSMITH_DB_URL" | sed -n 's#.*://[^@]*@[^/]*/\([^?]*\).*#\1#p')
+    # Generate a random password if DB_USER or DB_PASSWORD are empty
+    if [[ -z "$DB_USER" || -z "$DB_PASSWORD" ]]; then
+      DB_USER="appsmith"
+      DB_PASSWORD=$(openssl rand -base64 12)  # Generate a random password
+      echo "Generated random password for appsmith user: $DB_PASSWORD"
+    fi
 
-      # Generate a random password if DB_USER or DB_PASSWORD are empty
-      if [[ -z "$DB_USER" || -z "$DB_PASSWORD" ]]; then
-        DB_USER="postgres"
-        DB_PASSWORD=$(openssl rand -base64 12)  # Generate a random password
-        echo "Generated random password for postgres user: $DB_PASSWORD"
-      fi
+    # Set defaults for host, port, and database name if not set
+    DB_HOST=${DB_HOST:-localhost}
+    DB_PORT=${DB_PORT:-5432}
+    DB_NAME=${DB_NAME:-appsmith}
 
-      # Set defaults for host, port, and database name if not set
-      DB_HOST=${DB_HOST:-localhost}
-      DB_PORT=${DB_PORT:-5432}
-      DB_NAME=${DB_NAME:-appsmith}
+    echo "Connecting to PostgreSQL at $DB_HOST:$DB_PORT with user $DB_USER"
 
-      echo "Connecting to PostgreSQL at $DB_HOST:$DB_PORT with user $DB_USER"
+    # Execute SQL to create the appsmith schema if it doesn't exist (single line)
+    PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -c "CREATE SCHEMA IF NOT EXISTS appsmith;"
 
-      # Execute SQL to create the appsmith schema if it doesn't exist (single line)
-      PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -c "CREATE SCHEMA IF NOT EXISTS appsmith;"
-
-      # Check if the schema creation was successful
-      if [ $? -eq 0 ]; then
-        echo "Schema 'appsmith' created or already exists."
-      else
-        echo "Failed to create schema 'appsmith'."
-        exit 1
-      fi
-
-      echo "PostgreSQL initialization completed."
+    # Check if the schema creation was successful
+    if [ $? -eq 0 ]; then
+      echo "Schema 'appsmith' created or already exists."
     else
+      echo "Failed to create schema 'appsmith'."
+      exit 1
+    fi
+    echo "PostgreSQL initialization completed."
+  else
       echo "APPSMITH_DB_URL is either empty or not a PostgreSQL URL. Skipping PostgreSQL initialization."
     fi
-  }
 }
 
 safe_init_postgres() {

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -439,7 +439,7 @@ init_postgres() {
     echo "Initializing PostgreSQL..."
 
     # Extract credentials from APPSMITH_DB_URL
-    if [[ -n "$APPSMITH_DB_URL" ]]; then
+    if [[ -n "$APPSMITH_DB_URL" && "$APPSMITH_DB_URL" == postgres*://*  ]]; then
       # Extract username, password, host, port, and database name
       DB_PROTOCOL=$(echo "$APPSMITH_DB_URL" | awk -F'://' '{print $1}')
       if [[ "$DB_PROTOCOL" == "postgres" ]]; then


### PR DESCRIPTION
## Description
Create schema for the pg used by Appsmith. The default public schema can cause issues and creating a new schema allows us to have isolation with the other data in pg. This also creates a user and password which is used to access the schema. 


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11051541656>
> Commit: 973dabfc3946157a70210e5858d5bceac2a6e293
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11051541656&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Sanity
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Git/GitSync/SwitchBranches_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Thu, 26 Sep 2024 12:13:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced automatic initialization of the PostgreSQL database schema for improved setup.
	- Enhanced handling of database credentials with defaults for user and password.

- **Bug Fixes**
	- Improved logging for schema creation success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->