### PR TITLE
chore: merge updateActionData with an evaluation

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.test.ts
+++ b/app/client/src/sagas/EvaluationsSaga.test.ts
@@ -76,6 +76,7 @@ describe("evaluateTreeSaga", () => {
         widgetsMeta: {},
         shouldRespondWithLogs: true,
         affectedJSObjects: { ids: [], isAllAffected: false },
+        actionDataPayloadConsolidated: undefined,
       })
       .run();
   });
@@ -121,6 +122,7 @@ describe("evaluateTreeSaga", () => {
         widgetsMeta: {},
         shouldRespondWithLogs: false,
         affectedJSObjects: { ids: [], isAllAffected: false },
+        actionDataPayloadConsolidated: undefined,
       })
       .run();
   });
@@ -175,6 +177,7 @@ describe("evaluateTreeSaga", () => {
         widgetsMeta: {},
         shouldRespondWithLogs: false,
         affectedJSObjects,
+        actionDataPayloadConsolidated: undefined,
       })
       .run();
   });

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -843,7 +843,9 @@ function* evaluationChangeListenerSaga(): any {
       hasDebouncedHandleUpdate,
     } = action as unknown as BUFFERED_ACTION;
 
-    // when there are
+    // when there are both debounced action updates evaluation and a regular evaluation
+    // we will convert that to a regular evaluation this should help in performance by
+    // not performing a debounced action updates evaluation
     if (hasDebouncedHandleUpdate && hasBufferedAction) {
       const affectedJSObjects = getAffectedJSObjectIdsFromAction(action);
 

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -34,6 +34,7 @@ import {
 import type { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
 import type { MetaWidgetsReduxState } from "reducers/entityReducers/metaWidgetsReducer";
 import type { Attributes } from "instrumentation/types";
+import { updateActionsToEvalTree } from "./updateActionData";
 
 // TODO: Fix this the next time the file is edited
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,6 +71,7 @@ export async function evalTree(
   let isNewWidgetAdded = false;
 
   const {
+    actionDataPayloadConsolidated,
     affectedJSObjects,
     allActionValidationConfig,
     appMode,
@@ -190,6 +192,10 @@ export async function evalTree(
       });
       staleMetaIds = dataTreeResponse.staleMetaIds;
     } else {
+      const tree = dataTreeEvaluator.getEvalTree();
+
+      updateActionsToEvalTree(tree, actionDataPayloadConsolidated);
+
       if (dataTreeEvaluator && !isEmpty(allActionValidationConfig)) {
         dataTreeEvaluator.setAllActionValidationConfig(
           allActionValidationConfig,
@@ -212,6 +218,7 @@ export async function evalTree(
             configTree,
             webworkerTelemetry,
             affectedJSObjects,
+            actionDataPayloadConsolidated,
           ),
       );
 

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -18,6 +18,7 @@ import type { APP_MODE } from "entities/App";
 import type { WebworkerSpanData, Attributes } from "instrumentation/types";
 import type { ICacheProps } from "../common/AppComputationCache/types";
 import type { AffectedJSObjects } from "actions/EvaluationReduxActionTypes";
+import type { actionDataPayload } from "actions/pluginActionActions";
 
 // TODO: Fix this the next time the file is edited
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -51,6 +52,7 @@ export interface EvalTreeRequestData {
   widgetsMeta: Record<string, any>;
   shouldRespondWithLogs?: boolean;
   affectedJSObjects: AffectedJSObjects;
+  actionDataPayloadConsolidated?: actionDataPayload;
 }
 
 export interface EvalTreeResponseData {

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -155,6 +155,7 @@ import { getDataTreeContext } from "ee/workers/Evaluation/Actions";
 import { WorkerEnv } from "workers/Evaluation/handlers/workerEnv";
 import type { WebworkerSpanData, Attributes } from "instrumentation/types";
 import type { AffectedJSObjects } from "actions/EvaluationReduxActionTypes";
+import type { UpdateActionProps } from "workers/Evaluation/handlers/updateActionData";
 
 type SortedDependencies = Array<string>;
 export interface EvalProps {
@@ -637,6 +638,7 @@ export default class DataTreeEvaluator {
     configTree: ConfigTree,
     webworkerTelemetry: Record<string, WebworkerSpanData | Attributes> = {},
     affectedJSObjects: AffectedJSObjects = { isAllAffected: false, ids: [] },
+    actionDataPayloadConsolidated?: UpdateActionProps[],
   ): {
     unEvalUpdates: DataTreeDiff[];
     evalOrder: string[];
@@ -677,7 +679,7 @@ export default class DataTreeEvaluator {
 
     // Since eval tree is listening to possible events that don't cause differences
     // We want to check if no diffs are present and bail out early
-    if (differences.length === 0) {
+    if (differences.length === 0 && !actionDataPayloadConsolidated?.length) {
       return {
         removedPaths: [],
         unEvalUpdates: [],
@@ -724,7 +726,12 @@ export default class DataTreeEvaluator {
     this.dependencies = dependencies;
     this.inverseDependencies = inverseDependencies;
 
-    const pathsChangedSet = new Set<string[]>();
+    const pathsChangedSet = new Set<string[]>(
+      actionDataPayloadConsolidated?.map(({ dataPath, entityName }) => [
+        entityName,
+        dataPath,
+      ]) || [],
+    );
 
     for (const diff of differences) {
       if (isArray(diff.path)) {
@@ -741,10 +748,18 @@ export default class DataTreeEvaluator {
       undefined,
       webworkerTelemetry,
       () => {
+        const pathsToSkipFromEval =
+          actionDataPayloadConsolidated
+            ?.map(({ dataPath, entityName }) => {
+              return [entityName, dataPath];
+            })
+            .map((path: string[]) => path.join(".")) || [];
+
         return this.setupTree(updatedUnEvalTreeJSObjects, updatedValuePaths, {
           dependenciesOfRemovedPaths,
           removedPaths,
           translatedDiffs,
+          pathsToSkipFromEval,
         });
       },
     );


### PR DESCRIPTION
## Description
Whenever we have debounced updateActionData and an evalTree we will merge that to a single evaluation. Seeing a 10-20% reduction in LCP,  for a configured customer app we are seeing the LCP reduce from 20-23 seconds to about 15-20 seconds.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12715835754>
> Commit: 693a3f819beeaaca1a3c316dd8631fc7b31aa467
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12715835754&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Sat, 11 Jan 2025 16:27:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced evaluation and linting processes with support for consolidated action data payloads.
	- Improved dynamic updating of evaluation trees based on action data.

- **Chores**
	- Updated type definitions to support new data payload consolidation.

- **Technical Improvements**
	- Expanded functionality for handling complex action updates during tree evaluation.
	- Improved modularity and clarity in the code structure for action data updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->