### PR TITLE
chore: Add widget list split to show modules list in tabs

### DIFF
--- a/app/client/src/ce/pages/AppIDE/components/WidgetAdd/UIModulesList.tsx
+++ b/app/client/src/ce/pages/AppIDE/components/WidgetAdd/UIModulesList.tsx
@@ -1,0 +1,10 @@
+export interface UIModulesListProps {
+  focusSearchInput?: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const UIModulesList = (props: UIModulesListProps) => {
+  return null;
+};
+
+export default UIModulesList;

--- a/app/client/src/ce/selectors/modulesSelector.ts
+++ b/app/client/src/ce/selectors/modulesSelector.ts
@@ -9,3 +9,5 @@ export const getAllModules = (
 ): Record<string, Module> | any => {};
 
 export const getCurrentModuleId = (state: AppState) => "";
+
+export const showUIModulesList = (state: AppState) => false;

--- a/app/client/src/ee/pages/AppIDE/components/WidgetAdd/UIModulesList.tsx
+++ b/app/client/src/ee/pages/AppIDE/components/WidgetAdd/UIModulesList.tsx
@@ -1,0 +1,2 @@
+export * from "ce/pages/AppIDE/components/WidgetAdd/UIModulesList";
+export { default } from "ce/pages/AppIDE/components/WidgetAdd/UIModulesList";

--- a/app/client/src/pages/AppIDE/components/WidgetAdd/WidgetsList.tsx
+++ b/app/client/src/pages/AppIDE/components/WidgetAdd/WidgetsList.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { useUIExplorerItems } from "pages/Editor/widgetSidebar/hooks";
+import UIEntitySidebar from "pages/Editor/widgetSidebar/UIEntitySidebar";
+
+interface WidgetsListProps {
+  focusSearchInput?: boolean;
+}
+
+function WidgetsList({ focusSearchInput }: WidgetsListProps) {
+  const { cards, entityLoading, groupedCards } = useUIExplorerItems();
+
+  return (
+    <UIEntitySidebar
+      cards={cards}
+      entityLoading={entityLoading}
+      focusSearchInput={focusSearchInput}
+      groupedCards={groupedCards}
+      isActive
+    />
+  );
+}
+
+export default WidgetsList;

--- a/app/client/src/pages/AppIDE/components/WidgetAdd/index.tsx
+++ b/app/client/src/pages/AppIDE/components/WidgetAdd/index.tsx
@@ -1,21 +1,32 @@
 import React, { useCallback } from "react";
-import { Button, Flex, Text } from "@appsmith/ads";
+import {
+  Button,
+  Flex,
+  Tab,
+  TabPanel,
+  Tabs,
+  TabsList,
+  Text,
+} from "@appsmith/ads";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
 
 import history from "utils/history";
-import UIEntitySidebar from "../../Editor/widgetSidebar/UIEntitySidebar";
 import { widgetListURL } from "ee/RouteBuilder";
 import { EDITOR_PANE_TEXTS, createMessage } from "ee/constants/messages";
 import { getCurrentBasePageId } from "selectors/editorSelectors";
+import UIModulesList from "ee/pages/AppIDE/components/WidgetAdd/UIModulesList";
+import WidgetsList from "./WidgetsList";
+import { showUIModulesList } from "ee/selectors/modulesSelector";
 
 const Container = styled(Flex)`
   padding-right: var(--ads-v2-spaces-2);
   background-color: var(--ads-v2-color-gray-50);
 `;
 
-const AddWidgets = (props: { focusSearchInput?: boolean }) => {
+const WidgetsAdd = (props: { focusSearchInput?: boolean }) => {
   const basePageId = useSelector(getCurrentBasePageId) as string;
+  const showUIModules = useSelector(showUIModulesList);
 
   const closeButtonClickHandler = useCallback(() => {
     history.push(widgetListURL({ basePageId }));
@@ -45,10 +56,26 @@ const AddWidgets = (props: { focusSearchInput?: boolean }) => {
         />
       </Container>
       <Flex flexDirection="column" gap="spaces-3" overflowX="auto">
-        <UIEntitySidebar focusSearchInput={props.focusSearchInput} isActive />
+        {showUIModules && (
+          <Tabs defaultValue="widgets">
+            <TabsList>
+              <Tab value="widgets">Widgets</Tab>
+              <Tab value="modules">Modules</Tab>
+            </TabsList>
+            <TabPanel className="TabsContent" value="widgets">
+              <WidgetsList focusSearchInput={props.focusSearchInput} />
+            </TabPanel>
+            <TabPanel className="TabsContent" value="modules">
+              <UIModulesList focusSearchInput={props.focusSearchInput} />
+            </TabPanel>
+          </Tabs>
+        )}
+        {!showUIModules && (
+          <WidgetsList focusSearchInput={props.focusSearchInput} />
+        )}
       </Flex>
     </>
   );
 };
 
-export default AddWidgets;
+export default WidgetsAdd;

--- a/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
@@ -16,16 +16,22 @@ import { debounce } from "lodash";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { groupWidgetCardsByTags } from "../utils";
 import UIEntityTagGroup from "./UIEntityTagGroup";
-import { useUIExplorerItems } from "./hooks";
+import type { WidgetCardProps } from "widgets/BaseWidget";
+interface UIEntitySidebarProps {
+  focusSearchInput?: boolean;
+  isActive: boolean;
+  cards: WidgetCardProps[];
+  entityLoading?: Partial<Record<WidgetTags, boolean>>;
+  groupedCards: WidgetCardsGroupedByTags;
+}
 
 function UIEntitySidebar({
+  cards,
+  entityLoading,
   focusSearchInput,
+  groupedCards,
   isActive,
-}: {
-  isActive: boolean;
-  focusSearchInput?: boolean;
-}) {
-  const { cards, entityLoading, groupedCards } = useUIExplorerItems();
+}: UIEntitySidebarProps) {
   const [filteredCards, setFilteredCards] =
     useState<WidgetCardsGroupedByTags>(groupedCards);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
@@ -91,7 +97,7 @@ function UIEntitySidebar({
   // update widgets list after building blocks have been fetched async
   useEffect(() => {
     setFilteredCards(groupedCards);
-  }, [entityLoading[WIDGET_TAGS.BUILDING_BLOCKS]]);
+  }, [entityLoading?.[WIDGET_TAGS.BUILDING_BLOCKS]]);
 
   useEffect(() => {
     if (focusSearchInput) searchInputRef.current?.focus();
@@ -132,7 +138,10 @@ function UIEntitySidebar({
         )}
         <div>
           {Object.entries(filteredCards).map(([tag, cardsForThisTag]) => {
-            if (!cardsForThisTag?.length && !entityLoading[tag as WidgetTags]) {
+            if (
+              !cardsForThisTag?.length &&
+              !entityLoading?.[tag as WidgetTags]
+            ) {
               return null;
             }
 
@@ -143,7 +152,7 @@ function UIEntitySidebar({
             return (
               <UIEntityTagGroup
                 cards={cardsForThisTag}
-                isLoading={!!entityLoading[tag as WidgetTags]}
+                isLoading={!!entityLoading?.[tag as WidgetTags]}
                 key={tag}
                 tag={tag}
               />

--- a/app/client/src/pages/Editor/widgetSidebar/tests/UIEntitySidebar.test.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/tests/UIEntitySidebar.test.tsx
@@ -5,11 +5,16 @@ import {
 } from "ee/constants/messages";
 import "@testing-library/jest-dom";
 import { fireEvent, waitFor } from "@testing-library/react";
-import { WIDGET_TAGS } from "constants/WidgetConstants";
+import {
+  WIDGET_TAGS,
+  type WidgetCardsGroupedByTags,
+  type WidgetTags,
+} from "constants/WidgetConstants";
 import UIEntitySidebar from "../UIEntitySidebar";
 import { cards, groupedCards } from "./UIEntitySidebar.fixture";
 import { render } from "test/testUtils";
 import { getIDETestState } from "test/factories/AppIDEFactoryUtils";
+import type { WidgetCardProps } from "widgets/BaseWidget";
 
 jest.mock("utils/hooks/useFeatureFlag", () => ({
   useFeatureFlag: jest.fn(),
@@ -25,9 +30,18 @@ describe("UIEntitySidebar", () => {
     isActive: boolean,
     focusSearchInput: boolean,
   ) => {
+    const mockItems = {
+      cards: cards as unknown as WidgetCardProps[],
+      groupedCards: groupedCards as unknown as WidgetCardsGroupedByTags,
+      entityLoading: {} as Partial<Record<WidgetTags, boolean>>,
+    };
+
     return render(
       <UIEntitySidebar
+        cards={mockItems.cards}
+        entityLoading={mockItems.entityLoading}
         focusSearchInput={focusSearchInput}
+        groupedCards={mockItems.groupedCards}
         isActive={isActive}
       />,
       {
@@ -38,7 +52,6 @@ describe("UIEntitySidebar", () => {
 
   const mockUIExplorerItems = (
     items: unknown = {
-      //return an object with cards, groupedCards and entityLoading states
       cards,
       groupedCards,
       entityLoading: {},
@@ -76,9 +89,19 @@ describe("UIEntitySidebar", () => {
       groupedCards: {},
     });
 
-    const { getByPlaceholderText, queryByTestId } = renderUIEntitySidebar(
-      true,
-      true,
+    const emptyGroupedCards = {} as WidgetCardsGroupedByTags;
+
+    const { getByPlaceholderText, queryByTestId } = render(
+      <UIEntitySidebar
+        cards={[] as WidgetCardProps[]}
+        entityLoading={{} as Partial<Record<WidgetTags, boolean>>}
+        focusSearchInput
+        groupedCards={emptyGroupedCards}
+        isActive
+      />,
+      {
+        initialState: getIDETestState({}),
+      },
     );
 
     const input = getByPlaceholderText(


### PR DESCRIPTION
## Description
Splits the AddWidget widget to include UI modules list

[Figma](https://www.figma.com/design/Z0QsSdGOydURn6WIMQ3rHM/Appsmith-Reusability?node-id=8513-74506&t=HKor4HzUlfKtvFbm-0) 

EE PR - https://github.com/appsmithorg/appsmith-ee/pull/6343

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13541143766>
> Commit: 1ce3172fb27f3b50e36146e20007e58fdbdb8f61
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13541143766&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 26 Feb 2025 11:15:30 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new tabbed interface in the widget addition area that allows users to easily switch between selecting Widgets and Modules.
  - Launched an improved widget listing view to streamline the selection process.

- **Refactor**
  - Enhanced the sidebar display logic for a more reliable and smoother presentation of content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->