### PR TITLE
fix: toggle leave and delete workspace states

### DIFF
--- a/app/client/src/ce/pages/Applications/WorkspaceMenu.tsx
+++ b/app/client/src/ce/pages/Applications/WorkspaceMenu.tsx
@@ -171,7 +171,7 @@ function WorkspaceMenu({
             className="error-menuitem workspace-menu-item"
             onClick={() => {
               !warnLeavingWorkspace
-                ? setWarnLeavingWorkspace(true)
+                ? (setWarnLeavingWorkspace(true), setWarnDeleteWorkspace(false))
                 : leaveWS(workspace.id);
             }}
           >
@@ -185,7 +185,8 @@ function WorkspaceMenu({
             onClick={() => {
               warnDeleteWorkspace
                 ? handleDeleteWorkspace(workspace.id)
-                : setWarnDeleteWorkspace(true);
+                : (setWarnDeleteWorkspace(true),
+                  setWarnLeavingWorkspace(false));
             }}
           >
             <Icon name="delete-bin-line" size="md" />


### PR DESCRIPTION
**Issue Description:**

When the user interacts with the workspace options (**Leave Workspace** or **Delete Workspace**) on the homepage, the `Are you sure` prompt does not reset properly. After clicking on  **Leave Workspace,** the `Are you sure` message appears as expected. However, if the user clicks on `Delete Workspace` afterward, the **Are you sure** message for "Leave Workspace" remains instead of switching to reflect the new "Delete Workspace" action.

`Before Implementation:`
![Screenshot from 2024-10-15 08-11-26](https://github.com/user-attachments/assets/0cf5e6cd-9f3d-484d-8416-c72e5f128056)

`After Implementation`


[Screencast from 21-10-24 04:37:51 PM IST.webm](https://github.com/user-attachments/assets/f2155b40-27fe-4638-92ab-53ff5e560d9a)

Fixes #15664 

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user experience with enhanced confirmation prompts for leaving and deleting workspaces.
	- Warnings are now appropriately displayed based on user actions, ensuring clarity in workspace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->