### PR TITLE
Fix: Fix for GHSL-2024-277

### DIFF
--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -266,16 +266,20 @@ jobs:
       - name: Set Commit Message
         env:
           EVENT_COMMITS: ${{ toJson(github.event.commits[0].message) }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.commits[0].author.name }}
         run: |
-          if [[ ${{ inputs.pr }} -ne 0 && ${{github.event_name}} == 'repository_dispatch' ]]; then
-            echo "COMMIT_INFO_MESSAGE=${{ env.COMMIT_INFO_MESSAGE }}" >> $GITHUB_ENV
-          elif [[ ${{ inputs.pr }} -ne 0 && ${{github.event_name}} == 'workflow_dispatch' ]]; then
+          COMMIT_MESSAGE="$EVENT_COMMITS"
+          
+          if [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'repository_dispatch' ]]; then
+            echo "COMMIT_INFO_MESSAGE=$COMMIT_INFO_MESSAGE" >> $GITHUB_ENV
+          elif [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "COMMIT_INFO_MESSAGE=Workflow run on PR# ${{ inputs.pr }}" >> $GITHUB_ENV
           else
-            if [[ '${{env.EVENT_COMMITS}}' == 'null' ]]; then
-              echo "COMMIT_INFO_MESSAGE=${{ github.event_name }} by ${{ env.COMMIT_INFO_AUTHOR }}" >> $GITHUB_ENV
+            if [[ "$COMMIT_MESSAGE" == "null" ]]; then
+              echo "COMMIT_INFO_MESSAGE=${{ github.event_name }} by $COMMIT_INFO_AUTHOR" >> $GITHUB_ENV
             else
-              echo "COMMIT_INFO_MESSAGE=$(echo \"${{ env.EVENT_COMMITS }}\" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')" >> $GITHUB_ENV
+              COMMIT_FIRST_LINE=$(echo "$COMMIT_MESSAGE" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')
+              echo "COMMIT_INFO_MESSAGE=$COMMIT_FIRST_LINE" >> $GITHUB_ENV
             fi
           fi
 

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -268,17 +268,15 @@ jobs:
           EVENT_COMMITS: ${{ toJson(github.event.commits[0].message) }}
           COMMIT_INFO_AUTHOR: ${{ github.event.commits[0].author.name }}
         run: |
-          COMMIT_MESSAGE="$EVENT_COMMITS"
-          
           if [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'repository_dispatch' ]]; then
             echo "COMMIT_INFO_MESSAGE=$COMMIT_INFO_MESSAGE" >> $GITHUB_ENV
           elif [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "COMMIT_INFO_MESSAGE=Workflow run on PR# ${{ inputs.pr }}" >> $GITHUB_ENV
           else
-            if [[ "$COMMIT_MESSAGE" == "null" ]]; then
+            if [[ "$EVENT_COMMITS" == "null" ]]; then
               echo "COMMIT_INFO_MESSAGE=${{ github.event_name }} by $COMMIT_INFO_AUTHOR" >> $GITHUB_ENV
             else
-              COMMIT_FIRST_LINE=$(echo "$COMMIT_MESSAGE" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')
+              COMMIT_FIRST_LINE=$(echo "$EVENT_COMMITS" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')
               echo "COMMIT_INFO_MESSAGE=$COMMIT_FIRST_LINE" >> $GITHUB_ENV
             fi
           fi

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -258,17 +258,15 @@ jobs:
           EVENT_COMMITS: ${{ toJson(github.event.commits[0].message) }}
           COMMIT_INFO_AUTHOR: ${{ github.event.commits[0].author.name }}
         run: |
-          COMMIT_MESSAGE="$EVENT_COMMITS"
-        
           if [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'repository_dispatch' ]]; then
             echo "COMMIT_INFO_MESSAGE=$COMMIT_INFO_MESSAGE" >> $GITHUB_ENV
           elif [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "COMMIT_INFO_MESSAGE=Workflow run on PR# ${{ inputs.pr }}" >> $GITHUB_ENV
           else
-            if [[ "$COMMIT_MESSAGE" == "null" ]]; then
+            if [[ "$EVENT_COMMITS" == "null" ]]; then
               echo "COMMIT_INFO_MESSAGE=${{ github.event_name }} by $COMMIT_INFO_AUTHOR" >> $GITHUB_ENV
             else
-              COMMIT_FIRST_LINE=$(echo "$COMMIT_MESSAGE" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')
+              COMMIT_FIRST_LINE=$(echo "$EVENT_COMMITS" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')
               echo "COMMIT_INFO_MESSAGE=$COMMIT_FIRST_LINE" >> $GITHUB_ENV
             fi
           fi

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -256,16 +256,20 @@ jobs:
       - name: Set Commit Message
         env:
           EVENT_COMMITS: ${{ toJson(github.event.commits[0].message) }}
+          COMMIT_INFO_AUTHOR: ${{ github.event.commits[0].author.name }}
         run: |
-          if [[ ${{ inputs.pr }} -ne 0 && ${{github.event_name}} == 'repository_dispatch' ]]; then
-            echo "COMMIT_INFO_MESSAGE=${{ env.COMMIT_INFO_MESSAGE }}" >> $GITHUB_ENV
-          elif [[ ${{ inputs.pr }} -ne 0 && ${{github.event_name}} == 'workflow_dispatch' ]]; then
+          COMMIT_MESSAGE="$EVENT_COMMITS"
+        
+          if [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'repository_dispatch' ]]; then
+            echo "COMMIT_INFO_MESSAGE=$COMMIT_INFO_MESSAGE" >> $GITHUB_ENV
+          elif [[ ${{ inputs.pr }} -ne 0 && ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             echo "COMMIT_INFO_MESSAGE=Workflow run on PR# ${{ inputs.pr }}" >> $GITHUB_ENV
           else
-            if [[ '${{env.EVENT_COMMITS}}' == 'null' ]]; then
-              echo "COMMIT_INFO_MESSAGE=${{ github.event_name }} by ${{ env.COMMIT_INFO_AUTHOR }}" >> $GITHUB_ENV
+            if [[ "$COMMIT_MESSAGE" == "null" ]]; then
+              echo "COMMIT_INFO_MESSAGE=${{ github.event_name }} by $COMMIT_INFO_AUTHOR" >> $GITHUB_ENV
             else
-              echo "COMMIT_INFO_MESSAGE=$(echo \"${{ env.EVENT_COMMITS }}\" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')" >> $GITHUB_ENV
+              COMMIT_FIRST_LINE=$(echo "$COMMIT_MESSAGE" | awk -F '\\\\n' '{print $1}' | sed 's/^\"//')
+              echo "COMMIT_INFO_MESSAGE=$COMMIT_FIRST_LINE" >> $GITHUB_ENV
             fi
           fi
 


### PR DESCRIPTION
## Description
Fix : https://github.com/appsmithorg/appsmith/security/advisories/GHSA-5f24-4j99-h3gc#event-330907

Use bash syntax to access the environment variable: $EVENT_COMMITS

Fixes #`36835`

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 18af8361443cfcdd98239fbc4af52c96aaadf501 yet
> <hr>Mon, 14 Oct 2024 04:55:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `run_count` input parameter for specifying the number of test repetitions.
	- Added input parameters for manual triggering in the CI workflow.
	- New environment variable `COMMIT_INFO_AUTHOR` captures the author name for better context in commit messages.

- **Improvements**
	- Enhanced logic for handling commit messages and test run conditions.
	- Improved caching mechanism for better tracking of test outcomes across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->