### PR TITLE
fix:Widget Column test case fix

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
@@ -160,7 +160,10 @@ describe(
       );
       _.agHelper.GetNClick(OneClickBindingLocator.searchableColumn);
       _.agHelper.GetNClick(
-        OneClickBindingLocator.columnDropdownOption("searchableColumn", "imdb_id"),
+        OneClickBindingLocator.columnDropdownOption(
+          "searchableColumn",
+          "imdb_id",
+        ),
       );
       _.agHelper.GetNClick(OneClickBindingLocator.connectData);
       _.table.WaitUntilTableLoad(0, 0, "v2");

--- a/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
@@ -160,11 +160,11 @@ describe(
       );
       _.agHelper.GetNClick(OneClickBindingLocator.searchableColumn);
       _.agHelper.GetNClick(
-        OneClickBindingLocator.columnDropdownOption("searchableColumn", "id"),
+        OneClickBindingLocator.columnDropdownOption("searchableColumn", "imdb_id"),
       );
       _.agHelper.GetNClick(OneClickBindingLocator.connectData);
       _.table.WaitUntilTableLoad(0, 0, "v2");
-      _.propPane.OpenTableColumnSettings("id");
+      _.propPane.OpenTableColumnSettings("imdb_id");
       _.propPane.TypeTextIntoField("Regex", "{{test}}");
       _.debuggerHelper.AssertErrorCount(1);
       _.propPane.ToggleSection("validation");
@@ -172,7 +172,7 @@ describe(
 
       _.debuggerHelper.OpenDebugger();
       _.debuggerHelper.ClicklogEntityLink();
-      _.agHelper.GetNAssertContains(_.propPane._paneTitle, "id");
+      _.agHelper.GetNAssertContains(_.propPane._paneTitle, "imdb_id");
       _.debuggerHelper.CloseBottomBar();
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget);
       _.entityExplorer.DeleteWidgetFromEntityExplorer("Table1");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,6 +1,5 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
-
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*


### PR DESCRIPTION
## Description
Column name updates.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12235074532>
> Commit: 245d0f2ad786f4e348c1ab268c7f85e2454f81bf
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12235074532&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Mon, 09 Dec 2024 13:04:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated widget property navigation test cases to reflect changes in widget properties.
  
- **Chores**
	- Modified the list of limited tests to replace an outdated test entry with a new focus on widget property navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->