### PR TITLE
chore: generateDataTreeWidget Fix

### DIFF
--- a/app/client/src/entities/DataTree/dataTreeFactory.ts
+++ b/app/client/src/entities/DataTree/dataTreeFactory.ts
@@ -54,9 +54,6 @@ export class DataTreeFactory {
   }
 
   static widgets(
-    moduleInputs: ModuleInputSection[],
-    moduleInstances: Record<string, ModuleInstance> | null,
-    moduleInstanceEntities: unknown,
     widgets: CanvasWidgetsReduxState,
     widgetsMeta: MetaState,
     loadingEntities: LoadingEntitiesState,
@@ -64,6 +61,36 @@ export class DataTreeFactory {
     isMobile: boolean,
   ) {
     const widgetsSpan = startRootSpan("DataTreeFactory.widgets");
+
+    const dataTree: UnEvalTree = {};
+    const configTree: ConfigTree = {};
+
+    Object.values(widgets).forEach((widget) => {
+      const { configEntity, unEvalEntity } = generateDataTreeWidget(
+        widget,
+        widgetsMeta[widget.metaWidgetId || widget.widgetId],
+        loadingEntities,
+        layoutSystemType,
+        isMobile,
+      );
+
+      dataTree[widget.widgetName] = unEvalEntity;
+      configTree[widget.widgetName] = configEntity;
+    });
+
+    endSpan(widgetsSpan);
+
+    return { dataTree, configTree };
+  }
+
+  public static moduleComponents(
+    moduleInputs: ModuleInputSection[],
+    moduleInstances: Record<string, ModuleInstance> | null,
+    moduleInstanceEntities: unknown,
+  ) {
+    const moduleComponentsSpan = startRootSpan(
+      "DataTreeFactory.moduleComponents",
+    );
 
     const dataTree: UnEvalTree = {};
     const configTree: ConfigTree = {};
@@ -92,22 +119,12 @@ export class DataTreeFactory {
       });
     }
 
