### PR TITLE
fix: Array Field width css

### DIFF
--- a/app/client/src/components/formControls/FieldArrayControl.tsx
+++ b/app/client/src/components/formControls/FieldArrayControl.tsx
@@ -16,7 +16,7 @@ const CenteredIconButton = styled(Button)<{
 
 const PrimaryBox = styled.div`
   display: flex;
-  width: min-content;
+  width: 100%;
   flex-direction: column;
   padding: 10px 0px 0px 0px;
 

--- a/app/client/src/components/formControls/FieldArrayControl.tsx
+++ b/app/client/src/components/formControls/FieldArrayControl.tsx
@@ -37,12 +37,6 @@ const SecondaryBox = styled.div`
     margin-right: 8px;
     margin-bottom: 8px;
   }
-
-  & > .t--form-control-DROP_DOWN,
-  & > .t--form-control-DROP_DOWN > div > div,
-  & > .t--form-control-DROP_DOWN > div > div > div > div {
-    width: 12vw;
-  }
 `;
 
 const AddMoreAction = styled.div`
@@ -81,10 +75,7 @@ function NestedComponents(props: any) {
                 sch = {
                   ...sch,
                   configProperty: `${field}.${sch.key}`,
-                  customStyles: {
-                    width: "20vw",
-                    ...(props.customStyles ?? {}),
-                  },
+                  customStyles: props.customStyles,
                 };
 
                 return (


### PR DESCRIPTION
## Description

Updates the CSS rule missed while updating [this change](https://github.com/appsmithorg/appsmith-ee/commit/78718229da4079ad25bddb8a9084c46a1dc72208#diff-5f39427d6d336597e2fb2a74425b5d4bc285809695650d7092f6f33a29911d9bL31) that renders contents of the Array field in a very limited space


Before
<img width="1024" alt="Screenshot 2025-02-27 at 11 15 45 AM" src="https://github.com/user-attachments/assets/55b6b512-b3e7-405f-902d-dd732ca7bbfa" />

After
<img width="1028" alt="Screenshot 2025-02-27 at 11 15 24 AM" src="https://github.com/user-attachments/assets/07fd439b-e0aa-42dc-916a-265cdeb8d879" />



Fixes #39452

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13561110465>
> Commit: f8d8cebb2baa6d908771b763d6689ed232062ca9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13561110465&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 27 Feb 2025 08:10:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Adjusted the component layout to expand fully within its container, ensuring improved visual consistency and better integration with surrounding elements.
	- Simplified styling properties for enhanced flexibility and customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
