### PR TITLE
fix: 28114 shadow pr for 36504

### DIFF
--- a/app/client/src/pages/Editor/EditorName/NavigationMenu.tsx
+++ b/app/client/src/pages/Editor/EditorName/NavigationMenu.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 
 import type { noop } from "lodash";
 
@@ -13,9 +13,12 @@ interface NavigationMenuProps {
 
 export function NavigationMenu(props: NavigationMenuProps) {
   const { menuItems, setIsPopoverOpen } = props;
+  const handleInteractionOutside = useCallback(() => {
+    setIsPopoverOpen(false);
+  }, [setIsPopoverOpen]);
 
   return (
-    <MenuContent width="214px">
+    <MenuContent onInteractOutside={handleInteractionOutside} width="214px">
       {menuItems?.map((item, idx) => {
         return (
           <NavigationMenuItem


### PR DESCRIPTION
## Description
This is a shadow PR for [36504](https://github.com/appsmithorg/appsmith/pull/36504)


Fixes #28114

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11254766134>
> Commit: 35e95b69363027236a4f84a0b88e77f7af194d30
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11254766134&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/11254766134" target="_blank">workflow here</a>.
> <hr>Wed, 09 Oct 2024 14:28:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved interaction handling in the Navigation Menu to close the popover when clicking outside of it.

- **Bug Fixes**
	- Enhanced state management for the popover, ensuring a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->