### PR TITLE
fix: added support for both openssh and rsa private keys

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/BasePluginErrorMessages.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/BasePluginErrorMessages.java
@@ -18,4 +18,7 @@ public abstract class BasePluginErrorMessages {
     public static final String DS_MISSING_SSH_HOSTNAME_ERROR_MSG = "SSH host value cannot be empty";
     public static final String DS_INVALID_SSH_HOSTNAME_ERROR_MSG =
             "SSH host value cannot contain `/` or `:` " + "characters.";
+    public static final String INVALID_SSH_KEY_FORMAT_ERROR_MSG =
+            "Invalid SSH key format. Supported formats: OpenSSH, PKCS#8, or RSA PEM.";
+    public static final String SSH_KEY_PARSING_ERROR_MSG = "The provided SSH key could not be parsed.";
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/SSHUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/SSHUtils.java
@@ -13,6 +13,7 @@ import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
 import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile;
 import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile;
 import net.schmizz.sshj.userauth.method.AuthPublickey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,6 +23,7 @@ import java.io.StringReader;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
+import java.security.Security;
 
 import static com.appsmith.external.constants.ConnectionMethod.CONNECTION_METHOD_SSH;
 import static com.appsmith.external.constants.PluginConstants.HostName.LOCALHOST;
@@ -73,12 +75,13 @@ public class SSHUtils {
         String keyContent = new String(key.getDecodedContent(), StandardCharsets.UTF_8);
 
         if (keyContent.contains("BEGIN OPENSSH PRIVATE KEY")) {
-            // OpenSSH format
+            // Use BouncyCastle to handle OpenSSH keys
+            Security.addProvider(new BouncyCastleProvider());
             OpenSSHKeyFile openSSHKeyFile = new OpenSSHKeyFile();
             openSSHKeyFile.init(new StringReader(keyContent));
             keyFile = openSSHKeyFile;
         } else {
-            // PEM (PKCS#8) format
+            // Handle PEM (PKCS#8) keys
             PKCS8KeyFile pkcs8KeyFile = new PKCS8KeyFile();
             pkcs8KeyFile.init(new StringReader(keyContent));
             keyFile = pkcs8KeyFile;

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/SSHUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/SSHUtilsTest.java
@@ -6,8 +6,15 @@ import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.SSHConnection;
 import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile;
+import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.Reader;
+import java.io.StringReader;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,13 +23,57 @@ import static com.appsmith.external.helpers.SSHUtils.getDBPortFromConfigOrDefaul
 import static com.appsmith.external.helpers.SSHUtils.getSSHPortFromConfigOrDefault;
 import static com.appsmith.external.helpers.SSHUtils.isSSHEnabled;
 import static com.appsmith.external.helpers.SSHUtils.isSSHTunnelConnected;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SSHUtilsTest {
+
+    @BeforeAll
+    static void setup() {
+        Security.addProvider(new BouncyCastleProvider()); // Ensure BouncyCastle is available for OpenSSH keys
+    }
+
+    /* Test OpenSSH Key Parsing */
+    @Test
+    public void testOpenSSHKeyParsing() throws Exception {
+        String opensshKey = "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                + "b3BlbnNzaC1rZXktdmVyc2lvbjE=\n"
+                + "-----END OPENSSH PRIVATE KEY-----";
+
+        Reader reader = new StringReader(opensshKey);
+        OpenSSHKeyFile openSSHKeyFile = new OpenSSHKeyFile();
+        openSSHKeyFile.init(reader);
+
+        assertNotNull(openSSHKeyFile);
+    }
+
+    /* Test PKCS#8 PEM Key Parsing */
+    @Test
+    public void testPKCS8PEMKeyParsing() throws Exception {
+        String pkcs8Key =
+                "-----BEGIN PRIVATE KEY-----\n" + "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...\n" + "-----END PRIVATE KEY-----";
+
+        Reader reader = new StringReader(pkcs8Key);
+        PKCS8KeyFile pkcs8KeyFile = new PKCS8KeyFile();
+        pkcs8KeyFile.init(reader);
+
+        assertNotNull(pkcs8KeyFile);
+    }
+
+    /* Test RSA PEM Key Parsing */
+    @Test
+    public void testRSAPEMKeyParsing() throws Exception {
+        String rsaKey =
+                "-----BEGIN RSA PRIVATE KEY-----\n" + "MIIEowIBAAKCAQEA7...\n" + "-----END RSA PRIVATE KEY-----";
+
+        Reader reader = new StringReader(rsaKey);
+        PKCS8KeyFile pkcs8KeyFile = new PKCS8KeyFile();
+        pkcs8KeyFile.init(reader);
+
+        assertNotNull(pkcs8KeyFile);
+    }
+
     /* Test is ssh enabled method */
     @Test
     public void testIsSSHEnabled_trueCase() {


### PR DESCRIPTION
## Description
> This PR adds support for OpenSSH private keys in the SSHUtils. Earlier we only supported RSA, DSA, EC key formats.

Fixes #39015 

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13160498931>
> Commit: 0c06208089c6e3498f5fca0b7ee861b7797e5cef
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13160498931&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Wed, 05 Feb 2025 15:56:40 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced secure connection setup by automatically detecting and supporting multiple SSH key formats, ensuring more reliable authentication during tunnel creation.
	- Improved error messaging for invalid SSH key formats and parsing issues.

- **Tests**
	- Added new tests to validate the parsing of OpenSSH, PKCS#8 PEM, and RSA PEM key formats, improving test coverage for SSH key handling functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->