### PR TITLE
fix: Add custom deserialiser for idPolicies projection

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/IdPoliciesOnly.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/projections/IdPoliciesOnly.java
@@ -1,11 +1,29 @@
 package com.appsmith.server.projections;
 
 import com.appsmith.external.models.Policy;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
 
+import java.util.HashMap;
 import java.util.Map;
 
-public interface IdPoliciesOnly {
-    String getId();
+@Getter
+public class IdPoliciesOnly {
+    String id;
+    Map<String, Policy> policyMap = new HashMap<>();
 
-    Map<String, Policy> getPolicyMap();
+    // TODO Abhijeet: This is a temporary fix to convert the map of Object to map of Policy
+    public IdPoliciesOnly(String id, Map<String, Object> policyMap) {
+        this.id = id;
+        if (policyMap == null) {
+            return;
+        }
+        policyMap.forEach((key, value) -> {
+            if (value instanceof Policy) {
+                this.policyMap.put(key, (Policy) value);
+            } else if (value instanceof Map) {
+                this.policyMap.put(key, new ObjectMapper().convertValue(value, Policy.class));
+            }
+        });
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/ActionCollectionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/ActionCollectionRepositoryCE.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.ActionCollection;
-import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseRepository;
 import com.appsmith.server.repositories.CustomActionCollectionRepository;
 
@@ -10,6 +9,4 @@ import java.util.List;
 public interface ActionCollectionRepositoryCE
         extends BaseRepository<ActionCollection, String>, CustomActionCollectionRepository {
     List<ActionCollection> findByApplicationId(String applicationId);
-
-    List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
@@ -4,6 +4,7 @@ import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.AppsmithRepository;
 import org.springframework.data.domain.Sort;
 
@@ -43,4 +44,6 @@ public interface CustomActionCollectionRepositoryCE extends AppsmithRepository<A
 
     List<ActionCollection> findAllNonComposedByPageIdAndViewMode(
             String pageId, boolean viewMode, AclPermission permission, User currentUser);
+
+    List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -4,9 +4,11 @@ import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.ActionCollection;
+import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
+import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import org.springframework.data.domain.Sort;
 
@@ -180,5 +182,12 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
     public List<ActionCollection> findAllNonComposedByPageIdAndViewMode(
             String pageId, boolean viewMode, AclPermission permission, User currentUser) {
         return this.findByPageIdAndViewMode(pageId, viewMode, permission, currentUser);
+    }
+
+    @Override
+    public List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds) {
+        return queryBuilder()
+                .criteria(Bridge.in(NewAction.Fields.applicationId, applicationIds))
+                .all(IdPoliciesOnly.class);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
@@ -4,6 +4,7 @@ import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.AppsmithRepository;
 import org.springframework.data.domain.Sort;
 
@@ -90,4 +91,6 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
             boolean includeJs);
 
     List<NewAction> findAllByApplicationIds(List<String> branchedArtifactIds, List<String> includedFields);
+
+    List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -7,6 +7,7 @@ import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
+import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.transaction.Transactional;
@@ -484,5 +485,12 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
                 .criteria(Bridge.in(NewAction.Fields.applicationId, applicationIds))
                 .fields(includedFields)
                 .all();
+    }
+
+    @Override
+    public List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds) {
+        return queryBuilder()
+                .criteria(Bridge.in(NewAction.Fields.applicationId, applicationIds))
+                .all(IdPoliciesOnly.class);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
@@ -3,6 +3,7 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.AppsmithRepository;
 
 import java.util.Collection;
@@ -48,4 +49,6 @@ public interface CustomNewPageRepositoryCE extends AppsmithRepository<NewPage> {
     List<NewPage> findAllByApplicationIdsWithoutPermission(List<String> applicationIds, List<String> includeFields);
 
     Optional<Integer> updateDependencyMap(String pageId, Map<String, List<String>> dependencyMap);
+
+    List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -10,6 +10,7 @@ import com.appsmith.server.helpers.ce.bridge.Bridge;
 import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.helpers.ce.bridge.BridgeUpdate;
 import com.appsmith.server.projections.IdOnly;
+import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -262,5 +263,12 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         BridgeUpdate update = Bridge.update();
         update.set(NewPage.Fields.unpublishedPage_dependencyMap, dependencyMap);
         return Optional.of(queryBuilder().criteria(q).updateFirst(update));
+    }
+
+    @Override
+    public List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds) {
+        return queryBuilder()
+                .criteria(Bridge.in(NewPage.Fields.applicationId, applicationIds))
+                .all(IdPoliciesOnly.class);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewActionRepositoryCE.java
@@ -3,7 +3,6 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.dtos.PluginTypeAndCountDTO;
 import com.appsmith.server.newactions.projections.IdAndDatasourceIdNewActionView;
-import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseRepository;
 import com.appsmith.server.repositories.CustomNewActionRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,8 +19,6 @@ public interface NewActionRepositoryCE extends BaseRepository<NewAction, String>
     List<NewAction> findAllByIdIn(Collection<String> ids);
 
     Optional<Long> countByDeletedAtNull();
-
-    List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 
     List<IdAndDatasourceIdNewActionView> findIdAndDatasourceIdByApplicationIdIn(List<String> applicationIds);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewPageRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewPageRepositoryCE.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.repositories.ce;
 
 import com.appsmith.server.domains.NewPage;
-import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseRepository;
 import com.appsmith.server.repositories.CustomNewPageRepository;
 
@@ -13,6 +12,4 @@ public interface NewPageRepositoryCE extends BaseRepository<NewPage, String>, Cu
     List<NewPage> findByApplicationId(String applicationId);
 
     Optional<Long> countByDeletedAtNull();
-
-    List<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 }


### PR DESCRIPTION
## Description
PR to move projection methods with IdPoliciesOnly class to custom repository.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve ID and policy mappings based on application IDs across multiple repositories.
  
- **Bug Fixes**
	- Removed outdated methods that previously provided ID and policy mappings, streamlining repository functionalities.

- **Documentation**
	- Updated import statements to include necessary dependencies for new functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->