### PR TITLE
chore: Add grants for appsmith user for embedded postgres

### DIFF
--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -160,9 +160,9 @@ grant_permissions_for_schema() {
   local user=${USER-$DB_USER} schema=${SCHEMA-$DB_SCHEMA} db=${DB-$DB_NAME} host=${HOST-$DB_HOST} port=${PORT-$DB_PORT}
   tlog "Granting permissions to user '${user}' on schema '$schema' in database '$db' on host '$host' and port '$port'..."
   psql -h ${host} -p ${port} -U ${postgres_admin_user} -d ${db} -c "GRANT ALL PRIVILEGES ON SCHEMA ${schema} TO ${user};"
-  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d "$db" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${schema} TO ${user};"
-  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d "$db" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema} GRANT ALL PRIVILEGES ON TABLES TO ${user};"
-  psql -h ${host} -p ${port} -U ${postgres_admin_user} -c "GRANT CONNECT ON DATABASE ${db} TO ${user};"
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d ${db} -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${schema} TO ${user};"
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d ${db} -c "ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema} GRANT ALL PRIVILEGES ON TABLES TO ${user};"
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d ${db} -c "GRANT CONNECT ON DATABASE ${db} TO ${user};"
 }
 
 # Example usage of the functions

--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -145,6 +145,17 @@ init_pg_db() {
   fi
 }
 
+# Utility function to grant permissions to a user on a schema in a database on a host and port in PostgreSQL database
+# Args:
+#     USER (string): User to grant permissions to
+#     SCHEMA (string): Schema to grant permissions on
+#     DB (string): Database to grant permissions on
+#     HOST (string): Host to grant permissions on
+#     PORT (int): Port to grant permissions on
+# Returns:
+#     None
+# Example:
+#     USER="user" SCHEMA="schema" DB="db" HOST="host" PORT="port" grant_permissions_for_schema
 grant_permissions_for_schema() {
   local user=${USER-$DB_USER} schema=${SCHEMA-$DB_SCHEMA} db=${DB-$DB_NAME} host=${HOST-$DB_HOST} port=${PORT-$DB_PORT}
   tlog "Granting permissions to user '${user}' on schema '$schema' in database '$db' on host '$host' and port '$port'..."
@@ -158,4 +169,4 @@ grant_permissions_for_schema() {
 # waitForPostgresAvailability
 # extract_postgres_db_params "postgresql://user:password@localhost:5432/dbname"
 # init_pg_db
-# grant_permissions_for_schema "user" "schema" "db" "host" "port"
+# USER="user" SCHEMA="schema" DB="db" HOST="host" PORT="port" grant_permissions_for_schema

--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -162,7 +162,7 @@ grant_permissions_for_schema() {
   psql -h ${host} -p ${port} -U ${postgres_admin_user} -d ${db} -c "GRANT ALL PRIVILEGES ON SCHEMA ${schema} TO ${user};"
   psql -h ${host} -p ${port} -U ${postgres_admin_user} -d "$db" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${schema} TO ${user};"
   psql -h ${host} -p ${port} -U ${postgres_admin_user} -d "$db" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema} GRANT ALL PRIVILEGES ON TABLES TO ${user};"
-  psql -h ${host} -p ${port} -U ${postgres_admin_user} -c "GRANT CONNECT ON DATABASE ${schema} TO ${user};"
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -c "GRANT CONNECT ON DATABASE ${db} TO ${user};"
 }
 
 # Example usage of the functions

--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# default values
+DB_USER="appsmith"
+DB_HOST="127.0.0.1"
+DB_PORT="5432"
+DB_SCHEMA="appsmith"
+DB_NAME="appsmith"
+postgres_admin_user="postgres"
+
 waitForPostgresAvailability() {
   if [ -z "$PG_DB_HOST" ]; then
     tlog "PostgreSQL host name is empty. Check env variables. Error. Exiting java setup"
@@ -119,6 +127,8 @@ init_pg_db() {
         echo "Schema 'appsmith' does not exist. Creating schema..."
         psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U postgres -d "$PG_DB_NAME" -c "CREATE SCHEMA appsmith;"
       fi
+
+      USER=$PG_DB_USER SCHEMA="appsmith" DB=$PG_DB_NAME HOST=$PG_DB_HOST PORT=$PG_DB_PORT grant_permissions_for_schema
     else
       echo "Remote PostgreSQL detected, running as current user."
       PGPASSWORD=$PG_DB_PASSWORD psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U "$PG_DB_USER" -d "$PG_DB_NAME" -c "CREATE SCHEMA IF NOT EXISTS appsmith;"
@@ -135,6 +145,17 @@ init_pg_db() {
   fi
 }
 
+grant_permissions_for_schema() {
+  local user=${USER-$DB_USER} schema=${SCHEMA-$DB_SCHEMA} db=${DB-$DB_NAME} host=${HOST-$DB_HOST} port=${PORT-$DB_PORT}
+  tlog "Granting permissions to user '${user}' on schema '$schema' in database '$db' on host '$host' and port '$port'..."
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d ${db} -c "GRANT ALL PRIVILEGES ON SCHEMA ${schema} TO ${user};"
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d "$db" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${schema} TO ${user};"
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -d "$db" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema} GRANT ALL PRIVILEGES ON TABLES TO ${user};"
+  psql -h ${host} -p ${port} -U ${postgres_admin_user} -c "GRANT CONNECT ON DATABASE ${schema} TO ${user};"
+}
+
 # Example usage of the functions
 # waitForPostgresAvailability
 # extract_postgres_db_params "postgresql://user:password@localhost:5432/dbname"
+# init_pg_db
+# grant_permissions_for_schema "user" "schema" "db" "host" "port"


### PR DESCRIPTION
## Description
PR to add the necessary grants to `appsmith` user when user opts for Postgres embedded DB.

fixes https://github.com/appsmithorg/appsmith/issues/36661

## Automation

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11155064003>
> Commit: 1fb82e52a3f05da1b9bb4082cf871a62d3554d78
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11155064003&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 03 Oct 2024 04:22:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced default values for PostgreSQL database connection parameters.
  - Added a new function to manage user permissions on database schemas.

- **Improvements**
  - Enhanced the existing database initialization process to include permission granting after schema verification.
  - Updated documentation within the script for better clarity on new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->