### PR TITLE
chore: Remove `/restart` API

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Admin_settings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Admin_settings_spec.js
@@ -181,9 +181,6 @@ describe("Admin settings page", { tags: ["@tag.Settings"] }, function () {
       fromAddress = uuid;
       cy.get(adminsSettings.fromAddress).clear().type(`${uuid}@appsmith.com`);
     });
-    cy.intercept("POST", "/api/v1/admin/restart", {
-      body: { responseMeta: { status: 200, success: true }, data: true },
-    });
     cy.get(adminsSettings.saveButton).click();
     cy.wait("@postTenantConfig").then((interception) => {
       expect(interception.request.body.instanceName).to.equal(instanceName);

--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Admin_settings_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Admin_settings_1_spec.js
@@ -134,9 +134,6 @@ describe(
         fromAddress = uuid;
         cy.get(adminsSettings.fromAddress).clear().type(`${uuid}@appsmith.com`);
       });
-      cy.intercept("POST", "/api/v1/admin/restart", {
-        body: { responseMeta: { status: 200, success: true }, data: true },
-      });
       cy.get(adminsSettings.saveButton).click();
       cy.wait("@postTenantConfig").then((interception) => {
         expect(interception.request.body.instanceName).to.equal(instanceName);

--- a/app/client/src/ce/actions/settingsAction.ts
+++ b/app/client/src/ce/actions/settingsAction.ts
@@ -1,12 +1,9 @@
 import { ReduxActionTypes } from "ee/constants/ReduxActionConstants";
 
-// TODO: Fix this the next time the file is edited
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const saveSettings = (settings: any, needsRestart = true) => ({
+export const saveSettings = (settings: Record<string, string>) => ({
   type: ReduxActionTypes.SAVE_ADMIN_SETTINGS,
   payload: {
     settings,
-    needsRestart,
   },
 });
 

--- a/app/client/src/ce/api/UserApi.tsx
+++ b/app/client/src/ce/api/UserApi.tsx
@@ -4,11 +4,6 @@ import type { ApiResponse } from "api/ApiResponses";
 import type { FeatureFlags } from "ee/entities/FeatureFlag";
 import type { ProductAlert } from "../../reducers/uiReducers/usersReducer";
 
-export interface LoginUserRequest {
-  email: string;
-  password: string;
-}
-
 export interface CreateUserRequest {
   email: string;
   password: string;
@@ -32,14 +27,6 @@ export interface TokenPasswordUpdateRequest {
 export interface VerifyTokenRequest {
   email: string;
   token: string;
-}
-
-export type FetchUserResponse = ApiResponse & {
-  id: string;
-};
-
-export interface FetchUserRequest {
-  id: string;
 }
 
 export interface LeaveWorkspaceRequest {
@@ -93,7 +80,6 @@ export class UserApi extends Api {
   static inviteUserURL = "v1/users/invite";
   static verifyInviteTokenURL = `${UserApi.inviteUserURL}/verify`;
   static confirmUserInviteURL = `${UserApi.inviteUserURL}/confirm`;
-  static addWorkspaceURL = `${UserApi.usersURL}/addWorkspace`;
   static leaveWorkspaceURL = `${UserApi.usersURL}/leaveWorkspace`;
   static logoutURL = "v1/logout";
   static currentUserURL = "v1/users/me";
@@ -101,7 +87,6 @@ export class UserApi extends Api {
   static featureFlagsURL = "v1/users/features";
   static superUserURL = "v1/users/super";
   static adminSettingsURL = "v1/admin/env";
-  static restartServerURL = "v1/admin/restart";
   static sendTestEmailURL = "/v1/admin/send-test-email";
 
   static async createUser(
@@ -114,12 +99,6 @@ export class UserApi extends Api {
     request: UpdateUserRequest,
   ): Promise<AxiosPromise<ApiResponse>> {
     return Api.put(UserApi.usersURL, request);
-  }
-
-  static async fetchUser(
-    request: FetchUserRequest,
-  ): Promise<AxiosPromise<FetchUserResponse>> {
-    return Api.get(UserApi.usersURL + "/" + request.id);
   }
 
   static async getCurrentUser(): Promise<AxiosPromise<ApiResponse>> {
@@ -250,5 +229,3 @@ export class UserApi extends Api {
     return Api.post(UserApi.resendEmailVerificationURL, { email });
   }
 }
-
-export default UserApi;

--- a/app/client/src/ce/api/UserApi.tsx
+++ b/app/client/src/ce/api/UserApi.tsx
@@ -234,10 +234,6 @@ export class UserApi extends Api {
     return Api.put(UserApi.adminSettingsURL, request);
   }
 
-  static async restartServer(): Promise<AxiosPromise<ApiResponse>> {
-    return Api.post(UserApi.restartServerURL);
-  }
-
   static async sendTestEmail(
     payload: SendTestEmailPayload,
   ): Promise<AxiosPromise<ApiResponse>> {

--- a/app/client/src/ee/sagas/SuperUserSagas.tsx
+++ b/app/client/src/ee/sagas/SuperUserSagas.tsx
@@ -4,7 +4,7 @@ import {
   FetchAdminSettingsErrorSaga,
   SaveAdminSettingsSaga,
   RestartServerPoll,
-  RestryRestartServerPoll,
+  RetryRestartServerPoll,
   SendTestEmail,
 } from "ce/sagas/SuperUserSagas";
 import { ReduxActionTypes } from "ee/constants/ReduxActionConstants";
@@ -32,7 +32,7 @@ export function* InitSuperUserSaga() {
       takeLatest(ReduxActionTypes.RESTART_SERVER_POLL, RestartServerPoll),
       takeLatest(
         ReduxActionTypes.RETRY_RESTART_SERVER_POLL,
-        RestryRestartServerPoll,
+        RetryRestartServerPoll,
       ),
       takeLatest(ReduxActionTypes.SEND_TEST_EMAIL, SendTestEmail),
     ]);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/InstanceAdminControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/InstanceAdminControllerCE.java
@@ -41,31 +41,26 @@ public class InstanceAdminControllerCE {
     @PutMapping(
             value = "/env",
             consumes = {MediaType.APPLICATION_JSON_VALUE})
-    public Mono<ResponseDTO<Void>> saveEnvChangesJSON(
+    public Mono<ResponseDTO<Map<String, ?>>> saveEnvChangesJSON(
             @Valid @RequestBody Map<String, String> changes, @RequestHeader("Origin") String originHeader) {
         log.debug("Applying env updates {}", changes.keySet());
         return envManager
                 .applyChanges(changes, originHeader)
-                .thenReturn(new ResponseDTO<>(HttpStatus.OK.value(), null, null));
+                .map(isRestarting ->
+                        new ResponseDTO<>(HttpStatus.OK.value(), Map.of("isRestarting", isRestarting), null));
     }
 
     @JsonView(Views.Public.class)
     @PutMapping(
             value = "/env",
             consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public Mono<ResponseDTO<Void>> saveEnvChangesMultipartFormData(
+    public Mono<ResponseDTO<Map<String, ?>>> saveEnvChangesMultipartFormData(
             @RequestHeader("Origin") String originHeader, ServerWebExchange exchange) {
         log.debug("Applying env updates from form data");
         return exchange.getMultipartData()
                 .flatMap(formData -> envManager.applyChangesFromMultipartFormData(formData, originHeader))
-                .thenReturn(new ResponseDTO<>(HttpStatus.OK.value(), null, null));
-    }
-
-    @JsonView(Views.Public.class)
-    @PostMapping("/restart")
-    public Mono<ResponseDTO<Boolean>> restart() {
-        log.debug("Received restart request");
-        return envManager.restart().thenReturn(new ResponseDTO<>(HttpStatus.OK.value(), true, null));
+                .map(isRestarting ->
+                        new ResponseDTO<>(HttpStatus.OK.value(), Map.of("isRestarting", isRestarting), null));
     }
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
@@ -13,11 +13,11 @@ public interface EnvManagerCE {
 
     List<String> transformEnvContent(String envContent, Map<String, String> changes);
 
-    Mono<Void> applyChanges(Map<String, String> changes, String originHeader);
+    Mono<Boolean> applyChanges(Map<String, String> changes, String originHeader);
 
     Mono<Map<String, String>> applyChangesToEnvFileWithoutAclCheck(Map<String, String> changes);
 
-    Mono<Void> applyChangesFromMultipartFormData(MultiValueMap<String, Part> formData, String originHeader);
+    Mono<Boolean> applyChangesFromMultipartFormData(MultiValueMap<String, Part> formData, String originHeader);
 
     void setAnalyticsEventAction(
             Map<String, Object> properties, String newVariable, String originalVariable, String authEnv);
@@ -33,8 +33,6 @@ public interface EnvManagerCE {
     Mono<Map<String, String>> getAllNonEmpty();
 
     Mono<User> verifyCurrentUserIsSuper();
-
-    Mono<Void> restart();
 
     Mono<Void> restartWithoutAclCheck();
 


### PR DESCRIPTION
This PR removes the `/restart` API. Currently, the client decides whether a restart is needed after saving some settings. Depending on that decision, a call is made to `/restart` and the server then restarts. This PR flips this by having the server take the decision, and merely informing the client of the decision.

This way, we don't need a `/restart` API. Fewer things there are, fewer things we have to protect.


## Automation

/test sanity settings

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11819840608>
> Commit: 4195fdf1d1dbd234bdcfde462b1036e4fd8fee25
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11819840608&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Sanity, @tag.Settings
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/11819840608" target="_blank">workflow here</a>.
> <hr>Thu, 14 Nov 2024 08:57:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
