### PR TITLE
fix: cypress test for multipart/form-data

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
@@ -111,7 +111,7 @@ describe(
       apiPage.EnterBodyFormData(
         "MULTIPART_FORM_DATA",
         "file",
-        "{{FilePicker1.files[0]}}",
+        "{{FilePicker1.files[0].data}}",
         "File",
       );
 

--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
@@ -15,6 +15,7 @@ import EditorNavigation, {
   AppSidebarButton,
   AppSidebar,
 } from "../../../../support/Pages/EditorNavigation";
+import PageList from "../../../../support/Pages/PageList";
 
 describe(
   "Validate API request body panel",
@@ -99,6 +100,7 @@ describe(
     });
 
     it("7. Checks MultiPart form data for a File Type upload + Bug 12476", () => {
+      PageList.AddNewPage();
       const imageNameToUpload = "ConcreteHouse.jpg";
       agHelper.AddDsl("multiPartFormDataDsl");
 
@@ -141,7 +143,7 @@ describe(
       EditorNavigation.SelectEntityByName("MultipartAPI", EntityType.Api);
 
       apiPage.ToggleOnPageLoadRun(false); //Bug 12476
-      EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
+      EditorNavigation.SelectEntityByName("Page2", EntityType.Page);
       deployMode.DeployApp(locators._buttonByText("Select Files"));
       agHelper.ClickButton("Select Files");
       agHelper.UploadFile(imageNameToUpload);


### PR DESCRIPTION
## Description
> This PR fixes the cypress test for API multipart/form-data when the FilePicker is selected as Base64

We have updated the cypress test to use `{{FilePicker1.files[0].data}}` instead of `{{FilePicker1.files[0]}}`, this is because for base64 type file picker we have to use `.data` property to make the file upload work successfully.
Earlier, while the cypress test was passing with {{FilePicker1.files[0]}} but the uploaded image was corrupted (please check the screen recording below).

https://github.com/user-attachments/assets/c8cf07a1-db1c-4065-913a-00d544fe7e2b




Fixes #39354 

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13408509228>
> Commit: 7b2360f4c5967d6082a442ed2eba15d6348dad6b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13408509228&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Wed, 19 Feb 2025 09:28:34 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated file upload tests to properly validate file data extraction.
  - Added a test scenario for adding new pages to enhance page management verification.
  - Revised page selection during tests for more accurate validation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->