### PR TITLE
chore: Added capability of running ITs on maven

### DIFF
--- a/app/server/appsmith-server/src/test/it/com/appsmith/server/git/templates/contexts/GitContext.java
+++ b/app/server/appsmith-server/src/test/it/com/appsmith/server/git/templates/contexts/GitContext.java
@@ -25,6 +25,7 @@ public class GitContext implements TestTemplateInvocationContext, ParameterResol
         ExtensionContext.Store contextStore = extensionContext.getStore(ExtensionContext.Namespace.create(ArtifactBuilderExtension.class));
         contextStore.put(ArtifactExchangeJson.class, artifactExchangeJsonType);
         contextStore.put("filePath", fileName);
+        contextStore.put("artifactType", artifactType);
         this.fileName = fileName;
         this.artifactExchangeJsonType = artifactExchangeJsonType;
     }

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -43,6 +43,9 @@
         <reactor-test.version>3.5.1</reactor-test.version>
         <!-- By default skip the dockerization step. Only activate if necessary -->
         <skipDockerBuild>true</skipDockerBuild>
+        <skipITs>${skipTests}</skipITs>
+        <skipTests>false</skipTests>
+        <skipUTs>${skipTests}</skipUTs>
         <!-- We're forcing this version temporarily to fix CVE-2022-1471-->
         <snakeyaml.version>2.0</snakeyaml.version>
         <source.disabled>true</source.disabled>
@@ -75,6 +78,30 @@
                 <version>3.4.0</version>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <phase>generate-test-sources</phase>
+                        <configuration>
+                            <sources>
+                                <source>src/test/java</source>
+                                <!-- Default test directory -->
+                                <source>src/test/it</source>
+                                <!-- Additional test directory -->
+                                <source>src/test/utils</source>
+                                <!-- Another additional directory -->
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
@@ -84,6 +111,41 @@
                     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED
                         --add-opens java.base/java.time=ALL-UNNAMED
                         --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+                    <testSourceDirectory>src/test/java</testSourceDirectory>
+                    <skipTests>${skipUTs}</skipTests>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.6.2</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>org.junit.platform</groupId>
+                                <artifactId>junit-platform-commons</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <printSummary>true</printSummary>
+                    <!-- Allow JUnit to access the test classes -->
+                    <argLine>-ea
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.time=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+                    <systemPropertyVariables>
+                        <pf4j.pluginsDir>../dist/plugins</pf4j.pluginsDir>
+                        <!-- Specify plugin directory -->
+                    </systemPropertyVariables>
+                    <testSourceDirectory>src/test/it</testSourceDirectory>
+                    <skipITs>${skipITs}</skipITs>
+                    <!-- Property for skipping integration tests -->
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
## Description
Enables running UTs and ITs as desired on maven. The skipTests command continues to skip all tests.
To run only UTs, use:
```mvn test```

To run only ITs, use:
```mvn verify -DskipUTs=true```

## Automation

/ok-to-test tags="@tag.Git"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced context management by associating `artifactType` with the `extensionContext`.
	- Updated service structure for SSH key pair management, focusing on artifact-level services.

- **Bug Fixes**
	- Improved test execution control with new properties for skipping tests in the build process.

- **Documentation**
	- Enhanced test configuration and management within the Maven build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12483043596>
> Commit: 9b65433e9ed8d780965a49cc7fdb38599d1f424e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12483043596&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Tue, 24 Dec 2024 15:24:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->
