### PR TITLE
test: verifying replication of JS Object settings during copy action

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/JSObject/Copied_JSObject_Settings_Bug31475_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/JSObject/Copied_JSObject_Settings_Bug31475_spec.ts
@@ -1,0 +1,43 @@
+import HomePage from "../../../../locators/HomePage";
+import { jsEditor, agHelper } from "../../../../support/Objects/ObjectsCore";
+import EditorNavigation, {
+  PageLeftPane,
+  PagePaneSegment,
+} from "../../../../support/Pages/EditorNavigation";
+import PageList from "../../../../support/Pages/PageList";
+
+describe(
+  " To test [Bug]: Function settings of a JS Object are not obeyed when copied/moved to another page #31475",
+  { tags: ["@tag.JS"] },
+  () => {
+    // Bug: https://github.com/appsmithorg/appsmith/issues/31475
+    it.skip("Verify if settings are replicated in a copied JS Object", () => {
+      jsEditor.CreateJSObject("", { prettify: false, toRun: false });
+
+      // Step 2: Add a new blank page
+      PageList.AddNewPage("New blank page");
+
+      // Step 3: Navigate back to the source page
+      EditorNavigation.NavigateToPage("Page1", true);
+
+      // Step 4: Switch to the JS Objects segment in the left pane
+      PageLeftPane.switchSegment(PagePaneSegment.JS);
+
+      // Step 5: Enable "Run on page load" for a specific function
+      jsEditor.EnableDisableAsyncFuncSettings("myFun1");
+
+      // Step 6: Copy the JS Object to the target page
+      agHelper.GetNClick(jsEditor._moreActions, 0, true);
+      agHelper.HoverElement(
+        `${HomePage.portalMenuItem}:contains("Copy to page")`,
+      );
+      agHelper.GetNClick(`${HomePage.portalMenuItem}:contains("Page2")`);
+
+      // Step 7: Refresh the page to ensure the JS Object is updated
+      agHelper.RefreshPage();
+
+      // Step 8: Verify that the "Run on page load" setting is still enabled for the function
+      jsEditor.VerifyAsyncFuncSettings("myFun1", true);
+    });
+  },
+);

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/VisualTests/JSEditorIndent_spec.js
+cypress/e2e/Regression/ClientSide/JSObject/Copied_JSObject_Settings_Bug31475_spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 


### PR DESCRIPTION
## Description

This PR introduces a test case designed to validate whether the "Run on page load" setting for a specific function in a JS Object is correctly retained when the object is copied to another page.

Relevant bug: https://github.com/appsmithorg/appsmith/issues/31475

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12558090952>
> Commit: 2c9eb153d00bcceec00c9e30f72a8fa0a82d73bc
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12558090952&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Tue, 31 Dec 2024 10:36:11 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new test specification to validate JavaScript Object settings when copied between pages.
	- Test case currently skipped, focusing on verifying "Run on page load" setting preservation during object copying.
	- Updated test execution path to prioritize the new test related to copied JS objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->