### PR TITLE
chore: disable sourcemaps for non-prod builds and cleanup craco configs

### DIFF
--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -18,6 +18,6 @@ export REACT_APP_SENTRY_RELEASE=$GIT_SHA
 export REACT_APP_CLIENT_LOG_LEVEL=ERROR
 # Disable CRA built-in ESLint checks since we have our own config and a separate step for this
 export DISABLE_ESLINT_PLUGIN=true
-craco --max-old-space-size=10240 build --config craco.build.config.js
+craco --max-old-space-size=7168 build --config craco.build.config.js
 
 echo "build finished"

--- a/app/client/craco.build.config.js
+++ b/app/client/craco.build.config.js
@@ -53,8 +53,6 @@ if (env === "PRODUCTION" || env === "STAGING") {
   );
 }
 
-plugins.push(new CompressionPlugin());
-
 plugins.push(
   new CompressionPlugin({
     algorithm: "brotliCompress",
@@ -78,17 +76,16 @@ plugins.push(
 );
 
 module.exports = merge(common, {
-  webpack: {
-    configure: {
-      plugins,
+  babel: {
+    plugins: ["babel-plugin-lodash"],
+    loaderOptions: {
+      cacheDirectory: false,
     },
   },
-  jest: {
+  webpack: {
     configure: {
-      moduleNameMapper: {
-        // Jest module mapper which will detect our absolute imports.
-        "^@test(.*)$": "<rootDir>/test$1",
-      },
+      devtool: env === "PRODUCTION" ? "source-map" : false,
+      plugins,
     },
   },
   plugins: [

--- a/app/client/craco.build.config.js
+++ b/app/client/craco.build.config.js
@@ -38,7 +38,7 @@ plugins.push(
   }),
 );
 
-if (env === "PRODUCTION" || env === "STAGING") {
+if (env === "PRODUCTION") {
   plugins.push(
     new FaroSourceMapUploaderPlugin({
       appId: process.env.REACT_APP_FARO_APP_ID,

--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -4,19 +4,6 @@ const path = require("path");
 const webpack = require("webpack");
 
 module.exports = {
-  devServer: {
-    client: {
-      webSocketURL: {
-        hostname: "127.0.0.1",
-        pathname: "/ws",
-        port: 3000,
-        protocol: "ws",
-      },
-    },
-  },
-  babel: {
-    plugins: ["babel-plugin-lodash"],
-  },
   eslint: {
     enable: false,
   },

--- a/app/client/craco.dev.config.js
+++ b/app/client/craco.dev.config.js
@@ -5,23 +5,31 @@ const common = require("./craco.common.config.js");
 module.exports = merge(common, {
   devServer: {
     client: {
+      webSocketURL: {
+        hostname: "127.0.0.1",
+        pathname: "/ws",
+        port: 3000,
+        protocol: "ws",
+      },
       overlay: {
         warnings: false,
         errors: false,
       },
     },
   },
-  optimization: {
-    minimize: false,
-  },
-  cache: {
-    type: "filesystem",
-    memoryCacheUnaffected: true,
-  },
-  experiments: {
-    cacheUnaffected: true,
-  },
   webpack: {
+    configure: {
+      optimization: {
+        minimize: false,
+      },
+      cache: {
+        type: "filesystem",
+        memoryCacheUnaffected: true,
+      },
+      experiments: {
+        cacheUnaffected: true,
+      },
+    },
     plugins: [
       new WorkboxPlugin.InjectManifest({
         swSrc: "./src/serviceWorker.ts",


### PR DESCRIPTION
## Description
- reduce --max-old-space-size to 7168 for build. [Test for EE here](https://github.com/appsmithorg/appsmith-ee/pull/5932).
- disable sourcemaps for non-prod build
- cleanup craco configs

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12825105662>
> Commit: 80b63a627b312f486f0d0baccf8a7d98b810471d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12825105662&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Binding/Api_withPageload_Input_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Fri, 17 Jan 2025 09:34:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Reduced memory allocation for the build process.
	- Updated Webpack configuration with Brotli compression.
	- Modified WebSocket settings for the development server.
	- Streamlined build configuration by removing unnecessary sections.

- **Performance Optimization**
	- Adjusted build memory limits.
	- Improved compression algorithm for build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->