### PR TITLE
fix: [ADS] Entity Tree node overflow

### DIFF
--- a/app/client/packages/design-system/ads/src/Templates/EntityExplorer/EntityListTree/EntityListTree.styles.ts
+++ b/app/client/packages/design-system/ads/src/Templates/EntityExplorer/EntityListTree/EntityListTree.styles.ts
@@ -11,6 +11,7 @@ export const CollapseSpacer = styled.div`
 
 export const PaddingOverrider = styled.div`
   width: 100%;
+  overflow-x: hidden;
 
   & > div {
     // Override the padding of the entity item since collapsible icon can be on the left


### PR DESCRIPTION
## Description

Fixes the overflow of Entity item node that happens in deeply nested items

Before
<img width="333" alt="Screenshot 2025-01-14 at 4 22 10 PM" src="https://github.com/user-attachments/assets/63dac946-c91d-43c1-ab49-604541a22132" />

After
<img width="349" alt="Screenshot 2025-01-14 at 4 21 42 PM" src="https://github.com/user-attachments/assets/5f8d6315-ab05-4402-86e3-5b72b3f67121" />



## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12766145527>
> Commit: 5966a75c0b0c8df38890dec49130065020b5502b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12766145527&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Tue, 14 Jan 2025 11:29:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated component styling to prevent horizontal scrolling in the entity list tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->