### PR TITLE
chore: [Plugin Action Editor] Defer plugin config checks

### DIFF
--- a/app/client/src/PluginActionEditor/PluginActionContext.tsx
+++ b/app/client/src/PluginActionEditor/PluginActionContext.tsx
@@ -12,8 +12,8 @@ import type { ActionResponse } from "api/ActionAPI";
 interface PluginActionContextType {
   action: Action;
   actionResponse?: ActionResponse;
-  editorConfig: unknown[];
-  settingsConfig: unknown[];
+  editorConfig?: unknown[];
+  settingsConfig?: unknown[];
   plugin: Plugin;
   datasource?: EmbeddedRestDatasource | Datasource;
 }

--- a/app/client/src/PluginActionEditor/PluginActionEditor.tsx
+++ b/app/client/src/PluginActionEditor/PluginActionEditor.tsx
@@ -62,16 +62,6 @@ const PluginActionEditor = (props: ChildrenProps) => {
     );
   }
 
-  if (!settingsConfig || !editorConfig) {
-    return (
-      <CenteredWrapper>
-        <Text color="var(--ads-v2-color-fg-error)" kind="heading-m">
-          Editor config not found!
-        </Text>
-      </CenteredWrapper>
-    );
-  }
-
   const actionResponse = actionResponses[action.id];
 
   return (

--- a/app/client/src/PluginActionEditor/components/PluginActionForm/PluginActionForm.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/PluginActionForm.tsx
@@ -1,15 +1,27 @@
 import React from "react";
-import { Flex } from "@appsmith/ads";
+import { Flex, Text } from "@appsmith/ads";
 import { useChangeActionCall } from "./hooks/useChangeActionCall";
 import { usePluginActionContext } from "../../PluginActionContext";
 import { UIComponentTypes } from "api/PluginApi";
 import APIEditorForm from "./components/ApiEditor";
 import GraphQLEditorForm from "./components/GraphQLEditor";
 import UQIEditorForm from "./components/UQIEditor";
+import CenteredWrapper from "components/designSystems/appsmith/CenteredWrapper";
+import { createMessage, UNEXPECTED_ERROR } from "ee/constants/messages";
 
 const PluginActionForm = () => {
   useChangeActionCall();
-  const { plugin } = usePluginActionContext();
+  const { editorConfig, plugin } = usePluginActionContext();
+
+  if (!editorConfig) {
+    return (
+      <CenteredWrapper>
+        <Text color="var(--ads-v2-color-fg-error)" kind="heading-m">
+          {createMessage(UNEXPECTED_ERROR)}
+        </Text>
+      </CenteredWrapper>
+    );
+  }
 
   return (
     <Flex flex="1" overflow="hidden" p="spaces-4" w="100%">

--- a/app/client/src/PluginActionEditor/components/PluginActionForm/components/UQIEditor/FormRender.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/components/UQIEditor/FormRender.tsx
@@ -22,7 +22,8 @@ import {
 import { isValidFormConfig } from "reducers/evaluationReducers/formEvaluationReducer";
 import FormControl from "pages/Editor/FormControl";
 import type { ControlProps } from "components/formControls/BaseControl";
-import { Spinner } from "@appsmith/ads";
+import { Spinner, Text } from "@appsmith/ads";
+import CenteredWrapper from "components/designSystems/appsmith/CenteredWrapper";
 import type { QueryAction, SaaSAction } from "entities/Action";
 import { Section, Zone } from "../ActionForm";
 
@@ -265,7 +266,13 @@ const FormRender = (props: Props) => {
     };
 
   if (!editorConfig || editorConfig.length < 0) {
-    return <ErrorComponent errorMessage={createMessage(UNEXPECTED_ERROR)} />;
+    return (
+      <CenteredWrapper>
+        <Text color="var(--ads-v2-color-fg-error)" kind="heading-m">
+          {createMessage(UNEXPECTED_ERROR)}
+        </Text>
+      </CenteredWrapper>
+    );
   }
 
   return renderConfig();

--- a/app/client/src/pages/Editor/ActionSettings.tsx
+++ b/app/client/src/pages/Editor/ActionSettings.tsx
@@ -5,6 +5,7 @@ import log from "loglevel";
 import type { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
 import styled from "styled-components";
 import { Text } from "@appsmith/ads";
+import CenteredWrapper from "../../components/designSystems/appsmith/CenteredWrapper";
 
 interface ActionSettingsProps {
   // TODO: Fix this the next time the file is edited
@@ -43,9 +44,11 @@ function ActionSettings(props: ActionSettingsProps): JSX.Element {
   return (
     <ActionSettingsWrapper>
       {!props.actionSettingsConfig ? (
-        <Text color="var(--ads-v2-color-fg-error)" kind="heading-m">
-          Error: No settings config found
-        </Text>
+        <CenteredWrapper>
+          <Text color="var(--ads-v2-color-fg-error)" kind="heading-m">
+            Error: No settings config found
+          </Text>
+        </CenteredWrapper>
       ) : (
         /* TODO: Fix this the next time the file is edited */
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Description

Updates Plugin Action Editor to defer the plugin check till needed. This ensures the usage of Plugin Action Context in scenarios the config is not needed.

Eg: If we want to show Plugin Action Response in App View Mode but not the form, we can still use the Plugin Action Editor with its context.


## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/11973235246>
> Commit: 88d7be19a01fb68a6417ee06cdc0430161c26e84
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=11973235246&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 22 Nov 2024 14:25:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced error message presentation with centered layout in various components.
	- Improved rendering logic for form configurations, ensuring clearer separation based on type.

- **Bug Fixes**
	- Simplified error handling in the `PluginActionEditor` component, removing unnecessary error checks.
	- Updated error handling in the `ActionSettings` component to improve message display.

- **Documentation**
	- Updated error handling and rendering logic for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->