### PR TITLE
fix: Response view not passing error to support

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/Response/components/ErrorView/ErrorView.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/Response/components/ErrorView/ErrorView.tsx
@@ -82,6 +82,7 @@ export const ErrorView: React.FC<ErrorViewProps> = ({
           <div data-testid="t--response-error">{errorMessage}</div>
           <LogHelper
             logType={LOG_TYPE.ACTION_EXECUTION_ERROR}
+            message={`${errorMessage}`}
             name="PluginExecutionError"
             pluginErrorDetails={
               actionResponse && actionResponse.pluginErrorDetails


### PR DESCRIPTION
## Description

Make sure the error message is passing to the Log helper so that it can relay it to Appsmith support when invoked

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12708128489>
> Commit: 585747d3908cb8b4001058d2c48eda0bc7ad0f08
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12708128489&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 10 Jan 2025 11:37:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging by adding more detailed error message information to the `LogHelper` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->