### PR TITLE
fix: Leaving editable tab in error state

### DIFF
--- a/app/client/src/IDE/Components/EditableName/EditableName.test.tsx
+++ b/app/client/src/IDE/Components/EditableName/EditableName.test.tsx
@@ -151,7 +151,7 @@ describe("EditableName", () => {
 
       await userEvent.click(document.body);
 
-      expect(getByRole("tooltip").textContent).toEqual(validationError);
+      expect(getByRole("tooltip").textContent).toEqual("");
 
       expect(exitEditing).toHaveBeenCalled();
       expect(onNameSave).not.toHaveBeenCalledWith(invalidTitle);
@@ -187,7 +187,7 @@ describe("EditableName", () => {
       });
 
       fireEvent.focusOut(inputElement);
-      expect(getByRole("tooltip").textContent).toEqual(validationError);
+      expect(getByRole("tooltip").textContent).toEqual("");
       expect(exitEditing).toHaveBeenCalled();
       expect(onNameSave).not.toHaveBeenCalledWith(invalidTitle);
     });

--- a/app/client/src/IDE/Components/EditableName/EditableName.tsx
+++ b/app/client/src/IDE/Components/EditableName/EditableName.tsx
@@ -5,10 +5,11 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Spinner, Text, Tooltip } from "@appsmith/ads";
+import { Spinner, Text as ADSText, Tooltip } from "@appsmith/ads";
 import { useEventCallback, useEventListener } from "usehooks-ts";
 import { usePrevious } from "@mantine/hooks";
 import { useNameEditor } from "./useNameEditor";
+import styled from "styled-components";
 
 interface EditableTextProps {
   name: string;
@@ -28,6 +29,10 @@ interface EditableTextProps {
   icon: React.ReactNode;
   inputTestId?: string;
 }
+
+export const Text = styled(ADSText)`
+  min-width: 3ch;
+`;
 
 export const EditableName = ({
   exitEditing,
@@ -80,9 +85,7 @@ export const EditableName = ({
       onNameSave(editableName);
     } else {
       // Exit edit mode and revert name
-      setEditableName(name);
-      setValidationError(null);
-      exitEditing();
+      exitWithoutSaving();
     }
   }, [
     editableName,
@@ -126,7 +129,9 @@ export const EditableName = ({
   useEventListener(
     "focusout",
     function handleFocusOut() {
-      if (isEditing) {
+      const input = inputRef.current;
+
+      if (input) {
         attemptSave();
       }
     },

--- a/app/client/src/IDE/Components/EditableName/EditableName.tsx
+++ b/app/client/src/IDE/Components/EditableName/EditableName.tsx
@@ -72,10 +72,17 @@ export const EditableName = ({
     const nameError = validate(editableName);
 
     if (editableName === name) {
+      // No change detected
       exitWithoutSaving();
     } else if (nameError === null) {
+      // Save the new name
       exitEditing();
       onNameSave(editableName);
+    } else {
+      // Exit edit mode and revert name
+      setEditableName(name);
+      setValidationError(null);
+      exitEditing();
     }
   }, [
     editableName,


### PR DESCRIPTION
## Description

fixes the editable tab handling of error states. Earlier the tab would stay in error state (with tooltip active) when you leave (focus out or press esc) the input with an invalid value.

Now it would revert the context back to the old name and let go of the error state.


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12179074325>
> Commit: 0ba7f5f74286b14900b72e57dd3a14f7f031fc34
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12179074325&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 05 Dec 2024 14:27:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation handling for the `EditableName` component, improving user experience during name editing.
	- Tooltip behavior updated to show an empty string instead of validation messages during certain user interactions.

- **Bug Fixes**
	- Improved logic for saving names, ensuring no unnecessary saves occur when the name hasn't changed.

- **Documentation**
	- Clarified the validation error handling process in the component's interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->