### PR TITLE
test: Skipping one test in API Edit Spec for functional bugs

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
@@ -48,7 +48,8 @@ describe(
       PageLeftPane.assertAbsence("SecondAPI");
     });
 
-    it("2. Should update loading state after cancellation of confirmation for run query", function () {
+    //Existing Bug: https://github.com/appsmithorg/appsmith/issues/38165
+    it.skip("2. Should update loading state after cancellation of confirmation for run query", function () {
       cy.CreateAPI("FirstAPI");
       cy.get(".CodeMirror-placeholder")
         .first()

--- a/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
@@ -16,7 +16,8 @@ describe(
   function () {
     let clientId, clientSecret;
 
-    it("1. Create an API with app url and save as Datasource for Authorization code details test", function () {
+    //Existing Bug:  https://github.com/appsmithorg/appsmith/issues/37353
+    it.skip("1. Create an API with app url and save as Datasource for Authorization code details test", function () {
       dataSources.CreateOAuthClient("authorization_code");
       apiPage.CreateAndFillApi(
         dataManager.dsValues[dataManager.defaultEnviorment].OAuth_ApiUrl +

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
+cypress/e2e/Regression/ClientSide/JSObject/JSObject_Tests_spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/JSObject/JSObject_Tests_spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/locators/apiWidgetslocator.json
+++ b/app/client/cypress/locators/apiWidgetslocator.json
@@ -47,7 +47,7 @@
   "page": ".single-select >div",
   "propertyList": ".binding",
   "actionlist": ".action div div",
-  "settings": "span:contains('Settings')",
+  "settings": "[data-testid='t--action-settings-trigger']",
   "headers": "span:contains('Headers')",
   "onPageLoad": "[name=executeOnLoad]",
   "renameEntity": "div[role='menuitem']:contains('Rename')",


### PR DESCRIPTION
cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts --> there is a bug hence commenting this test
cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js --> there is a bug hence commenting one test in this spec file

/ok-to-test tags="@tag.Sanity"



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12349492331>
> Commit: b7237c480acc2c974d124101c986caa13672049a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12349492331&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 16 Dec 2024 10:00:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the locator for the "settings" element to enhance precision.
	- Skipped a test case related to loading state after cancellation due to an existing bug.
	- Skipped a test case for creating an API with app URL due to an existing bug.

- **Tests**
	- Adjusted test case statuses to reflect current functionality and known issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->