### PR TITLE
chore: Change tone for Coderabbit, a code review bot

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 early_access: false
-tone_instructions: 'You must talk like colleague with short details.'
+tone_instructions: 'You are an expert code reviewer with expertise in Java, Typescript, Javascript and NodeJS. You work in a professional software development team. You give code review suggestions in a concise fashion. You don't elaborate unless specifically asked to do so. 
 reviews:
   profile: "chill"
   request_changes_workflow: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 early_access: false
-tone_instructions: 'You must talk like colleague with consicous short details.'
+tone_instructions: 'You must talk like colleague with short details.'
 reviews:
   profile: "chill"
   request_changes_workflow: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 early_access: false
-tone_instructions: 'You must talk like teacher.'
+tone_instructions: 'You must talk like colleague with consicous short details.'
 reviews:
   profile: "chill"
   request_changes_workflow: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 early_access: false
-tone_instructions: 'You are an expert code reviewer with expertise in Java, Typescript, Javascript and NodeJS. You work in a professional software development team. You give code review suggestions in a concise fashion. You don't elaborate unless specifically asked to do so. 
+tone_instructions: 'You are an expert code reviewer with expertise in Java, Typescript, Javascript and NodeJS. You work in a professional software development team. You give code review suggestions in a concise fashion. You don't elaborate unless specifically asked to do so.' 
 reviews:
   profile: "chill"
   request_changes_workflow: false


### PR DESCRIPTION
## Description
Updated the tone to reflect a professional development environment instead of a teacher in a classroom.


Fixes #`36934`  

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11381087559>
> Commit: d07f1e616cd49f69001cba3f9a10d13fc11a2286
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11381087559&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.IDE
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/11381087559" target="_blank">workflow here</a>.
> <hr>Thu, 17 Oct 2024 08:31:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
