### PR TITLE
chore: Add isModuleInstance property to EXECUTE_ACTION event

### DIFF
--- a/app/client/src/ce/sagas/analyticsSaga.ts
+++ b/app/client/src/ce/sagas/analyticsSaga.ts
@@ -6,12 +6,12 @@ import { getCurrentPageId } from "selectors/editorSelectors";
 import type { TriggerMeta } from "ee/sagas/ActionExecution/ActionExecutionSagas";
 import { isArray } from "lodash";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
-import { getAppMode, getJSCollection } from "ee/selectors/entitiesSelector";
+import { getAllJSCollections, getAppMode } from "ee/selectors/entitiesSelector";
 import type { AppState } from "ee/reducers";
 import { getWidget } from "sagas/selectors";
 import { getUserSource } from "ee/utils/AnalyticsUtil";
 import { getCurrentApplication } from "ee/selectors/applicationSelectors";
-import type { JSCollection } from "entities/JSCollection";
+import type { JSCollectionData } from "ee/reducers/entityReducers/jsActionsReducer";
 
 export interface UserAndAppDetails {
   pageId: string;
@@ -73,10 +73,12 @@ export function* logDynamicTriggerExecution({
   const widget: ReturnType<typeof getWidget> | undefined = yield select(
     (state: AppState) => getWidget(state, triggerMeta.source?.id || ""),
   );
-  const jsCollection: JSCollection | undefined = yield select(
-    getJSCollection,
-    triggerMeta?.source?.id || "",
+  const jsCollectionsData: JSCollectionData[] =
+    yield select(getAllJSCollections);
+  const jsCollectionData = (jsCollectionsData || []).find(
+    ({ config }) => config.id === triggerMeta?.source?.id || "",
   );
+  const jsCollection = jsCollectionData?.config;
 
   const dynamicPropertyPathList = widget?.dynamicPropertyPathList;
   const isJSToggled = !!dynamicPropertyPathList?.find(


### PR DESCRIPTION
## Description
Update 'EXECUTE_ACTION' event to include `isModuleInstance` property

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11658289069>
> Commit: 4e2d9a8cdfff06e9f588eb501e8295a7a1435871
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11658289069&attempt=3&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker2_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Mon, 04 Nov 2024 06:28:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced analytics logging for dynamic trigger executions, now capturing additional details such as `isModuleInstance`.
	- Improved retrieval of user and application details, including `instanceId` and `pageId`.

- **Bug Fixes**
	- Removed unnecessary conditional check in the logging function, streamlining event logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->