### PR TITLE
chore: Add named-use-effect custom eslint rule

### DIFF
--- a/app/client/packages/eslint-plugin/src/index.ts
+++ b/app/client/packages/eslint-plugin/src/index.ts
@@ -1,13 +1,16 @@
 import { objectKeysRule } from "./object-keys/rule";
+import { namedUseEffectRule } from "./named-use-effect/rule";
 
 const plugin = {
   rules: {
     "object-keys": objectKeysRule,
+    "named-use-effect": namedUseEffectRule,
   },
   configs: {
     recommended: {
       rules: {
         "@appsmith/object-keys": "warn",
+        "@appsmith/named-use-effect": "warn",
       },
     },
   },

--- a/app/client/packages/eslint-plugin/src/named-use-effect/rule.test.ts
+++ b/app/client/packages/eslint-plugin/src/named-use-effect/rule.test.ts
@@ -1,0 +1,22 @@
+import { TSESLint } from "@typescript-eslint/utils";
+import { namedUseEffectRule } from "./rule";
+
+const ruleTester = new TSESLint.RuleTester();
+
+ruleTester.run("named-use-effect", namedUseEffectRule, {
+  valid: [
+    {
+      code: "useEffect(function add(){ }, [])",
+    },
+  ],
+  invalid: [
+    {
+      code: "useEffect(function (){ }, [])",
+      errors: [{ messageId: "useNamedUseEffect" }],
+    },
+    {
+      code: "useEffect(() => {})",
+      errors: [{ messageId: "useNamedUseEffect" }],
+    },
+  ],
+});

--- a/app/client/packages/eslint-plugin/src/named-use-effect/rule.test.ts
+++ b/app/client/packages/eslint-plugin/src/named-use-effect/rule.test.ts
@@ -8,6 +8,9 @@ ruleTester.run("named-use-effect", namedUseEffectRule, {
     {
       code: "useEffect(function add(){ }, [])",
     },
+    {
+      code: "React.useEffect(function add(){ }, [])",
+    },
   ],
   invalid: [
     {
@@ -15,7 +18,7 @@ ruleTester.run("named-use-effect", namedUseEffectRule, {
       errors: [{ messageId: "useNamedUseEffect" }],
     },
     {
-      code: "useEffect(() => {})",
+      code: "React.useEffect(function (){ }, [])",
       errors: [{ messageId: "useNamedUseEffect" }],
     },
   ],

--- a/app/client/packages/eslint-plugin/src/named-use-effect/rule.ts
+++ b/app/client/packages/eslint-plugin/src/named-use-effect/rule.ts
@@ -11,30 +11,49 @@ export const namedUseEffectRule: TSESLint.RuleModule<"useNamedUseEffect"> = {
     schema: [], // No options
     messages: {
       useNamedUseEffect:
-        "The function inside the useEffect should be named for better readability",
+        "The function inside the useEffect should be named for better readability eg: useEffect(function mySideEffect() {...}, [])",
     },
   },
   create(context) {
     return {
       CallExpression(node) {
-        // Check if the useEffect has a named function
-        if (
-          node.callee.type === "Identifier" &&
-          node.callee.name === "useEffect"
-        ) {
-          const firstArg = node.arguments[0];
+        // useEffect used directly
+        // eg
+        // import { useEffect } from "react";
+        // ...
+        // useEffect(() => {}, [])
+        const isDirectCall =
+          node.callee.type === "Identifier" && node.callee.name === "useEffect";
 
-          if (firstArg.type === "ArrowFunctionExpression") {
+        // useEffect used via React object
+        // eg
+        // import React from "react";
+        // ...
+        // React.useEffect(() => {}, [])
+        const isMemberExpressionCall =
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.type === "Identifier" &&
+          node.callee.object.name === "React" &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "useEffect";
+
+        if (isDirectCall || isMemberExpressionCall) {
+          // Get the first argument which should be a function
+          const callbackArg = node.arguments[0];
+
+          // Arrow function are never named so it is discouraged
+          if (callbackArg.type === "ArrowFunctionExpression") {
             context.report({
-              node,
+              node: callbackArg,
               messageId: "useNamedUseEffect",
             });
           }
 
-          if (firstArg.type === "FunctionExpression") {
-            if (!firstArg.id) {
+          // Function Expressions can be unnamed. This is also discouraged
+          if (callbackArg.type === "FunctionExpression") {
+            if (!callbackArg.id) {
               context.report({
-                node,
+                node: callbackArg,
                 messageId: "useNamedUseEffect",
               });
             }

--- a/app/client/packages/eslint-plugin/src/named-use-effect/rule.ts
+++ b/app/client/packages/eslint-plugin/src/named-use-effect/rule.ts
@@ -1,0 +1,46 @@
+import type { TSESLint } from "@typescript-eslint/utils";
+
+export const namedUseEffectRule: TSESLint.RuleModule<"useNamedUseEffect"> = {
+  defaultOptions: [],
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Warns when useEffect hook has an anonymous function",
+      recommended: "warn",
+    },
+    schema: [], // No options
+    messages: {
+      useNamedUseEffect:
+        "The function inside the useEffect should be named for better readability",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Check if the useEffect has a named function
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "useEffect"
+        ) {
+          const firstArg = node.arguments[0];
+
+          if (firstArg.type === "ArrowFunctionExpression") {
+            context.report({
+              node,
+              messageId: "useNamedUseEffect",
+            });
+          }
+
+          if (firstArg.type === "FunctionExpression") {
+            if (!firstArg.id) {
+              context.report({
+                node,
+                messageId: "useNamedUseEffect",
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Description

Adds a custom es lint rule that would add a warning when a useEffect is used without a named function inside it

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11252621528>
> Commit: 334c68048e53d6414d8ece2cde017cac17d859a1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11252621528&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 09 Oct 2024 10:55:00 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new ESLint rule to enforce the use of named functions within the `useEffect` hook, promoting better code readability.
	- Updated recommended ESLint configuration to include the new rule with a warning level.

- **Tests**
	- Added a comprehensive test suite for the new `namedUseEffectRule`, covering both valid and invalid usage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->