### PR TITLE
ci: Add some build details to image labels as per OCI

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -349,14 +349,16 @@ jobs:
           rm app/client/packages/rts/dist/rts-dist.tar
 
       - name: Generate info.json
+        id: info_json
         run: |
-          if [[ -f scripts/generate_info_json.sh ]]; then
-            scripts/generate_info_json.sh
-          fi
+          content="$(scripts/generate_info_json.sh)"
+          echo "$content"
+          echo "commitSha=$(echo "$content" | jq -r .commitSha)" | tee -a "$GITHUB_OUTPUT"
+          echo "repo=$(echo "$content" | jq -r .commitUrl | sed 's,/commit/.*$,,')" | tee -a "$GITHUB_OUTPUT"
+          echo "version=$(echo "$content" | jq -r .version)" | tee -a "$GITHUB_OUTPUT"
 
       - name: Place server artifacts-es
         run: |
-          run: |
           if [[ -f scripts/prepare_server_artifacts.sh ]]; then
             scripts/prepare_server_artifacts.sh
           else
@@ -386,6 +388,11 @@ jobs:
             BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:release
           tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:${{ github.ref_name }}
+          # Labels taken from https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+          labels: |
+            org.opencontainers.image.revision=${{ steps.info_json.outputs.commitSha }}
+            org.opencontainers.image.source=${{ steps.info_json.outputs.repo }}
+            org.opencontainers.image.version=${{ steps.info_json.outputs.version }}
 
   package-master:
     needs: [ci-test, client-unit-tests, server-unit-tests]


### PR DESCRIPTION
## Description

This will allow us to identify the commit used for a Docker image, via DockerHub API, without having to download the image and inspecting the `info.json` inside.

Only doing it on `release` image for starters. If it works out well, and provides value, I'll open another PR to do this for the other places we're building the image.


## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Docker images now include enhanced metadata (commit revision, source, and version details) to improve image traceability and support deployment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->