### PR TITLE
chore: add executeActionDTO as additional parameter to be used when creating query for AppsmithAI plugin queries

### DIFF
--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/AppsmithAiPlugin.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/AppsmithAiPlugin.java
@@ -172,7 +172,7 @@ public class AppsmithAiPlugin extends BasePlugin {
             Feature feature =
                     Feature.valueOf(RequestUtils.extractDataFromFormData(actionConfiguration.getFormData(), USECASE));
             AiFeatureService aiFeatureService = AiFeatureServiceFactory.getAiFeatureService(feature);
-            Query query = aiFeatureService.createQuery(actionConfiguration, datasourceConfiguration);
+            Query query = aiFeatureService.createQuery(actionConfiguration, datasourceConfiguration, executeActionDTO);
             AiServerRequestDTO aiServerRequestDTO = new AiServerRequestDTO(feature, query);
 
             ActionExecutionResult actionExecutionResult = new ActionExecutionResult();

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/AiFeatureService.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/AiFeatureService.java
@@ -1,9 +1,13 @@
 package com.external.plugins.services;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.external.plugins.dtos.Query;
 
 public interface AiFeatureService {
-    Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration);
+    Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO);
 }

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/ImageCaptioningServiceImpl.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/ImageCaptioningServiceImpl.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -16,7 +17,10 @@ import static com.external.plugins.utils.FieldValidationHelper.validateTextInput
 
 public class ImageCaptioningServiceImpl implements AiFeatureService {
     @Override
-    public Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration) {
+    public Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO) {
         Map<String, Object> formData = actionConfiguration.getFormData();
         validateTextInput(formData, IMAGE_CAPTIONING);
         String input = PluginUtils.getDataValueSafelyFromFormData(formData, IMAGE_CAPTION_INPUT, STRING_TYPE);

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/ImageClassificationServiceImpl.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/ImageClassificationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -20,7 +21,10 @@ import static com.external.plugins.utils.FieldValidationHelper.validateTextInput
 
 public class ImageClassificationServiceImpl implements AiFeatureService {
     @Override
-    public Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration) {
+    public Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO) {
 
         Map<String, Object> formData = actionConfiguration.getFormData();
         validateTextInputAndProperties(formData, IMAGE_CLASSIFICATION, List.of(LABELS));

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/ImageEntityExtractionServiceImpl.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/ImageEntityExtractionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -20,7 +21,10 @@ import static com.external.plugins.utils.FieldValidationHelper.validateTextInput
 
 public class ImageEntityExtractionServiceImpl implements AiFeatureService {
     @Override
-    public Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration) {
+    public Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO) {
         Map<String, Object> formData = actionConfiguration.getFormData();
         validateTextInputAndProperties(formData, IMAGE_ENTITY_EXTRACTION, List.of(LABELS));
         String input = PluginUtils.getDataValueSafelyFromFormData(formData, IMAGE_ENTITY_INPUT, STRING_TYPE);

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextClassificationServiceImpl.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextClassificationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -20,7 +21,10 @@ import static com.external.plugins.utils.FieldValidationHelper.validateTextInput
 
 public class TextClassificationServiceImpl implements AiFeatureService {
     @Override
-    public Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration) {
+    public Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO) {
         Map<String, Object> formData = actionConfiguration.getFormData();
         validateTextInputAndProperties(formData, TEXT_CLASSIFICATION, List.of(LABELS));
         String input = PluginUtils.getDataValueSafelyFromFormData(formData, TEXT_CLASSIFY_INPUT, STRING_TYPE);

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextEntityExtractionServiceImpl.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextEntityExtractionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -20,7 +21,10 @@ import static com.external.plugins.utils.FieldValidationHelper.validateTextInput
 
 public class TextEntityExtractionServiceImpl implements AiFeatureService {
     @Override
-    public Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration) {
+    public Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO) {
         Map<String, Object> formData = actionConfiguration.getFormData();
         validateTextInputAndProperties(formData, TEXT_ENTITY_EXTRACTION, List.of(LABELS));
         String input = PluginUtils.getDataValueSafelyFromFormData(formData, TEXT_ENTITY_INPUT, STRING_TYPE);

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextGenerationServiceImpl.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextGenerationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -18,7 +19,10 @@ import static com.external.plugins.utils.FieldValidationHelper.validateTextInput
 
 public class TextGenerationServiceImpl implements AiFeatureService {
     @Override
-    public Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration) {
+    public Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO) {
         Map<String, Object> formData = actionConfiguration.getFormData();
         validateTextInput(formData, TEXT_GENERATION);
         String input = PluginUtils.getDataValueSafelyFromFormData(formData, TEXT_GENERATION_INPUT, STRING_TYPE);

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextSummarizationServiceImpl.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/java/com/external/plugins/services/features/TextSummarizationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.helpers.PluginUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -16,7 +17,10 @@ import static com.external.plugins.utils.FieldValidationHelper.validateTextInput
 
 public class TextSummarizationServiceImpl implements AiFeatureService {
     @Override
-    public Query createQuery(ActionConfiguration actionConfiguration, DatasourceConfiguration datasourceConfiguration) {
+    public Query createQuery(
+            ActionConfiguration actionConfiguration,
+            DatasourceConfiguration datasourceConfiguration,
+            ExecuteActionDTO executeActionDTO) {
         Map<String, Object> formData = actionConfiguration.getFormData();
         validateTextInput(formData, TEXT_SUMMARY);
         String input = PluginUtils.getDataValueSafelyFromFormData(formData, TEXT_SUMMARY_INPUT, STRING_TYPE);

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/ImageCaptioningServiceImplTest.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/ImageCaptioningServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -33,7 +34,8 @@ class ImageCaptioningServiceImplTest {
                         INSTRUCTIONS, Map.of(DATA, "Some instructions")));
         actionConfiguration.setFormData(formData);
 
-        Query query = imageCaptioningService.createQuery(actionConfiguration, datasourceConfiguration);
+        Query query = imageCaptioningService.createQuery(
+                actionConfiguration, datasourceConfiguration, new ExecuteActionDTO());
 
         assertNotNull(query);
         assertEquals("Some image data", query.getInput());
@@ -53,7 +55,8 @@ class ImageCaptioningServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> imageCaptioningService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> imageCaptioningService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/ImageClassificationServiceImplTest.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/ImageClassificationServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -36,7 +37,8 @@ class ImageClassificationServiceImplTest {
                         INSTRUCTIONS, Map.of(DATA, "Some instructions")));
         actionConfiguration.setFormData(formData);
 
-        Query query = imageClassificationService.createQuery(actionConfiguration, datasourceConfiguration);
+        Query query = imageClassificationService.createQuery(
+                actionConfiguration, datasourceConfiguration, new ExecuteActionDTO());
 
         assertNotNull(query);
         assertEquals("Some image data", query.getInput());
@@ -56,7 +58,8 @@ class ImageClassificationServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> imageClassificationService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> imageClassificationService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/ImageEntityExtractionServiceImplTest.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/ImageEntityExtractionServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -36,7 +37,8 @@ class ImageEntityExtractionServiceImplTest {
                         INSTRUCTIONS, Map.of(DATA, "Some instructions")));
         actionConfiguration.setFormData(formData);
 
-        Query query = imageEntityExtractionService.createQuery(actionConfiguration, datasourceConfiguration);
+        Query query = imageEntityExtractionService.createQuery(
+                actionConfiguration, datasourceConfiguration, new ExecuteActionDTO());
 
         assertNotNull(query);
         assertEquals("Some image data", query.getInput());
@@ -56,7 +58,8 @@ class ImageEntityExtractionServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> imageEntityExtractionService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> imageEntityExtractionService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextClassificationServiceImplTest.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextClassificationServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -36,7 +37,8 @@ class TextClassificationServiceImplTest {
                         INSTRUCTIONS, Map.of(DATA, "Some instructions")));
         actionConfiguration.setFormData(formData);
 
-        Query query = textClassificationService.createQuery(actionConfiguration, datasourceConfiguration);
+        Query query = textClassificationService.createQuery(
+                actionConfiguration, datasourceConfiguration, new ExecuteActionDTO());
 
         assertNotNull(query);
         assertEquals("Some text", query.getInput());
@@ -56,7 +58,8 @@ class TextClassificationServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> textClassificationService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> textClassificationService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextEntityExtractionServiceImplTest.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextEntityExtractionServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -37,7 +38,8 @@ class TextEntityExtractionServiceImplTest {
                         Map.of(DATA, "Some instructions")));
         actionConfiguration.setFormData(formData);
 
-        Query query = textEntityExtractionService.createQuery(actionConfiguration, datasourceConfiguration);
+        Query query = textEntityExtractionService.createQuery(
+                actionConfiguration, datasourceConfiguration, new ExecuteActionDTO());
 
         assertNotNull(query);
         assertEquals("Some text", query.getInput());
@@ -57,7 +59,8 @@ class TextEntityExtractionServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> textEntityExtractionService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> textEntityExtractionService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextGenerationServiceImplTest.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextGenerationServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -27,7 +28,8 @@ class TextGenerationServiceImplTest {
         formData.put(TEXT_GENERATION, Map.of(INPUT, Map.of(DATA, "Hello, World!")));
         actionConfiguration.setFormData(formData);
 
-        Query query = textGenerationService.createQuery(actionConfiguration, datasourceConfiguration);
+        Query query =
+                textGenerationService.createQuery(actionConfiguration, datasourceConfiguration, new ExecuteActionDTO());
 
         assertNotNull(query);
         assertEquals("Hello, World!", query.getInput());
@@ -45,7 +47,8 @@ class TextGenerationServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> textGenerationService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> textGenerationService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }
@@ -62,7 +65,8 @@ class TextGenerationServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> textGenerationService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> textGenerationService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextSummarizationServiceImplTest.java
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/test/java/com/external/plugins/services/features/TextSummarizationServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins.services.features;
 
+import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -30,7 +31,8 @@ class TextSummarizationServiceImplTest {
                 Map.of(INPUT, Map.of(DATA, "Some text"), INSTRUCTIONS, Map.of(DATA, "Some instructions")));
         actionConfiguration.setFormData(formData);
 
-        Query query = textSummarizationService.createQuery(actionConfiguration, datasourceConfiguration);
+        Query query = textSummarizationService.createQuery(
+                actionConfiguration, datasourceConfiguration, new ExecuteActionDTO());
 
         assertNotNull(query);
         assertEquals("Some text", query.getInput());
@@ -49,7 +51,8 @@ class TextSummarizationServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> textSummarizationService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> textSummarizationService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }
@@ -66,7 +69,8 @@ class TextSummarizationServiceImplTest {
 
         AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> textSummarizationService.createQuery(actionConfiguration, datasourceConfiguration));
+                () -> textSummarizationService.createQuery(
+                        actionConfiguration, datasourceConfiguration, new ExecuteActionDTO()));
 
         assertEquals("input is not provided", exception.getMessage());
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -252,17 +252,24 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
         Mono<ExecuteActionDTO> systemInfoPopulatedExecuteActionDTOMono =
                 actionExecutionSolutionHelper.populateExecuteActionDTOWithSystemInfo(executeActionDTO);
 
-        return systemInfoPopulatedExecuteActionDTOMono.flatMap(
-                populatedExecuteActionDTO -> Mono.zip(instanceIdMono, defaultTenantIdMono)
-                        .map(tuple -> {
-                            String instanceId = tuple.getT1();
-                            String tenantId = tuple.getT2();
-                            populatedExecuteActionDTO.setActionId(newAction.getId());
-                            populatedExecuteActionDTO.setWorkspaceId(newAction.getWorkspaceId());
-                            populatedExecuteActionDTO.setInstanceId(instanceId);
-                            populatedExecuteActionDTO.setTenantId(tenantId);
-                            return populatedExecuteActionDTO;
-                        }));
+        return systemInfoPopulatedExecuteActionDTOMono.flatMap(populatedExecuteActionDTO -> Mono.zip(
+                        instanceIdMono, defaultTenantIdMono)
+                .map(tuple -> {
+                    String instanceId = tuple.getT1();
+                    String tenantId = tuple.getT2();
+                    populatedExecuteActionDTO.setActionId(newAction.getId());
+                    populatedExecuteActionDTO.setWorkspaceId(newAction.getWorkspaceId());
+                    if (TRUE.equals(executeActionDTO.getViewMode())) {
+                        populatedExecuteActionDTO.setDatasourceId(
+                                newAction.getPublishedAction().getDatasource().getId());
+                    } else {
+                        populatedExecuteActionDTO.setDatasourceId(
+                                newAction.getUnpublishedAction().getDatasource().getId());
+                    }
+                    populatedExecuteActionDTO.setInstanceId(instanceId);
+                    populatedExecuteActionDTO.setTenantId(tenantId);
+                    return populatedExecuteActionDTO;
+                }));
     }
 
     /**


### PR DESCRIPTION
## Description
> Add executeActionDTO as an additional parameter when executing queries for Appsmith AI Plugin

Fixes https://github.com/appsmithorg/appsmith/issues/37637

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11949422399>
> Commit: 116c3842f59001837599aab01fb907e1e290cf45
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11949422399&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 21 Nov 2024 09:04:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
