### PR TITLE
chore: pin version of Appsmith in chart to avoid surprise upgrades

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,7 @@
 annotations:
   category: Application
 apiVersion: v2
+appVersion: 1.57
 name: appsmith
 type: application
 description: Appsmith is an open source framework to build admin panels, CRUD apps and workflows. Build everything you need, 10x faster.
@@ -11,7 +12,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.6.0
+version: 3.6.1
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- $customImage := .Values._image | default dict }}
-          image: {{ dig "registry" "index.docker.io" $customImage }}/{{ dig "repository" "appsmith/appsmith-ee" $customImage }}:{{ dig "tag" (.Values.image.tag | default "latest") $customImage }}
+          image: {{ dig "registry" "index.docker.io" $customImage }}/{{ dig "repository" "appsmith/appsmith-ee" $customImage }}:{{ dig "tag" (default .Chart.AppVersion .Values.image.tag) $customImage }}
           imagePullPolicy: {{ dig "pullPolicy" "IfNotPresent" $customImage }}
           ports:
             - name: http

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -134,7 +134,7 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: ""
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 ## ServiceAccount
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##


### PR DESCRIPTION
## Description
Pin the version of Appsmith deployed by the chart with the version that was tested when the chart was published.

Fixes #38713   

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Updates**
	- Updated Helm chart version to `3.6.1`
	- Updated application version to `1.57`
	- Modified image tag configuration to use chart's app version as default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->