### PR TITLE
chore: Enable sharing spring context in pf4j plugins

### DIFF
--- a/app/server/appsmith-interfaces/pom.xml
+++ b/app/server/appsmith-interfaces/pom.xml
@@ -61,6 +61,12 @@
             <artifactId>pf4j</artifactId>
             <version>${org.pf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.pf4j</groupId>
+            <artifactId>pf4j-spring</artifactId>
+            <version>0.8.0</version>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.data</groupId>

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
@@ -4,6 +4,7 @@ import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.pf4j.PluginWrapper;
 import org.pf4j.spring.SpringPlugin;
+import org.springframework.context.ApplicationContext;
 
 public abstract class BasePlugin extends SpringPlugin {
 
@@ -12,5 +13,10 @@ public abstract class BasePlugin extends SpringPlugin {
 
     public BasePlugin(PluginWrapper wrapper) {
         super(wrapper);
+    }
+
+    @Override
+    protected ApplicationContext createApplicationContext() {
+        return null;
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
@@ -2,10 +2,10 @@ package com.appsmith.external.plugins;
 
 import com.appsmith.util.SerializationUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
+import org.pf4j.spring.SpringPlugin;
 
-public abstract class BasePlugin extends Plugin {
+public abstract class BasePlugin extends SpringPlugin {
 
     protected static final ObjectMapper objectMapper =
             SerializationUtils.getObjectMapperWithSourceInLocationAndMaxStringLengthEnabled();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/PluginConfiguration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/PluginConfiguration.java
@@ -1,7 +1,16 @@
 package com.appsmith.server.configurations;
 
+import jakarta.annotation.PostConstruct;
+import org.pf4j.ExtensionFactory;
 import org.pf4j.PropertiesPluginDescriptorFinder;
+import org.pf4j.spring.ExtensionsInjector;
+import org.pf4j.spring.SpringExtensionFactory;
+import org.pf4j.spring.SpringPlugin;
 import org.pf4j.spring.SpringPluginManager;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,16 +18,88 @@ import org.springframework.context.annotation.Configuration;
 public class PluginConfiguration {
 
     @Bean
-    public SpringPluginManager pluginManager() {
-        return new CustomPluginManager();
+    public SpringPluginManager pluginManager(ApplicationContext applicationContext) {
+        return new CustomPluginManager(applicationContext);
     }
 
     private static class CustomPluginManager extends SpringPluginManager {
-        public CustomPluginManager() {
+
+        private ApplicationContext applicationContext;
+
+        private CustomSpringExtensionFactory ef;
+
+        public CustomPluginManager(ApplicationContext applicationContext) {
             super();
+            this.applicationContext = applicationContext;
+            this.ef = new CustomSpringExtensionFactory(this);
             pluginDescriptorFinder = "development".equals(System.getProperty("pf4j.mode"))
                     ? new PropertiesPluginDescriptorFinder("target/classes/plugin.properties")
                     : new PropertiesPluginDescriptorFinder();
+        }
+
+        @Override
+        protected ExtensionFactory createExtensionFactory() {
+            ef = new CustomSpringExtensionFactory(this);
+            return ef;
+        }
+
+        @Override
+        public ExtensionFactory getExtensionFactory() {
+            return ef;
+        }
+
+        @Override
+        public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+            this.applicationContext = applicationContext;
+            ef.setApplicationContext(applicationContext);
+        }
+
+        public ApplicationContext getApplicationContext() {
+            return applicationContext;
+        }
+
+        /**
+         * This method load, start plugins and inject extensions in Spring
+         */
+        @PostConstruct
+        public void init() {
+            loadPlugins();
+            startPlugins();
+
+            AbstractAutowireCapableBeanFactory beanFactory =
+                    (AbstractAutowireCapableBeanFactory) applicationContext.getAutowireCapableBeanFactory();
+            ExtensionsInjector extensionsInjector = new ExtensionsInjector(this, beanFactory);
+
+            ef.setApplicationContext(this.applicationContext);
+            extensionsInjector.injectExtensions();
+        }
+    }
+
+    static class CustomSpringExtensionFactory extends SpringExtensionFactory {
+
+        private ApplicationContext applicationContext;
+
+        public CustomSpringExtensionFactory(SpringPluginManager pluginManager) {
+            this(pluginManager, true);
+        }
+
+        public CustomSpringExtensionFactory(SpringPluginManager pluginManager, boolean autowire) {
+            super(pluginManager, autowire);
+        }
+
+        @Override
+        public <T> T create(Class<T> extensionClass) {
+            T extension = createWithSpring(extensionClass, this.applicationContext);
+            if (extension instanceof SpringPlugin sp) {
+                ConfigurableApplicationContext pluginContext =
+                        (ConfigurableApplicationContext) sp.getApplicationContext();
+                pluginContext.setParent(applicationContext);
+            }
+            return extension;
+        }
+
+        public void setApplicationContext(ApplicationContext applicationContext) {
+            this.applicationContext = applicationContext;
         }
     }
 }


### PR DESCRIPTION
## Description
As of today, we do not use any DI concepts in plugins because our extensions are unable to use the same application context as server. This PR allows us to extend from the same application context. Implications of clashes across plugins will need to be checked, and conventions and compile time checks for it need to be established.

## Automation

/ok-to-test tags="@tag.Git,@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11452764576>
> Commit: 7547480692f69f28e50f41f89a59f078bbc6fa65
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11452764576&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Git,@tag.Sanity
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/OnLoadTests/OnLoadActions_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/QueryPane/DSDocs_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Tue, 22 Oct 2024 04:34:00 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Integrated the PF4J (Plugin Framework for Java) with Spring, enhancing plugin management capabilities.
	- Added a new dependency for `pf4j-spring` to facilitate this integration.

- **Improvements**
	- Updated the `BasePlugin` class to extend `SpringPlugin`, allowing better compatibility with Spring's plugin architecture.
	- Enhanced `PluginConfiguration` to utilize Spring's `ApplicationContext`, improving plugin lifecycle management and extension creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->