### PR TITLE
fix: New query button does not show up issue fixed

### DIFF
--- a/app/client/src/ce/hooks/hooks.test.ts
+++ b/app/client/src/ce/hooks/hooks.test.ts
@@ -1,0 +1,25 @@
+import { useEditorType, EditorNames } from "./index";
+import {
+  BUILDER_VIEWER_PATH_PREFIX,
+  BUILDER_BASE_PATH_DEPRECATED,
+} from "constants/routes";
+
+describe("useEditorType", () => {
+  it('should return "app" for BUILDER_VIEWER_PATH_PREFIX', () => {
+    const result = useEditorType(BUILDER_VIEWER_PATH_PREFIX);
+
+    expect(result).toBe(EditorNames.APPLICATION);
+  });
+
+  it('should return "app" for BUILDER_BASE_PATH_DEPRECATED', () => {
+    const result = useEditorType(BUILDER_BASE_PATH_DEPRECATED);
+
+    expect(result).toBe(EditorNames.APPLICATION);
+  });
+
+  it('should default to "app" for unmatched paths', () => {
+    const result = useEditorType("/some-random-path");
+
+    expect(result).toBe(EditorNames.APPLICATION);
+  });
+});

--- a/app/client/src/ce/hooks/index.ts
+++ b/app/client/src/ce/hooks/index.ts
@@ -15,6 +15,7 @@ export interface EditorType {
 
 export const editorType: EditorType = {
   [BUILDER_VIEWER_PATH_PREFIX]: EditorNames.APPLICATION,
+  [BUILDER_BASE_PATH_DEPRECATED]: EditorNames.APPLICATION,
 };
 
 export const useEditorType = (path: string) => {


### PR DESCRIPTION
## Description

This PR fixes two issues:
1. When importing older application jsons with applicationVersion 1, they get redirected to `/applications` (older url) as opposed to `/app` (newer slug based url). This results in new query button not showing up on datasource view page, because new query button is hidden behind a condition of editorType and editorType was depending on the new url path. This PR fixes the issue by adding support for older path as well to provide backwards compatibility.
2. Second similar issue was seen intermittently, when we do save and authorise in REST API datasource, then sometimes the redirection was happening to older url (/applications), in that case new query button would not show up. This has been fixed too


Fixes #35626   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11240765031>
> Commit: 015ef2a11ff65ec213dd36593b624ba268494325
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11240765031&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 08 Oct 2024 18:19:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
