### PR TITLE
test: replace 3rd party api with TED

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
@@ -37,8 +37,8 @@ describe(
       cy.fixture("datasources").then((datasourceFormData: any) => {
         AppSidebar.navigate(AppSidebarButton.Editor);
         apiPage.CreateAndFillApi(
-          "https://api.forismatic.com/api/1.0/?method=getQuote&lang=en&format=json",
-          "Quotes",
+          "http://host.docker.internal:5001",
+          "AppsmithTed",
           30000,
         );
         apiPage.ToggleConfirmBeforeRunning(true);
@@ -54,8 +54,8 @@ describe(
         `export default {
       callTrump: async () => {
         return WhatTrumpThinks.run()},
-      callQuotes: () => {
-        return Quotes.run().then(()=> Quotes.data.quoteText);}
+      callAppsmithTed: () => {
+        return AppsmithTed.run()}
     }`,
         {
           paste: true,
@@ -71,16 +71,16 @@ describe(
           jsName as string,
           EntityType.JSObject,
         );
-        jsEditor.EnableDisableAsyncFuncSettings("callQuotes", false); //OnPageLoad made true once mapped with widget
+        jsEditor.EnableDisableAsyncFuncSettings("callAppsmithTed", false); //OnPageLoad made true once mapped with widget
 
         EditorNavigation.SelectEntityByName("Input1", EntityType.Widget);
         propPane.UpdatePropertyFieldValue(
           "Default value",
-          "{{" + jsObjName + ".callQuotes.data}}",
+          "{{" + jsObjName + ".callAppsmithTed.data}}",
         );
         cy.get(locators._toastMsg)
           .children()
-          .should("contain", "Quotes") //Quotes api also since its .data is accessed in callQuotes()
+          .should("contain", "AppsmithTed")
           .and("contain", jsName as string)
           .and("contain", "will be executed automatically on page load");
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
replace 3rd party API with TED
/ok-to-test tags="@tag.JS"




<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11102666520>
> Commit: 06354a9c09ce1e5f7d9018ce4eabeaac857ba023
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11102666520&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Mon, 30 Sep 2024 09:26:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->
