### PR TITLE
fix: fix url evaluation

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Edit_spec.js
@@ -103,8 +103,7 @@ describe(
         .wait(3000)
         .click({
           force: true,
-        })
-        .type("{enter}", { parseSpecialCharSequences: true });
+        });
 
       cy.validateEvaluatedValue(
         "http://host.docker.internal:5001/Cancel?key=test&val=Cancel",


### PR DESCRIPTION
## Description
Fixes API_Edit_spec.js

Fixes #38135 

## Automation

/ok-to-test tags="@tag.AccessControl"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12507336996>
> Commit: 7ff55522e4fe8ee3206c8d3812fcc330b8c7ce72
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12507336996&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.AccessControl`
> Spec:
> <hr>Thu, 26 Dec 2024 21:27:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the test case for URL field interaction by removing the Enter key action after clicking, streamlining the validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->