### PR TITLE
fix: drop the organization collection (ex workspace) before inserting the default organization (tenant)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration065_CopyTenantIdToOrganizationId.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration065_CopyTenantIdToOrganizationId.java
@@ -64,6 +64,13 @@ public class Migration065_CopyTenantIdToOrganizationId {
     }
 
     private void migrateTenantCollection() {
+
+        // Drop the organization collection if it exists
+        if (mongoTemplate.collectionExists(Organization.class)) {
+            log.info("Dropping existing organization collection");
+            mongoTemplate.dropCollection(Organization.class);
+        }
+
         try {
             // Get the single tenant document
             Document tenant = mongoTemplate.findOne(new Query(), Document.class, "tenant");


### PR DESCRIPTION

## Description
This is for old deployments which existed before the ACL changes came in migrating organization to workspace. 


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the data migration process to automatically clear outdated organization records before migrating tenant data, reducing potential conflicts and ensuring a smoother update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->