### PR TITLE
chore: Improve null safety in `ctl` code

### DIFF
--- a/app/client/packages/rts/src/ctl/backup/backup.test.ts
+++ b/app/client/packages/rts/src/ctl/backup/backup.test.ts
@@ -171,8 +171,8 @@ describe("Backup Tests", () => {
     const backupArchivesLimit = 4;
 
     fsPromises.rm = jest.fn().mockImplementation(async (a) => console.log(a));
-    const backupFiles = [];
-    const expectedBackupFiles = [];
+    const backupFiles: string[] = [];
+    const expectedBackupFiles: string[] = [];
     const res = await backup.removeOldBackups(backupFiles, backupArchivesLimit);
 
     console.log(res);

--- a/app/client/packages/rts/src/ctl/backup/backup.test.ts
+++ b/app/client/packages/rts/src/ctl/backup/backup.test.ts
@@ -46,15 +46,6 @@ describe("Backup Tests", () => {
     );
   });
 
-  test("Test backup contents path generation", () => {
-    const root = "/rootDir";
-    const timestamp = "0000-00-0T00-00-00.00Z";
-
-    expect(backup.getBackupContentsPath(root, timestamp)).toBe(
-      "/rootDir/appsmith-backup-0000-00-0T00-00-00.00Z",
-    );
-  });
-
   test("Test mongodump CMD generation", async () => {
     const dest = "/dest";
     const appsmithMongoURI = "mongodb://username:password@host/appsmith";
@@ -117,14 +108,6 @@ describe("Backup Tests", () => {
     ).toMatch(
       `APPSMITH_REDIS_URL=redis://127.0.0.1:6379\nAPPSMITH_INSTANCE_NAME=Appsmith\n`,
     );
-  });
-
-  test("Backup Archive Limit when env APPSMITH_BACKUP_ARCHIVE_LIMIT is null", () => {
-    expect(backup.getBackupArchiveLimit()).toBe(4);
-  });
-
-  test("Backup Archive Limit when env APPSMITH_BACKUP_ARCHIVE_LIMIT is 5", () => {
-    expect(backup.getBackupArchiveLimit(5)).toBe(5);
   });
 
   test("Cleanup Backups when limit is 4 and there are 5 files", async () => {

--- a/app/client/packages/rts/src/ctl/backup/index.ts
+++ b/app/client/packages/rts/src/ctl/backup/index.ts
@@ -48,9 +48,7 @@ export async function run(args: string[]) {
 
     console.log("Post-backup done. Final archive at", state.archivePath);
 
-    await logger.backupInfo(
-      "Finished taking a backup at " + state.archivePath,
-    );
+    await logger.backupInfo("Finished taking a backup at " + state.archivePath);
   } catch (err) {
     process.exitCode = 1;
     await logger.backupError(err.stack);

--- a/app/client/packages/rts/src/ctl/backup/index.ts
+++ b/app/client/packages/rts/src/ctl/backup/index.ts
@@ -111,25 +111,15 @@ async function createFinalArchive(destFolder: string, timestamp: string) {
 
 async function postBackupCleanup() {
   console.log("Starting cleanup.");
-  const backupArchivesLimit = getBackupArchiveLimit(
-    parseInt(process.env.APPSMITH_BACKUP_ARCHIVE_LIMIT, 10),
+  const backupArchivesLimit = parseInt(
+    process.env.APPSMITH_BACKUP_ARCHIVE_LIMIT || "4",
+    10,
   );
   const backupFiles = await utils.listLocalBackupFiles();
 
   await removeOldBackups(backupFiles, backupArchivesLimit);
 
   console.log("Cleanup completed.");
-}
-
-export function getBackupContentsPath(
-  backupRootPath: string,
-  timestamp: string,
-): string {
-  return backupRootPath + "/appsmith-backup-" + timestamp;
-}
-
-export function getBackupArchiveLimit(backupArchivesLimit?: number): number {
-  return backupArchivesLimit || Constants.APPSMITH_DEFAULT_BACKUP_ARCHIVE_LIMIT;
 }
 
 export async function removeOldBackups(

--- a/app/client/packages/rts/src/ctl/backup/index.ts
+++ b/app/client/packages/rts/src/ctl/backup/index.ts
@@ -48,12 +48,12 @@ export async function run(args: string[]) {
 
     console.log("Post-backup done. Final archive at", state.archivePath);
 
-    await logger.backup_info(
+    await logger.backupInfo(
       "Finished taking a backup at " + state.archivePath,
     );
   } catch (err) {
     process.exitCode = 1;
-    await logger.backup_error(err.stack);
+    await logger.backupError(err.stack);
 
     if (state.args.includes("--error-mail")) {
       const currentTS = new Date().getTime();

--- a/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
+++ b/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
@@ -49,7 +49,7 @@ export class EnvFileLink implements Link {
 
 export function removeSensitiveEnvData(content: string): string {
   // Remove encryption and Mongodb data from docker.env
-  const output_lines = [];
+  const outLines: string[] = [];
 
   content.split(/\r?\n/).forEach((line) => {
     if (
@@ -57,9 +57,9 @@ export function removeSensitiveEnvData(content: string): string {
       !line.startsWith("APPSMITH_MONGODB") &&
       !line.startsWith("APPSMITH_DB_URL=")
     ) {
-      output_lines.push(line);
+      outLines.push(line);
     }
   });
 
-  return output_lines.join("\n");
+  return outLines.join("\n");
 }

--- a/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
+++ b/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
@@ -47,11 +47,13 @@ export class EnvFileLink implements Link {
   }
 }
 
+/**
+ * Remove encryption and database credentials data from docker.env
+ */
 export function removeSensitiveEnvData(content: string): string {
-  // Remove encryption and Mongodb data from docker.env
   const outLines: string[] = [];
 
-  content.split(/\r?\n/).forEach((line) => {
+  for (const line of content.split(/\r?\n/)) {
     if (
       !line.startsWith("APPSMITH_ENCRYPTION") &&
       !line.startsWith("APPSMITH_MONGODB") &&
@@ -59,7 +61,7 @@ export function removeSensitiveEnvData(content: string): string {
     ) {
       outLines.push(line);
     }
-  });
+  }
 
   return outLines.join("\n");
 }

--- a/app/client/packages/rts/src/ctl/backup/links/ManifestLink.ts
+++ b/app/client/packages/rts/src/ctl/backup/links/ManifestLink.ts
@@ -14,7 +14,7 @@ export class ManifestLink implements Link {
     const version = await utils.getCurrentAppsmithVersion();
     const manifestData = {
       appsmithVersion: version,
-      dbName: utils.getDatabaseNameFromMongoURI(utils.getDburl()),
+      dbName: utils.getDatabaseNameFromMongoURI(utils.getDbUrl()),
     };
 
     await fsPromises.writeFile(

--- a/app/client/packages/rts/src/ctl/backup/links/MongoDumpLink.ts
+++ b/app/client/packages/rts/src/ctl/backup/links/MongoDumpLink.ts
@@ -10,7 +10,7 @@ export class MongoDumpLink implements Link {
 
   async doBackup() {
     console.log("Exporting database");
-    await executeMongoDumpCMD(this.state.backupRootPath, utils.getDburl());
+    await executeMongoDumpCMD(this.state.backupRootPath, utils.getDbUrl());
     console.log("Exporting database done.");
   }
 }

--- a/app/client/packages/rts/src/ctl/check_replica_set.ts
+++ b/app/client/packages/rts/src/ctl/check_replica_set.ts
@@ -1,15 +1,12 @@
 import { MongoClient, MongoServerError } from "mongodb";
 
-import { preprocessMongoDBURI } from "./utils";
+import * as utils from "./utils";
 
 export async function exec() {
-  const client = new MongoClient(
-    preprocessMongoDBURI(process.env.APPSMITH_DB_URL),
-    {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    } as any,
-  );
+  const client = new MongoClient(utils.preprocessMongoDBURI(utils.getDburl()), {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  } as any);
 
   let isReplicaSetEnabled = false;
 

--- a/app/client/packages/rts/src/ctl/check_replica_set.ts
+++ b/app/client/packages/rts/src/ctl/check_replica_set.ts
@@ -3,7 +3,7 @@ import { MongoClient, MongoServerError } from "mongodb";
 import * as utils from "./utils";
 
 export async function exec() {
-  const client = new MongoClient(utils.preprocessMongoDBURI(utils.getDburl()), {
+  const client = new MongoClient(utils.preprocessMongoDBURI(utils.getDbUrl()), {
     useNewUrlParser: true,
     useUnifiedTopology: true,
   } as any);

--- a/app/client/packages/rts/src/ctl/constants.ts
+++ b/app/client/packages/rts/src/ctl/constants.ts
@@ -14,5 +14,3 @@ export const ENV_PATH = "/appsmith-stacks/configuration/docker.env";
 export const MIN_REQUIRED_DISK_SPACE_IN_BYTES = 2_147_483_648; // 2GB
 
 export const DURATION_BETWEEN_BACKUP_ERROR_MAILS_IN_MILLI_SEC = 21_600_000; // 6 hrs
-
-export const APPSMITH_DEFAULT_BACKUP_ARCHIVE_LIMIT = 4; // 4 backup archives

--- a/app/client/packages/rts/src/ctl/export_db.ts
+++ b/app/client/packages/rts/src/ctl/export_db.ts
@@ -23,7 +23,7 @@ export async function run() {
 
   try {
     console.log("stop backend & rts application before export database");
-    await utils.stop(["backend", "rts"]);
+    await utils.stop("backend", "rts");
     await exportDatabase();
     console.log("start backend & rts application after export database");
     console.log();
@@ -39,7 +39,7 @@ export async function run() {
     console.log(err);
     errorCode = 1;
   } finally {
-    await utils.start(["backend", "rts"]);
+    await utils.start("backend", "rts");
     process.exit(errorCode);
   }
 }

--- a/app/client/packages/rts/src/ctl/export_db.ts
+++ b/app/client/packages/rts/src/ctl/export_db.ts
@@ -4,7 +4,7 @@ import * as utils from "./utils";
 
 export async function exportDatabase() {
   console.log("export_database  ....");
-  const dbUrl = utils.getDburl();
+  const dbUrl = utils.getDbUrl();
 
   await fsPromises.mkdir(Constants.BACKUP_PATH, { recursive: true });
   await utils.execCommand([

--- a/app/client/packages/rts/src/ctl/import_db.ts
+++ b/app/client/packages/rts/src/ctl/import_db.ts
@@ -29,9 +29,8 @@ export async function run(forceOption: boolean) {
   try {
     console.log("stop backend & rts application before import database");
     await utils.stop("backend", "rts");
-    let shellCmdResult: string;
 
-    shellCmdResult = await utils.execCommandReturningOutput([
+    const shellCmdResult = await utils.execCommandReturningOutput([
       "mongo",
       utils.getDbUrl(),
       "--quiet",

--- a/app/client/packages/rts/src/ctl/import_db.ts
+++ b/app/client/packages/rts/src/ctl/import_db.ts
@@ -8,7 +8,7 @@ async function importDatabase() {
   try {
     await utils.execCommand([
       "mongorestore",
-      "--uri=" + utils.getDburl(),
+      "--uri=" + utils.getDbUrl(),
       "--drop",
       `--archive=${Constants.RESTORE_PATH}/${Constants.DUMP_FILE_NAME}`,
       "--gzip",
@@ -33,7 +33,7 @@ export async function run(forceOption: boolean) {
 
     shellCmdResult = await utils.execCommandReturningOutput([
       "mongo",
-      utils.getDburl(),
+      utils.getDbUrl(),
       "--quiet",
       "--eval",
       "db.getCollectionNames().length",

--- a/app/client/packages/rts/src/ctl/import_db.ts
+++ b/app/client/packages/rts/src/ctl/import_db.ts
@@ -21,28 +21,24 @@ async function importDatabase() {
 }
 
 // Main application workflow
-export async function run(forceOption) {
+export async function run(forceOption: boolean) {
   let errorCode = 0;
 
   await utils.ensureSupervisorIsRunning();
 
   try {
     console.log("stop backend & rts application before import database");
-    await utils.stop(["backend", "rts"]);
+    await utils.stop("backend", "rts");
     let shellCmdResult: string;
 
-    try {
-      shellCmdResult = await utils.execCommandReturningOutput([
-        "mongo",
-        process.env.APPSMITH_DB_URL,
-        "--quiet",
-        "--eval",
-        "db.getCollectionNames().length",
-      ]);
-    } catch (error) {
-      console.error("Failed to execute mongo command:", error);
-      throw error;
-    }
+    shellCmdResult = await utils.execCommandReturningOutput([
+      "mongo",
+      utils.getDburl(),
+      "--quiet",
+      "--eval",
+      "db.getCollectionNames().length",
+    ]);
+
     const collectionsLen = parseInt(shellCmdResult.trimEnd());
 
     if (collectionsLen > 0) {
@@ -83,7 +79,7 @@ export async function run(forceOption) {
     errorCode = 1;
   } finally {
     console.log("start backend & rts application after import database");
-    await utils.start(["backend", "rts"]);
+    await utils.start("backend", "rts");
     process.exit(errorCode);
   }
 }

--- a/app/client/packages/rts/src/ctl/logger.ts
+++ b/app/client/packages/rts/src/ctl/logger.ts
@@ -1,7 +1,7 @@
 import fsPromises from "fs/promises";
 import * as Constants from "./constants";
 
-export async function backupError(err) {
+export async function backupError(err: string) {
   console.error(err);
   try {
     await fsPromises.access(Constants.APPSMITHCTL_LOG_PATH);
@@ -14,7 +14,7 @@ export async function backupError(err) {
   );
 }
 
-export async function backupInfo(msg) {
+export async function backupInfo(msg: string) {
   console.log(msg);
   try {
     await fsPromises.access(Constants.APPSMITHCTL_LOG_PATH);

--- a/app/client/packages/rts/src/ctl/logger.ts
+++ b/app/client/packages/rts/src/ctl/logger.ts
@@ -1,7 +1,7 @@
 import fsPromises from "fs/promises";
 import * as Constants from "./constants";
 
-export async function backup_error(err) {
+export async function backupError(err) {
   console.error(err);
   try {
     await fsPromises.access(Constants.APPSMITHCTL_LOG_PATH);
@@ -14,7 +14,7 @@ export async function backup_error(err) {
   );
 }
 
-export async function backup_info(msg) {
+export async function backupInfo(msg) {
   console.log(msg);
   try {
     await fsPromises.access(Constants.APPSMITHCTL_LOG_PATH);

--- a/app/client/packages/rts/src/ctl/mailer.ts
+++ b/app/client/packages/rts/src/ctl/mailer.ts
@@ -3,7 +3,7 @@ import * as Constants from "./constants";
 import * as utils from "./utils";
 import * as logger from "./logger";
 
-export async function sendBackupErrorToAdmins(err, backupTimestamp) {
+export async function sendBackupErrorToAdmins(err: Error, backupTimestamp: string) {
   const mailEnabled = process.env.APPSMITH_MAIL_ENABLED;
   const mailFrom = process.env.APPSMITH_MAIL_FROM;
   const mailHost = process.env.APPSMITH_MAIL_HOST;

--- a/app/client/packages/rts/src/ctl/mailer.ts
+++ b/app/client/packages/rts/src/ctl/mailer.ts
@@ -3,7 +3,10 @@ import * as Constants from "./constants";
 import * as utils from "./utils";
 import * as logger from "./logger";
 
-export async function sendBackupErrorToAdmins(err: Error, backupTimestamp: string) {
+export async function sendBackupErrorToAdmins(
+  error: Error,
+  backupTimestamp: string,
+) {
   const mailEnabled = process.env.APPSMITH_MAIL_ENABLED;
   const mailFrom = process.env.APPSMITH_MAIL_FROM;
   const mailHost = process.env.APPSMITH_MAIL_HOST;
@@ -69,7 +72,7 @@ export async function sendBackupErrorToAdmins(err: Error, backupTimestamp: strin
           "\n";
       }
 
-      text = text + "\n" + err.stack;
+      text = text + "\n" + error.stack;
 
       const transporter = nodemailer.createTransport({
         host: mailHost,
@@ -88,6 +91,6 @@ export async function sendBackupErrorToAdmins(err: Error, backupTimestamp: strin
       });
     }
   } catch (err) {
-    await logger.backupError(err.stack);
+    await logger.backupError((err as Error).stack ?? "Error in sending email, but no stack");
   }
 }

--- a/app/client/packages/rts/src/ctl/mailer.ts
+++ b/app/client/packages/rts/src/ctl/mailer.ts
@@ -22,23 +22,22 @@ export async function sendBackupErrorToAdmins(err, backupTimestamp) {
       !mailUser ||
       !mailPass
     ) {
-      throw new Error(
+      await logger.backup_error(
         "Failed to send error mail. Email provider is not configured, please refer to https://docs.appsmith.com/setup/instance-configuration/email to configure it.",
       );
     } else if (!mailTo) {
-      throw new Error(
+      await logger.backup_error(
         "Failed to send error mail. Admin email(s) not configured, please refer to https://docs.appsmith.com/setup/instance-configuration/disable-user-signup#administrator-emails to configure it.",
       );
     } else if (!mailEnabled) {
-      throw new Error(
+      await logger.backup_error(
         "Mail not sent! APPSMITH_MAIL_ENABLED env val is disabled, please refer to https://docs.appsmith.com/setup/instance-configuration/email to enable it.",
       );
     } else {
       const backupFiles = await utils.listLocalBackupFiles();
       const lastBackupfile = backupFiles.pop();
-      const lastBackupTimestamp = lastBackupfile.match(
-        /appsmith-backup-(.*)\.tar.gz/,
-      )[1];
+      const lastBackupTimestamp =
+        lastBackupfile?.match(/appsmith-backup-(.*)\.tar.gz/)?.[1] ?? "Unknown";
       const lastBackupPath = Constants.BACKUP_PATH + "/" + lastBackupfile;
 
       const domainName = process.env.APPSMITH_CUSTOM_DOMAIN;

--- a/app/client/packages/rts/src/ctl/mailer.ts
+++ b/app/client/packages/rts/src/ctl/mailer.ts
@@ -91,6 +91,8 @@ export async function sendBackupErrorToAdmins(
       });
     }
   } catch (err) {
-    await logger.backupError((err as Error).stack ?? "Error in sending email, but no stack");
+    await logger.backupError(
+      (err as Error).stack ?? "Error in sending email, but no stack",
+    );
   }
 }

--- a/app/client/packages/rts/src/ctl/mailer.ts
+++ b/app/client/packages/rts/src/ctl/mailer.ts
@@ -22,15 +22,15 @@ export async function sendBackupErrorToAdmins(err, backupTimestamp) {
       !mailUser ||
       !mailPass
     ) {
-      await logger.backup_error(
+      await logger.backupError(
         "Failed to send error mail. Email provider is not configured, please refer to https://docs.appsmith.com/setup/instance-configuration/email to configure it.",
       );
     } else if (!mailTo) {
-      await logger.backup_error(
+      await logger.backupError(
         "Failed to send error mail. Admin email(s) not configured, please refer to https://docs.appsmith.com/setup/instance-configuration/disable-user-signup#administrator-emails to configure it.",
       );
     } else if (!mailEnabled) {
-      await logger.backup_error(
+      await logger.backupError(
         "Mail not sent! APPSMITH_MAIL_ENABLED env val is disabled, please refer to https://docs.appsmith.com/setup/instance-configuration/email to enable it.",
       );
     } else {
@@ -88,6 +88,6 @@ export async function sendBackupErrorToAdmins(err, backupTimestamp) {
       });
     }
   } catch (err) {
-    await logger.backup_error(err.stack);
+    await logger.backupError(err.stack);
   }
 }

--- a/app/client/packages/rts/src/ctl/mongo_shell_utils.ts
+++ b/app/client/packages/rts/src/ctl/mongo_shell_utils.ts
@@ -15,7 +15,7 @@ export async function exec() {
   }
 }
 
-async function execMongoEval(queryExpression, appsmithMongoURI) {
+async function execMongoEval(queryExpression: string, appsmithMongoURI: string) {
   queryExpression = queryExpression.trim();
 
   if (command_args.includes("--pretty")) {

--- a/app/client/packages/rts/src/ctl/mongo_shell_utils.ts
+++ b/app/client/packages/rts/src/ctl/mongo_shell_utils.ts
@@ -6,7 +6,7 @@ export async function exec() {
   let errorCode = 0;
 
   try {
-    await execMongoEval(command_args[0], process.env.APPSMITH_DB_URL);
+    await execMongoEval(command_args[0], utils.getDbUrl());
   } catch (err) {
     errorCode = 1;
     console.error("Error evaluating the mongo query", err);
@@ -15,7 +15,10 @@ export async function exec() {
   }
 }
 
-async function execMongoEval(queryExpression: string, appsmithMongoURI: string) {
+async function execMongoEval(
+  queryExpression: string,
+  appsmithMongoURI: string,
+) {
   queryExpression = queryExpression.trim();
 
   if (command_args.includes("--pretty")) {

--- a/app/client/packages/rts/src/ctl/restore.ts
+++ b/app/client/packages/rts/src/ctl/restore.ts
@@ -313,7 +313,7 @@ async function getBackupDatabaseName(restoreContentsPath: string) {
 export async function run() {
   let cleanupArchive = false;
   let overwriteEncryptionKeys = true;
-  let backupFilePath: string;
+  let backupFilePath: string | null = null;
 
   await utils.ensureSupervisorIsRunning();
 
@@ -364,7 +364,7 @@ export async function run() {
       console.log(
         "Restoring Appsmith instance from the backup at " + backupFilePath,
       );
-      await utils.stop(["backend", "rts"]);
+      await utils.stop("backend", "rts");
       await restoreDatabase(restoreContentsPath, utils.getDburl());
       await restoreDockerEnvFile(
         restoreContentsPath,
@@ -379,11 +379,11 @@ export async function run() {
     console.log(err);
     process.exitCode = 1;
   } finally {
-    if (cleanupArchive) {
+    if (cleanupArchive && backupFilePath) {
       await fsPromises.rm(backupFilePath, { force: true });
     }
 
-    await utils.start(["backend", "rts"]);
+    await utils.start("backend", "rts");
     process.exit();
   }
 }

--- a/app/client/packages/rts/src/ctl/restore.ts
+++ b/app/client/packages/rts/src/ctl/restore.ts
@@ -146,7 +146,7 @@ async function restoreDockerEnvFile(
 ) {
   console.log("Restoring docker environment file");
   const dockerEnvFile = "/appsmith-stacks/configuration/docker.env";
-  const updatedbUrl = utils.getDburl();
+  const updatedbUrl = utils.getDbUrl();
   let encryptionPwd = process.env.APPSMITH_ENCRYPTION_PASSWORD;
   let encryptionSalt = process.env.APPSMITH_ENCRYPTION_SALT;
 
@@ -209,7 +209,7 @@ async function restoreDockerEnvFile(
       "\nAPPSMITH_ENCRYPTION_SALT=" +
       encryptionSalt +
       "\nAPPSMITH_DB_URL=" +
-      utils.getDburl() +
+      utils.getDbUrl() +
       "\nAPPSMITH_MONGODB_USER=" +
       process.env.APPSMITH_MONGODB_USER +
       "\nAPPSMITH_MONGODB_PASSWORD=" +
@@ -365,7 +365,7 @@ export async function run() {
         "Restoring Appsmith instance from the backup at " + backupFilePath,
       );
       await utils.stop("backend", "rts");
-      await restoreDatabase(restoreContentsPath, utils.getDburl());
+      await restoreDatabase(restoreContentsPath, utils.getDbUrl());
       await restoreDockerEnvFile(
         restoreContentsPath,
         backupName,

--- a/app/client/packages/rts/src/ctl/utils.ts
+++ b/app/client/packages/rts/src/ctl/utils.ts
@@ -40,7 +40,7 @@ export async function start(...apps: AppName[]) {
   console.log("Started", apps);
 }
 
-export function getDburl(): string {
+export function getDbUrl(): string {
   const dbEnvUrl =
     process.env.APPSMITH_DB_URL || process.env.APPSMITH_MONGODB_URI;
 


### PR DESCRIPTION
Fix remaining type errors and improve null safety in `ctl` code. This code is now ready to have `strictNullChecks` enabled on it. But not doing that as we want this to happen in EE code as well first, and then look into that.


## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 03f4d971930174301f06353d4852bdb4b2a3ff90 yet
> <hr>Mon, 02 Dec 2024 05:13:59 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
