### PR TITLE
chore: convert consolidated api etag to a weak one

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -294,14 +294,6 @@ $(if [[ $use_https == 1 ]]; then echo "
 
         location /api {
             proxy_pass $backend;
-
-            gzip off; # Etag stripped from upstream if gzip is off. 
-            # Ref1: https://forum.nginx.org/read.php?2,242807,242810#msg-242810
-            # Ref2: https://www.ruby-forum.com/t/reverse-proxy-deleting-etag-header-from-response/246209/2
-            # Delete the Cache-Control header set in the server block above.
-            add_header Cache-Control '' always;
-            # Proxy pass the Cache-Control header from the upstream.
-            proxy_pass_header Cache-Control;
         }
 
         location /oauth2 {

--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -294,6 +294,10 @@ $(if [[ $use_https == 1 ]]; then echo "
 
         location /api {
             proxy_pass $backend;
+            # Delete the Cache-Control header set in the server block above.
+            add_header Cache-Control '' always;
+            # Proxy pass the Cache-Control header from the upstream.
+            proxy_pass_header Cache-Control;
         }
 
         location /oauth2 {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
@@ -692,7 +692,11 @@ public class ConsolidatedAPIServiceCEImpl implements ConsolidatedAPIServiceCE {
             byte[] hashBytes = digest.digest(consolidateAPISignatureJSON.getBytes(StandardCharsets.UTF_8));
             String etag = Base64.getEncoder().encodeToString(hashBytes);
 
-            return etag;
+            // Strong Etag are removed by nginx if gzip is enabled. Hence, we are using weak etags.
+            // Ref: https://github.com/kubernetes/ingress-nginx/issues/1390
+            // Weak Etag format: W/"<etag>"
+            // Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+            return "W/\"" + etag + "\"";
         } catch (Exception e) {
             log.error("Error while computing etag for ConsolidatedAPIResponseDTO", e);
             return "";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
@@ -692,9 +692,9 @@ public class ConsolidatedAPIServiceCEImpl implements ConsolidatedAPIServiceCE {
             byte[] hashBytes = digest.digest(consolidateAPISignatureJSON.getBytes(StandardCharsets.UTF_8));
             String etag = Base64.getEncoder().encodeToString(hashBytes);
 
-            // Strong Etag are removed by nginx if gzip is enabled. Hence, we are using weak etags.
+            // Strong Etags are removed by nginx if gzip is enabled. Hence, we are using weak etags.
             // Ref: https://github.com/kubernetes/ingress-nginx/issues/1390
-            // Weak Etag format: W/"<etag>"
+            // Weak Etag format is: W/"<etag>"
             // Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
             return "W/\"" + etag + "\"";
         } catch (Exception e) {

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -130,15 +130,6 @@ parts.push(`
     import file_server
   }
 
-  handle /api/v1/consolidated-api/view {
-    reverse_proxy {
-      to 127.0.0.1:8080
-      header_up -Forwarded
-      header_up X-Appsmith-Request-Id {http.request.uuid}
-      header_down +Etag
-    }
-  }
-
   @backend path /api/* /oauth2/* /login/*
   handle @backend {
     import reverse_proxy 8080


### PR DESCRIPTION
## Description
Updated the computeConsolidatedAPIResponseEtag method to return weak ETags instead of strong ETags to ensure compatibility with nginx when gzip is enabled. This change includes adding a prefix "W/" to the ETag value and includes references to related issues and documentation.

Ref: https://github.com/kubernetes/ingress-nginx/issues/1390


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13069342399>
> Commit: b09d978d0123359c20a16d02445f97d9b9102d83
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13069342399&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 31 Jan 2025 10:40:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
	- Modified NGINX configuration to potentially enable gzip compression for API responses
	- Updated ETag generation to use weak ETag format for better compatibility
	- Removed specific route handling for consolidated API endpoint in Caddy configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->