### PR TITLE
chore: disable faro session tracking

### DIFF
--- a/app/client/src/instrumentation/index.ts
+++ b/app/client/src/instrumentation/index.ts
@@ -51,6 +51,9 @@ if (isTracingEnabled()) {
     trackResources: true,
     trackWebVitalsAttribution: true,
     internalLoggerLevel,
+    sessionTracking: {
+      enabled: false,
+    },
   });
 
   const tracerProvider = new WebTracerProvider({

--- a/app/client/src/instrumentation/index.ts
+++ b/app/client/src/instrumentation/index.ts
@@ -52,7 +52,9 @@ if (isTracingEnabled()) {
     trackWebVitalsAttribution: true,
     internalLoggerLevel,
     sessionTracking: {
-      enabled: false,
+      generateSessionId: () => {
+        return "session-id";
+      },
     },
   });
 

--- a/app/client/src/instrumentation/index.ts
+++ b/app/client/src/instrumentation/index.ts
@@ -53,7 +53,9 @@ if (isTracingEnabled()) {
     internalLoggerLevel,
     sessionTracking: {
       generateSessionId: () => {
-        return "session-id";
+        // Disabling session tracing will not send any instrumentation data to the grafana backend
+        // Instead, hardcoding the session id to a constant value to indirecly disable session tracing
+        return "SESSION_ID";
       },
     },
   });


### PR DESCRIPTION
## Description
This PR disables faro's session tracking.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12666017173>
> Commit: b76a4381580c695e919325330fdcda8cd3f0a2d3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12666017173&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 08 Jan 2025 08:41:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Configuration**
	- Introduced a new `sessionTracking` option in Faro instrumentation for customizable session ID generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->