### PR TITLE
chore: add TBP failures to postgres channel 

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -517,7 +517,7 @@ jobs:
           run_url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}'
           slack_message="🚨 TBP workflow failed in <$run_url|${{ vars.EDITION }} attempt ${{ github.run_attempt }} (run ${{ github.run_id }})>."
 
-          # This is the ChannelId of the pro-postgres-sync channel.
+          # This is the ChannelId of the proj-postgres-sync channel.
           body="$(jq -nc \
             --arg channel C07JMLWEXDJ \
             --arg text "$slack_message" \

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -500,14 +500,31 @@ jobs:
             --header 'Content-Type: application/json; charset=utf-8' \
             --data-raw "$body"
 
+
+  notify-slack-for-pg:
+    needs: ci-test-result
+    runs-on: ubuntu-latest
+
+    if: ( failure() && github.ref == 'refs/heads/pg' )
+
+    steps:
+      - name: Notify failure on workflow run and on Slack
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o xtrace
+
+          run_url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}'
+          slack_message="🚨 TBP workflow failed in <$run_url|${{ vars.EDITION }} attempt ${{ github.run_attempt }} (run ${{ github.run_id }})>."
+
           # This is the ChannelId of the pro-postgres-sync channel.
           body="$(jq -nc \
             --arg channel C07JMLWEXDJ \
             --arg text "$slack_message" \
             '$ARGS.named'
           )"
-          curl --version
           curl -v https://slack.com/api/chat.postMessage \
+            --fail-with-body \
             --header 'Authorization: Bearer ${{ secrets.SLACK_APPSMITH_ALERTS_TOKEN }}' \
             --header 'Content-Type: application/json; charset=utf-8' \
             --data-raw "$body"

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -499,3 +499,15 @@ jobs:
             --header 'Authorization: Bearer ${{ secrets.SLACK_APPSMITH_ALERTS_TOKEN }}' \
             --header 'Content-Type: application/json; charset=utf-8' \
             --data-raw "$body"
+
+          # This is the ChannelId of the pro-postgres-sync channel.
+          body="$(jq -nc \
+            --arg channel C07JMLWEXDJ \
+            --arg text "$slack_message" \
+            '$ARGS.named'
+          )"
+          curl --version
+          curl -v https://slack.com/api/chat.postMessage \
+            --header 'Authorization: Bearer ${{ secrets.SLACK_APPSMITH_ALERTS_TOKEN }}' \
+            --header 'Content-Type: application/json; charset=utf-8' \
+            --data-raw "$body"


### PR DESCRIPTION
## Description

Notify the DB Infra team for any failures in TBP workflow for the Postgres failures. This is keep the PG stable and tackle the Cypres/JUnit failures when the changes are merged from release branch. 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/11174148513>
> Commit: 46166d857627d908a42008d0396093fcc8bf1211
> Workflow: `PR Automation test suite`
> Tags: `@tag.Sanity`
> Spec: ``
> <hr>Fri, 04 Oct 2024 04:47:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced failure notification mechanism for workflow failures, now notifying two Slack channels when the workflow fails on the `master` and `pg` branches.

- **Chores**
	- Updated workflow configuration to support additional notification channels for improved communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->