### PR TITLE
chore: add alerts for push failures in sync release to pg flow

### DIFF
--- a/.github/workflows/sync-release-to-pg.yml
+++ b/.github/workflows/sync-release-to-pg.yml
@@ -50,7 +50,36 @@ jobs:
       - name: Push changes
         if: env.MERGE_CONFLICT == 'false'
         run: |
-          git push origin pg
+          set -e
+          git push origin pg || echo "PUSH_FAILURE=true" >> $GITHUB_ENV
+
+      - name: Capture push failure message
+        if: env.PUSH_FAILURE == 'true'
+        run: |
+          # Capture the last git error message
+          push_error_message=$(git push origin pg 2>&1 | tail -n 1)
+          echo "PUSH_ERROR_MESSAGE=$push_error_message" >> $GITHUB_ENV
+
+      - name: Notify on push failure
+        if: env.PUSH_FAILURE == 'true'
+        env:
+          SLACK_MESSAGE: "Push to pg branch failed: ${{ env.PUSH_ERROR_MESSAGE }}"
+        run: |
+          # Format the Slack message
+          slack_message="${{ env.SLACK_MESSAGE }}"
+
+          # Set the Slack message body with channel ID and text
+          body="$(jq -nc \
+            --arg channel C07JMLWEXDJ \
+            --arg text "$slack_message" \
+            '$ARGS.named'
+          )"
+
+          # Send the message to Slack
+          curl -v https://slack.com/api/chat.postMessage \
+            --header "Authorization: Bearer ${{ secrets.SLACK_APPSMITH_ALERTS_TOKEN }}" \
+            --header "Content-Type: application/json; charset=utf-8" \
+            --data-raw "$body"
 
       - name: Notify on merge conflicts
         if: env.MERGE_CONFLICT == 'true'


### PR DESCRIPTION
## Description
Add a slack message alert when the push flow fails in the sync release to pg workflow. 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for push operations, including notifications for push failures and merge conflicts to Slack.
  
- **Bug Fixes**
	- Improved feedback mechanism for push failures with detailed error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->