### PR TITLE
fix: edit and launch button fail on keeping mouse over while reload

### DIFF
--- a/app/client/src/components/common/Card.tsx
+++ b/app/client/src/components/common/Card.tsx
@@ -336,13 +336,13 @@ function Card({
         className={testId}
         hasReadPermission={hasReadPermission}
         isContextMenuOpen={isContextMenuOpen}
-        onMouseOver={() => {
-          !isFetching && setShowOverlay(true);
-        }}
         onMouseLeave={() => {
           // If the menu is not open, then setOverlay false
           // Set overlay false on outside click.
           !isContextMenuOpen && setShowOverlay(false);
+        }}
+        onMouseOver={() => {
+          !isFetching && setShowOverlay(true);
         }}
         showOverlay={showOverlay}
         testId={testId}

--- a/app/client/src/components/common/Card.tsx
+++ b/app/client/src/components/common/Card.tsx
@@ -336,7 +336,7 @@ function Card({
         className={testId}
         hasReadPermission={hasReadPermission}
         isContextMenuOpen={isContextMenuOpen}
-        onMouseEnter={() => {
+        onMouseOver={() => {
           !isFetching && setShowOverlay(true);
         }}
         onMouseLeave={() => {


### PR DESCRIPTION
## Description

> Fixes edit and launch buttons fail to appear if mouse pointer is hovering over the Application box while loading webpage
> Tested it thoroughly.

https://github.com/user-attachments/assets/797df6c8-04b7-48af-ae87-51a89ad25e62




Fixes #36804  

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated mouse event handling in the Card component for improved overlay display behavior.

- **Refactor**
	- Adjusted event triggering from `onMouseEnter` to `onMouseOver` without altering overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->