### PR TITLE
chore: Replacing entity item component in schema tables with the new List item component in ADS

### DIFF
--- a/app/client/packages/design-system/ads/src/List/List.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.tsx
@@ -124,6 +124,7 @@ function ListItem(props: ListItemProps) {
       data-isblockdescription={isBlockDescription}
       data-rightcontrolvisibility={rightControlVisibility}
       data-selected={props.isSelected}
+      data-testid={props.dataTestId}
       id={props.id}
       onClick={handleOnClick}
       onDoubleClick={handleDoubleClick}

--- a/app/client/packages/design-system/ads/src/List/List.types.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.types.tsx
@@ -36,6 +36,8 @@ export interface ListItemProps {
   id?: string;
   /** customTitleComponent for the list item to use input component for name editing */
   customTitleComponent?: ReactNode | ReactNode[];
+  /** dataTestId which will be used in automated tests */
+  dataTestId?: string;
 }
 
 export interface ListProps {

--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/styles.ts
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/DatasourceTab/styles.ts
@@ -12,16 +12,9 @@ export const TableColumn = styled(Flex)`
 `;
 
 export const SchemaTableContainer = styled(Flex)`
-  & .t--entity-item {
-    height: 28px;
-    grid-template-columns: 0 auto 1fr auto auto auto auto auto;
-
-    .entity-icon > .ads-v2-icon {
+  & .ads-v2-listitem {
+    .datasource-table-icon {
       display: none;
-    }
-
-    .t--entity-name {
-      padding-left: 0;
     }
   }
 `;

--- a/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.tsx
@@ -24,7 +24,7 @@ import {
   isMatching,
   SEARCH_ITEM_TYPES,
 } from "./utils";
-import { type Plugin, PluginType } from "entities/Plugin";
+import { type Plugin, PluginType, UIComponentTypes } from "entities/Plugin";
 import { integrationEditorURL } from "ee/RouteBuilder";
 import type { AppState } from "ee/reducers";
 import { getCurrentAppWorkspace } from "ee/selectors/selectedWorkspaceSelectors";
@@ -313,7 +313,9 @@ export const updateActionOperations = (
   actionOps: ActionOperation[],
 ) => {
   const restApiPlugin = plugins.find(
-    (plugin) => plugin.type === PluginType.API,
+    (plugin) =>
+      plugin.type === PluginType.API &&
+      plugin.uiComponent === UIComponentTypes.ApiEditorForm,
   );
   const newApiActionIdx = actionOps.findIndex(
     (op) => op.title === "New blank API",

--- a/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
@@ -1,5 +1,5 @@
-import React, { memo, useMemo, useRef, useState } from "react";
-import Entity, { EntityClassNames } from "../Explorer/Entity";
+import React, { memo, useMemo, useState } from "react";
+import { EntityClassNames } from "../Explorer/Entity";
 import { datasourceTableIcon } from "../Explorer/ExplorerIcons";
 import QueryTemplates from "./QueryTemplates";
 import type { DatasourceTable } from "entities/Datasource";
@@ -10,13 +10,20 @@ import { useSelector } from "react-redux";
 import type { AppState } from "ee/reducers";
 import { getDatasource, getPlugin } from "ee/selectors/entitiesSelector";
 import { getPagePermissions } from "selectors/editorSelectors";
-import { Menu, MenuTrigger, Button, Tooltip, MenuContent } from "@appsmith/ads";
+import {
+  Menu,
+  MenuTrigger,
+  Button,
+  Tooltip,
+  MenuContent,
+  List,
+  ListItem,
+} from "@appsmith/ads";
 import { SHOW_TEMPLATES, createMessage } from "ee/constants/messages";
 import styled from "styled-components";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import type { Plugin } from "entities/Plugin";
 import { omit } from "lodash";
-import { Virtuoso } from "react-virtuoso";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 import { hasCreateDSActionPermissionInApp } from "ee/utils/BusinessFeatures/permissionPageHelpers";
@@ -47,13 +54,16 @@ const StructureWrapper = styled.div`
   height: 100%;
 `;
 
+const StyledList = styled(List)`
+  padding: 0;
+`;
+
 const DatasourceStructureItem = memo((props: DatasourceStructureItemProps) => {
   const dbStructure = props.dbStructure;
   let templateMenu = null;
   const [active, setActive] = useState(false);
 
   useCloseMenuOnScroll(SIDEBAR_ID, active, () => setActive(false));
-  const collapseRef = useRef<HTMLDivElement | null>(null);
 
   const datasource = useSelector((state: AppState) =>
     getDatasource(state, props.datasourceId),
@@ -137,17 +147,13 @@ const DatasourceStructureItem = memo((props: DatasourceStructureItemProps) => {
   }, [active, props.tableName]);
 
   return (
-    <Entity
-      action={onEntityClick}
-      active={activeState}
+    <ListItem
       className={`datasourceStructure-${props.context}`}
-      collapseRef={collapseRef}
-      contextMenu={templateMenu}
-      entityId={`${props.datasourceId}-${dbStructure.name}-${props.context}`}
-      icon={datasourceTableIcon}
-      isDefaultExpanded={props?.isDefaultOpen}
-      name={dbStructure.name}
-      step={props.step}
+      isSelected={activeState}
+      onClick={onEntityClick}
+      rightControl={templateMenu}
+      startIcon={datasourceTableIcon}
+      title={dbStructure.name}
     />
   );
 });
@@ -163,26 +169,18 @@ type DatasourceStructureProps = Partial<DatasourceStructureItemProps> & {
 };
 
 const DatasourceStructure = (props: DatasourceStructureProps) => {
-  const Row = (index: number) => {
-    const structure = props.tables[index];
-
-    return (
-      <DatasourceStructureItem
-        {...omit(props, ["tables"])}
-        dbStructure={structure}
-        key={`${props.datasourceId}${structure.name}-${props.context}`}
-        showTemplates={props.showTemplates}
-      />
-    );
-  };
-
   return (
     <StructureWrapper>
-      <Virtuoso
-        className="t--schema-virtuoso-container"
-        itemContent={Row}
-        totalCount={props.tables.length}
-      />
+      <StyledList>
+        {props.tables.map((dbStructure) => (
+          <DatasourceStructureItem
+            {...omit(props, ["tables"])}
+            dbStructure={dbStructure}
+            key={`${props.datasourceId}${dbStructure.name}-${props.context}`}
+            showTemplates={props.showTemplates}
+          />
+        ))}
+      </StyledList>
     </StructureWrapper>
   );
 };

--- a/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
@@ -16,7 +16,6 @@ import {
   Button,
   Tooltip,
   MenuContent,
-  List,
   ListItem,
 } from "@appsmith/ads";
 import { SHOW_TEMPLATES, createMessage } from "ee/constants/messages";
@@ -29,6 +28,7 @@ import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 import { hasCreateDSActionPermissionInApp } from "ee/utils/BusinessFeatures/permissionPageHelpers";
 import history from "utils/history";
 import { getIDETypeByUrl } from "ee/entities/IDE/utils";
+import { Virtuoso } from "react-virtuoso";
 
 interface DatasourceStructureItemProps {
   dbStructure: DatasourceTable;
@@ -52,10 +52,6 @@ const StructureWrapper = styled.div`
   flex-direction: column;
   flex-grow: 1;
   height: 100%;
-`;
-
-const StyledList = styled(List)`
-  padding: 0;
 `;
 
 const DatasourceStructureItem = memo((props: DatasourceStructureItemProps) => {
@@ -170,18 +166,26 @@ type DatasourceStructureProps = Partial<DatasourceStructureItemProps> & {
 };
 
 const DatasourceStructure = (props: DatasourceStructureProps) => {
+  const Row = (index: number) => {
+    const structure = props.tables[index];
+
+    return (
+      <DatasourceStructureItem
+        {...omit(props, ["tables"])}
+        dbStructure={structure}
+        key={`${props.datasourceId}${structure.name}-${props.context}`}
+        showTemplates={props.showTemplates}
+      />
+    );
+  };
+
   return (
     <StructureWrapper>
-      <StyledList className="t--schema-virtuoso-container">
-        {props.tables.map((dbStructure) => (
-          <DatasourceStructureItem
-            {...omit(props, ["tables"])}
-            dbStructure={dbStructure}
-            key={`${props.datasourceId}${dbStructure.name}-${props.context}`}
-            showTemplates={props.showTemplates}
-          />
-        ))}
-      </StyledList>
+      <Virtuoso
+        className="t--schema-virtuoso-container"
+        itemContent={Row}
+        totalCount={props.tables.length}
+      />
     </StructureWrapper>
   );
 };

--- a/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
@@ -148,7 +148,8 @@ const DatasourceStructureItem = memo((props: DatasourceStructureItemProps) => {
 
   return (
     <ListItem
-      className={`datasourceStructure-${props.context}`}
+      className={`datasourceStructure-${props.context} t--entity-item`}
+      data-testid={`t--entity-item-${dbStructure.name}`}
       isSelected={activeState}
       onClick={onEntityClick}
       rightControl={templateMenu}
@@ -171,7 +172,7 @@ type DatasourceStructureProps = Partial<DatasourceStructureItemProps> & {
 const DatasourceStructure = (props: DatasourceStructureProps) => {
   return (
     <StructureWrapper>
-      <StyledList>
+      <StyledList className="t--schema-virtuoso-container">
         {props.tables.map((dbStructure) => (
           <DatasourceStructureItem
             {...omit(props, ["tables"])}

--- a/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/DatasourceStructure.tsx
@@ -149,7 +149,7 @@ const DatasourceStructureItem = memo((props: DatasourceStructureItemProps) => {
   return (
     <ListItem
       className={`datasourceStructure-${props.context} t--entity-item`}
-      data-testid={`t--entity-item-${dbStructure.name}`}
+      dataTestId={`t--entity-item-${dbStructure.name}`}
       isSelected={activeState}
       onClick={onEntityClick}
       rightControl={templateMenu}

--- a/app/client/src/pages/Editor/DatasourceInfo/SchemaViewModeCSS.tsx
+++ b/app/client/src/pages/Editor/DatasourceInfo/SchemaViewModeCSS.tsx
@@ -43,10 +43,7 @@ export const DatasourceListContainer = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  padding-left: var(--ads-v2-spaces-5);
-  .t--entity.datasourceStructure-datasource-view-mode {
-    padding-right: var(--ads-v2-spaces-5);
-  }
+  padding: 0 var(--ads-v2-spaces-5);
   &.t--gsheet-structure {
     padding-bottom: var(--ads-v2-spaces-8);
     .t--gsheet-structure-list {
@@ -203,7 +200,6 @@ export const DatasourceStructureSearchContainer = styled.div`
   margin: var(--ads-v2-spaces-3) 0 var(--ads-v2-spaces-2) 0;
   background: white;
   flex-shrink: 0;
-  padding-right: var(--ads-v2-spaces-5);
   display: flex;
   align-items: center;
   gap: var(--ads-v2-spaces-2);
@@ -212,7 +208,6 @@ export const DatasourceStructureSearchContainer = styled.div`
     margin-bottom: var(--ads-v2-spaces-2);
   }
   &.t--search-container--query-editor {
-    padding-right: 0;
     margin: 0;
   }
 `;

--- a/app/client/src/pages/Editor/Explorer/ExplorerIcons.tsx
+++ b/app/client/src/pages/Editor/Explorer/ExplorerIcons.tsx
@@ -97,7 +97,9 @@ export const datasourceIcon = (
   />
 );
 
-export const datasourceTableIcon = <Icon name="layout-5-line" size="md" />;
+export const datasourceTableIcon = (
+  <Icon className="datasource-table-icon" name="layout-5-line" size="md" />
+);
 
 export const primaryKeyIcon = <Icon name="key-2-line" size="md" />;
 


### PR DESCRIPTION
## Description

Replacing entity item component in schema tables with the new List item component in ADS

Fixes [#38292](https://github.com/appsmithorg/appsmith/issues/38292)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13130548638>
> Commit: a280e4796a2ee1187ef7753107bb8dfb610b60b5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13130548638&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 04 Feb 2025 09:17:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved API action selection with refined filtering to ensure accurate plugin association.

- **Refactor**
  - Updated the datasource structure view for a streamlined and simplified list presentation.

- **Style**
  - Modernized styling across the datasource tab and schema view, including adjusted spacing.
  - Enhanced icon appearance for more consistent visual cues.
  - Added testability attributes to list items for improved automated testing support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->