### PR TITLE
chore: refactor new page crud repo methods

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
@@ -42,4 +42,8 @@ public interface CustomNewPageRepositoryCE extends AppsmithRepository<NewPage> {
     Flux<NewPage> findAllByApplicationIdsWithoutPermission(List<String> applicationIds, List<String> includeFields);
 
     Mono<Integer> updateDependencyMap(String pageId, Map<String, List<String>> dependencyMap);
+
+    Flux<NewPage> findByApplicationId(String applicationId);
+
+    Mono<Long> countByDeletedAtNull();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -261,4 +261,16 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         update.set(NewPage.Fields.unpublishedPage_dependencyMap, dependencyMap);
         return queryBuilder().criteria(q).updateFirst(update);
     }
+
+    @Override
+    public Flux<NewPage> findByApplicationId(String applicationId) {
+        final BridgeQuery<NewPage> q = Bridge.equal(NewPage.Fields.applicationId, applicationId);
+        return queryBuilder().criteria(q).all();
+    }
+
+    @Override
+    public Mono<Long> countByDeletedAtNull() {
+        final BridgeQuery<NewPage> q = Bridge.notExists(NewPage.Fields.deletedAt);
+        return queryBuilder().criteria(q).count();
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewPageRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewPageRepositoryCE.java
@@ -5,15 +5,10 @@ import com.appsmith.server.projections.IdPoliciesOnly;
 import com.appsmith.server.repositories.BaseRepository;
 import com.appsmith.server.repositories.CustomNewPageRepository;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 public interface NewPageRepositoryCE extends BaseRepository<NewPage, String>, CustomNewPageRepository {
-
-    Flux<NewPage> findByApplicationId(String applicationId);
-
-    Mono<Long> countByDeletedAtNull();
 
     Flux<IdPoliciesOnly> findIdsAndPolicyMapByApplicationIdIn(List<String> applicationIds);
 }


### PR DESCRIPTION
## Description
As part of transaction support in PG, we are moving from using the jpa methods for database operations. This PR is refactoring the code to use custom repository class for NewPageRepository from the default CrudRepository.

## Automation

/ok-to-test tags="@tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12329409662>
> Commit: d8ff386a0c54ae00c4abc51ec6012e4c220bcba6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12329409662&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.ImportExport`
> Spec:
> <hr>Sat, 14 Dec 2024 11:42:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods to retrieve pages by application ID and count non-deleted pages.
  
- **Bug Fixes**
	- Removed outdated methods from the `NewPageRepositoryCE` interface to streamline functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->