### PR TITLE
chore: fix for CVE-2024-1597⁠ for postgres build

### DIFF
--- a/app/server/appsmith-interfaces/pom.xml
+++ b/app/server/appsmith-interfaces/pom.xml
@@ -21,6 +21,8 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <!-- Overriding version to get fix for CVE-2024-1597. Remove once spring-boot is at least at 3.1.9 or 3.2.3 -->
+            <version>42.6.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This should get rid of the vulnerable Postgres driver version on pg branch.

fixes https://github.com/appsmithorg/appsmith-ee/issues/5193