### PR TITLE
chore: Remove unused JSON superuser signup route

### DIFF
--- a/app/client/src/ce/api/UserApi.tsx
+++ b/app/client/src/ce/api/UserApi.tsx
@@ -70,19 +70,6 @@ export interface SendTestEmailPayload {
   password?: string;
 }
 
-export interface CreateSuperUserRequest {
-  email: string;
-  name: string;
-  source: "FORM";
-  state: "ACTIVATED";
-  isEnabled: boolean;
-  password: string;
-  role: "Developer";
-  companyName: string;
-  allowCollectingAnonymousData: boolean;
-  signupForNewsletter: boolean;
-}
-
 export class UserApi extends Api {
   static usersURL = "v1/users";
   static productAlertURL = "v1/product-alert/alert";

--- a/app/client/src/ce/api/UserApi.tsx
+++ b/app/client/src/ce/api/UserApi.tsx
@@ -99,7 +99,6 @@ export class UserApi extends Api {
   static currentUserURL = "v1/users/me";
   static photoURL = "v1/users/photo";
   static featureFlagsURL = "v1/users/features";
-  static superUserURL = "v1/users/super";
   static adminSettingsURL = "v1/admin/env";
   static restartServerURL = "v1/admin/restart";
   static sendTestEmailURL = "/v1/admin/send-test-email";
@@ -212,12 +211,6 @@ export class UserApi extends Api {
     AxiosPromise<ApiResponse<FeatureFlags>>
   > {
     return Api.get(UserApi.featureFlagsURL);
-  }
-
-  static async createSuperUser(
-    request: CreateSuperUserRequest,
-  ): Promise<AxiosPromise<CreateUserResponse>> {
-    return Api.post(UserApi.superUserURL, request);
   }
 
   /*

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UserControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UserControllerCE.java
@@ -9,7 +9,6 @@ import com.appsmith.server.dtos.ResendEmailVerificationDTO;
 import com.appsmith.server.dtos.ResetUserPasswordDTO;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.dtos.UserProfileDTO;
-import com.appsmith.server.dtos.UserSignupRequestDTO;
 import com.appsmith.server.dtos.UserUpdateDTO;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
@@ -68,19 +67,6 @@ public class UserControllerCE {
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<Void> createFormEncoded(ServerWebExchange exchange) {
         return userSignup.signupAndLoginFromFormData(exchange);
-    }
-
-    @JsonView(Views.Public.class)
-    @PostMapping(
-            value = "/super",
-            consumes = {MediaType.APPLICATION_JSON_VALUE})
-    public Mono<ResponseDTO<User>> createSuperUser(
-            @Valid @RequestBody UserSignupRequestDTO resource,
-            @RequestHeader("Origin") String originHeader,
-            ServerWebExchange exchange) {
-        return userSignup
-                .signupAndLoginSuper(resource, originHeader, exchange)
-                .map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
     }
 
     @JsonView(Views.Public.class)

--- a/deploy/ansible/appsmith_playbook/roles/setup-appsmith/templates/appsmith/scripts/first-time-setup.sh
+++ b/deploy/ansible/appsmith_playbook/roles/setup-appsmith/templates/appsmith/scripts/first-time-setup.sh
@@ -111,16 +111,13 @@ if [[ $status_code -eq 401 ]]; then
     default_user_name="${tokens[0]}"
     default_user_password="${tokens[1]}"
 
-    curl -k -X POST 'http://localhost/api/v1/users/super' \
-    --header 'Content-Type: application/json' \
-    --data-raw '{
-        "name" : "'"$default_user_name"'",
-        "email" : "'"$default_user_name"'",
-        "source" : "FORM",
-        "state" : "ACTIVATED",
-        "isEnabled" : "true",
-        "password": "'"$default_user_password"'"
-    }'
+    curl http://localhost/api/v1/users/super \
+      --data-urlencode "name=$default_user_name" \
+      --data-urlencode "email=$default_user_name" \
+      --data-urlencode "password=$default_user_password" \
+      -d source=FORM \
+      -d state=ACTIVATED \
+      -d isEnabled=true
 
     curl -s --location --request POST 'https://hook.integromat.com/dkwb6i52am93pi30ojeboktvj32iw0fa' \
     --header 'Content-Type: text/plain' \

--- a/deploy/aws_ami/first-time-setup.sh
+++ b/deploy/aws_ami/first-time-setup.sh
@@ -110,16 +110,13 @@ if [[ $status_code -eq 401 ]]; then
     default_user_name="${tokens[0]}"
     default_user_password="${tokens[1]}"
 
-    curl -k -X POST 'http://localhost/api/v1/users/super' \
-    --header 'Content-Type: application/json' \
-    --data-raw '{
-        "name" : "'"$default_user_name"'",
-        "email" : "'"$default_user_name"'",
-        "source" : "FORM",
-        "state" : "ACTIVATED",
-        "isEnabled" : "true",
-        "password": "'"$default_user_password"'"
-    }'
+    curl http://localhost/api/v1/users/super \
+      --data-urlencode "name=$default_user_name" \
+      --data-urlencode "email=$default_user_name" \
+      --data-urlencode "password=$default_user_password" \
+      -d source=FORM \
+      -d state=ACTIVATED \
+      -d isEnabled=true
 
     curl -s --location --request POST 'https://hook.integromat.com/dkwb6i52am93pi30ojeboktvj32iw0fa' \
     --header 'Content-Type: text/plain' \


### PR DESCRIPTION
The JSON payload version of the super user signup route is not used anywhere significant. This PR removes it.


## Automation

/test sanity authentication

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11830003644>
> Commit: d051ed852ff68727805a81b5b59b54bdb50f1d2e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11830003644&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Authentication`
> Spec:
> <hr>Thu, 14 Nov 2024 03:53:00 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated user creation process to use URL-encoded data instead of JSON for super user creation.
  
- **Bug Fixes**
	- Removed deprecated `createSuperUser` methods from the API and server controllers, streamlining user management.

- **Chores**
	- Modified setup scripts to reflect changes in user data transmission for creating super users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->