### PR TITLE
fix: Update ChartWidget fontFamily handling to respect system default 

### DIFF
--- a/app/client/src/widgets/ChartWidget/widget/index.test.ts
+++ b/app/client/src/widgets/ChartWidget/widget/index.test.ts
@@ -54,7 +54,7 @@ describe("emptyChartData", () => {
   };
 
   describe("font family", () => {
-    it("uses theme font family with Nunito Sans fallback", () => {
+    it("Does not use any font family as a fallback", () => {
       const widget = new ChartWidget(defaultProps);
       const view = widget.renderChartWithData();
 
@@ -69,7 +69,7 @@ describe("emptyChartData", () => {
       ).renderChartWithData();
 
       expect(viewWithoutFont.props.children.props.fontFamily).toEqual(
-        "Nunito Sans",
+        undefined,
       );
     });
   });

--- a/app/client/src/widgets/ChartWidget/widget/index.tsx
+++ b/app/client/src/widgets/ChartWidget/widget/index.tsx
@@ -257,7 +257,11 @@ class ChartWidget extends BaseWidget<ChartWidgetProps, WidgetState> {
           customEChartConfig={this.props.customEChartConfig}
           customFusionChartConfig={this.props.customFusionChartConfig}
           dimensions={this.props}
-          fontFamily={this.props.fontFamily ?? "Nunito Sans"}
+          fontFamily={
+            this.props.fontFamily !== "System Default"
+              ? this.props.fontFamily
+              : undefined
+          }
           hasOnDataPointClick={Boolean(this.props.onDataPointClick)}
           isLoading={this.props.isLoading}
           isVisible={this.props.isVisible}


### PR DESCRIPTION
## Description
System font handling for chart widget


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Chart"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12883318829>
> Commit: 1978a033e550828901b7a4308b22c6c32eacb768
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12883318829&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Chart`
> Spec:
> <hr>Tue, 21 Jan 2025 09:17:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced chart widget font family configuration
	- Added support for system default font settings

- **Bug Fixes**
	- Improved font rendering logic to respect system default preferences
<!-- end of auto-generated comment: release notes by coderabbit.ai -->