### PR TITLE
chore: Fix chrome version to 129

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -254,13 +254,15 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
-          chrome-version: latest
+          chrome-version: 129
           install-chromedriver: true
           install-dependencies: true
       - run: |
-          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
       - name: Save Git values
         # pass env variables from this step to other steps

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -370,7 +370,7 @@ jobs:
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
         with:
-          browser: ${{ env.BROWSER_PATH }}
+          browser: /opt/hostedtoolcache/setup-chrome/chromium/129.0.6668.100/x64/chrome
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ inputs.spec }}

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -254,15 +254,24 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
-        id: setup-chrome
-        with:
-          chrome-version: 129
-          install-chromedriver: true
-          install-dependencies: true
-      - run: |
-          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+      # - uses: browser-actions/setup-chrome@latest
+      #   id: setup-chrome
+      #   with:
+      #     chrome-version: 129
+      #     install-chromedriver: true
+      #     install-dependencies: true
+      # - run: |
+      #     echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+      #     ${{ steps.setup-chrome.outputs.chrome-path }} --version
+
+      - name: Install Google Chrome 129.0.6668.100
+        run: |
+          CHROME_VERSION=129.0.6668.100
+          wget -q https://dl.google.com/linux/direct/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
+          sudo apt-get update
+          sudo apt-get install -y ./google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
+          echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
+          google-chrome --version
 
       - name: Save Git values
         # pass env variables from this step to other steps
@@ -370,7 +379,7 @@ jobs:
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
         with:
-          browser: /opt/hostedtoolcache/setup-chrome/chromium/129.0.6668.100/x64/chrome
+          browser: ${{ env.BROWSER_PATH }}
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ inputs.spec }}

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -33,9 +33,6 @@ on:
 jobs:
   ci-test:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
-      options: --user 1001
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||
       github.event_name == 'push' ||
@@ -73,7 +70,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
+      
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
@@ -373,7 +370,7 @@ jobs:
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
         with:
-          browser: ${{ env.BROWSER_PATH }}
+          browser: /opt/hostedtoolcache/setup-chrome/chromium/129.0.6668.100/x64/chrome
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ inputs.spec }}

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -367,6 +367,7 @@ jobs:
           CYPRESS_SKIP_FLAKY: true
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
+          CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
         with:
           browser: ${{ env.BROWSER_PATH }}
           install: false

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -258,6 +258,7 @@ jobs:
         with:
           chrome-version: 131
           install-chromedriver: true
+          install-dependencies: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -266,10 +266,9 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          CHROME_VERSION=129.0.6668.100
-          wget -q https://dl.google.com/linux/direct/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
+          wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get update
-          sudo apt-get install -y ./google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
+          sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version
 

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      
+
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
         if: inputs.pr != 0
@@ -254,15 +254,15 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      # - uses: browser-actions/setup-chrome@latest
-      #   id: setup-chrome
-      #   with:
-      #     chrome-version: 129
-      #     install-chromedriver: true
-      #     install-dependencies: true
-
+      - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
+        with:
+          chrome-version: 129
+          install-chromedriver: true
+          install-dependencies: true
       - run: |
-          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
       - name: Save Git values
         # pass env variables from this step to other steps
@@ -370,7 +370,7 @@ jobs:
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
         with:
-          browser: /opt/hostedtoolcache/setup-chrome/chromium/129.0.6668.100/x64/chrome
+          browser: ${{ env.BROWSER_PATH }}
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ inputs.spec }}

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -256,7 +256,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 130
+          chrome-version: 131
           install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -367,7 +367,6 @@ jobs:
           CYPRESS_SKIP_FLAKY: true
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
-          CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
         with:
           browser: ${{ env.BROWSER_PATH }}
           install: false

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -256,7 +256,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: 129
+          chrome-version: 130
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -266,6 +266,7 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
+          sudo apt-get remove google-chrome-stable
           wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -256,7 +256,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: stable
+          chrome-version: 129
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -257,6 +257,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
+          install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -256,7 +256,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 131
+          chrome-version: latest
           install-chromedriver: true
           install-dependencies: true
       - run: |

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -33,6 +33,9 @@ on:
 jobs:
   ci-test:
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
+      options: --user 1001
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||
       github.event_name == 'push' ||
@@ -254,15 +257,15 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
-        id: setup-chrome
-        with:
-          chrome-version: 129
-          install-chromedriver: true
-          install-dependencies: true
+      # - uses: browser-actions/setup-chrome@latest
+      #   id: setup-chrome
+      #   with:
+      #     chrome-version: 129
+      #     install-chromedriver: true
+      #     install-dependencies: true
+
       - run: |
-          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 
       - name: Save Git values
         # pass env variables from this step to other steps
@@ -370,7 +373,7 @@ jobs:
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
         with:
