### PR TITLE
chore: code split for consolidated api span names to add module instances and entities in EE 

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ConsolidatedApiSpanNames.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ConsolidatedApiSpanNames.java
@@ -1,34 +1,9 @@
 package com.appsmith.external.constants.spans;
 
-import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+import com.appsmith.external.constants.spans.ce.ConsolidatedApiSpanNamesCE;
 
 /**
  * Please make sure that all span names start with `appsmith.` because span with any other naming format would get
  * dropped / ignored as defined in TracingConfig.java
  */
-public class ConsolidatedApiSpanNames {
-    public static final String CONSOLIDATED_API_PREFIX = APPSMITH_SPAN_PREFIX + "consolidated-api.";
-    public static final String VIEW = "view.";
-    public static final String EDIT = "edit.";
-    public static final String ROOT = "root";
-    public static final String CONSOLIDATED_API_ROOT_EDIT = CONSOLIDATED_API_PREFIX + EDIT + ROOT;
-    public static final String CONSOLIDATED_API_ROOT_VIEW = CONSOLIDATED_API_PREFIX + VIEW + ROOT;
-    public static final String USER_PROFILE_SPAN = "user_profile";
-    public static final String FEATURE_FLAG_SPAN = "feature_flag";
-    public static final String TENANT_SPAN = "tenant";
-    public static final String PRODUCT_ALERT_SPAN = "product_alert";
-    public static final String APPLICATION_ID_SPAN = "application_id";
-    public static final String PAGES_SPAN = "pages";
-    public static final String PAGES_DSL_SPAN = "pages_dsl_list";
-    public static final String CURRENT_THEME_SPAN = "current_theme";
-    public static final String THEMES_SPAN = "themes";
-    public static final String CUSTOM_JS_LIB_SPAN = "js_libs";
-    public static final String CURRENT_PAGE_SPAN = "current_page";
-    public static final String ACTIONS_SPAN = "actions";
-    public static final String ACTION_COLLECTIONS_SPAN = "action_collections";
-    public static final String PLUGINS_SPAN = "plugins";
-    public static final String WORKSPACE_SPAN = "workspace";
-    public static final String DATASOURCES_SPAN = "datasources";
-    public static final String FORM_CONFIG_SPAN = "form_config";
-    public static final String MOCK_DATASOURCES_SPAN = "mock_datasources";
-}
+public class ConsolidatedApiSpanNames extends ConsolidatedApiSpanNamesCE {}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/ConsolidatedApiSpanNamesCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/ConsolidatedApiSpanNamesCE.java
@@ -1,0 +1,34 @@
+package com.appsmith.external.constants.spans.ce;
+
+import static com.appsmith.external.constants.spans.BaseSpan.APPSMITH_SPAN_PREFIX;
+
+/**
+ * Please make sure that all span names start with `appsmith.` because span with any other naming format would get
+ * dropped / ignored as defined in TracingConfig.java
+ */
+public class ConsolidatedApiSpanNamesCE {
+    public static final String CONSOLIDATED_API_PREFIX = APPSMITH_SPAN_PREFIX + "consolidated-api.";
+    public static final String VIEW = "view.";
+    public static final String EDIT = "edit.";
+    public static final String ROOT = "root";
+    public static final String CONSOLIDATED_API_ROOT_EDIT = CONSOLIDATED_API_PREFIX + EDIT + ROOT;
+    public static final String CONSOLIDATED_API_ROOT_VIEW = CONSOLIDATED_API_PREFIX + VIEW + ROOT;
+    public static final String USER_PROFILE_SPAN = "user_profile";
+    public static final String FEATURE_FLAG_SPAN = "feature_flag";
+    public static final String TENANT_SPAN = "tenant";
+    public static final String PRODUCT_ALERT_SPAN = "product_alert";
+    public static final String APPLICATION_ID_SPAN = "application_id";
+    public static final String PAGES_SPAN = "pages";
+    public static final String PAGES_DSL_SPAN = "pages_dsl_list";
+    public static final String CURRENT_THEME_SPAN = "current_theme";
+    public static final String THEMES_SPAN = "themes";
+    public static final String CUSTOM_JS_LIB_SPAN = "js_libs";
+    public static final String CURRENT_PAGE_SPAN = "current_page";
+    public static final String ACTIONS_SPAN = "actions";
+    public static final String ACTION_COLLECTIONS_SPAN = "action_collections";
+    public static final String PLUGINS_SPAN = "plugins";
+    public static final String WORKSPACE_SPAN = "workspace";
+    public static final String DATASOURCES_SPAN = "datasources";
+    public static final String FORM_CONFIG_SPAN = "form_config";
+    public static final String MOCK_DATASOURCES_SPAN = "mock_datasources";
+}


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12945714399>
> Commit: f794c0015850d4d8aa29f1ed359c506d80b7dc32
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12945714399&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 24 Jan 2025 12:14:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Restructured span naming constants for consolidated API tracing
	- Introduced a new base class `ConsolidatedApiSpanNamesCE` to centralize span name definitions
	- Updated inheritance structure for `ConsolidatedApiSpanNames`

- **New Features**
	- Added comprehensive span naming constants for various application components
	- Standardized span naming with `appsmith.` prefix for improved tracing consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->