### PR TITLE
fix: fixing usage pulse for anon user (#37940)

### DIFF
--- a/app/client/src/ce/sagas/NavigationSagas.ts
+++ b/app/client/src/ce/sagas/NavigationSagas.ts
@@ -1,10 +1,13 @@
-import { fork, put, select, call } from "redux-saga/effects";
+import { fork, put, select, call, take } from "redux-saga/effects";
 import type { RouteChangeActionPayload } from "actions/focusHistoryActions";
 import { FocusEntity, identifyEntityFromPath } from "navigation/FocusEntity";
 import log from "loglevel";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import { getRecentEntityIds } from "selectors/globalSearchSelectors";
-import type { ReduxAction } from "ee/constants/ReduxActionConstants";
+import {
+  ReduxActionTypes,
+  type ReduxAction,
+} from "ee/constants/ReduxActionConstants";
 import { getCurrentThemeDetails } from "selectors/themeSelectors";
 import type { BackgroundTheme } from "sagas/ThemeSaga";
 import { changeAppBackground } from "sagas/ThemeSaga";
@@ -86,6 +89,10 @@ function* clearErrors() {
 }
 
 function* watchForTrackableUrl(payload: RouteChangeActionPayload) {
+  yield take([
+    ReduxActionTypes.INITIALIZE_EDITOR_SUCCESS,
+    ReduxActionTypes.INITIALIZE_PAGE_VIEWER_SUCCESS,
+  ]);
   const oldPathname = payload.prevLocation.pathname;
   const newPathname = payload.location.pathname;
   const isOldPathTrackable: boolean = yield call(


### PR DESCRIPTION
## Description
- For usage pulse we need pageId
- URL contains basePageId
- basePageId needs to be converted to pageId
- The conversion needs application data to be populated into redux
- The PR adds a wait for application to initialise first before sending the usage pulse


Fixes [37904](https://github.com/appsmithorg/appsmith/issues/37904)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12173569202>
> Commit: 1edecf1afd3ff525f4dd7501bfbbc75855b2808f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12173569202&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 05 Dec 2024 06:57:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
- Enhanced user navigation tracking with improved handling of route changes.
- Introduced a new function for managing user activity tracking, improving clarity and control flow.

- **Bug Fixes**
- Improved error handling during route changes to ensure proper logging.

- **Refactor**
- Restructured user-related sagas for better organization and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
