### PR TITLE
fix: Added login for better flow

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Admin_settings_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Admin_settings_spec.ts
@@ -2,6 +2,7 @@ import adminsSettings from "../../../../locators/AdminsSettings";
 import {
   agHelper,
   adminSettings as adminSettingsHelper,
+  homePage,
 } from "../../../../support/Objects/ObjectsCore";
 
 const {
@@ -210,9 +211,9 @@ describe("Admin settings page", { tags: ["@tag.Settings"] }, function () {
     "11. Verify all admin setting sections are accessible",
     { tags: ["@tag.excludeForAirgap"] },
     () => {
-      cy.LogOut();
+      homePage.LogOutviaAPI();
       cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
-      cy.visit("/applications", { timeout: 60000 });
+      agHelper.VisitNAssert("/applications", "getAllWorkspaces");
       agHelper.GetNClick(adminSettingsHelper._adminSettingsBtn);
       cy.wait("@getEnvVariables");
       agHelper.GetNClick(adminsSettings.generalTab);

--- a/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Admin_settings_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Admin_settings_spec.ts
@@ -210,6 +210,8 @@ describe("Admin settings page", { tags: ["@tag.Settings"] }, function () {
     "11. Verify all admin setting sections are accessible",
     { tags: ["@tag.excludeForAirgap"] },
     () => {
+      cy.LogOut();
+      cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
       cy.visit("/applications", { timeout: 60000 });
       agHelper.GetNClick(adminSettingsHelper._adminSettingsBtn);
       cy.wait("@getEnvVariables");


### PR DESCRIPTION
## Description
Fix for flaky behaviour.


Fixes # https://app.zenhub.com/workspaces/stability-pod-6690c4814e31602e25cab7fd/issues/gh/appsmithorg/appsmith/38568


## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12705899394>
> Commit: e193fb3ff3ef923ed8b53b080935e932bd1a688a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12705899394&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Fri, 10 Jan 2025 08:50:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated the existing test case to verify accessibility of all admin setting sections.
	- Enhanced reliability by ensuring a fresh user session before testing admin settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->