### PR TITLE
chore: Set max height for Table Data property control

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -35,6 +35,7 @@ export default [
         controlType: "ONE_CLICK_BINDING_CONTROL",
         controlConfig: {
           searchableColumn: true,
+          maxHeight: "400px",
         },
         placeholderText: '[{ "name": "John" }]',
         inputType: "ARRAY",


### PR DESCRIPTION
## Description
Updates the Table Widget Property config to use the maxHeight property. This ensures that when users paste in huge amounts of static json, the content DOM elements dont overload the system

Fixes #39405

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13492213082>
> Commit: b67e2f9431d0511790ec53755a9bfd2ed3c7cc7b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13492213082&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Mon, 24 Feb 2025 07:14:31 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configurable maximum height for table controls, ensuring a consistent display with a fixed maximum size of 400px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->