### PR TITLE
fix: Updated the depreciated RunQueryNVerifyResponseViews to use runQueryAndVerifyResponseViews

### DIFF
--- a/app/client/cypress/e2e/GSheet/AllAccess_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/AllAccess_Spec.ts
@@ -126,7 +126,7 @@ describe.skip(
         dataSourceName,
         spreadSheetName,
       );
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
       dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language
       dataSources.AssertQueryTableResponse(2, "₹, $, €, ¥, £"); // Asserting different symbols
@@ -135,7 +135,7 @@ describe.skip(
       // Update query to fetch only 1 column and verify
       gsheetHelper.SelectMultiDropDownValue("Columns", "product_name");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].product_name);
 
       //Remove column filter and add Sort By Ascending and verify
@@ -145,7 +145,7 @@ describe.skip(
         directInput: false,
         inputFieldName: "Sort By",
       });
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         0,
         "5afbaf65680c9f378af5b3a3ae22427e",
@@ -161,7 +161,7 @@ describe.skip(
       dataSources.ClearSortByOption(); //clearing previous sort option
       dataSources.EnterSortByValues("price", "Descending");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         1,
         "ホーンビー ゲージ ウェスタン エクスプレス デジタル トレイン セット (eLink および TTS ロコ トレイン セット付き)",
@@ -181,7 +181,7 @@ describe.skip(
         dataSources._nestedWhereClauseValue(0),
       );
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(8);
+      dataSources.runQueryAndVerifyResponseViews({ count: 8 });
       dataSources.AssertQueryTableResponse(
         0,
         "87bbb472ef9d90dcef140a551665c929",
@@ -199,7 +199,7 @@ describe.skip(
         inputFieldName: "Cell range",
       });
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(4);
+      dataSources.runQueryAndVerifyResponseViews({ count: 4 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -246,7 +246,7 @@ describe.skip(
         0,
         true,
       );
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -281,7 +281,7 @@ describe.skip(
         true,
       ); // Converting the field to dropdown
       dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",

--- a/app/client/cypress/e2e/GSheet/GsheetMisc_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/GsheetMisc_Spec.ts
@@ -90,7 +90,7 @@ describe.skip(
       dataSources.ValidateNSelectDropdown("Entity", "Sheet Row(s)");
       dataSources.ValidateNSelectDropdown("Spreadsheet", "", spreadSheetName);
       dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryResponseHeaders(columnHeaders);
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
       dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language
@@ -104,7 +104,7 @@ describe.skip(
       dataSources.ValidateNSelectDropdown("Entity", "Sheet Row(s)");
       dataSources.ValidateNSelectDropdown("Spreadsheet", "", spreadSheetName);
       dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryResponseHeaders(columnHeaders);
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
       dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language

--- a/app/client/cypress/e2e/GSheet/ReadNWrite_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/ReadNWrite_Access_Spec.ts
@@ -128,7 +128,7 @@ describe.skip(
         dataSourceName.readNWrite,
         spreadSheetName,
       );
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
       dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language
       dataSources.AssertQueryTableResponse(2, "₹, $, €, ¥, £"); // Asserting different symbols
@@ -136,7 +136,7 @@ describe.skip(
       // Update query to fetch only 1 column and verify
       gsheetHelper.SelectMultiDropDownValue("Columns", "product_name");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].product_name);
       //Remove column filter and add Sort By Ascending and verify
       gsheetHelper.SelectMultiDropDownValue("Columns", "product_name"); //unselect the Columns dd value
@@ -145,7 +145,7 @@ describe.skip(
         directInput: false,
         inputFieldName: "Sort By",
       });
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         0,
         "5afbaf65680c9f378af5b3a3ae22427e",
@@ -160,7 +160,7 @@ describe.skip(
       dataSources.ClearSortByOption(); //clearing previous sort option
       dataSources.EnterSortByValues("price", "Descending");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         1,
         "ホーンビー ゲージ ウェスタン エクスプレス デジタル トレイン セット (eLink および TTS ロコ トレイン セット付き)",
@@ -179,7 +179,7 @@ describe.skip(
         dataSources._nestedWhereClauseValue(0),
       );
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(8);
+      dataSources.runQueryAndVerifyResponseViews({ count: 8 });
       dataSources.AssertQueryTableResponse(
         0,
         "87bbb472ef9d90dcef140a551665c929",
@@ -196,7 +196,7 @@ describe.skip(
         inputFieldName: "Cell range",
       });
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(4);
+      dataSources.runQueryAndVerifyResponseViews({ count: 4 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -242,7 +242,7 @@ describe.skip(
         0,
         true,
       );
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -275,7 +275,7 @@ describe.skip(
         true,
       ); // Converting the field to dropdown
       dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",

--- a/app/client/cypress/e2e/GSheet/ReadOnly_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/ReadOnly_Access_Spec.ts
@@ -136,7 +136,7 @@ describe.skip(
         dataSourceName.readOnly,
         spreadSheetName,
       );
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
       dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language
       dataSources.AssertQueryTableResponse(2, "₹, $, €, ¥, £"); // Asserting different symbols
@@ -144,7 +144,7 @@ describe.skip(
       // Update query to fetch only 1 column and verify
       gsheetHelper.SelectMultiDropDownValue("Columns", "product_name");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].product_name);
       //Remove column filter and add Sort By Ascending and verify
       gsheetHelper.SelectMultiDropDownValue("Columns", "product_name"); //unselect the Columns dd value
@@ -153,7 +153,7 @@ describe.skip(
         directInput: false,
         inputFieldName: "Sort By",
       });
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         0,
         "5afbaf65680c9f378af5b3a3ae22427e",
@@ -168,7 +168,7 @@ describe.skip(
       dataSources.ClearSortByOption(); //clearing previous sort option
       dataSources.EnterSortByValues("price", "Descending");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         1,
         "ホーンビー ゲージ ウェスタン エクスプレス デジタル トレイン セット (eLink および TTS ロコ トレイン セット付き)",
@@ -187,7 +187,7 @@ describe.skip(
         dataSources._nestedWhereClauseValue(0),
       );
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(8);
+      dataSources.runQueryAndVerifyResponseViews({ count: 8 });
       dataSources.AssertQueryTableResponse(
         0,
         "87bbb472ef9d90dcef140a551665c929",
@@ -204,7 +204,7 @@ describe.skip(
         inputFieldName: "Cell range",
       });
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(4);
+      dataSources.runQueryAndVerifyResponseViews({ count: 4 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -224,7 +224,7 @@ describe.skip(
         0,
         true,
       );
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -257,7 +257,7 @@ describe.skip(
         true,
       ); // Converting the field to dropdown
       dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",

--- a/app/client/cypress/e2e/GSheet/SelectedSheet_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/SelectedSheet_Access_Spec.ts
@@ -114,7 +114,7 @@ describe(
         dataSourceName,
         spreadSheetName,
       );
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
       dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language
       dataSources.AssertQueryTableResponse(2, "₹, $, €, ¥, £"); // Asserting different symbols
@@ -123,7 +123,7 @@ describe(
       // Update query to fetch only 1 column and verify
       gsheetHelper.SelectMultiDropDownValue("Columns", "product_name");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].product_name);
 
       //Remove column filter and add Sort By Ascending and verify
@@ -133,7 +133,7 @@ describe(
         directInput: false,
         inputFieldName: "Sort By",
       });
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         0,
         "5afbaf65680c9f378af5b3a3ae22427e",
@@ -149,7 +149,7 @@ describe(
       dataSources.ClearSortByOption(); //clearing previous sort option
       dataSources.EnterSortByValues("price", "Descending");
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(GSHEET_DATA.length);
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
       dataSources.AssertQueryTableResponse(
         1,
         "ホーンビー ゲージ ウェスタン エクスプレス デジタル トレイン セット (eLink および TTS ロコ トレイン セット付き)",
@@ -169,7 +169,7 @@ describe(
         dataSources._nestedWhereClauseValue(0),
       );
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(8);
+      dataSources.runQueryAndVerifyResponseViews({ count: 8 });
       dataSources.AssertQueryTableResponse(
         0,
         "87bbb472ef9d90dcef140a551665c929",
@@ -187,7 +187,7 @@ describe(
         inputFieldName: "Cell range",
       });
       dataSources.RunQuery();
-      dataSources.RunQueryNVerifyResponseViews(4);
+      dataSources.runQueryAndVerifyResponseViews({ count: 4 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -237,7 +237,7 @@ describe(
         0,
         true,
       );
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -272,7 +272,7 @@ describe(
         true,
       ); // Converting the field to dropdown
       dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",

--- a/app/client/cypress/e2e/GSheet/WidgetBinding_AllAccess_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/WidgetBinding_AllAccess_Spec.ts
@@ -57,7 +57,7 @@ describe.skip(
         dataSourceName,
         spreadSheetName,
       );
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
 
       // Adding suggested widgets and verify
       dataSources.AddSuggestedWidget(Widgets.Table);

--- a/app/client/cypress/e2e/GSheet/WidgetBinding_SelectedAccess_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/WidgetBinding_SelectedAccess_Spec.ts
@@ -57,7 +57,7 @@ describe(
         dataSourceName,
         spreadSheetName,
       );
-      dataSources.RunQueryNVerifyResponseViews(10);
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
 
       // Adding suggested widgets and verify
       dataSources.AddSuggestedWidget(Widgets.Table);

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
@@ -238,7 +238,7 @@ describe(
       );
       dataSources.RunQuery();
       dataSources.EnterQuery(selectQuery);
-      dataSources.RunQueryNVerifyResponseViews();
+      dataSources.runQueryAndVerifyResponseViews();
       dataSources.ToggleUsePreparedStatement(true);
       query = `ALTER TABLE ${guid} ADD (raw_data RAW(16), maintenance_interval INTERVAL YEAR(3) TO MONTH);`;
       dataSources.EnterQuery(query);
@@ -272,7 +272,7 @@ describe(
       dataSources.EnterQuery(query);
       dataSources.RunQuery();
       dataSources.EnterQuery(selectQuery);
-      dataSources.RunQueryNVerifyResponseViews(2);
+      dataSources.runQueryAndVerifyResponseViews({ count: 2 });
       query = `INSERT ALL
       INTO ${guid} (
           aircraft_id,
@@ -334,10 +334,10 @@ describe(
       dataSources.EnterQuery(query);
       dataSources.RunQuery();
       dataSources.EnterQuery(selectQuery);
-      dataSources.RunQueryNVerifyResponseViews(4);
+      dataSources.runQueryAndVerifyResponseViews({ count: 4 });
       selectQuery = selectQuery + ` and  aircraft_id IN (1, 6)`;
       dataSources.EnterQuery(selectQuery);
-      dataSources.RunQueryNVerifyResponseViews(2);
+      dataSources.runQueryAndVerifyResponseViews({ count: 2 });
       dataSources.AddSuggestedWidget(Widgets.Table);
       deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.TABLE));
       table.WaitUntilTableLoad(0, 0, "v2");
@@ -375,7 +375,7 @@ WHERE aircraft_type = 'Passenger Plane'`;
       dataSources.RunQuery();
       selectQuery = selectQuery + ` or  aircraft_type = 'Passenger Plane'`;
       dataSources.EnterQuery(selectQuery);
-      dataSources.RunQueryNVerifyResponseViews(3);
+      dataSources.runQueryAndVerifyResponseViews({ count: 3 });
       dataSources.AddSuggestedWidget(
         Widgets.Table,
         dataSources._addSuggestedExisting,
@@ -404,7 +404,7 @@ WHERE aircraft_type = 'Passenger Plane'`;
       dataSources.RunQuery();
       selectQuery = `SELECT * FROM ${guid}`;
       dataSources.EnterQuery(selectQuery);
-      dataSources.RunQueryNVerifyResponseViews(2);
+      dataSources.runQueryAndVerifyResponseViews({ count: 2 });
       dataSources.AddSuggestedWidget(
         Widgets.Table,
         dataSources._addSuggestedExisting,
@@ -439,7 +439,7 @@ WHERE aircraft_type = 'Passenger Plane'`;
         toastToValidate: "copied to page",
       });
       agHelper.GetNAssertContains(locators._queryName, "Query1Copy");
-      dataSources.RunQueryNVerifyResponseViews(2);
+      dataSources.runQueryAndVerifyResponseViews({ count: 2 });
       PageList.AddNewPage();
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
       agHelper.ActionContextMenuWithInPane({
@@ -449,7 +449,7 @@ WHERE aircraft_type = 'Passenger Plane'`;
       });
       agHelper.WaitUntilAllToastsDisappear();
       agHelper.GetNAssertContains(locators._queryName, "Query1Copy");
-      dataSources.RunQueryNVerifyResponseViews(2);
+      dataSources.runQueryAndVerifyResponseViews({ count: 2 });
       agHelper.ActionContextMenuWithInPane({
         action: "Delete",
         entityType: entityItems.Query,

--- a/app/client/cypress/e2e/Sanity/Datasources/MsSQL_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MsSQL_Basic_Spec.ts
@@ -140,7 +140,7 @@ describe(
     it("2. Run a Select query & Add Suggested widget - Table", () => {
       query = `Select * from Simpsons;`;
       dataSources.CreateQueryFromOverlay(dsName, query, "selectSimpsons"); //Creating query from EE overlay
-      dataSources.RunQueryNVerifyResponseViews(10); //Could be 99 in CI, to check aft init load script is working
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 }); //Could be 99 in CI, to check aft init load script is working
 
       dataSources.AddSuggestedWidget(Widgets.Table);
       agHelper.GetNClick(propPane._deleteWidget);


### PR DESCRIPTION
## Description

This PR removes the deprecated RunQueryNVerifyResponseViews and implemented runQueryAndVerifyResponseViews instead.


Fixes 


## Automation

/ok-to-test tags="@tag.Sanity, @tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12163035711>
> Commit: aaa6bcdcc1f1d448808b8d8c4b69172ae30e6855
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12163035711&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Sanity, @tag.Datasource
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Wed, 04 Dec 2024 16:36:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity and consistency in method calls for querying and verifying responses across various test cases related to Google Sheets and Oracle/MsSQL data sources.
	- Added a new test case for verifying the default port for Microsoft SQL Server.

- **Bug Fixes**
	- Improved error handling in MsSQL tests to validate missing fields with appropriate feedback messages.

- **Refactor**
	- Standardized method naming conventions and parameter formats across multiple test cases to improve readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->