### PR TITLE
chore: remove redundant copies in getWidgetDependencies

### DIFF
--- a/app/client/src/ce/workers/common/DependencyMap/utils/getEntityDependenciesByType.ts
+++ b/app/client/src/ce/workers/common/DependencyMap/utils/getEntityDependenciesByType.ts
@@ -57,14 +57,11 @@ export function getWidgetDependencies(
   widgetEntity: WidgetEntity,
   widgetConfig: WidgetEntityConfig,
 ): Record<string, string[]> {
-  let dependencies: Record<string, string[]> = {};
   const widgetName = widgetEntity.widgetName;
-  const widgetInternalDependencies = addWidgetPropertyDependencies({
+  const dependencies: Record<string, string[]> = addWidgetPropertyDependencies({
     widgetConfig,
     widgetName,
   });
-
-  dependencies = { ...widgetInternalDependencies };
 
   const dependencyMap = widgetConfig.dependencyMap;
 
@@ -97,7 +94,7 @@ export function getWidgetDependencies(
     const existingDeps = dependencies[fullPropertyPath] || [];
     const newDeps = union(existingDeps, dynamicPathDependencies);
 
-    dependencies = { ...dependencies, [fullPropertyPath]: newDeps };
+    dependencies[fullPropertyPath] = newDeps;
   }
 
   return dependencies;


### PR DESCRIPTION
## Description
We are doing excessive copies, this optimisation reduces the overall webworker scripting for configured xolair app by about 218ms (80% reduction in the contribution of getWidgetDependencies).


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13198011721>
> Commit: 84bc6bb003fabeb4adac6c49e68ddf0169e519ef
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13198011721&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 07 Feb 2025 13:19:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the dependency management logic to initialize and update dependencies in a more efficient and clear manner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->