### PR TITLE
test: enabling skipped tests in tabs spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tabs_2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Tab/Tabs_2_spec.ts
@@ -188,8 +188,7 @@ describe(
       propPane.SelectPropertiesDropDown("height", "Auto Height");
     });
 
-    // to work on redesign of the test, commenting for now
-    it.skip("7. Verify colors, borders and shadows", () => {
+    it("7. Verify colors, borders and shadows", () => {
       // Verify font color picker opens up
       propPane.MoveToTab("Style");
       agHelper.GetNClick(propPane._propertyControlColorPicker("accentcolor"));

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/Tab/Tabs_2_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
Enabling skipped tests in below tests
cypress/e2e/Regression/ClientSide/Widgets/Tab/Tabs_2_spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Activated tests for verifying style properties of the Tabs widget, including color, border, and shadow.
	- Added validation checks for default selected tabs and ensured correct handling of valid tab names.

- **Bug Fixes**
	- Enhanced test coverage for visibility and absence of elements based on property states in different modes (editor, preview, deploy).

- **Chores**
	- Updated test specification file in the testing environment to reflect the new Tabs widget tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->