### PR TITLE
fix: bugfix for validation of system messages in open ai vision command.

### DIFF
--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -154,17 +154,16 @@ public class VisionCommand implements OpenAICommand {
     }
 
     private List<VisionMessage> transformSystemMessages(Object messages) {
+        List<VisionMessage> visionMessages = new ArrayList<>();
+
         if (messages == null) {
-            throw new AppsmithPluginException(
-                    AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                    String.format(STRING_APPENDER, EXECUTION_FAILURE, INCORRECT_SYSTEM_MESSAGE_FORMAT));
+            return visionMessages;
         }
 
         Type chatListType = new TypeToken<List<LinkedHashMap<String, String>>>() {}.getType();
         try {
             List<LinkedHashMap<String, String>> systemMessagesMap = gson.fromJson(gson.toJson(messages), chatListType);
 
-            List<VisionMessage> visionMessages = new ArrayList<>();
             for (Map<String, String> systemMessageMap : systemMessagesMap) {
                 VisionMessage visionMessage = new VisionMessage();
                 if (StringUtils.hasText(systemMessageMap.get(CONTENT))) {


### PR DESCRIPTION
## Description
The systemMessages field doesn't have a default value in the action configuration when a new OpenAI Vision command query is created.  Because systemMessages is not a mandatory field, we can omit the null check. This pull request removes the unnecessary null check that was added.

Fixes https://github.com/appsmithorg/appsmith/issues/39395

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/13559573780>
> Commit: 0635d47845106232fd1867a4889975aa2c6802e9
> Workflow: `PR Automation test suite`
> Tags: `@tag.All`
> Spec: ``
> <hr>Thu, 27 Feb 2025 05:28:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the stability of message handling by ensuring that system messages are only processed when available, preventing potential errors when data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->