### PR TITLE
fix: Tab navigation issue in multi page apps

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Tabs_Navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Tabs_Navigation_spec.ts
@@ -1,0 +1,148 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+import {
+  agHelper,
+  dataSources,
+  locators,
+} from "../../../../support/Objects/ObjectsCore";
+import PageList from "../../../../support/Pages/PageList";
+import EditorNavigation, {
+  PageLeftPane,
+  PagePaneSegment,
+} from "../../../../support/Pages/EditorNavigation";
+import { EditorSegments } from "@appsmith/ads";
+
+const jsEditor = ObjectsRegistry.JSEditor;
+const datasources = ObjectsRegistry.DataSources;
+
+let dsName = "MongoDB";
+
+describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
+  before(() => {
+    datasources.CreateDataSource("Mongo");
+    cy.renameDatasource(dsName);
+  });
+
+  it("should create and switch between JS files", () => {
+    // Create first JS file
+    jsEditor.CreateJSObject("", { prettify: false, toRun: false });
+    jsEditor.RenameJSObjFromPane("Page1_JS1");
+
+    // Create second JS file
+    jsEditor.CreateJSObject("", { prettify: false, toRun: false });
+    jsEditor.RenameJSObjFromPane("Page1_JS2");
+
+    cy.get("[data-testid='t--ide-tab-page1_js1']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page1_JS1");
+    });
+
+    cy.get("[data-testid='t--ide-tab-page1_js2']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page1_JS2");
+    });
+  });
+
+  it("should create and switch between queries", () => {
+    datasources.CreateQueryFromOverlay(dsName, "", "Page1_Query1");
+    cy.get("[data-testid='t--ide-tab-page1_query1']").should("be.visible");
+    dataSources.CreateQueryFromOverlay(dsName, "", "Page1_Query2");
+
+    // Switch between tabs
+    cy.get("[data-testid='t--ide-tab-page1_query1']").click();
+
+    agHelper
+      .GetElement(locators._queryName)
+      .should("have.text", "Page1_Query1");
+
+    cy.get("[data-testid='t--ide-tab-page1_query2']").click();
+
+    agHelper
+      .GetElement(locators._queryName)
+      .should("have.text", "Page1_Query2");
+  });
+
+  it("should create items in the next page and navigate", () => {
+    // Create first page
+    PageList.AddNewPage("New blank page");
+
+    // Create first JS file
+    jsEditor.CreateJSObject("", { prettify: false, toRun: false });
+    jsEditor.RenameJSObjFromPane("Page2_JS1");
+
+    // Create second JS file
+    jsEditor.CreateJSObject("", { prettify: false, toRun: false });
+    jsEditor.RenameJSObjFromPane("Page2_JS2");
+
+    cy.get("[data-testid='t--ide-tab-page2_js1']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page2_JS1");
+    });
+
+    cy.get("[data-testid='t--ide-tab-page2_js2']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page2_JS2");
+    });
+
+    datasources.CreateQueryFromOverlay(dsName, "", "Page2_Query1");
+    datasources.CreateQueryFromOverlay(dsName, "", "Page2_Query2");
+
+    cy.get("[data-testid='t--ide-tab-page2_query1']").click();
+
+    agHelper
+      .GetElement(locators._queryName)
+      .should("have.text", "Page2_Query1");
+
+    cy.get("[data-testid='t--ide-tab-page2_query2']").click();
+
+    agHelper
+      .GetElement(locators._queryName)
+      .should("have.text", "Page2_Query2");
+  });
+
+  it("Use tabs navigation with multiple pages", () => {
+    EditorNavigation.NavigateToPage("Page1");
+    cy.get("[data-testid='t--ide-tab-page1_query1']").click();
+
+    agHelper
+      .GetElement(locators._queryName)
+      .should("have.text", "Page1_Query1");
+
+    cy.get("[data-testid='t--ide-tab-page1_query2']").click();
+
+    agHelper
+      .GetElement(locators._queryName)
+      .should("have.text", "Page1_Query2");
+
+    PageLeftPane.switchSegment(PagePaneSegment.JS);
+
+    cy.get("[data-testid='t--ide-tab-page1_js1']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page1_JS1");
+    });
+
+    cy.get("[data-testid='t--ide-tab-page1_js2']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page1_JS2");
+    });
+
+    EditorNavigation.NavigateToPage("Page2");
+    PageLeftPane.switchSegment(PagePaneSegment.JS);
+    cy.get("[data-testid='t--ide-tab-page2_js1']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page2_JS1");
+    });
+
+    cy.get("[data-testid='t--ide-tab-page2_js2']").click();
+
+    jsEditor.currentJSObjectName().then((jsObjName) => {
+      expect(jsObjName).equal("Page2_JS2");
+    });
+  });
+});

