### PR TITLE
chore: Updated doc urls

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/DocumentViewer/DocumentViewer_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/DocumentViewer/DocumentViewer_spec.ts
@@ -15,13 +15,12 @@ import EditorNavigation, {
 } from "../../../../../support/Pages/EditorNavigation";
 
 const ppt =
-  "https://ssz.sgp1.digitaloceanspaces.com/3ZEO2582C29EA0KKK2/ppt-on-population-pptxafa26c44-208f-46a3-89cc-8a5c020b6863.pptx";
+  "http://host.docker.internal:4200/ppt-on-population-pptxafa26c44-208f-46a3-89cc-8a5c020b6863.pptx";
 const pngImage =
   "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRb8umIiCU_K6ac-xS-ni4y6SP7XAd8C7Ms3Q&usqp=CAU";
 const jpgImage =
   "https://community.appsmith.com/sites/default/files/styles/small_thumbnail/public/2024-03/aws-logo.jpg?itok=yG4bpfFs";
-const pdf =
-  "https://www.learningcontainer.com/wp-content/uploads/2019/09/sample-pdf-file.pdf";
+const pdf = "http://host.docker.internal:4200/sample-pdf-file.pdf";
 
 describe(
   "DocumentViewer Widget Functionality",


### PR DESCRIPTION
## Description
Updated third party URLs.


Fixes #`36437`  

## Automation

/ok-to-test tags="@tag.DocumentViewer"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11125143689>
> Commit: 7d19fcce57eb2183d6e261feaa772d20d6fafa10
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11125143689&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.DocumentViewer`
> Spec:
> <hr>Tue, 01 Oct 2024 12:45:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated document link URLs for testing to ensure accurate functionality in the DocumentViewer widget.
  
- **Tests**
	- Maintained and validated tests for various document types, ensuring correct rendering and handling of different file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->