### PR TITLE
chore: Extracting out `showNudge` config from screen mode toggle component

### DIFF
--- a/app/client/src/pages/Editor/IDE/EditorTabs/ScreenModeToggle.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/ScreenModeToggle.tsx
@@ -53,7 +53,9 @@ export const ScreenModeToggle = (props: Props) => {
       to: EditorViewMode.SplitScreen,
     });
 
-    dismissNudge?.();
+    if (dismissNudge) {
+      dismissNudge();
+    }
 
     if ("startViewTransition" in document && isAnimatedIDEEnabled) {
       document.startViewTransition(() => {

--- a/app/client/src/pages/Editor/IDE/EditorTabs/ScreenModeToggle.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/ScreenModeToggle.tsx
@@ -17,12 +17,12 @@ import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 import { Nudge } from "IDE/Components/Nudge";
 
 interface Props {
-  showNudge: boolean;
-  dismissNudge: () => void;
+  showNudge?: boolean;
+  dismissNudge?: () => void;
 }
 
 export const ScreenModeToggle = (props: Props) => {
-  const { dismissNudge, showNudge } = props;
+  const { dismissNudge, showNudge = false } = props;
   const dispatch = useDispatch();
   const ideViewMode = useSelector(getIDEViewMode);
   const isAnimatedIDEEnabled = useSelector((state: AppState) => {
@@ -53,7 +53,7 @@ export const ScreenModeToggle = (props: Props) => {
       to: EditorViewMode.SplitScreen,
     });
 
-    dismissNudge();
+    dismissNudge?.();
 
     if ("startViewTransition" in document && isAnimatedIDEEnabled) {
       document.startViewTransition(() => {
@@ -98,7 +98,7 @@ export const ScreenModeToggle = (props: Props) => {
     );
   }
 
-  if (showNudge) {
+  if (showNudge && dismissNudge) {
     return (
       <Nudge
         align="center"

--- a/app/client/src/pages/Editor/IDE/EditorTabs/ScreenModeToggle.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/ScreenModeToggle.tsx
@@ -15,9 +15,14 @@ import type { AppState } from "ee/reducers";
 import { selectFeatureFlagCheck } from "ee/selectors/featureFlagsSelectors";
 import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 import { Nudge } from "IDE/Components/Nudge";
-import { useShowSideBySideNudge } from "../hooks";
 
-export const ScreenModeToggle = () => {
+interface Props {
+  showNudge: boolean;
+  dismissNudge: () => void;
+}
+
+export const ScreenModeToggle = (props: Props) => {
+  const { dismissNudge, showNudge } = props;
   const dispatch = useDispatch();
   const ideViewMode = useSelector(getIDEViewMode);
   const isAnimatedIDEEnabled = useSelector((state: AppState) => {
@@ -42,8 +47,6 @@ export const ScreenModeToggle = () => {
       dispatch(setIdeEditorViewMode(EditorViewMode.FullScreen));
     }
   }, [dispatch, isAnimatedIDEEnabled]);
-
-  const [showNudge, dismissNudge] = useShowSideBySideNudge();
 
   const switchToSplitScreen = useCallback(() => {
     AnalyticsUtil.logEvent("EDITOR_MODE_CHANGE", {

--- a/app/client/src/pages/Editor/IDE/EditorTabs/index.tsx
+++ b/app/client/src/pages/Editor/IDE/EditorTabs/index.tsx
@@ -10,7 +10,11 @@ import {
 } from "ee/entities/IDE/constants";
 
 import Container from "./Container";
-import { useCurrentEditorState, useIDETabClickHandlers } from "../hooks";
+import {
+  useCurrentEditorState,
+  useIDETabClickHandlers,
+  useShowSideBySideNudge,
+} from "../hooks";
 import { SCROLL_AREA_OPTIONS, TabSelectors } from "./constants";
 import { AddButton } from "./AddButton";
 import { useLocation } from "react-router";
@@ -32,6 +36,7 @@ const EditorTabs = () => {
   const entities = useSelector(tabsConfig.listSelector, shallowEqual);
   const files = useSelector(tabsConfig.tabsSelector, shallowEqual);
   const isListViewActive = useSelector(getListViewActiveState);
+  const [showNudge, dismissNudge] = useShowSideBySideNudge();
 
   const location = useLocation();
   const dispatch = useDispatch();
@@ -147,7 +152,7 @@ const EditorTabs = () => {
         </ScrollArea>
         {files.length > 0 ? <AddButton /> : null}
         {/* Switch screen mode button */}
-        <ScreenModeToggle />
+        <ScreenModeToggle dismissNudge={dismissNudge} showNudge={showNudge} />
       </Container>
 
       {/* Overflow list */}


### PR DESCRIPTION
## Description

Extracting out `showNudge` config from screen mode toggle component to make this component re-usable in other IDEs.

Fixes [#37690](https://github.com/appsmithorg/appsmith/issues/37690)

## Automation

/ok-to-test tags="@tag.Sanity, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/12948269268>
> Commit: 1a301308db3ca902e3df0e43f1129395078444c5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=12948269268&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.IDE`
> Spec:
> <hr>Fri, 24 Jan 2025 11:40:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new nudge system for side-by-side view functionality in the editor.
	- Enhanced user guidance with a dismissible nudge for screen mode switching.

- **Improvements**
	- Refined state management for screen mode toggle by utilizing props.
	- Improved component prop handling for better flexibility and interactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->