### PR TITLE
fix: Release blocker: toast with whitespace

### DIFF
--- a/app/client/packages/design-system/ads/src/Toast/Toast.tsx
+++ b/app/client/packages/design-system/ads/src/Toast/Toast.tsx
@@ -45,7 +45,7 @@ const toast = {
 
     return toastifyToast(
       <ToastBody kind="body-m">
-        <StyledPre> {content}</StyledPre>
+        <StyledPre>{content}</StyledPre>
         {actionText && (
           <StyledButton
             kind="tertiary"


### PR DESCRIPTION
## Description

There was an extra space infront of toast content which cause cypress failures. This PR address that issue.

PR cause this issue: https://github.com/appsmithorg/appsmith/pull/36126

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11121364189>
> Commit: a114bff4d20b72d611c52093820487fbbe5304e0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11121364189&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 01 Oct 2024 09:28:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor formatting adjustments made to the Toast component.
	- Added a TODO comment regarding future accessibility features for toasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->