### PR TITLE
chore: Fix appsmith store hydration from localstorage in view mode

### DIFF
--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -3,7 +3,6 @@ import { resetEditorSuccess } from "actions/initActions";
 import {
   fetchAllPageEntityCompletion,
   setupPageAction,
-  updateAppStore,
 } from "actions/pageActions";
 import {
   executePageLoadActions,
@@ -74,8 +73,8 @@ import {
   selectGitApplicationCurrentBranch,
   selectGitModEnabled,
 } from "selectors/gitModSelectors";
-import { getPersistentAppStore } from "constants/AppConstants";
 import { applicationArtifact } from "git-artifact-helpers/application";
+import log from "loglevel";
 
 export default class AppEditorEngine extends AppEngine {
   constructor(mode: APP_MODE) {
@@ -303,21 +302,17 @@ export default class AppEditorEngine extends AppEngine {
     if (isGitPersistBranchEnabled) {
       const currentUser: User = yield select(getCurrentUser);
 
-      if (currentUser.email && currentApplication?.baseId && currentBranch) {
+      if (currentUser?.email && currentApplication?.baseId && currentBranch) {
         yield setLatestGitBranchInLocal(
           currentUser.email,
           currentApplication.baseId,
           currentBranch,
         );
+      } else {
+        log.error(
+          `There was an error setting the latest git branch in local - userEmail: ${!!currentUser?.email}, applicationId: ${currentApplication?.baseId}, branch: ${currentBranch}`,
+        );
       }
-    }
-
-    if (currentApplication?.id) {
-      yield put(
-        updateAppStore(
-          getPersistentAppStore(currentApplication.id, currentBranch),
-        ),
-      );
     }
 
     const [isAnotherEditorTabOpen, currentTabs] = yield call(


### PR DESCRIPTION
## Description
Context - https://theappsmith.slack.com/archives/C0134BAVDB4/p1740027639910039?thread_ts=1739904050.960349&cid=C0134BAVDB4

The app store wasn't getting hydrated from local storage in view mode because of the changes in the PR  https://github.com/appsmithorg/appsmith/pull/39255

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13429852595>
> Commit: d9c5c62e4cb99be7c96adbb0e483a4b7d0882758
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13429852595&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 20 Feb 2025 08:36:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
