### PR TITLE
test: fix datepicker tests

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
@@ -19,7 +19,7 @@ describe(
 
     // ADS changes to date input property causes this test to fail
     // skipping it temporarily.
-    it.skip("DatePicker-Date Name validation", function () {
+    it("DatePicker-Date Name validation", function () {
       // changing the date to today
       cy.get(formWidgetsPage.defaultDate).click();
       cy.SetDateToToday();
@@ -36,10 +36,8 @@ describe(
 
       /**
        * setDate--> is a Command to select the date in the date picker
-       * @param1 --> its takes currentday+ <future day> eg: 1
-       * @param2 --> user date formate
        */
-      cy.setDate(1, "ddd MMM DD YYYY");
+      cy.setDate(1);
       const nextDay = dayjs().add(1, "days").format("DD/MM/YYYY");
       cy.log(nextDay);
       cy.get(formWidgetsPage.datepickerWidget + " .bp3-input").should(

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,6 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
-cypress/e2e/Regression/ClientSide/Binding/DatePicker_Text_spec.js
-cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker_With_Switch_spec.js
+
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,6 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
-
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,7 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
+cypress/e2e/Regression/ClientSide/Binding/DatePicker_Text_spec.js
+cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker_With_Switch_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -524,10 +524,9 @@ Cypress.Commands.add("getDate", (date, dateFormate) => {
   return eDate;
 });
 
-Cypress.Commands.add("setDate", (date, dateFormate) => {
-  const expDate = dayjs().add(date, "days").format(dateFormate);
-  const sel = `.DayPicker-Day[aria-label=\"${expDate}\"]`;
-  cy.get(sel).click();
+Cypress.Commands.add("setDate", (date) => {
+  const expDate = dayjs().add(date, "days").format("dddd, MMMM DD");
+  cy.get(`.react-datepicker__day[aria-label^="Choose ${expDate}"]`).click();
 });
 
 Cypress.Commands.add("validateDisableWidget", (widgetCss, disableCss) => {


### PR DESCRIPTION
EE PR:https://github.com/appsmithorg/appsmith-ee/pull/5438

Updated SetDate method as the older method was not working anymore

/ok-to-test tags="@tag.All"



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11512762742>
> Commit: 1e0ec01036959df5289b6d131f804166a7775e8f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11512762742&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 25 Oct 2024 08:22:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->
