### PR TITLE
fix: helm chart is rendering invalid fields in some situations

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.6.1
+version: 3.6.2
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -59,7 +59,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.redis.enabled .Values.mongodb.enabled .Values.postgresql.enabled }}
       initContainers:
+      {{- end }}
       {{- if .Values.redis.enabled }}
       - name: redis-init-container
       {{- if ((.Values.initContainer.redis).image) }}

--- a/deploy/helm/templates/persistentVolume.yaml
+++ b/deploy/helm/templates/persistentVolume.yaml
@@ -34,7 +34,6 @@ spec:
   {{- if .Values.persistence.efs.enabled }}
   csi:
     driver: {{ .Values.persistence.efs.driver }}
-    nfs:
     volumeHandle: {{ .Values.persistence.efs.volumeHandle }}
   {{ end }}
 {{- end }}

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -33,8 +33,6 @@ spec:
       targetPort: http
       {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
-      {{- else if eq .Values.service.type "ClusterIP" }}
-      nodePort: null
       {{- end }}
   selector:
     {{- include "appsmith.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Description

Fixing a few situations where the Helm chart can output manifests with invalid manifests. It seems that `helm install` is fine with them and they're being corrected on the server side. But some clients like Terraform's `kubernetes_manifest` is seeing diffs from the local version vs what's on the server.

deployment.yaml:
- if mongodb, redis, and postgres subcharts are all disabled, the manifest results in an empty `initContainers:` line

persistentVolume.yaml:
- `spec.csi` just has a stray `nfs:` 🤷 That doesn't conform to the spec https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/

service.yaml:
- when service.type is set to "ClusterIP" we add a `nodePort: null` which is wiped server-side when applying.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD d0d2bfbfb1f632ad662ea6462b555e208c7aed1c yet
> <hr>Fri, 31 Jan 2025 21:51:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced database initialization with conditional container setup for Redis, MongoDB, and PostgreSQL
	- Updated Helm chart configuration for improved storage management using EFS

- **Chores**
	- Incremented application version from 3.6.1 to 3.6.2
	- Simplified service configuration for ClusterIP type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->