### PR TITLE
chore: Enable source maps for RTS for better error traces

### DIFF
--- a/deploy/docker/fs/opt/appsmith/run-rts.sh
+++ b/deploy/docker/fs/opt/appsmith/run-rts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec node /opt/appsmith/rts/bundle/server.js
+exec node --enable-source-maps /opt/appsmith/rts/bundle/server.js


### PR DESCRIPTION
## Description

The source maps files are there in the RTS folder but aren't being used because they aren't enabled. This PR fixes that by adding the necessary option to node to get better stack traces that point to the actual TypeScript files.

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the server runtime to improve error reporting and debugging, resulting in more detailed and readable error traces for a smoother troubleshooting experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->