### PR TITLE
feat: add AIChat stories and tests

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/AIChat/src/AIChat.tsx
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/src/AIChat.tsx
@@ -1,4 +1,4 @@
-import { Button, Spinner, Text, TextArea } from "@appsmith/wds";
+import { Button, Text, TextArea } from "@appsmith/wds";
 import type { FormEvent, ForwardedRef, KeyboardEvent } from "react";
 import React, { forwardRef, useCallback } from "react";
 import { ChatTitle } from "./ChatTitle";
@@ -45,9 +45,10 @@ const _AIChat = (props: AIChatProps, ref: ForwardedRef<HTMLDivElement>) => {
   return (
     <div className={styles.root} ref={ref} {...rest}>
       <div className={styles.header}>
-        {chatTitle != null && <ChatTitle title={chatTitle} />}
+        <ChatTitle title={chatTitle} />
 
         {description ?? <Text size="body">{description}</Text>}
+
         <div className={styles.username}>
           <UserAvatar username={username} />
           <Text size="body">{username}</Text>
@@ -58,16 +59,12 @@ const _AIChat = (props: AIChatProps, ref: ForwardedRef<HTMLDivElement>) => {
         {thread.map((message: ChatMessage) => (
           <ThreadMessage {...message} key={message.id} username={username} />
         ))}
-
-        {isWaitingForResponse && (
-          <li>
-            <Spinner />
-          </li>
-        )}
       </ul>
 
       <form className={styles.promptForm} onSubmit={handleFormSubmit}>
         <TextArea
+          // TODO: Handle isWaitingForResponse: true state
+          isDisabled={isWaitingForResponse}
           name="prompt"
           onChange={onPromptChange}
           onKeyDown={handlePromptInputKeyDown}

--- a/app/client/packages/design-system/widgets/src/components/AIChat/src/AIChat.tsx
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/src/AIChat.tsx
@@ -13,7 +13,6 @@ const _AIChat = (props: AIChatProps, ref: ForwardedRef<HTMLDivElement>) => {
   const {
     // assistantName,
     chatTitle,
-    description,
     isWaitingForResponse = false,
     onPromptChange,
     onSubmit,
@@ -47,15 +46,15 @@ const _AIChat = (props: AIChatProps, ref: ForwardedRef<HTMLDivElement>) => {
       <div className={styles.header}>
         <ChatTitle title={chatTitle} />
 
-        {description ?? <Text size="body">{description}</Text>}
-
         <div className={styles.username}>
           <UserAvatar username={username} />
-          <Text size="body">{username}</Text>
+          <Text data-testid="t--aichat-username" size="body">
+            {username}
+          </Text>
         </div>
       </div>
 
-      <ul className={styles.thread}>
+      <ul className={styles.thread} data-testid="t--aichat-thread">
         {thread.map((message: ChatMessage) => (
           <ThreadMessage {...message} key={message.id} username={username} />
         ))}

--- a/app/client/packages/design-system/widgets/src/components/AIChat/src/ChatTitle/ChatTitle.tsx
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/src/ChatTitle/ChatTitle.tsx
@@ -5,7 +5,11 @@ import type { ChatTitleProps } from "./types";
 
 export const ChatTitle = ({ className, title, ...rest }: ChatTitleProps) => {
   return (
-    <div className={clsx(styles.root, className)} {...rest}>
+    <div
+      className={clsx(styles.root, className)}
+      {...rest}
+      data-testid="t--aichat-chat-title"
+    >
       <div className={styles.logo} />
       {title}
     </div>

--- a/app/client/packages/design-system/widgets/src/components/AIChat/src/ChatTitle/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/src/ChatTitle/types.ts
@@ -1,5 +1,5 @@
 import type { HTMLProps } from "react";
 
 export interface ChatTitleProps extends HTMLProps<HTMLDivElement> {
-  title: string;
+  title?: string;
 }

--- a/app/client/packages/design-system/widgets/src/components/AIChat/src/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/src/types.ts
@@ -10,7 +10,7 @@ export interface AIChatProps {
   username: string;
   promptInputPlaceholder?: string;
   chatTitle?: string;
-  description?: string;
+  chatDescription?: string;
   assistantName?: string;
   isWaitingForResponse?: boolean;
   onPromptChange: (prompt: string) => void;

--- a/app/client/packages/design-system/widgets/src/components/AIChat/stories/AIChat.stories.tsx
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/stories/AIChat.stories.tsx
@@ -1,9 +1,6 @@
 import { AIChat } from "@appsmith/wds";
 import type { Meta, StoryObj } from "@storybook/react";
 
-/**
- * A button is a clickable element that is used to trigger an action.
- */
 const meta: Meta<typeof AIChat> = {
   component: AIChat,
   title: "WDS/Widgets/AIChat",
@@ -19,7 +16,6 @@ export const Main: Story = {
     username: "John Doe",
     promptInputPlaceholder: "Type your message here",
     chatTitle: "Chat with Assistant",
-    description: "",
     assistantName: "",
     isWaitingForResponse: false,
   },

--- a/app/client/packages/design-system/widgets/src/components/AIChat/stories/AIChat.stories.tsx
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/stories/AIChat.stories.tsx
@@ -1,0 +1,82 @@
+import { AIChat } from "@appsmith/wds";
+import type { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * A button is a clickable element that is used to trigger an action.
+ */
+const meta: Meta<typeof AIChat> = {
+  component: AIChat,
+  title: "WDS/Widgets/AIChat",
+};
+
+export default meta;
+type Story = StoryObj<typeof AIChat>;
+
+export const Main: Story = {
+  args: {
+    thread: [],
+    prompt: "",
+    username: "John Doe",
+    promptInputPlaceholder: "Type your message here",
+    chatTitle: "Chat with Assistant",
+    description: "",
+    assistantName: "",
+    isWaitingForResponse: false,
+  },
+};
+
+export const EmptyHistory: Story = {
+  args: {
+    thread: [],
+    prompt: "",
+    username: "John Doe",
+    promptInputPlaceholder: "Type your message here",
+    chatTitle: "Chat with Assistant",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    thread: [],
+    prompt: "",
+    username: "John Doe",
+    promptInputPlaceholder: "Type your message here",
+    chatTitle: "Chat with Assistant",
+    isWaitingForResponse: true,
+  },
+};
+
+export const WithHistory: Story = {
+  args: {
+    thread: [
+      {
+        id: "1",
+        content: "Hi, how can I help you?",
+        isAssistant: true,
+      },
+      {
+        id: "2",
+        content: "Find stuck support requests",
+        isAssistant: false,
+      },
+      {
+        id: "3",
+        content: `Certainly! Here's what I can do to help you:
+* Search our customers database
+* Find stuck support requests
+* Provide advice on how to resolve customer issues
+`,
+        isAssistant: true,
+      },
+      {
+        id: "4",
+        content: "Thank you",
+        isAssistant: false,
+      },
+    ],
+    prompt: "",
+    username: "John Doe",
+    promptInputPlaceholder: "Type your message here",
+    chatTitle: "Chat with Assistant",
+  },
+};

--- a/app/client/packages/design-system/widgets/src/components/AIChat/tests/AIChat.test.tsx
+++ b/app/client/packages/design-system/widgets/src/components/AIChat/tests/AIChat.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, within } from "@testing-library/react";
+import { faker } from "@faker-js/faker";
+
+import { AIChat, type AIChatProps } from "..";
+import userEvent from "@testing-library/user-event";
+
+const renderComponent = (props: Partial<AIChatProps> = {}) => {
+  const defaultProps: AIChatProps = {
+    username: "",
+    thread: [],
+    prompt: "",
+    onPromptChange: jest.fn(),
+  };
+
+  return render(<AIChat {...defaultProps} {...props} />);
+};
+
+describe("@appsmith/wds/AIChat", () => {
+  it("should render chat's title", () => {
+    const chatTitle = faker.lorem.words(2);
+
+    renderComponent({ chatTitle });
+
+    expect(screen.getByTestId("t--aichat-chat-title")).toHaveTextContent(
+      chatTitle,
+    );
+  });
+
+  it("should render username", () => {
+    const username = faker.name.firstName();
+
+    renderComponent({ username });
+
+    expect(screen.getByTestId("t--aichat-username")).toHaveTextContent(
+      username,
+    );
+  });
+
+  it("should render thread", () => {
+    const thread = [
+      {
+        id: faker.datatype.uuid(),
+        content: faker.lorem.paragraph(1),
+        isAssistant: false,
+      },
+      {
+        id: faker.datatype.uuid(),
+        content: faker.lorem.paragraph(2),
+        isAssistant: true,
+      },
+    ];
+
+    renderComponent({ thread });
+
+    const messages = within(
+      screen.getByTestId("t--aichat-thread"),
+    ).getAllByRole("listitem");
+
+    expect(messages).toHaveLength(thread.length);
+    expect(messages[0]).toHaveTextContent(thread[0].content);
+    expect(messages[1]).toHaveTextContent(thread[1].content);
+  });
+
+  it("should render prompt input placeholder", () => {
+    const promptInputPlaceholder = faker.lorem.words(3);
+
+    renderComponent({
+      promptInputPlaceholder,
+    });
+
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "placeholder",
+      promptInputPlaceholder,
+    );
+  });
+
+  it("should render prompt input value", () => {
+    const prompt = faker.lorem.words(3);
+
+    renderComponent({
+      prompt,
+    });
+
+    expect(screen.getByRole("textbox")).toHaveValue(prompt);
+  });
+
+  it("should trigger user's prompt", async () => {
+    const onPromptChange = jest.fn();
+
+    renderComponent({
+      onPromptChange,
+    });
+
+    await userEvent.type(screen.getByRole("textbox"), "A");
+
+    expect(onPromptChange).toHaveBeenCalledWith("A");
+  });
+
+  it("should submit user's prompt", async () => {
+    const onSubmit = jest.fn();
+
+    renderComponent({
+      prompt: "ABCD",
+      onSubmit,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/index.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/index.tsx
@@ -198,7 +198,6 @@ class WDSAIChatWidget extends BaseWidget<WDSAIChatWidgetProps, State> {
       <AIChat
         assistantName={this.props.assistantName}
         chatTitle={this.props.chatTitle}
-        description={this.props.description}
         isWaitingForResponse={this.state.isWaitingForResponse}
         onPromptChange={this.handlePromptChange}
         onSubmit={this.handleMessageSubmit}

--- a/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/index.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/index.tsx
@@ -205,7 +205,7 @@ class WDSAIChatWidget extends BaseWidget<WDSAIChatWidgetProps, State> {
         prompt={this.state.prompt}
         promptInputPlaceholder={this.props.promptInputPlaceholder}
         thread={this.adaptMessages(this.state.messages)}
-        username={this.props.username}
+        username={this.props.username || ""}
       />
     );
   }

--- a/app/client/test/__mocks__/reactMarkdown.tsx
+++ b/app/client/test/__mocks__/reactMarkdown.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 jest.mock("react-markdown", () => (props: { children: unknown }) => {
   return <>{props.children}</>;
 });


### PR DESCRIPTION
## Description
- Add stories for storybook
- Add unit tests. Some case are not covered due to lack of clear requirements and will be added later
- Fix bug where `username` is `undefined`


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11177693011>
> Commit: ba99a27d5956a74dade5ae54998056bd2d3d6a44
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11177693011&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 04 Oct 2024 10:27:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new Storybook configuration for the `AIChat` component, showcasing various states including `Main`, `EmptyHistory`, `Loading`, and `WithHistory`.
  
- **Improvements**
	- Enhanced testability of the `AIChat` and `ChatTitle` components by adding `data-testid` attributes.
	- Updated `AIChat` component to streamline props and improve rendering logic.

- **Bug Fixes**
	- Ensured the `username` prop defaults to an empty string in the `WDSAIChatWidget` component.

- **Tests**
	- Added a comprehensive test suite for the `AIChat` component, validating its rendering and functionality across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->