### PR TITLE
fix: google sheets query getting executed even after changing sheet

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/constants/ErrorMessages.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/constants/ErrorMessages.java
@@ -40,7 +40,7 @@ public class ErrorMessages extends BasePluginErrorMessages {
     public static final String MISSING_ROW_INDEX_ERROR_MSG = "Missing required field 'Row index'";
 
     public static final String MISSING_SPREADSHEET_URL_SELECTED_SHEETS_ERROR_MSG =
-            "Missing required field 'Spreadsheet Url', Check if your datasource is authorised to use this spreadsheet or not";
+            "Missing required field 'Spreadsheet Url'. Please check if your datasource is authorized to use this spreadsheet.";
 
     public static final String UNABLE_TO_CREATE_URI_ERROR_MSG = "Unable to create URI";
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/constants/ErrorMessages.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/constants/ErrorMessages.java
@@ -39,6 +39,9 @@ public class ErrorMessages extends BasePluginErrorMessages {
 
     public static final String MISSING_ROW_INDEX_ERROR_MSG = "Missing required field 'Row index'";
 
+    public static final String MISSING_SPREADSHEET_URL_SELECTED_SHEETS_ERROR_MSG =
+            "Missing required field 'Spreadsheet Url', Check if your datasource is authorised to use this spreadsheet or not";
+
     public static final String UNABLE_TO_CREATE_URI_ERROR_MSG = "Unable to create URI";
 
     public static final String MISSING_VALID_RESPONSE_ERROR_MSG = "Missing a valid response object.";

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
@@ -51,7 +51,7 @@ import static com.appsmith.external.helpers.PluginUtils.STRING_TYPE;
 import static com.appsmith.external.helpers.PluginUtils.getDataValueSafelyFromFormData;
 import static com.appsmith.external.helpers.PluginUtils.setDataValueSafelyInFormData;
 import static com.appsmith.external.helpers.PluginUtils.validConfigurationPresentInFormData;
-import static com.external.utils.SheetsUtil.getUserAuthorizedSheetIds;
+import static com.external.utils.SheetsUtil.validateAndGetUserAuthorizedSheetIds;
 import static java.lang.Boolean.TRUE;
 
 @Slf4j
@@ -175,7 +175,8 @@ public class GoogleSheetsPlugin extends BasePlugin {
 
             // This will get list of authorised sheet ids from datasource config, and transform execution response to
             // contain only authorised files
-            final Set<String> userAuthorizedSheetIds = getUserAuthorizedSheetIds(datasourceConfiguration);
+            final Set<String> userAuthorizedSheetIds =
+                    validateAndGetUserAuthorizedSheetIds(datasourceConfiguration, methodConfig);
 
             // Triggering the actual REST API call
             return executionMethod
@@ -338,7 +339,8 @@ public class GoogleSheetsPlugin extends BasePlugin {
 
             // This will get list of authorised sheet ids from datasource config, and transform trigger response to
             // contain only authorised files
-            Set<String> userAuthorizedSheetIds = getUserAuthorizedSheetIds(datasourceConfiguration);
+            Set<String> userAuthorizedSheetIds =
+                    validateAndGetUserAuthorizedSheetIds(datasourceConfiguration, methodConfig);
 
             return triggerMethod
                     .getTriggerClient(client, methodConfig)

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/SheetsUtilTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/SheetsUtilTest.java
@@ -25,7 +25,7 @@ public class SheetsUtilTest {
         propList.add(prop);
         dsConfig.setProperties(propList);
         Set<String> result = SheetsUtil.validateAndGetUserAuthorizedSheetIds(dsConfig, null);
-        assertEquals(result, null);
+        assertEquals(null, result);
     }
 
     @Test
@@ -49,7 +49,7 @@ public class SheetsUtilTest {
 
         dsConfig.setProperties(propList);
         Set<String> result = SheetsUtil.validateAndGetUserAuthorizedSheetIds(dsConfig, null);
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
     }
 
     @Test

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/SheetsUtilTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/SheetsUtilTest.java
@@ -1,22 +1,22 @@
 package com.external.config;
 
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.OAuth2;
 import com.appsmith.external.models.Property;
+import com.external.constants.ErrorMessages;
 import com.external.utils.SheetsUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SheetsUtilTest {
 
     @Test
-    public void testGetUserAuthorizedSheetIds_allsheets_returnsNull() throws JsonProcessingException {
+    public void testValidateAndGetUserAuthorizedSheetIds_allsheets_returnsNull() throws JsonProcessingException {
         DatasourceConfiguration dsConfig = new DatasourceConfiguration();
         List<Property> propList = new ArrayList<Property>();
         Property prop = new Property();
@@ -24,12 +24,13 @@ public class SheetsUtilTest {
         prop.setValue("test_email");
         propList.add(prop);
         dsConfig.setProperties(propList);
-        Set<String> result = SheetsUtil.getUserAuthorizedSheetIds(dsConfig);
+        Set<String> result = SheetsUtil.validateAndGetUserAuthorizedSheetIds(dsConfig, null);
         assertEquals(result, null);
     }
 
     @Test
-    public void testGetUserAuthorizedSheetIds_specificSheets_returnsSetOfFileIds() throws JsonProcessingException {
+    public void testValidateAndGetUserAuthorizedSheetIds_specificSheets_returnsSetOfFileIds()
+            throws JsonProcessingException {
         DatasourceConfiguration dsConfig = new DatasourceConfiguration();
         List<Property> propList = new ArrayList<Property>();
         OAuth2 oAuth2 = new OAuth2();
@@ -47,7 +48,92 @@ public class SheetsUtilTest {
         propList.add(prop2);
 
         dsConfig.setProperties(propList);
-        Set<String> result = SheetsUtil.getUserAuthorizedSheetIds(dsConfig);
+        Set<String> result = SheetsUtil.validateAndGetUserAuthorizedSheetIds(dsConfig, null);
         assertEquals(result.size(), 1);
+    }
+
+    @Test
+    public void testValidateAndGetUserAuthorizedSheetIds_invalidSpecificSheets_throwsException() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        List<Property> propList = new ArrayList<>();
+        OAuth2 oAuth2 = new OAuth2();
+
+        oAuth2.setScopeString("https://www.googleapis.com/auth/drive.file");
+        dsConfig.setAuthentication(oAuth2);
+
+        Property prop1 = new Property("emailAddress", "test_email");
+        propList.add(prop1);
+
+        List<String> ids = new ArrayList<>();
+        ids.add("id1");
+
+        Property prop2 = new Property("userAuthorizedSheetIds", ids);
+        propList.add(prop2);
+
+        dsConfig.setProperties(propList);
+
+        // Create formData map with only the spreadsheetUrl
+        Map<String, Object> formData = new HashMap<>();
+        Map<String, Object> spreadsheetUrlData = new HashMap<>();
+        spreadsheetUrlData.put("data", "https://docs.google.com/spreadsheets/d/id2");
+        formData.put("sheetUrl", spreadsheetUrlData);
+
+        MethodConfig methodConfig = new MethodConfig(formData);
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            SheetsUtil.validateAndGetUserAuthorizedSheetIds(dsConfig, methodConfig);
+        });
+
+        String expectedErrorMessage = ErrorMessages.MISSING_SPREADSHEET_URL_SELECTED_SHEETS_ERROR_MSG;
+        assertEquals(expectedErrorMessage, exception.getMessage());
+    }
+
+    @Test
+    public void testValidateAndGetUserAuthorizedSheetIds_validSpecificSheets_returnsAuthorisedSheetIds() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        List<Property> propList = new ArrayList<>();
+        OAuth2 oAuth2 = new OAuth2();
+
+        oAuth2.setScopeString("https://www.googleapis.com/auth/drive.file");
+        dsConfig.setAuthentication(oAuth2);
+
+        Property prop1 = new Property("emailAddress", "test_email");
+        propList.add(prop1);
+
+        List<String> ids = new ArrayList<>();
+        ids.add("id1");
+
+        Property prop2 = new Property("userAuthorizedSheetIds", ids);
+        propList.add(prop2);
+
+        dsConfig.setProperties(propList);
+
+        // Create formData map with the spreadsheetUrl
+        Map<String, Object> formData = new HashMap<>();
+        Map<String, Object> spreadsheetUrlData = new HashMap<>();
+        spreadsheetUrlData.put("data", "https://docs.google.com/spreadsheets/d/id1");
+        formData.put("sheetUrl", spreadsheetUrlData);
+
+        MethodConfig methodConfig = new MethodConfig(formData);
+
+        Set<String> result = SheetsUtil.validateAndGetUserAuthorizedSheetIds(dsConfig, methodConfig);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains("id1"));
+    }
+
+    @Test
+    public void testValidateAndGetUserAuthorizedSheetIds_allSheets_returnsNull() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        OAuth2 oAuth2 = new OAuth2();
+
+        oAuth2.setScopeString("https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/spreadsheets");
+        dsConfig.setAuthentication(oAuth2);
+
+        // Not adding any properties to dsConfig
+
+        Set<String> result = SheetsUtil.validateAndGetUserAuthorizedSheetIds(dsConfig, null);
+
+        assertNull(result);
     }
 }


### PR DESCRIPTION
## Description

This PR fixes the issue with google sheets -> selected sheets option.  Following are the steps to reproduce the issue on cloud/release platform:

**Steps:**
1. Create a Google sheets datasource with selected sheets option
2. Select "spreadsheet1" from the file picker.
3. Create a query for this datasource and attach it to table widget
4. Now edit the datasource and change authorisation from "spreadsheet1" to "spreadsheet2"
5. Refresh the page and check the table data

This issue has been fixed, where we check if the correct spreadsheetId is present in authorisedSheetIds, if it's not throwing an exception so we don't execute the query.


Fixes #36747   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11473463879>
> Commit: e0f725a6246ff849c8666d5a34e6cf016111cf0f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11473463879&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 23 Oct 2024 05:43:59 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new error message for missing spreadsheet URLs to enhance user guidance.
	- Updated method for retrieving authorized sheet IDs to include validation, improving error handling.

- **Bug Fixes**
	- Enhanced error handling for cases where the spreadsheet URL is invalid or missing.

- **Tests**
	- Added new test cases to validate the updated functionality for authorized sheet IDs, ensuring robust error handling and correct returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->