### PR TITLE
fix: Support `NO_PROXY` for RTS-Temporal connection

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -25,6 +25,13 @@ setup_proxy_variables() {
     export NO_PROXY="127.0.0.1,$NO_PROXY"
   fi
 
+  # If one of NO_PROXY or no_proxy are set, copy it to the other. If both are set, prefer NO_PROXY.
+  if [[ -n ${NO_PROXY-} ]]; then
+    export no_proxy="$NO_PROXY"
+  elif [[ -n ${no_proxy-} ]]; then
+    export NO_PROXY="$no_proxy"
+  fi
+
   # If one of HTTPS_PROXY or https_proxy are set, copy it to the other. If both are set, prefer HTTPS_PROXY.
   if [[ -n ${HTTPS_PROXY-} ]]; then
     export https_proxy="$HTTPS_PROXY"


### PR DESCRIPTION
The Temporal connection SDK used in RTS, uses GRPC to talk to the Temporal server. The GRPC library being used only respects the lowercase proxy env variables (`http_proxy`, `https_proxy` and `no_proxy`), and not the uppercase ones. They have an [open issue asking for this since 2020](https://github.com/grpc/grpc-node/issues/1292).

However, in our `entrypoint.sh`, we normalize `http_proxy` and `HTTP_PROXY`, similarly for `https_proxy` and `HTTPS_PROXY`. But we're not doing this normalization for `no_proxy` and `NO_PROXY`.

This PR fixes this by doing the same normalization to `no_proxy`.

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11737259912>
> Commit: 310fa2c85ac45b4f9a9bc5ce63b1c54839192306
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11737259912&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 08 Nov 2024 07:00:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of proxy environment variables for enhanced configuration consistency.
  
- **Bug Fixes**
	- Ensured `localhost` and `127.0.0.1` are always included in the `NO_PROXY` variable for better connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->