### PR TITLE
chore: added buckets for 2s, 5s, 10s and 20s to be measured on grafana

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -95,7 +95,7 @@ management.opentelemetry.resource-attributes.service.instance.id=${HOSTNAME:apps
 management.opentelemetry.resource-attributes.deployment.name=${APPSMITH_DEPLOYMENT_NAME:self-hosted}
 management.tracing.sampling.probability=${APPSMITH_SAMPLING_PROBABILITY:0.1}
 management.prometheus.metrics.export.descriptions=true
-management.metrics.distribution.slo.http.server.requests=100,200,500,1000,30000
+management.metrics.distribution.slo.http.server.requests=100,200,500,1000,2000,5000,10000,20000,30000
 
 # Observability and Micrometer related configs
 # Keeping this license key around, until later


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13048938488>
> Commit: d03b480857d925f7e5b0c0375e58cee6c215b796
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13048938488&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 30 Jan 2025 10:24:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced HTTP server request metrics configuration with more granular size thresholds for improved performance monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->