### PR TITLE
chore: Fix theme CE change only in EE

### DIFF
--- a/app/client/packages/design-system/theming/src/hooks/src/useTheme.tsx
+++ b/app/client/packages/design-system/theming/src/hooks/src/useTheme.tsx
@@ -1,16 +1,14 @@
 import Color from "colorjs.io";
 import { useMemo } from "react";
 import { TokensAccessor, defaultTokens, tokensConfigs } from "../../token";
-import {
-  useSizing,
-  useSpacing,
-  useTypography,
-  useIconSizing,
-  useIconDensity,
-} from "./";
 
 import type { ColorMode } from "../../color";
 import type { TokenSource } from "../../token";
+import { useSizing } from "./useSizing";
+import { useSpacing } from "./useSpacing";
+import { useTypography } from "./useTypography";
+import { useIconSizing } from "./useIconSizing";
+import { useIconDensity } from "./useIconDensity";
 
 const tokensAccessor = new TokensAccessor({
   ...(defaultTokens as TokenSource),


### PR DESCRIPTION
## Description

While working on https://github.com/appsmithorg/appsmith-ee/pull/5914 saw that this certain CE change was only applied in EE. This PR makes sure the file in both repo is consistent


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12784507851>
> Commit: 89ff9b8758f04d55c320ef7cbc14664385fce56a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12784507851&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 15 Jan 2025 09:20:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated import statements in the `useTheme` hook to use explicit imports for theming-related hooks
	- Improved code clarity by specifying individual hook sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->