### PR TITLE
chore: refactor the crud method to custom repo class

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/ActionCollectionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/ActionCollectionRepositoryCE.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 public interface ActionCollectionRepositoryCE
         extends BaseRepository<ActionCollection, String>, CustomActionCollectionRepository {
-    Flux<ActionCollection> findByApplicationId(String applicationId);
 
     Flux<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCE.java
@@ -42,4 +42,6 @@ public interface CustomActionCollectionRepositoryCE extends AppsmithRepository<A
 
     Flux<ActionCollection> findAllNonComposedByPageIdAndViewMode(
             String pageId, boolean viewMode, AclPermission permission);
+
+    Flux<ActionCollection> findByApplicationId(String applicationId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomActionCollectionRepositoryCEImpl.java
@@ -168,4 +168,10 @@ public class CustomActionCollectionRepositoryCEImpl extends BaseAppsmithReposito
             String pageId, boolean viewMode, AclPermission permission) {
         return this.findByPageIdAndViewMode(pageId, viewMode, permission);
     }
+
+    @Override
+    public Flux<ActionCollection> findByApplicationId(String applicationId) {
+        final BridgeQuery<ActionCollection> q = Bridge.equal(ActionCollection.Fields.applicationId, applicationId);
+        return queryBuilder().criteria(q).all();
+    }
 }


### PR DESCRIPTION
## Description
As part of transaction support in PG, we are moving from using the jpa methods for database operations. This PR is refactoring the code to use custom repository class for DatasourceRepository from the default CrudRepository.

## Automation

/ok-to-test tags="@tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12304558211>
> Commit: d85d3ae9d9ca95a454b1f43f159e45b7643eea60
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12304558211&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.ImportExport`
> Spec:
> <hr>Thu, 12 Dec 2024 21:15:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve action collections by application ID without requiring additional parameters.

- **Bug Fixes**
	- Deprecated the previous method for fetching action collections that required more parameters, streamlining the querying process.

- **Documentation**
	- Updated method signatures to reflect the new querying capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->