### PR TITLE
fix: empty space is clickable when user edits app name or organisatio…

### DIFF
--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -117,7 +117,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isForkApplicationModalopen, setForkApplicationModalOpen] =
     useState(false);
-  const [lastUpdatedValue, setLastUpdatedValue] = useState("");
+  const lastUpdatedValue = "";
   const dispatch = useDispatch();
 
   const applicationId = props.application?.id;
@@ -370,9 +370,6 @@ export function ApplicationCard(props: ApplicationCardProps) {
                     props.update(applicationId, {
                       name: value,
                     });
-                }}
-                onTextChanged={(value: string) => {
-                  setLastUpdatedValue(value);
                 }}
                 placeholder={"Edit text input"}
                 savingState={


### PR DESCRIPTION

[Bug issue](https://github.com/appsmithorg/appsmith/issues/9643)

**Description:**
In the home page when the user clicks the edit(pencil) icon to edit the application or organization name, edit icon is hiding and if we click on empty space where the edit icon is initially placed, we are able to save the name. Now i have implemented Save(Tick) and Cancel(Cross) icons, if we click on Save icon it will save or click on Cancel icon to cancel the editing.
Initially, any changes to the edited data would automatically save and display the updated application name when the user clicked anywhere. However, I have modified the functionality so that the name only changes when the user explicitly clicks the "Save" (tick) icon. Otherwise, the old name will remain displayed.

**Screenshots**

Before the fix:
![Screenshot from 2024-10-15 16-32-34](https://github.com/user-attachments/assets/405a0834-a494-4851-a69e-f64c371ce552)

After the fix:
![Screenshot from 2024-10-15 16-32-41](https://github.com/user-attachments/assets/8d7e4019-cf2f-445c-ad60-30f85f1cb2a3)
![Screenshot from 2024-10-15 16-41-39](https://github.com/user-attachments/assets/24d1c6ed-5381-493b-ab69-b8c01b0d6b35)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced interactivity in the `EditableTextSubComponent` with clear cancel and confirm actions.
- **Improvements**
	- Streamlined state management in the `ApplicationCard` component for better performance and reduced unnecessary re-renders.
- **Bug Fixes**
	- Updated conditions for application name updates to ensure accurate tracking based on user actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->