### PR TITLE
chore: flexible return for test payload extraction func

### DIFF
--- a/app/client/src/ce/utils/actionExecutionUtils.ts
+++ b/app/client/src/ce/utils/actionExecutionUtils.ts
@@ -100,8 +100,9 @@ export function isBrowserExecutionAllowed(..._args: any[]) {
 
 /**
  * Function to extract the test payload from the collection data
- * @param collectionData from the js Object
- * @param defaultValue to be returned if no information is found
+ * @param [collectionData] from the js Object
+ * @param [defaultValue=""] to be returned if no information is found,
+ * returns an empty string by default
  * @returns stored value from the collectionData
  * */
 export const getTestPayloadFromCollectionData = (

--- a/app/client/src/ce/utils/actionExecutionUtils.ts
+++ b/app/client/src/ce/utils/actionExecutionUtils.ts
@@ -9,6 +9,7 @@ import { getCurrentEnvironmentDetails } from "ee/selectors/environmentSelectors"
 import type { Plugin } from "api/PluginApi";
 import { get, isNil } from "lodash";
 import type { JSCollectionData } from "ee/reducers/entityReducers/jsActionsReducer";
+import { objectKeys } from "@appsmith/utils";
 
 export function getPluginActionNameToDisplay(action: Action) {
   return action.name;
@@ -20,7 +21,7 @@ export const getActionProperties = (
 ) => {
   const actionProperties: Record<string, unknown> = {};
 
-  Object.keys(keyConfig).forEach((key) => {
+  objectKeys(keyConfig).forEach((key) => {
     const value = get(action, key);
 
     if (!isNil(value)) {
@@ -69,7 +70,7 @@ export function getActionExecutionAnalytics(
     datasourceId: datasourceId,
     isMock: !!datasource?.isMock,
     actionId: action?.id,
-    inputParams: Object.keys(params).length,
+    inputParams: objectKeys(params).length,
     source: ActionExecutionContext.EVALUATION_ACTION_TRIGGER, // Used in analytic events to understand who triggered action execution
   };
 

--- a/app/client/src/ce/utils/actionExecutionUtils.ts
+++ b/app/client/src/ce/utils/actionExecutionUtils.ts
@@ -98,7 +98,12 @@ export function isBrowserExecutionAllowed(..._args: any[]) {
   return true;
 }
 
-// Function to extract the test payload from the collection data
+/**
+ * Function to extract the test payload from the collection data
+ * @param collectionData from the js Object
+ * @param defaultValue to be returned if no information is found
+ * @returns stored value from the collectionData
+ * */
 export const getTestPayloadFromCollectionData = (
   collectionData: JSCollectionData | undefined,
   defaultValue = "",

--- a/app/client/src/ce/utils/actionExecutionUtils.ts
+++ b/app/client/src/ce/utils/actionExecutionUtils.ts
@@ -101,14 +101,15 @@ export function isBrowserExecutionAllowed(..._args: any[]) {
 // Function to extract the test payload from the collection data
 export const getTestPayloadFromCollectionData = (
   collectionData: JSCollectionData | undefined,
+  defaultValue = "",
 ): string => {
-  if (!collectionData) return "";
+  if (!collectionData) return defaultValue;
 
   const activeJSActionId = collectionData?.activeJSActionId;
   const testPayload: Record<string, unknown> | undefined = collectionData?.data
     ?.testPayload as Record<string, unknown>;
 
-  if (!activeJSActionId || !testPayload) return "";
+  if (!activeJSActionId || !testPayload) return defaultValue;
 
-  return (testPayload[activeJSActionId] as string) || "";
+  return testPayload[activeJSActionId] as string;
 };


### PR DESCRIPTION
## Description
The `getTestPayloadFromCollectionData` extracts the `testPayload` from passed `collectionData` and returns an empty string if no information is present. This PR updates the function definition to allow different default value based on the function call.


Fixes #37742 

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12572189037>
> Commit: 26ea6e2b17c9a31e836ced4e3787a0723db63680
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12572189037&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 01 Jan 2025 16:34:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced function handling for undefined collection data
  - Improved key iteration in action execution utilities

- **Documentation**
  - Added JSDoc comment to clarify function behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->