### PR TITLE
chore:  change the klona strategy of setting of values to evalTree and evalActionBindings

### DIFF
--- a/app/client/src/workers/Evaluation/__tests__/evaluation.test.ts
+++ b/app/client/src/workers/Evaluation/__tests__/evaluation.test.ts
@@ -593,8 +593,8 @@ describe("DataTreeEvaluator", () => {
     );
     evaluator.evalAndValidateFirstTree();
     // Hard check to not regress on the number of clone operations. Try to improve this number.
-    expect(klonaFullSpy).toBeCalledTimes(40);
-    expect(klonaJsonSpy).toBeCalledTimes(3);
+    expect(klonaFullSpy).toBeCalledTimes(15);
+    expect(klonaJsonSpy).toBeCalledTimes(28);
   });
 
   it("Evaluates a binding in first run", () => {
@@ -1115,7 +1115,7 @@ describe("DataTreeEvaluator", () => {
       unEvalUpdates,
     );
     // Hard check to not regress on the number of clone operations. Try to improve this number.
-    expect(klonaFullSpy).toBeCalledTimes(6);
-    expect(klonaJsonSpy).toBeCalledTimes(2);
+    expect(klonaFullSpy).toBeCalledTimes(4);
+    expect(klonaJsonSpy).toBeCalledTimes(4);
   });
 });

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -1207,7 +1207,7 @@ export default class DataTreeEvaluator {
             );
 
             set(contextTree, fullPropertyPath, parsedValue);
-            set(safeTree, fullPropertyPath, klona(parsedValue));
+            set(safeTree, fullPropertyPath, klonaJSON(parsedValue));
 
             staleMetaIds = staleMetaIds.concat(
               getStaleMetaStateIds({
@@ -1253,7 +1253,7 @@ export default class DataTreeEvaluator {
             if (!requiresEval) continue;
 
             set(contextTree, fullPropertyPath, evalPropertyValue);
-            set(safeTree, fullPropertyPath, klona(evalPropertyValue));
+            set(safeTree, fullPropertyPath, klonaJSON(evalPropertyValue));
             break;
           }
           case ENTITY_TYPE.JSACTION: {
@@ -1290,7 +1290,7 @@ export default class DataTreeEvaluator {
              * Their evaluated values need to be reset only when the variable is modified by the user.
              * When uneval value of a js variable hasn't changed, it means that the previously evaluated values are in both trees already  */
             if (!skipVariableValueAssignment) {
-              const valueForSafeTree = klona(evalValue);
+              const valueForSafeTree = klonaJSON(evalValue);
 
               set(contextTree, fullPropertyPath, evalValue);
               set(safeTree, fullPropertyPath, valueForSafeTree);
@@ -1305,7 +1305,7 @@ export default class DataTreeEvaluator {
           }
           default:
             set(contextTree, fullPropertyPath, evalPropertyValue);
-            set(safeTree, fullPropertyPath, klona(evalPropertyValue));
+            set(safeTree, fullPropertyPath, klonaJSON(evalPropertyValue));
         }
       }
     } catch (error) {
@@ -1793,7 +1793,7 @@ export default class DataTreeEvaluator {
     bindings: string[],
     executionParams?: Record<string, unknown> | string,
   ) {
-    const dataTree = klona(this.evalTree);
+    const dataTree = klonaJSON(this.evalTree);
     // We might get execution params as an object or as a string.
     // If the user has added a proper object (valid case) it will be an object
     // If they have not added any execution params or not an object


### PR DESCRIPTION
## Description
Changed the klona strategy of evalActionBindings and parsed values within evaluateTree to use klonaJSON instead of klona. Seeing a 10-20% reduction in webworker scripting and a 4 second drop in LCP within a windows machine.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12275133735>
> Commit: dbe08f90ef23d24131f27b7731c953a584fdd61f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12275133735&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 11 Dec 2024 12:37:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling during data evaluation, providing better context for debugging.
	- Improved logic for evaluating dynamic properties within the data tree.

- **Bug Fixes**
	- Addressed issues with data cloning methods to ensure more reliable data handling.

- **Refactor**
	- Updated method signatures for improved clarity and consistency across the evaluation processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->