-          browser: chrome
+          browser: ${{ env.BROWSER_PATH }}
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ inputs.spec }}

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -254,7 +254,7 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
+      - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
       - run: |

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -370,7 +370,7 @@ jobs:
           CYPRESS_STATIC_ALLOCATION: true
           DEBUG: ${{secrets.CYPRESS_GREP_DEBUG }} # This is derived from secrets so that we can toggle it without having to change any workflow. Only acceptable value is: @cypress/grep
         with:
-          browser: ${{ env.BROWSER_PATH }}
+          browser: chrome
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ inputs.spec }}

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -254,16 +254,6 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      # - uses: browser-actions/setup-chrome@latest
-      #   id: setup-chrome
-      #   with:
-      #     chrome-version: 129
-      #     install-chromedriver: true
-      #     install-dependencies: true
-      # - run: |
-      #     echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-      #     ${{ steps.setup-chrome.outputs.chrome-path }} --version
-
       - name: Install Google Chrome 129.0.6668.100
         run: |
           sudo apt-get remove google-chrome-stable

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -139,7 +139,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: 129
+          chrome-version: 130
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -244,7 +244,6 @@ jobs:
           CYPRESS_S3_ACCESS: ${{ secrets.CYPRESS_S3_ACCESS }}
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_STATIC_ALLOCATION: true
-          CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
         with:
           install: false
           config-file: cypress_ci_hosted.config.ts

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -139,7 +139,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 130
+          chrome-version: 131
           install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -137,15 +137,14 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
-        id: setup-chrome
-        with:
-          chrome-version: 129
-          install-chromedriver: true
-          install-dependencies: true
-      - run: |
-          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+      - name: Install Google Chrome 129.0.6668.100
+        run: |
+          sudo apt-get remove google-chrome-stable
+          wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
+          sudo apt-get update
+          sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
+          echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
+          google-chrome --version
 
       - name: Save Git values
         # pass env variables from this step to other steps
@@ -247,6 +246,7 @@ jobs:
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_STATIC_ALLOCATION: true
         with:
+          browser: ${{ env.BROWSER_PATH }}
           install: false
           config-file: cypress_ci_hosted.config.ts
           working-directory: app/client

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -139,7 +139,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: stable
+          chrome-version: 129
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -141,6 +141,7 @@ jobs:
         with:
           chrome-version: 131
           install-chromedriver: true
+          install-dependencies: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -139,7 +139,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 131
+          chrome-version: latest
           install-chromedriver: true
           install-dependencies: true
       - run: |

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -137,13 +137,15 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
-          chrome-version: latest
+          chrome-version: 129
           install-chromedriver: true
           install-dependencies: true
       - run: |
-          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
       - name: Save Git values
         # pass env variables from this step to other steps

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -244,6 +244,7 @@ jobs:
           CYPRESS_S3_ACCESS: ${{ secrets.CYPRESS_S3_ACCESS }}
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_STATIC_ALLOCATION: true
+          CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
         with:
           install: false
           config-file: cypress_ci_hosted.config.ts

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -140,6 +140,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
+          install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -137,7 +137,7 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
+      - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
       - run: |

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -233,6 +233,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
+          install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -232,7 +232,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 130
+          chrome-version: 131
           install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -232,7 +232,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: 129
+          chrome-version: 130
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -234,6 +234,7 @@ jobs:
         with:
           chrome-version: 131
           install-chromedriver: true
+          install-dependencies: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -352,7 +352,7 @@ jobs:
             cd app/client
             npx cypress-repeat-pro run -n ${{ inputs.run_count }} --force \
                 --spec ${{ env.specs_to_run }} \
-                --config-file "cypress_ci_custom.config.ts"
+                --config-file "cypress_ci_custom.config.ts" \
                 --browser ${{ env.BROWSER_PATH }}
             cat cy-repeat-summary.txt
             # Define the path for the failure flag file

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -232,7 +232,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 131
+          chrome-version: latest
           install-chromedriver: true
           install-dependencies: true
       - run: |

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -345,6 +345,7 @@ jobs:
             CYPRESS_S3_ACCESS: ${{ secrets.CYPRESS_S3_ACCESS }}
             CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
             CYPRESS_STATIC_ALLOCATION: true
+            CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
             NODE_ENV: development
         run: |
             cd app/client

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -230,15 +230,14 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
-        id: setup-chrome
-        with:
-          chrome-version: 129
-          install-chromedriver: true
-          install-dependencies: true
-      - run: |
-          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+      - name: Install Google Chrome 129.0.6668.100
+        run: |
+          sudo apt-get remove google-chrome-stable
+          wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
+          sudo apt-get update
+          sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
+          echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
+          google-chrome --version
 
       - name: Save Git values
         # pass env variables from this step to other steps

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -353,6 +353,7 @@ jobs:
             npx cypress-repeat-pro run -n ${{ inputs.run_count }} --force \
                 --spec ${{ env.specs_to_run }} \
                 --config-file "cypress_ci_custom.config.ts"
