### PR TITLE
chore: Remove unused `netcat` and `openssh-client`

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -159,12 +159,7 @@ This will need a restart of the Appsmith server, which can be done using the fol
 ```sh
 docker-compose exec appsmith-ce supervisorctl restart backend
 ```
-### Migrate To New Server
-To migrate a running container to a new server or other machine, you can use the following `migrate` command and replace the `<user>` and `<new-server-ip-address>` by the user and IP address of the destination server or machine.
-```
-docker exec appsmith-ce appsmithctl migrate <user>@<new-server-ip-address>
-```
-This command will migrate all data and configuration of running container on source machine to destination machine and start a new container on destination machine.
+
 ## Supervisor
 
 The container runs multiple processes, including the Appsmith server, Nginx, MongoDB etc., inside a single Docker container. These processes are started and managed by [supervisord](http://supervisord.org/).

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -18,7 +18,7 @@ RUN set -o xtrace \
   && apt-get update \
   && apt-get upgrade --yes \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-    supervisor curl nfs-common gnupg wget netcat openssh-client \
+    supervisor curl nfs-common gnupg wget \
     gettext \
     ca-certificates \
   # Install MongoDB v5, Redis, PostgreSQL v13


### PR DESCRIPTION
These packages were installed in https://github.com/appsmithorg/appsmith/commit/daf60fab72f7f05b47fa6024d4d4c9e3d31acc93 for use with the `appsmithctl migrate` command, which has never been documented, been deprecated and then deleted from code for some time now.

Removing these packages now as we don't need them any longer.

Tested on EE and verified `/test all` to have passed.

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the base image to `ubuntu:20.04` for improved compatibility.
	- Introduced a new builder stage for Caddy with the `caddy-ratelimit` module.
	- Enhanced support for internationalization by setting environment variables for language and locale.

- **Improvements**
	- Streamlined package installation process by removing unnecessary packages.
	- Optimized the final image size with cleanup commands and maintained essential database services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->