### PR TITLE
ci: Removed port 22 from ted in ci-test

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -150,7 +150,7 @@ jobs:
           sudo /etc/init.d/ssh stop ;
           mkdir -p ~/git-server/keys
           ted_tag="${{inputs.ted_tag}}"
-          docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
+          docker run --name test-event-driver -d -p 5001:5001 -p 3306:3306 \
             -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
             "appsmith/test-event-driver:${ted_tag:-latest}"
           docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \


### PR DESCRIPTION
## Description
Removed port 22 from ted in ci-test

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/11625284598>
> Commit: 8edce8c7fd10a59321ae73a3d09eb6d401a29c0a
> Workflow: `PR Automation test suite`
> Tags: `@tag.Sanity`
> Spec: ``
> <hr>Fri, 01 Nov 2024 06:19:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified CI workflow by removing unnecessary SSH port exposure.
	- Enhanced caching mechanism for test run results.
	- Improved artifact management with better organization of logs and reports.
	- Streamlined handling of environment variables for Cypress tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->