### PR TITLE
chore: git tag - ui components for tagging release

### DIFF
--- a/app/client/src/git/ce/constants/messages.tsx
+++ b/app/client/src/git/ce/constants/messages.tsx
@@ -1,0 +1,18 @@
+export const OPS_MODAL = {
+  TAB_RELEASE: "RELEASE",
+};
+
+export const TAB_RELEASE = {
+  TITLE: "Release version",
+  RELEASE_BTN: "Release",
+};
+
+export const RELEASE_VERSION_RADIO_GROUP = {
+  TITLE: "Version",
+  LAST_RELEASED: "Last released",
+};
+
+export const RELEASE_NOTES_INPUT = {
+  TITLE: "Release notes",
+  PLACEHOLDER: "Your release notes here",
+};

--- a/app/client/src/git/components/LatestCommitInfo/LatestCommitInfoView.tsx
+++ b/app/client/src/git/components/LatestCommitInfo/LatestCommitInfoView.tsx
@@ -1,0 +1,41 @@
+import { Flex, Icon, Text } from "@appsmith/ads";
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled(Flex)`
+  border-radius: 4px;
+  background-color: var(--ads-v2-color-gray-0);
+`;
+
+interface LatestCommitInfoViewProps {
+  authorName: string | null;
+  committedAt: string | null;
+  hash: string | null;
+  message: string | null;
+}
+
+function LatestCommitInfoView({
+  authorName = null,
+  committedAt = null,
+  hash = null,
+  message = null,
+}: LatestCommitInfoViewProps) {
+  return (
+    <Container marginBottom="spaces-4" padding="spaces-3">
+      <Flex flex={1} flexDirection="column" gap="spaces-3">
+        <Text renderAs="p">{message}</Text>
+        <Text kind="body-s" renderAs="p">
+          {authorName} committed {committedAt}
+        </Text>
+      </Flex>
+      <Flex alignItems="center" justifyContent="center">
+        <Flex gap="spaces-2">
+          <Icon name="git-commit" size="md" />
+          <Text renderAs="p">{hash}</Text>
+        </Flex>
+      </Flex>
+    </Container>
+  );
+}
+
+export default LatestCommitInfoView;

--- a/app/client/src/git/components/LatestCommitInfo/index.tsx
+++ b/app/client/src/git/components/LatestCommitInfo/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import LatestCommitInfoView from "./LatestCommitInfoView";
+
+function LatestCommitInfo() {
+  return (
+    <LatestCommitInfoView
+      authorName="John Doe"
+      committedAt="2 days ago"
+      hash="a3e9967"
+      message="Fix package resolution issue when transferring apps across workspaces"
+    />
+  );
+}
+
+export default LatestCommitInfo;

--- a/app/client/src/git/components/OpsModal/OpsModalView.tsx
+++ b/app/client/src/git/components/OpsModal/OpsModalView.tsx
@@ -15,6 +15,8 @@ import styled from "styled-components";
 // import ReconnectSSHError from "../components/ReconnectSSHError";
 import { GitOpsTab } from "git/constants/enums";
 import noop from "lodash/noop";
