### PR TITLE
test: Update Inline_editing_3_spec.js to include expected JSON parsing

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -4,6 +4,7 @@ import {
   agHelper,
   table as tableHelper,
   propPane,
+  locators,
 } from "../../../../../support/Objects/ObjectsCore";
 import { PROPERTY_SELECTOR } from "../../../../../locators/WidgetLocators";
 
@@ -148,9 +149,13 @@ describe(
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "newValue");
       cy.saveTableCellValue(0, 0);
-      const exected = JSON.parse(
-        `[  {    "index": 0,    "updatedFields": {      "step": "newValue"    },    "allFields": {      "step": "newValue",      "task": "Drop a table",      "status": "✅"    }  }]`,
-      );
+      const exected = [
+        {
+          index: 0,
+          updatedFields: { step: "newValue" },
+          allFields: { step: "newValue", task: "Drop a table", status: "✅" },
+        },
+      ];
       agHelper
         .GetText(locators._textWidget, "text")
         .should((text) => expect(JSON.parse(text)).to.deep.equal(exected));

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -148,10 +148,12 @@ describe(
       cy.editTableCell(0, 0);
       cy.enterTableCellValue(0, 0, "newValue");
       cy.saveTableCellValue(0, 0);
-      cy.get(".t--widget-textwidget .bp3-ui-text").should(
-        "contain",
+      const exected = JSON.parse(
         `[  {    "index": 0,    "updatedFields": {      "step": "newValue"    },    "allFields": {      "step": "newValue",      "task": "Drop a table",      "status": "✅"    }  }]`,
       );
+      agHelper
+        .GetText(".t--widget-textwidget .bp3-ui-text", "text")
+        .should((text) => expect(JSON.parse(text)).to.deep.equal(exected));
       cy.openPropertyPane("textwidget");
       cy.updateCodeInput(
         ".t--property-control-text",

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_3_spec.js
@@ -152,7 +152,7 @@ describe(
         `[  {    "index": 0,    "updatedFields": {      "step": "newValue"    },    "allFields": {      "step": "newValue",      "task": "Drop a table",      "status": "✅"    }  }]`,
       );
       agHelper
-        .GetText(".t--widget-textwidget .bp3-ui-text", "text")
+        .GetText(locators._textWidget, "text")
         .should((text) => expect(JSON.parse(text)).to.deep.equal(exected));
       cy.openPropertyPane("textwidget");
       cy.updateCodeInput(


### PR DESCRIPTION
## Description
<ins>Root cause</ins>
This spec was failing because it was string comparing the values, whereas the source was a JS Object. This sometimes caused spec to fail.

<ins>Solution</ins>
This pull request updates the `Inline_editing_3_spec.js` file to include the expected JSON parsing. The changes ensure that the correct JSON parsing is performed when editing a table cell and saving the changes.

Fixes #36720
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11211620961>
> Commit: 0cf810ba36f9947f9aff6c85c6c8d64bc7f1dbf3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11211620961&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Mon, 07 Oct 2024 09:27:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for inline editing functionality in table widget tests.
	- Enhanced assertions for save/discard operations to ensure accuracy after changes.
	- Added checks for various column types in the `onsubmit` event tests.

- **Tests**
	- Expanded end-to-end tests for inline editing, ensuring thorough validation across scenarios.
	- Incorporated additional checks for the display and retention of values during editing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->