### PR TITLE
chore: Remove unused `UserData.role`

### DIFF
--- a/app/client/src/ce/api/UserApi.tsx
+++ b/app/client/src/ce/api/UserApi.tsx
@@ -57,7 +57,6 @@ export interface UpdateUserRequest {
   name?: string;
   email?: string;
   proficiency?: string;
-  role?: string;
   useCase?: string;
   intercomConsentGiven?: boolean;
 }

--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -417,14 +417,13 @@ export function* inviteUsers(
 
 export function* updateUserDetailsSaga(action: ReduxAction<UpdateUserRequest>) {
   try {
-    const { email, intercomConsentGiven, name, proficiency, role, useCase } =
+    const { email, intercomConsentGiven, name, proficiency, useCase } =
       action.payload;
 
     const response: ApiResponse = yield callAPI(UserApi.updateUser, {
       email,
       name,
       proficiency,
-      role,
       useCase,
       intercomConsentGiven,
     });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
@@ -33,11 +33,6 @@ public class UserData extends BaseDomain {
     @JsonView(Views.Internal.class)
     String userId;
 
-    // Role of the user in their workspace, example, Designer, Developer, Product Lead etc.
-    @JsonView(Views.Public.class)
-    @Deprecated
-    private String role;
-
     // The development proficiency of the user for example, Beginner, Novice, Intermediate, Advanced.
     @JsonView(Views.Public.class)
     private String proficiency;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserSignupRequestDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserSignupRequestDTO.java
@@ -19,9 +19,6 @@ public class UserSignupRequestDTO {
 
     private String password;
 
-    @Deprecated
-    private String role;
-
     private String proficiency;
 
     private String useCase;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/UserUpdateCE_DTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ce/UserUpdateCE_DTO.java
@@ -9,8 +9,6 @@ import lombok.Data;
 public class UserUpdateCE_DTO {
     private String name;
 
-    private String role;
-
     private String proficiency;
 
     private String useCase;
@@ -22,6 +20,6 @@ public class UserUpdateCE_DTO {
     }
 
     public boolean hasUserDataUpdates() {
-        return role != null || proficiency != null || useCase != null || isIntercomConsentGiven;
+        return proficiency != null || useCase != null || isIntercomConsentGiven;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCE.java
@@ -17,13 +17,7 @@ public interface AnalyticsServiceCE {
     Mono<User> identifyUser(User user, UserData userData, String recentlyUsedWorkspaceId);
 
     void identifyInstance(
-            String instanceId,
-            String role,
-            String proficiency,
-            String useCase,
-            String adminEmail,
-            String adminFullName,
-            String ip);
+            String instanceId, String proficiency, String useCase, String adminEmail, String adminFullName, String ip);
 
     Mono<Void> sendEvent(String event, String userId, Map<String, ?> properties);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -141,7 +141,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
                                     "isSuperUser", isSuperUser,
                                     "instanceId", instanceId,
                                     "mostRecentlyUsedWorkspaceId", tuple.getT4(),
-                                    "role", ObjectUtils.defaultIfNull(userData.getRole(), ""),
+                                    "role", "",
                                     "proficiency", ObjectUtils.defaultIfNull(userData.getProficiency(), ""),
                                     "goal", ObjectUtils.defaultIfNull(userData.getUseCase(), ""))));
                     analytics.flush();
@@ -150,13 +150,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
     }
 
     public void identifyInstance(
-            String instanceId,
-            String role,
-            String proficiency,
-            String useCase,
-            String adminEmail,
-            String adminFullName,
-            String ip) {
+            String instanceId, String proficiency, String useCase, String adminEmail, String adminFullName, String ip) {
         if (!isActive()) {
             return;
         }
@@ -167,7 +161,7 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
                         "isInstance",
                         true, // Is this "identify" data-point for a user or an instance?
                         ROLE,
-                        ObjectUtils.defaultIfNull(role, ""),
+                        "",
                         PROFICIENCY,
                         ObjectUtils.defaultIfNull(proficiency, ""),
                         GOAL,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -618,9 +618,6 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
 
         if (allUpdates.hasUserDataUpdates()) {
             final UserData updates = new UserData();
-            if (StringUtils.hasLength(allUpdates.getRole())) {
-                updates.setRole(allUpdates.getRole());
-            }
             if (StringUtils.hasLength(allUpdates.getProficiency())) {
                 updates.setProficiency(allUpdates.getProficiency());
             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -300,7 +300,6 @@ public class UserSignupCEImpl implements UserSignupCE {
                 })
                 .flatMap(user -> {
                     final UserData userData = new UserData();
-                    userData.setRole(userFromRequest.getRole());
                     userData.setProficiency(userFromRequest.getProficiency());
                     userData.setUseCase(userFromRequest.getUseCase());
 
@@ -380,9 +379,6 @@ public class UserSignupCEImpl implements UserSignupCE {
                     if (formData.containsKey(FieldName.NAME)) {
                         user.setName(formData.getFirst(FieldName.NAME));
                     }
-                    if (formData.containsKey("role")) {
-                        user.setRole(formData.getFirst("role"));
-                    }
                     if (formData.containsKey("proficiency")) {
                         user.setProficiency(formData.getFirst("proficiency"));
                     }
@@ -446,7 +442,7 @@ public class UserSignupCEImpl implements UserSignupCE {
                     analyticsProps.put(DISABLE_TELEMETRY, !userFromRequest.isAllowCollectingAnonymousData());
                     analyticsProps.put(SUBSCRIBE_MARKETING, userFromRequest.isSignupForNewsletter());
                     analyticsProps.put(EMAIL, newsletterSignedUpUserEmail);
-                    analyticsProps.put(ROLE, ObjectUtils.defaultIfNull(userData.getRole(), ""));
+                    analyticsProps.put(ROLE, "");
                     analyticsProps.put(PROFICIENCY, ObjectUtils.defaultIfNull(userData.getProficiency(), ""));
                     analyticsProps.put(GOAL, ObjectUtils.defaultIfNull(userData.getUseCase(), ""));
                     // ip is a reserved keyword for tracking events in Mixpanel though this is allowed in
@@ -460,7 +456,6 @@ public class UserSignupCEImpl implements UserSignupCE {
 
                     analyticsService.identifyInstance(
                             instanceId,
-                            userData.getRole(),
                             userData.getProficiency(),
                             userData.getUseCase(),
                             newsletterSignedUpUserEmail,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
@@ -22,7 +22,6 @@ public class CommonConfigTest {
     @Test
     public void objectMapper_BeanCreated_WithPublicJsonViewAsDefault() throws JsonProcessingException {
         UserData userData = new UserData();
-        userData.setRole("new_role");
         userData.setProficiency("abcd"); // this is public field
         userData.setUserId("userId"); // this is internal field
         userData.setUserPermissions(null);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -427,21 +427,6 @@ public class UserServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
-    public void updateRoleOfUser() {
-        UserUpdateDTO updateUser = new UserUpdateDTO();
-        updateUser.setRole("New role of user");
-        final Mono<UserData> resultMono =
-                userService.updateCurrentUser(updateUser, null).then(userDataService.getForUserEmail("api_user"));
-        StepVerifier.create(resultMono)
-                .assertNext(userData -> {
-                    assertNotNull(userData);
-                    assertThat(userData.getRole()).isEqualTo("New role of user");
-                })
-                .verifyComplete();
-    }
-
-    @Test
-    @WithUserDetails(value = "api_user")
     public void updateIntercomConsentOfUser() {
         final Mono<UserData> userDataMono = userDataService.getForUserEmail("api_user");
         StepVerifier.create(userDataMono)
@@ -499,10 +484,9 @@ public class UserServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
-    public void updateNameRoleAndUseCaseOfUser() {
+    public void updateNameAndUseCaseOfUser() {
         UserUpdateDTO updateUser = new UserUpdateDTO();
         updateUser.setName("New name of user here");
-        updateUser.setRole("New role of user");
         updateUser.setUseCase("New use case");
         final Mono<Tuple2<User, UserData>> resultMono = userService
                 .updateCurrentUser(updateUser, null)
@@ -514,7 +498,6 @@ public class UserServiceTest {
                     assertNotNull(user);
                     assertNotNull(userData);
                     assertEquals("New name of user here", user.getName());
-                    assertEquals("New role of user", userData.getRole());
                     assertEquals("New use case", userData.getUseCase());
                 })
                 .verifyComplete();


### PR DESCRIPTION
The `role` field is not sent by the client and is not used by the server anywhere.

We're not removing the `role` field in analytics payloads, since changes like that in the past have broken other analytics pipelines (where a field value was `null` instead of `""` started to throw NPEs in some internal workflows). We can solve that as a separate problem later.


## Automation

/test sanity authentication

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11830985060>
> Commit: 986fc8986a81aa212eaed455e22181cf927002f0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11830985060&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Authentication`
> Spec:
> <hr>Thu, 14 Nov 2024 05:59:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Simplified user update requests by removing the `role` field, streamlining user data management.
  
- **Bug Fixes**
	- Adjusted analytics tracking to exclude user role information, ensuring compliance with updated data handling practices.

- **Documentation**
	- Updated test cases to reflect changes in user role management, focusing on name and use case updates instead.

These changes enhance the user experience by simplifying user management and improving data privacy in analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->