### PR TITLE
fix: MaintainContext&Focus test

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/MaintainContext&Focus_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/MaintainContext&Focus_spec.js
@@ -1,12 +1,12 @@
 import reconnectDatasourceModal from "../../../../locators/ReconnectLocators";
 import {
   agHelper,
-  apiPage,
   dataSources,
   homePage,
   locators,
 } from "../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
+  PageLeftPane,
   EntityType,
 } from "../../../../support/Pages/EditorNavigation";
 
@@ -36,6 +36,7 @@ describe("MaintainContext&Focus", { tags: ["@tag.IDE"] }, function () {
   });
 
   it("1. Focus on different entities", () => {
+    PageLeftPane.closeAddView();
     EditorNavigation.SelectEntityByName("Text1", EntityType.Widget, {}, [
       "Container1",
     ]);
@@ -56,7 +57,7 @@ describe("MaintainContext&Focus", { tags: ["@tag.IDE"] }, function () {
     EditorNavigation.SelectEntityByName("Rest_Api_2", EntityType.Api);
 
     cy.wait(1000);
-    cy.xpath("//span[contains(text(), 'Headers')]").click();
+    agHelper.GetNClick("//span[contains(text(), 'Headers')]", 0);
     cy.updateCodeInput(apiwidget.headerValue, "test");
     cy.wait("@saveAction");
 
@@ -160,30 +161,7 @@ describe("MaintainContext&Focus", { tags: ["@tag.IDE"] }, function () {
     cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 2 });
   });
 
-  it("3. Check if selected tab on right tab persists", () => {
-    EditorNavigation.SelectEntityByName("Rest_Api_1", EntityType.Api);
-    apiPage.SelectRightPaneTab("Connections");
-    EditorNavigation.SelectEntityByName("SQL_Query", EntityType.Query);
-    EditorNavigation.SelectEntityByName("Rest_Api_1", EntityType.Api);
-    apiPage.AssertRightPaneSelectedTab("Connections");
-
-    //Check if the URL is persisted while switching pages
-    cy.Createpage("Page2");
-
-    EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
-    EditorNavigation.SelectEntityByName("Rest_Api_1", EntityType.Api);
-
-    EditorNavigation.SelectEntityByName("Page2", EntityType.Page);
-    cy.dragAndDropToCanvas("textwidget", { x: 300, y: 200 });
-
-    EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
-    cy.get(".t--nameOfApi .bp3-editable-text-content").should(
-      "contain",
-      "Rest_Api_1",
-    );
-  });
-
-  it("4. Datasource edit mode has to be maintained", () => {
+  it("3. Datasource edit mode has to be maintained", () => {
     EditorNavigation.SelectEntityByName("Appsmith", EntityType.Datasource);
     dataSources.EditDatasource();
     EditorNavigation.SelectEntityByName("Github", EntityType.Datasource);
@@ -192,7 +170,7 @@ describe("MaintainContext&Focus", { tags: ["@tag.IDE"] }, function () {
     dataSources.AssertDSEditViewMode("Edit");
   });
 
-  it("5. Maintain focus of form control inputs", () => {
+  it("4. Maintain focus of form control inputs", () => {
     EditorNavigation.SelectEntityByName("SQL_Query", EntityType.Query);
     dataSources.ToggleUsePreparedStatement(false);
     EditorNavigation.SelectEntityByName("S3_Query", EntityType.Query);
@@ -202,14 +180,15 @@ describe("MaintainContext&Focus", { tags: ["@tag.IDE"] }, function () {
 
     EditorNavigation.SelectEntityByName("SQL_Query", EntityType.Query);
     cy.get(".bp3-editable-text-content").should("contain.text", "SQL_Query");
-    cy.get(".t--form-control-SWITCH input").should("be.focused");
+    cy.xpath(queryLocators.querySettingsTab).click();
+    agHelper.GetElement(dataSources._usePreparedStatement).should("be.focused");
     EditorNavigation.SelectEntityByName("S3_Query", EntityType.Query);
     agHelper.Sleep();
     cy.xpath(queryLocators.querySettingsTab).click();
     cy.xpath(queryLocators.queryTimeout).should("be.focused");
   });
 
-  it("6. Bug 21999 Maintain focus of code editor when Escape is pressed with autcomplete open + Bug 22960", () => {
+  it("5. Bug 21999 Maintain focus of code editor when Escape is pressed with autcomplete open + Bug 22960", () => {
     EditorNavigation.SelectEntityByName("JSObject1", EntityType.JSObject);
 
     cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 4 });

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+# cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/IDE/MaintainContext&Focus_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,4 @@
 # To run only limited tests - give the spec names in below format:
-# cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 cypress/e2e/Regression/ClientSide/IDE/MaintainContext&Focus_spec.js
 
 # For running all specs - uncomment below:

--- a/app/client/cypress/support/Pages/IDE/LeftPane.ts
+++ b/app/client/cypress/support/Pages/IDE/LeftPane.ts
@@ -57,7 +57,13 @@ export class LeftPane {
     if (!this.segments) {
       throw Error("No Segments configured");
     }
-    ObjectsRegistry.AggregateHelper.GetNClick(this.locators.segment(name));
+    ObjectsRegistry.AggregateHelper.GetElement(
+      this.locators.segment(name),
+    ).then(($body) => {
+      if ($body.first().attr("data-selected") !== "true") {
+        ObjectsRegistry.AggregateHelper.GetNClick(this.locators.segment(name));
+      }
+    });
   }
 
   public selectItem(
@@ -90,6 +96,7 @@ export class LeftPane {
         }
       });
   }
+
   public selectedItem(
     exists?: "exist" | "not.exist" | "noVerify",
   ): Cypress.Chainable {


### PR DESCRIPTION
## Description

Fixes the long time skipped MaintainContext&Focus test by updating the method of switching segments
Also removes some old features that were being tested


## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 89161b3359f2bae8d5c00d09581abbf56b1c73f0 yet
> <hr>Fri, 27 Sep 2024 08:35:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved focus management in the IDE by ensuring that the focus remains on the correct elements during interactions.
	- Updated test cases to better reflect expected behaviors and remove redundant checks.

- **Tests**
	- Adjusted and reorganized test cases for better clarity and effectiveness.
	- Added the `MaintainContext&Focus_spec.js` test file to limited tests while commenting out the `Fork_Template_spec.js` file.
	- Enhanced the `selectSegment` method to prevent unnecessary clicks on already selected segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->