### PR TITLE
ci: Only allow appsmith.com emails to signup on DPs

### DIFF
--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -100,6 +100,7 @@ helm upgrade -i "$CHARTNAME" "appsmith-ee/$HELMCHART" -n "$NAMESPACE" --create-n
   --set persistence.efs.volumeHandle="$DP_EFS_ID:/$edition/$edition$PULL_REQUEST_NUMBER" \
   --set resources.requests.cpu="1m" \
   --set resources.requests.memory="2048Mi" \
+  --set applicationConfig.APPSMITH_SIGNUP_ALLOWED_DOMAINS=appsmith.com \
   --set applicationConfig.APPSMITH_SENTRY_DSN="https://abf15a075d1347969df44c746cca7eaa@o296332.ingest.sentry.io/1546547" \
   --set applicationConfig.APPSMITH_SENTRY_ENVIRONMENT="$NAMESPACE" \
   --set applicationConfig.APPSMITH_DB_URL="mongodb+srv://$DB_USERNAME:$DB_PASSWORD@$DB_URL/$DBNAME?retryWrites=true&minPoolSize=1&maxPoolSize=10&maxIdleTimeMS=900000&authSource=admin" \


### PR DESCRIPTION
If we need someone without such an email to signup, let someone _with_ such an email signup as superuser first, then they can add more admin users in Admin Settings.


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced deployment configuration for the Appsmith application, allowing signup only from specified domains (`appsmith.com`).
  
- **Chores**
	- Maintained existing AWS and Kubernetes configurations, ensuring seamless deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->