### PR TITLE
feat: remove release_table_cell_label_value_enabled feature flag

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter1_1_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter1_1_Spec.ts
@@ -1,14 +1,13 @@
 import { demoTableDataForSelect } from "../../../../../fixtures/Table/DemoTableData";
-import { featureFlagIntercept } from "../../../../../support/Objects/FeatureFlags";
 import {
-  entityExplorer,
-  propPane,
-  deployMode,
-  table,
-  assertHelper,
-  locators,
-  draggableWidgets,
   agHelper,
+  assertHelper,
+  deployMode,
+  draggableWidgets,
+  entityExplorer,
+  locators,
+  propPane,
+  table,
 } from "../../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
   EntityType,
@@ -145,9 +144,6 @@ describe(
 
     it("11. Verify table search includes label and value for table with select column type", () => {
       deployMode.NavigateBacktoEditor();
-      // This flag is turned on to allow the label show in the table select cell content
-      // when this feature is turned on fully, this flag will be removed
-      featureFlagIntercept({ release_table_cell_label_value_enabled: true });
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       propPane.EnterJSContext("Table data", demoTableDataForSelect);
 
@@ -178,7 +174,6 @@ describe(
     });
 
     it("12. Verify table filter for select column type", function () {
-      featureFlagIntercept({ release_table_cell_label_value_enabled: true });
       table.OpenNFilterTable("role", "is exactly", "Product Manager");
       table.ReadTableRowColumnData(0, 2, "v2").then(($cellData) => {
         expect($cellData).to.eq("Product Manager");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Sorting_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Sorting_spec.js
@@ -1,8 +1,7 @@
-import { featureFlagIntercept } from "../../../../../support/Objects/FeatureFlags";
 import * as _ from "../../../../../support/Objects/ObjectsCore";
+import PageList from "../../../../../support/Pages/PageList";
 const testdata = require("../../../../../fixtures/testdata.json");
 const commonlocators = require("../../../../../locators/commonlocators.json");
-import PageList from "../../../../../support/Pages/PageList";
 
 const demoTableData = `
 {{
@@ -117,9 +116,6 @@ describe(
     });
 
     it("2. Verifies that default sorting works for a select column using the value property", function () {
-      // This flag is turned on to allow the label show in the table select cell content
-      // when this feature is turned on fully, this flag will be removed
-      featureFlagIntercept({ release_table_cell_label_value_enabled: true });
       cy.dragAndDropToCanvas("tablewidgetv2", { x: 350, y: 500 });
       _.propPane.EnterJSContext("Table data", demoTableData);
 
@@ -169,9 +165,6 @@ describe(
     });
 
     it("3. Verifies that sorting works for the select column type when sortBy is set to label", function () {
-      // This flag is turned on to allow the label show in the table select cell content
-      // when this feature is turned on fully, this flag will be removed
-      featureFlagIntercept({ release_table_cell_label_value_enabled: true });
       cy.dragAndDropToCanvas("tablewidgetv2", { x: 350, y: 500 });
       _.propPane.EnterJSContext("Table data", demoTableData);
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -1,11 +1,10 @@
+import * as _ from "../../../../../../support/Objects/ObjectsCore";
 import {
   PageLeftPane,
   PagePaneSegment,
 } from "../../../../../../support/Pages/EditorNavigation";
 
 const commonlocators = require("../../../../../../locators/commonlocators.json");
-import * as _ from "../../../../../../support/Objects/ObjectsCore";
-import { featureFlagIntercept } from "../../../../../../support/Objects/FeatureFlags";
 
 describe(
   "Table widget - Select column type functionality",
@@ -206,7 +205,6 @@ describe(
 
     it("7. should check that on option select is working", () => {
       _.agHelper.CheckForPageSaveError();
-      featureFlagIntercept({ release_table_cell_label_value_enabled: true });
       cy.openPropertyPane("tablewidgetv2");
       cy.editColumn("step");
       cy.get(".t--property-control-onoptionchange .t--js-toggle").click();

--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -32,8 +32,6 @@ export const FEATURE_FLAG = {
     "rollout_remove_feature_walkthrough_enabled",
   release_drag_drop_building_blocks_enabled:
     "release_drag_drop_building_blocks_enabled",
-  release_table_cell_label_value_enabled:
-    "release_table_cell_label_value_enabled",
   rollout_side_by_side_enabled: "rollout_side_by_side_enabled",
   release_layout_conversion_enabled: "release_layout_conversion_enabled",
   release_anvil_toggle_enabled: "release_anvil_toggle_enabled",
@@ -63,7 +61,6 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   license_gac_enabled: false,
   release_anvil_enabled: false,
   release_drag_drop_building_blocks_enabled: false,
-  release_table_cell_label_value_enabled: false,
   license_git_branch_protection_enabled: false,
   license_git_continuous_delivery_enabled: false,
   license_widget_rtl_support_enabled: false,

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
@@ -1,7 +1,5 @@
-import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
-import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import SelectComponent from "widgets/SelectWidget/component";
 import type { DropdownOption } from "widgets/SelectWidget/constants";
 import type { EditableCellActions } from "widgets/TableWidgetV2/constants";
@@ -196,25 +194,17 @@ export const SelectCell = (props: SelectProps) => {
     .map((d: DropdownOption) => d.value)
     .indexOf(value);
 
-  const releaseTableSelectCellLabelValue = useFeatureFlag(
-    FEATURE_FLAG.release_table_cell_label_value_enabled,
-  );
-
   const cellLabelValue = useMemo(() => {
-    if (releaseTableSelectCellLabelValue) {
-      if (!options.length) return value;
+    if (!options.length) return value;
 
-      const selectedOption = options.find(
-        (option) => option[TableSelectColumnOptionKeys.VALUE] === value,
-      );
+    const selectedOption = options.find(
+      (option) => option[TableSelectColumnOptionKeys.VALUE] === value,
+    );
 
-      return selectedOption
-        ? selectedOption[TableSelectColumnOptionKeys.LABEL]
-        : "";
-    } else {
-      return value;
-    }
-  }, [releaseTableSelectCellLabelValue, value, options]);
+    return selectedOption
+      ? selectedOption[TableSelectColumnOptionKeys.LABEL]
+      : "";
+  }, [value, options]);
 
   if (isEditable && isCellEditable && isCellEditMode) {
     return (


### PR DESCRIPTION
## Description
Removes the `release_table_cell_label_value_enabled` feature flag from the codebase.

This feature flag helped us launch the tables ability to show labels instead of values for select column types. It has been in production for over 2 months with no bug or unexpected behaviours reported, warranting a removal of the feature flag from the codebase.


Fixes #37109 

## Automation

/ok-to-test tags="@tag.Table, @tag.Sanity, @tag.Select"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11550654098>
> Commit: d225470d767c441c1b9e07d79e59e5f052339198
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11550654098&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table, @tag.Sanity, @tag.Select`
> Spec:
> <hr>Mon, 28 Oct 2024 09:57:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `SelectCell` component for improved label value determination.
  
- **Bug Fixes**
	- Removed unnecessary complexity related to feature flag checks, resulting in a more reliable display of cell labels.
  
- **Tests**
	- Updated test cases for table filtering and sorting functionalities, removing feature flag dependencies while maintaining core logic.
	- Enhanced test coverage for select column functionality, including dynamic bindings and server-side filtering checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->