### PR TITLE
chore: Remove unused constructor in `ResponseDTO`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/CloudServicesResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/CloudServicesResponseDTO.java
@@ -1,0 +1,5 @@
+package com.appsmith.server.dtos;
+
+public record CloudServicesResponseDTO<T>(ResponseMetaDTO responseMeta, T data) {
+    private record ResponseMetaDTO(Integer status, Boolean success) {}
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
@@ -24,11 +24,7 @@ public class ResponseDTO<T> implements Serializable {
     private T data;
 
     public ResponseDTO(HttpStatus status, T data) {
-        this(status.value(), data, null);
-    }
-
-    public ResponseDTO(int status, T data, String message) {
-        this.responseMeta = new ResponseMetaDTO(status, message);
+        this.responseMeta = new ResponseMetaDTO(status);
         this.data = data;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
@@ -2,6 +2,7 @@ package com.appsmith.server.dtos;
 
 import com.appsmith.external.exceptions.ErrorDTO;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.http.HttpStatus;
@@ -11,6 +12,7 @@ import java.io.Serializable;
 @Getter
 @Setter
 @ToString
+@NoArgsConstructor
 public class ResponseDTO<T> implements Serializable {
 
     private static final long serialVersionUID = 8965011907233699993L;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
@@ -1,9 +1,7 @@
 package com.appsmith.server.dtos;
 
 import com.appsmith.external.exceptions.ErrorDTO;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.http.HttpStatus;
@@ -13,8 +11,6 @@ import java.io.Serializable;
 @Getter
 @Setter
 @ToString
-@NoArgsConstructor
-@AllArgsConstructor
 public class ResponseDTO<T> implements Serializable {
 
     private static final long serialVersionUID = 8965011907233699993L;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseMetaDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseMetaDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Setter
@@ -28,9 +29,8 @@ public class ResponseMetaDTO {
         this.success = success;
     }
 
-    public ResponseMetaDTO(int status, String message) {
-        this.status = status;
-        this.message = message;
+    public ResponseMetaDTO(HttpStatus status) {
+        this.status = status.value();
     }
 
     public ResponseMetaDTO(int status, ErrorDTO errorDTO) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/ratelimiting/aspects/RateLimitAspect.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/ratelimiting/aspects/RateLimitAspect.java
@@ -10,6 +10,7 @@ import com.appsmith.server.services.SessionUserService;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
@@ -35,7 +36,8 @@ public class RateLimitAspect {
             return isAllowedMono.flatMap(isAllowed -> {
                 if (!isAllowed) {
                     AppsmithException exception = new AppsmithException(AppsmithError.TOO_MANY_REQUESTS);
-                    return Mono.just(new ResponseDTO<>(exception.getHttpStatus(), exception.getMessage(), null));
+                    return Mono.just(
+                            new ResponseDTO<>(HttpStatus.resolve(exception.getHttpStatus()), exception.getMessage()));
                 }
 
                 try {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/MockDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/MockDataServiceCEImpl.java
@@ -12,6 +12,7 @@ import com.appsmith.external.models.SSLDetails;
 import com.appsmith.server.configurations.CloudServicesConfig;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.CloudServicesResponseDTO;
 import com.appsmith.server.dtos.MockDataCredentials;
 import com.appsmith.server.dtos.MockDataDTO;
 import com.appsmith.server.dtos.MockDataSource;
@@ -20,8 +21,8 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.util.WebClientUtils;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.util.StringUtils;
@@ -37,6 +38,7 @@ import java.util.Optional;
 import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 
 @Slf4j
+@RequiredArgsConstructor
 public class MockDataServiceCEImpl implements MockDataServiceCE {
 
     private final CloudServicesConfig cloudServicesConfig;
@@ -47,22 +49,6 @@ public class MockDataServiceCEImpl implements MockDataServiceCE {
     public MockDataDTO mockData = new MockDataDTO();
 
     private Instant cacheExpiryTime = null;
-
-    private record MockDataResponseDTO(MockDataResponseMetaDTO responseMeta, MockDataDTO data) {}
-
-    private record MockDataResponseMetaDTO(Integer status, Boolean success) {}
-
-    @Autowired
-    public MockDataServiceCEImpl(
-            CloudServicesConfig cloudServicesConfig,
-            DatasourceService datasourceService,
-            AnalyticsService analyticsService,
-            SessionUserService sessionUserService) {
-        this.cloudServicesConfig = cloudServicesConfig;
-        this.datasourceService = datasourceService;
-        this.analyticsService = analyticsService;
-        this.sessionUserService = sessionUserService;
-    }
 
     @Override
     public Mono<MockDataDTO> getMockDataSet() {
@@ -84,8 +70,8 @@ public class MockDataServiceCEImpl implements MockDataServiceCE {
                                 AppsmithError.CLOUD_SERVICES_ERROR,
                                 "Unable to connect to cloud-services with error status {0}",
                                 response.statusCode())))
-                .bodyToMono(new ParameterizedTypeReference<MockDataResponseDTO>() {})
-                .map(MockDataResponseDTO::data)
+                .bodyToMono(new ParameterizedTypeReference<CloudServicesResponseDTO<MockDataDTO>>() {})
+                .map(CloudServicesResponseDTO::data)
                 .map(data -> {
                     mockData = data;
                     cacheExpiryTime = Instant.now().plusSeconds(2 * 60 * 60);


### PR DESCRIPTION
## Description

Cleanup unused signature in `ResponseDTO` class.

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 63fbdf9e4271600e7435a717507ee7db5d334529 yet
> <hr>Fri, 21 Feb 2025 16:20:33 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
