### PR TITLE
ci: Don't tag `latest` when not latest version

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,4 +1,4 @@
-name: Appsmith Github Release Workflow
+name: Github Release
 
 # This workflow builds Docker images for server and client, and then pushes them to Docker Hub.
 # The docker-tag with which this push happens is `latest` and the release tag (e.g., v1.2.3 etc.).
@@ -17,24 +17,27 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      tag: ${{ steps.get_version.outputs.tag }}
+      tag: ${{ steps.main.outputs.tag }}
+      docker_tags: ${{ steps.main.outputs.docker_tags }}
 
     steps:
-      - name: Environment details
-        run: |
-          echo "PWD: $PWD"
-          echo "GITHUB_REF: $GITHUB_REF"
-          echo "GITHUB_SHA: $GITHUB_SHA"
-          echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: "5"
+          fetch-tags: "true"
 
-      - name: Get the version
-        id: get_version
-        run: |
-          if ! [[ ${GITHUB_REF-} =~ ^refs/tags/v[[:digit:]]\.[[:digit:]]+(\.[[:digit:]]+)?$ ]]; then
-            echo "Invalid tag: '${GITHUB_REF-}'. Has to be like `v1.22`, `v1.22.33` only."
-            exit 1
-          fi
-          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Prelude checks and preparations
+        uses: actions/github-script@v7
+        id: main
+        with:
+          script: |
+            require(
+              "${{ github.workspace }}/.github/workflows/scripts/github-release/prelude.js",
+            )(
+              { core, context, github },
+              "${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}",
+            )
 
   client-build:
     needs:
@@ -273,5 +276,4 @@ jobs:
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
             BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:nightly
           tags: |
-            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:${{needs.prelude.outputs.tag}}
-            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:latest
+            ${{ needs.prelude.outputs.docker_tags }}

--- a/.github/workflows/scripts/github-release/prelude.js
+++ b/.github/workflows/scripts/github-release/prelude.js
@@ -28,6 +28,8 @@ module.exports = async function ({ core, context }, imageRepo) {
   core.summary.addHeading("Docker image tags", 3);
   core.summary.addCodeBlock(dockerTags.join("\n"));
   core.setOutput("docker_tags", dockerTags.join("\n"));
+
+  core.summary.write();
 }
 
 function getLatestTag() {

--- a/.github/workflows/scripts/github-release/prelude.js
+++ b/.github/workflows/scripts/github-release/prelude.js
@@ -1,0 +1,47 @@
+const { exec } = require("child_process");
+
+module.exports = async function ({ core, context }, imageRepo) {
+  core.summary.addList([
+    "PWD: " + process.cwd(),
+    "GITHUB_REF: " + context.ref,
+    "GITHUB_SHA: " + context.sha,
+    "GITHUB_EVENT_NAME: " + context.eventName,
+  ]);
+
+  if (!context.ref?.match(/^refs\/tags\/v/)) {
+    core.setFailed(`Invalid tag: '${context.ref}'. Has to be like 'v1.22', 'v1.22.33' only.`);
+    return;
+  }
+
+  const thisVersion = context.ref.replace("refs/tags/", "");
+  core.setOutput("tag", thisVersion);
+
+  const dockerTags = [
+    `${imageRepo}:${thisVersion}`,
+  ];
+  const latestVersion = await getLatestTag();
+
+  if (latestVersion === thisVersion) {
+    dockerTags.push(`${imageRepo}:latest`);
+  }
+
+  core.summary.addHeading("Docker image tags", 3);
+  core.summary.addCodeBlock(dockerTags.join("\n"));
+  core.setOutput("docker_tags", dockerTags.join("\n"));
+}
+
+function getLatestTag() {
+  return new Promise((resolve, reject) => {
+    exec("git tag --list --sort=-version:refname 'v*' | head -1", (error, stdout, stderr) => {
+      if (error) {
+        reject(`exec error: ${error}`);
+        return;
+      }
+      if (stderr) {
+        reject(`stderr: ${stderr}`);
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}

--- a/.github/workflows/scripts/github-release/prelude.js
+++ b/.github/workflows/scripts/github-release/prelude.js
@@ -1,11 +1,11 @@
 const { exec } = require("child_process");
 
 module.exports = async function ({ core, context }, imageRepo) {
-  core.summary.addList([
-    "PWD: " + process.cwd(),
-    "GITHUB_REF: " + context.ref,
-    "GITHUB_SHA: " + context.sha,
-    "GITHUB_EVENT_NAME: " + context.eventName,
+  core.summary.addTable([
+    [{ data: "PWD", header: true }, process.cwd()],
+    [{ data: "GITHUB_REF", header: true }, context.ref],
+    [{ data: "GITHUB_SHA", header: true }, context.sha],
+    [{ data: "GITHUB_EVENT_NAME", header: true }, context.eventName],
   ]);
 
   if (!context.ref?.match(/^refs\/tags\/v/)) {

--- a/.github/workflows/scripts/github-release/prelude.js
+++ b/.github/workflows/scripts/github-release/prelude.js
@@ -13,13 +13,17 @@ module.exports = async function ({ core, context }, imageRepo) {
     return;
   }
 
+  // Current version being tagged, including the 'v' prefix.
   const thisVersion = context.ref.replace("refs/tags/", "");
   core.setOutput("tag", thisVersion);
 
+  // The latest version of Appsmith available, including the 'v' prefix, including the currently tagged version.
+  const latestVersion = await getLatestTag();
+
+  // The docker tags to be pushed to the registry.
   const dockerTags = [
     `${imageRepo}:${thisVersion}`,
   ];
-  const latestVersion = await getLatestTag();
 
   if (latestVersion === thisVersion) {
     dockerTags.push(`${imageRepo}:latest`);


### PR DESCRIPTION
When we're tagging a version that's not the latest version, then don't update the `latest` Docker image on Docker hub. Like, if the current latest is `v1.20`, and we publish the hotfix tag `v1.18.1` to fix a critical bug in `v1.18`, then we only want to publish the Docker image at the tag `v1.18.1`, and _not_ update `latest`. We want `latest` to continue to point to `v1.20`.

Tested on a separate private repo, confirmed working.

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 21b3f9fe1ec7beea8b1f72b20f5406fb14fca4aa yet
> <hr>Sat, 21 Dec 2024 05:33:37 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined GitHub Actions workflow for Docker image tagging.
	- Added a summary log for workflow execution details.
	- Enhanced Docker tag generation with validation and error handling.

- **Bug Fixes**
	- Improved validation for GitHub reference formats to prevent failures.

- **Documentation**
	- Updated workflow names and outputs for clarity and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->