### PR TITLE
fix: connection pool config added for dynamoDB to avoid stale connections

### DIFF
--- a/app/server/appsmith-plugins/dynamoPlugin/pom.xml
+++ b/app/server/appsmith-plugins/dynamoPlugin/pom.xml
@@ -32,6 +32,23 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>2.15.3</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description
This PR configures connection time to live property for DynamoDB plugin. This is configured to be 1 day which means after 1 day, active/idle connections will be closed. This is done to ensure that we don't face issues if the connection becomes stale.  


Fixes #[`Issue Number`](https://github.com/appsmithorg/appsmith-ee/issues/6030)  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
