### PR TITLE
fix: use explicit jackson core databind dependency and exclude it from jjwt-jackson

### DIFF
--- a/app/server/appsmith-plugins/appsmithAiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jtuysackson-bom.version}</version>
+            <version>${jackson-bom.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/app/server/appsmith-plugins/appsmithAiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/pom.xml
@@ -65,7 +65,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/app/server/appsmith-plugins/appsmithAiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/pom.xml
@@ -62,6 +62,18 @@
             <artifactId>jjwt-jackson</artifactId>
             <!-- or jjwt-gson if Gson is preferred -->
             <version>${jjwt.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jtuysackson-bom.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--


### PR DESCRIPTION
## Description
> Exclude the Jackson Databind dependency from the `jjwt-jackson` and provide it explicitly from the integrated pom.xml.


Fixes  https://github.com/appsmithorg/appsmith/issues/38070

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12253612649>
> Commit: ec6cad8ae8d9a843cf43c9ed80f8c6aebaea515d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12253612649&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 10 Dec 2024 10:32:34 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency for `jackson-databind` to enhance data handling capabilities.
- **Bug Fixes**
	- Excluded conflicting artifacts from the `jjwt-jackson` dependency to resolve potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->