### PR TITLE
fix: SMTP datasource should work without username and password

### DIFF
--- a/app/server/appsmith-plugins/smtpPlugin/src/main/java/com/external/plugins/SmtpPlugin.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/main/java/com/external/plugins/SmtpPlugin.java
@@ -214,8 +214,9 @@ public class SmtpPlugin extends BasePlugin {
 
             Session session;
 
-            if (authentication != null && StringUtils.hasText(authentication.getUsername())
-                && StringUtils.hasText(authentication.getPassword())) {
+            if (authentication != null
+                    && StringUtils.hasText(authentication.getUsername())
+                    && StringUtils.hasText(authentication.getPassword())) {
 
                 String username = authentication.getUsername();
                 String password = authentication.getPassword();

--- a/app/server/appsmith-plugins/smtpPlugin/src/main/java/com/external/plugins/SmtpPlugin.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/main/java/com/external/plugins/SmtpPlugin.java
@@ -257,14 +257,6 @@ public class SmtpPlugin extends BasePlugin {
                     invalids.add(SMTPErrorMessages.DS_MISSING_HOST_ADDRESS_ERROR_MSG);
                 }
             }
-
-            DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
-            if (authentication == null
-                    || !StringUtils.hasText(authentication.getUsername())
-                    || !StringUtils.hasText(authentication.getPassword())) {
-                invalids.add(new AppsmithPluginException(AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR).getMessage());
-            }
-
             return invalids;
         }
 
@@ -273,9 +265,6 @@ public class SmtpPlugin extends BasePlugin {
             log.debug(Thread.currentThread().getName() + ": testDatasource() called for SMTP plugin.");
             return Mono.fromCallable(() -> {
                         Set<String> invalids = new HashSet<>();
-
-                        boolean isAuthRequired = connection.getProperty("mail.smtp.auth") != null
-                            && connection.getProperty("mail.smtp.auth").equals("true");
 
                         try {
                             Transport transport = connection.getTransport();
@@ -286,9 +275,7 @@ public class SmtpPlugin extends BasePlugin {
                         } catch (NoSuchProviderException e) {
                             invalids.add(SMTPErrorMessages.DS_NO_SUCH_PROVIDER_ERROR_MSG);
                         } catch (AuthenticationFailedException e) {
-                            if (isAuthRequired) {
-                                invalids.add(SMTPErrorMessages.DS_AUTHENTICATION_FAILED_ERROR_MSG);
-                            }
+                            invalids.add(SMTPErrorMessages.DS_AUTHENTICATION_FAILED_ERROR_MSG);
                         } catch (MessagingException e) {
                             log.error(e.getMessage());
                             invalids.add(SMTPErrorMessages.DS_CONNECTION_FAILED_TO_SMTP_SERVER_ERROR_MSG);

--- a/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
@@ -27,10 +27,18 @@ import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.util.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;

--- a/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
@@ -27,18 +27,17 @@ import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-
-import java.util.List;
-import java.util.Map;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -60,16 +59,17 @@ public class SmtpPluginTest {
                     + password + " -s 25");
 
     @Container
-    public static final GenericContainer smtpWithoutAuth = new GenericContainer(DockerImageName.parse("maildev/maildev"))
-        .withExposedPorts(1025)
-        .withCommand("bin/maildev --base-pathname /maildev --smtp-port 1025 --incoming-user '' --incoming-pass ''");
+    public static final GenericContainer smtpWithoutAuth = new GenericContainer(
+                    DockerImageName.parse("maildev/maildev"))
+            .withExposedPorts(1025)
+            .withCommand("bin/maildev --base-pathname /maildev --smtp-port 1025 --incoming-user '' --incoming-pass ''");
 
     private final SmtpPlugin.SmtpPluginExecutor pluginExecutor = new SmtpPlugin.SmtpPluginExecutor();
 
     @BeforeAll
     public static void setup() {
-        //Initialize SMTP connection with default configuration (can be changed per test)
-        configureSmtpConnection(smtp); //Default
+        // Initialize SMTP connection with default configuration (can be changed per test)
+        configureSmtpConnection(smtp); // Default
     }
 
     private static void configureSmtpConnection(GenericContainer container) {
@@ -148,12 +148,12 @@ public class SmtpPluginTest {
         Mono<DatasourceTestResult> testDatasourceMono = pluginExecutor.testDatasource(noAuthDatasourceConfiguration);
 
         StepVerifier.create(testDatasourceMono)
-            .assertNext(datasourceTestResult -> {
-                assertNotNull(datasourceTestResult);
-                assertTrue(datasourceTestResult.isSuccess());
-                assertTrue(datasourceTestResult.getInvalids().isEmpty());
-            })
-            .verifyComplete();
+                .assertNext(datasourceTestResult -> {
+                    assertNotNull(datasourceTestResult);
+                    assertTrue(datasourceTestResult.isSuccess());
+                    assertTrue(datasourceTestResult.getInvalids().isEmpty());
+                })
+                .verifyComplete();
         configureSmtpConnection(smtp);
     }
 

--- a/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
@@ -131,12 +131,10 @@ public class SmtpPluginTest {
 
     @Test
     public void testNullAuthentication() {
-        DatasourceConfiguration invalidDatasourceConfiguration = createDatasourceConfiguration();
-        invalidDatasourceConfiguration.setAuthentication(null);
+        DatasourceConfiguration noAuthDatasourceConfiguration = createDatasourceConfiguration();
+        noAuthDatasourceConfiguration.setAuthentication(null);
 
-        assertEquals(
-                Set.of(new AppsmithPluginException(AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR).getMessage()),
-                pluginExecutor.validateDatasource(invalidDatasourceConfiguration));
+        assertEquals(0, pluginExecutor.validateDatasource(noAuthDatasourceConfiguration).size());
     }
 
     @Test


### PR DESCRIPTION
## Description
### Bug Description
Issue: When configuring an SMTP datasource without a username and password, the system throws an error: “Invalid authentication credentials. Please check datasource configuration.”
Expected Behavior: The system should allow SMTP datasource configuration without requiring authentication credentials, as it is possible to connect to some SMTP servers without a username or password.
**Steps To Reproduce**
Use any email service for configuring SMTP datasource without setting up username and password
Create SMTP datasource with host port, keeping username and password blank
Test the configuration


**Root Cause**
Manual validation in the codebase was enforcing that both username and password fields are mandatory for SMTP configuration. This validation prevented the successful configuration of SMTP services that do not require authentication.

**Solution Details**
_To fix this, the following changes were implemented:
Updated Validation Method (validateDatasource)_
Before: Enforced mandatory username and password validation.
After: Removed the strict validation check for authentication fields, allowing for configurations without credentials.



```
if (authentication == null || !StringUtils.hasText(authentication.getUsername()) || !StringUtils.hasText(authentication.getPassword())) {
    invalids.add(new AppsmithPluginException(AppsmithPluginError.PLUGIN_AUTHENTICATION_ERROR).getMessage());
}

```
_Modified the SMTP Session Creation (datasourceCreate)_
Before: Always initialized the SMTP session with authentication, assuming credentials were required.
After: Updated the session creation to support both authenticated and unauthenticated configurations.



```
Properties prop = new Properties();
prop.put("mail.smtp.auth", "false"); // Default to no authentication

if (authentication != null && StringUtils.hasText(authentication.getUsername()) && StringUtils.hasText(authentication.getPassword())) {
    prop.put("mail.smtp.auth", "true");
    session = Session.getInstance(prop, new Authenticator() {
        @Override
        protected PasswordAuthentication getPasswordAuthentication() {
            return new PasswordAuthentication(username, password);
        }
    });
} else {
    session = Session.getInstance(prop);
}
```

_Enhanced Testing for Authentication Scenarios (testDatasource)_
Before: Errors were logged if authentication failed, even for servers where authentication wasn’t required.
After: Introduced a flag to detect if authentication was required based on the session configuration, and adjusted error handling accordingly.



```
boolean isAuthRequired = "true".equals(connection.getProperty("mail.smtp.auth"));
if (isAuthRequired && transport != null) {
    try {
        transport.connect();
    } catch (AuthenticationFailedException e) {
        invalids.add(SMTPErrorMessages.DS_AUTHENTICATION_FAILED_ERROR_MSG);
    }
}

```
**Testing and Verification**
**Unit Tests**
Without Authentication:
_Updated testNullAuthentication test case to ensure no errors are returned when authentication is absent._

```
@Test
public void testNullAuthentication() {
    DatasourceConfiguration invalidDatasourceConfiguration = createDatasourceConfiguration();
    invalidDatasourceConfiguration.setAuthentication(null);
    assertEquals(0, pluginExecutor.validateDatasource(invalidDatasourceConfiguration).size());
}
```


Fixes #37271

## Automation

/ok-to-test tags=""
updated testNullAuthentication() from SmtpPluginTest class


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced SMTP plugin now supports conditional authentication during session creation.
	- Improved error handling for authentication failures, providing clearer validation results.
	- Added support for testing SMTP connections without authentication.

- **Bug Fixes**
	- Streamlined validation logic for datasource configurations, particularly for authentication scenarios.

- **Documentation**
	- Updated test methods to clarify expected error messages for invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->