### PR TITLE
fix: fixed mysql plugin tests by increasing the max connections

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -80,11 +80,13 @@ public class MySqlPluginTest {
     @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is
     // pseudo-optional.
     @Container
-    public static MySQLContainer mySQLContainer = new MySQLContainer(
+    public static MySQLContainer mySQLContainer = (MySQLContainer) new MySQLContainer(
                     DockerImageName.parse("mysql/mysql-server:8.0.25").asCompatibleSubstituteFor("mysql"))
             .withUsername("mysql")
             .withPassword("password")
-            .withDatabaseName("test_db");
+            .withDatabaseName("test_db")
+            // Increased max connections to 400 to support the increased max connection pool size
+            .withCommand("--max_connections=400");
 
     @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is
     // pseudo-optional.

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/connectionpoolconfig/configurations/ConnectionPoolConfigCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/connectionpoolconfig/configurations/ConnectionPoolConfigCETest.java
@@ -18,7 +18,7 @@ public class ConnectionPoolConfigCETest {
     @Test
     public void verifyGetMaxConnectionPoolSizeProvidesDefaultValue() {
         // this is same as default
-        Integer connectionPoolMaxSize = 20;
+        Integer connectionPoolMaxSize = 5;
 
         Mono<Integer> connectionPoolMaxSizeMono = connectionPoolConfig.getMaxConnectionPoolSize();
         StepVerifier.create(connectionPoolMaxSizeMono).assertNext(poolSize -> {


### PR DESCRIPTION
## Description
This PR fixes the MySql plugin server unit tests which started to fail after increasing the max connection pool size from 5 to [20](https://github.com/appsmithorg/appsmith/pull/36631/files). The failures were due to the `Too Many Connections` error which is now resolved by increasing the connections. This is the case for test files because the connections are not reused within each test.
![image](https://github.com/user-attachments/assets/8f97f8c5-7e67-4503-9dcf-b5daa7dc517f)


Fixes #36656 
## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
