### PR TITLE
ci: CI update for commitMsg

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -371,6 +371,7 @@ jobs:
           CYPRESS_SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
           CYPRESS_SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           NODE_ENV: development
+          GITHUB_WORKFLOW : ${{ github.workflow }}
         run: |
             cd app/client
             ls -la

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -248,6 +248,7 @@ jobs:
           CYPRESS_SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
           CYPRESS_SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           NODE_ENV: development
+          GITHUB_WORKFLOW : ${{ github.workflow }}
         run: |
             cd app/client
             npx cypress-repeat-pro run -n 3 --rerun-failed-only \

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -427,6 +427,7 @@ jobs:
             CYPRESS_SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
             CYPRESS_SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
             NODE_ENV: development
+            GITHUB_WORKFLOW : ${{ github.workflow }}
         run: |
             cd app/client
             if [[ "${{ inputs.update_snapshot }}" == "true" ]]; then

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -342,6 +342,7 @@ jobs:
           CYPRESS_SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_ACCOUNT_NAME }}
           CYPRESS_SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
           CYPRESS_SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          GITHUB_WORKFLOW : ${{ github.workflow }}
         with:
           browser: ${{ env.BROWSER_PATH }}
           install: false

--- a/app/client/cypress/scripts/cypress-split-dynamic.ts
+++ b/app/client/cypress/scripts/cypress-split-dynamic.ts
@@ -98,6 +98,8 @@ export class dynamicSplit {
   private async createAttempt() {
     const client = await this.dbClient.connect();
     try {
+      const workflowName = this.util.getVars().gitWorkflowName;
+      const commitMsgWithWorkflow = `${this.util.getVars().commitMsg}_${workflowName}`;
       const runResponse = await client.query(
         `INSERT INTO public."attempt" ("workflowId", "attempt", "repo", "committer", "type", "commitMsg", "branch")
           VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -109,7 +111,7 @@ export class dynamicSplit {
           this.util.getVars().repository,
           this.util.getVars().committer,
           this.util.getVars().tag,
-          this.util.getVars().commitMsg,
+          commitMsgWithWorkflow,
           this.util.getVars().branch,
         ],
       );

--- a/app/client/cypress/scripts/cypress-split-static.ts
+++ b/app/client/cypress/scripts/cypress-split-static.ts
@@ -67,6 +67,8 @@ export class staticSplit {
   private async createAttempt() {
     const client = await this.dbClient.connect();
     try {
+      const workflowName = this.util.getVars().gitWorkflowName;
+      const commitMsgWithWorkflow = `${this.util.getVars().commitMsg}_${workflowName}`;
       const runResponse = await client.query(
         `INSERT INTO public."attempt" ("workflowId", "attempt", "repo", "committer", "type", "commitMsg", "branch")
           VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -78,7 +80,7 @@ export class staticSplit {
           this.util.getVars().repository,
           this.util.getVars().committer,
           this.util.getVars().tag,
-          this.util.getVars().commitMsg,
+          commitMsgWithWorkflow,
           this.util.getVars().branch,
         ],
       );

--- a/app/client/cypress/scripts/util.ts
+++ b/app/client/cypress/scripts/util.ts
@@ -42,6 +42,7 @@ export default class util {
       staticAllocation: this.getEnvValue("CYPRESS_STATIC_ALLOCATION", {
         required: false,
       }),
+      gitWorkflowName: this.getEnvValue("GITHUB_WORKFLOW", { required: false }),
     };
   }
 


### PR DESCRIPTION
## Description

**Problem**: The Schedule TBP data for both Release and Airgap workflows is currently identical in the database, making it difficult to distinguish between them.
**Solution**: Added the workflow name to the commitMsg column, ensuring a clear and accurate view of the data for each workflow.


Fixes # https://app.zenhub.com/workspaces/qa-63316faf86bb2e170ed2e46b/issues/gh/appsmithorg/appsmith/39253


## Automation

/ok-to-test tags="@tag.SignIn"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13309520198>
> Commit: 87d33db158fe9ded6261edd13cf7f89e5e643ab0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13309520198&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.SignIn`
> Spec:
> <hr>Thu, 13 Feb 2025 14:28:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable input to specify the number of test iterations.
  - Updated test commands to conditionally target specific test files based on provided parameters.

- **Tests**
  - Enhanced test reporting by appending workflow context to commit messages.
  - Improved workflow tracking with the addition of a variable reflecting the active workflow name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->