### PR TITLE
fix: fixing basePageId in settings url preview

### DIFF
--- a/app/client/src/pages/Editor/AppSettingsPane/AppSettings/PageSettings.tsx
+++ b/app/client/src/pages/Editor/AppSettingsPane/AppSettings/PageSettings.tsx
@@ -83,12 +83,12 @@ function PageSettings(props: { page: Page }) {
   const [isDefaultSaving, setIsDefaultSaving] = useState(false);
 
   const pathPreview = useCallback(getUrlPreview, [
-    page.pageId,
+    page.basePageId,
     pageName,
     page.pageName,
     customSlug,
     page.customSlug,
-  ])(page.pageId, pageName, page.pageName, customSlug, page.customSlug);
+  ])(page.basePageId, pageName, page.pageName, customSlug, page.customSlug);
 
   const conflictingNames = useSelector(
     (state: AppState) => getUsedActionNames(state, ""),

--- a/app/client/src/pages/Editor/AppSettingsPane/Utils.ts
+++ b/app/client/src/pages/Editor/AppSettingsPane/Utils.ts
@@ -3,7 +3,7 @@ import urlBuilder from "ee/entities/URLRedirect/URLAssembly";
 import { splitPathPreview } from "utils/helpers";
 
 export const getUrlPreview = (
-  pageId: string,
+  basePageId: string,
   newPageName: string,
   currentPageName: string,
   newCustomSlug?: string,
@@ -22,22 +22,25 @@ export const getUrlPreview = (
   // and when custom slug doesn't exist
   if (!newCustomSlug && newPageName !== currentPageName) {
     // show path based on page name
-    relativePath = urlBuilder.getPagePathPreview(pageId, newPageName);
+    relativePath = urlBuilder.getPagePathPreview(basePageId, newPageName);
   }
   // when custom slug is changed
   else if (newCustomSlug !== currentCustomSlug) {
     if (newCustomSlug) {
       // show custom slug preview
-      relativePath = urlBuilder.getCustomSlugPathPreview(pageId, newCustomSlug);
+      relativePath = urlBuilder.getCustomSlugPathPreview(
+        basePageId,
+        newCustomSlug,
+      );
     } else {
       // when custom slug is removed
       // show path based on page name
-      relativePath = urlBuilder.getPagePathPreview(pageId, newPageName);
+      relativePath = urlBuilder.getPagePathPreview(basePageId, newPageName);
     }
   }
   // when nothing has changed
   else {
-    relativePath = urlBuilder.generateBasePath(pageId, APP_MODE.PUBLISHED);
+    relativePath = urlBuilder.generateBasePath(basePageId, APP_MODE.PUBLISHED);
   }
 
   return {


### PR DESCRIPTION
## Description
Fixes issue with faulty pageId in the url preview in page settings


Fixes https://github.com/appsmithorg/appsmith/issues/37580

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12115733621>
> Commit: 4307381ba6caa022e630b1d4d3f51494f52714c4
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12115733621&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Mon, 02 Dec 2024 09:44:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced URL preview generation by utilizing the base page ID for more accurate path structures.

- **Bug Fixes**
	- Improved state management for page properties, ensuring accurate initialization and error handling when loading new pages.

- **Refactor**
	- Updated function parameters for URL generation to reflect changes in logic, maintaining overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->