### PR TITLE
fix: Bug where identifyUser not called in cloud

### DIFF
--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -98,19 +98,22 @@ export const initializeAnalyticsAndTrackers = async (currentUser: User) => {
     if (appsmithConfigs.segment.enabled && !(window as any).analytics) {
       if (appsmithConfigs.segment.apiKey) {
         // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
-        return AnalyticsUtil.initializeSegment(appsmithConfigs.segment.apiKey);
+        await AnalyticsUtil.initializeSegment(appsmithConfigs.segment.apiKey);
       } else if (appsmithConfigs.segment.ceKey) {
         // This value is set in self-hosted environments. But if the analytics are disabled, it's never used.
-        return AnalyticsUtil.initializeSegment(appsmithConfigs.segment.ceKey);
+        await AnalyticsUtil.initializeSegment(appsmithConfigs.segment.ceKey);
       }
+    }
+
+    if (
+      !currentUser.isAnonymous &&
+      currentUser.username !== ANONYMOUS_USERNAME
+    ) {
+      await AnalyticsUtil.identifyUser(currentUser);
     }
   } catch (e) {
     Sentry.captureException(e);
     log.error(e);
-  }
-
-  if (!currentUser.isAnonymous && currentUser.username !== ANONYMOUS_USERNAME) {
-    await AnalyticsUtil.identifyUser(currentUser);
   }
 };
 


### PR DESCRIPTION
## Description

Fix the bug where return was called before the await for cloud conditions. This made the identifyUser case being skipped almost always


Missed in https://github.com/appsmithorg/appsmith/pull/37303


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11791461362>
> Commit: 94bc9890be85ac51d52d9d0962e8f3f6e84fc7b0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11791461362&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 12 Nov 2024 06:23:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced analytics initialization process to ensure completion before user identification.
  
- **Bug Fixes**
	- Improved error handling for analytics setup with Sentry logging.

- **Documentation**
	- Updated function signatures for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->