### PR TITLE
fix: adding branch in url for search entities

### DIFF
--- a/app/client/src/pages/common/SearchBar/EntitySearchBar.tsx
+++ b/app/client/src/pages/common/SearchBar/EntitySearchBar.tsx
@@ -138,9 +138,23 @@ function EntitySearchBar(props: any) {
     const defaultPage = searchedApplication?.pages.find(
       (page: PageDefaultMeta) => page.isDefault === true,
     );
-    const viewURL = viewerURL({
-      basePageId: defaultPage.baseId,
-    });
+
+    const isGitEnabled = searchedApplication?.gitApplicationMetadata;
+    let viewURL = null;
+
+    if (isGitEnabled) {
+      const defaultBranch =
+        searchedApplication?.gitApplicationMetadata?.defaultBranchName;
+
+      viewURL = viewerURL({
+        basePageId: defaultPage.baseId,
+        branch: defaultBranch,
+      });
+    } else {
+      viewURL = viewerURL({
+        basePageId: defaultPage.baseId,
+      });
+    }
 
     window.location.href = `${viewURL}`;
   }

--- a/app/client/src/pages/common/SearchBar/EntitySearchBar.tsx
+++ b/app/client/src/pages/common/SearchBar/EntitySearchBar.tsx
@@ -36,6 +36,7 @@ import { getPackagesList } from "ee/selectors/packageSelectors";
 import Fuse from "fuse.js";
 import { useOutsideClick } from "ee/hooks";
 import type { PageDefaultMeta } from "ee/api/ApplicationApi";
+import log from "loglevel";
 
 const HeaderSection = styled.div`
   display: flex;
@@ -135,11 +136,19 @@ function EntitySearchBar(props: any) {
       (app: ApplicationPayload) => app.id === applicationId,
     );
 
-    const defaultPage = searchedApplication?.pages.find(
+    let defaultPage = searchedApplication?.pages.find(
       (page: PageDefaultMeta) => page.isDefault === true,
     );
 
-    const isGitEnabled = searchedApplication?.gitApplicationMetadata;
+    if (!defaultPage) {
+      defaultPage = searchedApplication?.pages[0];
+    }
+
+    if (!defaultPage) {
+      log.error("No default page or pages found for the application");
+    }
+
+    const isGitEnabled = !!searchedApplication?.gitApplicationMetadata;
     let viewURL = null;
 
     if (isGitEnabled) {


### PR DESCRIPTION
## Description
Fixes application redirection issue from search bar ~
1. Appends branch to the url

Fixes https://github.com/appsmithorg/appsmith/issues/36782

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11390479742>
> Commit: 02eb26e4911a4854daeb068f1c80004cec66de96
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11390479742&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Thu, 17 Oct 2024 18:34:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
