### PR TITLE
chore: remove redundant klona within first evaluation

### DIFF
--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -1059,7 +1059,9 @@ export default class DataTreeEvaluator {
     staleMetaIds: string[];
     contextTree: DataTree;
   } {
-    const safeTree = klona(unEvalTree);
+    const { isFirstTree, metaWidgets, unevalUpdates } = options;
+
+    const safeTree = isFirstTree ? unEvalTree : klona(unEvalTree);
     const dataStore = DataStore.getDataStore();
     const dataStoreClone = klonaJSON(dataStore);
 
@@ -1081,7 +1083,6 @@ export default class DataTreeEvaluator {
     );
 
     const evalMetaUpdates: EvalMetaUpdates = [];
-    const { isFirstTree, metaWidgets, unevalUpdates } = options;
     let staleMetaIds: string[] = [];
 
     try {


### PR DESCRIPTION
## Description
Removes redundant klona since we are already performing a klona json within evalAndValidateFirstTree. Noticed a 1.54% reduction evalAndValidateFirstTree after these changes.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12175749741>
> Commit: 812ac8f9d8d6484e32dc5747a13eb15c1781c5e8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12175749741&attempt=4" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/12175749741" target="_blank">workflow here</a>.
> <hr>Wed, 11 Dec 2024 13:15:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the evaluation process for data trees, allowing for more flexible handling of tree evaluations based on whether it's the first evaluation.
	- Improved error handling during dynamic value evaluations, ensuring better logging and robustness.

- **Bug Fixes**
	- Adjusted the initialization of the `safeTree` variable to prevent unintended mutations in subsequent evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->