### PR TITLE
chore: Handle changed NodeJS download links

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -10,8 +10,8 @@ LABEL maintainer="tech@appsmith.com"
 WORKDIR /opt/appsmith
 
 # The env variables are needed for Appsmith server to correctly handle non-roman scripts like Arabic.
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 # Install dependency packages
 RUN set -o xtrace \
@@ -46,8 +46,8 @@ RUN set -o xtrace \
 # Install NodeJS
 RUN set -o xtrace \
   && mkdir -p /opt/node \
-  && file="$(curl -sS 'https://nodejs.org/dist/latest-v20.x/' | awk -F\" '$2 ~ /linux-'"$(uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/')"'.tar.gz/ {print $2}')" \
-  && curl "https://nodejs.org/dist/latest-v20.x/$file" | tar -xz -C /opt/node --strip-components 1
+  && path="$(curl -LsS 'https://nodejs.org/dist/latest-v20.x/' | awk -F\" '$2 ~ /linux-'"$(uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/')"'.tar.gz/ {print $2}')" \
+  && curl "https://nodejs.org$path" | tar -xz -C /opt/node --strip-components 1
 
 # Install Caddy
 RUN set -o xtrace \


### PR DESCRIPTION
NodeJS have slightly changed the way they publish their artifacts and the way we download isn't working anymore. This PR fixes that.

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated environment variable formatting for clarity and conciseness.
	- Enhanced the NodeJS installation process for improved integrity verification.
	- Maintained existing structure and dependencies within the Dockerfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

/test sanity

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11833162543>
> Commit: 4aa1ca2b40a520d696450b249428d52f94258be7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11833162543&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 14 Nov 2024 08:42:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->
