### PR TITLE
fix: UQI dropdown search issue fixed

### DIFF
--- a/app/client/src/components/formControls/DropDownControl.test.tsx
+++ b/app/client/src/components/formControls/DropDownControl.test.tsx
@@ -554,6 +554,7 @@ describe("DropdownControl Single select tests", () => {
     isLoading: false,
     maxTagCount: 3,
     isAllowClear: true,
+    isSearchable: true,
   };
 
   beforeEach(() => {
@@ -586,5 +587,35 @@ describe("DropdownControl Single select tests", () => {
 
       expect(options.length).toBe(0);
     });
+  });
+
+  it("should filter options when searching", async () => {
+    render(
+      <Provider store={store}>
+        <ReduxFormDecorator>
+          <DropDownControl {...dropDownPropsSingleSelect} />
+        </ReduxFormDecorator>
+      </Provider>,
+    );
+
+    // Find and click the dropdown to open it
+    const dropdownSelect = await screen.findByTestId(
+      "t--dropdown-actionConfiguration.testPath",
+    );
+
+    fireEvent.mouseDown(dropdownSelect.querySelector(".rc-select-selector")!);
+
+    // Find the search input and type "Option 2"
+    const searchInput = screen.getByPlaceholderText("Type to search...");
+
+    fireEvent.change(searchInput, { target: { value: "Option 2" } });
+
+    // Get all visible options
+    const visibleOptions = screen.getAllByRole("option");
+
+    // // Should only show one option
+    expect(visibleOptions).toHaveLength(1);
+    // The visible option should be "Option 1"
+    expect(visibleOptions[0]).toHaveTextContent("Option 2");
   });
 });

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -466,6 +466,10 @@ function renderDropdown(
       onDeselect={onRemoveOptions}
       onPopupScroll={handlePopupScroll}
       onSelect={onSelectOptions}
+      // Default value of optionFilterProp prop is `value` which searches the dropdown based on value and not label,
+      // hence explicitly setting this to label to search based on label.
+      // For eg. If value is `Create_ticket` and label is `Create ticket`, we should be able to search using `Create ticket`.
+      optionFilterProp="label"
       placeholder={props.placeholderText}
       showSearch={props.isSearchable}
       value={isMultiSelect ? selectedOptions : selectedOptions[0]}


### PR DESCRIPTION
## Description
This PR fixes search issues with dropdown UQI control. 

Steps to reproduce:
1. Create zendesk datasource
2. Create a query
3. Check commands dropdown
4. Try searching for "Create ticket"
5. It should show the relevant options


Fixes #39164   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
