### PR TITLE
chore: No need for replica set anymore?

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -276,14 +276,14 @@ init_replica_set() {
     mongod --fork --port 27017 --dbpath "$MONGO_DB_PATH" --logpath "$MONGO_LOG_PATH" --replSet mr1 --keyFile "$MONGODB_TMP_KEY_PATH" --bind_ip localhost
     tlog "Waiting 10s for MongoDB to start with Replica Set"
     sleep 10
-    mongosh "$APPSMITH_DB_URL" --eval 'rs.initiate()'
+    #mongosh "$APPSMITH_DB_URL" --eval 'rs.initiate()'
     mongod --dbpath "$MONGO_DB_PATH" --shutdown || true
   fi
 
   if [[ $isUriLocal -gt 0 ]]; then
     tlog "Checking Replica Set of external MongoDB"
 
-    if appsmithctl check-replica-set; then
+    if true || appsmithctl check-replica-set; then
       tlog "MongoDB ReplicaSet is enabled"
     else
       echo -e "\033[0;31m***************************************************************************************\033[0m"


### PR DESCRIPTION
⚠️ Experiment.

Technically, we no longer need the MongoDB to have to have a ReplicaSet configured. This was a requirement a long time ago (~when we had commenting in apps), but that's been gone for a _long_ time.

This PR is an experiment to see if we can simplify our stack and lives by not having this requirement at all, and working with a plain MongoDB server in full.

This is part of the effort to improve `appsmithctl`, which has a `check-replica-set` command, which we don't really need.

## Automation

/test rating

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11811807125>
> Commit: 66294cf19bdfa9e3a118201fcbd9068fc5893ef3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11811807125&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Rating
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/11811807125" target="_blank">workflow here</a>.
> <hr>Wed, 13 Nov 2024 06:37:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
