### PR TITLE
chore: Bust OAuth2 client cache for spring boot 3.3

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
@@ -215,7 +215,7 @@ public class RedisConfig {
                 boolean allValuesAreClientDTOs = true;
                 for (final LoginSource loginSource : LoginSource.oauthSources) {
                     final Object value = data.get(loginSource.name().toLowerCase());
-                    if (value != null && !(value instanceof OAuth2AuthorizedClientDTO)) {
+                    if (value != null && !(value instanceof OAuth2AuthorizedClient)) {
                         allValuesAreClientDTOs = false;
                         break;
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration063CacheBustSpringBoot3_3.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration063CacheBustSpringBoot3_3.java
@@ -1,0 +1,38 @@
+package com.appsmith.server.migrations.db.ce;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+import reactor.core.publisher.Flux;
+
+@RequiredArgsConstructor
+@Slf4j
+@ChangeUnit(order = "063", id = "reset_session_oauth2_spring_3_3")
+public class Migration063CacheBustSpringBoot3_3 {
+
+    private final ReactiveRedisOperations<String, String> reactiveRedisOperations;
+
+    @RollbackExecution
+    public void rollbackExecution() {}
+
+    @Execution
+    public void execute() {
+        doClearRedisOAuth2AuthClientKeys(reactiveRedisOperations);
+    }
+
+    public static void doClearRedisOAuth2AuthClientKeys(
+            ReactiveRedisOperations<String, String> reactiveRedisOperations) {
+        final String authorizedClientsKey =
+                "sessionAttr:org.springframework.security.oauth2.client.web.server.WebSessionServerOAuth2AuthorizedClientRepository.AUTHORIZED_CLIENTS";
+        final String script =
+                "for _,k in ipairs(redis.call('keys','spring:session:sessions:*')) do local fieldExists = redis.call('hexists', k, '"
+                        + authorizedClientsKey + "'); if fieldExists == 1 then redis.call('del', k) end end";
+        final Flux<Object> flushdb = reactiveRedisOperations.execute(RedisScript.of(script));
+
+        flushdb.blockLast();
+    }
+}


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced serialization and deserialization of OAuth2 client data for improved handling.
	- Introduced a migration process to clear outdated OAuth2 session data from Redis.

- **Bug Fixes**
	- Corrected type handling for OAuth2AuthorizedClient during data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->