### PR TITLE
feat: allow persistent volume name to be overridden in the helm chart

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.6.0
+version: 3.6.1
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -121,6 +121,12 @@ Return  the proper Storage Class
 {{- end -}}
 
 {{- end -}}
+{{/*
+Get the PV name, using override if specified
+*/}}
+{{- define "appsmith.pvname" -}}
+{{- .Values.persistence.pvNameOverride | default (include "appsmith.fullname" .) -}}
+{{- end -}}
 
 {{/*
 Renders a value that contains template.

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -124,7 +124,7 @@ Return  the proper Storage Class
 {{/*
 Get the PV name, using override if specified
 */}}
-{{- define "appsmith.pvname" -}}
+{{- define "appsmith.pvName" -}}
 {{- .Values.persistence.pvNameOverride | default (include "appsmith.fullname" .) -}}
 {{- end -}}
 

--- a/deploy/helm/templates/persistentVolume.yaml
+++ b/deploy/helm/templates/persistentVolume.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "appsmith.fullname" . }}
+  name: {{ include "appsmith.pvname" . }}
   namespace: {{ include "appsmith.namespace" . }}
 spec:
   capacity:

--- a/deploy/helm/templates/persistentVolume.yaml
+++ b/deploy/helm/templates/persistentVolume.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "appsmith.pvname" . }}
+  name: {{ include "appsmith.pvName" . }}
   namespace: {{ include "appsmith.namespace" . }}
 spec:
   capacity:

--- a/deploy/helm/templates/persistentVolume.yaml
+++ b/deploy/helm/templates/persistentVolume.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ include "appsmith.pvName" . }}
-  namespace: {{ include "appsmith.namespace" . }}
 spec:
   capacity:
     storage: {{ .Values.persistence.size | quote }}

--- a/deploy/helm/templates/persistentVolumeClaim.yaml
+++ b/deploy/helm/templates/persistentVolumeClaim.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.persistence.existingClaim.enabled }}
   volumeName: {{ .Values.persistence.existingClaim.name }}
   {{- else}}
-  volumeName: {{ include "appsmith.fullname" . }}
+  volumeName: {{ include "appsmith.pvname" . }}
   {{- end }}
   resources:
     requests:

--- a/deploy/helm/templates/persistentVolumeClaim.yaml
+++ b/deploy/helm/templates/persistentVolumeClaim.yaml
@@ -21,7 +21,7 @@ spec:
   {{- if .Values.persistence.existingClaim.enabled }}
   volumeName: {{ .Values.persistence.existingClaim.name }}
   {{- else}}
-  volumeName: {{ include "appsmith.pvname" . }}
+  volumeName: {{ include "appsmith.pvName" . }}
   {{- end }}
   resources:
     requests:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -323,6 +323,13 @@ persistence:
   ## Fine tuning for volumeClaimTemplates
   ##
   reclaimPolicy: Retain
+
+  ## @param persistence.pvNameOverride Override the PV name
+  ## Useful when deploying multiple releases across different namespaces with the same name
+  ## since PersistentVolumes are cluster-scoped resources
+  ##
+  pvNameOverride: ""
+
   existingClaim:
     enabled:
     name:


### PR DESCRIPTION
## Description

Exposes a value under the `persistence` key to allow the PV name to be overridden. This was requested by a customer that does multiple deploys of Appsmith per cluster in different namespaces with the same Helm release name. Since PV's are not namespaced, the deploy was failing.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 8a0e2ba2354c9a6742ca5d1a31d87559408325ec yet
> <hr>Thu, 23 Jan 2025 14:35:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to override Persistent Volume (PV) name in Helm chart.
	- Enhanced configuration options for multi-namespace deployments.

- **Improvements**
	- Introduced more flexible naming strategy for Persistent Volume resources.
	- Updated PersistentVolume and PersistentVolumeClaim resources to utilize the new naming convention.
	- Updated application version from 3.6.0 to 3.6.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->