### PR TITLE
chore: Read mail env variables only when needed

### DIFF
--- a/app/client/packages/rts/src/ctl/mailer.ts
+++ b/app/client/packages/rts/src/ctl/mailer.ts
@@ -3,15 +3,15 @@ import * as Constants from "./constants";
 import * as utils from "./utils";
 import * as logger from "./logger";
 
-const mailEnabled = process.env.APPSMITH_MAIL_ENABLED;
-const mailFrom = process.env.APPSMITH_MAIL_FROM;
-const mailHost = process.env.APPSMITH_MAIL_HOST;
-const mailPort = process.env.APPSMITH_MAIL_PORT;
-const mailUser = process.env.APPSMITH_MAIL_USERNAME;
-const mailPass = process.env.APPSMITH_MAIL_PASSWORD;
-const mailTo = process.env.APPSMITH_ADMIN_EMAILS;
-
 export async function sendBackupErrorToAdmins(err, backupTimestamp) {
+  const mailEnabled = process.env.APPSMITH_MAIL_ENABLED;
+  const mailFrom = process.env.APPSMITH_MAIL_FROM;
+  const mailHost = process.env.APPSMITH_MAIL_HOST;
+  const mailPort = process.env.APPSMITH_MAIL_PORT;
+  const mailUser = process.env.APPSMITH_MAIL_USERNAME;
+  const mailPass = process.env.APPSMITH_MAIL_PASSWORD;
+  const mailTo = process.env.APPSMITH_ADMIN_EMAILS;
+
   console.log("Sending Error mail to admins.");
   try {
     if (


### PR DESCRIPTION
Loading env variables at import time doesn't work now since we're importing first, and them loading env variables, after having moved to TypeScript.

This PR fixes that in the mailer module.


## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for email configuration by ensuring environment variables are validated before sending emails. 

- **Refactor**
	- Adjusted the scope of several environment variables to enhance code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->