### PR TITLE
ci: Checking no_data with contains to avoid error

### DIFF
--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -144,35 +144,47 @@ jobs:
       # Step to get specs from the file or use the provided specs
       - name: Get specs to run
         run: |
-          # Check if specs_to_run is provided; if not, use the fallback file
-          echo "[DEBUG] Initial specs_to_run value: $specs_to_run"
-          if [[ -z "$specs_to_run" || "$specs_to_run" == "no_data" ]]; then
-            echo "[INFO] No specs provided, falling back to limited-tests.txt file."
-            
-            # Verify if the fallback file exists
-            if [[ ! -f app/client/cypress/limited-tests.txt ]]; then
-              echo "[ERROR] limited-tests.txt file not found in app/client/cypress!" >&2
-              exit 1
-            else
-              echo "[DEBUG] limited-tests.txt file found. Proceeding to read specs."
-            fi
+          ls -l
+          echo "[DEBUG] Checking inputs.specs_to_run: '${{ inputs.specs_to_run }}'"
+          echo "[DEBUG] Checking github.event.inputs.specs_to_run: '${{ github.event.inputs.specs_to_run }}'"
+          
+          # Determine the source of the specs_to_run input
+          if [[ -n "${{ inputs.specs_to_run }}" ]]; then
+            specs_to_run="${{ inputs.specs_to_run }}" # For workflow_call
+            echo "[INFO] specs_to_run provided via workflow_call: $specs_to_run"
+          elif [[ -n "${{ github.event.inputs.specs_to_run }}" ]]; then
+            specs_to_run="${{ github.event.inputs.specs_to_run }}" # For workflow_dispatch
+            echo "[INFO] specs_to_run provided via workflow_dispatch: $specs_to_run"
+          else
+            specs_to_run=""
+            echo "[INFO] No specs provided. Falling back to limited-tests.txt."
+          fi
 
+          # Check if specs_to_run is provided; if not, use the fallback file
+          echo "[DEBUG] Initial specs_to_run value: '$specs_to_run'"
+
+          if [[ "$specs_to_run" == *"no_data"* || -z "$specs_to_run" || "$specs_to_run" == "" ]]; then
+            echo "[INFO] No specs provided or 'no_data' detected, falling back to limited-tests.txt file."
+
+            # Verify if the fallback file exists
+            limited_tests_file="${{ github.workspace }}/app/client/cypress/limited-tests.txt"
+            ls -l ${{ github.workspace }}/app/client/cypress/limited-tests.txt
+            cat ${{ github.workspace }}/app/client/cypress/limited-tests.txt
             specs_to_run=""
 
             # Read each line of limited-tests.txt
             while IFS= read -r line || [[ -n "$line" ]]; do
-              # Log each line being read
-              echo "[DEBUG] Reading line: $line"
+              echo "[DEBUG] Read line: '$line'" 
 
               # Skip comments and empty lines
               if [[ $line =~ ^#|^\/\/ || -z $line ]]; then
-                echo "[DEBUG] Skipping comment/empty line: $line"
+                echo "[DEBUG] Skipped line: '$line'" # Indicate skipped lines
                 continue
-              else
-                echo "[DEBUG] Adding spec to specs_to_run: $line"
-                specs_to_run="$specs_to_run,$line"
               fi
-            done < app/client/cypress/limited-tests.txt
+
+              # Add the line to specs_to_run
+              specs_to_run="$specs_to_run,$line"
+            done < ${{ github.workspace }}/app/client/cypress/limited-tests.txt
 
             # Remove leading comma
             specs_to_run=${specs_to_run#,}
@@ -187,10 +199,8 @@ jobs:
             echo "[INFO] Using provided specs: $specs_to_run"
           fi
 
-          # Log the final specs_to_run value before writing it to GitHub environment
+          # Log the final specs_to_run value
           echo "[DEBUG] Setting specs_to_run to GitHub environment variable: $specs_to_run"
-
-          # Set the final specs_to_run to GitHub environment variable
           echo "specs_to_run=$specs_to_run" >> $GITHUB_ENV
           
 


### PR DESCRIPTION
## Description
Found that existing text file was not reading when no_data passed. Fixed the problem by adding that condition.

Fixes # https://app.zenhub.com/workspaces/qa-63316faf86bb2e170ed2e46b/issues/gh/appsmithorg/appsmith/38591

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12740786426>
> Commit: 7c4e5488fb4dfc564b9d34feaba0f2312277f54f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12740786426&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 13 Jan 2025 05:09:41 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for improved test specification handling
	- Enhanced debug logging and error handling in CI test workflow
	- Refined mechanism for processing test input sources
	- Added more robust file checking and fallback logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->