### PR TITLE
ci: allow port for mssql-server

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -155,8 +155,8 @@ jobs:
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
             -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 -p 1433:1433 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
             "appsmith/test-event-driver:${ted_tag:-latest}"
-          docker exec -it test-event-driver systemctl status mssql-server
-          docker exec -it test-event-driver /opt/mssql/bin/mssql-conf setup accept-eula
+          docker exec test-event-driver systemctl status mssql-server
+          docker exec test-event-driver /opt/mssql/bin/mssql-conf setup accept-eula
           docker restart test-event-driver
           docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \
             --privileged --pid=host --ipc=host --add-host=host.docker.internal:host-gateway\

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -149,6 +149,7 @@ jobs:
         run: |
           sudo /etc/init.d/ssh stop ;
           sudo systemctl disable --now ssh.socket
+          sudo ufw allow 1433/tcp
           mkdir -p ~/git-server/keys
           ted_tag="${{inputs.ted_tag}}"
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -28,7 +28,7 @@ on:
         description: TestEventDriver image tag
         required: false
         type: string
-        default: latest
+        default: nightly
 
 jobs:
   ci-test:

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -153,8 +153,11 @@ jobs:
           mkdir -p ~/git-server/keys
           ted_tag="${{inputs.ted_tag}}"
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
-            -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
+            -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 -p 1433:1433 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
             "appsmith/test-event-driver:${ted_tag:-latest}"
+          docker exec -it test-event-driver systemctl status mssql-server
+          docker exec -it test-event-driver /opt/mssql/bin/mssql-conf setup accept-eula
+          docker restart test-event-driver
           docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \
             --privileged --pid=host --ipc=host --add-host=host.docker.internal:host-gateway\
             -e APPSMITH_CLOUD_SERVICES_MONGODB_URI=mongodb://host.docker.internal:27017 \
@@ -470,9 +473,9 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-            name: docker-logs-${{ matrix.job }}
-            path: app/server/docker-logs.log
-            overwrite: true
+          name: docker-logs-${{ matrix.job }}
+          path: app/server/docker-logs.log
+          overwrite: true
 
       # Set status = success
       - name: Save the status of the run


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13138688065>
> Commit: 514fc7b437edc02cf6deb828f8f5cfc625e0af81
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13138688065&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Datasource
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/13138688065" target="_blank">workflow here</a>.
> <hr>Tue, 04 Feb 2025 15:26:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chore**
	- Updated the default value for the `ted_tag` input in the testing workflow to improve version management.
	- Enhanced network access settings in our testing workflow to improve connectivity and ensure a more stable environment during specific scenarios.
	- Enhanced Docker configuration to expose necessary ports for better communication with services.
	- Added steps to check the status of the SQL Server service and accept the EULA during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->