### PR TITLE
chore: deprecate ce helm charts and publish ee helm charts

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -69,6 +69,6 @@ jobs:
           helm dep build
           helm package .
           aws s3 cp s3://${{ secrets.HELM_S3_BUCKET }}/index.yaml .
-          helm repo index . --url https://${{ secrets.HELM_S3_BUCKET_URL }} --merge index.yaml
+          helm repo index . --url https://${{ secrets.HELM_S3_BUCKET }} --merge index.yaml
           aws s3 cp appsmith-${{ steps.chart-version.outputs.version }}.tgz s3://${{ secrets.HELM_S3_BUCKET }}
           aws s3 cp index.yaml s3://${{ secrets.HELM_S3_BUCKET }}

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -69,6 +69,6 @@ jobs:
           helm dep build
           helm package .
           aws s3 cp s3://${{ secrets.HELM_S3_BUCKET }}/index.yaml .
-          helm repo index . --url https://${{ secrets.HELM_S3_BUCKET }} --merge index.yaml
+          helm repo index . --url https://${{ secrets.HELM_S3_BUCKET_URL }} --merge index.yaml
           aws s3 cp appsmith-${{ steps.chart-version.outputs.version }}.tgz s3://${{ secrets.HELM_S3_BUCKET }}
           aws s3 cp index.yaml s3://${{ secrets.HELM_S3_BUCKET }}

--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.11.2
-- name: mongodb
-  repository: https://charts.bitnami.com/bitnami
-  version: 12.1.16
-digest: sha256:5c331a59e883c66893d2896c24aa2c4edf53423b12d440d1ec832e2c18637805
-generated: "2023-01-26T10:40:02.874578+05:30"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.4.6
+version: 3.5.0
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.5.0
+version: 3.6.0
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,15 +11,25 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 2.3.0
+version: 3.4.6
 dependencies:
-- condition: redis.enabled
-  name: redis
-  version: 16.11.2
-  appVersion: 6.2.7
-  repository: https://charts.bitnami.com/bitnami
-- condition: mongodb.enabled
-  name: mongodb
-  version: 12.1.16
-  appVersion: 6.0.10
-  repository: https://charts.bitnami.com/bitnami
+  - condition: redis.enabled
+    name: redis
+    version: 16.11.2
+    appVersion: 6.2.7
+    repository: https://charts.bitnami.com/bitnami
+  - condition: mongodb.enabled
+    name: mongodb
+    version: 12.1.16
+    appVersion: 6.0.10
+    repository: https://charts.bitnami.com/bitnami
+  - condition: postgresql.enabled
+    name: postgresql
+    version: 11.9.5
+    appVersion: 14.12.0
+    repository: https://charts.bitnami.com/bitnami
+  - condition: prometheus.enabled
+    name: prometheus
+    version: 25.27.0
+    appVersion: 2.54.1
+    repository: https://prometheus-community.github.io/helm-charts

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -174,6 +174,8 @@ To change Appsmith configurations, you can use configuration UI in application o
 | `applicationConfig.APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET`| `""`									|
 | `applicationConfig.APPSMITH_OAUTH2_GITHUB_CLIENT_ID`		| `""`									|
 | `applicationConfig.APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET`| `""`									|
+| `applicationConfig.APPSMITH_OAUTH2_OIDC_CLIENT_ID`      | `""`                  |
+| `applicationConfig.APPSMITH_OAUTH2_OIDC_CLIENT_SECRET`  | `""`                  |
 | `applicationConfig.APPSMITH_CLIENT_LOG_LEVEL`						| `""`									|
 | `applicationConfig.APPSMITH_MAIL_ENABLED`								| `""`									|
 | `applicationConfig.APPSMITH_MAIL_HOST`									| `""`									|

--- a/deploy/helm/templates/configMap.yaml
+++ b/deploy/helm/templates/configMap.yaml
@@ -1,8 +1,10 @@
 {{- $nameSpace := include "appsmith.namespace" . -}}
