### PR TITLE
fix: use feature flags when hide form control

### DIFF
--- a/app/client/src/pages/Editor/FormControl.tsx
+++ b/app/client/src/pages/Editor/FormControl.tsx
@@ -31,6 +31,7 @@ import TemplateMenu from "PluginActionEditor/components/PluginActionForm/compone
 import { SQL_DATASOURCES } from "constants/QueryEditorConstants";
 import type { Datasource, DatasourceStructure } from "entities/Datasource";
 import { getCurrentEditingEnvironmentId } from "ee/selectors/environmentSelectors";
+import { selectFeatureFlags } from "ee/selectors/featureFlagsSelectors";
 
 export interface FormControlProps {
   config: ControlProps;
@@ -48,6 +49,7 @@ function FormControl(props: FormControlProps) {
 
   const dispatch = useDispatch();
   const currentEditingEnvId = useSelector(getCurrentEditingEnvironmentId);
+  const featureFlags = useSelector(selectFeatureFlags);
 
   // adding this to prevent excessive rerendering
   const [convertFormToRaw, setConvertFormToRaw] = useState(false);
@@ -60,7 +62,11 @@ function FormControl(props: FormControlProps) {
       .datasourceStorages[currentEditingEnvId];
   }
 
-  const hidden = isHidden(formValueForEvaluatingHiddenObj, props.config.hidden);
+  const hidden = isHidden(
+    formValueForEvaluatingHiddenObj,
+    props.config.hidden,
+    featureFlags,
+  );
   const configErrors: EvaluationError[] = useSelector(
     (state: AppState) =>
       getConfigErrors(state, {


### PR DESCRIPTION
## Description


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11596803399>
> Commit: 7f833e9e29b8df5023709f7238d2c9bccdde489c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11596803399&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 30 Oct 2024 16:28:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility logic in the FormControl component based on feature flags.
	- Improved configurability of the component's rendering based on application state.

- **Bug Fixes**
	- Updated memoization logic to prevent unnecessary re-renders when props remain unchanged.

- **Refactor**
	- Adjusted internal state management to incorporate feature flags for better performance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->