### PR TITLE
ci: Fix re-runs in server suite

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -233,21 +233,16 @@ jobs:
           rm -f "$OUTPUT_FILE"
           touch "$OUTPUT_FILE"
 
-          failed_modules=()
           skipped_modules=()
 
           # Process mvn_test.log for FAILURE and SKIPPED statuses
           while IFS= read -r line; do
-              if [[ $line == *"FAILURE"* ]]; then
-                  module_name=$(echo "$line" | awk '{print $2}')
-                  failed_modules+=("$module_name")
-              elif [[ $line == *"SKIPPED"* ]]; then
+              if [[ $line == *"SKIPPED"* ]]; then
                   module_name=$(echo "$line" | awk '{print $2}')
                   skipped_modules+=("$module_name")
               fi
           done < mvn_test.log
 
-          echo "Failed Modules: ${failed_modules[*]}"
           echo "Skipped Modules: ${skipped_modules[*]}"
 
           # Handle older approach for reading failed tests from XML files
@@ -255,11 +250,6 @@ jobs:
           gawk -F\" '/<testcase / {cur_test = $4 "#" $2} /<(failure|error) / {print cur_test}' $(find . -type f -name 'TEST-*.xml') \
             | sort -u \
             | tee "$failed_tests_from_xml"
-
-          # Filter out failed modules and add only relevant tests to the final failed list
-          for module in "${failed_modules[@]}"; do
-              grep -v "$module" "$failed_tests_from_xml" > temp_file && mv temp_file "$failed_tests_from_xml"
-          done
 
           # Include all skipped module test files in the final list
           for module in "${skipped_modules[@]}"; do
@@ -287,7 +277,7 @@ jobs:
                   sed 's/^/- /' "$OUTPUT_FILE"
               )"
               echo "$content" >> "$GITHUB_STEP_SUMMARY"
-              
+
               # Post a comment to the PR
               curl --silent --show-error \
                   --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
## Description

Server suite passes on re-runs even if there's test failures. This is leading to false CI green.

This is because we're not adding all the failed tests to the failed test file. We look for failed tests in both the logs and surefire reports. Then we remove the failed-tests-found-in-logs, from the list of failed-tests-in-surefire, and only re-run the rest.

This PR is removing this logic of `failed_modules`.

[Slack conversation](https://theappsmith.slack.com/archives/CPQNLFHTN/p1740403807300079).

![shot-2025-02-25-07-37-09](https://github.com/user-attachments/assets/35265050-5138-43fe-9168-a25b4e180770)

![shot-2025-02-25-07-41-21](https://github.com/user-attachments/assets/dd9e088a-b8d2-470c-9f40-b98416842ab4)


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the CI build process by simplifying test reporting.
	- Now only skipped tests are highlighted, reducing redundant failure output and simplifying the test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->