### PR TITLE
chore: Removed unwanted focus test case

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Focus_retentions_inputs_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Focus_retentions_inputs_spec.js
@@ -15,6 +15,7 @@ import { PluginActionForm } from "../../../../support/Pages/PluginActionForm";
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 const queryLocators = require("../../../../locators/QueryEditor.json");
 
+//test comment
 describe("Focus Retention of Inputs", { tags: ["@tag.IDE"] }, function () {
   let pluginActionForm = new PluginActionForm();
 

--- a/app/client/cypress/e2e/Regression/ClientSide/IDE/Focus_retentions_inputs_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/IDE/Focus_retentions_inputs_spec.js
@@ -15,7 +15,6 @@ import { PluginActionForm } from "../../../../support/Pages/PluginActionForm";
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 const queryLocators = require("../../../../locators/QueryEditor.json");
 
-//test comment
 describe("Focus Retention of Inputs", { tags: ["@tag.IDE"] }, function () {
   let pluginActionForm = new PluginActionForm();
 
@@ -94,84 +93,7 @@ describe("Focus Retention of Inputs", { tags: ["@tag.IDE"] }, function () {
     cy.focusCodeInput(".js-editor", { ch: 2, line: 2 });
   });
 
-  it("2. Maintains focus on property/Api/Query/Js Pane", () => {
-    //Maintains focus on the property pane
-    EditorNavigation.ShowCanvas();
-
-    cy.get(".t--widget-name").should("have.text", "Text1");
-    cy.assertSoftFocusOnCodeInput(".t--property-control-text", {
-      ch: 2,
-      line: 0,
-    });
-
-    PageLeftPane.switchSegment(PagePaneSegment.Queries);
-
-    //Maintains focus on the API pane
-    PageLeftPane.selectItem("Graphql_Query");
-
-    agHelper
-      .GetElement(locators._queryName)
-      .should("have.text", "Graphql_Query");
-
-    cy.xpath("//span[contains(text(), 'Body')]/parent::button").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
-    cy.assertCursorOnCodeInput(".t--graphql-query-editor", { ch: 4, line: 1 });
-
-    PageLeftPane.selectItem("Rest_Api_1");
-
-    agHelper.GetElement(locators._queryName).should("have.text", "Rest_Api_1");
-
-    cy.xpath("//span[contains(text(), 'Params')]/parent::button").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
-    cy.assertCursorOnCodeInput(apiwidget.queryKey, { ch: 0, line: 0 });
-
-    PageLeftPane.selectItem("Rest_Api_2");
-
-    agHelper.GetElement(locators._queryName).should("have.text", "Rest_Api_2");
-
-    cy.xpath("//span[contains(text(), 'Headers')]/parent::button").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
-    cy.assertCursorOnCodeInput(apiwidget.headerValue);
-
-    //Maintains focus on Query panes
-    PageLeftPane.selectItem("SQL_Query");
-
-    agHelper.GetElement(locators._queryName).should("have.text", "SQL_Query");
-
-    cy.assertCursorOnCodeInput(".t--actionConfiguration\\.body", {
-      ch: 5,
-      line: 0,
-    });
-
-    PageLeftPane.selectItem("S3_Query");
-
-    cy.assertCursorOnCodeInput(
-      ".t--actionConfiguration\\.formData\\.bucket\\.data",
-      { ch: 2, line: 0 },
-    );
-
-    PageLeftPane.switchSegment(PagePaneSegment.JS);
-
-    //Maintains focus on JS Objects
-    PageLeftPane.selectItem("JSObject1");
-
-    cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 4 });
-
-    PageLeftPane.selectItem("JSObject2");
-
-    cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 2 });
-  });
-
-  it("3. Datasource edit mode has to be maintained", () => {
+  it("2. Datasource edit mode has to be maintained", () => {
     EditorNavigation.SelectEntityByName("Appsmith", EntityType.Datasource);
     dataSources.EditDatasource();
     EditorNavigation.SelectEntityByName("Github", EntityType.Datasource);
@@ -180,7 +102,7 @@ describe("Focus Retention of Inputs", { tags: ["@tag.IDE"] }, function () {
     dataSources.AssertDSEditViewMode("Edit");
   });
 
-  it("4. Maintain focus of form control inputs", () => {
+  it("3. Maintain focus of form control inputs", () => {
     EditorNavigation.SelectEntityByName("SQL_Query", EntityType.Query);
     dataSources.ToggleUsePreparedStatement(false);
     EditorNavigation.SelectEntityByName("S3_Query", EntityType.Query);
@@ -197,7 +119,7 @@ describe("Focus Retention of Inputs", { tags: ["@tag.IDE"] }, function () {
     cy.xpath(queryLocators.queryTimeout).should("be.focused");
   });
 
-  it("5. Bug 21999 Maintain focus of code editor when Escape is pressed with autcomplete open + Bug 22960", () => {
+  it("4. Bug 21999 Maintain focus of code editor when Escape is pressed with autcomplete open + Bug 22960", () => {
     EditorNavigation.SelectEntityByName("JSObject1", EntityType.JSObject);
 
     cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 4 });


### PR DESCRIPTION
## Description
We cover the focus functionality already.


Fixes # https://app.zenhub.com/workspaces/stability-pod-6690c4814e31602e25cab7fd/issues/gh/appsmithorg/appsmith/38356


## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12483068905>
> Commit: 42b50f9a931d8dd24af625621752c1e94fc6eb4c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12483068905&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Tue, 24 Dec 2024 15:13:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Removed an existing test case for focus retention on specific panes.
- **Tests**
	- Renumbered test cases to reflect changes, while maintaining focus retention validation across various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->