### PR TITLE
chore: fix typos in markdown documentation

### DIFF
--- a/contributions/CodeContributionsGuidelines.md
+++ b/contributions/CodeContributionsGuidelines.md
@@ -15,7 +15,7 @@ Looking for issues to contribute to? Check out our [Inviting Contribution Issues
 3. Create PR(s) without proper description. 
 4. Requesting for review without latest release pull on PR. 
 5. Raising PR(s) without tests.  
-6. Not going though the code contibution guidelines before first contribution. Just kidding, you are already here 😉
+6. Not going through the code contribution guidelines before first contribution. Just kidding, you are already here 😉
 
 ### 🍴 Git Workflow
 

--- a/contributions/docs/TestAutomation.md
+++ b/contributions/docs/TestAutomation.md
@@ -6,7 +6,7 @@
 
 1. Cypress tests are located in the `app/client/cypress` directory.
 
-1. All the test spec _must_ be in the e2e directory only i.e `app/client/cypress/e2e`
+1. All the test spec _must_ be in the e2e directory only i.e. `app/client/cypress/e2e`
 
 1. You can create directories under `app/client/cypress` but make sure you place the spec within the `app/client/cypress/e2e` directory.
 


### PR DESCRIPTION
- Fixed 'though' to 'through' and 'contibution' to 'contribution' in CodeContributionsGuidelines.md
- Added missing period after 'i.e' in TestAutomation.md

These small changes improve the readability and professionalism of the documentation.


