### PR TITLE
test: Cypress test for validating file uploads greater than 20MB

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Bug_Upload_File_GreaterThan_20MB_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_Bug_Upload_File_GreaterThan_20MB_spec.ts
@@ -1,0 +1,63 @@
+const commonlocators = require("../../../../locators/commonlocators.json");
+import {
+  agHelper,
+  apiPage,
+  dataManager,
+  draggableWidgets,
+  entityExplorer,
+  locators,
+  propPane,
+} from "../../../../support/Objects/ObjectsCore";
+const apiwidget = require("../../../../locators/apiWidgetslocator.json");
+
+describe(
+  "To test [Bug]: A-force -> Not being able to upload file using binary format and multi part form data #34123",
+  { tags: ["@tag.Datasource", "@tag.Git", "@tag.AccessControl"] },
+  () => {
+    // Bug: https://github.com/appsmithorg/appsmith/issues/34123
+    it("1. Validate whether file >20MB can be uploaded", () => {
+      // Step 1: Add a File Picker widget and configure it
+      entityExplorer.DragDropWidgetNVerify(draggableWidgets.FILEPICKER);
+
+      // Set allowed file types
+      propPane.EnterJSContext("Allowed file types", `["*"]`);
+
+      // Set file data format to 'Array of Objects'
+      cy.get(commonlocators.filePickerDataFormat).click({ force: true });
+      cy.contains("Array of Objects").should("be.visible").click();
+
+      // Set max file size to 50MB
+      propPane.UpdatePropertyFieldValue("Max file size(Mb)", "50");
+
+      // Step 2: Upload a file greater than 20MB
+      agHelper.ClickButton("Select Files");
+      agHelper.UploadFile("FileGreaterThan20MB.json");
+
+      // Assert that the file is selected
+      agHelper.AssertText(locators._buttonText, "text", "1 files selected");
+
+      // Step 3: Create and configure the API
+      apiPage.CreateAndFillApi(
+        dataManager.dsValues[dataManager.defaultEnviorment].multipartAPI,
+        "TestUpload20MB",
+        80000,
+        "POST",
+      );
+      apiPage.EnterBodyFormData(
+        "MULTIPART_FORM_DATA",
+        "file",
+        "{{FilePicker1.files[0]}}",
+        "File",
+      );
+
+      // Step 4: Run the API and verify the response
+      apiPage.RunAPI();
+      apiPage.ResponseStatusCheck("200");
+
+      // Assert the response contains the uploaded file name
+      cy.get(apiwidget.responseText).contains(
+        `"file": "FileGreaterThan20MB.json"`,
+      );
+    });
+  },
+);

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/ApiTests/API_Bug_Upload_File_GreaterThan_20MB_spec.ts
+cypress/e2e/Regression/ClientSide/VisualTests/JSEditorIndent_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/VisualTests/JSEditorIndent_spec.js
+cypress/e2e/Regression/ServerSide/ApiTests/API_Bug_Upload_File_GreaterThan_20MB_spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 


### PR DESCRIPTION
## Description
This PR introduces a Cypress test to validate the functionality of uploading files larger than 20MB using the File Picker widget and a POST API.

Tests: https://github.com/appsmithorg/appsmith/issues/34123

## Automation

/ok-to-test tags="@tag.Datasource, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12633295995>
> Commit: 5ee713a15beabfaf8f7fec613fb29cfcc1ee2759
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12633295995&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.Sanity`
> Spec:
> <hr>Mon, 06 Jan 2025 14:20:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Tests**
	- Added a new Cypress test suite for validating file uploads larger than 20MB
	- Test covers file upload via File Picker widget with multipart form data
	- Verifies successful file upload and API response for large files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->