### PR TITLE
chore: message string added for links

### DIFF
--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -4,7 +4,7 @@ type ID = string;
 
 export interface WorkflowScheduleSpecInterface {
   cronExpressions: Array<string>;
-  timezone: string;
+  timeZoneName: string;
 }
 
 export enum WorkflowScheduleState {

--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -4,6 +4,7 @@ type ID = string;
 
 export interface WorkflowScheduleSpecInterface {
   cronExpressions: Array<string>;
+  timezone: string;
 }
 
 export enum WorkflowScheduleState {

--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -2,6 +2,22 @@ import type { EvaluationVersion } from "constants/EvalConstants";
 
 type ID = string;
 
+export interface WorkflowScheduleSpecInterface {
+  cronExpressions: Array<string>;
+}
+
+export enum WorkflowScheduleState {
+  ACTIVE = "ACTIVE",
+  INACTIVE = "INACTIVE",
+}
+
+export interface WorkflowScheduleInterface {
+  scheduleSpec: WorkflowScheduleSpecInterface;
+  triggerData: Record<string, unknown>;
+  name: string;
+  state: WorkflowScheduleState;
+}
+
 // Type for the workflow object.
 export interface Workflow {
   id: ID;
@@ -20,6 +36,7 @@ export interface Workflow {
   // PR for reference: https://github.com/appsmithorg/appsmith/pull/8796
   evaluationVersion: EvaluationVersion;
   token?: string;
+  schedules?: Record<string, WorkflowScheduleInterface>;
 }
 
 export type WorkflowMetadata = Workflow;

--- a/app/client/src/ce/constants/WorkflowConstants.ts
+++ b/app/client/src/ce/constants/WorkflowConstants.ts
@@ -2,23 +2,6 @@ import type { EvaluationVersion } from "constants/EvalConstants";
 
 type ID = string;
 
-export interface WorkflowScheduleSpecInterface {
-  cronExpressions: Array<string>;
-  timeZoneName: string;
-}
-
-export enum WorkflowScheduleState {
-  ACTIVE = "ACTIVE",
-  INACTIVE = "INACTIVE",
-}
-
-export interface WorkflowScheduleInterface {
-  scheduleSpec: WorkflowScheduleSpecInterface;
-  triggerData: Record<string, unknown>;
-  name: string;
-  state: WorkflowScheduleState;
-}
-
 // Type for the workflow object.
 export interface Workflow {
   id: ID;
@@ -37,7 +20,6 @@ export interface Workflow {
   // PR for reference: https://github.com/appsmithorg/appsmith/pull/8796
   evaluationVersion: EvaluationVersion;
   token?: string;
-  schedules?: Record<string, WorkflowScheduleInterface>;
 }
 
 export type WorkflowMetadata = Workflow;

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -247,6 +247,7 @@ export const FORK_APP = () => `Fork app`;
 export const SIGN_IN = () => `Sign in`;
 export const SHARE_APP = () => `Share app`;
 export const ALL_APPS = () => `All apps`;
+export const KNOW_MORE = () => "Know more";
 
 export const EDITOR_HEADER = {
   saving: () => "Saving",


### PR DESCRIPTION
## Description
Adding a messages file for general usage, currently only referenced in EE.



## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/11160777706>
> Commit: 47a2d0ff83ec9ba265f8e6e0ca20bbd5f2601d9f
> Workflow: `PR Automation test suite`
> Tags: `@tag.Sanity`
> Spec: ``
> <hr>Thu, 03 Oct 2024 11:04:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new message constant "Know more" for enhanced user communication throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->