### PR TITLE
chore: Rename app-viewers to widgets-blocks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,12 +27,12 @@ app/client/src/widgets/wds/* @appsmithorg/wds-team @appsmithorg/anvil-team
 app/client/src/layoutSystems/anvil/* @appsmithorg/anvil-team
 
 # App viewers pod
-app/client/src/widgets/* @appsmithorg/app-viewers
-app/client/src/components/propertyControls/* @appsmithorg/app-viewers
-app/client/src/sagas/OneClickBindingSaga.ts @appsmithorg/app-viewers
-app/client/src/WidgetQueryGenerators/* @appsmithorg/app-viewers
-app/client/src/components/editorComponents/WidgetQueryGeneratorForm/* @appsmithorg/app-viewers
-app/client/src/pages/AppViewer/* @appsmithorg/app-viewers
+app/client/src/widgets/* @appsmithorg/widgets-blocks
+app/client/src/components/propertyControls/* @appsmithorg/widgets-blocks
+app/client/src/sagas/OneClickBindingSaga.ts @appsmithorg/widgets-blocks
+app/client/src/WidgetQueryGenerators/* @appsmithorg/widgets-blocks
+app/client/src/components/editorComponents/WidgetQueryGeneratorForm/* @appsmithorg/widgets-blocks
+app/client/src/pages/AppViewer/* @appsmithorg/widgets-blocks
 
 # New Developers Pod
 app/server/appsmith-server/src/main/java/com/appsmith/server/featureflags/* @nilanshbansal


### PR DESCRIPTION

![shot-2024-11-19-08-08-13](https://github.com/user-attachments/assets/ae7ccd1f-bfe9-4b9e-bf63-c7885d055a68)


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated ownership assignments for various directories related to widget functionality, transferring responsibilities from `@appsmithorg/app-viewers` to `@appsmithorg/widgets-blocks`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->