### PR TITLE
fix: remove dependency listening to success or failure of mock ds api for initializing app

### DIFF
--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -227,8 +227,15 @@ export default class AppEditorEngine extends AppEngine {
 
     if (!isAirgappedInstance) {
       initActions.push(fetchMockDatasources(mockDatasources));
-      successActions.push(ReduxActionTypes.FETCH_MOCK_DATASOURCES_SUCCESS);
-      errorActions.push(ReduxActionErrorTypes.FETCH_MOCK_DATASOURCES_ERROR);
+      /*
+       * We don't want to restrict the users using the app even if the mock datasources api fails and
+       * the user is not on the airgap instance.
+       * One of those edge cases could be if the user disconnect from the internet but the mock datasources plugins
+       * are returned from the consolidated api. Hence, we want to be independent of mock datasources api response.
+       *
+       * successActions.push(ReduxActionTypes.FETCH_MOCK_DATASOURCES_SUCCESS);
+       * errorActions.push(ReduxActionErrorTypes.FETCH_MOCK_DATASOURCES_ERROR);
+       */
     }
 
     const initActionCalls: boolean = yield call(


### PR DESCRIPTION
## Description
Removing the listener to mock api error or success action to avoid breaking the apps and continue initialization process of the app. This will avoid breaking of apps if the mock datasource api is not working.


Fixes #39114
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13199761170>
> Commit: 8bbb33d56ae1787dcd92a6b6c2ea89ce9f0d6086
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13199761170&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 07 Feb 2025 14:50:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes  
  - Enhanced the reliability of data loading by adjusting how external resources are managed. The application now provides continued access to full functionality even when external data encounters issues, such as during offline scenarios. This improvement leads to a more stable and seamless editing experience for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->