### PR TITLE
chore: Switch rate limit key to client_ip

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -146,7 +146,7 @@ parts.push(`
 
   ${isRateLimitingEnabled ? `rate_limit {
     zone dynamic_zone {
-      key {http.request.remote_ip}
+      key {http.request.client_ip}
       events ${RATE_LIMIT}
       window 1s
     }


### PR DESCRIPTION
## Description
Remote IP points to the node IP so requests get rate limited in totality. Client IP allows to differentiate by end machine. For probes, client IP will still be node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SSL certificate handling with fallback options.
	- Improved rate limiting configuration for better request management.
	- Conditional logic for custom domain binding and HTTP to HTTPS redirection.

- **Bug Fixes**
	- Improved error handling for reading configuration files.

- **Documentation**
	- Updated metadata handling in the index.html file for better integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->