-    Object.values(widgets).forEach((widget) => {
-      const { configEntity, unEvalEntity } = generateDataTreeWidget(
-        widget,
-        widgetsMeta[widget.metaWidgetId || widget.widgetId],
-        loadingEntities,
-        layoutSystemType,
-        isMobile,
-      );
+    endSpan(moduleComponentsSpan);
 
-      dataTree[widget.widgetName] = unEvalEntity;
-      configTree[widget.widgetName] = configEntity;
-    });
-
-    endSpan(widgetsSpan);
-
-    return { dataTree, configTree };
+    return {
+      dataTree,
+      configTree,
+    };
   }
 
   static jsActions(jsActions: JSCollectionDataState) {

--- a/app/client/src/entities/DataTree/dataTreeFactory.ts
+++ b/app/client/src/entities/DataTree/dataTreeFactory.ts
@@ -1,88 +1,72 @@
 import { generateDataTreeAction } from "ee/entities/DataTree/dataTreeAction";
 import { generateDataTreeJSAction } from "ee/entities/DataTree/dataTreeJSAction";
 import { generateDataTreeWidget } from "entities/DataTree/dataTreeWidget";
-import log from "loglevel";
+import type { DependencyMap } from "utils/DynamicBindingUtils";
+
 import {
   ENTITY_TYPE,
   EvaluationSubstitutionType,
 } from "ee/entities/DataTree/types";
 import { generateDataTreeModuleInputs } from "ee/entities/DataTree/utils";
-import type {
-  DataTreeSeed,
-  AppsmithEntity,
-  EntityTypeValue,
-} from "ee/entities/DataTree/types";
-import type {
-  unEvalAndConfigTree,
-  ConfigTree,
-  UnEvalTree,
-} from "entities/DataTree/dataTreeTypes";
+import type { EntityTypeValue } from "ee/entities/DataTree/types";
+import type { ConfigTree, UnEvalTree } from "entities/DataTree/dataTreeTypes";
 import { isEmpty } from "lodash";
 import { generateModuleInstance } from "ee/entities/DataTree/dataTreeModuleInstance";
-import {
-  endSpan,
-  startNestedSpan,
-  startRootSpan,
-} from "UITelemetry/generateTraces";
+import { endSpan, startRootSpan } from "UITelemetry/generateTraces";
+
+import type { LayoutSystemTypes } from "layoutSystems/types";
+import type { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
+import type { MetaState } from "reducers/entityReducers/metaReducer";
+import type { LoadingEntitiesState } from "reducers/evaluationReducers/loadingEntitiesReducer";
+import type { MetaWidgetsReduxState } from "reducers/entityReducers/metaWidgetsReducer";
+import type { ActionDataState } from "ee/reducers/entityReducers/actionsReducer";
+import type { JSCollectionDataState } from "ee/reducers/entityReducers/jsActionsReducer";
+import type { ModuleInputSection } from "ee/constants/ModuleConstants";
+import type { ModuleInstance } from "ee/constants/ModuleInstanceConstants";
+
 export class DataTreeFactory {
-  static create({
-    actions,
-    appData,
-    editorConfigs,
-    isMobile,
-    jsActions,
-    layoutSystemType,
-    loadingEntities,
-    metaWidgets,
-    moduleInputs,
-    moduleInstanceEntities,
-    moduleInstances,
-    pluginDependencyConfig,
-    theme,
-    widgets,
-    widgetsMeta,
-  }: DataTreeSeed): unEvalAndConfigTree {
-    const dataTree: UnEvalTree = {};
-    const configTree: ConfigTree = {};
-    const start = performance.now();
-    const startActions = performance.now();
-    const rootSpan = startRootSpan("DataTreeFactory.create");
-    const actionsSpan = startNestedSpan("DataTreeFactory.actions", rootSpan);
+  static metaWidgets(
+    metaWidgets: MetaWidgetsReduxState,
+    widgetsMeta: MetaState,
+    loadingEntities: LoadingEntitiesState,
+  ) {
+    const widgetsSpan = startRootSpan("DataTreeFactory.metaWidgets");
 
-    actions.forEach((action) => {
-      const editorConfig = editorConfigs[action.config.pluginId];
-      const dependencyConfig = pluginDependencyConfig[action.config.pluginId];
-      const { configEntity, unEvalEntity } = generateDataTreeAction(
-        action,
-        editorConfig,
-        dependencyConfig,
-      );
+    const res = Object.values(metaWidgets).reduce(
+      (acc, widget) => {
+        const { configEntity, unEvalEntity } = generateDataTreeWidget(
+          widget,
+          widgetsMeta[widget.metaWidgetId || widget.widgetId],
+          loadingEntities,
+        );
 
-      dataTree[action.config.name] = unEvalEntity;
-      configTree[action.config.name] = configEntity;
-    });
-    const endActions = performance.now();
+        acc.dataTree[widget.widgetName] = unEvalEntity;
+        acc.configTree[widget.widgetName] = configEntity;
 
-    endSpan(actionsSpan);
-
-    const startJsActions = performance.now();
-    const jsActionsSpan = startNestedSpan(
-      "DataTreeFactory.jsActions",
-      rootSpan,
+        return acc;
+      },
+      { dataTree: {} as UnEvalTree, configTree: {} as ConfigTree },
     );
 
-    jsActions.forEach((js) => {
-      const { configEntity, unEvalEntity } = generateDataTreeJSAction(js);
+    endSpan(widgetsSpan);
 
-      dataTree[js.config.name] = unEvalEntity;
-      configTree[js.config.name] = configEntity;
-    });
-    const endJsActions = performance.now();
+    return res;
+  }
 
-    endSpan(jsActionsSpan);
+  static widgets(
+    moduleInputs: ModuleInputSection[],
+    moduleInstances: Record<string, ModuleInstance> | null,
+    moduleInstanceEntities: unknown,
+    widgets: CanvasWidgetsReduxState,
+    widgetsMeta: MetaState,
+    loadingEntities: LoadingEntitiesState,
+    layoutSystemType: LayoutSystemTypes,
+    isMobile: boolean,
+  ) {
+    const widgetsSpan = startRootSpan("DataTreeFactory.widgets");
 
-    const startWidgets = performance.now();
-    const widgetsSpan = startNestedSpan("DataTreeFactory.widgets", rootSpan);
+    const dataTree: UnEvalTree = {};
+    const configTree: ConfigTree = {};
 
     if (!isEmpty(moduleInputs)) {
       const { configEntity, unEvalEntity } =
@@ -121,53 +105,62 @@ export class DataTreeFactory {
       configTree[widget.widgetName] = configEntity;
     });
 
-    const endWidgets = performance.now();
-
     endSpan(widgetsSpan);
 
-    dataTree.appsmith = {
-      ...appData,
-      // combine both persistent and transient state with the transient state
-      // taking precedence in case the key is the same
-      store: appData.store,
-      theme,
-    } as AppsmithEntity;
-    (dataTree.appsmith as AppsmithEntity).ENTITY_TYPE = ENTITY_TYPE.APPSMITH;
+    return { dataTree, configTree };
+  }
 
-    const startMetaWidgets = performance.now();
-    const metaWidgetsSpan = startNestedSpan(
-      "DataTreeFactory.metaWidgets",
-      rootSpan,
+  static jsActions(jsActions: JSCollectionDataState) {
+    const actionsSpan = startRootSpan("DataTreeFactory.jsActions");
+
+    const res = jsActions.reduce(
+      (acc, js) => {
+        const { configEntity, unEvalEntity } = generateDataTreeJSAction(js);
+
+        acc.dataTree[js.config.name] = unEvalEntity;
+        acc.configTree[js.config.name] = configEntity;
+
+        return acc;
+      },
+      {
+        dataTree: {} as UnEvalTree,
+        configTree: {} as ConfigTree,
+      },
     );
 
-    Object.values(metaWidgets).forEach((widget) => {
-      const { configEntity, unEvalEntity } = generateDataTreeWidget(
-        widget,
-        widgetsMeta[widget.metaWidgetId || widget.widgetId],
-        loadingEntities,
-      );
+    endSpan(actionsSpan);
 
-      dataTree[widget.widgetName] = unEvalEntity;
-      configTree[widget.widgetName] = configEntity;
-    });
-    const endMetaWidgets = performance.now();
+    return res;
+  }
 
-    endSpan(metaWidgetsSpan);
-    endSpan(rootSpan);
+  public static actions(
+    actions: ActionDataState,
+    editorConfigs: Record<string, unknown[]>,
+    pluginDependencyConfig: Record<string, DependencyMap>,
+  ) {
+    const actionsSpan = startRootSpan("DataTreeFactory.actions");
 
-    const end = performance.now();
+    const res = actions.reduce(
+      (acc, action) => {
+        const editorConfig = editorConfigs[action.config.pluginId];
+        const dependencyConfig = pluginDependencyConfig[action.config.pluginId];
+        const { configEntity, unEvalEntity } = generateDataTreeAction(
+          action,
+          editorConfig,
+          dependencyConfig,
+        );
 
-    const out = {
-      total: end - start,
-      widgets: endWidgets - startWidgets,
-      actions: endActions - startActions,
-      jsActions: endJsActions - startJsActions,
-      metaWidgets: endMetaWidgets - startMetaWidgets,
-    };
+        acc.dataTree[action.config.name] = unEvalEntity;
+        acc.configTree[action.config.name] = configEntity;
 
-    log.debug("### Create unevalTree timing", out);
+        return acc;
+      },
+      { dataTree: {} as UnEvalTree, configTree: {} as ConfigTree },
+    );
 
-    return { unEvalTree: dataTree, configTree };
+    endSpan(actionsSpan);
+
+    return res;
   }
 }
 

--- a/app/client/src/entities/DataTree/dataTreeWidget.test.ts
+++ b/app/client/src/entities/DataTree/dataTreeWidget.test.ts
@@ -225,8 +225,6 @@ describe("generateDataTreeWidget", () => {
       parentColumnSpace: 0,
       parentRowSpace: 0,
       rightColumn: 0,
-      renderMode: RenderModes.CANVAS,
-      version: 0,
       topRow: 0,
       widgetId: "123",
       widgetName: "Input1",

--- a/app/client/src/entities/DataTree/dataTreeWidget.ts
+++ b/app/client/src/entities/DataTree/dataTreeWidget.ts
@@ -1,5 +1,5 @@
 import { getAllPathsFromPropertyConfig } from "entities/Widget/utils";
-import _, { get, isEmpty } from "lodash";
+import _, { get, isEmpty, omit } from "lodash";
 import memoize from "micro-memoize";
 import type { FlattenedWidgetProps } from "reducers/entityReducers/canvasWidgetsReducer";
 import type { DynamicPath } from "utils/DynamicBindingUtils";
@@ -21,6 +21,7 @@ import WidgetFactory from "WidgetProvider/factory";
 import { getComponentDimensions } from "layoutSystems/common/utils/ComponentSizeUtils";
 import type { LoadingEntitiesState } from "reducers/evaluationReducers/loadingEntitiesReducer";
 import { LayoutSystemTypes } from "layoutSystems/types";
+import { WIDGET_PROPS_TO_SKIP_FROM_EVAL } from "constants/WidgetConstants";
 
 /**
  *
@@ -176,13 +177,17 @@ export function getSetterConfig(
 // Widget changes only when dynamicBindingPathList changes.
 // Only meta properties change very often, for example typing in an input or selecting a table row.
 const generateDataTreeWidgetWithoutMeta = (
-  widget: FlattenedWidgetProps,
+  pureWidget: FlattenedWidgetProps,
 ): {
   dataTreeWidgetWithoutMetaProps: WidgetEntity;
   overridingMetaPropsMap: Record<string, boolean>;
   defaultMetaProps: Record<string, unknown>;
   entityConfig: WidgetEntityConfig;
 } => {
+  const widget = omit(
+    pureWidget,
+    Object.keys(WIDGET_PROPS_TO_SKIP_FROM_EVAL),
+  ) as FlattenedWidgetProps;
   // TODO: Fix this the next time the file is edited
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const derivedProps: any = {};

--- a/app/client/src/entities/Widget/utils.ts
+++ b/app/client/src/entities/Widget/utils.ts
@@ -367,6 +367,7 @@ const getAllPathsFromPropertyConfigWithoutMemo = (
 
 export const getAllPathsFromPropertyConfig = memoize(
   getAllPathsFromPropertyConfigWithoutMemo,
+
   { maxSize: 1000 },
 );
 

--- a/app/client/src/reducers/evaluationReducers/loadingEntitiesReducer.ts
+++ b/app/client/src/reducers/evaluationReducers/loadingEntitiesReducer.ts
@@ -1,6 +1,7 @@
 import { createReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "ee/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "ee/constants/ReduxActionConstants";
+import { isEqual } from "lodash";
 
 export type LoadingEntitiesState = Set<string>;
 
@@ -10,7 +11,16 @@ const loadingEntitiesReducer = createReducer(initialState, {
   [ReduxActionTypes.SET_LOADING_ENTITIES]: (
     state: LoadingEntitiesState,
     action: ReduxAction<Set<string>>,
-  ): LoadingEntitiesState => action.payload,
+  ): LoadingEntitiesState => {
+    const newLoadingEntities = action.payload;
+
+    // its just a set with string properties time complexity of equal is not too bad
+    if (isEqual(state, newLoadingEntities)) {
+      return state;
+    }
+
+    return newLoadingEntities;
+  },
   [ReduxActionTypes.FETCH_PAGE_INIT]: () => initialState,
 });
 

--- a/app/client/src/selectors/dataTreeSelectors.ts
+++ b/app/client/src/selectors/dataTreeSelectors.ts
@@ -21,7 +21,7 @@ import { DataTreeFactory } from "entities/DataTree/dataTreeFactory";
 import {
   getIsMobileBreakPoint,
   getMetaWidgets,
-  getWidgetsForEval,
+  getWidgets,
   getWidgetsMeta,
 } from "sagas/selectors";
 import "url-search-params-polyfill";
@@ -117,27 +117,43 @@ const getJSActionsFromUnevaluatedTree = createSelector(
     return DataTreeFactory.jsActions(jsActions);
   },
 );
-const getWidgetsFromUnevaluatedTree = createSelector(
+
+const getModuleComponentsFromUnEvaluatedTree = createSelector(
   getModulesData,
-  getWidgetsForEval,
+
+  (moduleData) => {
+    const { moduleInputs, moduleInstanceEntities, moduleInstances } =
+      moduleData;
+
+    return DataTreeFactory.moduleComponents(
+      moduleInputs,
+      moduleInstances,
+      moduleInstanceEntities,
+    );
+  },
+);
+
+const getWidgetsFromUnevaluatedTree = createSelector(
+  getModuleComponentsFromUnEvaluatedTree,
+  getWidgets,
   getWidgetsMeta,
   getLoadingEntities,
   getLayoutSystemPayload,
   (moduleData, widgets, widgetsMeta, loadingEntities, layoutSystemPayload) => {
-    const { moduleInputs, moduleInstanceEntities, moduleInstances } =
-      moduleData;
     const { isMobile, layoutSystemType } = layoutSystemPayload;
 
-    return DataTreeFactory.widgets(
-      moduleInputs,
-      moduleInstances,
-      moduleInstanceEntities,
+    const widgetsDataTree = DataTreeFactory.widgets(
       widgets,
       widgetsMeta,
       loadingEntities,
       layoutSystemType,
       isMobile,
     );
+
+    return {
+      configTree: { ...moduleData.configTree, ...widgetsDataTree.configTree },
+      dataTree: { ...moduleData.dataTree, ...widgetsDataTree.dataTree },
+    };
   },
 );
 const getMetaWidgetsFromUnevaluatedTree = createSelector(

--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
@@ -16,7 +16,6 @@ import {
 } from "./helpers";
 import type { DataTreeDiff } from "ee/workers/Evaluation/evaluationUtils";
 import type DataTreeEvaluator from "workers/common/DataTreeEvaluator";
-import { klona } from "klona/json";
 
 const getDefaultEvalResponse = (): EvalTreeResponseData => ({
   updates: "[]",
@@ -135,10 +134,9 @@ export const evaluateAndGenerateResponse = (
   );
 
   /** Make sure evalMetaUpdates is sanitized to prevent postMessage failure */
-  defaultResponse.evalMetaUpdates = klona([
-    ...(metaUpdates || []),
-    ...updateResponse.evalMetaUpdates,
-  ]);
+  defaultResponse.evalMetaUpdates = JSON.parse(
+    JSON.stringify([...(metaUpdates || []), ...updateResponse.evalMetaUpdates]),
+  );
 
   defaultResponse.staleMetaIds = updateResponse.staleMetaIds;
   defaultResponse.dependencies = dataTreeEvaluator.inverseDependencies;

--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers";
 import type { DataTreeDiff } from "ee/workers/Evaluation/evaluationUtils";
 import type DataTreeEvaluator from "workers/common/DataTreeEvaluator";
+import { klona } from "klona/json";
 
 const getDefaultEvalResponse = (): EvalTreeResponseData => ({
   updates: "[]",
@@ -134,9 +135,10 @@ export const evaluateAndGenerateResponse = (
   );
 
   /** Make sure evalMetaUpdates is sanitized to prevent postMessage failure */
-  defaultResponse.evalMetaUpdates = JSON.parse(
-    JSON.stringify([...(metaUpdates || []), ...updateResponse.evalMetaUpdates]),
-  );
+  defaultResponse.evalMetaUpdates = klona([
+    ...(metaUpdates || []),
+    ...updateResponse.evalMetaUpdates,
+  ]);
 
   defaultResponse.staleMetaIds = updateResponse.staleMetaIds;
   defaultResponse.dependencies = dataTreeEvaluator.inverseDependencies;


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11612013649>
> Commit: a247e1f33bac9b0db146944f965fb50df9bc60f8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11612013649&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_setters_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Autocomplete/PropertyPaneSuggestion_spec.ts
> <li>cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/OtherUIFeatures/ErrorMessages_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/CurrencyInput/CurrencyInputDynamicCurrencyCode_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/PhoneInput/PhoneInputDynamicValue_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/table_data_change_spec.ts
> <li>cypress/e2e/Regression/ServerSide/JsFunctionExecution/PlatformFn_spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Thu, 31 Oct 2024 17:56:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new static methods in the DataTreeFactory for enhanced data tree generation: `metaWidgets`, `widgets`, and `actions`.
	- Added several new selector functions for improved data retrieval and organization, including `getActionsFromUnevaluatedTree` and `getWidgetsFromUnevaluatedTree`.

- **Improvements**
	- Streamlined logic in existing selector functions for better clarity and maintainability.
	- Enhanced performance in the `getAllPathsFromPropertyConfig` function with memoization.
	- Updated test cases to reflect changes in widget generation logic, improving specificity in expected outputs.

- **Bug Fixes**
	- Improved state management in the loadingEntitiesReducer to prevent unnecessary updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->