### PR TITLE
fix: added configurable connection pool support for mssql

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlTestDBContainerManager.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlTestDBContainerManager.java
@@ -1,5 +1,6 @@
 package com.external.plugins;
 
+import com.appsmith.external.configurations.connectionpool.ConnectionPoolConfig;
 import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
@@ -8,6 +9,7 @@ import com.external.plugins.utils.MssqlDatasourceUtils;
 import com.zaxxer.hikari.HikariDataSource;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
+import reactor.core.publisher.Mono;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -18,7 +20,15 @@ import static com.external.plugins.utils.MssqlExecuteUtils.closeConnectionPostEx
 
 public class MssqlTestDBContainerManager {
 
-    static MssqlPlugin.MssqlPluginExecutor mssqlPluginExecutor = new MssqlPlugin.MssqlPluginExecutor();
+    private static class MockConnectionPoolConfig implements ConnectionPoolConfig {
+        @Override
+        public Mono<Integer> getMaxConnectionPoolSize() {
+            return Mono.just(5);
+        }
+    }
+
+    static MssqlPlugin.MssqlPluginExecutor mssqlPluginExecutor =
+            new MssqlPlugin.MssqlPluginExecutor(new MockConnectionPoolConfig());
 
     public static MssqlDatasourceUtils mssqlDatasourceUtils = new MssqlDatasourceUtils();
 


### PR DESCRIPTION
## Description
With current implementation, MSSQL is configured with HikariCP to have maximum pool size of 10. But this means that if multiple concurrent users are accessing multiple queries of the same datasource at the same time, some of the queries might time out due to max pool size of 10. We have encountered this issue in https://theappsmith.slack.com/archives/C0341RERY4R/p1736150680663059. Where 40-50 concurrent users are simultaneously making 20-30 queries to MSSQL database.


This PR makes this connection pool size configurable from admin settings for MSSQL as well. 


Fixes #https://github.com/appsmithorg/appsmith-ee/issues/5928
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12925650660>
> Commit: ebda9364200b4df19c86b8ec4e68a95d6180f10c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12925650660&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 23 Jan 2025 11:18:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced connection pool configuration for MSSQL plugin
	- Added support for dynamically setting maximum connection pool size

- **Improvements**
	- Increased flexibility in database connection management
	- Implemented configurable connection pool settings

- **Tests**
	- Added mock configuration for testing connection pool settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->