### PR TITLE
fix: Super user cache eviction when user is added via env variable

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -28,7 +28,6 @@ import com.appsmith.server.dtos.Permission;
 import com.appsmith.server.helpers.TextUtils;
 import com.appsmith.server.migrations.solutions.UpdateSuperUserMigrationHelper;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.solutions.PolicySolution;
 import com.github.cloudyrock.mongock.ChangeLog;
 import com.github.cloudyrock.mongock.ChangeSet;
@@ -451,7 +450,7 @@ public class DatabaseChangelog2 {
     @ChangeSet(order = "10000", id = "update-super-users", author = "", runAlways = true)
     public void updateSuperUsers(
             MongoTemplate mongoTemplate,
-            PermissionGroupRepository permissionGroupRepository,
+            CacheableRepositoryHelper cacheableRepositoryHelper,
             PolicySolution policySolution,
             PolicyGenerator policyGenerator) {
         // Read the admin emails from the environment and update the super users accordingly
@@ -497,7 +496,7 @@ public class DatabaseChangelog2 {
 
         Set<String> oldSuperUsers = instanceAdminPG.getAssignedToUserIds();
         Set<String> updatedUserIds = findSymmetricDiff(oldSuperUsers, userIds);
-        evictPermissionCacheForUsers(updatedUserIds, mongoTemplate, permissionGroupRepository);
+        evictPermissionCacheForUsers(updatedUserIds, mongoTemplate, cacheableRepositoryHelper);
 
         Update update = new Update().set(PermissionGroup.Fields.assignedToUserIds, userIds);
         mongoTemplate.updateFirst(permissionGroupQuery, update, PermissionGroup.class);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/MigrationHelperMethods.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/MigrationHelperMethods.java
@@ -21,7 +21,7 @@ import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.CollectionUtils;
-import com.appsmith.server.repositories.PermissionGroupRepository;
+import com.appsmith.server.repositories.CacheableRepositoryHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.minidev.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -211,7 +211,7 @@ public class MigrationHelperMethods {
     }
 
     public static void evictPermissionCacheForUsers(
-            Set<String> userIds, MongoTemplate mongoTemplate, PermissionGroupRepository permissionGroupRepository) {
+            Set<String> userIds, MongoTemplate mongoTemplate, CacheableRepositoryHelper cacheableRepositoryHelper) {
 
         if (userIds == null || userIds.isEmpty()) {
             // Nothing to do here.
@@ -223,8 +223,8 @@ public class MigrationHelperMethods {
             User user = mongoTemplate.findOne(query, User.class);
             if (user != null) {
                 // blocking call for cache eviction to ensure its subscribed immediately before proceeding further.
-                permissionGroupRepository
-                        .evictAllPermissionGroupCachesForUser(user.getEmail(), user.getTenantId())
+                cacheableRepositoryHelper
+                        .evictPermissionGroupsUser(user.getEmail(), user.getTenantId())
                         .block();
             }
         });


### PR DESCRIPTION
## Description
PR to fix the issue with evicting the cache lines for super users added via env. Migration was getting stuck at `updateSuperUsers` repetitive migration as Mongock was not able to complete the eviction with PermissionGroupRepository which underneath have dependency on mongo driver. 

Fixes https://github.com/appsmithorg/appsmith/issues/37703

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12054789155>
> Commit: fccb1b34f5df87dc06f06ecfba31491b1f805093
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12054789155&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 27 Nov 2024 17:23:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
