### PR TITLE
feat: rename isApprovalRequired field

### DIFF
--- a/app/client/src/components/formControls/FunctionCallingConfigControl/components/FunctionCallingConfigForm.tsx
+++ b/app/client/src/components/formControls/FunctionCallingConfigControl/components/FunctionCallingConfigForm.tsx
@@ -34,7 +34,7 @@ export const FunctionCallingConfigForm = ({
       id: uuid(),
       description: "",
       entityId: "",
-      requiresApproval: false,
+      isApprovalRequired: false,
       entityType: "Query",
     });
   }, [fields]);

--- a/app/client/src/components/formControls/FunctionCallingConfigControl/components/FunctionCallingConfigToolField.tsx
+++ b/app/client/src/components/formControls/FunctionCallingConfigControl/components/FunctionCallingConfigToolField.tsx
@@ -147,7 +147,7 @@ export const FunctionCallingConfigToolField = ({
         <FormControl
           config={{
             controlType: "SWITCH",
-            configProperty: `${props.fieldPath}.requiresApproval`,
+            configProperty: `${props.fieldPath}.isApprovalRequired`,
             formName: props.formName,
             id: props.fieldPath,
             label: "Requires approval",

--- a/app/client/src/components/formControls/FunctionCallingConfigControl/types.ts
+++ b/app/client/src/components/formControls/FunctionCallingConfigControl/types.ts
@@ -14,6 +14,6 @@ export interface FunctionCallingConfigFormToolField {
   id: string;
   description: string;
   entityId: string;
-  requiresApproval: boolean;
+  isApprovalRequired: boolean;
   entityType: FunctionCallingEntityType;
 }


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13499103072>
> Commit: 0dc42b7e32144dd8f8afccef3481a7ca759ee4dd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13499103072&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`
> Spec:
> <hr>Mon, 24 Feb 2025 13:49:30 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the internal approval property from "requiresApproval" to "isApprovalRequired" for enhanced consistency.
	- The change is purely nominal; default values, behavior, and labels in the user interface remain unaltered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->