### PR TITLE
Add MailSettings to tenant configuration

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/EmailConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/EmailConfig.java
@@ -29,9 +29,6 @@ public class EmailConfig {
     @Value("${reply.to}")
     private String replyTo;
 
-    @Value("${emails.welcome.enabled:true}")
-    private boolean isWelcomeEmailEnabled;
-
     @Value("${mail.support}")
     private String supportEmailAddress;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/MailSettings.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/MailSettings.java
@@ -1,0 +1,11 @@
+package com.appsmith.server.domains;
+
+public record MailSettings(
+        Boolean isEnabled,
+        String protocol,
+        String host,
+        Integer port,
+        Boolean isStartTLSEnabled,
+        String username,
+        String password,
+        String replyToAddress) {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/TenantConfigurationCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/TenantConfigurationCE.java
@@ -5,6 +5,7 @@ import com.appsmith.server.constants.FeatureMigrationType;
 import com.appsmith.server.constants.LicensePlan;
 import com.appsmith.server.constants.MigrationStatus;
 import com.appsmith.server.domains.License;
+import com.appsmith.server.domains.MailSettings;
 import com.appsmith.server.domains.TenantConfiguration;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
@@ -55,6 +56,8 @@ public class TenantConfigurationCE implements Serializable {
     Boolean isStrongPasswordPolicyEnabled;
 
     private Boolean isAtomicPushAllowed = false;
+
+    private final MailSettings mailSettings;
 
     public void addThirdPartyAuth(String auth) {
         if (thirdPartyAuths == null) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCECompatibleImpl.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.git.common;
 
 import com.appsmith.external.git.GitExecutor;
-import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.exports.internal.ExportService;
@@ -36,7 +35,6 @@ public class CommonGitServiceCECompatibleImpl extends CommonGitServiceCEImpl imp
             SessionUserService sessionUserService,
             UserDataService userDataService,
             UserService userService,
-            EmailConfig emailConfig,
             TransactionalOperator transactionalOperator,
             AnalyticsService analyticsService,
             ObservationRegistry observationRegistry,
@@ -57,7 +55,6 @@ public class CommonGitServiceCECompatibleImpl extends CommonGitServiceCEImpl imp
                 sessionUserService,
                 userDataService,
                 userService,
-                emailConfig,
                 transactionalOperator,
                 analyticsService,
                 observationRegistry,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
@@ -13,7 +13,6 @@ import com.appsmith.external.git.constants.GitSpan;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.server.acl.AclPermission;
-import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.constants.Assets;
 import com.appsmith.server.constants.FieldName;
@@ -125,7 +124,6 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
     protected final SessionUserService sessionUserService;
     private final UserDataService userDataService;
     protected final UserService userService;
-    private final EmailConfig emailConfig;
     private final TransactionalOperator transactionalOperator;
 
     protected final AnalyticsService analyticsService;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceImpl.java
@@ -2,7 +2,6 @@ package com.appsmith.server.git.common;
 
 import com.appsmith.external.git.GitExecutor;
 import com.appsmith.git.service.GitExecutorImpl;
-import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.exports.internal.ExportService;
@@ -39,7 +38,6 @@ public class CommonGitServiceImpl extends CommonGitServiceCECompatibleImpl imple
             SessionUserService sessionUserService,
             UserDataService userDataService,
             UserService userService,
-            EmailConfig emailConfig,
             TransactionalOperator transactionalOperator,
             AnalyticsService analyticsService,
             ObservationRegistry observationRegistry,
@@ -60,7 +58,6 @@ public class CommonGitServiceImpl extends CommonGitServiceCECompatibleImpl imple
                 sessionUserService,
                 userDataService,
                 userService,
-                emailConfig,
                 transactionalOperator,
                 analyticsService,
                 observationRegistry,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -1,17 +1,13 @@
 package com.appsmith.server.services;
 
 import com.appsmith.server.configurations.CommonConfig;
-import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.helpers.UserServiceHelper;
 import com.appsmith.server.helpers.UserUtils;
-import com.appsmith.server.notifications.EmailSender;
 import com.appsmith.server.ratelimiting.RateLimitService;
-import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.EmailVerificationTokenRepository;
 import com.appsmith.server.repositories.PasswordResetTokenRepository;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.ce_compatible.UserServiceCECompatibleImpl;
-import com.appsmith.server.solutions.PolicySolution;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,14 +25,9 @@ public class UserServiceImpl extends UserServiceCECompatibleImpl implements User
             SessionUserService sessionUserService,
             PasswordResetTokenRepository passwordResetTokenRepository,
             PasswordEncoder passwordEncoder,
-            EmailSender emailSender,
-            ApplicationRepository applicationRepository,
-            PolicySolution policySolution,
             CommonConfig commonConfig,
-            EmailConfig emailConfig,
             UserDataService userDataService,
             TenantService tenantService,
-            PermissionGroupService permissionGroupService,
             UserUtils userUtils,
             EmailVerificationTokenRepository emailVerificationTokenRepository,
             EmailService emailService,

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -71,16 +71,8 @@ mail.enabled=${APPSMITH_MAIL_ENABLED:false}
 mail.from=${APPSMITH_MAIL_FROM:}
 mail.support=${APPSMITH_MAIL_SUPPORT:support@appsmith.com}
 reply.to=${APPSMITH_REPLY_TO:appsmith@localhost}
-spring.mail.host=${APPSMITH_MAIL_HOST:}
-spring.mail.port=${APPSMITH_MAIL_PORT:}
-spring.mail.username=${APPSMITH_MAIL_USERNAME:}
-spring.mail.password=${APPSMITH_MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=${APPSMITH_MAIL_SMTP_AUTH:}
-spring.mail.properties.mail.smtp.starttls.enable=${APPSMITH_MAIL_SMTP_TLS_ENABLED:}
 admin.emails = ${APPSMITH_ADMIN_EMAILS:}
-
-# Configuring individual emails
-emails.welcome.enabled = ${APPSMITH_EMAILS_WELCOME_ENABLED:true}
 
 # Appsmith Cloud Services
 appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:}

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -60,6 +60,7 @@ init_env_file() {
 
   # Build an env file with current env variables. We single-quote the values, as well as escaping any single-quote characters.
   printenv | grep -E '^APPSMITH_|^MONGO_' | sed "s/'/'\\\''/g; s/=/='/; s/$/'/" > "$TMP/pre-define.env"
+  set ugo-w "$TMP/pre-define.env"
 
   tlog "Initialize .env file"
   if ! [[ -e "$ENV_PATH" ]]; then
@@ -462,7 +463,7 @@ safe_init_postgres() {
   fi
 }
 
-# Method to create a appsmith database in the postgres 
+# Method to create a appsmith database in the postgres
 # Args:
 #     POSTGRES_DB_PATH (string): Path to the postgres data directory
 # Returns:


### PR DESCRIPTION
Experimental, work-in-progress, don't take anything seriously yet.

Effort to move email configuration from environment variables to the tenant configuration in database.


## Automation

/test sanity settings

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
