### PR TITLE
fix: datasource switch behaviour

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -1237,6 +1237,8 @@ const mapDispatchToProps = (
   switchDatasource: (id: string) => {
     // on reconnect data modal, it shouldn't be redirected to datasource edit page
     dispatch(switchDatasource(id, ownProps.isInsideReconnectModal));
+    // Set view mode to true after switching datasource
+    dispatch(setDatasourceViewModeFlag(true));
   },
   setDatasourceViewMode: (payload: {
     datasourceId: string;


### PR DESCRIPTION
## Description
Current behavior: If editing mode is enabled for few datasources, then when switching datasources, we do not update the state(check before video). Also, if something has been changed in the datasource form, then when switching, we call the confirm modal. Changes: now, when switching datasources, we switch to view mode if nothing has been changed on the form and if something has been changed, we still call the modal.

Before:
https://github.com/user-attachments/assets/a91437fa-dd1d-43ef-8c99-8521999b80be


After:
https://github.com/user-attachments/assets/2868f628-9996-4566-a5b1-73e19bdd491c

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13089216392>
> Commit: 256bcbb492337b997a126cfb600131aca79581b5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13089216392&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Sat, 01 Feb 2025 16:30:00 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the datasource editor so that switching to a new datasource now automatically activates the proper view mode, ensuring a consistent and smoother experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->