### PR TITLE
fix: Analytics identify user not called correctly

### DIFF
--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -189,17 +189,15 @@ export function* getCurrentUserSaga(action?: {
   }
 }
 
-function* init(currentUser: User) {
+function* initTrackers(currentUser: User) {
   const initializeSentry = initializeAnalyticsAndTrackers(currentUser);
 
-  if (initializeSentry instanceof Promise) {
-    const sentryInialized: boolean = yield initializeSentry;
+  const sentryInitialized: boolean = yield initializeSentry;
 
-    if (sentryInialized) {
-      yield put(segmentInitSuccess());
-    } else {
-      yield put(segmentInitUncertain());
-    }
+  if (sentryInitialized) {
+    yield put(segmentInitSuccess());
+  } else {
+    yield put(segmentInitUncertain());
   }
 }
 
@@ -209,7 +207,7 @@ export function* runUserSideEffectsSaga() {
   const isAirgappedInstance = isAirgapped();
 
   if (enableTelemetry) {
-    yield fork(init, currentUser);
+    yield fork(initTrackers, currentUser);
   }
 
   const isFFFetched: boolean = yield select(getFeatureFlagsFetched);

--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -43,7 +43,6 @@ import {
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import { INVITE_USERS_TO_WORKSPACE_FORM } from "ee/constants/forms";
 import type { User } from "constants/userConstants";
-import { ANONYMOUS_USERNAME } from "constants/userConstants";
 import {
   flushErrorsAndRedirect,
   safeCrashAppRequest,
@@ -190,9 +189,17 @@ export function* getCurrentUserSaga(action?: {
   }
 }
 
-function* intializeSmartLook(currentUser: User) {
-  if (!currentUser.isAnonymous && currentUser.username !== ANONYMOUS_USERNAME) {
-    yield AnalyticsUtil.identifyUser(currentUser);
+function* init(currentUser: User) {
+  const initializeSentry = initializeAnalyticsAndTrackers(currentUser);
+
+  if (initializeSentry instanceof Promise) {
+    const sentryInialized: boolean = yield initializeSentry;
+
+    if (sentryInialized) {
+      yield put(segmentInitSuccess());
+    } else {
+      yield put(segmentInitUncertain());
+    }
   }
 }
 
@@ -202,20 +209,7 @@ export function* runUserSideEffectsSaga() {
   const isAirgappedInstance = isAirgapped();
 
   if (enableTelemetry) {
-    // parallelize sentry and smart look initialization
-
-    yield fork(intializeSmartLook, currentUser);
-    const initializeSentry = initializeAnalyticsAndTrackers();
-
-    if (initializeSentry instanceof Promise) {
-      const sentryInialized: boolean = yield initializeSentry;
-
-      if (sentryInialized) {
-        yield put(segmentInitSuccess());
-      } else {
-        yield put(segmentInitUncertain());
-      }
-    }
+    yield fork(init, currentUser);
   }
 
   const isFFFetched: boolean = yield select(getFeatureFlagsFetched);

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -13,8 +13,10 @@ import type { JSCollectionData } from "ee/reducers/entityReducers/jsActionsReduc
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import type { CreateNewActionKeyInterface } from "ee/entities/Engine/actionHelpers";
 import { CreateNewActionKey } from "ee/entities/Engine/actionHelpers";
+import { ANONYMOUS_USERNAME } from "../constants/userConstants";
+import type { User } from "constants/userConstants";
 
-export const initializeAnalyticsAndTrackers = async () => {
+export const initializeAnalyticsAndTrackers = async (currentUser: User) => {
   const appsmithConfigs = getAppsmithConfigs();
 
   try {
@@ -105,6 +107,10 @@ export const initializeAnalyticsAndTrackers = async () => {
   } catch (e) {
     Sentry.captureException(e);
     log.error(e);
+  }
+
+  if (!currentUser.isAnonymous && currentUser.username !== ANONYMOUS_USERNAME) {
+    await AnalyticsUtil.identifyUser(currentUser);
   }
 };
 


### PR DESCRIPTION
## Description

Update the call sequence during init to solve for analytics issue. It was found that the `identifyUser` in analytics was not called properly when in edit mode. This change will fix the call sequence. It also ensures that the init of analytics is not a blocker by forking out the call into a different generator function

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11742239861>
> Commit: 984e325a14e8c4f9d3a0ac87d31365728b37785e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11742239861&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 08 Nov 2024 13:16:33 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced analytics tracking capabilities by integrating user identification into the analytics setup process.
	- Simplified the initialization of analytics trackers for improved performance.

- **Bug Fixes**
	- Improved error handling for analytics initialization and user tracking.

- **Documentation**
	- Updated comments for clarity regarding the new analytics tracking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->