### PR TITLE
feat: add unmount field validation logic to JSON form widget (#37220)

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/fields/FieldRenderer.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/FieldRenderer.tsx
@@ -5,6 +5,7 @@ import { useFormContext } from "react-hook-form";
 import FormContext from "../FormContext";
 import type { SchemaItem } from "../constants";
 import { FIELD_MAP } from "../constants";
+import useUnmountFieldValidation from "./useUnmountFieldValidation";
 
 interface FieldRendererProps {
   fieldName: ControllerRenderProps["name"];
@@ -30,6 +31,7 @@ function FieldRenderer({
 
   const FieldComponent = FIELD_MAP[fieldType];
 
+  useUnmountFieldValidation({ fieldName });
   useEffect(() => {
     /**
      * When a component is hidden, the field is removed from the form and the component unmounts.


### PR DESCRIPTION
## Description
<ins>Problem</ins>

When deleting all fields of array item, submit became disabled.

<ins>Root cause</ins>

The JSON form widget did not properly handle field validation during unmounting of array items, leading to inconsistencies in the form's error state.

<ins>Solution</ins>

This PR implements `useUnmountFieldValidation` to `FieldRenderer.tsx`, enhancing field validation for array items in the JSON form widget. This PR handles... 

- Ensuring proper cleanup of field validation when an array field is removed from the form, resolving visibility issues in list view mode.
- Maintaining a consistent and accurate form state even after field removal.


Fixes #18752
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JSONForm"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11703351095>
> Commit: 521fd25a83c099ddcc0273cf11b4cca80074c7a5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11703351095&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JSONForm`
> Spec:
> <hr>Wed, 06 Nov 2024 12:45:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new mechanism for handling field validation upon unmounting in the form widget.
  
- **Bug Fixes**
	- Improved field validation logic to enhance form data management during component unmounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->