### PR TITLE
fix: Quick fixes for current state of Plugin Action Editor

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionForm/PluginActionForm.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/PluginActionForm.tsx
@@ -2,13 +2,18 @@ import React from "react";
 import APIEditorForm from "./components/APIEditorForm";
 import { Flex } from "@appsmith/ads";
 import { useChangeActionCall } from "./hooks/useChangeActionCall";
+import { usePluginActionContext } from "../../PluginActionContext";
+import { UIComponentTypes } from "api/PluginApi";
 
 const PluginActionForm = () => {
   useChangeActionCall();
+  const { plugin } = usePluginActionContext();
 
   return (
     <Flex p="spaces-2" w="100%">
-      <APIEditorForm />
+      {plugin.uiComponent === UIComponentTypes.ApiEditorForm ? (
+        <APIEditorForm />
+      ) : null}
     </Flex>
   );
 };

--- a/app/client/src/PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/hooks/useGetFormActionValues.ts
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/hooks/useGetFormActionValues.ts
@@ -18,7 +18,7 @@ function useGetFormActionValues() {
 
   // In an unlikely scenario where form is not initialised,
   // return empty values to avoid form ui issues
-  if (!isAPIAction(formValues)) {
+  if (!formValues || !isAPIAction(formValues)) {
     return {
       actionHeaders: [],
       actionParams: [],

--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/PluginActionResponse.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/PluginActionResponse.tsx
@@ -57,7 +57,7 @@ function PluginActionResponse() {
         expandedHeight={`${ActionExecutionResizerHeight}px`}
         isCollapsed={!open}
         onSelect={updateSelectedResponseTab}
-        selectedTabKey={selectedTab || tabs[0].key}
+        selectedTabKey={selectedTab || tabs[0]?.key}
         tabs={tabs}
       />
     </IDEBottomView>


### PR DESCRIPTION
## Description

Fixes null values crashes in Plugin Action Editor


## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11064951469>
> Commit: 76523cdeb308c892063a53d532941a6ce0e0ce35
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11064951469&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Fri, 27 Sep 2024 05:58:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Conditional rendering of the API Editor Form based on plugin properties for improved user experience.
  
- **Bug Fixes**
	- Enhanced handling of form values to prevent issues when values are not initialized, ensuring smoother form functionality.
	- Improved robustness in the Plugin Action Response component to avoid runtime errors when accessing tab keys.

- **Documentation**
	- Updated import statements to reflect changes in dependencies for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->