### PR TITLE
fix: Fix copy issue in embedsetting spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
@@ -54,10 +54,7 @@ describe("Embed settings options", { tags: ["@tag.Settings"] }, function () {
 
     cy.window().then((win) => {
       new Cypress.Promise((resolve, reject) => {
-        win.navigator.clipboard
-          .readText()
-          .then(resolve)
-          .catch(reject);
+        win.navigator.clipboard.readText().then(resolve).catch(reject);
       }).then((text) => {
         clipboardData = text; // Store the clipboard content in a variable
         cy.log(`Clipboard Content: ${clipboardData}`); // Log clipboard content

--- a/app/client/cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
@@ -18,6 +18,8 @@ describe("Embed settings options", { tags: ["@tag.Settings"] }, function () {
     );
   };
 
+  let clipboardData;
+
   function ValidateEditModeSetting(setting) {
     _.deployMode.NavigateBacktoEditor();
     _.embedSettings.OpenEmbedSettings();
@@ -31,6 +33,7 @@ describe("Embed settings options", { tags: ["@tag.Settings"] }, function () {
   }
 
   before(() => {
+    _.agHelper.GiveChromeCopyPermission();
     _.homePage.NavigateToHome();
     _.homePage.CreateNewApplication();
     _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.IFRAME);
@@ -48,9 +51,25 @@ describe("Embed settings options", { tags: ["@tag.Settings"] }, function () {
       .click()
       .wait(1000);
     _.agHelper.ClickButton("Copy application url");
+
     cy.window().then((win) => {
-      cy.stub(win.navigator.clipboard, "writeText").as("deployUrl").resolves();
+      new Cypress.Promise((resolve, reject) => {
+        win.navigator.clipboard
+          .readText()
+          .then(resolve)
+          .catch(reject);
+      }).then((text) => {
+        clipboardData = text; // Store the clipboard content in a variable
+        cy.log(`Clipboard Content: ${clipboardData}`); // Log clipboard content
+        expect(clipboardData).to.equal("Expected clipboard text"); // Add assertions if needed
+      });
     });
+
+    // Log clipboard data after it's been set
+    cy.then(() => {
+      cy.log(`Stored Clipboard Data: ${clipboardData}`);
+    });
+
     cy.enablePublicAccess();
     cy.wait(8000); //adding wait time for iframe to load fully!
     _.agHelper.RefreshPage();
@@ -67,10 +86,8 @@ describe("Embed settings options", { tags: ["@tag.Settings"] }, function () {
     cy.get(adminSettings.saveButton).click();
     cy.waitForServerRestart();
     _.agHelper.Sleep(2000);
-    cy.get("@deployUrl").then((depUrl) => {
-      cy.log("deployUrl is " + depUrl);
-      cy.visit(depUrl, { timeout: 60000 });
-    });
+
+    cy.visit(clipboardData, { timeout: 60000 });
     getIframeBody().contains("Submit").should("exist");
     ValidateEditModeSetting(_.embedSettings.locators._restrictedText);
     // });
@@ -84,10 +101,7 @@ describe("Embed settings options", { tags: ["@tag.Settings"] }, function () {
     cy.get(adminSettings.saveButton).click();
     cy.waitForServerRestart();
     _.agHelper.Sleep(2000);
-    cy.get("@deployUrl").then((depUrl) => {
-      cy.log("deployUrl is " + depUrl);
-      cy.visit(depUrl, { timeout: 60000 });
-    });
+    cy.visit(clipboardData, { timeout: 60000 });
     getIframeBody().contains("Submit").should("exist");
     ValidateEditModeSetting(_.embedSettings.locators._allowAllText);
     // });
@@ -98,13 +112,11 @@ describe("Embed settings options", { tags: ["@tag.Settings"] }, function () {
     cy.get(".t--admin-settings-APPSMITH_ALLOWED_FRAME_ANCESTORS").within(() => {
       cy.get("input").last().click();
     });
+
     cy.get(adminSettings.saveButton).click();
     cy.waitForServerRestart();
     _.agHelper.Sleep(2000);
-    cy.get("@deployUrl").then((depUrl) => {
-      cy.log("deployUrl is " + depUrl);
-      cy.visit(depUrl, { timeout: 60000 });
-    });
+    cy.visit(clipboardData, { timeout: 60000 });
     getIframeBody().contains("Submit").should("not.exist");
 
     ValidateEditModeSetting(_.embedSettings.locators._disabledText);

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -2,6 +2,6 @@
 #cypress/e2e/Regression/ClientSide/VisualTests/JSEditorIndent_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
-cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
+cypress/e2e/Regression/ClientSide/Anvil/Widgets/*
 
 #ci-test-limit uses this file to run minimum of specs. Do not run entire suite with this command.

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -2,6 +2,6 @@
 #cypress/e2e/Regression/ClientSide/VisualTests/JSEditorIndent_spec.js
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
-cypress/e2e/Regression/ClientSide/Anvil/Widgets/*
+cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
 
 #ci-test-limit uses this file to run minimum of specs. Do not run entire suite with this command.


### PR DESCRIPTION
## Description
RCA: Found the copy the clipboard is not working in chrome. Have enabled spec specific permission for copy and the store the cypress variable in local variable to get firm run results.


Fixes # https://app.zenhub.com/workspaces/qa-63316faf86bb2e170ed2e46b/issues/gh/appsmithorg/appsmith/38589

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12740837386>
> Commit: e1903dbd34f17722bf798e4a79687cb6201a78ed
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12740837386&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Mon, 13 Jan 2025 05:11:28 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated clipboard handling in end-to-end testing
	- Improved clipboard permission and content retrieval for test scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->