### PR TITLE
fix: Fix flakiness of JSObjects_navigation_spec.ts spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Debugger/JSObjects_navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Debugger/JSObjects_navigation_spec.ts
@@ -7,8 +7,6 @@ import {
 } from "../../../../support/Objects/ObjectsCore";
 import EditorNavigation, {
   EditorViewMode,
-  PageLeftPane,
-  PagePaneSegment,
 } from "../../../../support/Pages/EditorNavigation";
 
 describe("JSObjects", { tags: ["@tag.JS"] }, () => {
@@ -73,9 +71,10 @@ describe("JSObjects", { tags: ["@tag.JS"] }, () => {
     agHelper.AssertCursorInput(jsEditor._editor, { ch: 20, line: 6 });
 
     jsEditor.DeleteJSObjectFromContextMenu();
+    agHelper.WaitUntilToastDisappear("JSObject1 deleted successfully"); // Confirming deletion
   });
 
-  it("2. Bug 24990 Clears logs filter using backspace", function () {
+  it("3. Bug 24990 Clears logs filter using backspace", function () {
     const JS_OBJECT_BODY = `export default {
       myVar1: [],
       myVar2: {},
@@ -87,6 +86,7 @@ describe("JSObjects", { tags: ["@tag.JS"] }, () => {
           return []
       }
   }`;
+    EditorNavigation.SwitchScreenMode(EditorViewMode.FullScreen); // Switching back to full screen as CreateJSObject() was failing in split screen mode
     jsEditor.CreateJSObject(JS_OBJECT_BODY, {
       paste: true,
       completeReplace: true,


### PR DESCRIPTION
## Description
This PR fixes the flakiness of `cypress/e2e/Regression/ClientSide/Debugger/JSObjects_navigation_spec.ts` by making the following improvements:

1. Adding an assertion to verify the deletion of a JS Object in the second test case.
2. Switching to full-screen mode before creating a JS Object in the third test case.


Fixes https://github.com/appsmithorg/appsmith/issues/39267

## Automation

/ok-to-test tags="@tag.JS, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13325804763>
> Commit: 1e5af6110108e9694317e6943e487cc03c2edb34
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13325804763&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS, @tag.Sanity`
> Spec:
> <hr>Fri, 14 Feb 2025 09:51:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced deletion confirmation checks to ensure users see successful deletion notifications.
  - Improved test stability by enforcing the correct screen mode before creating new objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->