### PR TITLE
chore: fix prop name in options control

### DIFF
--- a/app/client/src/components/propertyControls/OptionControl.tsx
+++ b/app/client/src/components/propertyControls/OptionControl.tsx
@@ -20,7 +20,7 @@ class OptionControl extends BaseControl<ControlProps> {
     options: SegmentedControlOption[],
     isUpdatedViaKeyboard = false,
   ) => {
-    this.updateProperty("options", options, isUpdatedViaKeyboard);
+    this.updateProperty(this.props.propertyName, options, isUpdatedViaKeyboard);
   };
 
   static getControlType() {


### PR DESCRIPTION
/ok-to-test tags="@tag.Widget"

The options control was using `options` as the property name for the options array even when thee prop name was not `options`. This was causing issues when the property name was different.

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11590623056>
> Commit: 1e16edb367a0bbbfb54db681cb34283f01724e0a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11590623056&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Wed, 30 Oct 2024 11:11:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `OptionControl` component to support dynamic property updates based on component props.

- **Bug Fixes**
	- Improved the handling of property updates, allowing for more flexible and accurate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->