### PR TITLE
ci: Fix for command without spec

### DIFF
--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -48,10 +48,11 @@ jobs:
           else
               echo "update_snapshot=$checkArg" >> $GITHUB_OUTPUT
           fi
+          
           # Check for spec file
           checkArg=${{ github.event.client_payload.slash_command.args.named.specs_to_run }}
           if [[ -z "$checkArg" ]]; then
-              echo "specs_to_run=''" >> $GITHUB_OUTPUT
+              echo "specs_to_run='no_data'" >> $GITHUB_OUTPUT
           else
               echo "specs_to_run=$checkArg" >> $GITHUB_OUTPUT
           fi
@@ -114,7 +115,7 @@ jobs:
           body: |
             Tests running at: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>.
             [Cypress dashboard](https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}&selectiontype=test&testsstatus=failed&specsstatus=fail)
-            PR: #${{ fromJson(steps.args.outputs.pr) }} with spec: ${{steps.args.outputs.specs_to_run}} .
+            PR: #${{ fromJson(steps.args.outputs.pr) }} .
 
   server-build:
     name: server-build

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -28,6 +28,7 @@ on:
         description: 'Cypress spec file(s) to run'
         required: false
         type: string
+        default: 'no_data'
 
   workflow_call:
     inputs:
@@ -53,7 +54,8 @@ on:
       specs_to_run:
         description: 'Cypress spec file(s) to run'
         required: false
-        type: string  
+        type: string
+        default: 'no_data'
 
 jobs:
   ci-test-limited:
@@ -139,21 +141,58 @@ jobs:
           path: ${{ github.workspace }}/app/client/cypress/snapshots
           overwrite: true    
 
-      # Get specs to run
+      # Step to get specs from the file or use the provided specs
       - name: Get specs to run
-        if: ${{ (inputs.specs_to_run == '' || inputs.specs_to_run == null || !inputs.specs_to_run) && steps.run_result.outputs.run_result != 'success' && steps.run_result.outputs.run_result != 'failedtest' }}
         run: |
-          specs_to_run=""
-          while IFS= read -r line
-          do
-            if [[ $line =~ ^#|^\/\/ ]]; then
-              continue
+          # Check if specs_to_run is provided; if not, use the fallback file
+          echo "[DEBUG] Initial specs_to_run value: $specs_to_run"
+          if [[ -z "$specs_to_run" || "$specs_to_run" == "no_data" ]]; then
+            echo "[INFO] No specs provided, falling back to limited-tests.txt file."
+            
+            # Verify if the fallback file exists
+            if [[ ! -f app/client/cypress/limited-tests.txt ]]; then
+              echo "[ERROR] limited-tests.txt file not found in app/client/cypress!" >&2
+              exit 1
             else
-              specs_to_run="$specs_to_run,$line"
+              echo "[DEBUG] limited-tests.txt file found. Proceeding to read specs."
             fi
-          done < app/client/cypress/limited-tests.txt
-          specs_to_run=${specs_to_run#,}
+
+            specs_to_run=""
+
+            # Read each line of limited-tests.txt
+            while IFS= read -r line || [[ -n "$line" ]]; do
+              # Log each line being read
+              echo "[DEBUG] Reading line: $line"
+
+              # Skip comments and empty lines
+              if [[ $line =~ ^#|^\/\/ || -z $line ]]; then
+                echo "[DEBUG] Skipping comment/empty line: $line"
+                continue
+              else
+                echo "[DEBUG] Adding spec to specs_to_run: $line"
+                specs_to_run="$specs_to_run,$line"
+              fi
+            done < app/client/cypress/limited-tests.txt
+
+            # Remove leading comma
+            specs_to_run=${specs_to_run#,}
+            echo "[DEBUG] Final specs_to_run after processing limited-tests.txt: $specs_to_run"
+
+            # If no specs found, return an error
+            if [[ -z "$specs_to_run" ]]; then
+              echo "[ERROR] No specs found in limited-tests.txt after processing!" >&2
+              exit 1
+            fi
+          else
+            echo "[INFO] Using provided specs: $specs_to_run"
+          fi
+
+          # Log the final specs_to_run value before writing it to GitHub environment
+          echo "[DEBUG] Setting specs_to_run to GitHub environment variable: $specs_to_run"
+
+          # Set the final specs_to_run to GitHub environment variable
           echo "specs_to_run=$specs_to_run" >> $GITHUB_ENV
+          
 
       # In case of run-id provided download the artifact from the previous run
       - name: Download Docker image artifact


### PR DESCRIPTION
## Description
Fix for command without spec.


Fixes # https://app.zenhub.com/workspaces/stability-pod-6690c4814e31602e25cab7fd/issues/gh/appsmithorg/appsmith/38352

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12482462821>
> Commit: add048b0795ebf1f9a3fb6c2cfa1837fdb179ebd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12482462821&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 24 Dec 2024 14:11:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in specifying test files with a new input parameter `specs_to_run`.
	- Default value for `specs_to_run` is now set to `'no_data'` when not provided.
  
- **Bug Fixes**
	- Improved error handling for cases where no specifications are provided, including fallback to a specified file.

- **Documentation**
	- Updated comments for clarity in workflow processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->