### PR TITLE
chore: Code split for logout success handler (#39296)

### DIFF
--- a/app/client/cypress/support/Pages/HomePage.ts
+++ b/app/client/cypress/support/Pages/HomePage.ts
@@ -358,12 +358,8 @@ export class HomePage {
 
   //Maps to LogOut in command.js
   public LogOutviaAPI() {
-    let httpMethod = "POST";
-    if (CURRENT_REPO === REPO.EE) {
-      httpMethod = "GET";
-    }
     cy.request({
-      method: httpMethod,
+      method: "POST",
       url: "/api/v1/logout",
       headers: {
         "X-Requested-By": "Appsmith",

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -225,9 +225,6 @@ Cypress.Commands.add("LogOut", (toCheckgetPluginForm = true) => {
 
   // Logout is a POST request in CE
   let httpMethod = "POST";
-  if (CURRENT_REPO === REPO.EE) {
-    httpMethod = "GET";
-  }
 
   if (CURRENT_REPO === REPO.CE)
     toCheckgetPluginForm &&
@@ -582,11 +579,8 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.intercept("GET", "/api/v1/users/profile").as("getUser");
   cy.intercept("GET", "/api/v1/plugins?workspaceId=*").as("getPlugins");
 
-  if (CURRENT_REPO === REPO.CE) {
-    cy.intercept("POST", "/api/v1/logout").as("postLogout");
-  } else if (CURRENT_REPO === REPO.EE) {
-    cy.intercept("GET", "/api/v1/logout").as("postLogout");
-  }
+  cy.intercept("POST", "/api/v1/logout").as("postLogout");
+
   cy.intercept("GET", "/api/v1/datasources?workspaceId=*").as("getDataSources");
   cy.intercept("GET", "/api/v1/pages?*mode=EDIT").as("getPagesForCreateApp");
   cy.intercept("GET", "/api/v1/pages?*mode=PUBLISHED").as("getPagesForViewApp");

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/LogoutSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/LogoutSuccessHandlerCE.java
@@ -6,16 +6,21 @@ import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.services.AnalyticsService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
 @Slf4j
@@ -24,9 +29,12 @@ public class LogoutSuccessHandlerCE implements ServerLogoutSuccessHandler {
     private final ObjectMapper objectMapper;
     private final AnalyticsService analyticsService;
 
+    @Getter(AccessLevel.PROTECTED)
+    private final String postLogoutRedirectUri = "/user/login";
+
     public LogoutSuccessHandlerCE(ObjectMapper objectMapper, AnalyticsService analyticsService) {
-        this.objectMapper = objectMapper;
         this.analyticsService = analyticsService;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -37,21 +45,59 @@ public class LogoutSuccessHandlerCE implements ServerLogoutSuccessHandler {
         ServerHttpResponse response = exchange.getResponse();
         response.setStatusCode(HttpStatus.OK);
         response.getHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        ResponseDTO<Boolean> responseBody = new ResponseDTO<>(HttpStatus.OK.value(), true, null);
+        String responseStr;
         try {
-            ResponseDTO<Boolean> responseBody = new ResponseDTO<>(HttpStatus.OK.value(), true, null);
-            String responseStr = objectMapper.writeValueAsString(responseBody);
-            DataBuffer buffer =
-                    exchange.getResponse().bufferFactory().allocateBuffer().write(responseStr.getBytes());
-            return analyticsService
-                    .sendObjectEvent(AnalyticsEvents.LOGOUT, (User) authentication.getPrincipal())
-                    .then(response.writeWith(Mono.just(buffer)));
+            responseStr = objectMapper.writeValueAsString(responseBody);
         } catch (JsonProcessingException e) {
             log.error("Unable to write to response json. Cause: ", e);
             // Returning a hard-coded failure json
-            String responseStr = "{\"responseMeta\":{\"status\":500,\"success\":false},\"data\":false}";
-            DataBuffer buffer =
-                    exchange.getResponse().bufferFactory().allocateBuffer().write(responseStr.getBytes());
+            responseStr = "{\"responseMeta\":{\"status\":500,\"success\":false},\"data\":false}";
+            DataBuffer buffer = exchange.getResponse()
+                    .bufferFactory()
+                    .allocateBuffer(responseStr.length())
+                    .write(responseStr.getBytes());
             return response.writeWith(Mono.just(buffer));
         }
+
+        DataBuffer buffer = exchange.getResponse()
+                .bufferFactory()
+                .allocateBuffer(responseStr.length())
+                .write(responseStr.getBytes());
+        Mono<Void> postLogoutRedirectionMono = this.generatePostLogoutRedirectUri(webFilterExchange, authentication)
+                .flatMap(this::clearOAuthSessionIfRequired)
+                .then(response.writeWith(Mono.just(buffer)));
+        return analyticsService
+                .sendObjectEvent(AnalyticsEvents.LOGOUT, (User) authentication.getPrincipal())
+                .then(postLogoutRedirectionMono);
+    }
+
+    protected Mono<String> generatePostLogoutRedirectUri(
+            WebFilterExchange webFilterExchange, Authentication authentication) {
+        return Mono.just(postLogoutRedirectUri(webFilterExchange.getExchange().getRequest()));
+    }
+
+    protected static UriComponents getUriComponents(ServerHttpRequest request) {
+        return UriComponentsBuilder.fromUri(request.getURI())
+                .replacePath(request.getPath().contextPath().value())
+                .replaceQuery(null)
+                .fragment(null)
+                .build();
+    }
+
+    protected String postLogoutRedirectUri(ServerHttpRequest request) {
+        UriComponents uriComponents = getUriComponents(request);
+        String scheme = uriComponents.getScheme();
+        String host = uriComponents.getHost();
+        return UriComponentsBuilder.newInstance()
+                .scheme((scheme != null) ? scheme : "")
+                .host((host != null) ? host : "")
+                .path(this.getPostLogoutRedirectUri())
+                .build()
+                .toUriString();
+    }
+
+    protected Mono<Void> clearOAuthSessionIfRequired(String logoutRedirectUri) {
+        return Mono.empty();
     }
 }


### PR DESCRIPTION
## Description
Added redirect URL on user logout

Fixes https://github.com/appsmithorg/appsmith/issues/38933

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run:
<https://github.com/appsmithorg/appsmith/actions/runs/13369328042>
> Commit: 5b4bbe9381d8591234c5b76687ed83b88e288f17
> <a
href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13369328042&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 17 Feb 2025 12:14:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
- Users are now automatically redirected to the login page after logout for a smoother navigation experience.
- **Refactor**
- Simplified the logout request process to consistently use the "POST" method, enhancing reliability.
- Streamlined the interception logic for logout API calls, improving overall consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Albin <albin@appsmith.com>
(cherry picked from commit e4ed590822ef736fbd199b16390b8a94a4a9cd56)

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
