### PR TITLE
fix: Wrong pageId used for segment navigation

### DIFF
--- a/app/client/src/pages/Editor/IDE/hooks.ts
+++ b/app/client/src/pages/Editor/IDE/hooks.ts
@@ -27,8 +27,6 @@ import { closeJSActionTab } from "actions/jsActionActions";
 import { closeQueryActionTab } from "actions/pluginActionActions";
 import { getCurrentBasePageId } from "selectors/editorSelectors";
 import { getCurrentEntityInfo } from "../utils";
-import { useEditorType } from "ee/hooks";
-import { useParentEntityInfo } from "ee/hooks/datasourceEditorHooks";
 
 export const useCurrentEditorState = () => {
   const [selectedSegment, setSelectedSegment] = useState<EditorEntityTab>(
@@ -60,9 +58,7 @@ export const useCurrentEditorState = () => {
 export const useSegmentNavigation = (): {
   onSegmentChange: (value: string) => void;
 } => {
-  const editorType = useEditorType(location.pathname);
-  const { parentEntityId: baseParentEntityId } =
-    useParentEntityInfo(editorType);
+  const basePageId = useSelector(getCurrentBasePageId);
 
   /**
    * Callback to handle the segment change
@@ -74,17 +70,17 @@ export const useSegmentNavigation = (): {
   const onSegmentChange = (value: string) => {
     switch (value) {
       case EditorEntityTab.QUERIES:
-        history.push(queryListURL({ baseParentEntityId }), {
+        history.push(queryListURL({ basePageId }), {
           invokedBy: NavigationMethod.SegmentControl,
         });
         break;
       case EditorEntityTab.JS:
-        history.push(jsCollectionListURL({ baseParentEntityId }), {
+        history.push(jsCollectionListURL({ basePageId }), {
           invokedBy: NavigationMethod.SegmentControl,
         });
         break;
       case EditorEntityTab.UI:
-        history.push(widgetListURL({ baseParentEntityId }), {
+        history.push(widgetListURL({ basePageId }), {
           invokedBy: NavigationMethod.SegmentControl,
         });
         break;


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #38216

## Automation

/ok-to-test tags="@tag.Git, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12406790663>
> Commit: 194f2ec70ff59c89f80410ee0088f16372decaa7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12406790663&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git, @tag.IDE`
> Spec:
> <hr>Thu, 19 Dec 2024 06:19:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation management in the editor for improved user experience.
	- Streamlined retrieval of the base entity ID for navigation purposes.

- **Bug Fixes**
	- Improved consistency in widget selection behavior based on current focus entity and keyboard events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->