### PR TITLE
chore: Update selectors for Table Response

### DIFF
--- a/app/client/cypress/locators/QueryEditor.json
+++ b/app/client/cypress/locators/QueryEditor.json
@@ -9,7 +9,7 @@
   "addDatasource": ".t--add-datasource",
   "editDatasourceButton": ".t--edit-datasource",
   "switch": ".t--form-control-SWITCH input",
-  "queryResponse": "(//div[@class='table']//div[@class='tr'])[3]//div[@class='td']",
+  "queryResponse": "(//div[@class='table']//div[@class='tr'])[3]//div[@class='td mp-mask']",
   "querySelect": "//div[contains(@class, 't--template-menu')]//div[text()='Select']",
   "queryCreate": "//div[contains(@class, 't--template-menu')]//div[text()='Create']",
   "queryUpdate": "//div[contains(@class, 't--template-menu')]//div[text()='Update']",

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -814,7 +814,7 @@ Cypress.Commands.add("ValidatePaginateResponseUrlData", (runTestCss) => {
   cy.wait(2000);
   cy.get(runTestCss).click();
   cy.wait(2000);
-  cy.xpath("//div[@class='tr'][1]//div[@class='td'][6]//span")
+  cy.xpath("//div[@class='tr'][1]//div[@class='td mp-mask'][6]//span")
     .invoke("text")
     .then((valueToTest) => {
       // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -839,7 +839,7 @@ Cypress.Commands.add("ValidatePaginateResponseUrlDataV2", (runTestCss) => {
   cy.wait(2000);
   cy.get(runTestCss).click();
   cy.wait(2000);
-  cy.xpath("//div[@class='tr'][1]//div[@class='td'][6]//span")
+  cy.xpath("//div[@class='tr'][1]//div[@class='td mp-mask'][6]//span")
     .invoke("text")
     .then((valueToTest) => {
       // eslint-disable-next-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
## Description

Updates the xpath selectors with the correct class names. This is only updating missed cypress selectors


## Automation

/ok-to-test tags="@tag.Binding,@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12461769764>
> Commit: 14e0a90232a048121373c3363edf5650236b2571
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12461769764&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Binding,@tag.Datasource
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/QueryPane/AddWidgetTableAndBind_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Mon, 23 Dec 2024 07:19:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated XPath expressions for improved element identification in the Query Editor and validation commands.
  
These changes enhance the application's ability to accurately locate and interact with specific UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->