### PR TITLE
chore: remove zendesk and salesforce from premium tag

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -52,6 +52,8 @@ export const FEATURE_FLAG = {
   config_user_session_recordings_enabled:
     "config_user_session_recordings_enabled",
   release_ads_entity_item_enabled: "release_ads_entity_item_enabled",
+  release_external_saas_plugins_enabled:
+    "release_external_saas_plugins_enabled",
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG;
@@ -96,6 +98,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   config_user_session_recordings_enabled: true,
   config_mask_session_recordings_enabled: true,
   release_ads_entity_item_enabled: false,
+  release_external_saas_plugins_enabled: false,
 };
 
 export const AB_TESTING_EVENT_KEYS = {

--- a/app/client/src/pages/Editor/IntegrationEditor/APIOrSaasPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/APIOrSaasPlugins.tsx
@@ -43,13 +43,15 @@ import scrollIntoView from "scroll-into-view-if-needed";
 import PremiumDatasources from "./PremiumDatasources";
 import { pluginSearchSelector } from "./CreateNewDatasourceHeader";
 import {
-  PREMIUM_INTEGRATIONS,
+  getFilteredPremiumIntegrations,
   type PremiumIntegration,
 } from "./PremiumDatasources/Constants";
 import { getDatasourcesLoadingState } from "selectors/datasourceSelectors";
 import { getIDETypeByUrl } from "ee/entities/IDE/utils";
 import type { IDEType } from "ee/entities/IDE/constants";
 import { filterSearch } from "./util";
+import { selectFeatureFlagCheck } from "ee/selectors/featureFlagsSelectors";
+import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 
 interface CreateAPIOrSaasPluginsProps {
   location: {
@@ -321,10 +323,15 @@ const mapStateToProps = (
       ? authApiPlugin
       : undefined;
 
+  const isExternalSaasEnabled = selectFeatureFlagCheck(
+    state,
+    FEATURE_FLAG.release_external_saas_plugins_enabled,
+  );
+
   const premiumPlugins =
     props.showSaasAPIs && props.isPremiumDatasourcesViewEnabled
       ? (filterSearch(
-          PREMIUM_INTEGRATIONS,
+          getFilteredPremiumIntegrations(isExternalSaasEnabled),
           searchedPlugin,
         ) as PremiumIntegration[])
       : [];

--- a/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
@@ -11,10 +11,12 @@ import {
 import { useSelector } from "react-redux";
 import { pluginSearchSelector } from "./CreateNewDatasourceHeader";
 import { getPlugins } from "ee/selectors/entitiesSelector";
-import { PREMIUM_INTEGRATIONS } from "./PremiumDatasources/Constants";
+import { getFilteredPremiumIntegrations } from "./PremiumDatasources/Constants";
 import styled from "styled-components";
 import { filterSearch } from "./util";
 import type { MockDatasource } from "entities/Datasource";
+import { selectFeatureFlagCheck } from "ee/selectors/featureFlagsSelectors";
+import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 
 const EmptyImage = styled.img`
   margin-bottom: var(--ads-v2-spaces-6);
@@ -34,13 +36,23 @@ export default function EmptySearchedPlugins({
 
   searchedPlugin = (searchedPlugin || "").toLocaleLowerCase();
   const plugins = useSelector(getPlugins);
+
+  const isExternalSaasEnabled = useSelector((state) =>
+    selectFeatureFlagCheck(
+      state,
+      FEATURE_FLAG.release_external_saas_plugins_enabled,
+    ),
+  );
+
   const searchedItems =
     filterSearch(
       [
         ...plugins,
         { name: createMessage(CREATE_NEW_DATASOURCE_AUTHENTICATED_REST_API) },
         ...mockDatasources,
-        ...(isPremiumDatasourcesViewEnabled ? PREMIUM_INTEGRATIONS : []),
+        ...(isPremiumDatasourcesViewEnabled
+          ? getFilteredPremiumIntegrations(isExternalSaasEnabled)
+          : []),
       ],
       searchedPlugin,
     ).length > 0;

--- a/app/client/src/pages/Editor/IntegrationEditor/PremiumDatasources/Constants.ts
+++ b/app/client/src/pages/Editor/IntegrationEditor/PremiumDatasources/Constants.ts
@@ -25,6 +25,17 @@ export const PREMIUM_INTEGRATIONS: PremiumIntegration[] = [
   },
 ];
 
+export const getFilteredPremiumIntegrations = (
+  isExternalSaasEnabled: boolean,
+) => {
+  return isExternalSaasEnabled
+    ? PREMIUM_INTEGRATIONS.filter(
+        (integration) =>
+          integration.name !== "Salesforce" && integration.name !== "Zendesk",
+      )
+    : PREMIUM_INTEGRATIONS;
+};
+
 export const PREMIUM_INTEGRATION_CONTACT_FORM =
   "PREMIUM_INTEGRATION_CONTACT_FORM";
 


### PR DESCRIPTION
## Description
This PR removes soon and premium tags from zendesk and salesforce as they will be released soon


Fixes #`Issue Number`  
_or_  
Fixes https://github.com/appsmithorg/appsmith/issues/38879
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
