### PR TITLE
fix: Resolve list widget Error

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/ListWidget_Bug37683_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/ListWidget_Bug37683_spec.ts
@@ -1,0 +1,42 @@
+import {
+    agHelper,
+    locators,
+    propPane,
+  } from "../../../../support/Objects/ObjectsCore";
+ 
+  const widgetSelector = (name: string) => `[data-widgetname-cy="${name}"]`;
+  const containerWidgetSelector = `[type="CONTAINER_WIDGET"]`;
+ 
+  describe("Bug 37683: List widget auto-height update infinite loop error", () => {
+    it("The list widget height should not trigger an auto-height update", () => {
+      cy.dragAndDropToCanvas("listwidgetv2", {
+        x: 300,
+        y: 600,
+      });
+      propPane.EnterJSContext(
+        "onitemclick",
+        `{{List1.setVisibility(false)}}`,
+        true,
+        false,
+      );
+      cy.dragAndDropToCanvas("buttonwidget", {
+        x: 600,
+        y: 600,
+      });
+      propPane.EnterJSContext(
+        "onClick",
+        `{{List1.setVisibility(true)}}`,
+        true,
+        false,
+      );
+      agHelper.GetNClick(locators._enterPreviewMode);
+      cy.get(`${widgetSelector("List1")} ${containerWidgetSelector}`)
+        .eq(1)
+        .click({ force: true });
+      cy.wait(4000);
+      agHelper.GetNClick(`${widgetSelector("Button1")}`);
+      agHelper.AssertElementVisibility(locators._widgetInDeployed("list1"));
+      agHelper.AssertElementVisibility(locators._widgetInDeployed("button1"));
+      agHelper.GetNClick(locators._exitPreviewMode);
+    });
+  });

--- a/app/client/src/widgets/ListWidgetV2/widget/defaultProps.ts
+++ b/app/client/src/widgets/ListWidgetV2/widget/defaultProps.ts
@@ -56,6 +56,7 @@ export default {
   minWidth: FILL_WIDGET_MIN_WIDTH,
   responsiveBehavior: ResponsiveBehavior.Fill,
   flexVerticalAlignment: FlexVerticalAlignment.Top,
+  isMetaWidget: true,
   dynamicBindingPathList: [
     {
       key: "currentItemsView",

--- a/app/client/src/widgets/ListWidgetV2/widget/defaultProps.ts
+++ b/app/client/src/widgets/ListWidgetV2/widget/defaultProps.ts
@@ -56,7 +56,6 @@ export default {
   minWidth: FILL_WIDGET_MIN_WIDTH,
   responsiveBehavior: ResponsiveBehavior.Fill,
   flexVerticalAlignment: FlexVerticalAlignment.Top,
-  isMetaWidget: true,
   dynamicBindingPathList: [
     {
       key: "currentItemsView",

--- a/app/client/src/widgets/withWidgetProps.tsx
+++ b/app/client/src/widgets/withWidgetProps.tsx
@@ -301,7 +301,8 @@ function withWidgetProps(WrappedWidget: typeof BaseWidget) {
         // this flag serves as a way to avoid any unintended changes to the child widget's height.
         if (
           widgetProps.bottomRow !== widgetProps.topRow &&
-          !widgetProps.isMetaWidget
+          !widgetProps.isMetaWidget &&
+          !(type === "LIST_WIDGET_V2" && widgetProps.hasMetaWidgets)
         ) {
           dispatch({
             type: ReduxActionTypes.UPDATE_WIDGET_AUTO_HEIGHT,


### PR DESCRIPTION
## Description
This PR resolves an issue with the List widget caused by infinite auto height update loops. The child widgets of the List widget already have the isMetaWidget flag, which prevents auto height updates. However, the List widget itself did not have this flag, leading to the issue. This fix ensures that the isMetaWidget flag is also applied to the List widget, preventing the infinite update loop.

Fixes #37683

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new Cypress test specification for the List widget's auto-height functionality
	- Verifies widget behavior during interactions and visibility changes

- **Bug Fixes**
	- Improved logic for handling auto-height updates in List widgets
	- Prevented potential infinite loop scenarios during widget interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->