### PR TITLE
fix: False positive report GHSA-2jcg-qqmg-46q6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,24 @@ COPY ./app/client/packages/rts/dist rts/
 
 ENV PATH /opt/bin:/opt/appsmith/utils/node_modules/.bin:/opt/java/bin:/opt/node/bin:$PATH
 
-RUN cd ./utils && npm install --only=prod && npm install --only=prod -g . && cd - \
-  && chmod +x /opt/bin/* *.sh /watchtower-hooks/*.sh \
+RUN <<END
+  set -o errexit
+
+  cd ./utils
+  npm install --only=prod
+  npm install --only=prod -g .
+  rm -rf utils/node_modules/resolve/test
+  cd -
+
+  chmod +x /opt/bin/* *.sh /watchtower-hooks/*.sh
+
   # Disable setuid/setgid bits for the files inside container.
-  && find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true \
-  && mkdir -p /.mongodb/mongosh /appsmith-stacks \
-  && chmod ugo+w /etc /appsmith-stacks \
-  && chmod -R ugo+w /var/run /.mongodb /etc/ssl /usr/local/share
+  find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -exec chmod -s '{}' + \) || true
+
+  mkdir -p /.mongodb/mongosh /appsmith-stacks
+  chmod ugo+w /etc /appsmith-stacks
+  chmod -R ugo+w /var/run /.mongodb /etc/ssl /usr/local/share
+END
 
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-check=/watchtower-hooks/pre-check.sh
 LABEL com.centurylinklabs.watchtower.lifecycle.pre-update=/watchtower-hooks/pre-update.sh


### PR DESCRIPTION
## Description

Some scanner tools like Syft and Grype are reporting a **scary** false positive at GHSA-2jcg-qqmg-46q6, on the following file in the Docker image:

```
/opt/appsmith/utils/node_modules/resolve/test/resolver/multirepo/package.json
```

The advisory itself isn't applicable to Appsmith, and this above package is not used in the product at all. This PR deletes this `test` folder so this false positive is immediately taken out.

Nevertheless, we shouldn't even have the `node_modules` folder in the Docker image, and we should be "building" `appsmithctl` instead. That's part of a larger effort to improve/fix `appsmithctl` and will be coming up in future PRs.

<details><summary><b>The SBOM entry for the package in Syft’s proprietary format</b></summary>
<pre>
{
    "id": "8686a02f6819d5a1",
    "name": "monorepo-symlink-test",
    "version": "0.0.0",
    "type": "npm",
    "foundBy": "javascript-package-cataloger",
    "locations": [
        {
            "path": "/opt/appsmith/utils/node_modules/resolve/test/resolver/multirepo/package.json",
            "layerID": "sha256:02e68fb671fe8bc43f75862b43445160e17e3ec2f13f09bf346a65c66cd93557",
            "accessPath": "/opt/appsmith/utils/node_modules/resolve/test/resolver/multirepo/package.json",
            "annotations": {
                "evidence": "primary"
            }
        }
    ],
    "licenses": [
        {
            "value": "MIT",
            "spdxExpression": "MIT",
            "type": "declared",
            "urls": [],
            "locations": [
                {
                    "path": "/opt/appsmith/utils/node_modules/resolve/test/resolver/multirepo/package.json",
                    "layerID": "sha256:02e68fb671fe8bc43f75862b43445160e17e3ec2f13f09bf346a65c66cd93557",
                    "accessPath": "/opt/appsmith/utils/node_modules/resolve/test/resolver/multirepo/package.json",
                    "annotations": {
                        "evidence": "primary"
                    }
                }
            ]
        }
    ],
    "language": "javascript",
    "cpes": [
        {
            "cpe": "cpe:2.3:a:monorepo-symlink-test:monorepo-symlink-test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo-symlink-test:monorepo_symlink_test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo_symlink_test:monorepo-symlink-test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo_symlink_test:monorepo_symlink_test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo-symlink:monorepo-symlink-test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo-symlink:monorepo_symlink_test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo_symlink:monorepo-symlink-test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo_symlink:monorepo_symlink_test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo:monorepo-symlink-test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        },
        {
            "cpe": "cpe:2.3:a:monorepo:monorepo_symlink_test:0.0.0:*:*:*:*:*:*:*",
            "source": "syft-generated"
        }
    ],
    "purl": "pkg:npm/monorepo-symlink-test@0.0.0",
    "metadataType": "javascript-npm-package",
    "metadata": {
        "name": "monorepo-symlink-test",
        "version": "0.0.0",
        "author": "",
        "homepage": "",
        "description": "",
        "url": "",
        "private": true
    }
}
</pre>
</details>

Reported by a user.

⚠️ There will be conflicts on sync. Please do not merge unless the author of PR is available.

/test sanity

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11715737322>
> Commit: 42aa69c3de26d105a4184164f2ac9d18adce9b88
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11715737322&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 07 Nov 2024 03:26:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the Dockerfile for improved build process and error handling.
	- Streamlined npm package installation and organized script execution for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->