### PR TITLE
fix: fixing modal height by removing min-content

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnectionV2/index.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnectionV2/index.tsx
@@ -32,7 +32,6 @@ const StyledModalBody = styled(ModalBody)`
   overflow-y: initial;
   display: flex;
   flex-direction: column;
-  min-height: min-content;
   max-height: calc(
     100vh - 200px - 32px - 56px - 44px
   ); // 200px offset, 32px outer padding, 56px footer, 44px header


### PR DESCRIPTION
## Description
min-content css property is behaving weirdly in the latest update of the chrome browser

Fixes https://github.com/appsmithorg/appsmith/issues/36586

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11084506553>
> Commit: a888acf77730a014fe6d708bf8ed9b48e0cb8029
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11084506553&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Sat, 28 Sep 2024 14:34:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Removed the minimum height constraint from the modal body, allowing for more flexible vertical space allocation in the modal display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->