### PR TITLE
fix: replaced the stopwatch implementation with micrometer

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/constants/CommonConstants.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/constants/CommonConstants.java
@@ -35,4 +35,9 @@ public class CommonConstants {
 
     public static final String WIDGET_ID = "widgetId";
     public static final String PARENT_ID = "parentId";
+
+    public static final String GIT_SAVE_ARTIFACT = "git.saveArtifact";
+    public static final String TIME_TAKEN_TO_SAVE_ARTIFACT = "Time taken to save Artifact";
+    public static final String GIT_DESERIALIZE_ARTIFACT = "git.deserializeArtifact";
+    public static final String TIME_TAKEN_TO_DESERIALIZE_ARTIFACT = "Time taken to deserialize Artifact from Git repo";
 }


### PR DESCRIPTION
[Bug Issue](https://github.com/appsmithorg/appsmith/issues/32402)

**Description:** 
The stopwatch metrics are only being sent to logs, and we haven't been able to fully utilize them.
With Micrometer now handling our metrics collection, we can eliminate the stopwatch metrics in CommonGitFileUtils, as they no longer add value and are limited to log outputs.

