### PR TITLE
chore: update anvil  modal size api

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Modal/src/Modal.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/Modal.tsx
@@ -1,14 +1,16 @@
+import clsx from "clsx";
 import React from "react";
 import { Popover, PopoverModalContent } from "@appsmith/wds-headless";
-import styles from "./styles.module.css";
+
 import type { ModalProps } from "./types";
-import clsx from "clsx";
+import styles from "./styles.module.css";
 
 export const Modal = (props: ModalProps) => {
   const {
     children,
-    dataAttributes = {},
     overlayClassName,
+    overlayProps = {},
+    size = "medium",
     triggerRef,
     ...rest
   } = props;
@@ -17,7 +19,8 @@ export const Modal = (props: ModalProps) => {
     // don't forget to change the transition-duration CSS as well
     <Popover duration={200} modal triggerRef={triggerRef} {...rest}>
       <PopoverModalContent
-        {...dataAttributes}
+        data-size={size}
+        {...overlayProps}
         overlayClassName={clsx(styles.overlay, overlayClassName)}
       >
         {children}

--- a/app/client/packages/design-system/widgets/src/components/Modal/src/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/Modal/src/types.ts
@@ -3,6 +3,7 @@ import type {
   PopoverProps,
 } from "@appsmith/wds-headless";
 import type { ReactNode } from "react";
+import type { SIZES } from "@appsmith/wds";
 
 export interface ModalProps
   extends Pick<
@@ -15,9 +16,14 @@ export interface ModalProps
       | "dismissClickOutside"
     >,
     Pick<PopoverModalContentProps, "overlayClassName"> {
-  dataAttributes?: Record<string, string>;
+  /** size of the modal
+   * @default medium
+   */
+  size?: Omit<keyof typeof SIZES, "xSmall">;
   /** The children of the component. */
   children: ReactNode;
+  /** Additional props to be passed to the overlay */
+  overlayProps?: Record<string, string>;
 }
 
 export interface ModalContentProps {

--- a/app/client/packages/design-system/widgets/src/components/Modal/stories/ModalExamples.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Modal/stories/ModalExamples.tsx
@@ -51,10 +51,10 @@ export const ModalExamples = () => {
         }}
       />
       <Modal
-        dataAttributes={{ "data-size": "large" }}
         initialFocus={2}
         isOpen={isLargeOpen}
         setOpen={setLargeOpen}
+        size="large"
         triggerRef={largeRef}
       >
         <Unstyled>
@@ -121,10 +121,10 @@ export const ModalExamples = () => {
         </Unstyled>
       </Modal>
       <Modal
-        dataAttributes={{ "data-size": "small" }}
         initialFocus={2}
         isOpen={isSmallOpen}
         setOpen={setSmallOpen}
+        size="small"
         triggerRef={smallRef}
       >
         <Unstyled>

--- a/app/client/packages/design-system/widgets/src/testing/ComplexForm.tsx
+++ b/app/client/packages/design-system/widgets/src/testing/ComplexForm.tsx
@@ -202,10 +202,10 @@ export const ComplexForm = () => {
           Ok
         </Button>
         <Modal
-          dataAttributes={{ "data-size": "small" }}
           initialFocus={2}
           isOpen={isModalOpen}
           setOpen={setModalOpen}
+          size="small"
           triggerRef={submitRef}
         >
           <ModalContent>

--- a/app/client/src/modules/ui-builder/ui/wds/WDSModalWidget/widget/index.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSModalWidget/widget/index.tsx
@@ -140,16 +140,17 @@ class WDSModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
 
     return (
       <Modal
-        dataAttributes={{
+        isOpen={this.state.isVisible as boolean}
+        onClose={this.onModalClose}
+        overlayProps={{
           [AnvilDataAttributes.MODAL_SIZE]: this.props.size,
           [AnvilDataAttributes.WIDGET_NAME]: this.props.widgetName,
           [AnvilDataAttributes.IS_SELECTED_WIDGET]: this.props.isWidgetSelected
             ? "true"
             : "false",
         }}
-        isOpen={this.state.isVisible as boolean}
-        onClose={this.onModalClose}
         setOpen={(val) => this.setState({ isVisible: val })}
+        size={this.props.size}
       >
         {this.state.isVisible && (
           <ModalContent className={modalClassNames.trim()}>


### PR DESCRIPTION
Fixes the API for modal for setting modal.

/ok-to-test tags="@tag.Anvil"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11479189189>
> Commit: 1a07d20439ef71515a8246cc1065af60bf54f07a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11479189189&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`
> Spec:
> <hr>Wed, 23 Oct 2024 12:09:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `size` prop for the Modal component, allowing for flexible sizing options (e.g., small, medium, large).
	- Added `overlayProps` for enhanced customization of the Modal's overlay properties.

- **Bug Fixes**
	- Removed the outdated `dataAttributes` prop, streamlining the Modal configuration.

- **Documentation**
	- Updated examples to reflect the new prop structure for the Modal component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->