### PR TITLE
chore: Moving the  util for grouping & sorting entity list to a common folder

### DIFF
--- a/app/client/src/IDE/utils/groupAndSortEntitySegmentList.ts
+++ b/app/client/src/IDE/utils/groupAndSortEntitySegmentList.ts
@@ -1,0 +1,28 @@
+import { groupBy, sortBy } from "lodash";
+import type { EntityItem } from "ee/IDE/Interfaces/EntityItem";
+
+export type EditorSegmentList = Array<{
+  group: string | "NA";
+  items: EntityItem[];
+}>;
+
+export const groupAndSortEntitySegmentList = (
+  items: EntityItem[],
+): EditorSegmentList => {
+  const groups = groupBy(items, (item) => {
+    if (item.group) return item.group;
+
+    return "NA";
+  });
+
+  // Entity Segment Lists are sorted alphabetically at both group and item level
+  return sortBy(
+    Object.keys(groups).map((group) => {
+      return {
+        group: group,
+        items: sortBy(groups[group], "title"),
+      };
+    }),
+    "group",
+  );
+};

--- a/app/client/src/ce/selectors/appIDESelectors.test.ts
+++ b/app/client/src/ce/selectors/appIDESelectors.test.ts
@@ -1,5 +1,5 @@
 import type { EntityItem } from "ee/IDE/Interfaces/EntityItem";
-import { groupAndSortEntitySegmentList } from "./appIDESelectors";
+import { groupAndSortEntitySegmentList } from "IDE/utils/groupAndSortEntitySegmentList";
 import { PluginType } from "entities/Plugin";
 
 describe("groupAndSortEntitySegmentList", () => {

--- a/app/client/src/ce/selectors/appIDESelectors.ts
+++ b/app/client/src/ce/selectors/appIDESelectors.ts
@@ -1,6 +1,5 @@
-import { groupBy, keyBy, sortBy } from "lodash";
+import { keyBy } from "lodash";
 import { createSelector } from "reselect";
-import type { EntityItem } from "ee/IDE/Interfaces/EntityItem";
 import {
   getJSSegmentItems,
   getQuerySegmentItems,
@@ -10,32 +9,7 @@ import type { AppState } from "ee/reducers";
 import { identifyEntityFromPath } from "navigation/FocusEntity";
 import { getCurrentBasePageId } from "selectors/editorSelectors";
 import { getQueryEntityItemUrl } from "ee/pages/AppIDE/layouts/routers/utils/getQueryEntityItemUrl";
-
-export type EditorSegmentList = Array<{
-  group: string | "NA";
-  items: EntityItem[];
-}>;
-
-export const groupAndSortEntitySegmentList = (
-  items: EntityItem[],
-): EditorSegmentList => {
-  const groups = groupBy(items, (item) => {
-    if (item.group) return item.group;
-
-    return "NA";
-  });
-
-  // Entity Segment Lists are sorted alphabetically at both group and item level
-  return sortBy(
-    Object.keys(groups).map((group) => {
-      return {
-        group: group,
-        items: sortBy(groups[group], "title"),
-      };
-    }),
-    "group",
-  );
-};
+import { groupAndSortEntitySegmentList } from "IDE/utils/groupAndSortEntitySegmentList";
 
 export const selectQuerySegmentEditorList = createSelector(
   getQuerySegmentItems,

--- a/app/client/src/pages/AppIDE/components/JSExplorer/JSSegmentList.tsx
+++ b/app/client/src/pages/AppIDE/components/JSExplorer/JSSegmentList.tsx
@@ -77,7 +77,7 @@ export const ListJSObjects = () => {
       <Flex
         data-testid="t--ide-list"
         flexDirection="column"
-        gap="spaces-4"
+        gap="spaces-3"
         overflowY="auto"
       >
         {isNewADSTemplatesEnabled ? (

--- a/app/client/src/pages/AppIDE/components/QueryExplorer/Explorer.tsx
+++ b/app/client/src/pages/AppIDE/components/QueryExplorer/Explorer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ListQuery } from "./List";
+import { ListQuery } from "./QuerySegmentList";
 import styled from "styled-components";
 import { Flex } from "@appsmith/ads";
 import { useSelector } from "react-redux";

--- a/app/client/src/pages/AppIDE/components/QueryExplorer/QuerySegmentList.tsx
+++ b/app/client/src/pages/AppIDE/components/QueryExplorer/QuerySegmentList.tsx
@@ -72,7 +72,7 @@ export const ListQuery = () => {
       <Flex
         data-testid="t--ide-list"
         flexDirection={"column"}
-        gap="spaces-4"
+        gap="spaces-3"
         overflowY="auto"
       >
         {isNewADSTemplatesEnabled ? (

--- a/app/client/src/pages/AppIDE/components/QueryExplorer/index.tsx
+++ b/app/client/src/pages/AppIDE/components/QueryExplorer/index.tsx
@@ -1,2 +1,2 @@
 export { QueryExplorer } from "./Explorer";
-export { ListQuery } from "./List";
+export { ListQuery } from "./QuerySegmentList";


### PR DESCRIPTION
## Description

Moving the  util for grouping & sorting entity list to a common folder so that it can be re-used in other IDEs.

Fixes [#38906](https://github.com/appsmithorg/appsmith/issues/38906)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13527015959>
> Commit: cab5b52e516cd776835e081025584a7b741a086c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13527015959&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 25 Feb 2025 18:29:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Introduced a utility function for grouping and sorting entity items, improving organization and maintainability.
  - Updated selectors to utilize the new grouping and sorting utility, enhancing code structure.
- **Style**
  - Adjusted spacing between list items in both the JavaScript and Query explorers for a more balanced layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->