### PR TITLE
fix: bug run button not disabled in response pane

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.test.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import '@testing-library/jest-dom/extend-expect';
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import QueryResponseTab from "./QueryResponseTab";
@@ -193,5 +194,31 @@ describe("QueryResponseTab", () => {
     expect(
       container.querySelector("[data-testid='t--prepared-statement-warning']"),
     ).toBeNull();
+  });
+  it("6. Check if run button is disabled when query is empty", () => {
+    const propsWithEmptyQuery = {
+      ...defaultProps,
+      isRunDisabled: true,
+      currentActionConfig: {
+        ...defaultProps.currentActionConfig,
+        actionConfiguration: {
+          ...defaultProps.currentActionConfig.actionConfiguration,
+          body: "",
+        },
+      },
+    };
+  
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <Router>
+            <QueryResponseTab {...propsWithEmptyQuery} />
+          </Router>
+        </ThemeProvider>
+      </Provider>,
+    );
+  
+    const runButton = screen.getByRole('button');
+    expect(runButton).toBeDisabled();
   });
 });

--- a/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryResponseTab.tsx
@@ -96,6 +96,7 @@ const QueryResponseTab = (props: Props) => {
     isFeatureEnabled,
     currentActionConfig?.userPermissions,
   );
+  const isQueryEmpty = !currentActionConfig?.actionConfiguration?.body;
 
   const actionResponse = useSelector((state) =>
     getActionData(state, currentActionConfig.id),
@@ -345,7 +346,7 @@ const QueryResponseTab = (props: Props) => {
         )}
       {!output && !error && (
         <NoResponse
-          isRunDisabled={!isExecutePermitted}
+          isRunDisabled={!isExecutePermitted || isQueryEmpty}
           isRunning={isRunning}
           onRunClick={responseTabOnRunClick}
         />


### PR DESCRIPTION
## Description:

When no query is added in the query input box, the run button on the top query page is getting disabled. But the same behaviour is not maintained for the run button in the response pane.


> I have raised this PR to fix the `bug run button not disabled in response pane when there is no query input`

## [Issue Link](https://github.com/appsmithorg/appsmith/issues/36496)


## Screenshots:
### Before resoving bug:
![image](https://github.com/user-attachments/assets/ed54ae4c-18cd-4394-9baf-b0f86517fe14)


### After resoving bug:
![image](https://github.com/user-attachments/assets/00e16674-6555-4a9d-99e3-9eb7f33d43d6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a check to disable the run button when the query is empty, enhancing user experience in the Query Response Tab.
  
- **Bug Fixes**
	- Improved testing capabilities for the Query Response Tab to ensure the run button behaves correctly based on query state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->