### PR TITLE
feat: alt text in image widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_base64_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_base64_spec.js
@@ -21,9 +21,20 @@ describe(
         200,
       );
       cy.EvaluateCurrentValue(this.dataSet.base64image.withPrefix);
+      cy.testJsontext("alternativetext", this.dataSet.base64image.altText);
+      cy.wait("@updateLayout").should(
+        "have.nested.property",
+        "response.body.responseMeta.status",
+        200,
+      );
+      cy.EvaluateCurrentValue(this.dataSet.base64image.altText);
+      
       cy.get(viewWidgetsPage.imageinner)
         .invoke("attr", "src")
         .should("contain", this.dataSet.base64image.withPrefix);
+      cy.get(viewWidgetsPage.imageinner)
+        .invoke("attr", "alt")
+        .should("contain", this.dataSet.base64image.altText);
       cy.closePropertyPane();
     });
   },

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Image/Image_spec.js
@@ -38,6 +38,13 @@ describe(
       cy.get(viewWidgetsPage.imageinner)
         .invoke("attr", "src")
         .should("contain", this.dataSet.validateImage);
+      /**
+       * @param{TEXT} Alternative text
+       */
+      cy.testCodeMirrorLast(this.dataSet.NewImageAltText);
+      cy.get(viewWidgetsPage.imageinner)
+        .invoke("attr", "alt")
+        .should("contain", this.dataSet.validateImageAltText);
       cy.closePropertyPane();
     });
 

--- a/app/client/cypress/fixtures/TestDataSet1.json
+++ b/app/client/cypress/fixtures/TestDataSet1.json
@@ -92,9 +92,11 @@
   "multiSelectName": "MultiSelect1",
   "defaultimage": "https://i0.wp.com/www.heyuguys.com/images/2016/04/The-Joker.png?fit=1920%2C960",
   "NewImage": "https://cdn.dribbble.com/users/1787323/screenshots/4563995/dribbbe_hammer-01.png",
+  "NewImageAltText": "Thor's hammer planted into the ground",
   "base64image": {
     "withoutPrefix": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==",
-    "withPrefix": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg=="
+    "withPrefix": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==",
+    "altText": "A single pixel"
   },
   "textfun": "{{Table1.selectedRow.userName}}",
   "textfunID": "{{Table1.selectedRow.id}}",
@@ -118,6 +120,7 @@
   "RichTexteditorBody": "Here is the text area to edit html",
   "userApi": "http://host.docker.internal:5001/v1",
   "validateImage": "https://cdn.dribbble.com/users/1787323/screenshots/4563995/dribbbe_hammer-01.png",
+  "validateImageAltText": "Thor's hammer planted into the ground",
   "defaultdata": "TestData",
   "label": "one",
   "rgbValue": "rgb(255, 0, 0)",

--- a/app/client/src/widgets/ImageWidget/component/index.tsx
+++ b/app/client/src/widgets/ImageWidget/component/index.tsx
@@ -291,7 +291,7 @@ class ImageComponent extends React.Component<
                 >
                   {/* Used for running onImageError and onImageLoad Functions since Background Image doesn't have the functionality */}
                   <img
-                    alt={this.props.widgetName}
+                    alt={this.props.alt}
                     onError={this.onImageError}
                     onLoad={this.onImageLoad}
                     src={this.props.imageUrl || this.props.defaultImageUrl}
@@ -410,6 +410,7 @@ export interface ImageComponentProps extends ComponentProps {
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   borderRadius: string;
   boxShadow?: string;
+  alt?: string;
 }
 
 export default ImageComponent;

--- a/app/client/src/widgets/ImageWidget/component/index.tsx
+++ b/app/client/src/widgets/ImageWidget/component/index.tsx
@@ -291,7 +291,7 @@ class ImageComponent extends React.Component<
                 >
                   {/* Used for running onImageError and onImageLoad Functions since Background Image doesn't have the functionality */}
                   <img
-                    alt={this.props.alt}
+                    alt={this.props.alt || this.props.widgetName || "Image"}
                     onError={this.onImageError}
                     onLoad={this.onImageLoad}
                     src={this.props.imageUrl || this.props.defaultImageUrl}

--- a/app/client/src/widgets/ImageWidget/widget/index.tsx
+++ b/app/client/src/widgets/ImageWidget/widget/index.tsx
@@ -139,9 +139,16 @@ class ImageWidget extends BaseWidget<ImageWidgetProps, WidgetState> {
             label: "Alternative text",
             controlType: "INPUT_TEXT",
             placeholderText: "Alternative text",
-            isBindProperty: false,
+            isBindProperty: true,
+            defaultValue: "",
             isTriggerProperty: false,
-            validation: { type: ValidationTypes.TEXT },
+            validation: { 
+              type: ValidationTypes.TEXT,
+              params: {
+                required: true,
+                maxLength: 125
+              }
+            },
           },
         ],
       },

--- a/app/client/src/widgets/ImageWidget/widget/index.tsx
+++ b/app/client/src/widgets/ImageWidget/widget/index.tsx
@@ -134,7 +134,7 @@ class ImageWidget extends BaseWidget<ImageWidgetProps, WidgetState> {
             validation: { type: ValidationTypes.IMAGE_URL },
           },
           {
-            helpText: "Set alternative text for the image",
+            helpText: "Sets alternative text for the image",
             propertyName: "alt",
             label: "Alternative text",
             controlType: "INPUT_TEXT",

--- a/app/client/src/widgets/ImageWidget/widget/index.tsx
+++ b/app/client/src/widgets/ImageWidget/widget/index.tsx
@@ -133,6 +133,16 @@ class ImageWidget extends BaseWidget<ImageWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: { type: ValidationTypes.IMAGE_URL },
           },
+          {
+            helpText: "Set alternative text for the image",
+            propertyName: "alt",
+            label: "Alternative text",
+            controlType: "INPUT_TEXT",
+            placeholderText: "Alternative text",
+            isBindProperty: false,
+            isTriggerProperty: false,
+            validation: { type: ValidationTypes.TEXT },
+          },
         ],
       },
       {
@@ -328,6 +338,7 @@ class ImageWidget extends BaseWidget<ImageWidgetProps, WidgetState> {
         disableDrag={(disable: boolean) => {
           this.disableDrag(disable);
         }}
+        alt={this.props.alt ? this.props.alt : undefined}
         enableDownload={this.props.enableDownload}
         enableRotation={this.props.enableRotation}
         imageUrl={this.props.image}
@@ -368,6 +379,7 @@ export interface ImageWidgetProps extends WidgetProps {
   onClick?: string;
   borderRadius: string;
   boxShadow?: string;
+  alt?: string;
 }
 
 export default ImageWidget;


### PR DESCRIPTION
## Description
Add the alt attribute as a new widget property for the image widget.

Fixes [#13383](https://github.com/appsmithorg/appsmith/issues/13383)

## Automation
/test Image
/ok-to-test tags="Image"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [X] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for alternative text in the Image Widget, improving accessibility.
  - Enhanced test coverage for the Image Widget to validate both image sources and alternative text.

- **Bug Fixes**
  - Improved error handling for image loading within the Image Widget.

- **Documentation**
  - Updated test cases and data sets to include new fields for alternative text, enhancing clarity and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->