### PR TITLE
chore:  Use zone as form

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Button/src/types.ts
+++ b/app/client/packages/design-system/widgets/src/components/Button/src/types.ts
@@ -41,4 +41,8 @@ export interface ButtonProps extends HeadlessButtonProps {
    * @default medium
    */
   size?: Omit<keyof typeof SIZES, "large">;
+  /** Indicates if the button should be disabled when the form is invalid */
+  disableOnInvalidForm?: boolean;
+  /** Indicates if the button should reset the form when clicked */
+  resetFormOnClick?: boolean;
 }

--- a/app/client/src/WidgetProvider/constants.ts
+++ b/app/client/src/WidgetProvider/constants.ts
@@ -14,7 +14,6 @@ import moment from "moment";
 import type { SVGProps } from "react";
 import type { WidgetFeatures } from "utils/WidgetFeatures";
 import type { WidgetProps } from "../widgets/BaseWidget";
-import type { ExtraDef } from "utils/autocomplete/defCreatorUtils";
 import type { WidgetEntityConfig } from "ee/entities/DataTree/types";
 import type {
   WidgetQueryConfig,
@@ -26,6 +25,8 @@ import type {
   Positioning,
   ResponsiveBehavior,
 } from "layoutSystems/common/utils/constants";
+import type { DerivedPropertiesMap } from "./factory/types";
+import type { ExtraDef } from "utils/autocomplete/types";
 
 export interface WidgetSizeConfig {
   viewportMinWidth: number;
@@ -125,7 +126,7 @@ export interface WidgetConfiguration extends WidgetBaseConfiguration {
     // TODO: Fix this the next time the file is edited
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     meta: Record<string, any>;
-    derived: Record<string, string>;
+    derived: DerivedPropertiesMap;
     loadingProperties?: Array<RegExp>;
     stylesheetConfig?: Stylesheet;
     autocompleteDefinitions?: AutocompletionDefinitions;

--- a/app/client/src/WidgetProvider/constants.ts
+++ b/app/client/src/WidgetProvider/constants.ts
@@ -12,7 +12,6 @@ import type { Stylesheet } from "entities/AppTheming";
 import { omit } from "lodash";
 import moment from "moment";
 import type { SVGProps } from "react";
-import type { DerivedPropertiesMap } from "WidgetProvider/factory";
 import type { WidgetFeatures } from "utils/WidgetFeatures";
 import type { WidgetProps } from "../widgets/BaseWidget";
 import type { ExtraDef } from "utils/autocomplete/defCreatorUtils";
@@ -126,7 +125,7 @@ export interface WidgetConfiguration extends WidgetBaseConfiguration {
     // TODO: Fix this the next time the file is edited
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     meta: Record<string, any>;
-    derived: DerivedPropertiesMap;
+    derived: Record<string, string>;
     loadingProperties?: Array<RegExp>;
     stylesheetConfig?: Stylesheet;
     autocompleteDefinitions?: AutocompletionDefinitions;

--- a/app/client/src/WidgetProvider/factory/index.tsx
+++ b/app/client/src/WidgetProvider/factory/index.tsx
@@ -42,11 +42,16 @@ import type {
   PasteDestinationInfo,
 } from "layoutSystems/anvil/utils/paste/types";
 import { call } from "redux-saga/effects";
+import type { DerivedPropertiesMap } from "./types";
+
+// exporting it as well so that existing imports are not affected
+// TODO: remove this once all imports are updated
+export type { DerivedPropertiesMap };
 
 // TODO: Fix this the next time the file is edited
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type WidgetDerivedPropertyType = any;
-export type DerivedPropertiesMap = Record<string, string>;
+
 export type WidgetType = (typeof WidgetFactory.widgetTypes)[number];
 
 class WidgetFactory {

--- a/app/client/src/WidgetProvider/factory/types.ts
+++ b/app/client/src/WidgetProvider/factory/types.ts
@@ -1,0 +1,1 @@
+export type DerivedPropertiesMap = Record<string, string>;

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -1,4 +1,4 @@
-import type { SupportedLayouts } from "reducers/entityReducers/pageListReducer";
+import type { SupportedLayouts } from "reducers/entityReducers/types";
 import type { WidgetType as FactoryWidgetType } from "WidgetProvider/factory";
 import { THEMEING_TEXT_SIZES } from "./ThemeConstants";
 import type { WidgetCardProps } from "widgets/BaseWidget";

--- a/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/RecaptchaV2.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/RecaptchaV2.tsx
@@ -21,15 +21,16 @@ export function RecaptchaV2(props: RecaptchaV2Props) {
   const {
     isDisabled,
     isLoading,
-    onPress: onClickProp,
+    onClick: onClickProp,
     onRecaptchaSubmitError = noop,
     onRecaptchaSubmitSuccess,
+    onReset,
     recaptchaKey,
   } = props;
   const onClick = () => {
-    if (isDisabled) return onClickProp;
+    if (isDisabled) return () => onClickProp?.(onReset);
 
-    if (isLoading) return onClickProp;
+    if (isLoading) return () => onClickProp?.(onReset);
 
     if (isInvalidKey) {
       // Handle incorrent google recaptcha site key
@@ -43,7 +44,7 @@ export function RecaptchaV2(props: RecaptchaV2Props) {
         .then((token: any) => {
           if (token) {
             if (typeof onRecaptchaSubmitSuccess === "function") {
-              onRecaptchaSubmitSuccess(token);
+              onRecaptchaSubmitSuccess(token, onReset);
             }
           } else {
             // Handle incorrent google recaptcha site key

--- a/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/RecaptchaV3.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/RecaptchaV3.tsx
@@ -17,16 +17,17 @@ export function RecaptchaV3(props: RecaptchaV3Props) {
   };
 
   const {
-    onPress: onClickProp,
+    onClick: onClickProp,
     onRecaptchaSubmitError = noop,
     onRecaptchaSubmitSuccess,
+    onReset,
     recaptchaKey,
   } = props;
 
   const onClick: ButtonComponentProps["onPress"] = () => {
-    if (props.isDisabled) return onClickProp;
+    if (props.isDisabled) return () => onClickProp?.(onReset);
 
-    if (props.isLoading) return onClickProp;
+    if (props.isLoading) return () => onClickProp?.(onReset);
 
     if (status === ScriptStatus.READY) {
       // TODO: Fix this the next time the file is edited
@@ -42,7 +43,7 @@ export function RecaptchaV3(props: RecaptchaV3Props) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             .then((token: any) => {
               if (typeof onRecaptchaSubmitSuccess === "function") {
-                onRecaptchaSubmitSuccess(token);
+                onRecaptchaSubmitSuccess(token, onReset);
               }
             })
             .catch(() => {

--- a/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/index.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/index.tsx
@@ -1,10 +1,11 @@
 import React from "react";
+import { Button, Tooltip } from "@appsmith/wds";
+import type { ButtonProps } from "@appsmith/wds";
 
 import { Container } from "./Container";
 import { useRecaptcha } from "./useRecaptcha";
 import type { UseRecaptchaProps } from "./useRecaptcha";
-import { Button, Tooltip } from "@appsmith/wds";
-import type { ButtonProps } from "@appsmith/wds";
+import { useWDSZoneWidgetContext } from "../../WDSZoneWidget/widget/context";
 
 export interface ButtonComponentProps extends ButtonProps {
   text?: string;
@@ -12,17 +13,26 @@ export interface ButtonComponentProps extends ButtonProps {
   isVisible?: boolean;
   isLoading: boolean;
   isDisabled?: boolean;
+  onClick?: (onReset?: () => void) => void;
 }
 
 function ButtonComponent(props: ButtonComponentProps & UseRecaptchaProps) {
   const { icon, text, tooltip, ...rest } = props;
+  const { isFormValid, onReset } = useWDSZoneWidgetContext();
+  const { onClick, recpatcha } = useRecaptcha({ ...props, onReset });
 
-  const { onClick, recpatcha } = useRecaptcha(props);
+  const isDisabled =
+    props.isDisabled || (props.disableOnInvalidForm && isFormValid === false);
 
   return (
     <Container>
       <Tooltip tooltip={tooltip}>
-        <Button icon={icon} {...rest} onPress={onClick}>
+        <Button
+          icon={icon}
+          {...rest}
+          isDisabled={isDisabled}
+          onPress={() => onClick?.(onReset)}
+        >
           {text}
         </Button>
       </Tooltip>

--- a/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/useRecaptcha.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/component/useRecaptcha.tsx
@@ -7,11 +7,15 @@ export interface UseRecaptchaProps {
   recaptchaKey?: string;
   recaptchaType?: RecaptchaType;
   onRecaptchaSubmitError?: (error: string) => void;
-  onRecaptchaSubmitSuccess?: (token: string) => void;
+  onRecaptchaSubmitSuccess?: (token: string, onReset?: () => void) => void;
   handleRecaptchaV2Loading?: (isLoading: boolean) => void;
 }
 
-export type RecaptchaProps = ButtonComponentProps & UseRecaptchaProps;
+export type RecaptchaProps = ButtonComponentProps &
+  UseRecaptchaProps & {
+    onReset?: () => void;
+    onClick?: (onReset?: () => void) => void;
+  };
 
 interface UseRecaptchaReturn {
   // TODO: Fix this the next time the file is edited
@@ -21,10 +25,10 @@ interface UseRecaptchaReturn {
 }
 
 export const useRecaptcha = (props: RecaptchaProps): UseRecaptchaReturn => {
-  const { onPress: onClickProp, recaptchaKey } = props;
+  const { onClick: onClickProp, recaptchaKey } = props;
 
   if (!recaptchaKey) {
-    return { onClick: onClickProp };
+    return { onClick: () => onClickProp?.(props?.onReset) };
   }
 
   if (props.recaptchaType === "V2") {

--- a/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/config/defaultsConfig.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/config/defaultsConfig.ts
@@ -15,7 +15,7 @@ export const defaultsConfig = {
   widgetName: "Button",
   isDisabled: false,
   isVisible: true,
-  disabledWhenInvalid: false,
+  disableOnInvalidForm: false,
   resetFormOnClick: false,
   recaptchaType: RecaptchaTypes.V3,
   version: 1,

--- a/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/config/propertyPaneConfig/contentConfig.ts
@@ -118,4 +118,31 @@ export const propertyPaneContentConfig = [
       },
     ],
   },
+  {
+    sectionName: "Form settings",
+    children: [
+      {
+        helpText:
+          "Disabled if the form is invalid, if this widget exists directly within a Form widget.",
+        propertyName: "disableOnInvalidForm",
+        label: "Disable when form invalid",
+        controlType: "SWITCH",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: { type: ValidationTypes.BOOLEAN },
+      },
+      {
+        helpText:
+          "Resets the fields of the form, on click, if this widget exists directly within a Form widget.",
+        propertyName: "resetFormOnClick",
+        label: "Reset form on success",
+        controlType: "SWITCH",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: { type: ValidationTypes.BOOLEAN },
+      },
+    ],
+  },
 ];

--- a/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/widget/types.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSButtonWidget/widget/types.ts
@@ -9,7 +9,7 @@ export interface ButtonWidgetState extends WidgetState {
 
 export interface ButtonWidgetProps
   extends WidgetProps,
-    Omit<ButtonComponentProps, "type"> {
+    Omit<ButtonComponentProps, "type" | "onClick"> {
   text?: string;
   isVisible?: boolean;
   isDisabled?: boolean;
@@ -17,4 +17,5 @@ export interface ButtonWidgetProps
   googleRecaptchaKey?: string;
   recaptchaType?: RecaptchaType;
   disabledWhenInvalid?: boolean;
+  onClick?: string;
 }

--- a/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/config/defaultConfig.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/config/defaultConfig.ts
@@ -23,6 +23,7 @@ export const defaultConfig: WidgetDefaultProps = {
   version: 1,
   widgetName: "Zone",
   isVisible: true,
+  useAsForm: false,
   blueprint: {
     operations: [
       {

--- a/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/config/propertyPaneContent.ts
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/config/propertyPaneContent.ts
@@ -28,6 +28,16 @@ export const propertyPaneContent = [
     sectionName: "General",
     children: [
       {
+        propertyName: "useAsForm",
+        label: "Use as a form",
+        helpText: "Controls the visibility of the widget",
+        controlType: "SWITCH",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: { type: ValidationTypes.BOOLEAN },
+      },
+      {
         helpText: "Controls the visibility of the widget",
         propertyName: "isVisible",
         label: "Visible",

--- a/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/context.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/context.tsx
@@ -1,0 +1,61 @@
+import { useSelector } from "react-redux";
+import { getCanvasWidgets } from "ee/selectors/entitiesSelector";
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from "react";
+import type { WidgetProps } from "widgets/BaseWidget";
+import { getDataTree } from "selectors/dataTreeSelectors";
+
+interface WDSZoneWidgetContextType {
+  isFormValid: boolean;
+  onReset?: () => void;
+}
+
+const WDSZoneWidgetContext = createContext<
+  WDSZoneWidgetContextType | undefined
+>(undefined);
+
+export const useWDSZoneWidgetContext = () => {
+  const context = useContext(WDSZoneWidgetContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useWDSZoneWidgetContext must be used within a WDSZoneWidgetProvider",
+    );
+  }
+
+  return context;
+};
+
+export const WDSZoneWidgetContextProvider = (props: {
+  children: ReactNode;
+  widget: WidgetProps;
+  useAsForm?: boolean;
+  onReset?: () => void;
+}) => {
+  const { onReset, useAsForm, widget } = props;
+  const canvasWidgets = useSelector(getCanvasWidgets);
+  const dataTree = useSelector(getDataTree);
+  const isFormValid = useMemo(() => {
+    if (!useAsForm) return true;
+
+    const children = widget.children as WidgetProps["children"];
+
+    return children.reduce((isValid: boolean, child: WidgetProps) => {
+      const widget = dataTree[canvasWidgets[child.widgetId].widgetName];
+
+      return "isValid" in widget ? widget.isValid && isValid : isValid;
+    }, true);
+  }, [widget, canvasWidgets, dataTree, useAsForm]);
+
+  return (
+    <WDSZoneWidgetContext.Provider value={{ isFormValid, onReset }}>
+      {props.children}
+    </WDSZoneWidgetContext.Provider>
+  );
+};
+
+export default WDSZoneWidgetContext;

--- a/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/index.tsx
+++ b/app/client/src/modules/ui-builder/ui/wds/WDSZoneWidget/widget/index.tsx
@@ -34,6 +34,7 @@ import type {
 import { call } from "redux-saga/effects";
 import { pasteWidgetsInZone } from "layoutSystems/anvil/utils/paste/zonePasteUtils";
 import { SectionColumns } from "layoutSystems/anvil/sectionSpaceDistributor/constants";
+import { WDSZoneWidgetContextProvider } from "./context";
 
 class WDSZoneWidget extends BaseWidget<WDSZoneWidgetProps, WidgetState> {
   static type = anvilWidgets.ZONE_WIDGET;
@@ -143,6 +144,10 @@ class WDSZoneWidget extends BaseWidget<WDSZoneWidgetProps, WidgetState> {
     return res;
   }
 
+  onReset = () => {
+    this.resetChildrenMetaProperty(this.props.widgetId);
+  };
+
   getWidgetView(): ReactNode {
     return (
       <ContainerComponent
@@ -150,7 +155,13 @@ class WDSZoneWidget extends BaseWidget<WDSZoneWidgetProps, WidgetState> {
         elevation={Elevations.ZONE_ELEVATION}
         {...this.props}
       >
-        <LayoutProvider {...this.props} />
+        <WDSZoneWidgetContextProvider
+          onReset={this.onReset}
+          useAsForm={this.props.useAsForm}
+          widget={this.props}
+        >
+          <LayoutProvider {...this.props} />
+        </WDSZoneWidgetContextProvider>
       </ContainerComponent>
     );
   }
@@ -158,6 +169,7 @@ class WDSZoneWidget extends BaseWidget<WDSZoneWidgetProps, WidgetState> {
 
 export interface WDSZoneWidgetProps extends ContainerWidgetProps<WidgetProps> {
   layout: LayoutProps[];
+  useAsForm?: boolean;
 }
 
 export default WDSZoneWidget;

--- a/app/client/src/reducers/entityReducers/pageListReducer.tsx
+++ b/app/client/src/reducers/entityReducers/pageListReducer.tsx
@@ -16,6 +16,11 @@ import { sortBy } from "lodash";
 import type { DSL } from "reducers/uiReducers/pageCanvasStructureReducer";
 import { createReducer } from "utils/ReducerUtils";
 import type { Page } from "entities/Page";
+import type { SupportedLayouts } from "./types";
+
+// exporting it as well so that existing imports are not affected
+// TODO: remove this once all imports are updated
+export type { SupportedLayouts };
 
 const initialState: PageListReduxState = {
   pages: [],
@@ -312,13 +317,6 @@ export const pageListReducer = createReducer(initialState, {
     return { ...state, pages: sortedPages };
   },
 });
-
-export type SupportedLayouts =
-  | "DESKTOP"
-  | "TABLET_LARGE"
-  | "TABLET"
-  | "MOBILE"
-  | "FLUID";
 
 export interface AppLayoutConfig {
   type: SupportedLayouts;

--- a/app/client/src/reducers/entityReducers/types.ts
+++ b/app/client/src/reducers/entityReducers/types.ts
@@ -1,0 +1,6 @@
+export type SupportedLayouts =
+  | "DESKTOP"
+  | "TABLET_LARGE"
+  | "TABLET"
+  | "MOBILE"
+  | "FLUID";

--- a/app/client/src/utils/autocomplete/defCreatorUtils.ts
+++ b/app/client/src/utils/autocomplete/defCreatorUtils.ts
@@ -7,8 +7,9 @@ import type { Def } from "tern";
 import { Types, getType } from "utils/TypeHelpers";
 import { shouldAddSetter } from "workers/Evaluation/evaluate";
 import { typeToTernType } from "workers/common/JSLibrary/ternDefinitionGenerator";
+import type { ExtraDef } from "./types";
 
-export type ExtraDef = Record<string, Def | string>;
+export type { ExtraDef };
 
 export const flattenDef = (def: Def, entityName: string): Def => {
   const flattenedDef = def;

--- a/app/client/src/utils/autocomplete/types.ts
+++ b/app/client/src/utils/autocomplete/types.ts
@@ -1,3 +1,5 @@
+import type { Def } from "tern";
+
 export enum TernWorkerAction {
   INIT = "INIT",
   ADD_FILE = "ADD_FILE",
@@ -12,3 +14,5 @@ export enum TernWorkerAction {
 // TODO: Fix this the next time the file is edited
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CallbackFn = (...args: any) => any;
+
+export type ExtraDef = Record<string, Def | string>;


### PR DESCRIPTION
Fixes #38525 

/ok-to-test tags="@tag.Anvil"

https://github.com/user-attachments/assets/891ecf61-2850-46c4-acd3-b170196e5ab7



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12703524629>
> Commit: 64616e2f16ed1884c0e7fd86f511b35801b17b88
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12703524629&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`
> Spec:
> <hr>Fri, 10 Jan 2025 05:20:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added form validation controls for buttons
  - Introduced ability to disable buttons on invalid form
  - Added option to reset form on button click
  - New context provider for managing widget state in UI builder

- **Improvements**
  - Enhanced reCAPTCHA handling with reset functionality
  - Updated button click event management
  - Improved widget context management

- **Configuration Updates**
  - New form settings for button widgets
  - Added `useAsForm` configuration for zone widgets

These updates provide more granular control over form interactions and button behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->