### PR TITLE
chore: skipping cases for mockdb usage

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug26716_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug26716_Spec.ts
@@ -8,7 +8,7 @@ import EditorNavigation, {
 
 let dsName: any, userMock: string, movieMock: string;
 
-describe(
+describe.skip(
   "Bug 26716: Datasource selected from entity explorer should be correctly highlighted",
   {
     tags: [

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug28750_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug28750_Spec.ts
@@ -1,7 +1,7 @@
 import { agHelper, dataSources } from "../../../../support/Objects/ObjectsCore";
 import { featureFlagIntercept } from "../../../../support/Objects/FeatureFlags";
 
-describe(
+describe.skip(
   "Datasource structure schema preview data",
   {
     tags: [

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DatasourceSchema_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DatasourceSchema_spec.ts
@@ -65,7 +65,7 @@ describe(
       dataSources.DeleteDatasourceFromWithinDS(dataSourceName);
     });
 
-    it(
+    it.skip(
       "3. Verify if schema (table and column) exist in query editor and searching works",
       { tags: ["@tag.excludeForAirgap"] },
       () => {
@@ -83,7 +83,7 @@ describe(
       },
     );
 
-    it(
+    it.skip(
       "4. Verify if refresh works.",
       { tags: ["@tag.excludeForAirgap"] },
       () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
@@ -141,7 +141,7 @@ describe(
       _.entityExplorer.DeleteWidgetFromEntityExplorer("MenuButton1");
     });
 
-    it("7. Table widget validation regex", () => {
+    it.skip("7. Table widget validation regex", () => {
       _.agHelper.RefreshPage();
       _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE);
       _.agHelper.GetNClick(OneClickBindingLocator.datasourceDropdownSelector);

--- a/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionFlow_Generated_App_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/MobileResponsiveTests/ConversionFlow_Generated_App_spec.ts
@@ -4,7 +4,7 @@ import {
   draggableWidgets,
 } from "../../../../support/Objects/ObjectsCore";
 
-describe(
+describe.skip(
   "Handle Conversion for Generated/Imported Pages",
   { tags: ["@tag.Settings", "@tag.excludeForAirgap"] },
   () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
@@ -26,7 +26,7 @@ describe(
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 400);
     });
 
-    it("1. Should check the datasource selector and the form", () => {
+    it.skip("1. Should check the datasource selector and the form", () => {
       agHelper.GetNClick(oneClickBindingLocator.datasourceDropdownSelector);
       agHelper.AssertElementAbsence(
         oneClickBindingLocator.datasourceQueryBindHeaderSelector,

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
@@ -18,7 +18,7 @@ const oneClickBinding = new OneClickBinding();
 
 const upfrontContentCount = 4;
 
-describe(
+describe.skip(
   "One click binding control",
   { tags: ["@tag.excludeForAirgap", "@tag.Binding"] },
   () => {
@@ -26,7 +26,7 @@ describe(
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 400);
     });
 
-    it.skip("1. Should check the datasource selector and the form", () => {
+    it("1. Should check the datasource selector and the form", () => {
       agHelper.GetNClick(oneClickBindingLocator.datasourceDropdownSelector);
       agHelper.AssertElementAbsence(
         oneClickBindingLocator.datasourceQueryBindHeaderSelector,

--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/EntityBottomBar_spec.ts
@@ -77,7 +77,7 @@ describe(
       _.debuggerHelper.AssertOpen(PageType.DataSources);
     });
 
-    it(
+    it.skip(
       "5. Query bottom bar should be collapsable",
       { tags: ["@tag.excludeForAirgap"] },
       () => {

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad_cyclic_dependency_errors_spec.js
@@ -27,7 +27,7 @@ Cyclic Dependency Error if occurs, Message would be shown in following 6 cases:
 
 let dsname;
 
-describe(
+describe.skip(
   "Cyclic Dependency Informational Error Messages",
   { tags: ["@tag.PropertyPane", "@tag.JS", "@tag.Binding"] },
   function () {

--- a/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../support/Pages/EditorNavigation";
 import PageList from "../../../support/Pages/PageList";
 
-describe(
+describe.skip(
   "Validate Mock Query Active Ds querying & count",
   {
     tags: [

--- a/app/client/cypress/e2e/Sanity/Datasources/Styles_spec.js
+++ b/app/client/cypress/e2e/Sanity/Datasources/Styles_spec.js
@@ -1,7 +1,7 @@
 import { agHelper, dataSources } from "../../../support/Objects/ObjectsCore";
 
 let dsName;
-describe(
+describe.skip(
   "Validate Datasource Panel Styles",
   {
     tags: [

--- a/app/client/cypress/e2e/Smoke/GenerateCRUD/Generate_Crud_New_Page_spec.ts
+++ b/app/client/cypress/e2e/Smoke/GenerateCRUD/Generate_Crud_New_Page_spec.ts
@@ -1,7 +1,7 @@
 import * as _ from "../../../support/Objects/ObjectsCore";
 import PageList from "../../../support/Pages/PageList";
 
-describe(
+describe.skip(
   "Validate generate CRUD operation by creating a datasource from generate CRUD form",
   {
     tags: ["@tag.Datasource", "@tag.Sanity", "@tag.Git", "@tag.AccessControl"],


### PR DESCRIPTION
## Description
There were cases where mockdb is corrupt and we do see cypress failure. As it is not controlled by any of the team member to remain unchnaged, skipping test cases related to it.


Fixes # https://app.zenhub.com/workspaces/qa-63316faf86bb2e170ed2e46b/issues/gh/appsmithorg/appsmith/38889

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13028133245>
> Commit: 20e983d4a90d11115b90680facb14d61e8812c96
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13028133245&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 29 Jan 2025 12:03:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Skipped multiple test suites and individual test cases across various test specification files.
	- Temporarily disabled tests related to datasources, widget validation, mobile responsiveness, and CRUD operations.
	- Modifications made to prevent specific tests from running during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->