### PR TITLE
fix: add check to avoid NPE when binding value is null

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -144,6 +145,14 @@ public class AstServiceCEImpl implements AstServiceCE {
 
         return Flux.fromIterable(bindingValues)
                 .flatMap(bindingValue -> {
+                    if (!StringUtils.hasText(bindingValue.getValue())) {
+                        // If the binding value is null or empty, it indicates an incorrect entry in the
+                        // dynamicBindingPathList.
+                        // Such bindings are considered invalid and can be safely discarded during refactoring.
+                        // Therefore, we return an empty response.
+
+                        return Mono.empty();
+                    }
                     if (!bindingValue.getValue().contains(oldName)) {
                         // This case is not handled in RTS either, so skipping the RTS call here will not affect the
                         // behavior.


### PR DESCRIPTION
## Description
Slack thread: https://theappsmith.slack.com/archives/C04GRCN4CS3/p1733907474929399

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12277298947>
> Commit: 71ba98bf4e5028cd1e51615c8a998416a5f91487
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12277298947&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 11 Dec 2024 15:39:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for dynamic bindings by validating empty or null values.
  
- **Bug Fixes**
  - Improved test coverage for handling null binding values in dynamic bindings.

- **Tests**
  - Added a new test for verifying behavior with null binding values.
  - Updated existing tests to ensure they accurately reflect the expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->