### PR TITLE
fix: cannot see move to page option when there are exactly two pages in the app 

### DIFF
--- a/app/client/src/pages/Editor/AppPluginActionEditor/components/ToolbarMenu/Move.tsx
+++ b/app/client/src/pages/Editor/AppPluginActionEditor/components/ToolbarMenu/Move.tsx
@@ -46,7 +46,7 @@ export const Move = ({ disabled }: Props) => {
         {createMessage(CONTEXT_MOVE)}
       </MenuSubTrigger>
       <MenuSubContent>
-        {menuPages.length > 1 ? (
+        {menuPages.length ? (
           menuPages.map((page) => {
             return (
               <PageMenuItem


### PR DESCRIPTION
## Description
Fixes an issue where move between pages in query context menu was not possible.

Fixes [#38117](https://github.com/appsmithorg/appsmith/issues/38117)

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12468165994>
> Commit: 1ef7d576fc5d8c9261279cdc77c69c9688826262
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12468165994&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 23 Dec 2024 14:47:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
