### PR TITLE
fix: fixed autocommit spec for airgap

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitAutocommit_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitAutocommit_spec.ts
@@ -1,5 +1,4 @@
 import ReconnectLocators from "../../../../locators/ReconnectLocators";
-import { featureFlagIntercept } from "../../../../support/Objects/FeatureFlags";
 import {
   agHelper,
   gitSync,
@@ -7,7 +6,7 @@ import {
 } from "../../../../support/Objects/ObjectsCore";
 
 let wsName: string;
-let repoName: string = "TED-testrepo1";
+let repoName: string = "TED-autocommit-test-1";
 
 describe(
   "Git Autocommit",
@@ -15,8 +14,8 @@ describe(
     tags: [
       "@tag.Git",
       "@tag.GitAutocommit",
-      "@tag.excludeForAirgap",
       "@tag.Sanity",
+      "@tag.TedMigration",
     ],
   },
   function () {


### PR DESCRIPTION
## Description
Changes autocommit test repo to a new airgap compatiable repo

## Automation

```
/test
cypress/e2e/Regression/ClientSide/Git/GitAutocommit_spec.ts
```

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11065723641>
> Commit: ed27652b4fe386f943a937e0e7efdc059700d779
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11065723641&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: ``
> Spec: cypress/e2e/Regression/ClientSide/Git/GitAutocommit_spec.ts
> <hr>Fri, 27 Sep 2024 06:55:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the repository name in the autocommit tests to better reflect current context.
	- Revised test suite tags for improved organization and focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->