### PR TITLE
fix: Renaming tests with error expectations

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Entity_Naming_conflict_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/ExplorerTests/Entity_Naming_conflict_spec.js
@@ -22,8 +22,7 @@ describe(
       PageLeftPane.switchSegment(PagePaneSegment.UI);
       PageLeftPane.assertPresence("Table1");
       PageLeftPane.switchSegment(PagePaneSegment.Queries);
-      cy.RenameEntity(apiName);
-      cy.validateMessage(apiName);
+      cy.CreationOfUniqueAPIcheck(apiName);
     });
   },
 );

--- a/app/client/cypress/support/ApiCommands.js
+++ b/app/client/cypress/support/ApiCommands.js
@@ -4,6 +4,7 @@
 require("cy-verify-downloads").addCustomCommand();
 require("cypress-file-upload");
 import ApiEditor from "../locators/ApiEditor";
+
 const apiwidget = require("../locators/apiWidgetslocator.json");
 const explorer = require("../locators/explorerlocators.json");
 import { ObjectsRegistry } from "./Objects/Registry";
@@ -114,12 +115,10 @@ Cypress.Commands.add("CreationOfUniqueAPIcheck", (apiname) => {
   cy.wait("@createNewApi");
   // cy.wait("@getUser");
   cy.get(apiwidget.resourceUrl).should("be.visible");
-  agHelper.RenameQuery(apiname);
-  cy.get(".ads-v2-tooltip .ads-v2-text").should(($x) => {
-    expect($x).contain(
-      apiname.concat(" is already being used or is a restricted keyword."),
-    );
-  });
+  agHelper.RenameQuery(
+    apiname,
+    apiname.concat(" is already being used or is a restricted keyword."),
+  );
 });
 
 Cypress.Commands.add("RenameEntity", (value, selectFirst) => {
@@ -138,12 +137,7 @@ Cypress.Commands.add("CreateApiAndValidateUniqueEntityName", (apiname) => {
   agHelper.GetNClick(apiwidget.createapi);
   cy.wait("@createNewApi");
   cy.get(apiwidget.resourceUrl).should("be.visible");
-  agHelper.RenameQuery(apiname);
-  cy.get(".ads-v2-tooltip .ads-v2-text").should(($x) => {
-    expect($x).contain(
-      apiname.concat(" is already being used or is a restricted keyword."),
-    );
-  });
+  agHelper.RenameQuery(apiname, apiname.concat(" is already being used or is a restricted keyword."));
 });
 
 Cypress.Commands.add("validateMessage", (value) => {

--- a/app/client/cypress/support/ApiCommands.js
+++ b/app/client/cypress/support/ApiCommands.js
@@ -137,7 +137,10 @@ Cypress.Commands.add("CreateApiAndValidateUniqueEntityName", (apiname) => {
   agHelper.GetNClick(apiwidget.createapi);
   cy.wait("@createNewApi");
   cy.get(apiwidget.resourceUrl).should("be.visible");
-  agHelper.RenameQuery(apiname, apiname.concat(" is already being used or is a restricted keyword."));
+  agHelper.RenameQuery(
+    apiname,
+    apiname.concat(" is already being used or is a restricted keyword."),
+  );
 });
 
 Cypress.Commands.add("validateMessage", (value) => {

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -16,12 +16,14 @@ interface DeleteParams {
   entityType?: EntityItemsType;
   toastToValidate?: string;
 }
+
 interface SubActionParams {
   subAction: string;
   index?: number;
   force?: boolean;
   toastToValidate?: string;
 }
+
 interface SelectAndValidateParams {
   clickOptions?: Partial<ClickOptions>;
   widgetName: string;
@@ -33,6 +35,7 @@ interface SelectAndValidateParams {
 }
 
 let LOCAL_STORAGE_MEMORY: any = {};
+
 export interface IEnterValue {
   propFieldName: string;
   directInput: boolean;
@@ -53,12 +56,15 @@ export class AggregateHelper {
   public get isMac() {
     return Cypress.platform === "darwin";
   }
+
   private selectLine = `${
     this.isMac ? "{cmd}{shift}{leftArrow}" : "{shift}{home}"
   }`;
+
   public get removeLine() {
     return "{backspace}";
   }
+
   public _modifierKey = `${this.isMac ? "meta" : "ctrl"}`;
   private selectAll = `${this.isMac ? "{cmd}{a}" : "{ctrl}{a}"}`;
   private lazyCodeEditorFallback = ".t--lazyCodeEditor-fallback";
@@ -226,6 +232,7 @@ export class AggregateHelper {
     textInputLocator: string;
     renameVal: string;
     dblClick?: boolean;
+    willFailError?: string;
   }) {
     const { dblClick = false, nameLocator, renameVal, textInputLocator } = args;
 
@@ -240,11 +247,15 @@ export class AggregateHelper {
     cy.get(textInputLocator)
       .clear({ force: true })
       .type(renameVal, { force: true, delay: 0 })
-      .should("have.value", renameVal)
-      .blur();
+      .should("have.value", renameVal);
 
-    this.PressEnter();
-
+    debugger;
+    if (args.willFailError) {
+      this.AssertContains(args.willFailError, "exist", ".ads-v2-tooltip");
+      cy.get(textInputLocator).blur();
+    } else {
+      this.PressEnter();
+    }
     this.Sleep();
   }
 
@@ -257,12 +268,13 @@ export class AggregateHelper {
     this.AssertElementVisibility(this.locator._editIcon);
   }
 
-  public RenameQuery(renameVal: string) {
+  public RenameQuery(renameVal: string, willFailError?: string) {
     this.rename({
       nameLocator: this.locator._queryName,
       textInputLocator: this.locator._queryNameTxt,
       renameVal,
       dblClick: true,
+      willFailError,
     });
   }
 
@@ -937,6 +949,7 @@ export class AggregateHelper {
       this.TypeText(selector, totype, index);
     }
   }
+
   public ClickNClear(selector: string, force = false, index = 0) {
     this.GetNClick(selector, index, force);
     this.ClearTextField(selector, force, index);

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -249,11 +249,11 @@ export class AggregateHelper {
       .type(renameVal, { force: true, delay: 0 })
       .should("have.value", renameVal);
 
-    debugger;
     if (args.willFailError) {
       this.AssertContains(args.willFailError, "exist", ".ads-v2-tooltip");
       cy.get(textInputLocator).blur();
     } else {
+      cy.get(textInputLocator).blur();
       this.PressEnter();
     }
     this.Sleep();


### PR DESCRIPTION
## Description

Update renaming tests for tabs when error expectations need to be asserted



## Automation

/ok-to-test tags="@tag.IDE, @tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12199824922>
> Commit: 47dddde9817a3858a971aa5661ca069dd7d9786d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12199824922&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE, @tag.Datasource`
> Spec:
> <hr>Fri, 06 Dec 2024 14:30:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Streamlined the API renaming and validation process for improved accuracy and efficiency.

- **New Features**
	- Enhanced error handling capabilities in the API renaming process, allowing for more graceful management of error scenarios.
	- Introduced new interfaces for better handling of widget interactions and validations.

- **Refactor**
	- Consolidated multiple steps in API name validation into single method calls for improved clarity and efficiency. 

- **Style**
	- Minor formatting changes for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->