### PR TITLE
fix: Server startup issue for external postgres

### DIFF
--- a/deploy/docker/fs/opt/appsmith/pg-utils.sh
+++ b/deploy/docker/fs/opt/appsmith/pg-utils.sh
@@ -18,9 +18,14 @@ waitForPostgresAvailability() {
     MAX_RETRIES=50
     RETRYSECONDS=10
     retry_count=0
-    local unix_socket_directory=$(get_unix_socket_directory "$POSTGRES_DB_PATH")
+    local host_proxy
+    if [[ "$PG_DB_HOST" == "localhost" || "$PG_DB_HOST" == "127.0.0.1" ]]; then
+      host_proxy=$(get_unix_socket_directory)
+    else
+      host_proxy=$PG_DB_HOST
+    fi
     while true; do
-      su postgres -c "pg_isready -h $unix_socket_directory -p '${PG_DB_PORT}'"
+      su postgres -c "pg_isready -h $host_proxy -p '${PG_DB_PORT}'"
       status=$?
 
       case $status in


### PR DESCRIPTION
## Description
We introduced the auth for embedded Postgres, but in pg-utils we missed on updating the pg_isready condition to resort to db host in case of external postgres url. This caused the pg_isready to never pass when user configure external postgres url as a persistence DB in Appsmith. This PR checks if the local postgres url is configured and accordingly modifies the pg_isready command to target the embedded host vs external host.   

Why it did not get caught in our testing?
We are still investigating this but in local for some reason even if we opt for external Postgres DB embedded Postgres process is also initiating which runs the pg_isready against the embedded Postgres and startup goes through. 

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced PostgreSQL connection handling with dynamic checks for local or remote instances.
	- Improved flexibility in connection strategy for better database accessibility.

- **Bug Fixes**
	- Updated connection commands to ensure proper usage of the new host proxy variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->