### PR TITLE
fix: updated the max connection pool size and datasourceDestroy method

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -692,12 +692,11 @@ public class MySqlPlugin extends BasePlugin {
                                  */
                                 sshTunnelContext.getServerSocket().close();
                                 sshTunnelContext.getSshClient().disconnect();
-                                sshTunnelContext.getThread().stop();
+                                sshTunnelContext.getThread().interrupt(); // Gracefully interrupt the thread
                             } catch (IOException e) {
                                 log.error("Failed to destroy SSH tunnel context: " + e.getMessage());
                             }
                         }
-
                         return Mono.empty();
                     })
                     .subscribeOn(scheduler)

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
@@ -38,7 +38,7 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 
 public class MySqlDatasourceUtils {
 
-    public static int MAX_CONNECTION_POOL_SIZE = 5;
+    public static int MAX_CONNECTION_POOL_SIZE = 20;
 
     /**
      * 1 sec is the recommended value as shown in the example here:

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/connectionpoolconfig/configurations/ConnectionPoolConfigCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/connectionpoolconfig/configurations/ConnectionPoolConfigCETest.java
@@ -18,7 +18,7 @@ public class ConnectionPoolConfigCETest {
     @Test
     public void verifyGetMaxConnectionPoolSizeProvidesDefaultValue() {
         // this is same as default
-        Integer connectionPoolMaxSize = 5;
+        Integer connectionPoolMaxSize = 20;
 
         Mono<Integer> connectionPoolMaxSizeMono = connectionPoolConfig.getMaxConnectionPoolSize();
         StepVerifier.create(connectionPoolMaxSizeMono).assertNext(poolSize -> {


### PR DESCRIPTION
## Description
- This PR updates the max connection pool size for MySQL datasource from 5 to 20 as from the logs we found out that the maximum connections are always getting used. 
- This PR also updates the datasourceDestroy method for MySQL plugin to ensure the graceful shutdown of thread takes places and ensures the connection is closed as opposed to immediate termination of the thread earlier which does not ensure closure of existing connection.

<img width="1100" alt="SCR-20241001-lbq-2" src="https://github.com/user-attachments/assets/1f9e5b10-3036-41bc-94a7-8fa39056bcd6">



Fixes #34028  

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11129233985>
> Commit: 04617ce742961952b863cedaff60060bd46c02b0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11129233985&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 01 Oct 2024 16:44:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Increased the maximum connection pool size for MySQL from 5 to 20, allowing for more concurrent database connections.
  
- **Bug Fixes**
	- Improved the termination process of the SSH tunnel thread for better handling during datasource destruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->