### PR TITLE
test: commenting dependent test which was missed in RestApiOAuth2Validation_spec

### DIFF
--- a/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
@@ -42,7 +42,7 @@ describe(
       });
     });
 
-    it("2. Validate save and Authorise", function () {
+    it.skip("2. Validate save and Authorise", function () {
       agHelper.GetNClick(dataSources._saveDs);
 
       //Accept consent

--- a/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
@@ -8,7 +8,7 @@ import {
   dataManager,
 } from "../../../support/Objects/ObjectsCore";
 
-xdescribe(
+describe.skip(
   "Datasource form OAuth2 client credentials related tests",
   {
     tags: ["@tag.Datasource", "@tag.Sanity", "@tag.Git", "@tag.AccessControl"],

--- a/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/RestApiOAuth2Validation_spec.ts
@@ -8,7 +8,7 @@ import {
   dataManager,
 } from "../../../support/Objects/ObjectsCore";
 
-describe(
+xdescribe(
   "Datasource form OAuth2 client credentials related tests",
   {
     tags: ["@tag.Datasource", "@tag.Sanity", "@tag.Git", "@tag.AccessControl"],


### PR DESCRIPTION
/ok-to-test tags="@tag.Sanity"



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12405587425>
> Commit: baf2d3b85eb7016a426b3818d620828b7856ca74
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12405587425&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 19 Dec 2024 04:03:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Disabled the execution of the OAuth2 validation test suite.
	- Skipped a specific test case within the suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->