### PR TITLE
fix: Fix for locator for AddWidgetTableAndBind_spec test case

### DIFF
--- a/app/client/cypress/locators/QueryEditor.json
+++ b/app/client/cypress/locators/QueryEditor.json
@@ -9,7 +9,7 @@
   "addDatasource": ".t--add-datasource",
   "editDatasourceButton": ".t--edit-datasource",
   "switch": ".t--form-control-SWITCH input",
-  "queryResponse": "(//div[@class='table']//div[@class='tr'])[3]//div[@class='td mp-mask']",
+  "queryResponse": "(//div[@class='table']//div[@class='tr'])[2]//div[@class='td mp-mask']",
   "querySelect": "//div[contains(@class, 't--template-menu')]//div[text()='Select']",
   "queryCreate": "//div[contains(@class, 't--template-menu')]//div[text()='Create']",
   "queryUpdate": "//div[contains(@class, 't--template-menu')]//div[text()='Update']",


### PR DESCRIPTION
## Description
Found minor locator failure


Fixes # https://app.zenhub.com/workspaces/stability-pod-6690c4814e31602e25cab7fd/issues/gh/appsmithorg/appsmith/38314

## Automation

/ok-to-test tags="@tag.Datasource,@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12465389478>
> Commit: 9cf2fbe2bbda6abdb9547bbb8f38d578fe343f04
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12465389478&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource,@tag.Sanity`
> Spec:
> <hr>Mon, 23 Dec 2024 13:19:11 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the locator for the query response to ensure accurate referencing of the second row in the table, improving the application's interaction with query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->