### PR TITLE
chore: Remove unused param `branchName` on partial import method

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
@@ -329,7 +329,7 @@ public class ApplicationControllerCE {
             @PathVariable String branchedApplicationId,
             @RequestParam(name = FieldName.PAGE_ID) String branchedPageId) {
         return fileMono.flatMap(fileData -> partialImportService.importResourceInPage(
-                        workspaceId, branchedApplicationId, branchedPageId, null, fileData))
+                        workspaceId, branchedApplicationId, branchedPageId, fileData))
                 .map(fetchedResource -> new ResponseDTO<>(HttpStatus.CREATED.value(), fetchedResource, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCE.java
@@ -8,8 +8,7 @@ import reactor.core.publisher.Mono;
 
 public interface PartialImportServiceCE {
 
-    Mono<Application> importResourceInPage(
-            String workspaceId, String applicationId, String pageId, String branchName, Part file);
+    Mono<Application> importResourceInPage(String workspaceId, String applicationId, String pageId, Part file);
 
     Mono<BuildingBlockResponseDTO> importBuildingBlock(BuildingBlockDTO buildingBlockDTO);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/partial/PartialImportServiceCEImpl.java
@@ -6,7 +6,6 @@ import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.server.acl.AclPermission;
-import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.datasources.base.DatasourceService;
@@ -98,7 +97,6 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
     private final WidgetRefactorUtil widgetRefactorUtil;
     private final ApplicationPageService applicationPageService;
     private final NewActionService newActionService;
-    private final ActionCollectionService actionCollectionService;
     private final ArtifactBasedImportService<Application, ApplicationImportDTO, ApplicationJson>
             applicationImportService;
     private final DatasourceService datasourceService;
@@ -107,8 +105,7 @@ public class PartialImportServiceCEImpl implements PartialImportServiceCE {
     private final DryOperationRepository dryOperationRepository;
 
     @Override
-    public Mono<Application> importResourceInPage(
-            String workspaceId, String applicationId, String pageId, String branchName, Part file) {
+    public Mono<Application> importResourceInPage(String workspaceId, String applicationId, String pageId, Part file) {
         Mono<User> currUserMono = sessionUserService.getCurrentUser();
         return importService
                 .extractArtifactExchangeJson(file)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialImportServiceTest.java
@@ -285,7 +285,7 @@ public class PartialImportServiceTest {
         Part filePart = createFilePart("test_assets/ImportExportServiceTest/partial-export-resource.json");
 
         Mono<Tuple3<Application, List<NewAction>, List<ActionCollection>>> result = partialImportService
-                .importResourceInPage(workspaceId, testApplication.getId(), pageId, null, filePart)
+                .importResourceInPage(workspaceId, testApplication.getId(), pageId, filePart)
                 .flatMap(application -> {
                     Mono<List<NewAction>> actionList = newActionService
                             .findByPageId(pageId, Optional.empty())
@@ -338,7 +338,7 @@ public class PartialImportServiceTest {
 
         PageDTO finalSavedPage = savedPage;
         Mono<Tuple3<Application, List<NewAction>, List<ActionCollection>>> result = partialImportService
-                .importResourceInPage(workspaceId, application.getId(), savedPage.getId(), "master", filePart)
+                .importResourceInPage(workspaceId, application.getId(), savedPage.getId(), filePart)
                 .flatMap(application1 -> {
                     Mono<List<NewAction>> actionList = newActionService
                             .findByPageId(finalSavedPage.getId(), Optional.empty())
@@ -398,9 +398,8 @@ public class PartialImportServiceTest {
         Part filePart = createFilePart("test_assets/ImportExportServiceTest/partial-export-resource.json");
 
         Mono<Tuple3<Application, List<NewAction>, List<ActionCollection>>> result = partialImportService
-                .importResourceInPage(workspaceId, testApplication.getId(), pageId, null, filePart)
-                .then(partialImportService.importResourceInPage(
-                        workspaceId, testApplication.getId(), pageId, null, filePart))
+                .importResourceInPage(workspaceId, testApplication.getId(), pageId, filePart)
+                .then(partialImportService.importResourceInPage(workspaceId, testApplication.getId(), pageId, filePart))
                 .flatMap(application -> {
                     Mono<List<NewAction>> actionList = newActionService
                             .findByPageId(pageId, Optional.empty())


### PR DESCRIPTION
## Description

This method argument isn't used and is mostly set to `null` everywhere we're calling this. So we're removing it to cleanup.

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
