### PR TITLE
fix: prevent menu content to be rendered when there are no options

### DIFF
--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionRun.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionRun.tsx
@@ -69,15 +69,17 @@ export const JSFunctionRun = (props: Props) => {
             {props.selected.label}
           </Button>
         </MenuTrigger>
-        <MenuContent align="end" data-testid="t--js-functions-menu">
-          {props.options.map((option) => (
-            <JSFunctionItem
-              key={option.label}
-              onSelect={onFunctionSelect}
-              option={option}
-            />
-          ))}
-        </MenuContent>
+        {!!props.options.length && (
+          <MenuContent align="end" data-testid="t--js-functions-menu">
+            {props.options.map((option) => (
+              <JSFunctionItem
+                key={option.label}
+                onSelect={onFunctionSelect}
+                option={option}
+              />
+            ))}
+          </MenuContent>
+        )}
       </Menu>
 
       <Tooltip


### PR DESCRIPTION
## Description
Fixes an issue where JS run menu is being shown with no items in it.

Fixes #38151 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12468478974>
> Commit: f032137f9b4d9eeda85dfe1bb8d26e2e19f64c3b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12468478974&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 23 Dec 2024 15:12:31 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved dropdown menu rendering logic to prevent displaying an empty menu when no options are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->