### PR TITLE
batching handleActionUpdates

### DIFF
--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -9,7 +9,6 @@ import {
   takeLatest,
 } from "redux-saga/effects";
 import * as Sentry from "@sentry/react";
-import type { updateActionDataPayloadType } from "actions/pluginActionActions";
 import {
   clearActionResponse,
   executePageLoadActions,
@@ -104,7 +103,6 @@ import { EMPTY_RESPONSE } from "components/editorComponents/emptyResponse";
 import type { AppState } from "ee/reducers";
 import { DEFAULT_EXECUTE_ACTION_TIMEOUT_MS } from "ee/constants/ApiConstants";
 import { evaluateActionBindings } from "sagas/EvaluationsSaga";
-import { evalWorker } from "utils/workerInstances";
 import { isBlobUrl, parseBlobUrl } from "utils/AppsmithUtils";
 import { getType, Types } from "utils/TypeHelpers";
 import { matchPath } from "react-router";
@@ -152,7 +150,6 @@ import {
   getCurrentEnvironmentDetails,
   getCurrentEnvironmentName,
 } from "ee/selectors/environmentSelectors";
-import { EVAL_WORKER_ACTIONS } from "ee/workers/Evaluation/evalWorkerActions";
 import { getIsActionCreatedInApp } from "ee/utils/getIsActionCreatedInApp";
 import type { OtlpSpan } from "UITelemetry/generateTraces";
 import {
@@ -1656,22 +1653,6 @@ function* softRefreshActionsSaga() {
   yield put({ type: ReduxActionTypes.SWITCH_ENVIRONMENT_SUCCESS });
 }
 
-function* handleUpdateActionData(
-  action: ReduxAction<updateActionDataPayloadType>,
-) {
-  const { actionDataPayload, parentSpan } = action.payload;
-
-  yield call(
-    evalWorker.request,
-    EVAL_WORKER_ACTIONS.UPDATE_ACTION_DATA,
-    actionDataPayload,
-  );
-
-  if (parentSpan) {
-    endSpan(parentSpan);
-  }
-}
-
 export function* watchPluginActionExecutionSagas() {
   yield all([
     takeLatest(ReduxActionTypes.RUN_ACTION_REQUEST, runActionSaga),
@@ -1685,6 +1666,5 @@ export function* watchPluginActionExecutionSagas() {
     ),
     takeLatest(ReduxActionTypes.PLUGIN_SOFT_REFRESH, softRefreshActionsSaga),
     takeEvery(ReduxActionTypes.EXECUTE_JS_UPDATES, makeUpdateJSCollection),
-    takeEvery(ReduxActionTypes.UPDATE_ACTION_DATA, handleUpdateActionData),
   ]);
 }


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12427297344>
> Commit: c0e1115ed374d7a2893ad07c7261a56050dd80ba
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12427297344&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/Apps/CommunityIssues_Spec.ts
> <li>cypress/e2e/Regression/Apps/EchoApiCMS_spec.js
> <li>cypress/e2e/Regression/Apps/ImportExportForkApplication_spec.js
> <li>cypress/e2e/Regression/Apps/MongoDBShoppingCart_spec.ts
> <li>cypress/e2e/Regression/Apps/PgAdmin_spec.js
> <li>cypress/e2e/Regression/Apps/PromisesApp_spec.js
> <li>cypress/e2e/Regression/ClientSide/ActionExecution/Bug33601_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Binding/API_with_List_Widget_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/Api_withPageload_Input_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/JSObjectToListWidget_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Binding/JSObject_Postgress_Table_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/TableTextPagination_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/TableV2TextPagination_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/TableV2_Api_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Derived_Column_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/Table_Api_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/Table_Widget_API_Derived_Column_spec.js
> <li>cypress/e2e/Regression/ClientSide/Binding/Widget_loading_spec.js
> <li>cypress/e2e/Regression/ClientSide/BugTests/ApiBugs_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/BugTests/DS_Bug28985_spec.ts
> <li>cypress/e2e/Regression/ClientSide/BugTests/ListWidgetOnPageLoad_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/BugTests/SelectWidget_Bug9334_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Git/ExistingApps/v1.9.24/DSCrudAndBindings_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Git/GitDiscardChange/DiscardChanges_spec.js
> <li>cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
> <li>cypress/e2e/Regression/ClientSide/Git/GitSync/GitSyncedApps_spec.js
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/Snipping_mode_Basic_test.js
> <li>cypress/e2e/Regression/ClientSide/MobileResponsiveTests/SuggestedWidgets_spec.js
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/ConnectToWidget_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/JSONForm_mongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/JSONFormWidget/JSONForm_postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/MultiSelect_MongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/MultiSelectWidget/MultiSelect_postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/mongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/SelectWidget/postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/OneClickBindingMysql_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/Table_MongoDB_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/Table_postgres_spec.ts
> <li>cypress/e2e/Regression/ClientSide/OtherUIFeatures/PageOnLoad_spec.ts
> <li>cypress/e2e/Regression/ClientSide/PartialImportExport/PartialImportRegularApp.ts
> <li>cypress/e2e/Regression/ClientSide/PeekOverlay/PeekOverlay_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Button/Button2_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Checkbox/CheckboxGroup_withQuery_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/DataIdentifier_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/DefaultSelectItem_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/ListV2_PageNo_PageSize_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicServerSideData_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Migration_Spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Modal/Modal_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Multiselect/MultiSelect4_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Others/StatboxDsl_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/Radio/Radio2_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Select/Select3_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Select/Select_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV1/TableFilter2_2_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Derived_Column_Data_validation_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV1/Table_Property_JsonUpdate_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter2_2_Spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Derived_Column_Data_validation_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2_Property_JsonUpdate_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/server_side_filtering_spec_1.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_Bugs_Spec.js
> <li>cypress/e2e/Regression/ServerSide/Datasources/Firestore_Basic_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/Mongo_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MySQL1_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MySQL2_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/Postgres1_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/Postgres2_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/MySQL_Datatypes/Basic_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/OnLoadTests/ExecuteAction_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Params/ExecutionParams_spec.js
> <li>cypress/e2e/Regression/ServerSide/Params/PassingParams_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Array_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Binary_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Character_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/DateTime_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Json_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/Numeric_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/Postgres_DataTypes/UUID_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/QueryPane/AddWidgetTableAndBind_spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/AddWidget_spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/Mongo1_spec.ts
> <li>cypress/e2e/Regression/ServerSide/QueryPane/QueryPane_MySQL_Spec.ts
> <li>cypress/e2e/Regression/ServerSide/QueryPane/QueryPane_Postgres_Spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/Querypane_Mongo_Spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
> <li>cypress/e2e/Regression/ServerSide/QueryPane/S3_2_spec.ts
> <li>cypress/e2e/Sanity/Datasources/SMTPDatasource_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Fri, 20 Dec 2024 10:21:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of evaluation actions, allowing for better management of action data updates.
	- Introduced a mechanism to collect and process updates alongside evaluation actions.

- **Bug Fixes**
	- Streamlined the control flow for processing action data updates, reducing potential errors in handling.

- **Refactor**
	- Simplified saga responsibilities by removing outdated functions and updating the action flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->