### PR TITLE
fix: Updating the logic for datasource selector to fox the client build failure on prod

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/Datasource.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/Datasource.tsx
@@ -25,6 +25,7 @@ import { BOTTOMBAR_HEIGHT } from "./constants";
 import { useEditorType } from "ee/hooks";
 import { useParentEntityInfo } from "ee/hooks/datasourceEditorHooks";
 import DatasourceInfo from "./DatasourceInfo";
+import { getPlugin } from "ee/selectors/entitiesSelector";
 
 interface Props {
   datasourceId: string;
@@ -44,6 +45,8 @@ const Datasource = (props: Props) => {
   const pluginId = useSelector((state) =>
     getPluginIdFromDatasourceId(state, props.datasourceId),
   );
+
+  const plugin = useSelector((state) => getPlugin(state, pluginId || ""));
 
   const editorType = useEditorType(location.pathname);
   const { parentEntityId } = useParentEntityInfo(editorType);
@@ -143,6 +146,7 @@ const Datasource = (props: Props) => {
         <DatasourceInfo
           datasourceId={props.datasourceId}
           datasourceName={props.datasourceName}
+          plugin={plugin}
           showEditButton={!isLoading}
         />
         <StatusDisplay
@@ -170,6 +174,7 @@ const Datasource = (props: Props) => {
           datasourceId={props.datasourceId}
           datasourceName={props.datasourceName}
           datasourceStructure={datasourceStructure}
+          plugin={plugin}
           selectedTable={selectedTable}
           setSelectedTable={setSelectedTable}
         />

--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/DatasourceInfo.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/DatasourceInfo.tsx
@@ -10,16 +10,19 @@ import { getQueryParams } from "utils/URLUtils";
 import history from "utils/history";
 import { useEditorType } from "ee/hooks";
 import { useParentEntityInfo } from "ee/hooks/datasourceEditorHooks";
+import type { Plugin } from "api/PluginApi";
 
 interface Props {
   datasourceId: string;
   datasourceName: string;
   showEditButton: boolean;
+  plugin?: Plugin;
 }
 
 const DatasourceInfo = ({
   datasourceId,
   datasourceName,
+  plugin,
   showEditButton,
 }: Props) => {
   const editorType = useEditorType(location.pathname);
@@ -50,6 +53,7 @@ const DatasourceInfo = ({
       <DatasourceSelector
         datasourceId={datasourceId}
         datasourceName={datasourceName}
+        plugin={plugin}
       />
       {showEditButton && (
         <Tooltip content={createMessage(EDIT_DS_CONFIG)} placement="top">

--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/DatasourceSelector/index.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/DatasourceSelector/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { UIComponentTypes } from "api/PluginApi";
-import { usePluginActionContext } from "PluginActionEditor/PluginActionContext";
+import { UIComponentTypes, type Plugin } from "api/PluginApi";
 import ApiDatasourceSelector from "./ApiDatasourceSelector";
 import QueryDatasourceSelector from "./QueryDatasourceSelector";
 import {
@@ -16,16 +15,17 @@ const API_FORM_COMPONENTS = [
 export interface DatasourceProps {
   datasourceId: string;
   datasourceName: string;
+  plugin?: Plugin;
 }
 
 const DatasourceSelector = (props: DatasourceProps) => {
-  const { plugin } = usePluginActionContext();
-
-  return API_FORM_COMPONENTS.includes(plugin.uiComponent) ? (
-    <ApiDatasourceSelector {...props} formName={API_EDITOR_FORM_NAME} />
-  ) : (
-    <QueryDatasourceSelector {...props} formName={QUERY_EDITOR_FORM_NAME} />
-  );
+  return props.plugin ? (
+    API_FORM_COMPONENTS.includes(props.plugin.uiComponent) ? (
+      <ApiDatasourceSelector {...props} formName={API_EDITOR_FORM_NAME} />
+    ) : (
+      <QueryDatasourceSelector {...props} formName={QUERY_EDITOR_FORM_NAME} />
+    )
+  ) : null;
 };
 
 export default DatasourceSelector;

--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/DatasourceTables.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/DatasourceTables.tsx
@@ -9,12 +9,14 @@ import { refreshDatasourceStructure } from "actions/datasourceActions";
 import { useDispatch } from "react-redux";
 import { SchemaTableContainer } from "./styles";
 import DatasourceInfo from "./DatasourceInfo";
+import type { Plugin } from "api/PluginApi";
 
 interface Props {
   datasourceId: string;
   datasourceName: string;
   currentActionId: string;
   datasourceStructure: DatasourceStructure;
+  plugin?: Plugin;
   setSelectedTable: (table: string) => void;
   selectedTable: string | undefined;
 }
@@ -24,6 +26,7 @@ const DatasourceTables = ({
   datasourceId,
   datasourceName,
   datasourceStructure,
+  plugin,
   selectedTable,
   setSelectedTable,
 }: Props) => {
@@ -56,6 +59,7 @@ const DatasourceTables = ({
         <DatasourceInfo
           datasourceId={datasourceId}
           datasourceName={datasourceName}
+          plugin={plugin}
           showEditButton
         />
         <Button


### PR DESCRIPTION
## Description

Updating the logic for datasource selector to fox the client build failure on prod

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
