### PR TITLE
ci: Pinning the server build runs to Ubuntu 22.04 because of Flapdoodle errors

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -51,7 +51,7 @@ defaults:
 
 jobs:
   server-unit-tests:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04-8core
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -93,7 +93,7 @@ jobs:
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}
-      
+
       - name: Default database URL
         run: echo "Is this a PG build? ${{ inputs.is-pg-build }}"
 
@@ -203,105 +203,104 @@ jobs:
           APPSMITH_ENVFILE_PATH: /tmp/dummy.env
           APPSMITH_VERBOSE_LOGGING_ENABLED: false
         run: |
-            if [[ "${{ inputs.is-pg-build }}" == "true" ]]; then
-                export APPSMITH_DB_URL="postgresql://postgres:password@localhost:5432/postgres"
-            else
-                export APPSMITH_DB_URL="mongodb://localhost:27017/mobtools"
-            fi
+          if [[ "${{ inputs.is-pg-build }}" == "true" ]]; then
+              export APPSMITH_DB_URL="postgresql://postgres:password@localhost:5432/postgres"
+          else
+              export APPSMITH_DB_URL="mongodb://localhost:27017/mobtools"
+          fi
 
-            args=()
+          args=()
 
-            if [[ "${{ steps.run_result.outputs.run_result }}" == "failedtest" ]]; then
-                failed_tests="${{ steps.failed_tests.outputs.tests }}"
-                args+=("-DfailIfNoTests=false" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dtest=${failed_tests}")
-            fi
+          if [[ "${{ steps.run_result.outputs.run_result }}" == "failedtest" ]]; then
+              failed_tests="${{ steps.failed_tests.outputs.tests }}"
+              args+=("-DfailIfNoTests=false" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dtest=${failed_tests}")
+          fi
 
-            # Run tests and capture logs
-            mvn test "${args[@]}" | tee mvn_test.log
-            
-            # Check for "BUILD FAILURE" in the mvn_test.log
-            if grep -q "BUILD FAILURE" mvn_test.log; then
-                test_result="failed"
-            else
-                test_result="passed"
-            fi
+          # Run tests and capture logs
+          mvn test "${args[@]}" | tee mvn_test.log
 
-            echo "test_result variable value: ${test_result}"
+          # Check for "BUILD FAILURE" in the mvn_test.log
+          if grep -q "BUILD FAILURE" mvn_test.log; then
+              test_result="failed"
+          else
+              test_result="passed"
+          fi
 
-            # Prepare output file for failed tests and ensure a fresh file is created
-            OUTPUT_FILE="failed-server-tests.txt"
-            rm -f "$OUTPUT_FILE"
-            touch "$OUTPUT_FILE"
+          echo "test_result variable value: ${test_result}"
 
-            failed_modules=()
-            skipped_modules=()
+          # Prepare output file for failed tests and ensure a fresh file is created
+          OUTPUT_FILE="failed-server-tests.txt"
+          rm -f "$OUTPUT_FILE"
+          touch "$OUTPUT_FILE"
 
-            # Process mvn_test.log for FAILURE and SKIPPED statuses
-            while IFS= read -r line; do
-                if [[ $line == *"FAILURE"* ]]; then
-                    module_name=$(echo "$line" | awk '{print $2}')
-                    failed_modules+=("$module_name")
-                elif [[ $line == *"SKIPPED"* ]]; then
-                    module_name=$(echo "$line" | awk '{print $2}')
-                    skipped_modules+=("$module_name")
-                fi
-            done < mvn_test.log
+          failed_modules=()
+          skipped_modules=()
 
-            echo "Failed Modules: ${failed_modules[*]}"
-            echo "Skipped Modules: ${skipped_modules[*]}"
+          # Process mvn_test.log for FAILURE and SKIPPED statuses
+          while IFS= read -r line; do
+              if [[ $line == *"FAILURE"* ]]; then
+                  module_name=$(echo "$line" | awk '{print $2}')
+                  failed_modules+=("$module_name")
+              elif [[ $line == *"SKIPPED"* ]]; then
+                  module_name=$(echo "$line" | awk '{print $2}')
+                  skipped_modules+=("$module_name")
+              fi
+          done < mvn_test.log
 
-            # Handle older approach for reading failed tests from XML files
-            failed_tests_from_xml="$PWD/failed-tests-from-xml.txt"
-            gawk -F\" '/<testcase / {cur_test = $4 "#" $2} /<(failure|error) / {print cur_test}' $(find . -type f -name 'TEST-*.xml') \
-              | sort -u \
-              | tee "$failed_tests_from_xml"
+          echo "Failed Modules: ${failed_modules[*]}"
+          echo "Skipped Modules: ${skipped_modules[*]}"
 
-            # Filter out failed modules and add only relevant tests to the final failed list
-            for module in "${failed_modules[@]}"; do
-                grep -v "$module" "$failed_tests_from_xml" > temp_file && mv temp_file "$failed_tests_from_xml"
-            done
+          # Handle older approach for reading failed tests from XML files
+          failed_tests_from_xml="$PWD/failed-tests-from-xml.txt"
+          gawk -F\" '/<testcase / {cur_test = $4 "#" $2} /<(failure|error) / {print cur_test}' $(find . -type f -name 'TEST-*.xml') \
+            | sort -u \
+            | tee "$failed_tests_from_xml"
 
-            # Include all skipped module test files in the final list
-            for module in "${skipped_modules[@]}"; do
-                module_directories=$(find . -path "*/${module}*/src/test/java/*" -type f -name "*Test.java" -exec dirname {} \; | sort -u)
-                for module_directory in $module_directories; do
-                    test_classes=$(find "$module_directory" -type f -name "*Test.java" | sed 's|.*/src/test/java/||; s|\.java$||; s|/|.|g')
-                    for class_name in $test_classes; do
-                        if [[ ${#class_name} -le 240 ]] && ! grep -Fxq "$class_name#" "$OUTPUT_FILE"; then
-                            echo "${class_name}#" >> "$OUTPUT_FILE"
-                        fi
-                    done
-                done
-            done
+          # Filter out failed modules and add only relevant tests to the final failed list
+          for module in "${failed_modules[@]}"; do
+              grep -v "$module" "$failed_tests_from_xml" > temp_file && mv temp_file "$failed_tests_from_xml"
+          done
 
-            # Combine the XML file test cases and skipped module test files into the final output file
-            cat "$failed_tests_from_xml" >> "$OUTPUT_FILE"
-            
-            # Print the final output
-            cat "$OUTPUT_FILE"
+          # Include all skipped module test files in the final list
+          for module in "${skipped_modules[@]}"; do
+              module_directories=$(find . -path "*/${module}*/src/test/java/*" -type f -name "*Test.java" -exec dirname {} \; | sort -u)
+              for module_directory in $module_directories; do
+                  test_classes=$(find "$module_directory" -type f -name "*Test.java" | sed 's|.*/src/test/java/||; s|\.java$||; s|/|.|g')
+                  for class_name in $test_classes; do
+                      if [[ ${#class_name} -le 240 ]] && ! grep -Fxq "$class_name#" "$OUTPUT_FILE"; then
+                          echo "${class_name}#" >> "$OUTPUT_FILE"
+                      fi
+                  done
+              done
+          done
 
-            if [[ -s $OUTPUT_FILE ]]; then
-                content="$(
-                    echo "## Failed server tests"
-                    echo
-                    sed 's/^/- /' "$OUTPUT_FILE"
-                )"
-                echo "$content" >> "$GITHUB_STEP_SUMMARY"
-                
-                # Post a comment to the PR
-                curl --silent --show-error \
-                    --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                    --data "$(jq -n --arg body "$content" '$ARGS.named')" \
-                    "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/${{ inputs.pr }}/comments" \
-                    > /dev/null
-            fi
+          # Combine the XML file test cases and skipped module test files into the final output file
+          cat "$failed_tests_from_xml" >> "$OUTPUT_FILE"
 
-            # Fail the script if tests did not pass
-            if [[ "$test_result" == "failed" ]]; then
-                echo "Tests failed, exiting with status 1."
-                exit 1
-            fi
+          # Print the final output
+          cat "$OUTPUT_FILE"
 
+          if [[ -s $OUTPUT_FILE ]]; then
+              content="$(
+                  echo "## Failed server tests"
+                  echo
+                  sed 's/^/- /' "$OUTPUT_FILE"
+              )"
+              echo "$content" >> "$GITHUB_STEP_SUMMARY"
+              
+              # Post a comment to the PR
+              curl --silent --show-error \
+                  --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  --data "$(jq -n --arg body "$content" '$ARGS.named')" \
+                  "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/${{ inputs.pr }}/comments" \
+                  > /dev/null
+          fi
+
+          # Fail the script if tests did not pass
+          if [[ "$test_result" == "failed" ]]; then
+              echo "Tests failed, exiting with status 1."
+              exit 1
+          fi
 
       # Set status = failedtest
       - name: Set fail if there are test failures

--- a/.github/workflows/server-integration-tests.yml
+++ b/.github/workflows/server-integration-tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04-8core
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||
       github.event_name == 'workflow_dispatch'
@@ -65,7 +65,7 @@ jobs:
         with:
           name: server-build
           path: app/server/dist/
-      
+
       - name: Download the rts build artifact
         uses: actions/download-artifact@v4
         with:
@@ -93,16 +93,14 @@ jobs:
           APPSMITH_ENVFILE_PATH: /tmp/dummy.env
           APPSMITH_VERBOSE_LOGGING_ENABLED: false
         run: |
-            if [[ "${{ inputs.is-pg-build }}" == "true" ]]; then
-                export APPSMITH_DB_URL="postgresql://postgres:password@localhost:5432/postgres"
-            else
-                export APPSMITH_DB_URL="mongodb://localhost:27017/mobtools"
-            fi
+          if [[ "${{ inputs.is-pg-build }}" == "true" ]]; then
+              export APPSMITH_DB_URL="postgresql://postgres:password@localhost:5432/postgres"
+          else
+              export APPSMITH_DB_URL="mongodb://localhost:27017/mobtools"
+          fi
 
-            args=()
+          args=()
 
-            # Run tests and capture logs
-            cd app/server
-            mvn verify -DskipUTs=true "${args[@]}" | tee mvn_integration_test.log
-
-
+          # Run tests and capture logs
+          cd app/server
+          mvn verify -DskipUTs=true "${args[@]}" | tee mvn_integration_test.log


### PR DESCRIPTION
## Description
Flapdoodle, our Mongo embedded testing library throws errors when running Junit tests on Ubuntu 24.04.  This is because of a mismatch of openssl version from Ubuntu 22.04 to Ubuntu 24.04. Hence pinning our CI for server builds to Ubuntu 22.04 for now. Will issue a holistic fix with Flapdoodle upgrade later.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations for server build and integration tests
	- Migrated workflow environments from `ubuntu-latest-8-cores` to `ubuntu-22.04-8core`
	- Refined workflow logic for test execution and artifact management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->