### PR TITLE
test: fixed failing EntityBottomBar spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
@@ -102,7 +102,7 @@ describe(
           //Create and run query.
 
           _.dataSources.EnterQuery(
-            "SELECT * FROM users ORDER BY id LIMIT 10;",
+            "SELECT * FROM users ORDER BY username LIMIT 10;",
             1000,
           );
           _.dataSources.RunQuery();

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 


### PR DESCRIPTION
Query result set had changed we updated the query accordingly
/ok-to-test tags="@tag.Sanity"




<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12196327858>
> Commit: 29660e7ae6853069d7c39aa8aaf6a0c07a572ba6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12196327858&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 06 Dec 2024 10:08:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->
