### PR TITLE
fix: Widget property test case fix

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
@@ -160,14 +160,11 @@ describe(
       );
       _.agHelper.GetNClick(OneClickBindingLocator.searchableColumn);
       _.agHelper.GetNClick(
-        OneClickBindingLocator.columnDropdownOption(
-          "searchableColumn",
-          "imdb_id",
-        ),
+        OneClickBindingLocator.columnDropdownOption("searchableColumn", "id"),
       );
       _.agHelper.GetNClick(OneClickBindingLocator.connectData);
       _.table.WaitUntilTableLoad(0, 0, "v2");
-      _.propPane.OpenTableColumnSettings("imdb_id");
+      _.propPane.OpenTableColumnSettings("id");
       _.propPane.TypeTextIntoField("Regex", "{{test}}");
       _.debuggerHelper.AssertErrorCount(1);
       _.propPane.ToggleSection("validation");
@@ -175,7 +172,7 @@ describe(
 
       _.debuggerHelper.OpenDebugger();
       _.debuggerHelper.ClicklogEntityLink();
-      _.agHelper.GetNAssertContains(_.propPane._paneTitle, "imdb_id");
+      _.agHelper.GetNAssertContains(_.propPane._paneTitle, "id");
       _.debuggerHelper.CloseBottomBar();
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       _.entityExplorer.DeleteWidgetFromEntityExplorer("Table1");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
+
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
+cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,6 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
-
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 


### PR DESCRIPTION
## Description
Fix test case as DB data updated.


Fixes # https://app.zenhub.com/workspaces/stability-pod-6690c4814e31602e25cab7fd/issues/gh/appsmithorg/appsmith/38022

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12228999115>
> Commit: 9eb9d9815071ff963011db7c4cdab9ade9c7b478
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12228999115&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 09 Dec 2024 05:14:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated test specification to focus on a new TypeScript test file.
	- Streamlined references to column identifiers in widget property navigation tests for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->