### PR TITLE
chore: make first eval tree a blocking call

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -736,7 +736,7 @@ function* evaluationChangeListenerSaga(): any {
   }
 
   widgetTypeConfigMap = WidgetFactory.getWidgetTypeConfigMap();
-  yield fork(evalAndLintingHandler, false, initAction, {
+  yield call(evalAndLintingHandler, true, initAction, {
     shouldReplay: false,
     forceEvaluation: false,
     // during startup all JS objects are affected


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11433762767>
> Commit: 56ee22a33f0ad39807bf017c9e052e9d8b4f0003
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11433762767&attempt=3&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
> <li>cypress/e2e/Regression/ClientSide/Github/EnableGithub_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OtherUIFeatures/GlobalSearch_spec.js
> <li>cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Tue, 22 Oct 2024 07:40:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
