### PR TITLE
chore: enforce deterministic JSON ordering for etag computation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceCEImpl.java
@@ -33,7 +33,9 @@ import com.appsmith.server.services.TenantService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.services.UserService;
 import com.appsmith.server.themes.base.ThemeService;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Span;
@@ -692,6 +694,10 @@ public class ConsolidatedAPIServiceCEImpl implements ConsolidatedAPIServiceCE {
                     "lastDeployedAt", lastDeployedAt);
 
             ObjectMapper objectMapper = new ObjectMapper();
+            // For deterministic map key ordering.
+            objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+            // For deterministic ordering of bean properties.
+            objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
             objectMapper.registerModule(new JavaTimeModule());
 
             String consolidateAPISignatureJSON = objectMapper.writeValueAsString(consolidateAPISignature);


### PR DESCRIPTION
## Description
Configured the ObjectMapper for etag computation to ensure canonical JSON output by enabling:
- SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS for consistent map key ordering
- MapperFeature.SORT_PROPERTIES_ALPHABETICALLY for deterministic bean property ordering

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13128026961>
> Commit: 105da408bd6c24a5783828ab37495925376b7648
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13128026961&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 04 Feb 2025 05:05:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the consistency of API responses to ensure more predictable and reliable behavior for clients, improving caching effectiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->