### PR TITLE
chore: Add code-split for injecting JIT pull in app CI/CD

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
@@ -322,4 +322,9 @@ public class GitApplicationHelperCEImpl implements GitArtifactHelperCE<Applicati
     public Mono<Application> publishArtifactPostCommit(Artifact committedArtifact) {
         return publishArtifact(committedArtifact, true);
     }
+
+    @Override
+    public Mono<? extends Artifact> validateAndPublishArtifact(Artifact artifact, boolean publish) {
+        return publishArtifact(artifact, publish);
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
@@ -1262,6 +1262,10 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
         return Mono.create(sink -> pushStatusMono.subscribe(sink::success, sink::error, null, sink.currentContext()));
     }
 
+    protected Mono<? extends Artifact> validateAndPublishArtifact(Artifact artifact, boolean publish) {
+        return publishArtifact(artifact, publish);
+    }
+
     private Mono<? extends Artifact> publishArtifact(Artifact artifact, boolean publish) {
         if (!Boolean.TRUE.equals(publish)) {
             return Mono.just(artifact);
@@ -2288,7 +2292,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                                     artifactExchangeJson,
                                     branchName))
                             // Update the last deployed status after the rebase
-                            .flatMap(importedArtifact -> publishArtifact(importedArtifact, true));
+                            .flatMap(importedArtifact -> validateAndPublishArtifact(importedArtifact, true));
                 })
                 .flatMap(branchedArtifact -> releaseFileLock(
                                 branchedArtifact.getGitArtifactMetadata().getDefaultArtifactId())

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
@@ -2245,8 +2245,10 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
 
         Mono<? extends Artifact> branchedArtifactMonoCached =
                 gitArtifactHelper.getArtifactById(branchedArtifactId, artifactEditPermission);
+        Mono<? extends Artifact> discardChangeMono;
 
-        Mono<? extends Artifact> discardChangeMono = branchedArtifactMonoCached
+        // Rehydrate the artifact from local file system
+        discardChangeMono = branchedArtifactMonoCached
                 .flatMap(branchedArtifact -> {
                     GitArtifactMetadata branchedGitData = branchedArtifact.getGitArtifactMetadata();
                     if (branchedGitData == null || !hasText(branchedGitData.getDefaultArtifactId())) {
@@ -2287,18 +2289,17 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                                     branchName))
                             // Update the last deployed status after the rebase
                             .flatMap(importedArtifact ->
-                                    gitApplicationHelper.validateAndPublishArtifact(importedArtifact, true));
+                                    gitArtifactHelper.validateAndPublishArtifact(importedArtifact, true));
                 })
-                .flatMap(branchedArtifact ->
-                        this.addAnalyticsForGitOperation(AnalyticsEvents.GIT_DISCARD_CHANGES, branchedArtifact, null))
+                .flatMap(branchedArtifact -> releaseFileLock(
+                                branchedArtifact.getGitArtifactMetadata().getDefaultArtifactId())
+                        .then(this.addAnalyticsForGitOperation(
+                                AnalyticsEvents.GIT_DISCARD_CHANGES, branchedArtifact, null)))
+                .onErrorResume(error -> branchedArtifactMonoCached.flatMap(branchedArtifact -> releaseFileLock(
+                                branchedArtifact.getGitArtifactMetadata().getDefaultArtifactId())
+                        .then(Mono.error(error))))
                 .name(GitSpan.OPS_DISCARD_CHANGES)
-                .tap(Micrometer.observation(observationRegistry))
-                .doFinally(signalType -> {
-                    branchedArtifactMonoCached
-                            .flatMap(branchedArtifact -> releaseFileLock(
-                                    branchedArtifact.getGitArtifactMetadata().getDefaultArtifactId()))
-                            .subscribe();
-                });
+                .tap(Micrometer.observation(observationRegistry));
 
         return Mono.create(
                 sink -> discardChangeMono.subscribe(sink::success, sink::error, null, sink.currentContext()));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitArtifactHelperCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitArtifactHelperCE.java
@@ -68,4 +68,6 @@ public interface GitArtifactHelperCE<T extends Artifact> {
     T getNewArtifact(String workspaceId, String repoName);
 
     Mono<T> publishArtifactPostCommit(Artifact committedArtifact);
+
+    Mono<? extends Artifact> validateAndPublishArtifact(Artifact artifact, boolean publish);
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/testhelpers/git/GitFileSystemTestHelper.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/testhelpers/git/GitFileSystemTestHelper.java
@@ -64,6 +64,18 @@ public class GitFileSystemTestHelper {
         // checkout to the new branch
         gitExecutor.createAndCheckoutToBranch(suffix, branchName).block();
 
+        commitArtifact(workspaceId, applicationId, branchName, repoName, applicationJson, "commit message two");
+    }
+
+    public void commitArtifact(
+            String workspaceId,
+            String applicationId,
+            String branchName,
+            String repoName,
+            ApplicationJson applicationJson,
+            String commitMessage)
+            throws GitAPIException, IOException {
+        Path suffix = Paths.get(workspaceId, applicationId, repoName);
         // saving the files into the git repository from application json
         // The files would later be saved in this git repository from resources section instead of applicationJson
         commonGitFileUtils
@@ -72,7 +84,7 @@ public class GitFileSystemTestHelper {
 
         // commit the application
         gitExecutor
-                .commitArtifact(suffix, "commit message two", "user", "user@domain.xy", true, false)
+                .commitArtifact(suffix, commitMessage, "user", "user@domain.xy", true, false)
                 .block();
     }
 


### PR DESCRIPTION
## Description
EE counterpart PR: https://github.com/appsmithorg/appsmith-ee/pull/5780


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12471975301>
> Commit: f0a7b1e6c49b647d9530d74f7275b862d2deef5c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12471975301&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 23 Dec 2024 20:06:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a method for validating and publishing artifacts before discarding changes.
	- Added functionality to commit artifacts to a Git repository with customizable commit messages.
	- Expanded interface capabilities with a new method for validating artifacts.

- **Bug Fixes**
	- Enhanced error handling in the discard changes process to improve resource management during failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->