### PR TITLE
chore: Automation test cases added for shared drive gsheet

### DIFF
--- a/app/client/cypress/e2e/GSheet/SelectedSheet_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/SelectedSheet_Access_Spec.ts
@@ -15,7 +15,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-selected";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet-automation-selected";
-describe(
+describe.skip(
   "GSheet-Functional Tests With Selected Access",
   {
     tags: ["@tag.Datasource", "@tag.GSheet", "@tag.Git", "@tag.AccessControl"],

--- a/app/client/cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts
@@ -1,0 +1,359 @@
+/// <reference types="Cypress" />
+import { GSHEET_DATA } from "../../fixtures/test-data-gsheet";
+import {
+  homePage,
+  gsheetHelper,
+  dataSources,
+  agHelper,
+  entityExplorer,
+  assertHelper,
+  table,
+  appSettings,
+} from "../../support/Objects/ObjectsCore";
+
+const workspaceName = "gsheet apps";
+const dataSourceName = "gsheet-shared-selected";
+let appName = "gsheet-app";
+let spreadSheetName = "test-sheet-automation-selected";
+describe(
+  "GSheet-Functional Tests With Selected Access",
+  {
+    tags: ["@tag.Datasource", "@tag.GSheet", "@tag.Git", "@tag.AccessControl"],
+  },
+  function () {
+    before("Setup app", function () {
+      //Setting up app name
+      const uuid = Cypress._.random(0, 10000);
+      appName = appName + "-" + uuid;
+
+      //Adding app
+      homePage.NavigateToHome();
+      homePage.SelectWorkspace(workspaceName);
+      homePage.CreateAppInWorkspace(workspaceName, appName);
+    });
+
+    it("1. Add and verify fetch details query", () => {
+      entityExplorer.CreateNewDsQuery(dataSourceName);
+      agHelper.RenameQuery("Fetch_Details");
+      dataSources.ValidateNSelectDropdown(
+        "Operation",
+        "Fetch Many",
+        "Fetch Details",
+      );
+      dataSources.ValidateNSelectDropdown("Entity", "Spreadsheet");
+      agHelper.Sleep(500);
+      dataSources.ValidateNSelectDropdown("Spreadsheet", "", spreadSheetName);
+      dataSources.RunQuery();
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body.name).to.deep.equal(
+          spreadSheetName,
+        );
+      });
+    });
+
+    it("2. Verify Insert One and Insert Many queries", () => {
+      // add insert one query and verify
+      gsheetHelper.AddInsertOrUpdateQuery(
+        "Insert One",
+        dataSourceName,
+        spreadSheetName,
+        JSON.stringify(GSHEET_DATA[0]),
+      );
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body.message).to.deep.equal(
+          "Inserted row successfully!",
+        );
+      });
+
+      // add insert many query and verify
+      gsheetHelper.AddInsertOrUpdateQuery(
+        "Insert Many",
+        dataSourceName,
+        spreadSheetName,
+        JSON.stringify(GSHEET_DATA.slice(1, 10)),
+      );
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body.message).to.deep.equal(
+          "Inserted rows successfully!",
+        );
+      });
+    });
+
+    it("3. Verify Update one and Update many queries", () => {
+      // add update one query and verify
+      gsheetHelper.AddInsertOrUpdateQuery(
+        "Update One",
+        dataSourceName,
+        spreadSheetName,
+        JSON.stringify(GSHEET_DATA[1]),
+      );
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body.message).to.deep.equal(
+          "Updated sheet successfully!",
+        );
+      });
+
+      // add update many query and verify
+      gsheetHelper.AddInsertOrUpdateQuery(
+        "Update Many",
+        dataSourceName,
+        spreadSheetName,
+        JSON.stringify(GSHEET_DATA.slice(2, 4)),
+      );
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body.message).to.deep.equal(
+          "Updated sheet successfully!",
+        );
+      });
+    });
+
+    it("4. Verify Fetch many query", () => {
+      // Add simple Fetch many query and verify
+      gsheetHelper.EnterBasicQueryValues(
+        "Fetch Many",
+        dataSourceName,
+        spreadSheetName,
+      );
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
+      dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language
+      dataSources.AssertQueryTableResponse(2, "₹, $, €, ¥, £"); // Asserting different symbols
+      dataSources.AssertQueryTableResponse(3, "!@#$%^&*"); // Asserting special chars
+
+      // Update query to fetch only 1 column and verify
+      gsheetHelper.SelectMultiDropDownValue("Columns", "product_name");
+      dataSources.RunQuery();
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].product_name);
+
+      //Remove column filter and add Sort By Ascending and verify
+      gsheetHelper.SelectMultiDropDownValue("Columns", "product_name"); //unselect the Columns dd value
+      agHelper.EnterValue("price", {
+        propFieldName: "",
+        directInput: false,
+        inputFieldName: "Sort By",
+      });
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      dataSources.AssertQueryTableResponse(
+        0,
+        "5afbaf65680c9f378af5b3a3ae22427e",
+      );
+      dataSources.AssertQueryTableResponse(
+        1,
+        "ラーニング カーブ チャギントン インタラクティブ チャッツワース",
+      ); // Asserting other language
+      dataSources.AssertQueryTableResponse(2, "₹, $, €, ¥, £"); // Asserting different symbols
+      dataSources.AssertQueryTableResponse(3, "!@#$%^&*"); // Asserting special chars
+
+      // Sort by descending and verify
+      dataSources.ClearSortByOption(); //clearing previous sort option
+      dataSources.EnterSortByValues("price", "Descending");
+      dataSources.RunQuery();
+      dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      dataSources.AssertQueryTableResponse(
+        1,
+        "ホーンビー ゲージ ウェスタン エクスプレス デジタル トレイン セット (eLink および TTS ロコ トレイン セット付き)",
+      ); // Asserting other language
+      dataSources.AssertQueryTableResponse(
+        4,
+        "Hornby Gauge Western Express Digital Train Set with eLink and TTS Loco Train Set",
+      );
+
+      // Filter by where clause and verify
+      agHelper.TypeDynamicInputValueNValidate(
+        "price",
+        dataSources._nestedWhereClauseKey(0),
+      );
+      agHelper.TypeDynamicInputValueNValidate(
+        "100",
+        dataSources._nestedWhereClauseValue(0),
+      );
+      dataSources.RunQuery();
+      dataSources.runQueryAndVerifyResponseViews({ count: 8 });
+      dataSources.AssertQueryTableResponse(
+        0,
+        "87bbb472ef9d90dcef140a551665c929",
+      );
+
+      // Filter by cell range and verify
+      dataSources.ValidateNSelectDropdown(
+        "Filter Format",
+        "Where Clause",
+        "Cell range",
+      );
+      agHelper.EnterValue("A2:A5", {
+        propFieldName: "",
+        directInput: false,
+        inputFieldName: "Cell range",
+      });
+      dataSources.RunQuery();
+      dataSources.runQueryAndVerifyResponseViews({ count: 4 });
+      dataSources.AssertQueryTableResponse(
+        0,
+        "eac7efa5dbd3d667f26eb3d3ab504464",
+      );
+    });
+
+    it("5. Update a record which is not present and verify the error", () => {
+      //preparing data
+      const data = GSHEET_DATA[1];
+      data.rowIndex = `${Cypress._.random(100, 1031)}`;
+
+      // add update one query and verify
+      gsheetHelper.EnterBasicQueryValues(
+        "Update One",
+        dataSourceName,
+        spreadSheetName,
+        false,
+      );
+      agHelper.EnterValue(JSON.stringify(data), {
+        propFieldName: "",
+        directInput: false,
+        inputFieldName: "Update row object",
+      });
+      dataSources.RunQuery({
+        expectedStatus: false,
+      });
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body).to.deep.equal(
+          "No data found at this row index.",
+        );
+      });
+
+      //reset the row index
+      data.rowIndex = "1";
+    });
+
+    it("6. Convert field to JS and verify", () => {
+      // Switch js on sheet name then run query and verify
+      gsheetHelper.EnterBasicQueryValues(
+        "Fetch Many",
+        dataSourceName,
+        spreadSheetName,
+        false,
+      );
+      agHelper.GetNClick(
+        dataSources._getJSONswitchLocator("Sheet name"),
+        0,
+        true,
+      );
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
+      dataSources.AssertQueryTableResponse(
+        0,
+        "eac7efa5dbd3d667f26eb3d3ab504464",
+      );
+
+      //Enter a wrong sheet name then run query and verify
+      agHelper.EnterValue("Sheet 2", {
+        propFieldName: "",
+        directInput: false,
+        inputFieldName: "Sheet name",
+      });
+      dataSources.RunQuery({
+        expectedStatus: false,
+      });
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body).to.deep.equal(
+          "Unable to parse range: 'Sheet 2'!1:1",
+        );
+      });
+
+      //Covert sheet name field to dropdown then run query and verify
+      agHelper.HoverElement(dataSources._getJSONswitchLocator("Sheet name"));
+      agHelper.AssertTooltip("Clear the field to toggle back");
+      agHelper.EnterValue("", {
+        propFieldName: "",
+        directInput: false,
+        inputFieldName: "Sheet name",
+      }); //Clearing the sheet name field
+      agHelper.GetNClick(
+        dataSources._getJSONswitchLocator("Sheet name"),
+        0,
+        true,
+      ); // Converting the field to dropdown
+      dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
+      dataSources.AssertQueryTableResponse(
+        0,
+        "eac7efa5dbd3d667f26eb3d3ab504464",
+      );
+    });
+
+    it("7. Verify Delete query", function () {
+      // Delete data on the basis of row index
+      gsheetHelper.EnterBasicQueryValues(
+        "Delete One",
+        dataSourceName,
+        spreadSheetName,
+      );
+      GSHEET_DATA.reverse().forEach((d) => {
+        agHelper.EnterValue(d.rowIndex, {
+          propFieldName: "",
+          directInput: false,
+          inputFieldName: "Row Index",
+        });
+        dataSources.RunQuery();
+        cy.get("@postExecute").then((interception: any) => {
+          expect(interception.response.body.data.body.message).to.deep.equal(
+            "Deleted row successfully!",
+          );
+        });
+        agHelper.Sleep(500);
+      });
+      // Fetch many to verify all the data is deleted
+      gsheetHelper.EnterBasicQueryValues(
+        "Fetch Many",
+        dataSourceName,
+        spreadSheetName,
+        false,
+      );
+      dataSources.RunQuery();
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body).to.deep.equal([]);
+      });
+    });
+
+    it("8. Import an app with selected access sheet", function () {
+      homePage.NavigateToHome();
+      homePage.ImportApp("ImportAppSelectedAccess.json", workspaceName);
+      assertHelper.WaitForNetworkCall("importNewApplication").then(() => {
+        agHelper.Sleep();
+        //Validate table is not empty!
+        table.WaitUntilTableLoad(0, 0, "v2");
+      });
+      // Assert table data
+      table.ReadTableRowColumnData(0, 0, "v2").then((cellData) => {
+        expect(cellData).to.eq("eac7efa5dbd3d667f26eb3d3ab504464");
+      });
+      homePage.NavigateToHome();
+      homePage.DeleteApplication("ImportAppSelectedAccess");
+    });
+
+    it("9. App level import of app with Selected sheet access gsheet", function () {
+      homePage.CreateAppInWorkspace(
+        workspaceName,
+        "AppLevelImportSelectedAccess",
+      );
+      appSettings.OpenAppSettings();
+      appSettings.GoToImport();
+      agHelper.ClickButton("Import");
+      homePage.ImportApp("ImportAppSelectedAccess.json", "", true);
+      cy.wait("@importNewApplication").then(() => {
+        agHelper.Sleep();
+        agHelper.RefreshPage();
+        table.WaitUntilTableLoad(0, 0, "v2");
+      });
+      // Assert table data
+      table.ReadTableRowColumnData(0, 0, "v2").then((cellData) => {
+        expect(cellData).to.eq("eac7efa5dbd3d667f26eb3d3ab504464");
+      });
+      homePage.NavigateToHome();
+      homePage.DeleteApplication("AppLevelImportSelectedAccess");
+    });
+
+    after("Delete app", function () {
+      // Delete app
+      homePage.DeleteApplication(appName);
+    });
+  },
+);

