### PR TITLE
chore: converted isNewEntity lookup to use a set 

### DIFF
--- a/app/client/src/ce/workers/Evaluation/evaluationUtils.ts
+++ b/app/client/src/ce/workers/Evaluation/evaluationUtils.ts
@@ -14,7 +14,7 @@ import type {
   ConfigTree,
 } from "entities/DataTree/dataTreeTypes";
 import { ENTITY_TYPE } from "ee/entities/DataTree/types";
-import _, { difference, find, get, has, isEmpty, isNil, set } from "lodash";
+import _, { difference, get, has, isEmpty, isNil, set } from "lodash";
 import type { WidgetTypeConfigMap } from "WidgetProvider/factory";
 import { PluginType } from "entities/Action";
 import { klona } from "klona/full";
@@ -987,11 +987,8 @@ export const isATriggerPath = (
 };
 
 // Checks if entity newly got added to the unevalTree
-export const isNewEntity = (updates: DataTreeDiff[], entityName: string) => {
-  return !!find(updates, {
-    event: DataTreeDiffEvent.NEW,
-    payload: { propertyPath: entityName },
-  });
+export const isNewEntity = (updates: Set<string>, entityName: string) => {
+  return updates.has(entityName);
 };
 
 const widgetPathsNotToOverride = (

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -1092,6 +1092,11 @@ export default class DataTreeEvaluator {
     const { isFirstTree, metaWidgets, unevalUpdates } = options;
     let staleMetaIds: string[] = [];
 
+    const allNewEntityDiffSet = new Set(
+      unevalUpdates
+        .filter((v) => v.event === DataTreeDiffEvent.NEW)
+        .map((v) => v.payload.propertyPath),
+    );
     let evalContextCache;
 
     if (WorkerEnv.flags.release_evaluation_scope_cache) {
@@ -1198,7 +1203,7 @@ export default class DataTreeEvaluator {
             if (isATriggerPath) continue;
 
             const isNewWidget =
-              isFirstTree || isNewEntity(unevalUpdates, entityName);
+              isFirstTree || isNewEntity(allNewEntityDiffSet, entityName);
 
             const widgetEntity = entity as WidgetEntity;
 


### PR DESCRIPTION
## Description
Converted the lookup the in isNewEntity to use a Set, this has reduced the cost of webworker scripting by about 5%.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12415891373>
> Commit: 5dfc7a06a7ff2beabb41e005f1c83892896ef6fe
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12415891373&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 19 Dec 2024 16:55:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced evaluation logic for newly created entities.
	- Improved error handling for dynamic bindings during evaluations.

- **Bug Fixes**
	- Refined error tracking for property evaluations.

- **Documentation**
	- Minor updates to comments and formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->