### PR TITLE
fix: move ee utitls

### DIFF
--- a/app/client/packages/utils/src/file/getFileExtension.ts
+++ b/app/client/packages/utils/src/file/getFileExtension.ts
@@ -1,0 +1,9 @@
+/**
+ * @example
+ * getFileExtension("file.txt") => "txt"
+ * getFileExtension("file") => ""
+ * getFileExtension("file.txt.txt") => "txt"
+ */
+export const getFileExtension = (fileName: string): string => {
+  return fileName.split(".").pop() ?? "";
+};

--- a/app/client/packages/utils/src/file/getFileName.ts
+++ b/app/client/packages/utils/src/file/getFileName.ts
@@ -1,0 +1,9 @@
+/**
+ * @example
+ * getFileName("file.txt") => "file"
+ * getFileName("file") => "file"
+ * getFileName("file.txt.txt") => "file.txt"
+ */
+export const getFileName = (fileName: string): string => {
+  return fileName.split(".").slice(0, 1)?.[0] || "";
+};

--- a/app/client/packages/utils/src/file/index.ts
+++ b/app/client/packages/utils/src/file/index.ts
@@ -1,0 +1,2 @@
+export { getFileExtension } from "./getFileExtension";
+export { getFileName } from "./getFileName";

--- a/app/client/packages/utils/src/index.ts
+++ b/app/client/packages/utils/src/index.ts
@@ -1,2 +1,5 @@
-export * from "./object";
 export * from "./compose";
+export * from "./file";
+export * from "./object";
+export * from "./url";
+export * from "./validateApiPath";

--- a/app/client/packages/utils/src/url/buildUrlTextFragment.test.ts
+++ b/app/client/packages/utils/src/url/buildUrlTextFragment.test.ts
@@ -1,0 +1,17 @@
+import { buildUrlTextFragment } from "./buildUrlTextFragment";
+
+it("should return an empty array if no fragments are provided", () => {
+  expect(buildUrlTextFragment([])).toEqual("");
+});
+
+it("should encode special characters", () => {
+  expect(buildUrlTextFragment(["text 1 = 2"])).toEqual(
+    ":~:text=text%201%20%3D%202",
+  );
+});
+
+it("should join fragments", () => {
+  expect(buildUrlTextFragment(["text 1", "text 2"])).toEqual(
+    ":~:text=text%201&text=text%202",
+  );
+});

--- a/app/client/packages/utils/src/url/buildUrlTextFragment.ts
+++ b/app/client/packages/utils/src/url/buildUrlTextFragment.ts
@@ -1,0 +1,17 @@
+/**
+ * @example
+ * buildUrlTextFragment(["text1"]) // ":~:text=text1"
+ * buildUrlTextFragment(["text1", "text2"]) // ":~:text=text1&text=text2"
+ * buildUrlTextFragment([]) // ""
+ */
+export const buildUrlTextFragment = (fragments: string[]): string => {
+  if (fragments.length === 0) {
+    return "";
+  }
+
+  const textFragments = fragments
+    .map(encodeURIComponent)
+    .map((line) => `text=${line}`);
+
+  return `:~:${textFragments.join("&")}`;
+};

--- a/app/client/packages/utils/src/url/index.ts
+++ b/app/client/packages/utils/src/url/index.ts
@@ -1,0 +1,1 @@
+export { buildUrlTextFragment } from "./buildUrlTextFragment";

--- a/app/client/packages/utils/src/validateApiPath/index.ts
+++ b/app/client/packages/utils/src/validateApiPath/index.ts
@@ -1,0 +1,1 @@
+export { validateApiPath } from "./validateApiPath";

--- a/app/client/packages/utils/src/validateApiPath/validateApiPath.test.ts
+++ b/app/client/packages/utils/src/validateApiPath/validateApiPath.test.ts
@@ -1,0 +1,17 @@
+import { validateApiPath } from "./validateApiPath";
+
+describe("validateApiPath", () => {
+  it("should return the path if it starts with 'https://'", () => {
+    const validPath = "https://example.com";
+
+    expect(validateApiPath(validPath)).toBe(validPath);
+  });
+
+  it("should throw an error if the path does not start with 'https://'", () => {
+    const invalidPath = "example.com";
+
+    expect(() => validateApiPath(invalidPath)).toThrow(
+      "The example.com path must start with 'https://'.",
+    );
+  });
+});

--- a/app/client/packages/utils/src/validateApiPath/validateApiPath.ts
+++ b/app/client/packages/utils/src/validateApiPath/validateApiPath.ts
@@ -1,0 +1,15 @@
+/**
+ * Validates if the given path starts with "https://".
+ * Throws an error if the path does not start with "https://".
+ *
+ * @param path - The path to validate.
+ * @returns path if the path starts with "https://".
+ * @throws Error if the path does not start with "https://".
+ */
+export const validateApiPath = (path: string): string => {
+  if (path.startsWith("https://")) {
+    return path;
+  } else {
+    throw new Error(`The ${path} path must start with 'https://'.`);
+  }
+};


### PR DESCRIPTION
## Description
Move mised utilities from the EE repo. [Part of EE PR](https://github.com/appsmithorg/appsmith-ee/pull/6082).


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced utilities to simplify file handling by extracting extensions and base names.
  - Added a function to construct URL-friendly text fragments from string arrays.
  - Implemented a utility to validate that API paths use a secure protocol.

- **Tests**
  - Added unit tests to ensure proper behavior for URL fragment construction and API path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->