### PR TITLE
chore: Add version input for generate info json script

### DIFF
--- a/.github/workflows/ad-hoc-docker-image.yml
+++ b/.github/workflows/ad-hoc-docker-image.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Generate info.json
         run: |
           if [[ -f scripts/generate_info_json.sh ]]; then
-            scripts/generate_info_json.sh
+            scripts/generate_info_json.sh ${{ inputs.tag }}
           fi
 
       - name: Place server artifacts-es

--- a/scripts/generate_info_json.sh
+++ b/scripts/generate_info_json.sh
@@ -8,7 +8,15 @@ commit_sha="$(git rev-parse HEAD)"
 # Base URL of the current repository on GitHub.
 base_url="$(git remote get-url origin | sed 's,^git@github\.com:,https://github.com/,; s/\.git$//')"
 
-if [[ "${GITHUB_REF-}" =~ ^refs/tags/v ]]; then
+if [[ $# -gt 0 ]]; then
+  input_version="$1"
+  if [[ "$input_version" =~ ^v[0-9]+(\.[0-9]+){1,2}$ ]]; then
+    version="$input_version"
+  else
+    echo "Invalid version format. Use v[major].[minor] or v[major].[minor].[patch]." >&2
+    exit 1
+  fi
+elif [[ "${GITHUB_REF-}" =~ ^refs/tags/v ]]; then
   version="${GITHUB_REF#refs/tags/}"
 else
   latest_released_version="$(git ls-remote --tags --sort=-v:refname "$(git remote | head -1)" 'v*' | awk -F/ '{print $NF; exit}')"
@@ -31,3 +39,8 @@ jq -n \
   --arg imageBuiltAt "$(date -u -Iseconds)" \
   --argjson isCI "${CI:-false}" \
   '$ARGS.named' | tee "$(git rev-parse --show-toplevel)/deploy/docker/fs/opt/appsmith/info.json"
+
+# Usage 
+# ./scripts/generate_info_json.sh v0.0.1
+# ./scripts/generate_info_json.sh v0.1
+# ./scripts/generate_info_json.sh


### PR DESCRIPTION
## Description
PR to add version field in generate info json script. This will be used to override the version coming from the GH so that hotfixed tags should refelect the correct version instead of some random commit sha.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
