### PR TITLE
chore: Added endpoint and impl for ssh key pairs

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCE.java
@@ -4,6 +4,7 @@ import com.appsmith.server.artifacts.base.artifactbased.ArtifactBasedService;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.domains.Artifact;
 import com.appsmith.server.domains.GitAuth;
+import com.appsmith.server.dtos.GitAuthDTO;
 import reactor.core.publisher.Mono;
 
 public interface ArtifactServiceCE {
@@ -21,4 +22,6 @@ public interface ArtifactServiceCE {
      * @return public key which will be used by user to copy to relevant platform
      */
     Mono<GitAuth> createOrUpdateSshKeyPair(ArtifactType artifactType, String branchedArtifactId, String keyType);
+
+    Mono<GitAuthDTO> getSshKey(ArtifactType artifactType, String branchedArtifactId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCEImpl.java
@@ -4,12 +4,15 @@ import com.appsmith.external.constants.AnalyticsEvents;
 import com.appsmith.server.artifacts.base.artifactbased.ArtifactBasedService;
 import com.appsmith.server.artifacts.permissions.ArtifactPermission;
 import com.appsmith.server.constants.ArtifactType;
+import com.appsmith.server.constants.Assets;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.ApplicationMode;
 import com.appsmith.server.domains.Artifact;
 import com.appsmith.server.domains.GitArtifactMetadata;
 import com.appsmith.server.domains.GitAuth;
+import com.appsmith.server.dtos.GitAuthDTO;
+import com.appsmith.server.dtos.GitDeployKeyDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.GitDeployKeyGenerator;
@@ -19,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -112,5 +116,60 @@ public class ArtifactServiceCEImpl implements ArtifactServiceCE {
                             });
                 })
                 .thenReturn(gitAuth);
+    }
+
+    /**
+     * Method to get the SSH public key
+     *
+     * @param branchedArtifactId package for which the SSH key is requested
+     * @return public SSH key
+     */
+    @Override
+    public Mono<GitAuthDTO> getSshKey(ArtifactType artifactType, String branchedArtifactId) {
+        ArtifactBasedService<?> artifactBasedService = getArtifactBasedService(artifactType);
+        ArtifactPermission artifactPermission = artifactBasedService.getPermissionService();
+        return artifactBasedService
+                .findById(branchedArtifactId, artifactPermission.getEditPermission())
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.ARTIFACT_ID, branchedArtifactId)))
+                .flatMap(artifact -> {
+                    GitArtifactMetadata gitData = artifact.getGitArtifactMetadata();
+                    List<GitDeployKeyDTO> gitDeployKeyDTOList = GitDeployKeyGenerator.getSupportedProtocols();
+                    if (gitData == null) {
+                        return Mono.error(new AppsmithException(
+                                AppsmithError.INVALID_GIT_CONFIGURATION,
+                                "Can't find valid SSH key. Please configure the artifact with git"));
+                    }
+                    // Check if the package is base package
+                    if (branchedArtifactId.equals(gitData.getDefaultArtifactId())) {
+                        gitData.getGitAuth().setDocUrl(Assets.GIT_DEPLOY_KEY_DOC_URL);
+                        GitAuthDTO gitAuthDTO = new GitAuthDTO();
+                        gitAuthDTO.setPublicKey(gitData.getGitAuth().getPublicKey());
+                        gitAuthDTO.setPrivateKey(gitData.getGitAuth().getPrivateKey());
+                        gitAuthDTO.setDocUrl(gitData.getGitAuth().getDocUrl());
+                        gitAuthDTO.setGitSupportedSSHKeyType(gitDeployKeyDTOList);
+                        return Mono.just(gitAuthDTO);
+                    }
+
+                    if (gitData.getDefaultArtifactId() == null) {
+                        throw new AppsmithException(
+                                AppsmithError.INVALID_GIT_CONFIGURATION,
+                                "Can't find root package. Please configure the package with git");
+                    }
+
+                    return artifactBasedService
+                            .findById(gitData.getDefaultArtifactId(), artifactPermission.getEditPermission())
+                            .map(baseArtifact -> {
+                                GitAuthDTO gitAuthDTO = new GitAuthDTO();
+                                GitAuth gitAuth =
+                                        baseArtifact.getGitArtifactMetadata().getGitAuth();
+                                gitAuth.setDocUrl(Assets.GIT_DEPLOY_KEY_DOC_URL);
+                                gitAuthDTO.setPublicKey(gitAuth.getPublicKey());
+                                gitAuthDTO.setPrivateKey(gitAuth.getPrivateKey());
+                                gitAuthDTO.setDocUrl(gitAuth.getDocUrl());
+                                gitAuthDTO.setGitSupportedSSHKeyType(gitDeployKeyDTOList);
+                                return gitAuthDTO;
+                            });
+                });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/artifacts/base/ArtifactServiceCEImpl.java
@@ -121,7 +121,7 @@ public class ArtifactServiceCEImpl implements ArtifactServiceCE {
     /**
      * Method to get the SSH public key
      *
-     * @param branchedArtifactId package for which the SSH key is requested
+     * @param branchedArtifactId artifact for which the SSH key is requested
      * @return public SSH key
      */
     @Override
@@ -140,7 +140,7 @@ public class ArtifactServiceCEImpl implements ArtifactServiceCE {
                                 AppsmithError.INVALID_GIT_CONFIGURATION,
                                 "Can't find valid SSH key. Please configure the artifact with git"));
                     }
