### PR TITLE
chore: create pg_trm extension for the GIN index creation

### DIFF
--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -130,13 +130,13 @@ init_pg_db() {
       USER=$PG_DB_USER SCHEMA="appsmith" DB=$PG_DB_NAME HOST=$PG_DB_HOST PORT=$PG_DB_PORT grant_permissions_for_schema
 
       echo "Creating pg_trgm extension..."
-      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U postgres -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U $PG_DB_USER -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
     else
       echo "Remote PostgreSQL detected, running as current user."
       PGPASSWORD=$PG_DB_PASSWORD psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U "$PG_DB_USER" -d "$PG_DB_NAME" -c "CREATE SCHEMA IF NOT EXISTS appsmith;"
 
       echo "Creating pg_trgm extension..."
-      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U postgres -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U $PG_DB_USER -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
     fi
 
     # Check if the schema creation was successful

--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -127,11 +127,16 @@ init_pg_db() {
         echo "Schema 'appsmith' does not exist. Creating schema..."
         psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U postgres -d "$PG_DB_NAME" -c "CREATE SCHEMA appsmith;"
       fi
-
       USER=$PG_DB_USER SCHEMA="appsmith" DB=$PG_DB_NAME HOST=$PG_DB_HOST PORT=$PG_DB_PORT grant_permissions_for_schema
+
+      echo "Creating pg_trgm extension..."
+      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U postgres -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
     else
       echo "Remote PostgreSQL detected, running as current user."
       PGPASSWORD=$PG_DB_PASSWORD psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U "$PG_DB_USER" -d "$PG_DB_NAME" -c "CREATE SCHEMA IF NOT EXISTS appsmith;"
+
+      echo "Creating pg_trgm extension..."
+      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U postgres -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
     fi
 
     # Check if the schema creation was successful

--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -130,13 +130,13 @@ init_pg_db() {
       USER=$PG_DB_USER SCHEMA="appsmith" DB=$PG_DB_NAME HOST=$PG_DB_HOST PORT=$PG_DB_PORT grant_permissions_for_schema
 
       echo "Creating pg_trgm extension..."
-      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U $PG_DB_USER -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U postgres -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
     else
       echo "Remote PostgreSQL detected, running as current user."
       PGPASSWORD=$PG_DB_PASSWORD psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U "$PG_DB_USER" -d "$PG_DB_NAME" -c "CREATE SCHEMA IF NOT EXISTS appsmith;"
 
       echo "Creating pg_trgm extension..."
-      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U $PG_DB_USER -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+      psql -h "$PG_DB_HOST" -p "$PG_DB_PORT" -U "$PG_DB_USER" -d "$PG_DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
     fi
 
     # Check if the schema creation was successful


### PR DESCRIPTION
## Description
Due to the size limit on the BTree index we are creating GIN index for a permission group. To support this we need to create a pg_trm extension. 


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11212861701>
> Commit: d62be8f46ad45b1190bf5c014c0a8ea0c50cf284
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11212861701&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 07 Oct 2024 10:46:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced database initialization by adding the creation of the `pg_trgm` extension for PostgreSQL, improving text search capabilities.

- **Bug Fixes**
	- Ensured the extension is created only if it does not already exist, preventing unnecessary errors during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->