### PR TITLE
chore: fixing discard message

### DIFF
--- a/app/client/src/git/components/OpsModal/TabDeploy/TabDeployView.tsx
+++ b/app/client/src/git/components/OpsModal/TabDeploy/TabDeployView.tsx
@@ -12,6 +12,7 @@ import {
   COMMITTING_AND_PUSHING_CHANGES,
   createMessage,
   DISCARD_CHANGES,
+  DISCARD_SUCCESS,
   DISCARDING_AND_PULLING_CHANGES,
   GIT_NO_UPDATED_TOOLTIP,
   PULL_CHANGES,
@@ -239,7 +240,7 @@ function TabDeployView({
     AnalyticsUtil.logEvent("GIT_DISCARD", {
       source: "GIT_DISCARD_BUTTON_PRESS_2",
     });
-    discard(createMessage(DISCARD_CHANGES));
+    discard(createMessage(DISCARD_SUCCESS));
     setShowDiscardWarning(false);
     setShouldDiscard(true);
     setIsDiscarding(true);


### PR DESCRIPTION
## Description
Discard toast issue, introduced in https://github.com/appsmithorg/appsmith/pull/39140

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13240898404>
> Commit: f8e760a40de3d8fb8b03ec606903030df6cf0643
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13240898404&attempt=4&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Git
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/QueryPane/Mongo1_spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Mon, 10 Feb 2025 22:21:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the discard confirmation so users now receive a clear success notification, ensuring more accurate feedback when changes are discarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->