### PR TITLE
fix: stop tooltip from overflowing out of view in preview and deployed mode.

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input3_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Input3_Spec.ts
@@ -104,6 +104,7 @@ describe(
       );
       agHelper.HoverElement(locators._tooltipIcon);
       agHelper.AssertPopoverTooltip("Input tooltip");
+      agHelper.AssertCSS(locators._tooltipIcon, "overflow", "hidden");
       agHelper.ClearNType(
         locators._widgetInDeployed(draggableWidgets.INPUT_V2) + " textarea",
         "test",

--- a/app/client/packages/design-system/widgets-old/src/Tooltip/index.tsx
+++ b/app/client/packages/design-system/widgets-old/src/Tooltip/index.tsx
@@ -76,7 +76,13 @@ if (!portalContainer) {
 function TooltipComponent(props: TooltipProps) {
   const modifiers = useMemo(
     () => ({
-      preventOverflow: { enabled: false },
+      preventOverflow: {
+        enabled: true,
+        boundariesElement: "viewport",
+      },
+      flip: {
+        enabled: true,
+      },
       ...props.modifiers,
     }),
     [props.modifiers],


### PR DESCRIPTION
### Problem
Tooltips in the application were overflowing out of the viewport, causing them to be partially or completely hidden.

### Why This is Happening
The preventOverflow modifier was disabled, and the flip modifier was not enabled in the Tooltip component, leading to improper positioning of tooltips.

### Solution
- Enabled the preventOverflow modifier and set its boundary to the viewport.
- Enabled the flip modifier to ensure better positioning of tooltips.
- Added a CSS assertion in the Input widget tests to verify that the tooltip icon has an overflow property set to "hidden".

### Why This is the Best Solution
Enabling these modifiers ensures that tooltips adjust dynamically to remain fully on-screen, improving the user experience by making tooltips consistently visible. The additional test assertion helps maintain the integrity of the tooltip icon's CSS properties.

Fixes #34445 

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13305105052>
> Commit: 1f20716e5ad8bc3fff67da40e43a245ca8a0890f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13305105052&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 13 Feb 2025 11:33:13 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced tooltip behavior improves positioning and visibility by ensuring tooltips adjust dynamically to remain fully on-screen.
  
- **Tests**
  - Added assertions to validate tooltip appearance and behavior in the InputV2 widget tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->