+import TabRelease from "./TabRelease";
+import { OPS_MODAL } from "git/ee/constants/messages";
 
 const StyledModalContent = styled(ModalContent)`
   &&& {
@@ -91,10 +93,18 @@ function OpsModalView({
               >
                 {createMessage(MERGE)}
               </Tab>
+              <Tab
+                data-testid={"t--git-ops-tab-release"}
+                disabled={isProtectedMode}
+                value={GitOpsTab.Release}
+              >
+                {OPS_MODAL.TAB_RELEASE}
+              </Tab>
             </TabsList>
           </Tabs>
           {opsModalTab === GitOpsTab.Deploy && <TabDeploy />}
           {opsModalTab === GitOpsTab.Merge && <TabMerge />}
+          {opsModalTab === GitOpsTab.Release && <TabRelease />}
         </StyledModalContent>
       </Modal>
       {/* <GitErrorPopup /> */}

--- a/app/client/src/git/components/OpsModal/TabRelease.tsx
+++ b/app/client/src/git/components/OpsModal/TabRelease.tsx
@@ -1,0 +1,60 @@
+import { Button, ModalBody, ModalFooter, Text } from "@appsmith/ads";
+import LatestCommitInfo from "git/components/LatestCommitInfo";
+import ReleaseNotesInput from "git/components/ReleaseNotesInput";
+import ReleaseVersionRadioGroup from "git/components/ReleaseVersionRadioGroup";
+import { TAB_RELEASE } from "git/ee/constants/messages";
+import React, { useCallback, useState } from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  min-height: 360px;
+  overflow: unset;
+  padding-bottom: 4px;
+`;
+
+const TabTitle = styled(Text)`
+  margin-bottom: 12px;
+  color: var(--ads-v2-color-fg-emphasis);
+`;
+
+const StyledModalFooter = styled(ModalFooter)`
+  min-height: 52px;
+`;
+
+function TabRelease() {
+  const [releaseVersion, setReleaseVersion] = useState<string | null>(null);
+  const [releaseNotes, setReleaseNotes] = useState<string | null>(null);
+
+  const isReleaseDisabled = !releaseVersion || !releaseNotes;
+
+  const handleClickOnRelease = useCallback(() => {}, []);
+
+  return (
+    <>
+      <ModalBody>
+        <Container>
+          <TabTitle kind="heading-s" renderAs="p">
+            {TAB_RELEASE.TITLE}
+          </TabTitle>
+          <LatestCommitInfo />
+          <ReleaseVersionRadioGroup onVersionChange={setReleaseVersion} />
+          <ReleaseNotesInput
+            onTextChange={setReleaseNotes}
+            text={releaseNotes}
+          />
+        </Container>
+      </ModalBody>
+      <StyledModalFooter>
+        <Button
+          isDisabled={isReleaseDisabled}
+          onClick={handleClickOnRelease}
+          size="md"
+        >
+          {TAB_RELEASE.RELEASE_BTN}
+        </Button>
+      </StyledModalFooter>
+    </>
+  );
+}
+
+export default TabRelease;

--- a/app/client/src/git/components/ReleaseNotesInput/index.tsx
+++ b/app/client/src/git/components/ReleaseNotesInput/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Flex, Input } from "@appsmith/ads";
+import { RELEASE_NOTES_INPUT } from "git/ee/constants/messages";
+import { noop } from "lodash";
+
+interface ReleaseNotesInputProps {
+  onTextChange: (text: string | null) => void;
+  text: string | null;
+}
+
+function ReleaseNotesInput({
+  onTextChange = noop,
+  text = null,
+}: ReleaseNotesInputProps) {
+  return (
+    <Flex flexDirection={"column"}>
+      <Input
+        autoFocus
+        label={RELEASE_NOTES_INPUT.TITLE}
+        onChange={onTextChange}
+        placeholder={RELEASE_NOTES_INPUT.PLACEHOLDER}
+        renderAs="textarea"
+        size="md"
+        type="text"
+        value={text ?? undefined}
+      />
+    </Flex>
+  );
+}
+
+export default ReleaseNotesInput;

