### PR TITLE
chore: Don't need `wget` anymore

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -18,7 +18,7 @@ RUN set -o xtrace \
   && apt-get update \
   && apt-get upgrade --yes \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-    supervisor curl nfs-common gnupg wget \
+    supervisor curl nfs-common gnupg \
     gettext \
     ca-certificates \
   # Install MongoDB v5, Redis, PostgreSQL v13


### PR DESCRIPTION
We don't use `wget`, just `curl` in all places.

Tested with full suite on EE.

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated PostgreSQL version from 13 to 14 in the installation process.
	- Removed `wget` from the package installation command, streamlining the setup.
	- Retained language settings and environment variables for compatibility.
	- Maintained existing installation steps for Java and NodeJS, ensuring consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->