### PR TITLE
fix: Workflow query conversion

### DIFF
--- a/app/client/src/pages/Editor/AppPluginActionEditor/components/ConvertToModule/ConvertToModuleCTA.tsx
+++ b/app/client/src/pages/Editor/AppPluginActionEditor/components/ConvertToModule/ConvertToModuleCTA.tsx
@@ -10,9 +10,10 @@ import {
 } from "ee/utils/BusinessFeatures/permissionPageHelpers";
 import { MODULE_TYPE } from "ee/constants/ModuleConstants";
 import ConvertToModuleInstanceCTA from "ee/pages/Editor/EntityEditor/ConvertToModuleInstanceCTA";
+import { PluginType } from "entities/Plugin";
 
 const ConvertToModuleCTA = () => {
-  const { action } = usePluginActionContext();
+  const { action, plugin } = usePluginActionContext();
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
   const pagePermissions = useSelector(getPagePermissions);
   const isCreatePermitted = getHasCreateActionPermission(
@@ -23,6 +24,12 @@ const ConvertToModuleCTA = () => {
     isFeatureEnabled,
     action.userPermissions,
   );
+
+  if (plugin.type === PluginType.INTERNAL) {
+    // Workflow queries cannot be converted to modules
+    return null;
+  }
+
   const convertToModuleProps = {
     canCreateModuleInstance: isCreatePermitted,
     canDeleteEntity: isDeletePermitted,


### PR DESCRIPTION
## Description

Don't show "Convert to module" for a workflow query

Shadow EE PR: https://github.com/appsmithorg/appsmith-ee/pull/5958


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12805150630>
> Commit: cfb2b2f46c887283df42f8adfb969af77a0cb4aa
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12805150630&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 16 Jan 2025 10:26:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented conversion of workflow queries to modules for internal plugins
	- Updated plugin context retrieval to include plugin information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->