### PR TITLE
chore: Add custom tag for pg build in ad-hoc image builder

### DIFF
--- a/.github/workflows/ad-hoc-docker-image.yml
+++ b/.github/workflows/ad-hoc-docker-image.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ad-hoc
+      pg_tag:
+        description: Tag to use for image
+        required: false
+        type: string
+        default: pg
 
 jobs:
   server-build:
@@ -94,7 +99,7 @@ jobs:
         run: |
           run: |
           if [[ -f scripts/prepare_server_artifacts.sh ]]; then
-            scripts/prepare_server_artifacts.sh
+            PG_TAG=${{ inputs.pg_tag }} scripts/prepare_server_artifacts.sh
           else
             echo "No script found to prepare server artifacts"
             exit 1

--- a/.github/workflows/ad-hoc-docker-image.yml
+++ b/.github/workflows/ad-hoc-docker-image.yml
@@ -15,7 +15,7 @@ on:
         type: string
         default: ad-hoc
       pg_tag:
-        description: Tag to use for image
+        description: Postgres tag to use for image
         required: false
         type: string
         default: pg


### PR DESCRIPTION
## Description
PR to add support for custom pg image during the ad-hoc-builder script. Procedure for the hotfixes from v1.45 is as follows:

### Steps to perform the hotfix:

1. Create a hotfix branch from the tag where we need the hotfix, `hotfix/<version>` and note down the commit-sha
2. Create hotfix branch `pg-hotfix/<version>` from commit sha on `pg` branch from step 1
3. Cherry-pick commits from release to hotfix branches
4. Build the server locally by running `./build.sh -DskipTests` within server directory to avoid any build failures at later stages on both the hotfix branches
5. If we are seeing any build failure involve `@db-infra` team as required 
6. Run the ad-hoc image builder with `pg-hotfix/<version>` branch to generate `pg` specific tag `pg-vx.y.z`
7. Do the sanity testing with postgres url
8. Only after successful generation of `pg-vx.y.z` tag from step 4, run the ad-hoc image builder with `hotfix/<version>` branch to generate specific tag `vx.y.z` and pass the `pg_tag` created in step 4 i.e. `pg-vx.y.z`
9. Do the sanity test for mongo DB URLs on `vx.y.z`
10. Ask devops to create latest tags from `vx.y.z` as this is not supported in the ad-hoc image generation script. Make sure to have support for platforms: `linux/arm64,linux/amd64`

Fixes https://github.com/appsmithorg/appsmith/issues/36838

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 9af256c80cf2c44b855bb0ea3c009f499bb7b0fc yet
> <hr>Wed, 16 Oct 2024 13:05:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
