### PR TITLE
chore: update the min required node version in client setup guide.

### DIFF
--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -94,7 +94,7 @@ On your development machine, please ensure that:
    - Check below for installation and usage details:
 
      1. Install a node version manager. For eg: check [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm).
-     1. In the project's root, run `nvm use 18.17.1` or `fnm use 18.17.1`.
+     1. In the project's root, run `nvm use 20.11.1` or `fnm use 20.11.1`.
 
 ### Running Tests on Client
 


### PR DESCRIPTION
## Description
The `ClientSetup.md` file still suggests to use node version 18.x to run the client code, however, as per the latest project requirements, node version ^20.11.1 is required.

Fixes #37379

## Fix
Updated the `ClientSetup.md` file to reflect the correct minimum required node version.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Node.js version requirement from 18.17.1 to 20.11.1.
	- Enhanced setup instructions for the development environment, including clearer prompts and options.
	- Expanded installation guidance for `mkcert` with specific commands for Linux users.
	- Updated troubleshooting section for common issues with WSL and Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->