### PR TITLE
fix: Avoid canvas tooltip unmount

### DIFF
--- a/app/client/src/pages/Editor/WidgetsEditor/components/CodeModeTooltip.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/components/CodeModeTooltip.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "@appsmith/ads";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { modText } from "utils/helpers";
 import { useSelector } from "react-redux";
 import { getWidgetSelectionBlock } from "selectors/ui";
@@ -19,26 +19,33 @@ const CodeModeTooltip = (props: { children: React.ReactElement }) => {
   const editorState = useCurrentAppState();
   const [shouldShow, setShouldShow] = useState<boolean>(false);
 
-  useEffect(() => {
-    retrieveCodeWidgetNavigationUsed()
-      .then((timesUsed) => {
-        if (timesUsed < 2) {
+  useEffect(
+    function handleMaxTimesTooltipShown() {
+      retrieveCodeWidgetNavigationUsed()
+        .then((timesUsed) => {
+          if (timesUsed < 2) {
+            setShouldShow(true);
+          }
+        })
+        .catch(() => {
           setShouldShow(true);
-        }
-      })
-      .catch(() => {
-        setShouldShow(true);
-      });
-  }, [isWidgetSelectionBlock]);
+        });
+    },
+    [isWidgetSelectionBlock],
+  );
 
-  if (!isWidgetSelectionBlock) return props.children;
-
-  if (editorState !== EditorState.EDITOR) return props.children;
+  const isDisabled = useMemo(() => {
+    return (
+      !shouldShow ||
+      !isWidgetSelectionBlock ||
+      editorState !== EditorState.EDITOR
+    );
+  }, [editorState, isWidgetSelectionBlock, shouldShow]);
 
   return (
     <Tooltip
       content={createMessage(CANVAS_VIEW_MODE_TOOLTIP, `${modText()}`)}
-      isDisabled={!shouldShow}
+      isDisabled={isDisabled}
       placement={"bottom"}
       showArrow={false}
       trigger={"hover"}


### PR DESCRIPTION
## Description

Instead of updating the component layer when choosing to show the tooltip on canvas view mode, we would instead just mark the tooltip disabled when no required. This makes sure the children are not remounted based on conditions in the tooltip component

Fixes #38886

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13026069462>
> Commit: a593a658a94ccfa6db4c24d813f5644f28849907
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13026069462&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Wed, 29 Jan 2025 07:22:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code structure and clarity in the `CodeModeTooltip` component
  - Optimized tooltip display logic using `useMemo` hook
  - Streamlined error handling for tooltip state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->