-                    // Check if the package is base package
+                    // Check if the artifact is base artifact
                     if (branchedArtifactId.equals(gitData.getDefaultArtifactId())) {
                         gitData.getGitAuth().setDocUrl(Assets.GIT_DEPLOY_KEY_DOC_URL);
                         GitAuthDTO gitAuthDTO = new GitAuthDTO();
@@ -154,7 +154,7 @@ public class ArtifactServiceCEImpl implements ArtifactServiceCE {
                     if (gitData.getDefaultArtifactId() == null) {
                         throw new AppsmithException(
                                 AppsmithError.INVALID_GIT_CONFIGURATION,
-                                "Can't find root package. Please configure the package with git");
+                                "Can't find root artifact. Please configure the artifact with git");
                     }
 
                     return artifactBasedService

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/controllers/GitApplicationController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/controllers/GitApplicationController.java
@@ -1,9 +1,9 @@
 package com.appsmith.server.git.controllers;
 
+import com.appsmith.server.artifacts.base.ArtifactService;
 import com.appsmith.server.constants.Url;
 import com.appsmith.server.git.autocommit.AutoCommitService;
 import com.appsmith.server.git.central.CentralGitService;
-import com.appsmith.server.git.utils.GitProfileUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GitApplicationController extends GitApplicationControllerCE {
 
     public GitApplicationController(
-            CentralGitService centralGitService, GitProfileUtils gitProfileUtils, AutoCommitService autoCommitService) {
-        super(centralGitService, gitProfileUtils, autoCommitService);
+            CentralGitService centralGitService, AutoCommitService autoCommitService, ArtifactService artifactService) {
+        super(centralGitService, autoCommitService, artifactService);
     }
 }


### PR DESCRIPTION
## Description
 - Added implementation for creating and retrieving ssh keys for git artifacts
 - Added endpoint for application to create or retrieve ssh keys.

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13179515187>
> Commit: 37f6866fee527ccd049ce49d186266a54b4468b9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13179515187&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Thu, 06 Feb 2025 13:59:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced SSH key management, allowing users to easily retrieve and generate SSH key pairs.
  - New endpoints provide improved handling and validation of SSH key details, ensuring reliable key operations for artifacts.
  - Added functionality to retrieve SSH key information based on artifact type and branched artifact ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->