### PR TITLE
Git Locker issue while discard and pull is fixed

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
@@ -1293,6 +1293,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                             AppsmithError.GIT_UPSTREAM_CHANGES.getErrorType(),
                             AppsmithError.GIT_UPSTREAM_CHANGES.getMessage(),
                             gitMetadata.getIsRepoPrivate())
+                    .then(releaseFileLock(artifact.getGitArtifactMetadata().getDefaultArtifactId()))
                     .flatMap(application1 -> Mono.error(new AppsmithException(AppsmithError.GIT_UPSTREAM_CHANGES)));
         } else if (pushResult.contains("REJECTED_OTHERREASON") || pushResult.contains("pre-receive hook declined")) {
 


### PR DESCRIPTION
## Description
When there are uncommitted changes in a Git-connected app, and the user attempts to pull upstream changes, a "Git lock" error appears. This prevents the user from discarding or pulling changes, causing workflow disruptions.

**Steps to Reproduce:**
Create a git connected app
Create a page and let it stay as an uncommitted change
Make some changes to the application via the remote repo
Try to commit the uncommitted changes from step 2
Notice that git lock error is seen on any discard/pull actions subsequently

**Updated Steps to Reproduce:**
Create a Git-connected app.
Create a new branch from the main branch.
Create a page with uncommitted changes.
Make additional changes to the app in the remote repository on the same branch.
Attempt to commit the uncommitted changes from Step 3.
Notice the Git lock error when trying to discard or pull changes.

**Root Cause Analysis:**
The issue occurs when a commit command attempts to acquire a lock on the file system, which it then saves to Redis using baseArtifactId/baseAppId as the key.
The lock has a duration of 3 minutes with 20 retries and a 1-second interval between retries.
The commit command obtains this lock before the discard action is attempted. If the user quickly tries to discard, the lock remains active, and they must wait up to 3 minutes for it to be released.

**Solution**
 Call releaseFileLock() from CommonGitServiceCEImpl.java before throwing the GIT_UPSTREAM_CHANGES error.
```
`if (pushResult.contains("REJECTED_NONFASTFORWARD")) {
            return addAnalyticsForGitOperation(
                            AnalyticsEvents.GIT_PUSH,
                            artifact,
                            AppsmithError.GIT_UPSTREAM_CHANGES.getErrorType(),
                            AppsmithError.GIT_UPSTREAM_CHANGES.getMessage(),
                            gitMetadata.getIsRepoPrivate())
                   @ .then(releaseFileLock(artifact.getGitArtifactMetadata().getDefaultArtifactId()))
                    .flatMap(application1 -> Mono.error(new AppsmithException(AppsmithError.GIT_UPSTREAM_CHANGES)));`
```




Fixes #36781

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for retrieving Git documentation URLs and managing branches.
	- Enhanced branch management capabilities with improved conflict resolution.

- **Bug Fixes**
	- Improved error handling for Git operations, including detailed messages for failures.

- **Analytics**
	- Expanded analytics integration for monitoring branch protection changes and Git operations.

- **Refactor**
	- Refactored methods for better readability and maintainability, particularly in artifact import processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->