+                --browser ${{ env.BROWSER_PATH }}
             cat cy-repeat-summary.txt
             # Define the path for the failure flag file
             FAILURE_FLAG_FILE="ci_test_status.txt"

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -230,13 +230,15 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
-          chrome-version: latest
+          chrome-version: 129
           install-chromedriver: true
           install-dependencies: true
       - run: |
-          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
       - name: Save Git values
         # pass env variables from this step to other steps

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -232,7 +232,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: stable
+          chrome-version: 129
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -345,7 +345,6 @@ jobs:
             CYPRESS_S3_ACCESS: ${{ secrets.CYPRESS_S3_ACCESS }}
             CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
             CYPRESS_STATIC_ALLOCATION: true
-            CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
             NODE_ENV: development
         run: |
             cd app/client

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -230,7 +230,7 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
+      - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
       - run: |

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -223,7 +223,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 130
+          chrome-version: 131
           install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -337,6 +337,7 @@ jobs:
           CYPRESS_S3_ACCESS: ${{ secrets.CYPRESS_S3_ACCESS }}
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_STATIC_ALLOCATION: true
+          CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
         with:
           browser: ${{ env.BROWSER_PATH }}
           install: false

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -220,14 +220,16 @@ jobs:
           cd app/client
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
-
-      - uses: browser-actions/setup-chrome@v1
+          
+      - uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
-          chrome-version: latest
+          chrome-version: 129
           install-chromedriver: true
           install-dependencies: true
       - run: |
-          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
       - name: Save Git values
         # pass env variables from this step to other steps

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -223,7 +223,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 131
+          chrome-version: latest
           install-chromedriver: true
           install-dependencies: true
       - run: |

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -221,15 +221,14 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
           
-      - uses: browser-actions/setup-chrome@latest
-        id: setup-chrome
-        with:
-          chrome-version: 129
-          install-chromedriver: true
-          install-dependencies: true
-      - run: |
-          echo "BROWSER_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+      - name: Install Google Chrome 129.0.6668.100
+        run: |
+          sudo apt-get remove google-chrome-stable
+          wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
+          sudo apt-get update
+          sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
+          echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
+          google-chrome --version
 
       - name: Save Git values
         # pass env variables from this step to other steps
@@ -340,7 +339,7 @@ jobs:
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_STATIC_ALLOCATION: true
         with:
-          browser: /opt/hostedtoolcache/setup-chrome/chromium/129.0.6668.100/x64/chrome
+          browser: ${{ env.BROWSER_PATH }}
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ env.specs_to_run }}

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -221,7 +221,7 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - uses: browser-actions/setup-chrome@latest
+      - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
       - run: |

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -337,7 +337,6 @@ jobs:
           CYPRESS_S3_ACCESS: ${{ secrets.CYPRESS_S3_ACCESS }}
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_STATIC_ALLOCATION: true
-          CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT: 300000
         with:
           browser: ${{ env.BROWSER_PATH }}
           install: false

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -225,6 +225,7 @@ jobs:
         with:
           chrome-version: 131
           install-chromedriver: true
+          install-dependencies: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -224,6 +224,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 130
+          install-chromedriver: true
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -223,7 +223,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: 129
+          chrome-version: 130
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -223,7 +223,7 @@ jobs:
 
       - uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: stable
+          chrome-version: 129
       - run: |
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -340,7 +340,7 @@ jobs:
           CYPRESS_S3_SECRET: ${{ secrets.CYPRESS_S3_SECRET }}
           CYPRESS_STATIC_ALLOCATION: true
         with:
-          browser: ${{ env.BROWSER_PATH }}
+          browser: /opt/hostedtoolcache/setup-chrome/chromium/129.0.6668.100/x64/chrome
           install: false
           config-file: cypress_ci_custom.config.ts
           spec: ${{ env.specs_to_run }}

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/DynamicHeight/TextWidget_Spec.ts
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/DynamicHeight/TextWidget_Spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 


### PR DESCRIPTION
## Description
Fix chrome version for snapshot testing.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12371605353>
> Commit: cc4ac1083ab6abf6bc0b37eaff74d491d197b0fc
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12371605353&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 17 Dec 2024 11:35:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new input parameters (`ted_tag`, `run_count`, `previous-workflow-run-id`) to enhance workflow flexibility.
	- Introduced service containers for Redis and MongoDB in CI tests.
	- Improved Slack notifications with dynamic messages based on test outcomes.

- **Bug Fixes**
	- Enhanced error handling and logging for better management of previous run results.

- **Improvements**
	- Updated Chrome installation method to a specific version (129.0.6668.100) across all workflows.
	- Refined job conditions to ensure proper execution under specific scenarios. 

- **Chores**
	- Adjusted cron schedule for CI tests to run every weekday at 1:30 AM UTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->