--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Tabs_Navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Tabs_Navigation_spec.ts
@@ -3,22 +3,20 @@ import {
   agHelper,
   dataSources,
   locators,
+  jsEditor,
 } from "../../../../support/Objects/ObjectsCore";
 import PageList from "../../../../support/Pages/PageList";
 import EditorNavigation, {
+  editorTabSelector,
   PageLeftPane,
   PagePaneSegment,
 } from "../../../../support/Pages/EditorNavigation";
-import { EditorSegments } from "@appsmith/ads";
-
-const jsEditor = ObjectsRegistry.JSEditor;
-const datasources = ObjectsRegistry.DataSources;
 
 let dsName = "MongoDB";
 
 describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
   before(() => {
-    datasources.CreateDataSource("Mongo");
+    dataSources.CreateDataSource("Mongo");
     cy.renameDatasource(dsName);
   });
 
@@ -31,13 +29,13 @@ describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
     jsEditor.CreateJSObject("", { prettify: false, toRun: false });
     jsEditor.RenameJSObjFromPane("Page1_JS2");
 
-    cy.get("[data-testid='t--ide-tab-page1_js1']").click();
+    agHelper.GetNClick(editorTabSelector("page1_js1"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page1_JS1");
     });
 
-    cy.get("[data-testid='t--ide-tab-page1_js2']").click();
+    agHelper.GetNClick(editorTabSelector("page1_js2"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page1_JS2");
@@ -45,18 +43,20 @@ describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
   });
 
   it("should create and switch between queries", () => {
-    datasources.CreateQueryFromOverlay(dsName, "", "Page1_Query1");
-    cy.get("[data-testid='t--ide-tab-page1_query1']").should("be.visible");
+    dataSources.CreateQueryFromOverlay(dsName, "", "Page1_Query1");
+    agHelper
+      .GetElement("[data-testid='t--ide-tab-page1_query1']")
+      .should("be.visible");
     dataSources.CreateQueryFromOverlay(dsName, "", "Page1_Query2");
 
     // Switch between tabs
-    cy.get("[data-testid='t--ide-tab-page1_query1']").click();
+    agHelper.GetNClick(editorTabSelector("page1_query1"));
 
     agHelper
       .GetElement(locators._queryName)
       .should("have.text", "Page1_Query1");
 
-    cy.get("[data-testid='t--ide-tab-page1_query2']").click();
+    agHelper.GetNClick(editorTabSelector("page1_query2"));
 
     agHelper
       .GetElement(locators._queryName)
@@ -75,28 +75,28 @@ describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
     jsEditor.CreateJSObject("", { prettify: false, toRun: false });
     jsEditor.RenameJSObjFromPane("Page2_JS2");
 
-    cy.get("[data-testid='t--ide-tab-page2_js1']").click();
+    agHelper.GetNClick(editorTabSelector("page2_js1"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page2_JS1");
     });
 
-    cy.get("[data-testid='t--ide-tab-page2_js2']").click();
+    agHelper.GetNClick(editorTabSelector("page2_js2"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page2_JS2");
     });
 
-    datasources.CreateQueryFromOverlay(dsName, "", "Page2_Query1");
-    datasources.CreateQueryFromOverlay(dsName, "", "Page2_Query2");
+    dataSources.CreateQueryFromOverlay(dsName, "", "Page2_Query1");
+    dataSources.CreateQueryFromOverlay(dsName, "", "Page2_Query2");
 
-    cy.get("[data-testid='t--ide-tab-page2_query1']").click();
+    agHelper.GetNClick(editorTabSelector("page2_query1"));
 
     agHelper
       .GetElement(locators._queryName)
       .should("have.text", "Page2_Query1");
 
-    cy.get("[data-testid='t--ide-tab-page2_query2']").click();
+    agHelper.GetNClick(editorTabSelector("page2_query2"));
 
     agHelper
       .GetElement(locators._queryName)
@@ -105,13 +105,13 @@ describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
 
   it("Use tabs navigation with multiple pages", () => {
     EditorNavigation.NavigateToPage("Page1");
-    cy.get("[data-testid='t--ide-tab-page1_query1']").click();
+    agHelper.GetNClick(editorTabSelector("page1_query1"));
 
     agHelper
       .GetElement(locators._queryName)
       .should("have.text", "Page1_Query1");
 
-    cy.get("[data-testid='t--ide-tab-page1_query2']").click();
+    agHelper.GetNClick(editorTabSelector("page1_query2"));
 
     agHelper
       .GetElement(locators._queryName)
@@ -119,13 +119,13 @@ describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
 
     PageLeftPane.switchSegment(PagePaneSegment.JS);
 
-    cy.get("[data-testid='t--ide-tab-page1_js1']").click();
+    agHelper.GetNClick(editorTabSelector("page1_js1"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page1_JS1");
     });
 
-    cy.get("[data-testid='t--ide-tab-page1_js2']").click();
+    agHelper.GetNClick(editorTabSelector("page1_js2"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page1_JS2");
@@ -133,13 +133,13 @@ describe("Tabs Navigation", { tags: ["@tag.IDE"] }, () => {
 
     EditorNavigation.NavigateToPage("Page2");
     PageLeftPane.switchSegment(PagePaneSegment.JS);
-    cy.get("[data-testid='t--ide-tab-page2_js1']").click();
+    agHelper.GetNClick(editorTabSelector("page2_js1"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page2_JS1");
     });
 
-    cy.get("[data-testid='t--ide-tab-page2_js2']").click();
+    agHelper.GetNClick(editorTabSelector("page2_js2"));
 
     jsEditor.currentJSObjectName().then((jsObjName) => {
       expect(jsObjName).equal("Page2_JS2");

--- a/app/client/cypress/support/Pages/EditorNavigation.ts
+++ b/app/client/cypress/support/Pages/EditorNavigation.ts
@@ -20,6 +20,9 @@ export enum PagePaneSegment {
   JS = "JS",
 }
 
+export const editorTabSelector = (name: string) =>
+  `[data-testid='t--ide-tab-${name.toLowerCase()}']`;
+
 export enum EditorViewMode {
   FullScreen = "FullScreen",
   SplitScreen = "SplitScreen",

--- a/app/client/src/pages/Editor/IDE/EditorTabs/index.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { Flex, ScrollArea, ToggleButton } from "@appsmith/ads";
 import {
@@ -86,10 +86,13 @@ const EditorTabs = () => {
   });
 
   // TODO: this returns a new function every time, needs to be recomposed
-  const handleTabClick = useEventCallback((tab: EntityItem) => () => {
-    dispatch(setListViewActiveState(false));
-    tabClickHandler(tab);
-  });
+  const handleTabClick = useCallback(
+    (tab: EntityItem) => () => {
+      dispatch(setListViewActiveState(false));
+      tabClickHandler(tab);
+    },
+    [dispatch, tabClickHandler],
+  );
 
   const handleNewTabClick = useEventCallback(() => {
     dispatch(setListViewActiveState(false));


### PR DESCRIPTION
## Description

Fixes the caching in useEventCallback for tabClickHandler that was getting the old pageId 

Fixes #38216

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12429634967>
> Commit: 3715ac2cec6918060ac1d6ff8b8c440d9c279bc0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12429634967&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Fri, 20 Dec 2024 10:53:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced Cypress end-to-end tests for tab navigation within the IDE, ensuring seamless switching between JavaScript and query tabs.
	- Added a new function `editorTabSelector` for generating string selectors for IDE tabs.

- **Bug Fixes**
	- Optimized tab click handling in the editor for improved performance.

- **Chores**
	- Updated imports to include necessary hooks for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->