### PR TITLE
klona fix

### DIFF
--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers";
 import type { DataTreeDiff } from "ee/workers/Evaluation/evaluationUtils";
 import type DataTreeEvaluator from "workers/common/DataTreeEvaluator";
+import { klona } from "klona/json";
 
 const getDefaultEvalResponse = (): EvalTreeResponseData => ({
   updates: "[]",
@@ -134,9 +135,10 @@ export const evaluateAndGenerateResponse = (
   );
 
   /** Make sure evalMetaUpdates is sanitized to prevent postMessage failure */
-  defaultResponse.evalMetaUpdates = JSON.parse(
-    JSON.stringify([...(metaUpdates || []), ...updateResponse.evalMetaUpdates]),
-  );
+  defaultResponse.evalMetaUpdates = klona([
+    ...(metaUpdates || []),
+    ...updateResponse.evalMetaUpdates,
+  ]);
 
   defaultResponse.staleMetaIds = updateResponse.staleMetaIds;
   defaultResponse.dependencies = dataTreeEvaluator.inverseDependencies;


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11595966535>
> Commit: a32d996fa5796b32b0a60ceaf527c9af269546bd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11595966535&attempt=4&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/BugTests/Moment_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Thu, 31 Oct 2024 03:17:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the efficiency and reliability of data handling for updates.
	- Enhanced the deep cloning process for `evalMetaUpdates`, replacing the previous JSON method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->