### PR TITLE
fix: Add default RTS port in CE

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/RTSCallerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/RTSCallerCEImpl.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import static com.appsmith.server.filters.MDCFilter.INTERNAL_REQUEST_ID_HEADER;
 import static com.appsmith.server.filters.MDCFilter.REQUEST_ID_HEADER;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Component
 public class RTSCallerCEImpl implements RTSCallerCE {
@@ -42,10 +41,6 @@ public class RTSCallerCEImpl implements RTSCallerCE {
 
     @PostConstruct
     private void makeWebClient() {
-        if (isEmpty(rtsPort)) {
-            rtsPort = "8091";
-        }
-
         final ConnectionProvider connectionProvider = ConnectionProvider.builder("rts-provider")
                 .maxConnections(100)
                 .maxIdleTime(Duration.ofSeconds(30))

--- a/app/server/appsmith-server/src/main/resources/application-ce.properties
+++ b/app/server/appsmith-server/src/main/resources/application-ce.properties
@@ -100,7 +100,7 @@ appsmith.plugin.response.size.max=${APPSMITH_PLUGIN_MAX_RESPONSE_SIZE_MB:5}
 appsmith.admin.envfile=${APPSMITH_ENVFILE_PATH:/appsmith-stacks/configuration/docker.env}
 
 # RTS port
-appsmith.rts.port=${APPSMITH_RTS_PORT:}
+appsmith.rts.port=${APPSMITH_RTS_PORT:8091}
 
 appsmith.internal.password=${APPSMITH_INTERNAL_PASSWORD:}
 


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13538744339>
> Commit: 0c3ee991f26237589d2119a0048045552690c3c2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13538744339&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 26 Feb 2025 08:06:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the application’s default real-time service port configuration. The system now directly uses a default value of 8091 when no explicit port is provided, ensuring consistent connectivity behavior and reducing potential configuration ambiguities. Users relying on default settings will benefit from improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->