### PR TITLE
fix: ds structure issue fixed for zendesk integration

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -452,9 +452,12 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
 
     @Override
     public <T> Mono<T> retryOnce(DatasourceStorage datasourceStorage, Function<DatasourceContext<?>, Mono<T>> task) {
-
         final Mono<T> taskRunnerMono = Mono.justOrEmpty(datasourceStorage)
-                .flatMap(this::getDatasourceContext)
+                .flatMap(ds -> {
+                    return pluginService
+                            .findById(datasourceStorage.getPluginId())
+                            .flatMap(plugin -> getDatasourceContext(datasourceStorage, plugin));
+                })
                 // Now that we have the context (connection details), call the task.
                 .flatMap(task);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -384,8 +384,10 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                 && !isInErrorState;
     }
 
-    // This method is deprecated and should not be used. Use the method with Plugin parameter instead.
-    // As EE implementation requires plugin parameter to determine if the plugin is external saas or not.
+    /**
+     * This method is deprecated and should not be used. Use the method {@link #getDatasourceContext(DatasourceStorage, Plugin)}  instead.
+     * such entities as possible candidates for domain mapping.
+     */
     @Deprecated
     @Override
     public Mono<DatasourceContext<?>> getDatasourceContext(DatasourceStorage datasourceStorage) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -384,6 +384,9 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                 && !isInErrorState;
     }
 
+    // This method is deprecated and should not be used. Use the method with Plugin parameter instead.
+    // As EE implementation requires plugin parameter to determine if the plugin is external saas or not.
+    @Deprecated
     @Override
     public Mono<DatasourceContext<?>> getDatasourceContext(DatasourceStorage datasourceStorage) {
         final String datasourceId = datasourceStorage.getDatasourceId();


### PR DESCRIPTION
## Description
This PR fixes the issue where for Saas integrations like zendesk, we do not have a structure to be displayed, in that case we should show appropriate error message. 


Fixes #38736 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12907027118>
> Commit: 5a9ef72ef41275bcd6303e311313758f0c24789d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12907027118&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 22 Jan 2025 12:24:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Deprecated the previous method for retrieving datasource context.
	- Updated the datasource context retrieval process to include plugin information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->