### PR TITLE
chore: Fix env varibles in 404.html

### DIFF
--- a/app/client/public/404.html
+++ b/app/client/public/404.html
@@ -27,8 +27,8 @@
       return result;
     }
 
-    const smartLookId = parseConfig("__APPSMITH_SMART_LOOK_ID__");
-    const sentryDSN = parseConfig("__APPSMITH_SENTRY_DSN__");
+    const smartLookId = parseConfig('{{env "APPSMITH_SMART_LOOK_ID"}}');
+    const sentryDSN = parseConfig('{{env "APPSMITH_SENTRY_DSN"}}');
   </script>
   <script type='text/javascript'>
     if(smartLookId) {

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -225,7 +225,7 @@ if (CUSTOM_DOMAIN !== "") {
 }
 
 if (!process.argv.includes("--no-finalize-index-html")) {
-  finalizeIndexHtml()
+  finalizeHtmlFiles()
 }
 
 fs.mkdirSync(dirname(CaddyfilePath), { recursive: true })
@@ -233,7 +233,7 @@ fs.writeFileSync(CaddyfilePath, parts.join("\n"))
 spawnSync(AppsmithCaddy, ["fmt", "--overwrite", CaddyfilePath])
 spawnSync(AppsmithCaddy, ["reload", "--config", CaddyfilePath])
 
-function finalizeIndexHtml() {
+function finalizeHtmlFiles() {
   let info = null;
   try {
     info = JSON.parse(fs.readFileSync("/opt/appsmith/info.json", "utf8"))
@@ -248,12 +248,14 @@ function finalizeIndexHtml() {
     APPSMITH_VERSION_RELEASE_DATE: info?.imageBuiltAt ?? "",
   }
 
-  const content = fs.readFileSync("/opt/appsmith/editor/index.html", "utf8").replaceAll(
-    /\{\{env\s+"(APPSMITH_[A-Z0-9_]+)"}}/g,
-    (_, name) => (process.env[name] || extraEnv[name] || "")
-  )
+  for (const file of ["index.html", "404.html"]) {
+    const content = fs.readFileSync("/opt/appsmith/editor/" + file, "utf8").replaceAll(
+      /\{\{env\s+"(APPSMITH_[A-Z0-9_]+)"}}/g,
+      (_, name) => (process.env[name] || extraEnv[name] || "")
+    )
 
-  fs.writeFileSync(process.env.WWW_PATH + "/index.html", content)
+    fs.writeFileSync(process.env.WWW_PATH + "/" + file, content)
+  }
 }
 
 function isCertExpired(path) {
@@ -261,4 +263,3 @@ function isCertExpired(path) {
   console.log(path, cert)
   return new Date(cert.validTo) < new Date()
 }
-


### PR DESCRIPTION
Environment variables in `404.html` page aren't getting replaced with their values. This PR fixes that.


## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12005727044>
> Commit: 56b10fddf2ee7ed180ed59845b6f0223cd26b06a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12005727044&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Sanity
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/12005727044" target="_blank">workflow here</a>.
> <hr>Mon, 25 Nov 2024 08:48:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved dynamic retrieval of environment variables for better integration with environment-specific settings in the 404 error page.
	- Enhanced handling of HTML files, including the 404 page, during the configuration process.

- **Bug Fixes**
	- Improved error handling for missing SSL certificates and custom domains.

- **Documentation**
	- Updated logic for processing HTML files to ensure correct paths and configurations are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->