### PR TITLE
chore: restore removed ts expect error comments

### DIFF
--- a/app/client/packages/ast/src/actionCreator/index.ts
+++ b/app/client/packages/ast/src/actionCreator/index.ts
@@ -808,7 +808,7 @@ export function canTranslateToUI(
         canTranslate = false;
       }
     },
-    LogicalExpression(node: Node) {
+    LogicalExpression(node) {
       // @ts-expect-error: types not matched
       if (isCallExpressionNode(node.left) || isCallExpressionNode(node.right)) {
         canTranslate = false;

--- a/app/client/packages/ast/src/actionCreator/index.ts
+++ b/app/client/packages/ast/src/actionCreator/index.ts
@@ -800,13 +800,16 @@ export function canTranslateToUI(
   simple(astWithComments, {
     ConditionalExpression(node) {
       if (
+        // @ts-expect-error: types not matched
         isCallExpressionNode(node.consequent) ||
+        // @ts-expect-error: types not matched
         isCallExpressionNode(node.alternate)
       ) {
         canTranslate = false;
       }
     },
-    LogicalExpression(node) {
+    LogicalExpression(node: Node) {
+      // @ts-expect-error: types not matched
       if (isCallExpressionNode(node.left) || isCallExpressionNode(node.right)) {
         canTranslate = false;
       }
@@ -909,10 +912,12 @@ export function getMainAction(
     ExpressionStatement(node) {
       simple(node, {
         CallExpression(node) {
+          // @ts-expect-error: types not matched
           if (node.callee.type === NodeTypes.Identifier) {
             mainAction = generate(node, { comments: true }).trim();
           } else {
             mainAction =
+              // @ts-expect-error: types not matched
               generate(node.callee, { comments: true }).trim() + "()";
           }
         },


### PR DESCRIPTION
## Description
I removed ts expect error comments while upgrading the jest lib. This was erroneous, the comments are still needed. No change in functionality, just to suppress ts errors.


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
