### PR TITLE
fix: common form editor header z-index

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/styles.ts
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/styles.ts
@@ -17,7 +17,7 @@ export const FormHeader = styled.div`
   top: calc(-1 * var(--ads-v2-spaces-4));
   padding-top: var(--ads-v2-spaces-4);
   margin-top: calc(-1 * var(--ads-v2-spaces-4));
-  z-index: var(--ads-v2-z-index-21);
+  z-index: var(--ads-v2-z-index-1);
   background-color: var(--ads-color-background);
   height: 100px;
 `;


### PR DESCRIPTION
## Description
Fixes an issue where common form editor header appears to have z-index higher that the one of entity explorer.

Fixes #38366 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12493865322>
> Commit: 009a486ba59c0d390c50e0f77ac26f9b1d1923f3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12493865322&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Wed, 25 Dec 2024 14:46:11 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the stacking order of the `FormHeader` component to enhance its visibility and layering within the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->