### PR TITLE
chore: Add plugin name to server execution metrics

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ExecuteActionMetaDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ExecuteActionMetaDTO.java
@@ -1,10 +1,12 @@
 package com.appsmith.server.dtos;
 
+import com.appsmith.server.domains.Plugin;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Mono;
 
 @Data
 @AllArgsConstructor
@@ -14,4 +16,5 @@ public class ExecuteActionMetaDTO {
     String environmentId;
     HttpHeaders headers;
     boolean operateWithoutPermission = false;
+    Mono<Plugin> plugin;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ExecuteActionMetaDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ExecuteActionMetaDTO.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import reactor.core.publisher.Mono;
 
 @Data
 @AllArgsConstructor
@@ -16,5 +15,5 @@ public class ExecuteActionMetaDTO {
     String environmentId;
     HttpHeaders headers;
     boolean operateWithoutPermission = false;
-    Mono<Plugin> plugin;
+    Plugin plugin;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -297,13 +297,12 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                 createExecuteActionDTO(partFlux).cache();
         Mono<Plugin> pluginMono = executeActionDTOMono.flatMap(executeActionDTO -> newActionService
                 .findById(executeActionDTO.getActionId())
-                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.INVALID_ACTION)))
                 .flatMap(newAction -> {
                     if (newAction.getPluginId() == null
                             || newAction.getPluginId().isEmpty()) {
                         return Mono.empty();
                     } else {
-                        return pluginService.findById(newAction.getPluginId()).switchIfEmpty(Mono.empty());
+                        return pluginService.findById(newAction.getPluginId());
                     }
                 })
                 .cache());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -287,30 +287,21 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
     @Override
     public Mono<ActionExecutionResult> executeAction(
             Flux<Part> partFlux, String environmentId, HttpHeaders httpHeaders, Boolean operateWithoutPermission) {
-
-        // Cache the multipart data so it can be reused
-        Mono<List<Part>> cachedPartsMono = partFlux.collectList().cache();
-
-        // Build the metadata DTO
         ExecuteActionMetaDTO executeActionMetaDTO = ExecuteActionMetaDTO.builder()
                 .headers(httpHeaders)
                 .operateWithoutPermission(operateWithoutPermission)
                 .environmentId(environmentId)
                 .build();
-
-        // Derive ExecuteActionDTO from cached parts
         Mono<ExecuteActionDTO> executeActionDTOMono =
-                cachedPartsMono.flatMap(parts -> createExecuteActionDTO(Flux.fromIterable(parts)));
-
-        // Fetch the plugin using the cached data
+                createExecuteActionDTO(partFlux).cache();
         Mono<Plugin> pluginMono = executeActionDTOMono.flatMap(executeActionDTO -> newActionService
                 .findById(executeActionDTO.getActionId())
                 .flatMap(newAction -> pluginService.findById(newAction.getPluginId()))
                 .cache());
-        executeActionMetaDTO.setPlugin(pluginMono);
-        // Execute the action with both plugin name and parts
+
         return pluginMono.flatMap(plugin -> {
             String pluginName = plugin.getName();
+            executeActionMetaDTO.setPlugin(plugin);
             return executeActionDTOMono
                     .flatMap(executeActionDTO -> populateAndExecuteAction(executeActionDTO, executeActionMetaDTO))
                     .tag("plugin", pluginName)
@@ -342,8 +333,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
 
         // 3. Instantiate the implementation class based on the query type
         Mono<DatasourceStorage> datasourceStorageMono = getCachedDatasourceStorage(actionDTOMono, executeActionMetaDTO);
-        //        Mono<Plugin> pluginMono = getCachedPluginForActionExecution(datasourceStorageMono);
-        Mono<Plugin> pluginMono = executeActionMetaDTO.getPlugin();
+        Mono<Plugin> pluginMono = Mono.just(executeActionMetaDTO.getPlugin());
         Mono<PluginExecutor> pluginExecutorMono = pluginExecutorHelper.getPluginExecutor(pluginMono);
 
         // 4. Execute the query

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -333,7 +333,9 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
 
         // 3. Instantiate the implementation class based on the query type
         Mono<DatasourceStorage> datasourceStorageMono = getCachedDatasourceStorage(actionDTOMono, executeActionMetaDTO);
-        Mono<Plugin> pluginMono = Mono.just(executeActionMetaDTO.getPlugin());
+        Mono<Plugin> pluginMono = executeActionMetaDTO.getPlugin() != null
+                ? Mono.just(executeActionMetaDTO.getPlugin())
+                : getCachedPluginForActionExecution(datasourceStorageMono);
         Mono<PluginExecutor> pluginExecutorMono = pluginExecutorHelper.getPluginExecutor(pluginMono);
 
         // 4. Execute the query


### PR DESCRIPTION
## Description
Adding plugin name to the custom micrometer metrics. Fetching plugin name at the start of the execute call and avoiding to be called from inner functions.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13582634663>
> Commit: 3908bbe3a0b997187e3e5a8d758504289f924f0d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13582634663&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 28 Feb 2025 07:43:34 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced asynchronous processing for action executions to improve performance and reliability.
  - Implemented caching for multipart data and refined plugin data tagging, providing streamlined operations and clearer tracking during action execution.
  - Added a new property to hold a reference to a Plugin object in the action execution metadata.
  - Improved plugin retrieval process for action executions, enhancing efficiency and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->