### PR TITLE
chore: fetch spec with removed third party 

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
@@ -83,6 +83,7 @@ describe("Tests fetch calls", { tags: ["@tag.JS"] }, () => {
         `{{this.params.person}}`,
       "Gender_Age",
     );
+    apiPage.RunAPI();
     entityExplorer.DragDropWidgetNVerify("buttonwidget", 500, 200);
     EditorNavigation.SelectEntityByName("Button1", EntityType.Widget);
     propPane.TypeTextIntoField("Label", "getUserName");

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
@@ -91,8 +91,8 @@ describe("Tests fetch calls", { tags: ["@tag.JS"] }, () => {
       "onClick",
       `{{(async function(){
           const gender = await Gender_Age.run({ person: "sagar" });
-          storeValue("Gender", gender); // No need to await
-          showAlert("Your name is " + appsmith.store.Gender.name); // Assuming 'name' is a string
+          storeValue("Gender", gender);
+          showAlert("Your name is " + appsmith.store.Gender.name);
         })()}}`,
     );
 

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
@@ -95,7 +95,7 @@ describe("Tests fetch calls", { tags: ["@tag.JS"] }, () => {
         .catch(error => {
           console.error("Fetch error:", error);
           showAlert("Failed to fetch user data: " + error.message);
-        })}}`
+        })}}`,
     );
 
     agHelper.Sleep(2000);

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
@@ -78,16 +78,28 @@ describe("Tests fetch calls", { tags: ["@tag.JS"] }, () => {
   it("3. Tests if fetch works with store value", function () {
     entityExplorer.DragDropWidgetNVerify("buttonwidget", 500, 200);
     EditorNavigation.SelectEntityByName("Button1", EntityType.Widget);
-    propPane.TypeTextIntoField("Label", "getUserID");
+    propPane.TypeTextIntoField("Label", "getUserName");
     propPane.EnterJSContext(
       "onClick",
-      `{{fetch('https://jsonplaceholder.typicode.com/todos/1')
-    .then(res => res.json())
-    .then(json => storeValue('userId', json.userId))
-    .then(() => showAlert("UserId: " + appsmith.store.userId))}}`,
+      `{{fetch('http://host.docker.internal:5001/v1/genderize_agify?name=sagar')
+        .then(res => {
+          if (!res.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return res.json();
+        })
+        .then(json => {
+          const name = json.name; // Get the name
+          showAlert("Name: " + name);
+        })
+        .catch(error => {
+          console.error("Fetch error:", error);
+          showAlert("Failed to fetch user data: " + error.message);
+        })}}`
     );
+
     agHelper.Sleep(2000);
-    agHelper.ClickButton("getUserID");
-    agHelper.AssertContains("UserId: 1", "exist");
+    agHelper.ClickButton("getUserName");
+    agHelper.AssertContains("Name: sagar", "exist");
   });
 });

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
@@ -81,21 +81,29 @@ describe("Tests fetch calls", { tags: ["@tag.JS"] }, () => {
     propPane.TypeTextIntoField("Label", "getUserName");
     propPane.EnterJSContext(
       "onClick",
-      `{{fetch('http://host.docker.internal:5001/v1/genderize_agify?name=sagar')
-        .then(res => {
-          if (!res.ok) {
-            throw new Error('Network response was not ok');
-          }
-          return res.json();
-        })
-        .then(json => {
-          const name = json.name; // Get the name
-          showAlert("Name: " + name);
-        })
-        .catch(error => {
-          console.error("Fetch error:", error);
-          showAlert("Failed to fetch user data: " + error.message);
-        })}}`,
+      `{{ 
+        (function fetchData(retries = 3) {
+          return fetch('http://host.docker.internal:5001/v1/genderize_agify?name=sagar')
+            .then(res => {
+              if (!res.ok) {
+                throw new Error('Network response was not ok');
+              }
+              return res.json();
+            })
+            .then(json => {
+              const name = json.name;
+              showAlert("Name: " + name);
+            })
+            .catch(error => {
+              if (retries > 0) {
+                return fetchData(retries - 1);
+              } else {
+                console.error("Fetch error:", error);
+                showAlert("Failed to fetch user data: " + error.message);
+              }
+            });
+        })()
+      }}`,
     );
 
     agHelper.Sleep(2000);

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
@@ -101,6 +101,5 @@ describe("Tests fetch calls", { tags: ["@tag.JS"] }, () => {
     agHelper.Sleep(2000);
     agHelper.ClickButton("getUserName");
     agHelper.AssertContains("Name: sagar", "exist");
-    agHelper.AssertContains("Name: sagar", "exist");
   });
 });

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
@@ -101,5 +101,6 @@ describe("Tests fetch calls", { tags: ["@tag.JS"] }, () => {
     agHelper.Sleep(2000);
     agHelper.ClickButton("getUserName");
     agHelper.AssertContains("Name: sagar", "exist");
+    agHelper.AssertContains("Name: sagar", "exist");
   });
 });

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/JsFunctionExecution/Fetch_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
Updated third party URLs.

Fixes #`36437`  

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11157028440>
> Commit: 3a3ab548300e8e8a7338b93491dab0ce36c33fda
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11157028440&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Thu, 03 Oct 2024 07:04:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced fetch functionality with improved error handling and updated button interactions.
	- Introduced delay mechanism for fetch calls to ensure functionality after a timeout.

- **Bug Fixes**
	- Updated button label and fetch endpoint to correctly retrieve and display user names.

- **Documentation**
	- Updated test specifications to focus on server-side JavaScript function execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->