### PR TITLE
fix: Remove Excel download option from Table widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter2_2_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/TableV2Filter2_2_Spec.ts
@@ -36,8 +36,9 @@ describe(
       //cy.verifyDownload("Table1.csv")
       table.ValidateDownloadNVerify("Table1.csv", "Michael Lawson");
 
-      table.DownloadFromTable("Download as Excel");
-      table.ValidateDownloadNVerify("Table1.xlsx", "Michael Lawson");
+      // @rahulbarwal temporarily commenting download as excel feature till we have a proper fix to the issue: https://github.com/appsmithorg/appsmith/issues/38995
+      // table.DownloadFromTable("Download as Excel");
+      // table.ValidateDownloadNVerify("Table1.xlsx", "Michael Lawson");
     });
 
     it("2. Verify Searched data - download csv and download Excel", function () {
@@ -51,16 +52,18 @@ describe(
       //cy.verifyDownload("Table1.csv")
       table.ValidateDownloadNVerify("Table1.csv", "byron.fields@reqres.in");
 
-      table.DownloadFromTable("Download as Excel");
-      table.ValidateDownloadNVerify("Table1.xlsx", "Ryan Holmes");
+      // @rahulbarwal temporarily commenting download as excel feature till we have a proper fix to the issue: https://github.com/appsmithorg/appsmith/issues/38995
+      // table.DownloadFromTable("Download as Excel");
+      // table.ValidateDownloadNVerify("Table1.xlsx", "Ryan Holmes");
 
       table.RemoveSearchTextNVerify("2381224", "v2");
 
       table.DownloadFromTable("Download as CSV");
       table.ValidateDownloadNVerify("Table1.csv", "2736212");
 
-      table.DownloadFromTable("Download as Excel");
-      table.ValidateDownloadNVerify("Table1.xlsx", "Beef steak");
+      // @rahulbarwal temporarily commenting download as excel feature till we have a proper fix to the issue: https://github.com/appsmithorg/appsmith/issues/38995
+      // table.DownloadFromTable("Download as Excel");
+      // table.ValidateDownloadNVerify("Table1.xlsx", "Beef steak");
     });
 
     it("3. Verify Filtered data - download csv and download Excel", function () {
@@ -75,8 +78,9 @@ describe(
       //cy.verifyDownload("Table1.csv")
       table.ValidateDownloadNVerify("Table1.csv", "Beef steak");
 
-      table.DownloadFromTable("Download as Excel");
-      table.ValidateDownloadNVerify("Table1.xlsx", "tobias.funke@reqres.in");
+      // @rahulbarwal temporarily commenting download as excel feature till we have a proper fix to the issue: https://github.com/appsmithorg/appsmith/issues/38995
+      // table.DownloadFromTable("Download as Excel");
+      // table.ValidateDownloadNVerify("Table1.xlsx", "tobias.funke@reqres.in");
 
       agHelper.GetNClick(table._filterBtn);
       table.RemoveFilterNVerify("2381224", true, false, 0, "v2");
@@ -84,8 +88,9 @@ describe(
       table.DownloadFromTable("Download as CSV");
       table.ValidateDownloadNVerify("Table1.csv", "Tuna Salad");
 
-      table.DownloadFromTable("Download as Excel");
-      table.ValidateDownloadNVerify("Table1.xlsx", "Avocado Panini");
+      // @rahulbarwal temporarily commenting download as excel feature till we have a proper fix to the issue: https://github.com/appsmithorg/appsmith/issues/38995
+      // table.DownloadFromTable("Download as Excel");
+      // table.ValidateDownloadNVerify("Table1.xlsx", "Avocado Panini");
     });
 
     it("4. Import TableFilter application & verify all filters for same FirstName (one word column) + Bug 13334", () => {

--- a/app/client/cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
@@ -206,8 +206,9 @@ describe(
       table.DownloadFromTable("Download as CSV");
       table.ValidateDownloadNVerify("data_table.csv", "USB Stick (Green)");
 
-      table.DownloadFromTable("Download as Excel");
-      table.ValidateDownloadNVerify("data_table.xlsx", "USB Stick (Leaf)");
+      // @rahulbarwal temporarily commenting download as excel feature till we have a proper fix to the issue: https://github.com/appsmithorg/appsmith/issues/38995
+      // table.DownloadFromTable("Download as Excel");
+      // table.ValidateDownloadNVerify("data_table.xlsx", "USB Stick (Leaf)");
       table.OpenFilter();
       table.RemoveFilter();
       agHelper

--- a/app/client/src/widgets/TableWidgetV2/component/header/actions/Download.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/header/actions/Download.tsx
@@ -91,10 +91,6 @@ const dowloadOptions: DownloadOptionProps[] = [
     label: "Download as CSV",
     value: "CSV",
   },
-  {
-    label: "Download as Excel",
-    value: "EXCEL",
-  },
 ];
 
 const downloadDataAsCSV = (props: {


### PR DESCRIPTION
## Description
As a temporary fix till we go about solving this as a whole we are disabling the download as excel option. 
Related issue: #38995

## Automation

/ok-to-test tags="@tag.Datasource, @tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13132497764>
> Commit: d0be63915a030de9d15141d36d3d10ed9c41843c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13132497764&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.Table`
> Spec:
> <hr>Tue, 04 Feb 2025 10:31:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Refined export functionality by removing the "Download as Excel" option. Downloads are now available exclusively in CSV format, streamlining the export process and offering a more focused user experience. This update is part of ongoing efforts to simplify file export options for enhanced clarity, ease of use, and overall efficiency moving forward.
- **Tests**
  - Temporarily disabled tests related to the Excel download feature due to an identified issue, ensuring the test suite remains stable while addressing this functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->