### PR TITLE
chore: perf optimisation for js action creation phase 1

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -436,10 +436,14 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                     String name = action.getValidName();
                     CreatorContextType contextType =
                             action.getContextType() == null ? CreatorContextType.PAGE : action.getContextType();
-                    return refactoringService
-                            .isNameAllowed(page.getId(), contextType, layout.getId(), name)
-                            .name(IS_NAME_ALLOWED)
-                            .tap(Micrometer.observation(observationRegistry));
+
+                    if (!isJsAction) {
+                        return refactoringService
+                                .isNameAllowed(page.getId(), contextType, layout.getId(), name)
+                                .name(IS_NAME_ALLOWED)
+                                .tap(Micrometer.observation(observationRegistry));
+                    }
+                    return Mono.just(true);
                 })
                 .flatMap(nameAllowed -> {
                     // If the name is allowed, return pageMono for further processing

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -317,7 +317,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
 
         // If duplicate action name exists, throw an error
         final Map<String, Long> actionNameCountMap = actionCollectionDTO.getActions().stream()
-                .collect(Collectors.groupingBy(ActionDTO::getName, Collectors.counting()));
+                .collect(Collectors.groupingBy(ActionDTO::getValidName, Collectors.counting()));
         List<String> duplicateNames = actionNameCountMap.entrySet().stream()
                 .filter(entry -> entry.getValue() > 1)
                 .map(Map.Entry::getKey)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
@@ -840,7 +840,7 @@ public class ActionCollectionServiceTest {
         assert createdActionCollectionDTO.getId() != null;
         String createdActionCollectionId = createdActionCollectionDTO.getId();
 
-        // Update JS object to create two actions with same name
+        // Update JS object to create an action with same name as previously created action
         ActionDTO action2 = new ActionDTO();
         action2.setName("testAction1");
         action2.setActionConfiguration(new ActionConfiguration());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
@@ -810,7 +810,7 @@ public class ActionCollectionServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void
-            testUpdateUnpublishedActionCollection_createMultipleActionsWithSameName_returnsDuplicateActionNameError() {
+            testUpdateUnpublishedActionCollection_createNewActionsWithSameNameAsExisting_returnsDuplicateActionNameError() {
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(pluginExecutor));
         Mockito.when(pluginExecutor.getHintMessages(Mockito.any(), Mockito.any()))
                 .thenReturn(Mono.zip(Mono.just(new HashSet<>()), Mono.just(new HashSet<>())));
@@ -862,7 +862,67 @@ public class ActionCollectionServiceTest {
 
         StepVerifier.create(updatedActionCollectionDTO).verifyErrorSatisfies(error -> {
             assertTrue(error instanceof AppsmithException);
-            String expectedMessage = "testCollection1.testAction1 already exists. Please use a different name";
+            String expectedMessage = "testAction1 already exists. Please use a different name";
+            assertEquals(expectedMessage, error.getMessage());
+        });
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void
+            testUpdateUnpublishedActionCollection_createMultipleActionsWithSameName_returnsDuplicateActionNameError() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(pluginExecutor));
+        Mockito.when(pluginExecutor.getHintMessages(Mockito.any(), Mockito.any()))
+                .thenReturn(Mono.zip(Mono.just(new HashSet<>()), Mono.just(new HashSet<>())));
+
+        ActionCollectionDTO actionCollectionDTO = new ActionCollectionDTO();
+        actionCollectionDTO.setName("testCollection1");
+        actionCollectionDTO.setPageId(testPage.getId());
+        actionCollectionDTO.setApplicationId(testApp.getId());
+        actionCollectionDTO.setWorkspaceId(workspaceId);
+        actionCollectionDTO.setPluginId(datasource.getPluginId());
+        actionCollectionDTO.setVariables(List.of(new JSValue("test", "String", "test", true)));
+        actionCollectionDTO.setBody("collectionBody");
+        actionCollectionDTO.setPluginType(PluginType.JS);
+
+        // Create actions
+        ActionDTO action1 = new ActionDTO();
+        action1.setName("testAction1");
+        action1.setActionConfiguration(new ActionConfiguration());
+        action1.getActionConfiguration().setBody("initial body");
+        action1.getActionConfiguration().setIsValid(false);
+        actionCollectionDTO.setActions(List.of(action1));
+
+        // Create Js object
+        ActionCollectionDTO createdActionCollectionDTO =
+                layoutCollectionService.createCollection(actionCollectionDTO).block();
+        assert createdActionCollectionDTO != null;
+        assert createdActionCollectionDTO.getId() != null;
+        String createdActionCollectionId = createdActionCollectionDTO.getId();
+
+        // Update JS object to create an action with same name as previously created action
+        ActionDTO action2 = new ActionDTO();
+        action2.setName("testAction2");
+        action2.setActionConfiguration(new ActionConfiguration());
+        action2.getActionConfiguration().setBody("mockBody");
+        action2.getActionConfiguration().setIsValid(false);
+
+        ActionDTO action3 = new ActionDTO();
+        action3.setName("testAction2");
+        action3.setActionConfiguration(new ActionConfiguration());
+        action3.getActionConfiguration().setBody("mockBody");
+        action3.getActionConfiguration().setIsValid(false);
+
+        actionCollectionDTO.setActions(
+                List.of(createdActionCollectionDTO.getActions().get(0), action2, action3));
+
+        final Mono<ActionCollectionDTO> updatedActionCollectionDTO =
+                layoutCollectionService.updateUnpublishedActionCollection(
+                        createdActionCollectionId, actionCollectionDTO);
+
+        StepVerifier.create(updatedActionCollectionDTO).verifyErrorSatisfies(error -> {
+            assertTrue(error instanceof AppsmithException);
+            String expectedMessage = "testAction2 already exists. Please use a different name";
             assertEquals(expectedMessage, error.getMessage());
         });
     }


### PR DESCRIPTION
## Description

[During analysis of action creation flow metrics](https://github.com/appsmithorg/appsmith/issues/37151#issuecomment-2468354426), we observed that RefactoringService.isNameAllowed is taking 80-90% of the total JS object action time. This PR optimises this part in a way that for any jsobject action, instead of fetching all actions from DB and comparing it 
to see if current action name is allowed, we simply do that check in memory where for current action collection, if any action names are being duplicated, we throw the error.

We could make this change easily because recently we merged a [PR](https://github.com/appsmithorg/appsmith/pull/36958) which removes the actions with duplicate name from client payload whenever Js object update API is called, with this change, we can guarantee that for any JS object update call, all actions inside it will always have unique names. This PR makes the similar check on backend where if any action has duplicate name within collection, we throw an error and don't store that action in the DB.

We may need to consider following test case in both before and after implementation of this approach. This can be covered during PR testing:
What happens if the client sends multiple requests to add a new function in an existing collection. That is, as a result of the debounce logic, if the server receives 2 consecutive requests with a populated collection but without actionId associated to either request.

Relevant thread: https://theappsmith.slack.com/archives/C040LHZN03V/p1731571364933089

Fixes #37365 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11911295324>
> Commit: d5c75edd301e75b2432b642f366bc80c6fea6b89
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11911295324&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Tue, 19 Nov 2024 11:14:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation to prevent the creation of actions with duplicate names in action collections.
	- Simplified handling of JavaScript actions, allowing them to bypass certain validation checks.

- **Bug Fixes**
	- Improved error handling during action updates and collection modifications to ensure better logging and management of failures.

- **Tests**
	- Added tests to verify that duplicate action names trigger appropriate error messages, enhancing the robustness of the action collection feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->