### PR TITLE
fix: Updating empty state message when searching items in queries segment

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorPane/Query/List.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorPane/Query/List.tsx
@@ -98,7 +98,7 @@ const ListQuery = () => {
         })}
         {localFiles.length === 0 && searchTerm !== "" ? (
           <EmptySearchResult
-            type={createMessage(EDITOR_PANE_TEXTS.search_objects.jsObject)}
+            type={createMessage(EDITOR_PANE_TEXTS.search_objects.queries)}
           />
         ) : null}
       </Flex>


### PR DESCRIPTION
## Description

Updating empty state message when searching items in queries segment

Fixes [#37635](https://github.com/appsmithorg/appsmith/issues/37635)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11953608015>
> Commit: 7cd8517137aa42ca2c5bfd7ef78fb9daa686647f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11953608015&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 21 Nov 2024 13:34:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated messaging in the search results for improved clarity when no queries are found.
  
- **Bug Fixes**
	- Corrected the context of the empty search result message from JavaScript objects to queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->