### PR TITLE
fix: Change the 'eventName' of each template of Custom Widget

### DIFF
--- a/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/Header/CodeTemplates/Templates/react.ts
+++ b/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/Header/CodeTemplates/Templates/react.ts
@@ -66,7 +66,7 @@ function App() {
 
 	const handleReset = () => {
 		setCurrentIndex(0);
-		appsmith.triggerEvent("onReset");
+		appsmith.triggerEvent("onResetClick");
 	};
 
 	return (

--- a/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/Header/CodeTemplates/Templates/vanillaJs.ts
+++ b/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/Header/CodeTemplates/Templates/vanillaJs.ts
@@ -108,7 +108,7 @@ export default {
 	reset.addEventListener("click", () => {
 		currentIndex = 0;
 		updateDom();
-		appsmith.triggerEvent("onReset");
+		appsmith.triggerEvent("onResetClick");
 	});
 
 	updateDom();

--- a/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/Header/CodeTemplates/Templates/vue.ts
+++ b/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/Header/CodeTemplates/Templates/vue.ts
@@ -107,7 +107,7 @@ export default {
 			},
 			reset() {
 				this.currentIndex = 0;
-				appsmith.triggerEvent("onReset");
+				appsmith.triggerEvent("onResetClick");
 			},
 		},
 	});


### PR DESCRIPTION
## Description
The 'eventName' of each template is incorrect, so I have renamed it.

`appsmith.triggerEvent("onReset");`  to `appsmith.triggerEvent("onResetClick");`

Fixes #37395

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated event handling for reset actions in the React, Vanilla JS, and Vue templates to improve clarity and functionality.

- **Bug Fixes**
	- Adjusted event names from `"onReset"` to `"onResetClick"` to ensure proper communication with the appsmith framework during reset actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->