### PR TITLE
fix: Minor changes in Datasource and API

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/CommonEditorForm.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/components/CommonEditorForm/CommonEditorForm.tsx
@@ -52,7 +52,11 @@ const CommonEditorForm = (props: Props) => {
   const paramsCount = getParamsCount(actionParams, datasourceHeaders);
 
   return (
-    <Styled.Tabs onValueChange={setCurrentTab} value={currentTab}>
+    <Styled.Tabs
+      data-testid={props.dataTestId}
+      onValueChange={setCurrentTab}
+      value={currentTab}
+    >
       <Styled.FormHeader>
         <InfoFields
           actionName={action.name}

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -2307,6 +2307,7 @@ export const DATA_PANE_TITLE = () => "Datasources in your workspace";
 export const DATASOURCE_LIST_BLANK_DESCRIPTION = () =>
   "Connect a datasource to write your first query";
 export const DATASOURCE_BLANK_STATE_MESSAGE = () => "No datasources to display";
+export const DATASOURCE_BLANK_STATE_CTA = () => "Bring your data";
 
 // Create New Apps Intermediary step
 export const CREATE_NEW_APPS_STEP_TITLE = () => "How would you like to start?";

--- a/app/client/src/pages/Editor/IDE/LeftPane/DataSidePane.tsx
+++ b/app/client/src/pages/Editor/IDE/LeftPane/DataSidePane.tsx
@@ -17,11 +17,12 @@ import { useLocation } from "react-router";
 import {
   createMessage,
   DATA_PANE_TITLE,
+  DATASOURCE_BLANK_STATE_CTA,
   DATASOURCE_LIST_BLANK_DESCRIPTION,
 } from "ee/constants/messages";
 import PaneHeader from "./PaneHeader";
 import { useEditorType } from "ee/hooks";
-import { INTEGRATION_TABS } from "../../../../constants/routes";
+import { INTEGRATION_TABS } from "constants/routes";
 import type { AppState } from "ee/reducers";
 import { getCurrentAppWorkspace } from "ee/selectors/selectedWorkspaceSelectors";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
@@ -99,7 +100,7 @@ const DataSidePane = (props: DataSidePaneProps) => {
     () => ({
       className: "t--add-datasource-button-blank-screen",
       testId: "t--add-datasource-button-blank-screen",
-      text: createMessage(DATA_PANE_TITLE),
+      text: createMessage(DATASOURCE_BLANK_STATE_CTA),
       onClick: canCreateDatasource ? addButtonClickHandler : undefined,
     }),
     [addButtonClickHandler, canCreateDatasource],


### PR DESCRIPTION
## Description

Fixes issues introduced in #38317 and #38321


## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12500529563>
> Commit: 92a1b596d75ae9318aa716cfabfee734042d18eb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12500529563&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Thu, 26 Dec 2024 06:56:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a call-to-action message for users when no datasources are available, encouraging them to "Bring your data."
	- Introduced options for starting new applications, including templates, scratch, or with data, enhancing user guidance during app creation.

- **Bug Fixes**
	- Updated button text in the data side pane to reflect the new call-to-action message.

- **Chores**
	- Improved testability of the `CommonEditorForm` component by adding a `data-testid` attribute. 
	- Updated import paths for better module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->