### PR TITLE
chore: skipping file change

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -66,11 +66,15 @@ jobs:
         with:
           fetch-tags: true
 
-      - name: Get changed files in the client folder
+      # - name: Get changed files in the client folder
+      #   id: changed-files-specific
+      #   uses: tj-actions/changed-files@v41
+      #   with:
+      #     files: "app/client/**"
+
+      - name: Updating the client changed file variable
         id: changed-files-specific
-        uses: tj-actions/changed-files@v41
-        with:
-          files: "app/client/**"
+        run: echo "any_changed=true" >> "$GITHUB_OUTPUT"
 
       #- name: Run step if any file(s) in the client folder change
       #  if: steps.changed-files-specific.outputs.any_changed == 'true'


### PR DESCRIPTION
## Description
Skipping file change check for client build.

Fixes https://app.zenhub.com/workspaces/stability-pod-6690c4814e31602e25cab7fd/issues/gh/appsmithorg/appsmith/37768


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow configuration to simplify the client build process by removing file change detection.
	- Introduced a new variable to streamline subsequent steps in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->