### PR TITLE
chore: bump DSL version to 91 and update migration logic

### DIFF
--- a/app/client/packages/dsl/src/migrate/index.ts
+++ b/app/client/packages/dsl/src/migrate/index.ts
@@ -93,7 +93,7 @@ import { migrateCustomWidgetDynamicHeight } from "./migrations/088-migrate-custo
 import { migrateTableWidgetV2CurrentRowInValidationsBinding } from "./migrations/089-migrage-table-widget-v2-currentRow-binding";
 import type { DSLWidget } from "./types";
 
-export const LATEST_DSL_VERSION = 90;
+export const LATEST_DSL_VERSION = 91;
 
 export const calculateDynamicHeight = () => {
   const DEFAULT_GRID_ROW_HEIGHT = 10;
@@ -613,6 +613,17 @@ const migrateVersionedDSL = async (currentDSL: DSLWidget, newPage = false) => {
 
   if (currentDSL.version === 89) {
     currentDSL = migrateTableWidgetV2CurrentRowInValidationsBinding(currentDSL);
+    currentDSL.version = 90;
+  }
+
+  if (currentDSL.version === 90) {
+    /**
+     * This is just a version bump without any migration
+     * History: With this PR: https://github.com/appsmithorg/appsmith/pull/38391
+     * we updated the `clientVersion` to 2.
+     * What we missed was that, the auto-commit does not handle clientVersion, which lead to this bug: https://github.com/appsmithorg/appsmith/issues/38511
+     * We are bumping this version to make sure that the auto-commit will handle this version bump.
+     */
     currentDSL.version = LATEST_DSL_VERSION;
   }
 

--- a/app/client/packages/dsl/src/migrate/tests/DSLMigration.test.ts
+++ b/app/client/packages/dsl/src/migrate/tests/DSLMigration.test.ts
@@ -930,6 +930,10 @@ const migrations: Migration[] = [
     ],
     version: 89,
   },
+  {
+    functionLookup: [],
+    version: 90,
+  },
 ];
 
 const mockFnObj: Record<number, any> = {};


### PR DESCRIPTION
## Description

This commit updates the LATEST_DSL_VERSION constant to 91 and modifies the migration logic to ensure proper handling of the new version. The change addresses an issue with auto-commit functionality not managing the clientVersion correctly, as detailed in the linked issue. No migrations are introduced with this version bump, ensuring backward compatibility.



Fixes #`Issue Number`  
_or_  
Fixes https://github.com/appsmithorg/appsmith/issues/38511
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.ImportExport, @tag.Git, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12651263937>
> Commit: 593cba725091749fbe088cdcc6f1efa1f1492a5e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12651263937&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.ImportExport, @tag.Git, @tag.Sanity`
> Spec:
> <hr>Tue, 07 Jan 2025 13:13:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated DSL version from 90 to 91 to support auto-commit functionality.
	- Improved version handling mechanism for DSL migrations.
	- Added a new migration entry for version 90 in the migration tests.
	- Introduced a new method to handle client schema migrations before server migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->