### PR TITLE
fix: remove cache control headers for requests handled with an error in Caddy

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -74,13 +74,13 @@ parts.push(`
   }
 
   # skip logs for health check
-  skip_log /api/v1/health
+  log_skip /api/v1/health
 
   # skip logs for sourcemap files
   @source-map-files {
     path_regexp ^.*\.(js|css)\.map$
   }
-  skip_log @source-map-files
+  log_skip @source-map-files
 
   # The internal request ID header should never be accepted from an incoming request.
   request_header -X-Appsmith-Request-Id
@@ -101,15 +101,7 @@ parts.push(`
   }
 
   header /static/* {
-   # Match the response with status 200
-    @successful {
-        status 200
-    }
-
-    # Cache the response for 1 year if the response is successful
-    # @successful {
-        Cache-Control "public, max-age=31536000, immutable"
-    # }
+    Cache-Control "public, max-age=31536000, immutable"
   }
 
   request_body {
@@ -162,7 +154,12 @@ parts.push(`
 
   handle_errors {
     respond "{err.status_code} {err.status_text}" {err.status_code}
-    header -Server
+    header {
+      # Remove the Server header from the response.
+      -Server
+      # Remove Cache-Control header from the response.
+      -Cache-Control
+    }
   }
 }
 

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -101,7 +101,15 @@ parts.push(`
   }
 
   header /static/* {
-    Cache-Control "public, max-age=31536000, immutable"
+   # Match the response with status 200
+    @successful {
+        status 200
+    }
+
+    # Cache the response for 1 year if the response is successful
+    # @successful {
+        Cache-Control "public, max-age=31536000, immutable"
+    # }
   }
 
   request_body {


### PR DESCRIPTION
## Description
Changes
1. Remove the Cache Control header in the handle errors block. This change makes sure that the Cache control header set for /static/* route is remove in case the file is not found.
2. Rename the skip_log directive to log_skip. 
As per the caddy server docs
> Prior to v2.8.0, this directive was named skip_log, but was renamed for consistency with other directives.

Ref: https://caddyserver.com/docs/caddyfile/directives/log_skip

----
After this change the following are the response headers for a requests to valid and invalid static file path.

#### Valid file path (status 200)
```
curl -I https://ce-36590.dp.appsmith.com/static/js/main.43ec809e.js
```
```
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: public, max-age=31536000, immutable
Content-Length: 7859533
Content-Security-Policy: default-src 'self' release-appcdn.appsmith.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' *; worker-src 'self' blob: release-appcdn.appsmith.com; connect-src * 'self' blob: raw.githubusercontent.com *.intercom.io wss://*.intercom.io *.algolianet.com *.algolia.net api.segment.io *.sentry.io *.hotjar.com maps.googleapis.com fonts.googleapis.com www.gstatic.com fonts.gstatic.com release-appcdn.appsmith.com; img-src * data: blob:; media-src * data: blob:; style-src * 'self' 'unsafe-inline'; font-src * 'self' data:; frame-ancestors *; frame-src * data: blob:
Content-Type: application/javascript
Date: Sun, 06 Oct 2024 12:55:14 GMT
Etag: "d4gwcg4flczk4oggd"
Last-Modified: Fri, 27 Sep 2024 07:43:14 GMT
Status: 200
Strict-Transport-Security: max-age=31536000
Vary: Accept-Encoding
Vary: Accept-Encoding
X-Appsmith-Request-Id: 9ea84a03-e2e7-4ca6-9e78-4eb8a202dbb6
X-Content-Type-Options: nosniff
X-Request-Id: invalid_request_id
X-XSS-Protection: 0
Connection: keep-alive
```

#### Invalid file path (status 404)
```
curl -I https://ce-36590.dp.appsmith.com/static/js/main.js
```
```
HTTP/1.1 404 Not Found
Content-Length: 13
Content-Security-Policy: default-src 'self' release-appcdn.appsmith.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' *; worker-src 'self' blob: release-appcdn.appsmith.com; connect-src * 'self' blob: raw.githubusercontent.com *.intercom.io wss://*.intercom.io *.algolianet.com *.algolia.net api.segment.io *.sentry.io *.hotjar.com maps.googleapis.com fonts.googleapis.com www.gstatic.com fonts.gstatic.com release-appcdn.appsmith.com; img-src * data: blob:; media-src * data: blob:; style-src * 'self' 'unsafe-inline'; font-src * 'self' data:; frame-ancestors *; frame-src * data: blob:
Content-Type: text/plain; charset=utf-8
Date: Sun, 06 Oct 2024 12:56:12 GMT
Status: 200
Strict-Transport-Security: max-age=31536000
X-Content-Type-Options: nosniff
X-Request-Id: invalid_request_id
X-XSS-Protection: 0
Connection: keep-alive

```

Fixes #`Issue Number`  
_or_  
Fixes [Issue URL](https://github.com/appsmithorg/cloud-deployment/issues/619)
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11202369772>
> Commit: 0f87242253027dfa4dbb5779da0a330c0dfefdd0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11202369772&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Sun, 06 Oct 2024 15:03:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
