### PR TITLE
chore:update README.md to reflect Youtube stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 <a href="https://docs.appsmith.com/getting-started/setup/installation-guides/docker?utm_source=github&utm_medium=organic&utm_campaign=readme&utm_content=badge">
 <img src="https://img.shields.io/docker/pulls/appsmith/appsmith-ce?color=4591df&style=for-the-badge">
 </a>
+<a href="https://www.youtube.com/@appsmith/?sub_confirmation=1" target="_blank">
+    <img alt="YouTube Channel Views" src="https://img.shields.io/youtube/channel/views/UCMYwzPG2txS8nR5ZbNY6T5g?color=00FF0&style=for-the-badge">
+</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <img src="https://img.shields.io/docker/pulls/appsmith/appsmith-ce?color=4591df&style=for-the-badge">
 </a>
 <a href="https://www.youtube.com/@appsmith/?sub_confirmation=1" target="_blank">
-    <img alt="YouTube Channel Views" src="https://img.shields.io/youtube/channel/subscribers/UCMYwzPG2txS8nR5ZbNY6T5g?color=00FF0&style=for-the-badge">
+    <img alt="YouTube Channel Subscribers" src="https://img.shields.io/youtube/channel/subscribers/UCMYwzPG2txS8nR5ZbNY6T5g?color=00FF0&style=for-the-badge">
 </a>
 <a href="https://www.youtube.com/@appsmith/?sub_confirmation=1" target="_blank">
     <img alt="YouTube Channel Views" src="https://img.shields.io/youtube/channel/views/UCMYwzPG2txS8nR5ZbNY6T5g?color=00FF0&style=for-the-badge">

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 <img src="https://img.shields.io/docker/pulls/appsmith/appsmith-ce?color=4591df&style=for-the-badge">
 </a>
 <a href="https://www.youtube.com/@appsmith/?sub_confirmation=1" target="_blank">
+    <img alt="YouTube Channel Views" src="https://img.shields.io/youtube/channel/subscribers/UCMYwzPG2txS8nR5ZbNY6T5g?color=00FF0&style=for-the-badge">
+</a>
+<a href="https://www.youtube.com/@appsmith/?sub_confirmation=1" target="_blank">
     <img alt="YouTube Channel Views" src="https://img.shields.io/youtube/channel/views/UCMYwzPG2txS8nR5ZbNY6T5g?color=00FF0&style=for-the-badge">
 </a>
 </p>


### PR DESCRIPTION
Adding our Youtube link shield to our readme so users can easily subscribe from Github.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
Per recommendation from Abhishek and as a best practice to drive developers to our Youtube account for learning purposes, we are adding the youtube badge shield to the README to showcase the amount of views from our channel and subscribe directly using the link


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 4ab34c01c0b15cfc987fe0c72b3e7f19c5594302 yet
> <hr>Mon, 14 Oct 2024 20:27:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new badges to the README for the Appsmith YouTube channel, showcasing subscriber count and total views.
- **Documentation**
	- Enhanced visibility of the YouTube channel within the README without altering existing content structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->