### PR TITLE
chore: Exit the script if server artifact placer is not available

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -247,10 +247,14 @@ jobs:
         run: |
           scripts/generate_info_json.sh
 
+      # As pg docker image is continuously updated for each scheduled cron on release, we are using the nightly tag while building the latest tag
       - name: Place server artifacts-es
         run: |
           if [[ -f scripts/prepare_server_artifacts.sh ]]; then
-            scripts/prepare_server_artifacts.sh
+            PG_TAG=nightly scripts/prepare_server_artifacts.sh
+          else
+            echo "No script found to prepare server artifacts"
+            exit 1
           fi
 
       - name: Login to DockerHub

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -356,8 +356,12 @@ jobs:
 
       - name: Place server artifacts-es
         run: |
+          run: |
           if [[ -f scripts/prepare_server_artifacts.sh ]]; then
             scripts/prepare_server_artifacts.sh
+          else
+            echo "No script found to prepare server artifacts"
+            exit 1
           fi
 
       - name: Set up Depot CLI
@@ -439,6 +443,9 @@ jobs:
         run: |
           if [[ -f scripts/prepare_server_artifacts.sh ]]; then
             scripts/prepare_server_artifacts.sh
+          else
+            echo "No script found to prepare server artifacts"
+            exit 1
           fi
 
       - name: Set up Depot CLI


### PR DESCRIPTION
## Description
PR to fail fast at the build step only if the script to place the server artifacts for pg and mongo is not available. This PR also replaces pg tag with nightly tag for placing the server artifacts for pg to improve the stability of the image shipped to customers.

Fixes: https://github.com/appsmithorg/appsmith/issues/36478

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11050797504>
> Commit: 40c56218e2cb487cc79bdaab92abc53ded89b4fb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11050797504&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 26 Sep 2024 11:23:28 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for missing scripts in the build and release workflows, ensuring clearer error messages and preventing process failures. 

- **Chores**
	- Introduced a new environment variable for using the nightly PostgreSQL Docker image in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->