### PR TITLE
fix: AI query not showing any bottom tabs

### DIFF
--- a/app/client/src/ce/PluginActionEditor/components/PluginActionResponse/hooks/usePluginActionResponseTabs.tsx
+++ b/app/client/src/ce/PluginActionEditor/components/PluginActionResponse/hooks/usePluginActionResponseTabs.tsx
@@ -112,6 +112,7 @@ function usePluginActionResponseTabs() {
   if (
     [
       PluginType.DB,
+      PluginType.AI,
       PluginType.REMOTE,
       PluginType.SAAS,
       PluginType.INTERNAL,


### PR DESCRIPTION
## Description

fixes an incorrect merge resolution that happened in https://github.com/appsmithorg/appsmith/pull/38368/files#diff-b600a43ecf839dcfa5626f565229391ac7eedf26c2c51e201f379e26bda3a5a2L111


## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12803566566>
> Commit: bf2ad2542b38e7a5007718ee9b9bb6167738efe4
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12803566566&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Thu, 16 Jan 2025 07:35:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for AI plugin type in the plugin action response tabs configuration.
	- Enabled "Datasource" tab display for AI plugins when specific conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->