### PR TITLE
chore: remove deprecated feature flag for custom loading state in TableWidget

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -36,8 +36,6 @@ export const FEATURE_FLAG = {
   release_ide_animations_enabled: "release_ide_animations_enabled",
   release_ide_datasource_selector_enabled:
     "release_ide_datasource_selector_enabled",
-  release_table_custom_loading_state_enabled:
-    "release_table_custom_loading_state_enabled",
   release_custom_widget_ai_builder: "release_custom_widget_ai_builder",
   ab_request_new_integration_enabled: "ab_request_new_integration_enabled",
   release_evaluation_scope_cache: "release_evaluation_scope_cache",
@@ -86,7 +84,6 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_git_persist_branch_enabled: false,
   release_ide_animations_enabled: false,
   release_ide_datasource_selector_enabled: false,
-  release_table_custom_loading_state_enabled: false,
   release_custom_widget_ai_builder: false,
   ab_request_new_integration_enabled: false,
   release_evaluation_scope_cache: false,

--- a/app/client/src/widgets/TableWidgetV2/constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/constants.ts
@@ -244,8 +244,5 @@ export const DEFAULT_COLUMN_NAME = "Table Column";
 export const ALLOW_TABLE_WIDGET_SERVER_SIDE_FILTERING =
   FEATURE_FLAG["release_table_serverside_filtering_enabled"];
 
-export const CUSTOM_LOADING_STATE_ENABLED =
-  FEATURE_FLAG["release_table_custom_loading_state_enabled"];
-
 export const HTML_COLUMN_TYPE_ENABLED =
   FEATURE_FLAG["release_table_html_column_type_enabled"];

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -7,10 +7,7 @@ import { ValidationTypes } from "constants/WidgetValidation";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
 import type { TableWidgetProps } from "widgets/TableWidgetV2/constants";
-import {
-  ALLOW_TABLE_WIDGET_SERVER_SIDE_FILTERING,
-  CUSTOM_LOADING_STATE_ENABLED,
-} from "../../constants";
+import { ALLOW_TABLE_WIDGET_SERVER_SIDE_FILTERING } from "../../constants";
 import { InlineEditingSaveOptions } from "widgets/TableWidgetV2/constants";
 import { composePropertyUpdateHook } from "widgets/WidgetUtils";
 import {
@@ -513,7 +510,6 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
-        hidden: () => !Widget.getFeatureFlag(CUSTOM_LOADING_STATE_ENABLED),
       },
       {
         propertyName: "customIsLoadingValue",


### PR DESCRIPTION


## Description
- Removed the `release_table_custom_loading_state_enabled` feature flag from `FeatureFlag.ts` and its references in `TableWidgetV2` components.
- Updated property configurations to eliminate reliance on the deprecated flag, streamlining the widget's loading state handling.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12943660031>
> Commit: ebf8e036c830b23b5d052ded71551df9c1328c97
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12943660031&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Fri, 24 Jan 2025 05:46:41 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Feature Flag Removal**
	- Removed `release_table_custom_loading_state_enabled` feature flag
	- Eliminated custom loading state configuration for table widget

- **Configuration Updates**
	- Made `customIsLoading` property always visible
	- Added `expandedByDefault: true` to "Data" section in table widget configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->