### PR TITLE
fix: Broken UI on JS module instance in the side by side view mode

### DIFF
--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/old/JSFunctionRun.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/old/JSFunctionRun.tsx
@@ -25,10 +25,6 @@ export interface DropdownWithCTAWrapperProps {
 const DropdownWithCTAWrapper = styled.div<DropdownWithCTAWrapperProps>`
   display: flex;
   gap: var(--ads-v2-spaces-3);
-
-  &&&&& .function-select-dropdown {
-    width: 230px;
-  }
 `;
 
 const OptionWrapper = styled.div`

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/old/JSFunctionRun.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/old/JSFunctionRun.tsx
@@ -26,8 +26,8 @@ const DropdownWithCTAWrapper = styled.div<DropdownWithCTAWrapperProps>`
   display: flex;
   gap: var(--ads-v2-spaces-3);
 
-  .rc-select-selector {
-    min-width: unset;
+  &&&&& .function-select-dropdown {
+    width: 230px;
   }
 `;
 


### PR DESCRIPTION
## Description

Fixing the Broken UI on JS module instance in the side by side view mode.

Fixes #

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12135280169>
> Commit: bc011f06fa69836315e61986ce28d6d1ef88e0e5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12135280169&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Tue, 03 Dec 2024 08:32:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility of the dropdown selector in the JS Function Run component by removing the minimum width constraint.

- **Bug Fixes**
	- Adjusted layout to improve the visual adaptability of the dropdown selector based on its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->