### PR TITLE
chore: Add redesign for JS Editor Form

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
@@ -54,6 +54,11 @@ export const EditorThemes: Record<EditorTheme, string> = {
   [EditorTheme.DARK]: "duotone-dark",
 };
 
+export interface BlockCompletion {
+  parentPath: string;
+  subPath: string;
+}
+
 export interface FieldEntityInformation {
   entityName?: string;
   expectedType?: AutocompleteDataType;
@@ -61,7 +66,7 @@ export interface FieldEntityInformation {
   entityId?: string;
   propertyPath?: string;
   isTriggerPath?: boolean;
-  blockCompletions?: Array<{ parentPath: string; subPath: string }>;
+  blockCompletions?: Array<BlockCompletion>;
   example?: ExpectedValueExample;
   mode?: TEditorModes;
   token?: CodeMirror.Token;

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -47,6 +47,7 @@ import type {
   Hinter,
   HintHelper,
   MarkHelper,
+  BlockCompletion,
 } from "components/editorComponents/CodeEditor/EditorConfig";
 import {
   EditorModes,
@@ -199,7 +200,7 @@ export interface EditorStyleProps {
   evaluationSubstitutionType?: EvaluationSubstitutionType;
   popperPlacement?: Placement;
   popperZIndex?: Indices;
-  blockCompletions?: FieldEntityInformation["blockCompletions"];
+  blockCompletions?: Array<BlockCompletion>;
 }
 /**
  *  line => Line to which the gutter is added

--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -2,13 +2,7 @@ import type { ChangeEvent } from "react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { JSAction } from "entities/JSCollection";
 import type { DropdownOnSelect } from "@appsmith/ads-old";
-import {
-  CodeEditorBorder,
-  EditorModes,
-  EditorSize,
-  EditorTheme,
-  TabBehaviour,
-} from "components/editorComponents/CodeEditor/EditorConfig";
+import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
 import type { JSObjectNameEditorProps } from "./JSObjectNameEditor";
 import JSObjectNameEditor from "./JSObjectNameEditor";
 import {
@@ -40,7 +34,6 @@ import {
   getJSFunctionLineGutter,
   getJSPropertyLineFromName,
 } from "./utils";
-import JSFunctionSettingsView from "./JSFunctionSettings";
 import type { JSFunctionSettingsProps } from "./JSFunctionSettings";
 import JSObjectHotKeys from "./JSObjectHotKeys";
 import {
@@ -49,7 +42,6 @@ import {
   FormWrapper,
   NameWrapper,
   StyledFormRow,
-  TabbedViewContainer,
 } from "./styledComponents";
 import { getJSPaneConfigSelectedTab } from "selectors/jsPaneSelectors";
 import type { EventLocation } from "ee/utils/analyticsUtilTypes";
@@ -59,10 +51,8 @@ import {
 } from "actions/editorContextActions";
 import history from "utils/history";
 import { CursorPositionOrigin } from "ee/reducers/uiReducers/editorContextReducer";
-import LazyCodeEditor from "components/editorComponents/LazyCodeEditor";
 import styled from "styled-components";
-import { Tab, TabPanel, Tabs, TabsList } from "@appsmith/ads";
-import { JSEditorTab } from "reducers/uiReducers/jsPaneReducer";
+import type { JSEditorTab } from "reducers/uiReducers/jsPaneReducer";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 import {
@@ -72,6 +62,7 @@ import {
 import type { JSCollectionData } from "ee/reducers/entityReducers/jsActionsReducer";
 import { DEBUGGER_TAB_KEYS } from "components/editorComponents/Debugger/constants";
 import RunHistory from "ee/components/RunHistory";
+import { JSEditorForm as EditorForm } from "./JSEditorForm";
 
 interface JSFormProps {
   jsCollectionData: JSCollectionData;
@@ -384,73 +375,22 @@ function JSEditorForm({
           <Wrapper>
             <div className="flex flex-1 w-full">
               <SecondaryWrapper>
-                <TabbedViewContainer isExecuting={isExecutingCurrentJSAction}>
-                  <Tabs
-                    defaultValue={JSEditorTab.CODE}
-                    onValueChange={(string) =>
-                      setSelectedConfigTab(string as JSEditorTab)
-                    }
-                    value={selectedConfigTab}
-                  >
-                    <TabsList>
-                      <Tab
-                        data-testid={`t--js-editor-` + JSEditorTab.CODE}
-                        value={JSEditorTab.CODE}
-                      >
-                        Code
-                      </Tab>
-                      {showSettings && (
-                        <Tab
-                          data-testid={`t--js-editor-` + JSEditorTab.SETTINGS}
-                          value={JSEditorTab.SETTINGS}
-                        >
-                          Settings
-                        </Tab>
-                      )}
-                    </TabsList>
-                    <TabPanel value={JSEditorTab.CODE}>
-                      <div className="js-editor-tab">
-                        <LazyCodeEditor
-                          AIAssisted
-                          blockCompletions={blockCompletions}
-                          border={CodeEditorBorder.NONE}
-                          borderLess
-                          className={"js-editor"}
-                          customGutter={JSGutters}
-                          dataTreePath={`${currentJSCollection.name}.body`}
-                          disabled={!isChangePermitted}
-                          folding
-                          height={"100%"}
-                          hideEvaluatedValue
-                          input={{
-                            value: currentJSCollection.body,
-                            onChange: handleEditorChange,
-                          }}
-                          isJSObject
-                          jsObjectName={currentJSCollection.name}
-                          mode={EditorModes.JAVASCRIPT}
-                          placeholder="Let's write some code!"
-                          showLightningMenu={false}
-                          showLineNumbers
-                          size={EditorSize.EXTENDED}
-                          tabBehaviour={TabBehaviour.INDENT}
-                          theme={theme}
-                        />
-                      </div>
-                    </TabPanel>
-                    {showSettings && (
-                      <TabPanel value={JSEditorTab.SETTINGS}>
-                        <div className="js-editor-tab">
-                          <JSFunctionSettingsView
-                            actions={jsActions}
-                            disabled={!isChangePermitted}
-                            onUpdateSettings={onUpdateSettings}
-                          />
-                        </div>
-                      </TabPanel>
-                    )}
-                  </Tabs>
-                </TabbedViewContainer>
+                <EditorForm
+                  actions={jsActions}
+                  blockCompletions={blockCompletions}
+                  changePermitted={isChangePermitted}
+                  currentJSCollection={currentJSCollection}
+                  customGutter={JSGutters}
+                  executing={isExecutingCurrentJSAction}
+                  onChange={handleEditorChange}
+                  onUpdateSettings={onUpdateSettings}
+                  onValueChange={(string) =>
+                    setSelectedConfigTab(string as JSEditorTab)
+                  }
+                  showSettings={showSettings}
+                  theme={theme}
+                  value={selectedConfigTab}
+                />
                 <JSResponseView
                   currentFunction={activeResponse}
                   disabled={disableRunFunctionality || !isExecutePermitted}

--- a/app/client/src/pages/Editor/JSEditor/JSEditorForm/JSEditorForm.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorForm/JSEditorForm.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
+import type { JSEditorTab } from "reducers/uiReducers/jsPaneReducer";
+import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
+import {
+  type BlockCompletion,
+  CodeEditorBorder,
+  EditorModes,
+  EditorSize,
+  type EditorTheme,
+  TabBehaviour,
+} from "components/editorComponents/CodeEditor/EditorConfig";
+import type { CodeEditorGutter } from "components/editorComponents/CodeEditor";
+import type { JSAction, JSCollection } from "entities/JSCollection";
+import { OldJSEditorForm } from "./old/JSEditorForm";
+import type { OnUpdateSettingsProps } from "../JSFunctionSettings";
+import LazyCodeEditor from "components/editorComponents/LazyCodeEditor";
+import { Flex } from "@appsmith/ads";
+
+interface Props {
+  executing: boolean;
+  onValueChange: (value: string) => void;
+  value: JSEditorTab;
+  showSettings: undefined | boolean;
+  blockCompletions: Array<BlockCompletion>;
+  customGutter: CodeEditorGutter;
+  currentJSCollection: JSCollection;
+  changePermitted: boolean;
+  onChange: (valueOrEvent: React.ChangeEvent | string) => void;
+  theme: EditorTheme.LIGHT;
+  actions: JSAction[];
+  onUpdateSettings?: (props: OnUpdateSettingsProps) => void;
+}
+
+export const JSEditorForm = (props: Props) => {
+  const isActionRedesignEnabled = useFeatureFlag(
+    FEATURE_FLAG.release_actions_redesign_enabled,
+  );
+
+  if (!isActionRedesignEnabled) {
+    return (
+      <OldJSEditorForm
+        actions={props.actions}
+        blockCompletions={props.blockCompletions}
+        changePermitted={props.changePermitted}
+        currentJSCollection={props.currentJSCollection}
+        customGutter={props.customGutter}
+        executing={props.executing}
+        onChange={props.onChange}
+        onUpdateSettings={props.onUpdateSettings}
+        onValueChange={props.onValueChange}
+        showSettings={props.showSettings}
+        theme={props.theme}
+        value={props.value}
+      />
+    );
+  }
+
+  return (
+    <Flex flex="1" overflow="scroll">
+      <LazyCodeEditor
+        AIAssisted
+        blockCompletions={props.blockCompletions}
+        border={CodeEditorBorder.NONE}
+        borderLess
+        className={"js-editor"}
+        customGutter={props.customGutter}
+        dataTreePath={`${props.currentJSCollection.name}.body`}
+        disabled={!props.changePermitted}
+        folding
+        height={"100%"}
+        hideEvaluatedValue
+        input={{
+          value: props.currentJSCollection.body,
+          onChange: props.onChange,
+        }}
+        isJSObject
+        jsObjectName={props.currentJSCollection.name}
+        mode={EditorModes.JAVASCRIPT}
+        placeholder="Let's write some code!"
+        showLightningMenu={false}
+        showLineNumbers
+        size={EditorSize.EXTENDED}
+        tabBehaviour={TabBehaviour.INDENT}
+        theme={props.theme}
+      />
+    </Flex>
+  );
+};

--- a/app/client/src/pages/Editor/JSEditor/JSEditorForm/index.ts
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorForm/index.ts
@@ -1,0 +1,1 @@
+export { JSEditorForm } from "./JSEditorForm";

--- a/app/client/src/pages/Editor/JSEditor/JSEditorForm/old/JSEditorForm.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorForm/old/JSEditorForm.tsx
@@ -1,0 +1,105 @@
+import { JSEditorTab } from "reducers/uiReducers/jsPaneReducer";
+import React from "react";
+import type {
+  BlockCompletion,
+  EditorTheme,
+} from "components/editorComponents/CodeEditor/EditorConfig";
+import {
+  CodeEditorBorder,
+  EditorModes,
+  EditorSize,
+  TabBehaviour,
+} from "components/editorComponents/CodeEditor/EditorConfig";
+import { TabbedViewContainer } from "../../styledComponents";
+import { Tab, TabPanel, Tabs, TabsList } from "@appsmith/ads";
+import LazyCodeEditor from "components/editorComponents/LazyCodeEditor";
+import JSFunctionSettingsView, {
+  type OnUpdateSettingsProps,
+} from "../../JSFunctionSettings";
+import type { CodeEditorGutter } from "components/editorComponents/CodeEditor";
+import type { JSAction, JSCollection } from "entities/JSCollection";
+
+interface Props {
+  executing: boolean;
+  onValueChange: (value: string) => void;
+  value: JSEditorTab;
+  showSettings: undefined | boolean;
+  blockCompletions: Array<BlockCompletion>;
+  customGutter: CodeEditorGutter;
+  currentJSCollection: JSCollection;
+  changePermitted: boolean;
+  onChange: (valueOrEvent: React.ChangeEvent | string) => void;
+  theme: EditorTheme.LIGHT;
+  actions: JSAction[];
+  onUpdateSettings?: (props: OnUpdateSettingsProps) => void;
+}
+
+export function OldJSEditorForm(props: Props) {
+  return (
+    <TabbedViewContainer isExecuting={props.executing}>
+      <Tabs
+        defaultValue={JSEditorTab.CODE}
+        onValueChange={props.onValueChange}
+        value={props.value}
+      >
+        <TabsList>
+          <Tab
+            data-testid={`t--js-editor-` + JSEditorTab.CODE}
+            value={JSEditorTab.CODE}
+          >
+            Code
+          </Tab>
+          {props.showSettings && (
+            <Tab
+              data-testid={`t--js-editor-` + JSEditorTab.SETTINGS}
+              value={JSEditorTab.SETTINGS}
+            >
+              Settings
+            </Tab>
+          )}
+        </TabsList>
+        <TabPanel value={JSEditorTab.CODE}>
+          <div className="js-editor-tab">
+            <LazyCodeEditor
+              AIAssisted
+              blockCompletions={props.blockCompletions}
+              border={CodeEditorBorder.NONE}
+              borderLess
+              className={"js-editor"}
+              customGutter={props.customGutter}
+              dataTreePath={`${props.currentJSCollection.name}.body`}
+              disabled={!props.changePermitted}
+              folding
+              height={"100%"}
+              hideEvaluatedValue
+              input={{
+                value: props.currentJSCollection.body,
+                onChange: props.onChange,
+              }}
+              isJSObject
+              jsObjectName={props.currentJSCollection.name}
+              mode={EditorModes.JAVASCRIPT}
+              placeholder="Let's write some code!"
+              showLightningMenu={false}
+              showLineNumbers
+              size={EditorSize.EXTENDED}
+              tabBehaviour={TabBehaviour.INDENT}
+              theme={props.theme}
+            />
+          </div>
+        </TabPanel>
+        {props.showSettings && (
+          <TabPanel value={JSEditorTab.SETTINGS}>
+            <div className="js-editor-tab">
+              <JSFunctionSettingsView
+                actions={props.actions}
+                disabled={!props.changePermitted}
+                onUpdateSettings={props.onUpdateSettings}
+              />
+            </div>
+          </TabPanel>
+        )}
+      </Tabs>
+    </TabbedViewContainer>
+  );
+}


### PR DESCRIPTION
## Description

Adds the new JS Editor Form behind feature flags. It ensures the old flow is still easy to recover and change by keeping most items the same.


Fixes #36943

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11384887879>
> Commit: c32b614ce45d81863d7e40bcb1dbf9119d6b93ba
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11384887879&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Thu, 17 Oct 2024 17:51:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `BlockCompletion` interface for enhanced type safety.
	- Replaced the `TabbedViewContainer` with a consolidated `EditorForm` component for a streamlined editing experience.
	- Added a new `JSEditorForm` component for JavaScript code editing, with a fallback to an older version if needed.

- **Bug Fixes**
	- Improved handling of configuration tab selection in the new editor interface.

- **Documentation**
	- Updated export statements to ensure accessibility of the new components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->