### PR TITLE
chore: set datasourceId in executeActionDTO during execution

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -252,17 +252,24 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
         Mono<ExecuteActionDTO> systemInfoPopulatedExecuteActionDTOMono =
                 actionExecutionSolutionHelper.populateExecuteActionDTOWithSystemInfo(executeActionDTO);
 
-        return systemInfoPopulatedExecuteActionDTOMono.flatMap(
-                populatedExecuteActionDTO -> Mono.zip(instanceIdMono, defaultTenantIdMono)
-                        .map(tuple -> {
-                            String instanceId = tuple.getT1();
-                            String tenantId = tuple.getT2();
-                            populatedExecuteActionDTO.setActionId(newAction.getId());
-                            populatedExecuteActionDTO.setWorkspaceId(newAction.getWorkspaceId());
-                            populatedExecuteActionDTO.setInstanceId(instanceId);
-                            populatedExecuteActionDTO.setTenantId(tenantId);
-                            return populatedExecuteActionDTO;
-                        }));
+        return systemInfoPopulatedExecuteActionDTOMono.flatMap(populatedExecuteActionDTO -> Mono.zip(
+                        instanceIdMono, defaultTenantIdMono)
+                .map(tuple -> {
+                    String instanceId = tuple.getT1();
+                    String tenantId = tuple.getT2();
+                    populatedExecuteActionDTO.setActionId(newAction.getId());
+                    populatedExecuteActionDTO.setWorkspaceId(newAction.getWorkspaceId());
+                    if (TRUE.equals(executeActionDTO.getViewMode())) {
+                        populatedExecuteActionDTO.setDatasourceId(
+                                newAction.getPublishedAction().getDatasource().getId());
+                    } else {
+                        populatedExecuteActionDTO.setDatasourceId(
+                                newAction.getUnpublishedAction().getDatasource().getId());
+                    }
+                    populatedExecuteActionDTO.setInstanceId(instanceId);
+                    populatedExecuteActionDTO.setTenantId(tenantId);
+                    return populatedExecuteActionDTO;
+                }));
     }
 
     /**


### PR DESCRIPTION
## Description
> Set the correct datasourceId to executeActionDTO when an action is being executed.

Fixes https://github.com/appsmithorg/appsmith/issues/37627

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11948824843>
> Commit: 458b5c0d90fa138c57ed7f1dd491d985bfe0b5df
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11948824843&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 21 Nov 2024 08:22:41 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality to set the correct `datasourceId` based on the action's context, improving action execution accuracy.

- **Refactor**
	- Improved code formatting for clarity without altering existing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->