### PR TITLE
chore: add packagePullStatus to consolidated API

### DIFF
--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -31,6 +31,8 @@ import type {
   PageAction,
 } from "../constants/AppsmithActionConstants/ActionConstants";
 import { ReplayOperation } from "entities/Replay/ReplayEntity/ReplayOperations";
+import type { PACKAGE_PULL_STATUS } from "ee/constants/ModuleConstants";
+import type { ApiResponse } from "api/ApiResponses";
 
 export interface FetchPageListPayload {
   applicationId: string;
@@ -657,18 +659,21 @@ export interface SetupPageActionPayload {
   id: string;
   isFirstLoad?: boolean;
   pageWithMigratedDsl?: FetchPageResponse;
+  packagePullStatus?: ApiResponse<PACKAGE_PULL_STATUS>;
 }
 
-export const setupPageAction = (
-  pageId: string,
+export const setupPageAction = ({
+  id,
   isFirstLoad = false,
-  pageWithMigratedDsl?: FetchPageResponse,
-): ReduxAction<SetupPageActionPayload> => ({
+  packagePullStatus,
+  pageWithMigratedDsl,
+}: SetupPageActionPayload) => ({
   type: ReduxActionTypes.SETUP_PAGE_INIT,
   payload: {
-    id: pageId,
+    id,
     isFirstLoad,
     pageWithMigratedDsl,
+    packagePullStatus,
   },
 });
 

--- a/app/client/src/ce/components/BottomBar/PackageUpgradeStatus.tsx
+++ b/app/client/src/ce/components/BottomBar/PackageUpgradeStatus.tsx
@@ -1,0 +1,6 @@
+// The implementation of this is present in EE
+function PackageUpgradeStatus() {
+  return null;
+}
+
+export default PackageUpgradeStatus;

--- a/app/client/src/ce/constants/ModuleConstants.ts
+++ b/app/client/src/ce/constants/ModuleConstants.ts
@@ -32,3 +32,9 @@ export interface ModuleMetadata {
   pluginId: string;
   pluginType: PluginType;
 }
+
+export enum PACKAGE_PULL_STATUS {
+  UPGRADABLE = "UPGRADABLE",
+  UPGRADED = "UPGRADED",
+  UPGRADING = "UPGRADING",
+}

--- a/app/client/src/components/BottomBar/index.tsx
+++ b/app/client/src/components/BottomBar/index.tsx
@@ -15,6 +15,7 @@ import { useDispatch } from "react-redux";
 import { softRefreshActions } from "actions/pluginActionActions";
 import { START_SWITCH_ENVIRONMENT } from "ee/constants/messages";
 import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
+import PackageUpgradeStatus from "ee/components/BottomBar/PackageUpgradeStatus";
 
 export default function BottomBar() {
   const appId = useSelector(getCurrentApplicationId) || "";
@@ -44,6 +45,7 @@ export default function BottomBar() {
       </Wrapper>
       {!isPreviewMode && (
         <Wrapper>
+          <PackageUpgradeStatus />
           <ManualUpgrades showTooltip>
             <Button
               className="t--upgrade"

--- a/app/client/src/ee/components/BottomBar/PackageUpgradeStatus.tsx
+++ b/app/client/src/ee/components/BottomBar/PackageUpgradeStatus.tsx
@@ -1,0 +1,3 @@
+export * from "ce/components/BottomBar/PackageUpgradeStatus";
+import { default as CE_PackageUpgradeStatus } from "ce/components/BottomBar/PackageUpgradeStatus";
+export default CE_PackageUpgradeStatus;

--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -124,13 +124,19 @@ export default class AppEditorEngine extends AppEngine {
     const {
       currentTheme,
       customJSLibraries,
+      packagePullStatus,
       pageWithMigratedDsl,
       themes,
       unpublishedActionCollections,
       unpublishedActions,
     } = allResponses;
     const initActionsCalls = [
-      setupPageAction(toLoadPageId, true, pageWithMigratedDsl),
+      setupPageAction({
+        id: toLoadPageId,
+        isFirstLoad: true,
+        pageWithMigratedDsl,
+        packagePullStatus,
+      }),
       fetchActions({ applicationId, unpublishedActions }, []),
       fetchJSCollections({ applicationId, unpublishedActionCollections }),
       fetchSelectedAppThemeAction(applicationId, currentTheme),

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -241,7 +241,7 @@ const mapDispatchToProps = (dispatch: any) => {
     initEditor: (payload: InitEditorActionPayload) =>
       dispatch(initEditorAction(payload)),
     resetEditorRequest: () => dispatch(resetEditorRequest()),
-    setupPage: (pageId: string) => dispatch(setupPageAction(pageId)),
+    setupPage: (pageId: string) => dispatch(setupPageAction({ id: pageId })),
     updateCurrentPage: (pageId: string) => dispatch(updateCurrentPage(pageId)),
     widgetConfigBuildSuccess: () => dispatch(widgetInitialisationSuccess()),
   };

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -90,6 +90,7 @@ import {
 } from "UITelemetry/generateTraces";
 import type { ApplicationPayload } from "entities/Application";
 import type { Page } from "entities/Page";
+import type { PACKAGE_PULL_STATUS } from "ee/constants/ModuleConstants";
 
 export const URL_CHANGE_ACTIONS = [
   ReduxActionTypes.CURRENT_APPLICATION_NAME_UPDATE,
@@ -133,6 +134,7 @@ export interface EditConsolidatedApi {
   pluginFormConfigs: ApiResponse<PluginFormPayload>[];
   unpublishedActions: ApiResponse<Action[]>;
   unpublishedActionCollections: ApiResponse<JSCollection[]>;
+  packagePullStatus: ApiResponse<PACKAGE_PULL_STATUS>;
 }
 export type InitConsolidatedApi = DeployConsolidatedApi | EditConsolidatedApi;
 export function* failFastApiCalls(


### PR DESCRIPTION
## Description
This is a refactor PR to support auto pull of packages on page load.
1.  adds an additional property on the consolidated API which reflects if the application needs to upgrade it's packages (`packagePullStatus`)
2. A scaffold component to be extended in EE to show the package pull status as it's called in parallel to consolidated API and is non-blocking to the app's first page load

Not this is only relevant to the edit mode of the application

PR for https://github.com/appsmithorg/appsmith-ee/pull/5745

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12349195312>
> Commit: 9112f8a148a1f12c3f8cb3d59606d72afb962055
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12349195312&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 16 Dec 2024 12:30:28 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `PackageUpgradeStatus` component for future use.
	- Added a new enumeration `PACKAGE_PULL_STATUS` with status constants.
- **Enhancements**
	- Updated `setupPageAction` to accept additional parameters for improved data handling.
	- Enhanced error handling and logic in methods related to loading application data and managing plugins.
- **Bug Fixes**
	- Adjusted the argument structure for the `setupPage` method to ensure compatibility with updated action handling.
- **Documentation**
	- Updated interfaces and method signatures to reflect new parameters and structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->