### PR TITLE
chore: Add host explicitly for pg_isready signal at the startup

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -467,7 +467,7 @@ create_appsmith_pg_db() {
   # Start the postgres , wait for it to be ready and create a appsmith db
   su postgres -c "env PATH='$PATH' pg_ctl -D $POSTGRES_DB_PATH -l $POSTGRES_DB_PATH/logfile start"
   echo "Waiting for Postgres to start"
-  local max_attempts=100
+  local max_attempts=300
   local attempt=0
 
   until su postgres -c "env PATH='$PATH' pg_isready -h 127.0.0.1"; do

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -470,7 +470,7 @@ create_appsmith_pg_db() {
   local max_attempts=100
   local attempt=0
 
-  until su postgres -c "env PATH='$PATH' pg_isready -d postgres -h 127.0.0.1"; do
+  until su postgres -c "env PATH='$PATH' pg_isready -h 127.0.0.1"; do
     if (( attempt >= max_attempts )); then
       echo "Postgres failed to start within 100 seconds."
       return 1

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -470,7 +470,7 @@ create_appsmith_pg_db() {
   local max_attempts=100
   local attempt=0
 
-  until su postgres -c "env PATH='$PATH' pg_isready -d postgres"; do
+  until su postgres -c "env PATH='$PATH' pg_isready -d postgres -h 127.0.0.1"; do
     if (( attempt >= max_attempts )); then
       echo "Postgres failed to start within 100 seconds."
       return 1

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -472,7 +472,7 @@ create_appsmith_pg_db() {
 
   until su postgres -c "env PATH='$PATH' pg_isready -h 127.0.0.1"; do
     if (( attempt >= max_attempts )); then
-      echo "Postgres failed to start within 100 seconds."
+      echo "Postgres failed to start within 300 seconds."
       return 1
     fi
     tlog "Waiting for Postgres to be ready... Attempt $((++attempt))/$max_attempts"


### PR DESCRIPTION
## Description
PR to add the host explicitly for the `pg_isready` check at the startup. In the current implementation we haven't provided a host which can create issues if custom unix port is configured in the `postgres.conf`.  Possible issue that we have observed here: 
1. Misconfigured unix socket directory: This happens if the PostgreSQL server is not using the default Unix socket directory (usually /tmp or /var/run/postgresql), and we don't specify the correct socket directory with the --host parameter, pg_isready will fail to connect.
2. `postgres` DB is manually deleted by the user by stopping the postgres procedure, but the possibility is lower. 

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11499341453>
> Commit: ab0e1f4efead4f4571c070df8f37d2bae5a935ed
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11499341453&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 24 Oct 2024 13:04:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced PostgreSQL readiness check for more reliable connections by extending the timeout duration to 300 seconds.
- **Chores**
	- Minor formatting and comment updates for improved clarity in the script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->