### PR TITLE
chore: shadow PR for external contribution #37106 [DO NOT MERGE]

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
@@ -35,6 +35,9 @@ public class DatasourceConfiguration implements AppsmithDomain {
     AuthenticationDTO authentication;
 
     @JsonView({Views.Public.class, FromRequest.class})
+    TlsConfiguration tlsConfiguration;
+
+    @JsonView({Views.Public.class, FromRequest.class})
     SSHConnection sshProxy;
 
     @JsonView({Views.Public.class, FromRequest.class})

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/TlsConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/TlsConfiguration.java
@@ -1,0 +1,36 @@
+package com.appsmith.external.models;
+
+import com.appsmith.external.views.FromRequest;
+import com.appsmith.external.views.Views;
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class TlsConfiguration {
+
+    @JsonView({Views.Public.class, FromRequest.class})
+    Boolean tlsEnabled;
+
+    @JsonView({Views.Public.class, FromRequest.class})
+    Boolean verifyTlsCertificate;
+
+    @JsonView({Views.Public.class, FromRequest.class})
+    UploadedFile caCertificateFile;
+
+    @JsonView({Views.Public.class, FromRequest.class})
+    Boolean requiresClientAuth;
+
+    @JsonView({Views.Public.class, FromRequest.class})
+    UploadedFile clientCertificateFile;
+
+    @JsonView({Views.Public.class, FromRequest.class})
+    UploadedFile clientKeyFile;
+}

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -10,6 +10,7 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.RequestParamDTO;
+import com.appsmith.external.models.TlsConfiguration;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.external.plugins.exceptions.RedisErrorMessages;
@@ -45,6 +46,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
+import static com.external.utils.RedisTLSManager.createJedisPoolWithTLS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Slf4j
@@ -261,9 +263,16 @@ public class RedisPlugin extends BasePlugin {
                         int timeout =
                                 (int) Duration.ofSeconds(CONNECTION_TIMEOUT).toMillis();
                         URI uri = RedisURIUtils.getURI(datasourceConfiguration);
-                        JedisPool jedisPool = new JedisPool(poolConfig, uri, timeout);
-                        log.debug(Thread.currentThread().getName() + ": Created Jedis pool.");
-                        return jedisPool;
+                        if (datasourceConfiguration.getTlsConfiguration() != null
+                                && !datasourceConfiguration
+                                        .getTlsConfiguration()
+                                        .getTlsEnabled()) {
+                            JedisPool jedisPool = new JedisPool(poolConfig, uri, timeout);
+                            log.debug(Thread.currentThread().getName() + ": Created Jedis pool.");
+                            return jedisPool;
+                        } else {
+                            return createJedisPoolWithTLS(poolConfig, uri, timeout, datasourceConfiguration);
+                        }
                     })
                     .subscribeOn(scheduler);
         }
