### PR TITLE
fix: Show bindings hiding behind scroll

### DIFF
--- a/app/client/src/components/editorComponents/PropertyPaneSidebar.tsx
+++ b/app/client/src/components/editorComponents/PropertyPaneSidebar.tsx
@@ -16,12 +16,14 @@ import { getIsDraggingOrResizing } from "selectors/widgetSelectors";
 import { selectedWidgetsPresentInCanvas } from "selectors/propertyPaneSelectors";
 import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
+import { selectCombinedPreviewMode } from "selectors/gitModSelectors";
 
 export const PROPERTY_PANE_ID = "t--property-pane-sidebar";
 
 export const PropertyPaneSidebar = memo(() => {
   const sidebarRef = useRef<HTMLDivElement>(null);
   const prevSelectedWidgetId = useRef<string | undefined>();
+  const isPreviewMode = useSelector(selectCombinedPreviewMode);
 
   const selectedWidgetIds = useSelector(getSelectedWidgets);
   const isDraggingOrResizing = useSelector(getIsDraggingOrResizing);
@@ -31,6 +33,7 @@ export const PropertyPaneSidebar = memo(() => {
   //the current selected WidgetId is not equal to previous widget id,
   //then don't render PropertyPane
   const shouldNotRenderPane =
+    isPreviewMode ||
     (isDraggingOrResizing &&
       selectedWidgetIds[0] !== prevSelectedWidgetId.current) ||
     selectedWidgetIds[0] === MAIN_CONTAINER_WIDGET_ID;

--- a/app/client/src/pages/Editor/IDE/Layout/StaticLayout.tsx
+++ b/app/client/src/pages/Editor/IDE/Layout/StaticLayout.tsx
@@ -40,7 +40,6 @@ const GridContainer = styled.div`
 const LayoutContainer = styled.div<{ name: string }>`
   position: relative;
   grid-area: ${(props) => props.name};
-  overflow: auto;
 `;
 
 export const StaticLayout = React.memo(() => {


### PR DESCRIPTION
## Description

Fixes the show bindings been hidden because of the overflow setting. This was introduced in #38274 
To fix the original issue, we have made sure property pane does not render when in preview mode 


Fixes #38547

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12686267032>
> Commit: e374708aabcfe3efa6ff6a74aadc3beca494c6ef
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12686267032&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Thu, 09 Jan 2025 09:08:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added preview mode detection in the Property Pane Sidebar
- **Style**
	- Removed overflow restriction in Layout Container
- **Bug Fixes**
	- Adjusted property pane rendering logic to respect preview mode state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->