--- a/app/client/src/git/components/ReleaseVersionRadioGroup/ReleaseVersionRadioGroupView.tsx
+++ b/app/client/src/git/components/ReleaseVersionRadioGroup/ReleaseVersionRadioGroupView.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Flex, Radio, RadioGroup, Tag, Text } from "@appsmith/ads";
+import { RELEASE_VERSION_RADIO_GROUP } from "git/ee/constants/messages";
+import { inc } from "semver";
+import noop from "lodash/noop";
+
+type ReleaseType = "major" | "minor" | "patch" | null;
+
+interface ReleaseVersionRadioGroupViewProps {
+  currentVersion: string | null;
+  onVersionChange: (value: string | null) => void;
+  releasedAt: string | null;
+}
+
+function ReleaseVersionRadioGroupView({
+  currentVersion = null,
+  onVersionChange = noop,
+  releasedAt = null,
+}: ReleaseVersionRadioGroupViewProps) {
+  const [releaseType, setReleaseType] = useState<ReleaseType>("patch");
+
+  const nextVersion = useMemo(() => {
+    if (!currentVersion || !releaseType) return null;
+
+    return inc(currentVersion, releaseType);
+  }, [currentVersion, releaseType]);
+
+  useEffect(
+    function releaseVersionChangeEffect() {
+      onVersionChange(nextVersion);
+    },
+    [nextVersion, onVersionChange],
+  );
+
+  const handleRadioChange = useCallback((value: string) => {
+    setReleaseType(value as ReleaseType);
+  }, []);
+
+  return (
+    <Flex flexDirection="column" gap="spaces-2" marginBottom="spaces-4">
+      <Text renderAs="p">{RELEASE_VERSION_RADIO_GROUP.TITLE}</Text>
+      <Flex alignItems="center" gap="spaces-4">
+        <Flex minWidth="40px">
+          <Tag isClosable={false} kind="neutral">
+            {nextVersion ?? "-"}
+          </Tag>
+        </Flex>
+        <RadioGroup
+          UNSAFE_gap="var(--ads-v2-spaces-4)"
+          onChange={handleRadioChange}
+          orientation="horizontal"
+          value={releaseType ?? undefined}
+        >
+          <Radio value="major">Major</Radio>
+          <Radio value="minor">Minor</Radio>
+          <Radio value="patch">Patch</Radio>
+        </RadioGroup>
+      </Flex>
+      <Text kind="body-s" renderAs="p">
+        {RELEASE_VERSION_RADIO_GROUP.LAST_RELEASED}: {currentVersion ?? "-"} (
+        {releasedAt ?? "-"})
+      </Text>
+    </Flex>
+  );
+}
+
+export default ReleaseVersionRadioGroupView;

--- a/app/client/src/git/components/ReleaseVersionRadioGroup/index.tsx
+++ b/app/client/src/git/components/ReleaseVersionRadioGroup/index.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import ReleaseVersionRadioGroupView from "./ReleaseVersionRadioGroupView";
+import noop from "lodash/noop";
+
+interface ReleaseVersionRadioGroupProps {
+  onVersionChange: (version: string | null) => void;
+}
+
+function ReleaseVersionRadioGroup({
+  onVersionChange = noop,
+}: ReleaseVersionRadioGroupProps) {
+  const currentVersion = "4.1.2";
+  const releasedAt = "2 weeks ago";
+
+  return (
+    <ReleaseVersionRadioGroupView
+      currentVersion={currentVersion}
+      onVersionChange={onVersionChange}
+      releasedAt={releasedAt}
+    />
+  );
+}
+
+export default ReleaseVersionRadioGroup;

--- a/app/client/src/git/constants/enums.ts
+++ b/app/client/src/git/constants/enums.ts
@@ -7,6 +7,7 @@ export enum GitArtifactType {
 export enum GitOpsTab {
   Deploy = "Deploy",
   Merge = "Merge",
+  Release = "Release",
 }
 
 export enum GitSettingsTab {

--- a/app/client/src/git/ee/constants/messages.tsx
+++ b/app/client/src/git/ee/constants/messages.tsx
@@ -1,0 +1,1 @@
+export * from "../../ce/constants/messages";


### PR DESCRIPTION
## Description
- Adds release tab in git ops modal
- Adds flag to enable/disable the release tagging feature
- Release Tab contains LatestCommitInfo, ReleaseVersionRadioGroup and ReleaseNotesInput components 

Fixes https://github.com/appsmithorg/appsmith/issue/38808
Fixes https://github.com/appsmithorg/appsmith/issue/38809

## Automation

/ok-to-test tags="@tag.Module,@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
