### PR TITLE
feat: creation of datasource and query for ai chat 

### DIFF
--- a/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/config/defaultConfig.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/config/defaultConfig.ts
@@ -3,6 +3,8 @@ import {
   BlueprintOperationTypes,
   type WidgetDefaultProps,
 } from "WidgetProvider/constants";
+import { createOrUpdateDataSourceWithAction } from "sagas/DatasourcesSagas";
+import { PluginPackageName } from "entities/Action";
 
 export const defaultsConfig = {
   isVisible: true,
@@ -16,7 +18,14 @@ export const defaultsConfig = {
     operations: [
       {
         type: BlueprintOperationTypes.ADD_ACTION,
-        fn: () => {},
+        fn: function* () {
+          yield createOrUpdateDataSourceWithAction(
+            PluginPackageName.APPSMITH_AI,
+            {
+              usecase: { data: "TEXT_CLASSIFY" },
+            },
+          );
+        },
       },
     ],
   },

--- a/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/config/defaultConfig.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/config/defaultConfig.ts
@@ -5,6 +5,8 @@ import {
 } from "WidgetProvider/constants";
 import { createOrUpdateDataSourceWithAction } from "sagas/DatasourcesSagas";
 import { PluginPackageName } from "entities/Action";
+import type { ActionData } from "ee/reducers/entityReducers/actionsReducer";
+import type { WidgetProps } from "widgets/BaseWidget";
 
 export const defaultsConfig = {
   isVisible: true,
@@ -18,13 +20,21 @@ export const defaultsConfig = {
     operations: [
       {
         type: BlueprintOperationTypes.ADD_ACTION,
-        fn: function* () {
-          yield createOrUpdateDataSourceWithAction(
+        fn: function* (widget: WidgetProps & { children?: WidgetProps[] }) {
+          const action: ActionData = yield createOrUpdateDataSourceWithAction(
             PluginPackageName.APPSMITH_AI,
             {
               usecase: { data: "TEXT_CLASSIFY" },
             },
           );
+
+          return [
+            {
+              widgetId: widget.widgetId,
+              propertyName: "query",
+              propertyValue: action.config.name,
+            },
+          ];
         },
       },
     ],

--- a/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/config/defaultConfig.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSAIChatWidget/widget/config/defaultConfig.ts
@@ -1,5 +1,8 @@
 import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
-import type { WidgetDefaultProps } from "WidgetProvider/constants";
+import {
+  BlueprintOperationTypes,
+  type WidgetDefaultProps,
+} from "WidgetProvider/constants";
 
 export const defaultsConfig = {
   isVisible: true,
@@ -9,4 +12,12 @@ export const defaultsConfig = {
   responsiveBehavior: ResponsiveBehavior.Fill,
   initialAssistantMessage: "",
   initialAssistantSuggestions: [],
+  blueprint: {
+    operations: [
+      {
+        type: BlueprintOperationTypes.ADD_ACTION,
+        fn: () => {},
+      },
+    ],
+  },
 } as unknown as WidgetDefaultProps;

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -281,7 +281,7 @@ export function* createActionRequestSaga(
   actionPayload: ReduxAction<
     // TODO: Fix this the next time the file is edited
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Partial<Action> & { eventData: any; pluginId: string }
+    Partial<Action> & { eventData?: any; pluginId: string }
   >,
 ) {
   const payload = { ...actionPayload.payload };

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -1128,7 +1128,7 @@ function* createTempDatasourceFromFormSaga(
   );
 }
 
-function* createDatasourceFromFormSaga(
+export function* createDatasourceFromFormSaga(
   actionPayload: ReduxActionWithCallbacks<Datasource, unknown, unknown>,
 ) {
   try {

--- a/app/client/src/sagas/WidgetBlueprintSagas.ts
+++ b/app/client/src/sagas/WidgetBlueprintSagas.ts
@@ -1,8 +1,9 @@
+import { getFormValues } from "redux-form";
 import type { WidgetBlueprint } from "WidgetProvider/constants";
 import type { FlattenedWidgetProps } from "reducers/entityReducers/canvasWidgetsReducer";
 import type { WidgetProps } from "widgets/BaseWidget";
 import { generateReactKey } from "utils/generators";
-import { call, select } from "redux-saga/effects";
+import { call, put, select } from "redux-saga/effects";
 import { get } from "lodash";
 import WidgetFactory from "WidgetProvider/factory";
 
@@ -13,6 +14,33 @@ import * as log from "loglevel";
 import { toast } from "@appsmith/ads";
 import type { LayoutSystemTypes } from "layoutSystems/types";
 import { getLayoutSystemType } from "selectors/layoutSystemSelectors";
+import { getUntitledDatasourceSequence } from "utils/DatasourceSagaUtils";
+import { createTempDatasourceFromForm } from "actions/datasourceActions";
+import type { CreateDatasourceConfig } from "../api/DatasourcesApi";
+// import { createActionRequest } from "../actions/pluginActionActions";
+import DatasourcesApi from "api/DatasourcesApi";
+import type { Plugin } from "../api/PluginApi";
+import { getDefaultEnvId } from "../ce/api/ApiUtils";
+import { ReduxActionTypes } from "../ce/constants/ReduxActionConstants";
+import {
+  getDatasources,
+  // getEntities,
+  // getPlugin,
+  // getPluginForm,
+  // getPluginPackageFromDatasourceId,
+  getPlugins,
+} from "../ce/selectors/entitiesSelector";
+import { getCurrentEnvironmentId } from "../ce/selectors/environmentSelectors";
+import { getCurrentWorkspaceId } from "../ce/selectors/selectedWorkspaceSelectors";
+import {
+  DATASOURCE_NAME_DEFAULT_PREFIX,
+  TEMP_DATASOURCE_ID,
+} from "../constants/Datasource";
+import { PluginName } from "../entities/Action";
+import { type Datasource, ToastMessageType } from "../entities/Datasource";
+import { getCurrentPageId } from "../selectors/editorSelectors";
+import { getFormData } from "../selectors/formSelectors";
+import { createDatasourceFromFormSaga } from "./DatasourcesSagas";
 
 function buildView(view: WidgetBlueprint["view"], widgetId: string) {
   const children = [];
@@ -109,13 +137,78 @@ export function* executeWidgetBlueprintOperations(
   widgetId: string,
 ) {
   const layoutSystemType: LayoutSystemTypes = yield select(getLayoutSystemType);
+  // const datasources: Datasource[] = yield select(getDatasources);
+  const plugins: Plugin[] = yield select(getPlugins);
+  // const { initialValues } = yield select(getFormData, DATASOURCE_DB_FORM);
+  // const pluginId: string = yield select(
+  //   getPluginIdOfPackageName,
+  //   PluginPackageName.APPSMITH_AI,
+  // );
+  // const formConfig: Record<string, unknown>[] = yield select(
+  //   getPluginForm,
+  //   pluginId,
+  // );
+  //
+  // const formData = yield select(getFormValues(QUERY_EDITOR_FORM_NAME));
+  const pageId: string = yield select(getCurrentPageId);
+  const workspaceId: string = yield select(getCurrentWorkspaceId);
+  // let currentEnvironment: string = yield select(getCurrentEnvironmentId);
 
-  operations.forEach((operation: BlueprintOperation) => {
+  const dsList: Datasource[] = yield select(getDatasources);
+  const sequence = getUntitledDatasourceSequence(dsList);
+  const defaultEnvId = getDefaultEnvId();
+
+  const plugin = plugins.find(
+    (plugin: Plugin) => plugin.name === PluginName.APPSMITH_AI,
+  );
+
+  const payload = {
+    id: TEMP_DATASOURCE_ID,
+    name: DATASOURCE_NAME_DEFAULT_PREFIX + sequence,
+    type: plugin!.type,
+    pluginId: plugin!.id,
+    new: false,
+    workspaceId,
+    datasourceStorages: {
+      [defaultEnvId]: {
+        datasourceId: TEMP_DATASOURCE_ID,
+        environmentId: defaultEnvId,
+        isValid: false,
+        datasourceConfiguration: {
+          url: "",
+          properties: [],
+        },
+        toastMessage: ToastMessageType.EMPTY_TOAST_MESSAGE,
+      },
+    },
+  };
+
+  for (const operation of operations) {
     const widget: WidgetProps & { children?: string[] | WidgetProps[] } = {
       ...widgets[widgetId],
     };
 
     switch (operation.type) {
+      case BlueprintOperationTypes.ADD_ACTION:
+        yield createDatasourceFromFormSaga({
+          payload,
+          type: ReduxActionTypes.CREATE_DATASOURCE_FROM_FORM_INIT,
+        });
+        // yield put(
+        //   createActionRequest({
+        //     pageId,
+        //     pluginId: datasources[0].pluginId,
+        //     datasource: {
+        //       id: datasources[0].id,
+        //     },
+        //     actionConfiguration: {
+        //       formData: {
+        //         usecase: { data: "TEXT_CLASSIFY" },
+        //       },
+        //     },
+        //   }),
+        // );
+        break;
       case BlueprintOperationTypes.MODIFY_PROPS:
         if (widget.children && widget.children.length > 0) {
           widget.children = (widget.children as string[]).map(
@@ -139,7 +232,7 @@ export function* executeWidgetBlueprintOperations(
           });
         break;
     }
-  });
+  }
 
   const result: { [widgetId: string]: FlattenedWidgetProps } = yield widgets;
 

--- a/app/client/src/sagas/WidgetBlueprintSagas.ts
+++ b/app/client/src/sagas/WidgetBlueprintSagas.ts
@@ -1,9 +1,8 @@
-import { getFormValues } from "redux-form";
 import type { WidgetBlueprint } from "WidgetProvider/constants";
 import type { FlattenedWidgetProps } from "reducers/entityReducers/canvasWidgetsReducer";
 import type { WidgetProps } from "widgets/BaseWidget";
 import { generateReactKey } from "utils/generators";
-import { call, put, select } from "redux-saga/effects";
+import { call, select } from "redux-saga/effects";
 import { get } from "lodash";
 import WidgetFactory from "WidgetProvider/factory";
 
@@ -14,33 +13,6 @@ import * as log from "loglevel";
 import { toast } from "@appsmith/ads";
 import type { LayoutSystemTypes } from "layoutSystems/types";
 import { getLayoutSystemType } from "selectors/layoutSystemSelectors";
-import { getUntitledDatasourceSequence } from "utils/DatasourceSagaUtils";
-import { createTempDatasourceFromForm } from "actions/datasourceActions";
-import type { CreateDatasourceConfig } from "../api/DatasourcesApi";
-// import { createActionRequest } from "../actions/pluginActionActions";
-import DatasourcesApi from "api/DatasourcesApi";
-import type { Plugin } from "../api/PluginApi";
-import { getDefaultEnvId } from "../ce/api/ApiUtils";
-import { ReduxActionTypes } from "../ce/constants/ReduxActionConstants";
-import {
-  getDatasources,
-  // getEntities,
-  // getPlugin,
-  // getPluginForm,
-  // getPluginPackageFromDatasourceId,
-  getPlugins,
-} from "../ce/selectors/entitiesSelector";
-import { getCurrentEnvironmentId } from "../ce/selectors/environmentSelectors";
-import { getCurrentWorkspaceId } from "../ce/selectors/selectedWorkspaceSelectors";
-import {
-  DATASOURCE_NAME_DEFAULT_PREFIX,
-  TEMP_DATASOURCE_ID,
-} from "../constants/Datasource";
-import { PluginName } from "../entities/Action";
-import { type Datasource, ToastMessageType } from "../entities/Datasource";
-import { getCurrentPageId } from "../selectors/editorSelectors";
-import { getFormData } from "../selectors/formSelectors";
-import { createDatasourceFromFormSaga } from "./DatasourcesSagas";
 
 function buildView(view: WidgetBlueprint["view"], widgetId: string) {
   const children = [];
@@ -88,7 +60,7 @@ export interface UpdatePropertyArgs {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   propertyValue: any;
 }
-export type BlueprintOperationAddActionFn = () => void;
+export type BlueprintOperationAddActionFn = () => Generator;
 export type BlueprintOperationModifyPropsFn = (
   widget: WidgetProps & { children?: WidgetProps[] },
   widgets: { [widgetId: string]: FlattenedWidgetProps },
@@ -137,51 +109,6 @@ export function* executeWidgetBlueprintOperations(
   widgetId: string,
 ) {
   const layoutSystemType: LayoutSystemTypes = yield select(getLayoutSystemType);
-  // const datasources: Datasource[] = yield select(getDatasources);
-  const plugins: Plugin[] = yield select(getPlugins);
-  // const { initialValues } = yield select(getFormData, DATASOURCE_DB_FORM);
-  // const pluginId: string = yield select(
-  //   getPluginIdOfPackageName,
-  //   PluginPackageName.APPSMITH_AI,
-  // );
-  // const formConfig: Record<string, unknown>[] = yield select(
-  //   getPluginForm,
-  //   pluginId,
-  // );
-  //
-  // const formData = yield select(getFormValues(QUERY_EDITOR_FORM_NAME));
-  const pageId: string = yield select(getCurrentPageId);
-  const workspaceId: string = yield select(getCurrentWorkspaceId);
-  // let currentEnvironment: string = yield select(getCurrentEnvironmentId);
-
-  const dsList: Datasource[] = yield select(getDatasources);
-  const sequence = getUntitledDatasourceSequence(dsList);
-  const defaultEnvId = getDefaultEnvId();
-
-  const plugin = plugins.find(
-    (plugin: Plugin) => plugin.name === PluginName.APPSMITH_AI,
-  );
-
-  const payload = {
-    id: TEMP_DATASOURCE_ID,
-    name: DATASOURCE_NAME_DEFAULT_PREFIX + sequence,
-    type: plugin!.type,
-    pluginId: plugin!.id,
-    new: false,
-    workspaceId,
-    datasourceStorages: {
-      [defaultEnvId]: {
-        datasourceId: TEMP_DATASOURCE_ID,
-        environmentId: defaultEnvId,
-        isValid: false,
-        datasourceConfiguration: {
-          url: "",
-          properties: [],
-        },
-        toastMessage: ToastMessageType.EMPTY_TOAST_MESSAGE,
-      },
-    },
-  };
 
   for (const operation of operations) {
     const widget: WidgetProps & { children?: string[] | WidgetProps[] } = {
@@ -190,24 +117,10 @@ export function* executeWidgetBlueprintOperations(
 
     switch (operation.type) {
       case BlueprintOperationTypes.ADD_ACTION:
-        yield createDatasourceFromFormSaga({
-          payload,
-          type: ReduxActionTypes.CREATE_DATASOURCE_FROM_FORM_INIT,
-        });
-        // yield put(
-        //   createActionRequest({
-        //     pageId,
-        //     pluginId: datasources[0].pluginId,
-        //     datasource: {
-        //       id: datasources[0].id,
-        //     },
-        //     actionConfiguration: {
-        //       formData: {
-        //         usecase: { data: "TEXT_CLASSIFY" },
-        //       },
-        //     },
-        //   }),
-        // );
+        if (operation.fn) {
+          yield (operation.fn as BlueprintOperationAddActionFn)();
+        }
+
         break;
       case BlueprintOperationTypes.MODIFY_PROPS:
         if (widget.children && widget.children.length > 0) {

--- a/app/client/src/sagas/WidgetBlueprintSagas.ts
+++ b/app/client/src/sagas/WidgetBlueprintSagas.ts
@@ -60,7 +60,9 @@ export interface UpdatePropertyArgs {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   propertyValue: any;
 }
-export type BlueprintOperationAddActionFn = () => Generator;
+export type BlueprintOperationAddActionFn = (
+  widget: WidgetProps & { children?: WidgetProps[] },
+) => Generator;
 export type BlueprintOperationModifyPropsFn = (
   widget: WidgetProps & { children?: WidgetProps[] },
   widgets: { [widgetId: string]: FlattenedWidgetProps },
@@ -118,7 +120,16 @@ export function* executeWidgetBlueprintOperations(
     switch (operation.type) {
       case BlueprintOperationTypes.ADD_ACTION:
         if (operation.fn) {
-          yield (operation.fn as BlueprintOperationAddActionFn)();
+          const updatePropertyPayloads: UpdatePropertyArgs[] | undefined =
+            yield (operation.fn as BlueprintOperationAddActionFn)(
+              widget as WidgetProps & { children?: WidgetProps[] },
+            );
+
+          updatePropertyPayloads &&
+            updatePropertyPayloads.forEach((params: UpdatePropertyArgs) => {
+              widgets[params.widgetId][params.propertyName] =
+                params.propertyValue;
+            });
         }
 
         break;


### PR DESCRIPTION
## Description
After dropping chat widget, we create AI datasource If there is no suitable one or use already exist. After we simply create a quary for it. 

https://github.com/user-attachments/assets/3e46e113-e15b-46c5-b294-194da561b8a7

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11290285036>
> Commit: 3066160b39f72796703f0aae6161d21d0360a104
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11290285036&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
> <li>cypress/e2e/Regression/ClientSide/FormLogin/EnableFormLogin_spec.js
> <li>cypress/e2e/Regression/ClientSide/OtherUIFeatures/Analytics_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Fri, 11 Oct 2024 11:05:07 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced widget operations with the addition of a new `blueprint` property in the configuration.
	- Introduced a new function for streamlined datasource creation and updates.

- **Bug Fixes**
	- Improved API response handling in the datasource fetching saga.
	- Enhanced error handling in action management sagas.

- **Refactor**
	- Updated saga logic for better asynchronous operation handling.
	- Simplified the creation of initial payloads for datasources.
	- Refined logic for action creation and updates within the Redux-Saga context.

- **Documentation**
	- Updated type signatures for better clarity on function behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->