### PR TITLE
fix: action creator zendesk actions not shown fixed

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/Response/utils/getErrorFromActionResponse.ts
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/Response/utils/getErrorFromActionResponse.ts
@@ -23,6 +23,10 @@ export const getErrorMessageFromActionResponse = (
     );
   }
 
-  // Return body if plugin type is DB, otherwise return default error message
-  return pluginType === PluginType.DB ? body : DEFAULT_ERROR_MESSAGE;
+  // Return body if plugin type is DB/SAAS/ExternalSAAS, otherwise return default error message
+  return pluginType === PluginType.DB ||
+    pluginType === PluginType.SAAS ||
+    pluginType === PluginType.EXTERNAL_SAAS
+    ? body
+    : DEFAULT_ERROR_MESSAGE;
 };

--- a/app/client/src/components/editorComponents/ActionCreator/helpers.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/helpers.tsx
@@ -480,7 +480,7 @@ function getApiAndQueryOptions(
 
   const apis: ActionDataState = actions.filter(
     (action: ActionData) =>
-      action.config.pluginType == PluginType.API ||
+      action.config.pluginType === PluginType.API ||
       action.config.pluginType === PluginType.SAAS ||
       action.config.pluginType === PluginType.REMOTE ||
       action.config.pluginType === PluginType.INTERNAL ||

--- a/app/client/src/components/editorComponents/ActionCreator/helpers.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/helpers.tsx
@@ -480,11 +480,12 @@ function getApiAndQueryOptions(
 
   const apis: ActionDataState = actions.filter(
     (action: ActionData) =>
-      action.config.pluginType === PluginType.API ||
+      action.config.pluginType == PluginType.API ||
       action.config.pluginType === PluginType.SAAS ||
       action.config.pluginType === PluginType.REMOTE ||
       action.config.pluginType === PluginType.INTERNAL ||
-      action.config.pluginType === PluginType.AI,
+      action.config.pluginType === PluginType.AI ||
+      action.config.pluginType === PluginType.EXTERNAL_SAAS,
   );
 
   const queryOptions = actionList.find(


### PR DESCRIPTION
## Description
This Pr fixes two issues:
1. Action creator was not showing external saas actions
2. The error received from CS was not clearly visible in response tab


Fixes #`Issue Number`  
_or_  
Fixes https://github.com/appsmithorg/appsmith/issues/38899
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13046482198>
> Commit: 53f6abc4d3d979035359deb1b9cb7061b2fa8127
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13046482198&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Thu, 30 Jan 2025 06:41:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for different plugin types (DB, SAAS, EXTERNAL_SAAS)
	- Updated API action filtering logic to include EXTERNAL_SAAS plugin type and now includes AI plugin type as well
<!-- end of auto-generated comment: release notes by coderabbit.ai -->