### PR TITLE
ci: Include build information in Docker image labels

### DIFF
--- a/.github/workflows/ad-hoc-docker-image.yml
+++ b/.github/workflows/ad-hoc-docker-image.yml
@@ -90,14 +90,12 @@ jobs:
           rm app/client/packages/rts/dist/rts-dist.tar
 
       - name: Generate info.json
+        id: info_json
         run: |
-          if [[ -f scripts/generate_info_json.sh ]]; then
-            scripts/generate_info_json.sh ${{ inputs.tag }}
-          fi
+          scripts/generate_info_json.sh "${{ inputs.tag }}"
 
       - name: Place server artifacts-es
         run: |
-          run: |
           if [[ -f scripts/prepare_server_artifacts.sh ]]; then
             PG_TAG=${{ inputs.pg_tag }} scripts/prepare_server_artifacts.sh
           else
@@ -126,3 +124,7 @@ jobs:
             BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:nightly
           tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:${{ inputs.tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.info_json.outputs.commitSha }}
+            org.opencontainers.image.source=${{ steps.info_json.outputs.repo }}
+            org.opencontainers.image.version=${{ steps.info_json.outputs.version }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -70,11 +70,10 @@ jobs:
           rm app/client/packages/rts/dist/rts-dist.tar
 
       - name: Generate info.json
+        id: info_json
         run: |
-          if [[ -f scripts/generate_info_json.sh ]]; then
-            scripts/generate_info_json.sh
-          fi
-      
+          scripts/generate_info_json.sh
+
       - name: Place server artifacts-es
         env:
           EDITION: ${{ vars.EDITION }}
@@ -105,6 +104,9 @@ jobs:
             args+=(--build-arg "APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com")
           fi
           args+=(--build-arg "BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:$base_tag")
+          args+=(--label "org.opencontainers.image.revision=${{ steps.info_json.outputs.commitSha }}")
+          args+=(--label "org.opencontainers.image.source=${{ steps.info_json.outputs.repo }}")
+          args+=(--label "org.opencontainers.image.version=${{ steps.info_json.outputs.version }}")
           docker build -t cicontainer "${args[@]}" .
 
       # Saving the docker image to tar file

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -165,7 +165,7 @@ jobs:
         with:
           node-version-file: app/client/package.json
 
-      # actions/setup-node@v4 doesn’t work properly with Yarn 3
+      # actions/setup-node@v4 doesn't work properly with Yarn 3
       # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
       # Restoring the cache manually instead
       - name: Restore Yarn cache
@@ -247,6 +247,7 @@ jobs:
           rm app/client/packages/rts/dist/rts-dist.tar
 
       - name: Generate info.json
+        id: info_json
         run: |
           scripts/generate_info_json.sh
 
@@ -277,3 +278,7 @@ jobs:
             BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:nightly
           tags: |
             ${{ needs.prelude.outputs.docker_tags }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.info_json.outputs.commitSha }}
+            org.opencontainers.image.source=${{ steps.info_json.outputs.repo }}
+            org.opencontainers.image.version=${{ steps.info_json.outputs.version }}

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           node-version-file: app/client/package.json
 
-      # actions/setup-node@v4 doesn’t work properly with Yarn 3
+      # actions/setup-node@v4 doesn't work properly with Yarn 3
       # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
       # Restoring the cache manually instead
       - name: Restore Yarn cache
@@ -169,10 +169,9 @@ jobs:
           rm app/client/packages/rts/dist/rts-dist.tar
 
       - name: Generate info.json
+        id: info_json
         run: |
-          if [[ -f scripts/generate_info_json.sh ]]; then
-            scripts/generate_info_json.sh
-          fi
+          scripts/generate_info_json.sh
 
       - name: Place server artifacts-es
         run: |
@@ -209,6 +208,10 @@ jobs:
           cache-from: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:release
           tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp:${{ vars.EDITION }}-${{ github.event.client_payload.pull_request.number }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.info_json.outputs.commitSha }}
+            org.opencontainers.image.source=${{ steps.info_json.outputs.repo }}
+            org.opencontainers.image.version=${{ steps.info_json.outputs.version }}
           build-args: |
             APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com
             BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:${{ steps.set_base_tag.outputs.base_tag }}

--- a/scripts/generate_info_json.sh
+++ b/scripts/generate_info_json.sh
@@ -40,7 +40,16 @@ jq -n \
   --argjson isCI "${CI:-false}" \
   '$ARGS.named' | tee "$(git rev-parse --show-toplevel)/deploy/docker/fs/opt/appsmith/info.json"
 
-# Usage 
+# If running in GitHub Actions, also output the values to GITHUB_OUTPUT
+if [[ -n "${GITHUB_OUTPUT-}" ]]; then
+  {
+    echo "commitSha=$commit_sha"
+    echo "repo=$base_url"
+    echo "version=$version"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+# Usage
 # ./scripts/generate_info_json.sh v0.0.1
 # ./scripts/generate_info_json.sh v0.1
 # ./scripts/generate_info_json.sh


### PR DESCRIPTION
## Description

Completion of https://github.com/appsmithorg/appsmith/pull/39025.

We're able to see the labels with Docker API (script written by Cursor):

![shot-2025-02-06-04-41-44](https://github.com/user-attachments/assets/2523b85c-cd2c-4481-ac08-2de76a0dc979)


Implemented by these two Cursor prompts 🙂

![shot-2025-02-06-05-16-29](https://github.com/user-attachments/assets/6787e5f4-161e-41c6-b6fb-bdec4ea92b38)

![shot-2025-02-06-05-16-43](https://github.com/user-attachments/assets/1ec3d449-0dff-44b0-9b39-487ef6514eea)


## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Docker image builds now include added metadata (commit revision, source, and version details) to improve image traceability and version tracking.
  
- **Chores**
  - CI workflows have been streamlined to consistently generate and apply metadata labels, ensuring reliable and automated image processing across all pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->