### PR TITLE
chore: Removing usage of action right pane component

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
@@ -23,7 +23,6 @@ import {
   getHasManageActionPermission,
 } from "ee/utils/BusinessFeatures/permissionPageHelpers";
 import { ApiEditorContext } from "./ApiEditorContext";
-import ActionRightPane from "components/editorComponents/ActionRightPane";
 import RunHistory from "ee/components/RunHistory";
 import { HintMessages } from "PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/HintMessages";
 import { InfoFields } from "PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/InfoFields";
@@ -347,9 +346,7 @@ function CommonEditorForm(props: CommonFormPropsWithExtraParams) {
               <RunHistory />
             </SecondaryWrapper>
           </div>
-          <ActionRightPane
-            additionalSections={actionRightPaneAdditionSections}
-          />
+          {actionRightPaneAdditionSections}
         </Wrapper>
       </Form>
     </MainContainer>

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -17,7 +17,6 @@ import {
 import { useParams } from "react-router";
 import type { AppState } from "ee/reducers";
 import { thinScrollbar } from "constants/DefaultTheme";
-import ActionRightPane from "components/editorComponents/ActionRightPane";
 import type { ActionResponse } from "api/ActionAPI";
 import type { Plugin } from "api/PluginApi";
 import type { UIComponentTypes } from "api/PluginApi";
@@ -377,7 +376,7 @@ export function EditorJSONtoForm(props: Props) {
             <RunHistory />
           </SecondaryWrapper>
         </div>
-        <ActionRightPane additionalSections={actionRightPaneAdditionSections} />
+        {actionRightPaneAdditionSections}
       </Wrapper>
     </QueryFormContainer>
   );


### PR DESCRIPTION
## Description

Removing usage of action right pane component to use Module inputs form directly as right pane on EE.

Fixes [#36898](https://github.com/appsmithorg/appsmith/issues/36898)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11475223785>
> Commit: e404221a9e73ae6d45ac496905b5bf0a872eae22
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11475223785&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 23 Oct 2024 08:15:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified rendering of action sections in the `CommonEditorForm` and `EditorJSONtoForm` components by removing the `ActionRightPane` component.
  
- **Bug Fixes**
	- No bug fixes were implemented; overall functionality remains consistent.

- **Refactor**
	- Enhanced component structure for better direct manipulation of action sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->