### PR TITLE
fix: suppress error toast for update notifications

### DIFF
--- a/app/client/src/api/interceptors/response/failureHandlers/handleBadRequestError.ts
+++ b/app/client/src/api/interceptors/response/failureHandlers/handleBadRequestError.ts
@@ -12,18 +12,10 @@ export const handleBadRequestError = async (error: AxiosError<ApiResponse>) => {
     SERVER_ERROR_CODES.VERSION_MISMATCH.includes("" + errorCode)
   ) {
     const responseData = error?.response?.data;
-    const message = responseData?.responseMeta.error?.message;
     const serverVersion = (responseData?.data as { serverVersion: string })
       .serverVersion;
 
     handleVersionMismatch(getAppsmithConfigs().appVersion.id, serverVersion);
-
-    return Promise.reject({
-      ...error,
-      clientDefinedError: true,
-      statusCode: errorCode,
-      message,
-    });
   }
 
   return null;


### PR DESCRIPTION
## Description
Prevents error toasts for errors designed to show update notification toasts.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12811573044>
> Commit: 444b42858eece8b8454283480e5b72d96aee4290
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12811573044&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 16 Jan 2025 15:41:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling mechanism for bad request errors
	- Refined version mismatch error processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->