### PR TITLE
fix: Amazon S3 large file uploads issue fixed

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
@@ -7,7 +7,8 @@ import org.pf4j.PluginWrapper;
 
 public abstract class BasePlugin extends Plugin {
 
-    protected static final ObjectMapper objectMapper = SerializationUtils.getObjectMapperWithSourceInLocationEnabled();
+    protected static final ObjectMapper objectMapper =
+            SerializationUtils.getObjectMapperWithSourceInLocationAndMaxStringLengthEnabled();
 
     public BasePlugin(PluginWrapper wrapper) {
         super(wrapper);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/SerializationUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/SerializationUtils.java
@@ -6,6 +6,7 @@ import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -72,5 +73,19 @@ public class SerializationUtils {
 
     public static ObjectMapper getObjectMapperWithSourceInLocationEnabled() {
         return new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+    }
+
+    public static ObjectMapper getObjectMapperWithSourceInLocationAndMaxStringLengthEnabled() {
+        ObjectMapper objectMapper =
+                new ObjectMapper().enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+        // Multipart data would be parsed using object mapper, these files may be large in the size.
+        // Hence, the length should not be truncated, therefore allowing maximum length.
+        objectMapper
+                .getFactory()
+                .setStreamReadConstraints(StreamReadConstraints.builder()
+                        .maxStringLength(Integer.MAX_VALUE)
+                        .build());
+
+        return objectMapper;
     }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -43,6 +43,7 @@ import com.external.plugins.constants.AmazonS3Action;
 import com.external.plugins.exceptions.S3ErrorMessages;
 import com.external.plugins.exceptions.S3PluginError;
 import com.external.utils.AmazonS3ErrorUtils;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.extern.slf4j.Slf4j;
@@ -262,6 +263,13 @@ public class AmazonS3Plugin extends BasePlugin {
             byte[] payload;
             MultipartFormDataDTO multipartFormDataDTO;
             try {
+                // Multipart data would be parsed using object mapper, these files may be large in the size.
+                // Hence, the length should not be truncated, therefore allowing maximum length.
+                objectMapper
+                        .getFactory()
+                        .setStreamReadConstraints(StreamReadConstraints.builder()
+                                .maxStringLength(Integer.MAX_VALUE)
+                                .build());
                 multipartFormDataDTO = objectMapper.readValue(body, MultipartFormDataDTO.class);
             } catch (IOException e) {
                 throw new AppsmithPluginException(

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -43,7 +43,6 @@ import com.external.plugins.constants.AmazonS3Action;
 import com.external.plugins.exceptions.S3ErrorMessages;
 import com.external.plugins.exceptions.S3PluginError;
 import com.external.utils.AmazonS3ErrorUtils;
-import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.extern.slf4j.Slf4j;
@@ -263,13 +262,6 @@ public class AmazonS3Plugin extends BasePlugin {
             byte[] payload;
             MultipartFormDataDTO multipartFormDataDTO;
             try {
-                // Multipart data would be parsed using object mapper, these files may be large in the size.
-                // Hence, the length should not be truncated, therefore allowing maximum length.
-                objectMapper
-                        .getFactory()
-                        .setStreamReadConstraints(StreamReadConstraints.builder()
-                                .maxStringLength(Integer.MAX_VALUE)
-                                .build());
                 multipartFormDataDTO = objectMapper.readValue(body, MultipartFormDataDTO.class);
             } catch (IOException e) {
                 throw new AppsmithPluginException(


### PR DESCRIPTION
## Description
This PR fixes the file upload issue for S3. With S3 file upload, earlier users were able to upload files only upto 14mb but now with this PR fix they can upload larger files.


Fixes #35601 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11100760284>
> Commit: 38e08107cfbf6a90267241cc537872247a07159f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11100760284&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 30 Sep 2024 07:11:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced object mapping capabilities with a new method to handle maximum string length for large data.
- **Bug Fixes**
	- Improved handling of multipart data to prevent truncation during serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->