### PR TITLE
chore: check flaky failure

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
@@ -16,7 +16,7 @@ import {
 
 describe(
   "API Panel Test Functionality",
-  { tags: ["@tag.Datasource", "@tag.Git", "@tag.AccessControl"] },
+  { tags: ["@tag.Datasource", "@tag.Git", "@tag.AccessControl", "@tag.Visual"] },
   function () {
     before(() => {
       agHelper.AddDsl("uiBindDsl");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+cypress/e2e/Regression/ClientSide/VisualTests/JSEditorIndent_spec.js
+cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 


### PR DESCRIPTION
## Description
To test flaky failures


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Visual"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12501212844>
> Commit: 79bf80eab3651d2046b4834d68477c589c0ca724
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12501212844&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Visual
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/VisualTests/JSEditorIndent_spec.js
> <li>cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Thu, 26 Dec 2024 08:22:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
