### PR TITLE
chore: Fix condition syntax in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,11 @@ RUN <<END
   rm -rf utils/node_modules/resolve/test
   cd -
 
-  # Ensure all *.sh scripts are executable.
-  find . -name node_modules -prune -or -type f -name '*.sh' -print -exec chmod +x '{}' ';'
+  # Make all `*.sh` files executable, excliding `node_modules`.
+  find . \( -name node_modules -prune \) -o \( -type f -name '*.sh' \) -exec chmod +x '{}' +
 
   # Ensure all custom command-scripts have executable permission
-  chmod +x /opt/bin/* *.sh /watchtower-hooks/*.sh
+  chmod +x /opt/bin/* /watchtower-hooks/*.sh
 
   # Disable setuid/setgid bits for the files inside container.
   find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -exec chmod -s '{}' + \) || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,18 +17,10 @@ RUN <<END
     exit 1
   fi
 
-  if ! [ -f server/mongo/server.jar && -f server/pg/server.jar ]; then
+  if ! [ -f server/mongo/server.jar -a -f server/pg/server.jar ]; then
     echo "Missing one or both server.jar files in the right place. Are you using the build script?" >&2
     exit 1
   fi
-
-  mkdir -p ./editor ./rts
-
-  # Ensure all *.sh scripts are executable.
-  find . -name node_modules -prune -or -type f -name '*.sh' -print -exec chmod +x '{}' ';'
-
-  # Ensure all custom command-scripts have executable permission
-  chmod +x /opt/bin/*
 END
 
 # Add client UI - Application Layer
@@ -48,6 +40,10 @@ RUN <<END
   rm -rf utils/node_modules/resolve/test
   cd -
 
+  # Ensure all *.sh scripts are executable.
+  find . -name node_modules -prune -or -type f -name '*.sh' -print -exec chmod +x '{}' ';'
+
+  # Ensure all custom command-scripts have executable permission
   chmod +x /opt/bin/* *.sh /watchtower-hooks/*.sh
 
   # Disable setuid/setgid bits for the files inside container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN <<END
   rm -rf utils/node_modules/resolve/test
   cd -
 
-  # Make all `*.sh` files executable, excliding `node_modules`.
+  # Make all `*.sh` files executable, excluding `node_modules`.
   find . \( -name node_modules -prune \) -o \( -type f -name '*.sh' \) -exec chmod +x '{}' +
 
   # Ensure all custom command-scripts have executable permission


### PR DESCRIPTION
## Description

The `&&` syntax for `and`-ing conditions doesn't work with `[` **command**, it only works with `[[` **expressions**. But we can't use `[[` expressions, since this isn't bash, it's `/bin/sh`. We can't use bash, since doing so is throwing up a whole lot of other errors that I've parked for another day, several months ago.

Instead of `&&`, we have to use `-a` when using the `[` command.

Currently, when building the Docker image, we see the following error:

```
#8 [3/6] RUN <<END (if ! [ -f info.json ]; then...)
#8 0.142 /bin/sh: 6: [: missing ]
#8 0.142 /bin/sh: 6: -f: not found
```

It doesn't seem to have an impact, but it _is_ an error nonetheless.

We're also refactoring to not add the executable permission twice, which is redundant. We're only doing it once now.

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11718707642>
> Commit: 6c739439fa181f41245294a46321544edf61e878
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11718707642&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 07 Nov 2024 09:18:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

/test sanity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated the Dockerfile to enhance file existence checks and manage executable permissions for shell scripts.
	- Removed unnecessary directory creation commands for `./editor` and `./rts`.
	- Maintained existing structure, including exposed ports and health check commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->