### PR TITLE
add cronjobs to imago's permissions to fix error

### DIFF
--- a/deploy/helm/templates/autoupdate.yaml
+++ b/deploy/helm/templates/autoupdate.yaml
@@ -60,6 +60,7 @@ rules:
       - daemonsets
       - deployments
       - statefulsets
+      - cronjobs
     verbs:
       - get
       - list


### PR DESCRIPTION
## Description

I noticed that when the autoupdate.enabled is set to true in the Helm chart, that imago's pods are always failing. They _do_ upgrade any deployments/statefulsets/daemonsets in the namespace it's running in, but it's constantly failing with this error:

```
kubectl logs pod/imago-28998600-2h45w
2025/02/18 22:00:11 checking default/Deployment/appsmith
2025/02/18 22:00:12     appsmith ok
2025/02/18 22:00:12 the server could not find the requested resource
```

Looking at the imago docs, it appears that it also wants to update cronjobs. But cronjobs aren't allowed by the current role's rules. 

This chart doesn't use CronJobs today (or Daemonsets for that matter), but Imago doesn't support filtering by object type. So we can clean this up by simply changing the role's rules to allow it to see these object types and letting it retrieve them.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
