### PR TITLE
chore: Updating analytics events to use workspaceId instead of orgId

### DIFF
--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -207,12 +207,12 @@ export const createPageAction = (
   applicationId: string,
   pageName: string,
   layouts: Partial<PageLayout>[],
-  orgId: string,
+  workspaceId: string,
   instanceId?: string,
 ) => {
   AnalyticsUtil.logEvent("CREATE_PAGE", {
     pageName,
-    orgId,
+    workspaceId,
     instanceId,
   });
 
@@ -229,12 +229,12 @@ export const createPageAction = (
 export const createNewPageFromEntities = (
   applicationId: string,
   pageName: string,
-  orgId: string,
+  workspaceId: string,
   instanceId?: string,
 ) => {
   AnalyticsUtil.logEvent("CREATE_PAGE", {
     pageName,
-    orgId,
+    workspaceId,
     instanceId,
   });
 

--- a/app/client/src/ce/pages/workspace/InviteUsersForm.tsx
+++ b/app/client/src/ce/pages/workspace/InviteUsersForm.tsx
@@ -414,7 +414,7 @@ function InviteUsersForm(props: any) {
       ...(!isFeatureEnabled ? { users: usersAsStringsArray } : {}),
       role: roles,
       numberOfUsersInvited: usersAsStringsArray.length,
-      orgId: props.workspaceId,
+      workspaceId: props.workspaceId,
     });
 
     return inviteUsersToWorkspace(

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -350,7 +350,7 @@ function DatasourceAuth({
 
     AnalyticsUtil.logEvent("DATASOURCE_AUTHORIZE_CLICK", {
       dsName: datasource?.name,
-      orgId: datasource?.workspaceId,
+      workspaceId: datasource?.workspaceId,
       pluginName: pluginName,
       scopeValue: scopeValue,
     });

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -167,7 +167,7 @@ export function* logSuccessfulBindings(
               entityType,
               propertyPath,
               isUndefined,
-              orgId: workspaceId,
+              workspaceId: workspaceId,
               instanceId,
             });
           }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -449,7 +449,7 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
         analyticsProperties.put(
                 "applicationId", ObjectUtils.defaultIfNull(savedActionCollection.getApplicationId(), ""));
         analyticsProperties.put("pageId", ObjectUtils.defaultIfNull(unpublishedCollection.getPageId(), ""));
-        analyticsProperties.put("orgId", ObjectUtils.defaultIfNull(savedActionCollection.getWorkspaceId(), ""));
+        analyticsProperties.put("workspaceId", ObjectUtils.defaultIfNull(savedActionCollection.getWorkspaceId(), ""));
         return analyticsProperties;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/base/ApplicationServiceCEImpl.java
@@ -930,7 +930,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         Map<String, Object> analyticsProperties = new HashMap<>();
         analyticsProperties.put("appName", ObjectUtils.defaultIfNull(savedApplication.getName(), ""));
         analyticsProperties.put("applicationId", ObjectUtils.defaultIfNull(savedApplication.getId(), ""));
-        analyticsProperties.put("orgId", ObjectUtils.defaultIfNull(savedApplication.getWorkspaceId(), ""));
+        analyticsProperties.put("workspaceId", ObjectUtils.defaultIfNull(savedApplication.getWorkspaceId(), ""));
         return analyticsProperties;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCEImpl.java
@@ -98,7 +98,7 @@ public class ArtifactServiceCEImpl implements ArtifactServiceCE {
                     final Map<String, Object> data = Map.of(
                             FieldName.APPLICATION_ID,
                             artifact.getId(),
-                            "organizationId",
+                            "workspaceId",
                             artifact.getWorkspaceId(),
                             "isRegeneratedKey",
                             gitAuth.isRegeneratedKey(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/AutoCommitEventHandlerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/AutoCommitEventHandlerCEImpl.java
@@ -174,7 +174,7 @@ public class AutoCommitEventHandlerCEImpl implements AutoCommitEventHandlerCE {
         Map<String, Object> analyticsProps = new HashMap<>();
         analyticsProps.put("appId", autoCommitEvent.getApplicationId());
         analyticsProps.put(FieldName.BRANCH_NAME, autoCommitEvent.getBranchName());
-        analyticsProps.put("orgId", autoCommitEvent.getWorkspaceId());
+        analyticsProps.put("workspaceId", autoCommitEvent.getWorkspaceId());
         analyticsProps.put("isSystemGenerated", true);
         analyticsProps.put("repoUrl", autoCommitEvent.getRepoUrl());
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
@@ -518,7 +518,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                 gitArtifactMetadata.getDefaultArtifactId(),
                 FieldName.BRANCH_NAME,
                 gitArtifactMetadata.getRefName(),
-                "organizationId",
+                "workspaceId",
                 artifact.getWorkspaceId(),
                 "repoUrl",
                 gitArtifactMetadata.getRemoteUrl(),
@@ -2096,9 +2096,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
             analyticsProps.put(FieldName.IS_MERGEABLE, isMergeable);
         }
         analyticsProps.putAll(Map.of(
-                "organizationId",
-                defaultIfNull(artifact.getWorkspaceId(), ""),
-                "orgId",
+                "workspaceId",
                 defaultIfNull(artifact.getWorkspaceId(), ""),
                 "branchApplicationId",
                 defaultIfNull(artifact.getId(), ""),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/utils/GitAnalyticsUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/utils/GitAnalyticsUtils.java
@@ -199,7 +199,7 @@ public class GitAnalyticsUtils {
         GitArtifactMetadata gitData = artifact.getGitArtifactMetadata();
         Map<String, Object> analyticsProps = new HashMap<>();
 
-        // TODO: analytics generalisation
+        // TODO: analytics generalization
         analyticsProps.put("appId", gitData.getDefaultArtifactId());
         analyticsProps.put("workspaceId", artifact.getWorkspaceId());
         analyticsProps.put(FieldName.GIT_HOSTING_PROVIDER, GitUtils.getGitProviderName(gitData.getRemoteUrl()));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/utils/GitAnalyticsUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/utils/GitAnalyticsUtils.java
@@ -111,9 +111,7 @@ public class GitAnalyticsUtils {
             analyticsProps.put(FieldName.IS_MERGEABLE, isMergeable);
         }
         analyticsProps.putAll(Map.of(
-                "organizationId",
-                defaultIfNull(artifact.getWorkspaceId(), ""),
-                "orgId",
+                "workspaceId",
                 defaultIfNull(artifact.getWorkspaceId(), ""),
                 "branchApplicationId",
                 defaultIfNull(artifact.getId(), ""),
@@ -142,7 +140,7 @@ public class GitAnalyticsUtils {
                 gitArtifactMetadata.getDefaultArtifactId(),
                 FieldName.BRANCH_NAME,
                 gitArtifactMetadata.getRefName(),
-                "organizationId",
+                "workspaceId",
                 artifact.getWorkspaceId(),
                 "repoUrl",
                 gitArtifactMetadata.getRemoteUrl(),
@@ -203,7 +201,7 @@ public class GitAnalyticsUtils {
 
         // TODO: analytics generalisation
         analyticsProps.put("appId", gitData.getDefaultArtifactId());
-        analyticsProps.put("orgId", artifact.getWorkspaceId());
+        analyticsProps.put("workspaceId", artifact.getWorkspaceId());
         analyticsProps.put(FieldName.GIT_HOSTING_PROVIDER, GitUtils.getGitProviderName(gitData.getRemoteUrl()));
         analyticsProps.put(FieldName.REPO_URL, gitData.getRemoteUrl());
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DatasourceAnalyticsUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DatasourceAnalyticsUtils.java
@@ -24,7 +24,6 @@ public class DatasourceAnalyticsUtils {
 
     public static Map<String, Object> getAnalyticsProperties(Datasource datasource) {
         Map<String, Object> analyticsProperties = new HashMap<>();
-        analyticsProperties.put("orgId", datasource.getWorkspaceId());
         analyticsProperties.put("pluginName", datasource.getPluginName());
         analyticsProperties.put("pluginId", datasource.getPluginId());
         analyticsProperties.put("dsName", datasource.getName());
@@ -37,7 +36,6 @@ public class DatasourceAnalyticsUtils {
 
     public static Map<String, Object> getAnalyticsProperties(DatasourceStorage datasourceStroge) {
         Map<String, Object> analyticsProperties = new HashMap<>();
-        analyticsProperties.put("orgId", datasourceStroge.getWorkspaceId());
         analyticsProperties.put("pluginName", datasourceStroge.getPluginName());
         analyticsProperties.put("pluginId", datasourceStroge.getPluginId());
         analyticsProperties.put("dsName", datasourceStroge.getName());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
@@ -198,7 +198,7 @@ public class CommonGitFileUtilsCE {
                 final Map<String, Object> data = Map.of(
                         artifactConstant,
                         repoPath.getParent().getFileName().toString(),
-                        "organizationId",
+                        "workspaceId",
                         repoPath.getParent().getParent().getFileName().toString(),
                         FieldName.FLOW_NAME,
                         stopwatch.getFlow(),
@@ -676,7 +676,7 @@ public class CommonGitFileUtilsCE {
                     final Map<String, Object> data = Map.of(
                             constantsMap.get(FieldName.ID),
                             baseArtifactId,
-                            "organizationId",
+                            "workspaceId",
                             workspaceId,
                             FieldName.FLOW_NAME,
                             stopwatch.getFlow(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -1370,7 +1370,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         analyticsProperties.put("actionName", ObjectUtils.defaultIfNull(unpublishedAction.getValidName(), ""));
         analyticsProperties.put("applicationId", ObjectUtils.defaultIfNull(savedAction.getApplicationId(), ""));
         analyticsProperties.put("pageId", ObjectUtils.defaultIfNull(unpublishedAction.getPageId(), ""));
-        analyticsProperties.put("orgId", ObjectUtils.defaultIfNull(savedAction.getWorkspaceId(), ""));
+        analyticsProperties.put("workspaceId", ObjectUtils.defaultIfNull(savedAction.getWorkspaceId(), ""));
         analyticsProperties.put("pluginId", ObjectUtils.defaultIfNull(savedAction.getPluginId(), ""));
         analyticsProperties.put("pluginType", ObjectUtils.defaultIfNull(savedAction.getPluginType(), ""));
         analyticsProperties.put("pluginName", ObjectUtils.defaultIfNull(unpublishedAction.getPluginName(), ""));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -1218,7 +1218,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                     extraProperties.put("jsLibsCount", objects.getT5().size());
                     extraProperties.put("appId", defaultIfNull(application.getId(), ""));
                     extraProperties.put("appName", defaultIfNull(application.getName(), ""));
-                    extraProperties.put("orgId", defaultIfNull(application.getWorkspaceId(), ""));
+                    extraProperties.put("workspaceId", defaultIfNull(application.getWorkspaceId(), ""));
                     extraProperties.put("isManual", defaultIfNull(isPublishedManually, ""));
                     extraProperties.put("publishedAt", defaultIfNull(application.getLastDeployedAt(), ""));
                     extraProperties.put("isPublic", isApplicationPublic);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/MockDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/MockDataServiceCEImpl.java
@@ -259,8 +259,10 @@ public class MockDataServiceCEImpl implements MockDataServiceCE {
                         AnalyticsEvents.CREATE.getEventName(),
                         user.getUsername(),
                         Map.of(
-                                "MockDataSource", defaultIfNull(name, ""),
-                                "orgId", defaultIfNull(workspaceId, "")))
+                                "MockDataSource",
+                                defaultIfNull(name, ""),
+                                "workspaceId",
+                                defaultIfNull(workspaceId, "")))
                 .thenReturn(user));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -1081,7 +1081,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                             actionDTO.getName(),
                             "datasource",
                             Map.of("name", datasourceStorage.getName()),
-                            "orgId",
+                            "workspaceId",
                             application.getWorkspaceId(),
                             "appId",
                             actionDTO.getApplicationId(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -1152,8 +1152,7 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
                         "pageName", page.getName(),
                         "pluginName", pluginName,
                         "datasourceId", datasourceStorage.getDatasourceId(),
-                        "organizationId", datasourceStorage.getWorkspaceId(),
-                        "orgId", datasourceStorage.getWorkspaceId());
+                        "workspaceId", datasourceStorage.getWorkspaceId());
                 return analyticsService
                         .sendEvent(AnalyticsEvents.GENERATE_CRUD_PAGE.getEventName(), currentUser.getUsername(), data)
                         .thenReturn(crudPage);


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13068319246>
> Commit: 8428afa008593145fac8ab16d3539d5cb444fc35
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13068319246&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 31 Jan 2025 08:08:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Refactor**
    - Updated terminology from "organization ID" to "workspace ID" across multiple components and services.
    - Standardized analytics event logging to use a consistent workspace identifier.
    - Removed redundant organization ID references in analytics properties.

- **Technical Improvements**
    - Simplified data structures in analytics event tracking.
    - Improved consistency in workspace identification across client and server-side code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->