### PR TITLE
chore: Removing unused styles, extra space in entity item and passing button condition prop

### DIFF
--- a/app/client/src/IDE/Components/Sidebar/Sidebar.tsx
+++ b/app/client/src/IDE/Components/Sidebar/Sidebar.tsx
@@ -39,6 +39,7 @@ function IDESidebar(props: IDESidebarProps) {
       <div>
         {topButtons.map((button) => (
           <SidebarButton
+            condition={button.condition}
             icon={button.icon}
             key={button.state}
             onClick={onClick}
@@ -52,6 +53,7 @@ function IDESidebar(props: IDESidebarProps) {
       <div>
         {bottomButtons.map((button) => (
           <SidebarButton
+            condition={button.condition}
             icon={button.icon}
             key={button.state}
             onClick={onClick}

--- a/app/client/src/pages/Editor/Explorer/Entity/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/index.tsx
@@ -203,20 +203,10 @@ export const EntityItem = styled.div<{
 `;
 
 const IconWrapper = styled.span`
-  line-height: ${(props) => props.theme.lineHeights[0]}px;
-  color: var(--ads-v2-color-fg);
-  display: flex;
-  align-items: center;
-
-  div {
-    cursor: pointer;
-  }
-
   svg {
     width: 16px;
     height: 16px;
   }
-  margin-right: 4px;
 `;
 
 export const AddButtonWrapper = styled.div`


### PR DESCRIPTION
## Description

- Removing unused styles and extra space between icon and entity name in entity item component
- Passing button condition prop that is missing to show the warning icon on Data tab in sidebar, when there are no datasources connected in the workspace

Fixes [#37675](https://github.com/appsmithorg/appsmith/issues/37675)

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12009273207>
> Commit: f4bc4ab419a0b06a6910c0460bd0757db917fe72
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12009273207&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 25 Nov 2024 12:15:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `condition` property for enhanced button configuration in the sidebar.
	- Added an optional `preRightIcon` property to the `Entity` component for improved icon customization.

- **Bug Fixes**
	- Simplified styling of the `IconWrapper`, potentially improving icon display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->