--- a/app/client/cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts
@@ -16,7 +16,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-shared-selected";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet-automation-selected";
-describe(
+describe.skip(
   "GSheet-Functional Tests With Selected Access",
   {
     tags: ["@tag.Datasource", "@tag.GSheet", "@tag.Git", "@tag.AccessControl"],

--- a/app/client/cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts
@@ -10,6 +10,7 @@ import {
   table,
   appSettings,
 } from "../../support/Objects/ObjectsCore";
+import BottomTabs from "../../support/Pages/IDE/BottomTabs";
 
 const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-shared-selected";
@@ -115,6 +116,7 @@ describe(
         spreadSheetName,
       );
       dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].uniq_id);
       dataSources.AssertQueryTableResponse(1, "ホーンビィ 2014 カタログ"); // Asserting other language
       dataSources.AssertQueryTableResponse(2, "₹, $, €, ¥, £"); // Asserting different symbols
@@ -124,6 +126,7 @@ describe(
       gsheetHelper.SelectMultiDropDownValue("Columns", "product_name");
       dataSources.RunQuery();
       dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(0, GSHEET_DATA[0].product_name);
 
       //Remove column filter and add Sort By Ascending and verify
@@ -134,6 +137,7 @@ describe(
         inputFieldName: "Sort By",
       });
       dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(
         0,
         "5afbaf65680c9f378af5b3a3ae22427e",
@@ -150,6 +154,7 @@ describe(
       dataSources.EnterSortByValues("price", "Descending");
       dataSources.RunQuery();
       dataSources.runQueryAndVerifyResponseViews({ count: GSHEET_DATA.length });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(
         1,
         "ホーンビー ゲージ ウェスタン エクスプレス デジタル トレイン セット (eLink および TTS ロコ トレイン セット付き)",
@@ -170,6 +175,7 @@ describe(
       );
       dataSources.RunQuery();
       dataSources.runQueryAndVerifyResponseViews({ count: 8 });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(
         0,
         "87bbb472ef9d90dcef140a551665c929",
@@ -188,6 +194,7 @@ describe(
       });
       dataSources.RunQuery();
       dataSources.runQueryAndVerifyResponseViews({ count: 4 });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -238,6 +245,7 @@ describe(
         true,
       );
       dataSources.runQueryAndVerifyResponseViews({ count: 10 });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",
@@ -273,6 +281,7 @@ describe(
       ); // Converting the field to dropdown
       dataSources.ValidateNSelectDropdown("Sheet name", "", "Sheet1");
       dataSources.runQueryAndVerifyResponseViews({ count: 10 });
+      BottomTabs.response.selectResponseResponseTypeFromMenu("TABLE");
       dataSources.AssertQueryTableResponse(
         0,
         "eac7efa5dbd3d667f26eb3d3ab504464",

--- a/app/client/cypress/e2e/GSheet/WidgetBinding_SelectedAccess_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/WidgetBinding_SelectedAccess_Spec.ts
@@ -21,7 +21,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-selected";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet-automation-selected";
-describe(
+describe.skip(
   "GSheet-widget binding for selected sheet access",
   {
     tags: ["@tag.Datasource", "@tag.GSheet", "@tag.Git", "@tag.AccessControl"],

--- a/app/client/cypress/e2e/GSheet/WidgetBinding_SharedDrive_SelectedSheet_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/WidgetBinding_SharedDrive_SelectedSheet_Access_Spec.ts
@@ -21,7 +21,7 @@ const workspaceName = "gsheet apps";
 const dataSourceName = "gsheet-shared-selected";
 let appName = "gsheet-app";
 let spreadSheetName = "test-sheet-automation-selected";
-describe(
+describe.skip(
   "GSheet-widget binding for selected sheet access",
   {
     tags: ["@tag.Datasource", "@tag.GSheet", "@tag.Git", "@tag.AccessControl"],

--- a/app/client/cypress/e2e/GSheet/WidgetBinding_SharedDrive_SelectedSheet_Access_Spec.ts
+++ b/app/client/cypress/e2e/GSheet/WidgetBinding_SharedDrive_SelectedSheet_Access_Spec.ts
@@ -1,0 +1,112 @@
+/// <reference types="Cypress" />
+import { GSHEET_DATA } from "../../fixtures/test-data-gsheet";
+import {
+  homePage,
+  gsheetHelper,
+  dataSources,
+  agHelper,
+  entityExplorer,
+  propPane,
+  table,
+  draggableWidgets,
+} from "../../support/Objects/ObjectsCore";
+import { Widgets } from "../../support/Pages/DataSources";
+import oneClickBindingLocator from "../../locators/OneClickBindingLocator";
+import {
+  PageLeftPane,
+  PagePaneSegment,
+} from "../../support/Pages/EditorNavigation";
+
+const workspaceName = "gsheet apps";
+const dataSourceName = "gsheet-shared-selected";
+let appName = "gsheet-app";
+let spreadSheetName = "test-sheet-automation-selected";
+describe(
+  "GSheet-widget binding for selected sheet access",
+  {
+    tags: ["@tag.Datasource", "@tag.GSheet", "@tag.Git", "@tag.AccessControl"],
+  },
+  function () {
+    before("Setup app and spreadsheet", function () {
+      //Setting up the app name
+      const uuid = Cypress._.random(0, 10000);
+      appName = appName + "-" + uuid;
+
+      //Adding app and data to the selected sheet
+      homePage.NavigateToHome();
+      homePage.SelectWorkspace(workspaceName);
+      homePage.CreateAppInWorkspace(workspaceName);
+      homePage.RenameApplication(appName);
+      gsheetHelper.AddInsertOrUpdateQuery(
+        "Insert Many",
+        dataSourceName,
+        spreadSheetName,
+        JSON.stringify(GSHEET_DATA),
+      );
+      cy.get("@postExecute").then((interception: any) => {
+        expect(interception.response.body.data.body.message).to.deep.equal(
+          "Inserted rows successfully!",
+        );
+      });
+    });
+
+    it("1. Verify 'Add to widget [Widget Suggestion]' functionality for selected sheet access - GSheet", () => {
+      //Adding query
+      gsheetHelper.EnterBasicQueryValues(
+        "Fetch Many",
+        dataSourceName,
+        spreadSheetName,
+      );
+      dataSources.runQueryAndVerifyResponseViews({ count: 10 });
+
+      // Adding suggested widgets and verify
+      dataSources.AddSuggestedWidget(Widgets.Table);
+      agHelper.RefreshPage();
+      table.ReadTableRowColumnData(0, 0, "v2").then((cellData) => {
+        expect(cellData).to.eq("eac7efa5dbd3d667f26eb3d3ab504464");
+      });
+      agHelper.GetNClick(propPane._deleteWidget);
+    });
+
+    it("2. One click binding to table widget functionality for selected sheet access - GSheet", () => {
+      //Adding table widget
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 450, 200);
+      agHelper.GetNClick(oneClickBindingLocator.datasourceDropdownSelector);
+      agHelper.GetNClick(
+        oneClickBindingLocator.datasourceQuerySelector("fetch_many_query"),
+      );
+
+      // Assert table data
+      table.ReadTableRowColumnData(0, 0, "v2").then((cellData) => {
+        expect(cellData).to.eq("eac7efa5dbd3d667f26eb3d3ab504464");
+      });
+      agHelper.GetNClick(propPane._deleteWidget);
+    });
+
+    after("Delete app", function () {
+      // Delete data in spreadsheet and app
+      PageLeftPane.switchSegment(PagePaneSegment.Queries);
+      gsheetHelper.EnterBasicQueryValues(
+        "Delete One",
+        dataSourceName,
+        spreadSheetName,
+      );
+      GSHEET_DATA.reverse().forEach((d) => {
+        agHelper.EnterValue(d.rowIndex, {
+          propFieldName: "",
+          directInput: false,
+          inputFieldName: "Row Index",
+        });
+        dataSources.RunQuery();
+        cy.get("@postExecute").then((interception: any) => {
+          expect(interception.response.body.data.body.message).to.deep.equal(
+            "Deleted row successfully!",
+          );
+        });
+        agHelper.Sleep(500);
+      });
+      homePage.NavigateToHome();
+      homePage.DeleteApplication(appName);
+    });
+  },
+);

--- a/app/client/cypress_ci_hosted.config.ts
+++ b/app/client/cypress_ci_hosted.config.ts
@@ -53,10 +53,11 @@ export default defineConfig({
       return require("./cypress/plugins/index.js")(on, config);
     },
     specPattern: [
-      "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
-      "cypress/e2e/GSheet/**/**/*",
-      "cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts",
-      "cypress/e2e/Regression/ClientSide/Widgets/Others/MapWidget_Spec.ts",
+      // "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
+      // "cypress/e2e/GSheet/**/**/*",
+      // "cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts",
+      // "cypress/e2e/Regression/ClientSide/Widgets/Others/MapWidget_Spec.ts",
+      "cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts"
     ],
     testIsolation: false,
     excludeSpecPattern: ["cypress/e2e/**/spec_utility.ts"],

--- a/app/client/cypress_ci_hosted.config.ts
+++ b/app/client/cypress_ci_hosted.config.ts
@@ -53,11 +53,10 @@ export default defineConfig({
       return require("./cypress/plugins/index.js")(on, config);
     },
     specPattern: [
-      // "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
-      // "cypress/e2e/GSheet/**/**/*",
-      // "cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts",
-      // "cypress/e2e/Regression/ClientSide/Widgets/Others/MapWidget_Spec.ts",
-      "cypress/e2e/GSheet/SharedDrive_SelectedSheet_Access_Spec.ts"
+      "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
+      "cypress/e2e/GSheet/**/**/*",
+      "cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts",
+      "cypress/e2e/Regression/ClientSide/Widgets/Others/MapWidget_Spec.ts",
     ],
     testIsolation: false,
     excludeSpecPattern: ["cypress/e2e/**/spec_utility.ts"],


### PR DESCRIPTION
## Description
This PR adds automation test cases for Google sheet shared drive support feature. Skipping the cases due to chrome crash.

Run success : https://github.com/appsmithorg/appsmith/actions/runs/12599681652/job/35117116909

Fixes #37916 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12600683395>
> Commit: da066427cf3001acf4f273c10ad1fb2781ead800
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12600683395&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Fri, 03 Jan 2025 17:12:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Skipped multiple Cypress test suites for Google Sheets functionality
	- Added a new test suite for Google Sheets widget binding with selected sheet access
	- Disabled existing test suites for GSheet functional tests and widget binding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->