### PR TITLE
fix: Fix re-captcha case

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/Button_Text_WithRecaptcha_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/Button_Text_WithRecaptcha_spec.js
@@ -98,7 +98,9 @@ describe(
         "reCAPTCHA v2",
       );
       _.agHelper.ClickButton("Submit");
-      _.agHelper.ValidateToastMessage("Google reCAPTCHA token generation failed!");
+      _.agHelper.ValidateToastMessage(
+        "Google reCAPTCHA token generation failed!",
+      );
       _.agHelper.WaitUntilAllToastsDisappear();
     });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/Button_Text_WithRecaptcha_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/Button_Text_WithRecaptcha_spec.js
@@ -98,7 +98,8 @@ describe(
         "reCAPTCHA v2",
       );
       _.agHelper.ClickButton("Submit");
-      _.agHelper.AssertContains("Google reCAPTCHA token generation failed!");
+      _.agHelper.ValidateToastMessage("Google reCAPTCHA token generation failed!");
+      _.agHelper.WaitUntilAllToastsDisappear();
     });
 
     it("4. Validate the Button binding with Text Widget with Recaptcha Token with invalid key (after using valid key)", function () {
@@ -109,14 +110,16 @@ describe(
         testdata.invalidKey,
       );
       _.agHelper.ClickButton("Submit"); //for version 3
-      _.agHelper.WaitUntilToastDisappear(testdata.errorMsg);
+      _.agHelper.ValidateToastMessage(testdata.errorMsg);
+      _.agHelper.WaitUntilAllToastsDisappear();
       EditorNavigation.SelectEntityByName("Button1", EntityType.Widget);
       _.propPane.SelectPropertiesDropDown(
         "Google reCAPTCHA version",
         "reCAPTCHA v2",
       );
       _.agHelper.ClickButton("Submit");
-      _.agHelper.WaitUntilToastDisappear(testdata.errorMsg);
+      _.agHelper.ValidateToastMessage(testdata.errorMsg);
+      _.agHelper.WaitUntilAllToastsDisappear();
     });
   },
 );


### PR DESCRIPTION
## Description
Verify toast before disapper.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Binding"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13129952231>
> Commit: e0a07d11d559eff3a2d6e4e2bf62a98caf096c19
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13129952231&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Binding`
> Spec:
> <hr>Tue, 04 Feb 2025 08:41:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced error notification handling for Google reCAPTCHA failures to ensure users receive consistent and reliable feedback.
  - Improved the process for validating that error messages display correctly and clear as expected during failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->