### PR TITLE
fix: external saas redirection when api created and navigated

### DIFF
--- a/app/client/src/ce/PluginActionEditor/components/PluginActionResponse/hooks/usePluginActionResponseTabs.tsx
+++ b/app/client/src/ce/PluginActionEditor/components/PluginActionResponse/hooks/usePluginActionResponseTabs.tsx
@@ -115,6 +115,7 @@ function usePluginActionResponseTabs() {
       PluginType.REMOTE,
       PluginType.SAAS,
       PluginType.INTERNAL,
+      PluginType.EXTERNAL_SAAS,
     ].includes(plugin.type)
   ) {
     if (showSchema) {

--- a/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
@@ -62,7 +62,8 @@ export const resolveActionURL = ({
     pluginType === PluginType.DB ||
     pluginType === PluginType.REMOTE ||
     pluginType === PluginType.AI ||
-    pluginType === PluginType.INTERNAL
+    pluginType === PluginType.INTERNAL ||
+    pluginType === PluginType.EXTERNAL_SAAS
   ) {
     return queryEditorIdURL({
       baseParentEntityId,
@@ -86,6 +87,7 @@ export const ACTION_PLUGIN_MAP: Array<ActionGroupConfig | undefined> = [
       PluginType.REMOTE,
       PluginType.AI,
       PluginType.INTERNAL,
+      PluginType.EXTERNAL_SAAS,
     ],
     icon: dbQueryIcon,
     key: generateReactKey(),

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -398,6 +398,7 @@ function* handleQueryCreatedSaga(actionPayload: ReduxAction<QueryAction>) {
       PluginType.REMOTE,
       PluginType.AI,
       PluginType.INTERNAL,
+      PluginType.EXTERNAL_SAAS,
     ].includes(pluginType)
   )
     return;


### PR DESCRIPTION
## Description
Earlier on creation of the external saas api, the url doesn't gets redirected to the action page. And on clicking on the created api from the explorer section, the url wasn't getting redirected as well.
This PR fixes both of these


Fixes #38515  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
