### PR TITLE
test: udpated files by removing un-used APIs

### DIFF
--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -83,7 +83,7 @@
   "mockDatabaseUsername": "fakeapi",
   "mockDatabasePassword": "LimitedAccess123#",
   "readonly": "readonly",
-  "authenticatedApiUrl": "https://fakeapi.com",
+  "authenticatedApiUrl": "http://host.docker.internal:5001",
 
   "GraphqlApiUrl_TED": "http://host.docker.internal:4200/graphql",
   "GITEA_API_BASE_TED": "localhost",

--- a/app/client/cypress/support/Objects/DataManager.ts
+++ b/app/client/cypress/support/Objects/DataManager.ts
@@ -97,15 +97,12 @@ export class DataManager {
       firestore_projectID: "appsmith-22e8b",
       firestore_serviceaccountkey: Cypress.env("FIRESTORE_PRIVATE_KEY"),
 
-      restapi_url: "https://my-json-server.typicode.com/typicode/demo/posts",
-      connection_type: "Replica set",
-
       mockHostAddress: "fake_api.cvuydmurdlas.us-east-1.rds.amazonaws.com",
       mockDatabaseName: "fakeapi",
       mockDatabaseUsername: "fakeapi",
       mockDatabasePassword: "LimitedAccess123#",
       readonly: "readonly",
-      authenticatedApiUrl: "https://fakeapi.com",
+      authenticatedApiUrl: "http://host.docker.internal:5001",
 
       GraphqlApiUrl_TED: "http://host.docker.internal:4200/graphql",
 
@@ -192,15 +189,12 @@ export class DataManager {
       firestore_projectID: "appsmith-dummy",
       firestore_serviceaccountkey: "dummy_service_creds_key",
 
-      restapi_url: "https://my-json-server.typicode.com/typicode/demo/posts",
-      connection_type: "Replica set",
-
       mockHostAddress: "fake_api.cvuydmurdlas.us-east-1.rds.amazonaws.com",
       mockDatabaseName: "fakeapi",
       mockDatabaseUsername: "fakeapi",
       mockDatabasePassword: "LimitedAccess123#",
       readonly: "readonly",
-      authenticatedApiUrl: "https://fakeapi.com",
+      authenticatedApiUrl: "http://host.docker.internal:5001",
 
       GraphqlApiUrl_TED: "http://host.docker.internal:4200/graphql",
 


### PR DESCRIPTION
Removed APIs that are not in use
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11179855393>
> Commit: ce672b5ff1f3976034fd91b1c1ffe7eb9efbf925
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11179855393&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 04 Oct 2024 13:50:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the authenticated API URL for improved connectivity.
  
- **Bug Fixes**
	- Removed outdated properties (`restapi_url` and `connection_type`) from environment configurations to streamline the data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->