### PR TITLE
chore: refactor the crud method to custom repo class

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCE.java
@@ -6,9 +6,19 @@ import com.appsmith.server.repositories.AppsmithRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
 public interface CustomDatasourceRepositoryCE extends AppsmithRepository<Datasource> {
 
     Flux<Datasource> findAllByWorkspaceId(String workspaceId, AclPermission permission);
 
     Mono<Datasource> findByNameAndWorkspaceId(String name, String workspaceId, AclPermission aclPermission);
+
+    Flux<Datasource> findByWorkspaceId(String workspaceId, AclPermission aclPermission);
+
+    Flux<Datasource> findAllByWorkspaceIdWithoutPermissions(String workspaceId);
+
+    Flux<Datasource> findByIdIn(List<String> ids);
+
+    Mono<Long> countByDeletedAtNull();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCE.java
@@ -14,10 +14,6 @@ public interface CustomDatasourceRepositoryCE extends AppsmithRepository<Datasou
 
     Mono<Datasource> findByNameAndWorkspaceId(String name, String workspaceId, AclPermission aclPermission);
 
-    Flux<Datasource> findByWorkspaceId(String workspaceId, AclPermission aclPermission);
-
-    Flux<Datasource> findAllByWorkspaceIdWithoutPermissions(String workspaceId);
-
     Flux<Datasource> findByIdIn(List<String> ids);
 
     Mono<Long> countByDeletedAtNull();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
@@ -3,10 +3,13 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.helpers.ce.bridge.Bridge;
+import com.appsmith.server.helpers.ce.bridge.BridgeQuery;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import org.springframework.data.domain.Sort;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Datasource>
         implements CustomDatasourceRepositoryCE {
@@ -27,5 +30,29 @@ public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl
                 .criteria(Bridge.equal(Datasource.Fields.name, name).equal(Datasource.Fields.workspaceId, workspaceId))
                 .permission(aclPermission)
                 .one();
+    }
+
+    @Override
+    public Flux<Datasource> findByWorkspaceId(String workspaceId, AclPermission aclPermission) {
+        final BridgeQuery<Datasource> q = Bridge.equal(Datasource.Fields.workspaceId, workspaceId);
+        return queryBuilder().criteria(q).permission(aclPermission).all();
+    }
+
+    @Override
+    public Flux<Datasource> findAllByWorkspaceIdWithoutPermissions(String workspaceId) {
+        final BridgeQuery<Datasource> q = Bridge.equal(Datasource.Fields.workspaceId, workspaceId);
+        return queryBuilder().criteria(q).all();
+    }
+
+    @Override
+    public Flux<Datasource> findByIdIn(List<String> ids) {
+        final BridgeQuery<Datasource> q = Bridge.in(Datasource.Fields.id, ids);
+        return queryBuilder().criteria(q).all();
+    }
+
+    @Override
+    public Mono<Long> countByDeletedAtNull() {
+        final BridgeQuery<Datasource> q = Bridge.isNull(Datasource.Fields.deletedAt);
+        return queryBuilder().criteria(q).count();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomDatasourceRepositoryCEImpl.java
@@ -33,18 +33,6 @@ public class CustomDatasourceRepositoryCEImpl extends BaseAppsmithRepositoryImpl
     }
 
     @Override
-    public Flux<Datasource> findByWorkspaceId(String workspaceId, AclPermission aclPermission) {
-        final BridgeQuery<Datasource> q = Bridge.equal(Datasource.Fields.workspaceId, workspaceId);
-        return queryBuilder().criteria(q).permission(aclPermission).all();
-    }
-
-    @Override
-    public Flux<Datasource> findAllByWorkspaceIdWithoutPermissions(String workspaceId) {
-        final BridgeQuery<Datasource> q = Bridge.equal(Datasource.Fields.workspaceId, workspaceId);
-        return queryBuilder().criteria(q).all();
-    }
-
-    @Override
     public Flux<Datasource> findByIdIn(List<String> ids) {
         final BridgeQuery<Datasource> q = Bridge.in(Datasource.Fields.id, ids);
         return queryBuilder().criteria(q).all();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/DatasourceRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/DatasourceRepositoryCE.java
@@ -4,19 +4,12 @@ import com.appsmith.external.models.Datasource;
 import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseRepository;
 import com.appsmith.server.repositories.CustomDatasourceRepository;
+import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
-import java.util.List;
 import java.util.Set;
 
+@Repository
 public interface DatasourceRepositoryCE extends BaseRepository<Datasource, String>, CustomDatasourceRepository {
-
-    Flux<Datasource> findByIdIn(List<String> ids);
-
-    Flux<Datasource> findAllByWorkspaceId(String workspaceId);
-
-    Mono<Long> countByDeletedAtNull();
-
     Flux<IdPoliciesOnly> findIdsAndPolicyMapByIdIn(Set<String> datasourceIds);
 }


### PR DESCRIPTION
## Description

As part of transaction support in PG, we are moving from using the jpa methods for database operations. This PR is refactoring the code to use custom repository class for DatasourceRepository from the default CrudRepository.

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12388978242>
> Commit: df7dc42471f4790121f595ec04e1c29749ef6676
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12388978242&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Wed, 18 Dec 2024 08:59:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods to retrieve `Datasource` objects by IDs and count non-deleted `Datasource` instances.
- **Bug Fixes**
	- Removed outdated method signatures from the `DatasourceRepositoryCE` interface to streamline functionality.
- **Documentation**
	- Added `@Repository` annotation to the `DatasourceRepositoryCE` interface for clarity on its role within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->