### PR TITLE
chore: Support configurable timeout for reading request body

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -35,6 +35,9 @@ if (CUSTOM_DOMAIN !== "") {
 
 }
 
+// If timeout env variable is not set
+const readBodyTimeoutSeconds = Math.max(parseInt(process.env.APPSMITH_SERVER_TIMEOUT ?? "600", 10), 10)
+
 const frameAncestorsPolicy = (process.env.APPSMITH_ALLOWED_FRAME_ANCESTORS || "'self'")
   .replace(/;.*$/, "")
 
@@ -49,6 +52,10 @@ parts.push(`
   servers {
     trusted_proxies static 0.0.0.0/0
     metrics
+    timeouts {
+      read_body ${readBodyTimeoutSeconds}s
+      read_header 5s
+    }
   }
   ${isRateLimitingEnabled ? "order rate_limit before basicauth" : ""}
 }


### PR DESCRIPTION
The `APPSMITH_SERVER_TIMEOUT` env variable is not being used anywhere in the code today. This PR implements this env variable, by setting it to Caddy's `read_body` timeout. It defaults to 600s (10mins), and can't be set to below 10s.

We're also setting a timeout for reading request headers to 5s, since the default Caddy timeout is _no timeout_ at all. It shouldn't be longer than 5s to read the headers, in normal operations.

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11772289083>
> Commit: 2440c0995868fc2c56d0bcb4c8a9b900290ae279
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11772289083&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 11 Nov 2024 05:16:13 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
