### PR TITLE
Remove default "ngnix" value for ingress class

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
-  ingressClassName: {{ .Values.ingress.className |  default "nginx" }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
     {{- if not .Values.ingress.hosts }}


### PR DESCRIPTION
For some cases, when you are using `kubernetes.io/ingress.class: azure/application-gateway` you need to omit `ingressClassName` from spec. When you have this default value, it prevents doing so and the ingress is not created. I found an workround for now, to just put space in the `ingress.class` value.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved adaptability of the Ingress resource template for various Kubernetes versions.
	- Enhanced handling of ingress class annotations based on configuration settings.

- **Bug Fixes**
	- Ensured compatibility of backend service configurations with different Kubernetes versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->