### PR TITLE
test: replaced 3rd party apit in treeSelect

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
@@ -170,7 +170,9 @@ describe(
     });
 
     it("5. Verify Api binding", () => {
-      apiPage.CreateAndFillApi("https://mock-api.appsmith.com/users");
+      apiPage.CreateAndFillApi(
+        "http://host.docker.internal:5001/v1/dynamicrecords/getrecordsArray",
+      );
       apiPage.RunAPI();
       EditorNavigation.SelectEntityByName(
         "TreeSelect1",
@@ -181,7 +183,7 @@ describe(
       propPane.MoveToTab("Content");
       propPane.UpdatePropertyFieldValue(
         "Options",
-        `{{Api1.data.users.map((s)=>{return{"label":s.name,"value":s.name}})}}`,
+        `{{JSON.parse(Api1.data).map((item) => {return {"label":item.value, "value":item.abbr};})}}`,
       );
       agHelper.GetNClick(
         `${locators._widgetInDeployed("singleselecttreewidget")}`,
@@ -308,7 +310,7 @@ describe(
       propPane.ToggleJSMode("onOptionChange", true);
       propPane.UpdatePropertyFieldValue(
         "onOptionChange",
-        `{{download('http://host.docker.internal:4200/kiwi.svg', 'kiwi.svg', 'image/svg+xml').then(() => {
+        `{{download('http://host.docker.internal:4200/photo-1503469432756-4aae2e18d881.jpeg', 'flower.svg', 'image/svg+xml').then(() => {
             showAlert('Download Success', '');
           });}}`,
       );

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
Replaced 3rd Party API with TED
/ok-to-test tags="@tag.Select"



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11102740010>
> Commit: 692dd2810fb4520bac6fe8aec3658a0cb70525ba
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11102740010&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Select`
> Spec:
> <hr>Mon, 30 Sep 2024 09:21:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->
