### PR TITLE
chore: modified resources alter to send the jsLibFileName in resource identifier

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exportable/CustomJSLibExportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/jslibs/exportable/CustomJSLibExportableServiceCEImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.jslibs.exportable;
 
 import com.appsmith.external.git.models.GitResourceType;
+import com.appsmith.git.files.FileUtilsImpl;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.Artifact;
@@ -78,11 +79,16 @@ public class CustomJSLibExportableServiceCEImpl implements ExportableServiceCE<C
                     artifactExchangeJson
                             .getModifiedResources()
                             .putResource(FieldName.CUSTOM_JS_LIB_LIST, updatedCustomJSLibSet);
+
+                    Set<String> updatedCustomJsLibResourceIdentifiers = updatedCustomJSLibSet.stream()
+                            .map(FileUtilsImpl::getJsLibFileName)
+                            .collect(Collectors.toSet());
+
                     artifactExchangeJson
                             .getModifiedResources()
                             .getModifiedResourceIdentifiers()
                             .get(GitResourceType.JSLIB_CONFIG)
-                            .addAll(updatedCustomJSLibSet);
+                            .addAll(updatedCustomJsLibResourceIdentifiers);
 
                     /**
                      * Previously it was a Set and as Set is an unordered collection of elements that


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13452341615>
> Commit: 5c55da0707d29788aaddc99f3ef385d0c500d840
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13452341615&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Fri, 21 Feb 2025 08:34:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the process for exporting custom library resources, ensuring resource identifiers are generated more reliably during export operations for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->