### PR TITLE
test: udpated 3rd party api for Commandclick nav spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Command_Click_Navigation_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Command_Click_Navigation_spec.js
@@ -79,7 +79,7 @@ describe("1. CommandClickNavigation", { tags: ["@tag.IDE"] }, function () {
     //Assert working on url field
     cy.updateCodeInput(
       ".t--dataSourceField",
-      "https://www.test.com/{{ SQL_Query.data }}",
+      "http://host.docker.internal:5001/{{ SQL_Query.data }}",
     );
     agHelper.Sleep();
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/IDE/Command_Click_Navigation_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/IDE/Command_Click_Navigation_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
replace 3rd API with TED
/ok-to-test tags="@tag.IDE"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the test suite to focus on command click navigation within the IDE.
  
- **Bug Fixes**
	- Adjusted the base URL for the data source in the navigation test to reflect local development settings.

- **Chores**
	- Modified the limited tests execution list to prioritize IDE command click navigation tests over template-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11046090068>
> Commit: fd95c8bc6a69ad009ddc8377a1a3c2b20c7be033
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11046090068&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Thu, 26 Sep 2024 05:55:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->
