### PR TITLE
feat: pass workspace id to form control

### DIFF
--- a/app/client/src/components/formControls/BaseControl.tsx
+++ b/app/client/src/components/formControls/BaseControl.tsx
@@ -109,6 +109,7 @@ export interface ControlData {
   isSecretExistsPath?: string;
   addMoreButtonLabel?: string;
   datasourceId?: string;
+  workspaceId?: string;
 }
 export type FormConfigType = Omit<ControlData, "configProperty"> & {
   configProperty?: string;

--- a/app/client/src/pages/Editor/FormControl.tsx
+++ b/app/client/src/pages/Editor/FormControl.tsx
@@ -32,6 +32,7 @@ import { SQL_DATASOURCES } from "constants/QueryEditorConstants";
 import type { Datasource, DatasourceStructure } from "entities/Datasource";
 import { getCurrentEditingEnvironmentId } from "ee/selectors/environmentSelectors";
 import { selectFeatureFlags } from "ee/selectors/featureFlagsSelectors";
+import { getCurrentWorkspaceId } from "ee/selectors/selectedWorkspaceSelectors";
 
 export interface FormControlProps {
   config: ControlProps;
@@ -94,6 +95,7 @@ function FormControl(props: FormControlProps) {
   const pluginName: string = useSelector((state: AppState) =>
     getPluginNameFromId(state, pluginId),
   );
+  const workspaceId = useSelector(getCurrentWorkspaceId);
 
   // moving creation of template to the formControl layer, this way any formControl created can potentially have a template system.
   const isNewQuery =
@@ -181,6 +183,7 @@ function FormControl(props: FormControlProps) {
       {
         ...config,
         datasourceId: dsId,
+        workspaceId,
       },
       props.formName,
       props?.multipleConfig,


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11859064065>
> Commit: 3640388e4f5eae27e6bd833d1862e52e15500138
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11859064065&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 15 Nov 2024 16:30:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional property `workspaceId` to enhance form control data handling.
	- Updated logic in the `FormControl` component to utilize the current workspace ID for improved control rendering.

- **Bug Fixes**
	- Adjusted template visibility logic to consider the new workspace ID, ensuring accurate rendering in the template menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->