### PR TITLE
fix: Wrong url set for Editor

### DIFF
--- a/app/client/src/ce/pages/Editor/IDE/constants/SidebarButtons.ts
+++ b/app/client/src/ce/pages/Editor/IDE/constants/SidebarButtons.ts
@@ -23,4 +23,4 @@ export const BottomButtons = (datasourcesExist: boolean) => [
   LibrariesButton("libraries"),
   SettingsButton("settings"),
 ];
-export const TopButtons = [EditorButton("editor")];
+export const TopButtons = [EditorButton("")];


### PR DESCRIPTION
## Description

Fixes the wrong url set for Editor CTA in sidebar. This happened during the refactor of Sidebar buttons

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13236899041>
> Commit: 9d507db5ecba4d86883240ef7c6023c25c047eed
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13236899041&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 10 Feb 2025 09:21:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the configuration for the top button in the Editor interface to remove its fixed label. This change streamlines the button's display and behavior, offering a cleaner and more intuitive experience in the editor view. The update improves the overall visual consistency of the toolbar while all other interface elements remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->