### PR TITLE
chore: Always get version from $backend

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -86,13 +86,11 @@ if [[ ${backend-} == release ]]; then
   backend=https://release.app.appsmith.com
 fi
 
-if [[ ${backend-} == *.appsmith.com ]]; then
-  # If running client against release, we get the release's version and set it up, so we don't see version mismatches.
-  APPSMITH_VERSION_ID="$(
-    curl -sS "$backend/info" | grep -Eo '"version": ".+?"' | cut -d\" -f4
-  )"
-  export APPSMITH_VERSION_ID
-fi
+# Try to get a version from the "backend". If it's a full container, not just backend, then it'll give us a version.
+APPSMITH_VERSION_ID="$(
+  curl -sS "$backend/info" | grep -Eo '"version": ".+?"' | cut -d\" -f4
+)"
+export APPSMITH_VERSION_ID
 
 if [[ -z ${run_as-} ]]; then
     if type nginx; then

--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -88,7 +88,7 @@ fi
 
 # Try to get a version from the "backend". If it's a full container, not just backend, then it'll give us a version.
 APPSMITH_VERSION_ID="$(
-  curl -sS "$backend/info" | grep -Eo '"version": ".+?"' | cut -d\" -f4
+  curl -sS "${backend/host.docker.internal/localhost}/info" | grep -Eo '"version": ".+?"' | cut -d\" -f4
 )"
 export APPSMITH_VERSION_ID
 


### PR DESCRIPTION


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 0ce2dfa92e53dfbe93b02c29e75699dfcc77a10f yet
> <hr>Fri, 29 Nov 2024 10:20:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
