### PR TITLE
test: commenting tests with open bug for delete branch 

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/DeleteBranch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitSync/DeleteBranch_spec.js
@@ -82,7 +82,8 @@ describe(
       cy.get(".t--draggable-checkboxwidget").should("be.visible");
     });
 
-    it("3. Create new branch, commit data in that branch , delete the branch, verify data should not reflect in master ", () => {
+    //Open Bug: https://github.com/appsmithorg/appsmith/issues/39345
+    it.skip("3. Create new branch, commit data in that branch , delete the branch, verify data should not reflect in master ", () => {
       gitSync.CreateGitBranch("", true);
       cy.wait(1000);
       PageLeftPane.switchSegment(PagePaneSegment.UI);
@@ -105,7 +106,8 @@ describe(
       cy.get(gitSync.locators.branchCloseBtn).click({ force: true });
     });
 
-    it("4. Verify Default branch deletion not allowed ", () => {
+    //Open Bug: https://github.com/appsmithorg/appsmith/issues/39345
+    it.skip("4. Verify Default branch deletion not allowed ", () => {
       agHelper.Sleep(2000); //for toasts to appear then wait for disappear
       agHelper.WaitUntilAllToastsDisappear();
       DeleteBranchFromUI(0);


### PR DESCRIPTION
/ok-to-test tags="@tag.Sanity"



<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14027023498>
> Commit: b534037d9908fb042b3e4e66d27fff7cb0831030
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14027023498&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 24 Mar 2025 04:47:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Temporarily disabled internal tests related to branch deletion to reflect an identified issue. These adjustments ensure our quality checks remain aligned with current conditions without impacting your experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->