@@ -299,6 +308,33 @@ public class RedisPlugin extends BasePlugin {
             DBAuth auth = (DBAuth) datasourceConfiguration.getAuthentication();
             if (isAuthenticationMissing(auth)) {
                 invalids.add(RedisErrorMessages.DS_MISSING_PASSWORD_ERROR_MSG);
+            }
+
+            TlsConfiguration tlsConfiguration = datasourceConfiguration.getTlsConfiguration();
+            if (tlsConfiguration != null && tlsConfiguration.getTlsEnabled()) {
+                // Check for CA certificate if TLS verification is enabled
+                if (tlsConfiguration.getVerifyTlsCertificate()
+                        && (tlsConfiguration.getCaCertificateFile() == null
+                                || StringUtils.isNullOrEmpty(
+                                        tlsConfiguration.getCaCertificateFile().getBase64Content()))) {
+                    invalids.add(RedisErrorMessages.CA_CERTIFICATE_MISSING_ERROR_MSG);
+                }
+
+                // Check for client certificate and key if client authentication is required
+                if (tlsConfiguration.getRequiresClientAuth()) {
+                    if (tlsConfiguration.getClientCertificateFile() == null
+                            || StringUtils.isNullOrEmpty(
+                                    tlsConfiguration.getClientCertificateFile().getBase64Content())) {
+                        invalids.add(
+                                RedisErrorMessages.TLS_CLIENT_AUTH_ENABLED_BUT_CLIENT_CERTIFICATE_MISSING_ERROR_MSG);
+                    }
+
+                    if (tlsConfiguration.getClientKeyFile() == null
+                            || StringUtils.isNullOrEmpty(
+                                    tlsConfiguration.getClientKeyFile().getBase64Content())) {
+                        invalids.add(RedisErrorMessages.TLS_CLIENT_AUTH_ENABLED_BUT_CLIENT_KEY_MISSING_ERROR_MSG);
+                    }
+                }
             }
 
             return invalids;

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -263,8 +263,8 @@ public class RedisPlugin extends BasePlugin {
                         int timeout =
                                 (int) Duration.ofSeconds(CONNECTION_TIMEOUT).toMillis();
                         URI uri = RedisURIUtils.getURI(datasourceConfiguration);
-                        if (datasourceConfiguration.getTlsConfiguration() != null
-                                && !datasourceConfiguration
+                        if (datasourceConfiguration.getTlsConfiguration() == null
+                                || !datasourceConfiguration
                                         .getTlsConfiguration()
                                         .getTlsEnabled()) {
                             JedisPool jedisPool = new JedisPool(poolConfig, uri, timeout);

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/exceptions/RedisErrorMessages.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/exceptions/RedisErrorMessages.java
@@ -29,4 +29,19 @@ public class RedisErrorMessages extends BasePluginErrorMessages {
 
     public static final String DS_MISSING_PASSWORD_ERROR_MSG =
             "Could not find password. Please edit the 'Password' field to provide the password.";
+
+    /*
+    ************************************************************************************************************************************************
+                                       Error messages related to TLS configuration.
+    ************************************************************************************************************************************************
+    */
+
+    public static final String CA_CERTIFICATE_MISSING_ERROR_MSG =
+            "CA certificate is missing. Please upload the CA certificate.";
+
+    public static final String TLS_CLIENT_AUTH_ENABLED_BUT_CLIENT_CERTIFICATE_MISSING_ERROR_MSG =
+            "Client authentication is enabled but the client certificate is missing. Please upload the client certificate.";
+
+    public static final String TLS_CLIENT_AUTH_ENABLED_BUT_CLIENT_KEY_MISSING_ERROR_MSG =
+            "Client authentication is enabled but the client key is missing. Please upload the client key.";
 }

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisTLSManager.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisTLSManager.java
@@ -1,0 +1,131 @@
+package com.external.utils;
+
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.TlsConfiguration;
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+@Slf4j
+public class RedisTLSManager {
+
+    public static JedisPool createJedisPoolWithTLS(
+            JedisPoolConfig poolConfig, URI uri, int timeout, DatasourceConfiguration datasourceConfiguration)
+            throws Exception {
+
+        TlsConfiguration tlsConfiguration = datasourceConfiguration.getTlsConfiguration();
+        if (tlsConfiguration == null) {
+            throw new IllegalArgumentException("TLS configuration is missing");
+        }
+        Boolean verifyTlsCertificate = tlsConfiguration.getVerifyTlsCertificate();
+        Boolean requiresClientAuth = tlsConfiguration.getRequiresClientAuth();
+        if (verifyTlsCertificate == null || requiresClientAuth == null) {
+            throw new IllegalArgumentException("TLS configuration flags cannot be null");
+        }
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        KeyManagerFactory keyManagerFactory = null;
+
+        // Handle client authentication if required, regardless of certificate verification
+        if (requiresClientAuth) {
+
+            CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+
+            // Load client certificate
+            String clientCertContent =
+                    new String(tlsConfiguration.getClientCertificateFile().getDecodedContent(), StandardCharsets.UTF_8);
+            X509Certificate clientCert = (X509Certificate)
+                    certificateFactory.generateCertificate(new ByteArrayInputStream(clientCertContent.getBytes()));
+
+            // Load client private key
+            String clientKey =
+                    new String(tlsConfiguration.getClientKeyFile().getDecodedContent(), StandardCharsets.UTF_8);
+            PrivateKey privateKey = loadPrivateKey(clientKey);
+
+            // KeyStore for client authentication
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, null);
+            keyStore.setKeyEntry("client-key", privateKey, null, new X509Certificate[] {clientCert});
+
+            keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(keyStore, null);
+        }
+
+        // Handle server certificate verification
+        TrustManager[] trustManagers;
+        if (verifyTlsCertificate) {
+
+            // CA certificate verification
+            String caCertContent =
+                    new String(tlsConfiguration.getCaCertificateFile().getDecodedContent(), StandardCharsets.UTF_8);
+
+            CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+            X509Certificate caCert = (X509Certificate)
+                    certificateFactory.generateCertificate(new ByteArrayInputStream(caCertContent.getBytes()));
+
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("ca-cert", caCert);
+
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+            trustManagers = trustManagerFactory.getTrustManagers();
+        } else {
+            trustManagers = new TrustManager[] {
+                new X509TrustManager() {
+                    @Override
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return new X509Certificate[0];
+                    }
+
+                    @Override
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+
+                    @Override
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+                }
+            };
+        }
+
+        // Initialize SSL context with appropriate managers
+        sslContext.init(
+                requiresClientAuth ? keyManagerFactory.getKeyManagers() : null, trustManagers, new SecureRandom());
+
+        SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+
+        // Create and return JedisPool with TLS
+        JedisPool jedisPool = new JedisPool(poolConfig, uri, timeout, sslSocketFactory, null, null);
+        log.debug(Thread.currentThread().getName() + ": Created Jedis pool with TLS.");
+        return jedisPool;
+    }
+
+    private static PrivateKey loadPrivateKey(String clientKey) throws Exception {
+        clientKey = clientKey
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+
+        byte[] keyBytes = Base64.getDecoder().decode(clientKey);
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        return kf.generatePrivate(spec);
+    }
+}

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
@@ -20,7 +20,8 @@ public class RedisURIUtils {
     public static URI getURI(DatasourceConfiguration datasourceConfiguration) throws URISyntaxException {
         StringBuilder builder = new StringBuilder();
 
-        if (datasourceConfiguration.getTlsConfiguration() != null
+        if (datasourceConfiguration != null
+                && datasourceConfiguration.getTlsConfiguration() != null
                 && datasourceConfiguration.getTlsConfiguration().getTlsEnabled()) {
             builder.append(REDIS_SSL_SCHEME);
             Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
@@ -13,9 +13,17 @@ public class RedisURIUtils {
     public static final Long DEFAULT_PORT = 6379L;
     private static final String REDIS_SCHEME = "redis://";
 
+    private static final String REDIS_SSL_SCHEME = "rediss://";
+
     public static URI getURI(DatasourceConfiguration datasourceConfiguration) throws URISyntaxException {
         StringBuilder builder = new StringBuilder();
-        builder.append(REDIS_SCHEME);
+
+        if (datasourceConfiguration.getTlsConfiguration() != null
+                && datasourceConfiguration.getTlsConfiguration().getTlsEnabled()) {
+            builder.append(REDIS_SSL_SCHEME);
+        } else {
+            builder.append(REDIS_SCHEME);
+        }
 
         String uriAuth = getUriAuth(datasourceConfiguration);
         builder.append(uriAuth);

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
@@ -24,9 +24,12 @@ public class RedisURIUtils {
                 && datasourceConfiguration.getTlsConfiguration() != null
                 && datasourceConfiguration.getTlsConfiguration().getTlsEnabled()) {
             builder.append(REDIS_SSL_SCHEME);
-            Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
-            if (endpoint.getPort() != null && endpoint.getPort() == DEFAULT_PORT) {
-                log.warn("Using default non-TLS port {} with TLS enabled", DEFAULT_PORT);
+            if (datasourceConfiguration.getEndpoints() != null
+                    && !datasourceConfiguration.getEndpoints().isEmpty()) {
+                Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
+                if (endpoint.getPort() != null && endpoint.getPort() == DEFAULT_PORT) {
+                    log.warn("Using default non-TLS port {} with TLS enabled", DEFAULT_PORT);
+                }
             }
         } else {
             builder.append(REDIS_SCHEME);

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
@@ -3,12 +3,14 @@ package com.external.utils;
 import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.ObjectUtils;
 import org.pf4j.util.StringUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
+@Slf4j
 public class RedisURIUtils {
     public static final Long DEFAULT_PORT = 6379L;
     private static final String REDIS_SCHEME = "redis://";
@@ -21,6 +23,10 @@ public class RedisURIUtils {
         if (datasourceConfiguration.getTlsConfiguration() != null
                 && datasourceConfiguration.getTlsConfiguration().getTlsEnabled()) {
             builder.append(REDIS_SSL_SCHEME);
+            Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
+            if (endpoint.getPort() != null && endpoint.getPort() == DEFAULT_PORT) {
+                log.warn("Using default non-TLS port {} with TLS enabled", DEFAULT_PORT);
+            }
         } else {
             builder.append(REDIS_SCHEME);
         }

--- a/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
@@ -58,6 +58,78 @@
           ]
         }
       ]
+    },
+    {
+      "sectionName": "TLS Configuration",
+      "id": 3,
+      "children": [
+        {
+          "sectionName": null,
+          "children": [
+            {
+              "label": "Enable TLS",
+              "configProperty": "datasourceConfiguration.tlsConfiguration.tlsEnabled",
+              "controlType": "CHECKBOX",
+              "initialValue": false
+            },
+            {
+              "label": "Verify TLS Certificate",
+              "configProperty": "datasourceConfiguration.tlsConfiguration.verifyTlsCertificate",
+              "controlType": "CHECKBOX",
+              "initialValue": false,
+              "hidden": {
+                "path": "datasourceConfiguration.tlsConfiguration.tlsEnabled",
+                "comparison": "NOT_EQUALS",
+                "value": true
+              }
+            },
+            {
+              "label": "Upload CA Certificate",
+              "configProperty": "datasourceConfiguration.tlsConfiguration.caCertificateFile",
+              "controlType": "FILE_PICKER",
+              "encrypted": true,
+              "hidden": {
+                "path": "datasourceConfiguration.tlsConfiguration.tlsEnabled",
+                "comparison": "NOT_EQUALS",
+                "value": true
+              }
+            },
+            {
+              "label": "Requires TLS Client Authentication",
+              "configProperty": "datasourceConfiguration.tlsConfiguration.requiresClientAuth",
+              "controlType": "CHECKBOX",
+              "initialValue": false,
+              "hidden": {
+                "path": "datasourceConfiguration.tlsConfiguration.tlsEnabled",
+                "comparison": "NOT_EQUALS",
+                "value": true
+              }
+            },
+            {
+              "label": "Upload Client Certificate",
+              "configProperty": "datasourceConfiguration.tlsConfiguration.clientCertificateFile",
+              "controlType": "FILE_PICKER",
+              "encrypted": true,
+              "hidden": {
+                "path": "datasourceConfiguration.tlsConfiguration.requiresClientAuth",
+                "comparison": "EQUALS",
+                "value": false
+              }
+            },
+            {
+              "label": "Upload Client Key",
+              "configProperty": "datasourceConfiguration.tlsConfiguration.clientKeyFile",
+              "controlType": "FILE_PICKER",
+              "encrypted": true,
+              "hidden": {
+                "path": "datasourceConfiguration.tlsConfiguration.requiresClientAuth",
+                "comparison": "EQUALS",
+                "value": false
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -77,7 +77,7 @@ public class RedisPluginTest {
         return new UploadedFile(fileName, base64Content);
     }
 
-    private TlsConfiguration addTLSConfiguration(DatasourceConfiguration datasourceConfiguration) {
+    private TlsConfiguration addTLSConfiguration() {
         TlsConfiguration tlsConfiguration = new TlsConfiguration();
         tlsConfiguration.setTlsEnabled(false);
         return tlsConfiguration;
@@ -91,7 +91,7 @@ public class RedisPluginTest {
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
         datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
-        datasourceConfiguration.setTlsConfiguration(addTLSConfiguration(datasourceConfiguration));
+        datasourceConfiguration.setTlsConfiguration(addTLSConfiguration());
         return datasourceConfiguration;
     }
 
@@ -134,7 +134,7 @@ public class RedisPluginTest {
     @Test
     public void itShouldValidateDatasourceWithNoEndpoints() {
         DatasourceConfiguration invalidDatasourceConfiguration = new DatasourceConfiguration();
-        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration(invalidDatasourceConfiguration));
+        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration());
 
         assertEquals(
                 Set.of(RedisErrorMessages.DS_MISSING_HOST_ADDRESS_ERROR_MSG),
@@ -147,7 +147,7 @@ public class RedisPluginTest {
 
         Endpoint endpoint = new Endpoint();
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
-        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration(invalidDatasourceConfiguration));
+        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration());
 
         assertEquals(
                 Set.of(RedisErrorMessages.DS_MISSING_HOST_ADDRESS_ERROR_MSG),
@@ -161,7 +161,7 @@ public class RedisPluginTest {
         Endpoint endpoint = new Endpoint();
         endpoint.setHost("test-host");
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
-        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration(invalidDatasourceConfiguration));
+        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration());
 
         // Since default port is picked, set of invalids should be empty.
         assertEquals(pluginExecutor.validateDatasource(invalidDatasourceConfiguration), Set.of());
@@ -178,7 +178,7 @@ public class RedisPluginTest {
         invalidAuth.setUsername("username"); // skip password
         invalidDatasourceConfiguration.setAuthentication(invalidAuth);
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
-        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration(invalidDatasourceConfiguration));
+        invalidDatasourceConfiguration.setTlsConfiguration(addTLSConfiguration());
 
         assertEquals(
                 Set.of(RedisErrorMessages.DS_MISSING_PASSWORD_ERROR_MSG),
@@ -199,7 +199,7 @@ public class RedisPluginTest {
         endpoint.setPort(Long.valueOf(port));
         datasourceConfiguration.setAuthentication(auth);
         datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
-        datasourceConfiguration.setTlsConfiguration(addTLSConfiguration(datasourceConfiguration));
+        datasourceConfiguration.setTlsConfiguration(addTLSConfiguration());
 
         assertTrue(pluginExecutor.validateDatasource(datasourceConfiguration).isEmpty());
     }


### PR DESCRIPTION
## Description
> Shadow PR for external contribution https://github.com/appsmithorg/appsmith/pull/37106
Corresponding EE PR: https://github.com/appsmithorg/appsmith-ee/pull/5487

Fixes #26723 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11905466063>
> Commit: 5eb3b2ed01e08f3407b941d7cf1c31746a07f315
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11905466063&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 19 Nov 2024 03:45:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced TLS configuration options in the Redis plugin, allowing users to enable TLS and manage certificate uploads for secure connections.
	- Added a new section in the Redis configuration form for TLS settings, including options for enabling TLS, verifying certificates, and uploading necessary files.

- **Bug Fixes**
	- Enhanced error handling for TLS configuration, providing clearer messages for missing certificates.

- **Tests**
	- Expanded test coverage for TLS-related scenarios, ensuring robust validation of TLS settings in the Redis plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->