### PR TITLE
chore: removes premium integration tags for released ones

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/APIOrSaasPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/APIOrSaasPlugins.tsx
@@ -328,10 +328,12 @@ const mapStateToProps = (
     FEATURE_FLAG.release_external_saas_plugins_enabled,
   );
 
+  const pluginNames = allPlugins.map((plugin) => plugin.name);
+
   const premiumPlugins =
     props.showSaasAPIs && props.isPremiumDatasourcesViewEnabled
       ? (filterSearch(
-          getFilteredPremiumIntegrations(isExternalSaasEnabled),
+          getFilteredPremiumIntegrations(isExternalSaasEnabled, pluginNames),
           searchedPlugin,
         ) as PremiumIntegration[])
       : [];

--- a/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
@@ -44,6 +44,8 @@ export default function EmptySearchedPlugins({
     ),
   );
 
+  const pluginNames = plugins.map((plugin) => plugin.name);
+
   const searchedItems =
     filterSearch(
       [
@@ -51,7 +53,7 @@ export default function EmptySearchedPlugins({
         { name: createMessage(CREATE_NEW_DATASOURCE_AUTHENTICATED_REST_API) },
         ...mockDatasources,
         ...(isPremiumDatasourcesViewEnabled
-          ? getFilteredPremiumIntegrations(isExternalSaasEnabled)
+          ? getFilteredPremiumIntegrations(isExternalSaasEnabled, pluginNames)
           : []),
       ],
       searchedPlugin,

--- a/app/client/src/pages/Editor/IntegrationEditor/PremiumDatasources/Constants.ts
+++ b/app/client/src/pages/Editor/IntegrationEditor/PremiumDatasources/Constants.ts
@@ -27,11 +27,11 @@ export const PREMIUM_INTEGRATIONS: PremiumIntegration[] = [
 
 export const getFilteredPremiumIntegrations = (
   isExternalSaasEnabled: boolean,
+  pluginNames: string[],
 ) => {
   return isExternalSaasEnabled
     ? PREMIUM_INTEGRATIONS.filter(
-        (integration) =>
-          integration.name !== "Salesforce" && integration.name !== "Zendesk",
+        (integration) => !pluginNames.includes(integration.name),
       )
     : PREMIUM_INTEGRATIONS;
 };


### PR DESCRIPTION
## Description
This PR removes premimum/soon tags from paragon integrations as soon as they become available generally


Fixes #39439 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13561777558>
> Commit: 6e505376ab5ea29831495222cbdda97ac82abed1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13561777558&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Thu, 27 Feb 2025 09:04:46 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the premium integrations display with improved filtering that now considers active plugin selections for more refined results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->