### PR TITLE
chore: typofix `Obejct` -> `Object`

### DIFF
--- a/app/client/src/selectors/debuggerSelectors.tsx
+++ b/app/client/src/selectors/debuggerSelectors.tsx
@@ -14,13 +14,13 @@ import { getDataTree } from "./dataTreeSelectors";
 import type { CanvasDebuggerState } from "reducers/uiReducers/debuggerReducer";
 import { selectCombinedPreviewMode } from "./gitModSelectors";
 
-interface ErrorObejct {
+interface ErrorObject {
   [k: string]: Log;
 }
 
 export const getDebuggerErrors = (state: AppState) => state.ui.debugger.errors;
 export const hideErrors = (state: AppState) => state.ui.debugger.hideErrors;
-const emptyErrorObejct: ErrorObejct = {};
+const emptyErrorObject: ErrorObject = {};
 
 export const getFilteredErrors = createSelector(
   getDebuggerErrors,
@@ -28,9 +28,9 @@ export const getFilteredErrors = createSelector(
   getWidgets,
   getDataTree,
   (errors, hideErrors, canvasWidgets, dataTree: DataTree) => {
-    if (hideErrors) return emptyErrorObejct;
+    if (hideErrors) return emptyErrorObject;
 
-    if (isEmpty(errors)) return emptyErrorObejct;
+    if (isEmpty(errors)) return emptyErrorObject;
 
     const alwaysShowEntities: Record<string, boolean> = {};
 


### PR DESCRIPTION
## Description
Simple typofix

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal naming conventions for error handling to improve consistency and maintainability without altering the application's behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->