### PR TITLE
fix: Using create action permission for schema generation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
@@ -183,7 +183,7 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
     public Mono<ActionExecutionResult> getSchemaPreviewData(
             String datasourceId, String environmentId, Template queryTemplate) {
         return datasourceService
-                .findById(datasourceId, datasourcePermission.getExecutePermission())
+                .findById(datasourceId, datasourcePermission.getActionCreatePermission())
                 .zipWhen(datasource -> datasourceService.getTrueEnvironmentId(
                         datasource.getWorkspaceId(),
                         environmentId,


### PR DESCRIPTION
Currently, schema generation uses execute permission on the datasource to execute open ended queries for schema generation. Limiting it to developers who have create action permission on the said datasource (and hence have been given rights to run any query on the said datasource) instead of execute datasource permission which is given to everyone.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11702166169>
> Commit: 8946b48ca8cf2ffbb1ce2350c8ecc3fc19fff739
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11702166169&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 06 Nov 2024 12:46:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated permission model for accessing datasource schema previews, enhancing security.
  
- **Bug Fixes**
	- Improved error handling for specific exceptions, providing clearer feedback during errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->