### PR TITLE
chore: Adding the logic to fetch datasource structure for schema tab, if empty

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/Schema.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/Schema.tsx
@@ -12,17 +12,22 @@ import {
   getIsFetchingDatasourceStructure,
   getPluginImages,
   getPluginIdFromDatasourceId,
+  getPluginDatasourceComponentFromId,
 } from "ee/selectors/entitiesSelector";
 import DatasourceField from "pages/Editor/DatasourceInfo/DatasourceField";
 import { find } from "lodash";
 import type { AppState } from "ee/reducers";
 import RenderInterimDataState from "pages/Editor/DatasourceInfo/RenderInterimDataState";
 import { getPluginActionDebuggerState } from "../../../store";
-import { refreshDatasourceStructure } from "actions/datasourceActions";
+import {
+  fetchDatasourceStructure,
+  refreshDatasourceStructure,
+} from "actions/datasourceActions";
 import history from "utils/history";
 import { datasourcesEditorIdURL } from "ee/RouteBuilder";
 import { EntityIcon } from "pages/Editor/Explorer/ExplorerIcons";
 import { getAssetUrl } from "ee/utils/airgapHelpers";
+import { DatasourceComponentTypes } from "api/PluginApi";
 
 interface Props {
   datasourceId: string;
@@ -65,9 +70,30 @@ const Schema = (props: Props) => {
     getIsFetchingDatasourceStructure(state, props.datasourceId),
   );
 
+  const pluginDatasourceForm = useSelector((state) =>
+    getPluginDatasourceComponentFromId(state, pluginId || ""),
+  );
+
   useEffect(() => {
     setSelectedTable(undefined);
   }, [props.datasourceId]);
+
+  useEffect(() => {
+    if (
+      props.datasourceId &&
+      datasourceStructure === undefined &&
+      pluginDatasourceForm !== DatasourceComponentTypes.RestAPIDatasourceForm
+    ) {
+      dispatch(
+        fetchDatasourceStructure(
+          props.datasourceId,
+          true,
+          DatasourceStructureContext.QUERY_EDITOR,
+        ),
+      );
+    }
+  }, [props.datasourceId, datasourceStructure, dispatch, pluginDatasourceForm]);
+
   useEffect(() => {
     if (!selectedTable && datasourceStructure?.tables?.length && !isLoading) {
       setSelectedTable(datasourceStructure.tables[0].name);


### PR DESCRIPTION
## Description

Adding the logic to fetch datasource structure for schema tab, if empty

Fixes [#37247](https://github.com/appsmithorg/appsmith/issues/37247)

## Automation

/ok-to-test tags="@tag.Sanity, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11702661925>
> Commit: 7045b99d3133650f78fed890bc61c3797fe819d0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11702661925&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.IDE`
> Spec:
> <hr>Wed, 06 Nov 2024 12:13:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data-fetching logic for plugin datasource components.
	- Introduced a new selector to retrieve plugin datasource components by ID.
- **Improvements**
	- Refined conditions for fetching datasource structure, improving performance and reliability.
	- Maintained consistent user interface while updating backend logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->