### PR TITLE
chore: Update dispatch option

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -23,6 +23,27 @@ on:
         type: string
         default: "false"
 
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number for the workflow"
+        required: false
+        type: number
+      skip-tests:
+        description: "Skip tests flag"
+        required: false
+        type: string
+        default: "false"
+      branch:
+        description: "Branch for the build"
+        required: false
+        type: string
+      is-pg-build:
+        description: "Flag for PG build"
+        required: false
+        type: string
+        default: "false"
+
 # Change the working directory for all the jobs in this workflow
 defaults:
   run:


### PR DESCRIPTION
## Description
We’ve often faced challenges in running server-specific tests efficiently for individual PRs. To streamline this process and improve testing speed, I’ve implemented the workflow dispatch feature, enabling quick and on-demand execution of server tests.


Fixes #`37060`  

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11497895741>
> Commit: 48c3cd9618bc4a4dc61d0ecdb612cc1798f07442
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11497895741&attempt=6" target="_blank">Cypress dashboard</a>.
> Tags: @tag.IDE
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/11497895741" target="_blank">workflow here</a>.
> <hr>Fri, 25 Oct 2024 05:13:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
