### PR TITLE
chore: fixing dropdown issue with default branch

### DIFF
--- a/app/client/src/git/ce/components/DefaultBranch/DefaultBranchView.tsx
+++ b/app/client/src/git/ce/components/DefaultBranch/DefaultBranchView.tsx
@@ -39,6 +39,10 @@ const SectionDesc = styled(Text)`
 const StyledSelect = styled(Select)`
   width: 240px;
   margin-right: 12px;
+
+  .rc-virtual-list-holder {
+    max-height: 120px !important;
+  }
 `;
 
 const StyledLink = styled(Link)`

--- a/app/client/src/git/components/SettingsModal/TabBranch/index.tsx
+++ b/app/client/src/git/components/SettingsModal/TabBranch/index.tsx
@@ -5,6 +5,7 @@ import DefaultBranch from "git/ee/components/DefaultBranch";
 
 const Container = styled.div`
   overflow: auto;
+  min-height: 280px;
 `;
 
 interface TabBranchProps {

--- a/app/client/src/git/components/SettingsModal/TabGeneral/index.tsx
+++ b/app/client/src/git/components/SettingsModal/TabGeneral/index.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 
 const Container = styled.div`
   overflow: auto;
+  min-height: 280px;
 `;
 
 interface TabGeneralProps {


### PR DESCRIPTION
## Description
Dropdown for default branch was getting hidden due to the limited length of the git settings modal. This PR adds a min-height to the modal container and reduces the height of the dropdown option menu


Fixes https://github.com/appsmithorg/appsmith/issues/39499

## Automation
/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13654514775>
> Commit: b9e0d6e77643052654deb777182373e409623bf3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13654514775&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Tue, 04 Mar 2025 14:10:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the dropdown menu appearance by capping its height to ensure a neat and consistent display.
  - Updated settings interface panels with a fixed minimum height, providing a uniform and reliable layout across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->