-{{- $name := include "appsmith.fullname" . -}}
 {{- $mongoUser := .Values.mongodb.auth.rootUser -}}
 {{- $mongoPassword := .Values.mongodb.auth.rootPassword -}}
 {{- $mongoServicename := .Values.mongodb.service.nameOverride -}}
+{{- $postgresqlUser := .Values.postgresql.auth.username -}}
+{{- $postgresqlPassword := .Values.postgresql.auth.password -}}
+{{- $postgresqlDatabase := .Values.postgresql.auth.database -}}
 {{- $releaseName := .Release.Name -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,11 +20,28 @@ data:
   {{- end }}
 
   {{- range $key, $value := .Values.applicationConfig }}
+  {{- if and (eq "APPSMITH_KEYCLOAK_DB_DRIVER" $key) ( not $value) }}
+  {{ $key }}: {{ $.Values.postgresql.enabled | ternary "postgresql" "h2" | quote }}
+  {{- end }}
+
+  {{- if and (eq "APPSMITH_KEYCLOAK_DB_URL" $key) ( not $value) }}
+  {{ $key }}: {{ $.Values.postgresql.enabled | ternary (printf "%s-postgresql.%s.svc.cluster.local:5432/%s" $releaseName $nameSpace $postgresqlDatabase) "${jboss.server.data.dir}" | quote }}
+  {{- end }}
+
+  {{- if and (eq "APPSMITH_KEYCLOAK_DB_USERNAME" $key) ( not $value) }}
+  {{ $key }}: {{ $.Values.postgresql.enabled | ternary $postgresqlUser "sa" | quote }}
+  {{- end }}
+
+  {{- if and (eq "APPSMITH_KEYCLOAK_DB_PASSWORD" $key) ( not $value) }}
+  {{ $key }}: {{ $.Values.postgresql.enabled | ternary $postgresqlPassword "sa" | quote }}
+  {{- end }}
+
   {{- if and (eq "APPSMITH_REDIS_URL" $key) ( not $value) }}
   {{- if $.Values.redis.enabled }}
   {{ $key }}: redis://{{ $releaseName }}-redis-master.{{ $nameSpace }}.svc.cluster.local:6379
   {{- end }}
   {{- end }}
+
   {{- if $value }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,15 +1,27 @@
+{{- $updateStrategy := .Values.updateStrategy | default dict }}
+{{- $postgresuser := .Values.postgresql.auth.username }}
+{{- $postgrespass := .Values.postgresql.auth.password }}
+{{- $postgrespass := .Values.postgresql.auth.password }}
+{{- $releaseName := include "appsmith.fullname" . -}}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: {{ if not .Values.autoscaling.enabled }}StatefulSet{{- else }}Deployment{{- end }}
 metadata:
   name: {{ include "appsmith.fullname" . }}
   namespace: {{ include "appsmith.namespace" . }}
   labels:
     {{- include "appsmith.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: 1
   serviceName: {{ include "appsmith.fullname" . }}
   updateStrategy:
-    type: {{ .Values.strategyType }}
+  {{- else }}
+  strategy:
+    type: {{ .Values.strategyType | default "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ dig "maxSurge" 1 $updateStrategy }}
+      maxUnavailable: {{ dig "maxUnavailable" "0" $updateStrategy }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "appsmith.selectorLabels" . | nindent 6 }}
@@ -25,6 +37,10 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
@@ -62,18 +78,31 @@ spec:
       {{- end }}
         command: ['sh', '-c', "until mongo --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
       {{- end }}
+      {{- if .Values.postgresql.enabled }}
+      - name: psql-init-container
+      {{- if ((.Values.initContainer.postgresql).image) }}
+        image: {{ .Values.initContainer.postgresql.image }}
+      {{- else}}
+        image: docker.io/bitnami/postgresql:14.5.0-debian-11-r21
+      {{- end}}
+        command: ['sh', '-c', "until pg_isready -U $postgresuser -d $postgresdb -h {{.Release.Name}}-postgresql.{{.Release.Namespace}}.svc.cluster.local; do echo waiting for postgresql; sleep 2; done"]
+      {{- end }}
       containers:
         - name: {{ .Values.containerName }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- $customImage := .Values._image | default dict }}
+          image: {{ dig "registry" "index.docker.io" $customImage }}/{{ dig "repository" "appsmith/appsmith-ee" $customImage }}:{{ dig "tag" (.Values.image.tag | default "latest") $customImage }}
+          imagePullPolicy: {{ dig "pullPolicy" "IfNotPresent" $customImage }}
           ports:
             - name: http
               containerPort: {{ .Values.HTTPContainerPort | default 80 }}
               protocol: TCP
             - name: https
               containerPort: 443
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
               protocol: TCP
           {{- $probes := .Values.probes | default dict }}
           startupProbe:
@@ -100,6 +129,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /appsmith-stacks
+          {{- if .Values.customCAcert }}
+            - name: ca-cert
+              mountPath: "/appsmith-stacks/ca-certs"
+          {{- end }}
           env:
           {{- if .Values.HTTPContainerPort }}
             - name: PORT
@@ -107,6 +140,10 @@ spec:
           {{- end }}
             - name: APPSMITH_ENABLE_EMBEDDED_DB
               value: "0"
+            - name: JGROUPS_DISCOVERY_PROTOCOL
+              value: kubernetes.KUBE_PING
+            - name: APPSMITH_HEADLESS_SVC
+              value: {{ include "appsmith.fullname" . }}-headless
           envFrom:
             - configMapRef:
                 name: {{ include "appsmith.fullname" . }}
@@ -114,28 +151,57 @@ spec:
             - secretRef:
                 name: {{ .Values.secretName }}
             {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "appsmith.fullname" . }}
+            {{- end }}
+            {{- if .Values.externalSecrets.enabled }}
+            - secretRef:
+                name: "{{ include "appsmith.fullname" . }}-external-secret"
+            {{- end }}
       {{- if .Values.image.pullSecrets}}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecrets }}
       {{- end }}
       volumes:
+      {{- if .Values.customCAcert }}
+      - name: ca-cert
+        configMap: 
+          name: {{ $releaseName }}-trustedca
+          items:
+          {{- range $key, $value := .Values.customCAcert }}
+          - key: {{ $key }}
+            path: {{ $key }}.crt
+          {{- end }}
+      {{- end }}
   {{- if not .Values.persistence.enabled }}
       - name: data
         emptyDir: {}
-  {{- else }}
+  {{- else if and (not .Values.autoscaling.enabled) (.Values.persistence.enabled) }}
   volumeClaimTemplates:
     - metadata:
         name: data
-        {{- if .Values.persistence.annotations }}
-        annotations: {{- include "tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- if .Values.persistence.annotations}}
+        annotations:
+          {{- include "tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-        {{- range .Values.persistence.accessModes }}
-          - {{ . | quote }}
-        {{- end }}
+        - ReadWriteOnce
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        {{ include "storage.class" (dict "persistence" .Values.persistence "global" .Values.global) }}
+        {{- if .Values.persistence.volumeClaimTemplates.selector }}
+        selector:
+          {{- include "tplvalues.render" (dict "value" .Values.persistence.volumeClaimTemplates.selector "context" $) | nindent 10 }}
+        {{- end }}
+        {{ include "storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
+  {{- else }}
+      - name: data
+        persistentVolumeClaim:
+          {{- if .Values.persistence.existingClaim.enabled }}
+          claimName: {{ .Values.persistence.existingClaim.claimName }}
+          {{- else }}
+          claimName: {{ include "appsmith.fullname" . }}
+          {{- end }}
   {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -108,19 +108,19 @@ spec:
           startupProbe:
             # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.
             httpGet:
-              port: http
+              port: {{ dig "startupProbe" "port" "80" $probes }}
               path: {{ dig "startupProbe" "api" "/api/v1/health" $probes }}
             failureThreshold: {{ dig "startupProbe" "failureThreshold" 3 $probes }}
             periodSeconds: {{ dig "startupProbe" "periodSeconds" 60 $probes }}
           livenessProbe:
             httpGet:
-              port: http
+              port: {{ dig "livenessProbe" "port" "80" $probes }}
               path: {{ dig "livenessProbe" "api" "/api/v1/health" $probes }}
             failureThreshold: {{ dig "livenessProbe" "failureThreshold" 3 $probes }}
             periodSeconds: {{ dig "livenessProbe" "periodSeconds" 60 $probes }}
           readinessProbe:
             httpGet:
-              port: http
+              port: {{ dig "readinessProbe" "port" "80" $probes }}
               path: {{ dig "readinessProbe" "api" "/api/v1/health" $probes }}
             failureThreshold: {{ dig "readinessProbe" "failureThreshold" 3 $probes }}
             periodSeconds: {{ dig "readinessProbe" "periodSeconds" 60 $probes }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -74,9 +74,9 @@ spec:
       {{- if ((.Values.initContainer.mongodb).image) }}
         image: {{ .Values.initContainer.mongodb.image }}
       {{- else }}
-        image:  "docker.io/bitnami/mongodb:5.0.21-debian-11-r5"
+        image:  "docker.io/bitnami/mongodb:6.0.13"
       {{- end }}
-        command: ['sh', '-c', "until mongo --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
+        command: ['sh', '-c', "until mongosh --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
       {{- end }}
       {{- if .Values.postgresql.enabled }}
       - name: psql-init-container

--- a/deploy/helm/templates/external-secrets.yaml
+++ b/deploy/helm/templates/external-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+   name: "{{ include "appsmith.fullname" . }}-external-secret"
+   namespace: {{ include "appsmith.namespace" . }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: secretstore
+    kind: SecretStore
+  target:
+    name: "{{ include "appsmith.fullname" . }}-external-secret"
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: {{ .Values.externalSecrets.remoteSecretName }}
+{{- end }}

--- a/deploy/helm/templates/headless-svc.yaml
+++ b/deploy/helm/templates/headless-svc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "appsmith.fullname" . }}-headless
+  namespace: {{ include "appsmith.namespace" . }}
+  labels:
+    {{- include "appsmith.labels" . | nindent 4 }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  clusterIPs:
+  - None
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    {{- include "appsmith.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/templates/hpa.yml
+++ b/deploy/helm/templates/hpa.yml
@@ -1,0 +1,41 @@
+{{- if and (.Values.autoscaling.enabled) (not .Values.keda.enabled) }}
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "appsmith.fullname" . }}
+  namespace: {{ include "appsmith.namespace" . }}
+  labels:
+    {{- include "appsmith.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "appsmith.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+    {{- if .Capabilities.APIVersions.Has "autoscaling/v2"}}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- else }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+    {{- if .Capabilities.APIVersions.Has "autoscaling/v2"}}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- else }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/templates/import.yaml
+++ b/deploy/helm/templates/import.yaml
@@ -1,0 +1,28 @@
+{{- /* Fail helm chart if autoscaling is enabled and mongo is disabled */ -}}
+{{- if and ( .Values.autoscaling.enabled ) ( not .Values.mongodb.enabled ) }}
+{{- if and ( not .Values.applicationConfig.APPSMITH_DB_URL ) ( not .Values.applicationConfig.APPSMITH_MONGODB_URI ) }}
+{{- fail "To enable autoscaling on Appsmith, MongoDB needs to be enabled or an external MongoDB needs to be configured. Refer: https://docs.appsmith.com/getting-started/setup/installation-guides/kubernetes#install-appsmith" }}
+{{- end }}
+{{- end }}
+
+{{- /* Fail helm chart if keycloak is disabled and postgresql is enabled */ -}}
+{{- if and ( .Values.postgresql.enabled ) (eq .Values.applicationConfig.APPSMITH_DISABLE_EMBEDDED_KEYCLOAK "1" )}}
+{{- fail "Keycloak is disabled therefore postgresql is not required. Please disable postgres or to enable keycloak on Appsmith, set APPSMITH_DISABLE_EMBEDDED_KEYCLOAK to \"0\" Refer: https://docs.appsmith.com/getting-started/setup/installation-guides/kubernetes#install-appsmith" }}
+{{- end }}
+
+{{- /* Fail helm chart if autoscaling, keycloak is enabled and postgresql is disabled */ -}}
+{{- if and ( .Values.autoscaling.enabled ) ( not .Values.postgresql.enabled ) ( not .Values.applicationConfig.APPSMITH_KEYCLOAK_DB_URL ) (eq .Values.applicationConfig.APPSMITH_DISABLE_EMBEDDED_KEYCLOAK "0" )}}
+{{- fail "To enable autoscaling on Appsmith, PostgreSQL needs to be enabled or an external PostgreSQL has to be configured. Refer: https://docs.appsmith.com/getting-started/setup/installation-guides/kubernetes#install-appsmith" }}
+{{- end }}
+
+{{- /* Fail helm chart if mongodb is enabled along with APPSMITH_DB_URL in the ApplicationConfig */ -}}
+{{- if ( .Values.mongodb.enabled ) }}
+{{- if or ( .Values.applicationConfig.APPSMITH_DB_URL ) ( .Values.applicationConfig.APPSMITH_MONGODB_URI ) }}
+{{- fail "MongoDB is enabled, but also found APPSMITH_DB_URL or APPSMITH_MONGODB_URI configured to an external instance, MongoDB needs to be disabled if using an external MongoDB instance" }}
+{{- end }}
+{{- end }}
+
+{{- /* Fail helm chart if postgresql is enabled along with APPSMITH_DB_URL in the ApplicationConfig */ -}}
+{{- if and ( .Values.postgresql.enabled ) ( .Values.applicationConfig.APPSMITH_KEYCLOAK_DB_DRIVER ) ( .Values.applicationConfig.APPSMITH_KEYCLOAK_DB_URL )  }}
+{{- fail "PostgreSQL is enabled, but also found APPSMITH_KEYCLOAK_DB_URL configured to an external instance, PostgreSQL needs to be disabled if using an external PostgreSQL instance" }}
+{{- end }}

--- a/deploy/helm/templates/pdb.yml
+++ b/deploy/helm/templates/pdb.yml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudgets.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+apiVersion: policy/v1
+{{- else}}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+   name: "{{ include "appsmith.fullname" . }}-pdb"
+   namespace: {{ include "appsmith.namespace" . }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudgets.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "appsmith.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/templates/persistentVolume.yaml
+++ b/deploy/helm/templates/persistentVolume.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled .Values.persistence.localStorage }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim.enabled) ( .Values.autoscaling.enabled) }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -12,8 +12,8 @@ spec:
   {{- range .Values.persistence.accessModes }}
     - {{ . | quote }}
   {{- end }}
-  persistentVolumeReclaimPolicy: Delete
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
+  {{- if .Values.persistence.localStorage }}
   local:
     path: {{ .Values.persistence.storagePath }} # Path to the directory this PV refers to.
   nodeAffinity: # nodeAffinity is required when using local volumes.
@@ -24,4 +24,18 @@ spec:
           operator: In
           values: 
             {{- toYaml .Values.persistence.localCluster | nindent 12 }}
+  {{- end }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+  {{- end }}
+  {{- if .Values.persistence.efs.enabled }}
+  csi:
+    driver: {{ .Values.persistence.efs.driver }}
+    nfs:
+    volumeHandle: {{ .Values.persistence.efs.volumeHandle }}
+  {{ end }}
 {{- end }}

--- a/deploy/helm/templates/persistentVolumeClaim.yaml
+++ b/deploy/helm/templates/persistentVolumeClaim.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim.enabled) ( .Values.autoscaling.enabled) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "appsmith.fullname" . }}
+  namespace: {{ include "appsmith.namespace" . }}
+{{- with .Values.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ include "appsmith.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- if .Values.persistence.existingClaim.enabled }}
+  volumeName: {{ .Values.persistence.existingClaim.name }}
+  {{- else}}
+  volumeName: {{ include "appsmith.fullname" . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+{{- else }}
+  storageClassName: ""
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/scaledobject.yml
+++ b/deploy/helm/templates/scaledobject.yml
@@ -1,0 +1,28 @@
+{{- if .Values.keda.enabled -}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "appsmith.fullname" . }}
+  namespace: {{ include "appsmith.namespace" . }}
+  labels:
+    {{- include "appsmith.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "appsmith.fullname" . }}
+  pollingInterval: {{ .Values.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.keda.minReplicaCount }}
+  maxReplicaCount: {{ .Values.keda.maxReplicaCount }}
+  {{- with .Values.keda.fallback }}
+  fallback:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  triggers:
+  {{- range $v := .Values.keda.triggers }}
+  - type: {{ $v.type }}
+    metadata:
+      {{- toYaml $v.metadata | nindent 6 }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "appsmith.fullname" . }}
+  namespace: {{ include "appsmith.namespace" . }}
+  labels:
+    {{- include "appsmith.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{- if $value }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/templates/service-metrics.yaml
+++ b/deploy/helm/templates/service-metrics.yaml
@@ -1,24 +1,14 @@
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "appsmith.fullname" . }}
+  name: {{ include "appsmith.fullname" . }}-metrics
   namespace: {{ include "appsmith.namespace" . }}
   labels:
     {{- include "appsmith.labels" . | nindent 4 }}
-  {{- if or .Values.service.annotations .Values.commonAnnotations .Values.metrics.enabled }}
   annotations:
-    {{- if .Values.service.annotations }}
-    {{- include "tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.metrics.enabled }}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
-    prometheus.io/path: "/actuator/prometheus"
-    {{- end }}
-  {{- end }}
+     prometheus.io/port: {{ quote .Values.metrics.port }}
+     prometheus.io/scrape: "true"
 spec:
   type: {{ .Values.service.type }}
   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
@@ -29,8 +19,8 @@ spec:
   {{- end }}
   ports:
     - name: {{ .Values.service.portName }}
-      port: {{ .Values.service.port }}
-      targetPort: http
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
       {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
@@ -38,3 +28,4 @@ spec:
       {{- end }}
   selector:
     {{- include "appsmith.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/templates/trustedCA.yaml
+++ b/deploy/helm/templates/trustedCA.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.customCAcert }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "appsmith.fullname" . }}-trustedca
+  namespace: {{ include "appsmith.namespace" . }}
+  labels:
+    {{- include "appsmith.labels" . | nindent 4 }}
+data:
+{{- range $key, $value := .Values.customCAcert }}
+   {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -7,13 +7,13 @@ redis:
     nodeSelector: {}
     disableCommands: []
     affinity: {}
-    tolerations: []    
+    tolerations: []
   replica:
     replicaCount: 1
     nodeSelector: {}
     disableCommands: []
     affinity: {}
-    tolerations:[] 
+    tolerations: []
   image:
     registry: docker.io
     repository: redis
@@ -31,7 +31,7 @@ mongodb:
   replicaSetName: rs0
   nodeSelector: {}
   affinity: {}
-  tolerations:[]
+  tolerations: []
   image:
     registry: docker.io
     repository: bitnami/mongodb
@@ -39,11 +39,11 @@ mongodb:
   arbiter:
     nodeSelector: {}
     affinity: {}
-    tolerations:[]
+    tolerations: []
   hidden:
     nodeSelector: {}
     affinity: {}
-    tolerations:[]
+    tolerations: []
   image:
     registry: docker.io
     repository: bitnami/mongodb
@@ -61,6 +61,14 @@ postgresql:
     registry: docker.io
     repository: bitnami/postgresql
     tag: 14.12.0
+  primary:
+    affinity: {}
+    nodeSelector: {}
+    tolerations: []
+  readReplicas:
+    affinity: {}
+    nodeSelector: {}
+    tolerations: []
 
 ## external secrets parameters
 externalSecrets:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -5,9 +5,15 @@ redis:
     enabled: false
   master:
     nodeSelector: {}
+    disableCommands: []
+    affinity: {}
+    tolerations: []    
   replica:
     replicaCount: 1
     nodeSelector: {}
+    disableCommands: []
+    affinity: {}
+    tolerations:[] 
   image:
     registry: docker.io
     repository: redis
@@ -24,14 +30,50 @@ mongodb:
   architecture: "replicaset"
   replicaSetName: rs0
   nodeSelector: {}
+  affinity: {}
+  tolerations:[]
   image:
     registry: docker.io
     repository: bitnami/mongodb
     tag: 6.0.13
   arbiter:
     nodeSelector: {}
+    affinity: {}
+    tolerations:[]
   hidden:
     nodeSelector: {}
+    affinity: {}
+    tolerations:[]
+  image:
+    registry: docker.io
+    repository: bitnami/mongodb
+    tag: 6.0.13
+
+## postgresql parameters
+postgresql:
+  enabled: true
+  auth:
+    username: root
+    password: password
+    postgresPassword: password
+    database: keycloak
+  image:
+    registry: docker.io
+    repository: bitnami/postgresql
+    tag: 14.12.0
+
+## external secrets parameters
+externalSecrets:
+  enabled: false
+  refreshInterval: 1m
+  remoteNameSecret: "" # name of the secret in Secret provider
+
+
+## prometheus paramaters
+prometheus:
+  enabled: false
+  image:
+    tag: v0.74.0
 
 
 ## @section Global parameters
@@ -74,11 +116,13 @@ initContainer: {}
   #   image: docker.io/bitnami/redis-cluster:7.0.13-debian-11-r10
   # mongodb:
   #   image:  docker.io/bitnami/mongodb:5.0.21-debian-11-r5
+  # postgresql:
+  #   image: docker.io/bitnami/postgresql:14.5.0-debian-11-r21
 ## Image
 ##
 image:
   registry: index.docker.io
-  repository: appsmith/appsmith-ce
+  repository: appsmith/appsmith-ee
   pullPolicy: IfNotPresent
   pullSecrets: ""
   # Overrides the image tag whose default is the chart appVersion.
@@ -201,6 +245,12 @@ ingress:
   ##
   className: "nginx"
 
+customCAcert:
+# cert1: |
+# paste-cert-1-contents-here
+# cert2: |
+# paste-cert-2-contents-here
+
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -213,13 +263,28 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
   limits: {}
-  requests: {}
+  requests:
+     cpu: 500m
+     memory: 3000Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 5
 
 nodeSelector: {}
+
+#HTTPContainerPort: 8080
 
 tolerations: []
 
 affinity: {}
+
+#topologySpreadConstraints:
+#  - maxSkew: 1 # distribute pods in an absolute even manner
+#    topologyKey: kubernetes.io/hostname  # use the hostname as topology domain
+#    whenUnsatisfiable: ScheduleAnyway # always schedule pods even if it can’t satisfy even distribution of pods
 
 persistence:
   ## @param persistence.enabled - Enable data persistence using PVC
@@ -239,15 +304,39 @@ persistence:
   storagePath: /tmp/hostpath_pv
   ## @param persistence.localCluster
   ##
-  localCluster:
-    - minikube
+  localCluster: {}
   ## @param persistence.accessModes PV Access Mode
   ##
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   ## @param persistence.size PVC Storage Request
   ##
   size: 10Gi
+  ## Fine tuning for volumeClaimTemplates
+  ##
+  reclaimPolicy: Retain
+  existingClaim:
+    enabled:
+    name:
+    claimName:
+  efs:
+    enabled:
+    driver:
+    volumeHandle:
+  volumeClaimTemplates:
+    ## @param persistence.volumeClaimTemplates.selector A label query over volumes to consider for binding (e.g. when using local volumes)
+    ## A label query over volumes to consider for binding (e.g. when using local volumes)
+    ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta for more details
+    ##
+    selector: {}
+    ## @param persistence.volumeClaimTemplates.requests Custom PVC requests attributes
+    ## Sometime cloud providers use additional requests attributes to provision custom storage instance
+    ## See https://cloud.ibm.com/docs/containers?topic=containers-file_storage#file_dynamic_statefulset
+    ##
+    requests: {}
+    ## @param persistence.volumeClaimTemplates.dataSource Add dataSource to the VolumeClaimTemplate
+    ##
+    dataSource: {}
 # tags:
 #   install-ingress-nginx: true
 storageClass:
@@ -278,6 +367,25 @@ storageClass:
   ## @param storageClass.parameters - storage class parameters used for volumes created with this storage class
   ##
   parameters: {}
+
+podDisruptionBudgets:
+  enabled: true
+  minAvailable: 1
+
+metrics:
+  enabled: false
+  port: 2019
+
+keda:
+  enabled: false
+  pollingInterval: 30
+  cooldownPeriod: 60
+  minReplicaCount: 1
+  maxReplicaCount: 6
+  fallback:
+    failureThreshold: 3
+    replicas: 4
+  triggers: []
 
 autoupdate:
   ## @param autoupdate.enabled - Enable config autoupdate
@@ -316,5 +424,8 @@ applicationConfig:
   APPSMITH_ENCRYPTION_SALT: ""
   APPSMITH_CUSTOM_DOMAIN: ""
   APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX: "false"
-
-#HTTPContainerPort: 8080
+  APPSMITH_LICENSE_KEY: ""
+  APPSMITH_KEYCLOAK_DB_DRIVER: ""
+  APPSMITH_KEYCLOAK_DB_USERNAME: ""
+  APPSMITH_KEYCLOAK_DB_PASSWORD: ""
+  APPSMITH_KEYCLOAK_DB_URL: ""

--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -99,6 +99,7 @@ helm upgrade -i "$CHARTNAME" "appsmith-ee/$HELMCHART" -n "$NAMESPACE" --create-n
   --set persistence.efs.driver=efs.csi.aws.com --set persistence.storageClass=efs-dp-appsmith \
   --set persistence.efs.volumeHandle="$DP_EFS_ID:/$edition/$edition$PULL_REQUEST_NUMBER" \
   --set resources.requests.cpu="1m" \
+  --set podDisruptionBudgets.enabled=false \
   --set resources.requests.memory="2048Mi" \
   --set applicationConfig.APPSMITH_SENTRY_DSN="https://abf15a075d1347969df44c746cca7eaa@o296332.ingest.sentry.io/1546547" \
   --set applicationConfig.APPSMITH_SENTRY_ENVIRONMENT="$NAMESPACE" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced support for PostgreSQL and OpenID Connect (OIDC) authentication in the Helm chart.
	- Introduced a new template for managing external secrets and a dedicated service for metrics.
	- Added Horizontal Pod Autoscaler (HPA) and Pod Disruption Budget (PDB) configurations.
	- New configuration options for custom Certificate Authority (CA) certificates.

- **Improvements**
	- Updated application version and dependencies for better organization and readability.
	- Expanded configuration options for Redis, MongoDB, and PostgreSQL, allowing for improved customization.
	- Enhanced deployment configuration with dynamic scaling capabilities.

- **Bug Fixes**
	- Improved error handling for configuration misalignments to prevent runtime issues.

- **Documentation**
	- Updated README and values.yaml to reflect new configuration parameters and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 0e76b6af34501ed646ea840af22786b33426c9fe yet
> <hr>Tue, 31 Dec 2024 12:31:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->
