### PR TITLE
fix: WDS Storybook previews

### DIFF
--- a/app/client/packages/storybook/.storybook/styles.css
+++ b/app/client/packages/storybook/.storybook/styles.css
@@ -34,3 +34,11 @@ body,
 *:focus {
   outline: none;
 }
+
+.sb-unstyled {
+  background: none !important;
+}
+
+.docblock-argstable-body td {
+  background: none !important;
+}


### PR DESCRIPTION
## Description

Fixing previews of WDS components when dark mode is on:
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-04 at 10-51-57 WDS _ Widgets _ Text - Docs ⋅ Storybook](https://github.com/user-attachments/assets/82ca52c0-9ddb-4562-a8e7-4b784b99ce33) | ![Screenshot 2025-03-04 at 10-51-30 WDS _ Widgets _ Text - Docs ⋅ Storybook](https://github.com/user-attachments/assets/cc182dcc-9cb4-41ad-a94a-128bcc0ab552) |
| ![Screenshot 2025-03-04 at 10-52-10 WDS _ Widgets _ Text - Docs ⋅ Storybook](https://github.com/user-attachments/assets/df706311-f2ae-44d3-9289-1ec773ce4b91) | ![Screenshot 2025-03-04 at 10-51-17 WDS _ Widgets _ Text - Docs ⋅ Storybook](https://github.com/user-attachments/assets/eb86e993-91c3-4514-b15a-1a0aaebdfbd5) | 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13651440927>
> Commit: 41bf945eaeebef64b2e9efc49d1e59d358f9451a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13651440927&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 04 Mar 2025 10:58:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced updated styling options for a cleaner visual experience. Specific interface elements now render without background color, offering a more streamlined and consistent appearance while preserving the overall design integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->