### PR TITLE
fix: move to page redirection issue fixed for paragon integration

### DIFF
--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -1064,6 +1064,7 @@ function* handleMoveOrCopySaga(actionPayload: ReduxAction<Action>) {
   const isQuery = pluginType === PluginType.DB;
   const isSaas = pluginType === PluginType.SAAS;
   const isInternal = pluginType === PluginType.INTERNAL;
+  const isExternalSaas = pluginType === PluginType.EXTERNAL_SAAS;
   const { parentEntityId } = resolveParentEntityMetadata(actionPayload.payload);
 
   if (!parentEntityId) return;
@@ -1082,7 +1083,7 @@ function* handleMoveOrCopySaga(actionPayload: ReduxAction<Action>) {
     );
   }
 
-  if (isQuery || isInternal) {
+  if (isQuery || isInternal || isExternalSaas) {
     history.push(
       queryEditorIdURL({
         baseParentEntityId,

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -1060,11 +1060,6 @@ function* toggleActionExecuteOnLoadSaga(
 
 function* handleMoveOrCopySaga(actionPayload: ReduxAction<Action>) {
   const { baseId: baseActionId, pluginId, pluginType } = actionPayload.payload;
-  const isApi = pluginType === PluginType.API;
-  const isQuery = pluginType === PluginType.DB;
-  const isSaas = pluginType === PluginType.SAAS;
-  const isInternal = pluginType === PluginType.INTERNAL;
-  const isExternalSaas = pluginType === PluginType.EXTERNAL_SAAS;
   const { parentEntityId } = resolveParentEntityMetadata(actionPayload.payload);
 
   if (!parentEntityId) return;
@@ -1074,37 +1069,40 @@ function* handleMoveOrCopySaga(actionPayload: ReduxAction<Action>) {
     parentEntityId,
   );
 
-  if (isApi) {
-    history.push(
-      apiEditorIdURL({
-        baseParentEntityId,
-        baseApiId: baseActionId,
-      }),
-    );
-  }
+  switch (pluginType) {
+    case PluginType.API: {
+      history.push(
+        apiEditorIdURL({
+          baseParentEntityId,
+          baseApiId: baseActionId,
+        }),
+      );
+      break;
+    }
+    case PluginType.SAAS: {
+      const plugin = shouldBeDefined<Plugin>(
+        yield select(getPlugin, pluginId),
+        `Plugin not found for pluginId - ${pluginId}`,
+      );
 
-  if (isQuery || isInternal || isExternalSaas) {
-    history.push(
-      queryEditorIdURL({
-        baseParentEntityId,
-        baseQueryId: baseActionId,
-      }),
-    );
-  }
-
-  if (isSaas) {
-    const plugin = shouldBeDefined<Plugin>(
-      yield select(getPlugin, pluginId),
-      `Plugin not found for pluginId - ${pluginId}`,
-    );
-
-    history.push(
-      saasEditorApiIdURL({
-        baseParentEntityId,
-        pluginPackageName: plugin.packageName,
-        baseApiId: baseActionId,
-      }),
-    );
+      history.push(
+        saasEditorApiIdURL({
+          baseParentEntityId,
+          pluginPackageName: plugin.packageName,
+          baseApiId: baseActionId,
+        }),
+      );
+      break;
+    }
+    default: {
+      history.push(
+        queryEditorIdURL({
+          baseParentEntityId,
+          baseQueryId: baseActionId,
+        }),
+      );
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This PR fixes issue where if we move external saas integration query from page 1 to page 2, redirection to page 2 was not happening. It's been fixed in this PR. This issue was there for remote as well as AI plugin, it's been fixed as well.


Fixes #39163 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13286248107>
> Commit: 1cae0a7d35772483778126338fee5b4ed1d7f764
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13286248107&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Wed, 12 Feb 2025 14:03:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal navigation logic for plugin workflows by replacing multiple conditional checks with a structured approach. The update improves code maintainability without impacting existing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->