### PR TITLE
fix: Env for disabling Keycloak is set incorrect

### DIFF
--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -110,7 +110,6 @@ helm upgrade -i "$CHARTNAME" "appsmith-ee/$HELMCHART" -n "$NAMESPACE" --create-n
   --set applicationConfig.APPSMITH_SENTRY_DSN="https://abf15a075d1347969df44c746cca7eaa@o296332.ingest.sentry.io/1546547" \
   --set applicationConfig.APPSMITH_SENTRY_ENVIRONMENT="$NAMESPACE" \
   --set applicationConfig.APPSMITH_DB_URL="mongodb+srv://$DB_USERNAME:$DB_PASSWORD@$DB_URL/$DBNAME?retryWrites=true&minPoolSize=1&maxPoolSize=10&maxIdleTimeMS=900000&authSource=admin" \
-  --set applicationConfig.APPSMITH_DISABLE_EMBEDDED_KEYCLOAK=\"1\" \
   --set applicationConfig.OPENAI_ASSISTANT_ID="$OPENAI_ASSISTANT_ID" \
   --set applicationConfig.OPENAI_API_KEY="$OPENAI_API_KEY" \
   --set applicationConfig.APPSMITH_CARBON_API_KEY="$APPSMITH_CARBON_API_KEY" \


### PR DESCRIPTION
## Description

This env variable value isn't doing what it looks like it should, that is, to disable Keycloak. It's value is showing up as `"1"` and `1` and so Keycloak is not being disabled.

![shot-2025-02-06-05-44-14](https://github.com/user-attachments/assets/7e782db3-a605-4c18-91fe-b4ef4f98a23d)

But now since we _want_ embedded Keycloak on DPs, we're "fixing" this by removing this env variable to avoid confusion later.

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Modified the deployment configuration to remove an override that previously disabled the built-in authentication service. As a result, the integrated authentication system now activates by default, offering a more streamlined user management experience. Users deploying the solution may notice this service is enabled unless configured otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->