### PR TITLE
fix: add ResizeObserver to change textarea height based on width changes

### DIFF
--- a/app/client/packages/design-system/widgets/package.json
+++ b/app/client/packages/design-system/widgets/package.json
@@ -30,7 +30,8 @@
     "react-markdown": "^9.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "react-transition-group": "^4.4.5",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.0",
+    "usehooks-ts": "*"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/app/client/packages/design-system/widgets/src/components/Input/src/TextAreaInput.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Input/src/TextAreaInput.tsx
@@ -12,6 +12,7 @@ function _TextAreaInput(
   ref: React.Ref<HTMLTextAreaElement>,
 ) {
   const {
+    className,
     defaultValue,
     isLoading,
     isReadOnly,
@@ -34,7 +35,11 @@ function _TextAreaInput(
     <Group className={styles.inputGroup}>
       <HeadlessTextArea
         {...rest}
-        className={clsx(styles.input, getTypographyClassName("body"))}
+        className={clsx(
+          styles.input,
+          getTypographyClassName("body"),
+          className,
+        )}
         data-readonly={Boolean(isReadOnly) ? true : undefined}
         data-size={Boolean(size) ? size : undefined}
         defaultValue={defaultValue}

--- a/app/client/packages/design-system/widgets/src/components/Input/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Input/src/styles.module.css
@@ -21,6 +21,8 @@
   background-color: var(--color-bg-neutral-subtle);
   box-shadow: inset 0 0 0 1px var(--color-bd-on-neutral-subtle);
   isolation: isolate;
+  /* Delete overflow: hidden; when the max height is added */
+  overflow: hidden;
 }
 
 .input:has(> [data-select-text]) {
@@ -33,10 +35,6 @@
   align-items: flex-start;
   resize: none;
   font-family: inherit;
-}
-
-.input:is(textarea)[rows="1"] {
-  min-block-size: initial;
 }
 
 .input:autofill,
@@ -91,29 +89,6 @@
 .inputGroup:has(> [data-input-suffix]) [data-input-suffix] {
   right: var(--inner-spacing-1);
   position: absolute;
-}
-
-/* Note: the following calculations are done so that icon button in chat input is centered vertically */
-.inputGroup:has(.input[rows="1"]) [data-input-suffix] {
-  --icon-size: calc(
-    var(--body-line-height) + var(--body-margin-start) + var(--body-margin-end) +
-      var(--inner-spacing-3) * 2
-  );
-  --icon-offset: calc((var(--input-height) - var(--icon-size)) / 2);
-
-  bottom: round(up, var(--icon-offset), 0.5px);
-  right: var(--icon-offset);
-}
-
-.inputGroup:has(.input[rows="1"]) [data-input-prefix] {
-  --icon-size: calc(
-    var(--body-line-height) + var(--body-margin-start) + var(--body-margin-end) +
-      var(--inner-spacing-3) * 2
-  );
-  --icon-offset: calc((var(--input-height) - var(--icon-size)) / 2);
-
-  bottom: var(--icon-offset);
-  left: var(--icon-offset);
 }
 
 .inputGroup :is([data-input-suffix], [data-input-prefix]) {

--- a/app/client/packages/design-system/widgets/src/components/Input/src/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/Input/src/types.ts
@@ -21,4 +21,5 @@ export interface TextAreaInputProps
   extends Omit<HeadlessTextAreaProps, "prefix" | "size">,
     CommonInputProps {
   rows?: number;
+  className?: string;
 }

--- a/app/client/packages/design-system/widgets/src/components/TextArea/src/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/TextArea/src/types.ts
@@ -1,4 +1,4 @@
-import type { FieldProps } from "@appsmith/wds";
+import type { FieldProps, SIZES } from "@appsmith/wds";
 import type { ReactNode } from "react";
 import type { TextFieldProps as AriaTextFieldProps } from "react-aria-components";
 
@@ -8,4 +8,7 @@ export interface TextAreaProps extends AriaTextFieldProps, FieldProps {
   suffix?: ReactNode;
   prefix?: ReactNode;
   rows?: number;
+  fieldClassName?: string;
+  inputClassName?: string;
+  size?: Omit<keyof typeof SIZES, "xSmall">;
 }

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -159,6 +159,7 @@ __metadata:
     react-syntax-highlighter: ^15.5.0
     react-transition-group: ^4.4.5
     remark-gfm: ^4.0.0
+    usehooks-ts: "*"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   languageName: unknown
@@ -33469,7 +33470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"usehooks-ts@npm:^3.1.0":
+"usehooks-ts@npm:*, usehooks-ts@npm:^3.1.0":
   version: 3.1.0
   resolution: "usehooks-ts@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
## Description
Moving changes from [EE PR](https://github.com/appsmithorg/appsmith-ee/pull/5652).

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
