### PR TITLE
chore: fix code style in markdown

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
@@ -95,12 +95,13 @@
     overflow: auto;
   }
 
-  code:not(pre [data-component="code"]) {
+  code:not([class*="language-"]) {
     padding-inline: var(--inner-spacing-1);
     background: var(--color-bg-neutral-subtle);
     color: var(--color-fg-negative);
     border-radius: var(--border-radius-elevation-3);
     word-break: break-word;
+    white-space: normal;
     outline: var(--border-width-1) solid var(--color-bg-neutral-soft);
   }
 

--- a/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
@@ -95,7 +95,7 @@
     overflow: auto;
   }
 
-  code:not(pre code) {
+  code:not(pre [data-component="code"]) {
     padding-inline: var(--inner-spacing-1);
     background: var(--color-bg-neutral-subtle);
     color: var(--color-fg-negative);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted CSS styles for the Markdown component to improve the display of inline code elements without specific programming language classes.
  
- **Style**
	- Enhanced specificity of styles for inline code snippets, ensuring consistent styling across different scenarios.
	- Added `white-space: normal;` to improve whitespace handling within code elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 67606f8ceef02db5ef6f82bfb5691d6272e3ef5d yet
> <hr>Wed, 30 Oct 2024 14:03:46 UTC
<!-- end of auto-generated comment: Cypress test results  -->
