### PR TITLE
chore: Add polling for embedded pg start to create appsmith DB

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -467,8 +467,15 @@ create_appsmith_pg_db() {
   # Start the postgres , wait for it to be ready and create a appsmith db
   su postgres -c "env PATH='$PATH' pg_ctl -D $POSTGRES_DB_PATH -l $POSTGRES_DB_PATH/logfile start"
   echo "Waiting for Postgres to start"
+  local max_attempts=100
+  local attempt=0
+
   until su postgres -c "env PATH='$PATH' pg_isready -d postgres"; do
-    tlog "Waiting for Postgres to be ready..."
+    if (( attempt >= max_attempts )); then
+      echo "Postgres failed to start within 100 seconds."
+      return 1
+    fi
+    tlog "Waiting for Postgres to be ready... Attempt $((++attempt))/$max_attempts"
     sleep 1
   done
   # Check if the appsmith DB is present


### PR DESCRIPTION
## Description
PR to add the polling for `pg_isready` signal for embedded postgres DB. This will fix the infinite loop where postgres refuse to come up. We have seen this failure earlier with `openshift` setup. Current PR will make sure when the embedded postgres fails to startup we are not copying the postgres.conf file as well so supervisor won't have to start the postgres process at all.

Ref: https://theappsmith.slack.com/archives/C0341RERY4R/p1728565913269689?thread_ts=1728544650.663739&cid=C0341RERY4R  

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11322083108>
> Commit: df827906858747a0d9d134ae8ed04cc3b901811c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11322083108&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 14 Oct 2024 08:17:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced database initialization process with a maximum attempts mechanism for waiting on PostgreSQL to start.
	- Improved configuration handling for `APPSMITH_DB_URL` based on database type.

- **Bug Fixes**
	- Ensured robust error handling if PostgreSQL fails to start within the specified attempts.

- **Documentation**
	- Added comments for improved clarity in the deployment script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->