### PR TITLE
chore: Changes to introduce UI module instance creation

### DIFF
--- a/app/client/src/ce/sagas/moduleInterfaceSagas.ts
+++ b/app/client/src/ce/sagas/moduleInterfaceSagas.ts
@@ -1,0 +1,21 @@
+/**
+ * ModuleInterfaceSagas
+ *
+ * Purpose:
+ * This saga file serves as a bridge between the Community Edition (CE) and Enterprise Edition (EE)
+ * module-related functionalities. It provides a clean interface layer that handles all interactions
+ * between core widget operations and module-specific features available in the enterprise version.
+ */
+import type { WidgetAddChild } from "actions/pageActions";
+import type { CanvasWidgetsReduxState } from "ee/reducers/entityReducers/canvasWidgetsReducer";
+
+export interface HandleModuleWidgetCreationSagaPayload {
+  addChildPayload: WidgetAddChild;
+  widgets: CanvasWidgetsReduxState;
+}
+
+export function* handleModuleWidgetCreationSaga(
+  props: HandleModuleWidgetCreationSagaPayload,
+) {
+  return props.widgets;
+}

--- a/app/client/src/ee/sagas/moduleInterfaceSaga.ts
+++ b/app/client/src/ee/sagas/moduleInterfaceSaga.ts
@@ -1,0 +1,9 @@
+/**
+ * ModuleInterfaceSagas
+ *
+ * Purpose:
+ * This saga file serves as a bridge between the Community Edition (CE) and Enterprise Edition (EE)
+ * module-related functionalities. It provides a clean interface layer that handles all interactions
+ * between core widget operations and module-specific features available in the enterprise version.
+ */
+export * from "ce/sagas/moduleInterfaceSagas";

--- a/app/client/src/sagas/WidgetAdditionSagas.ts
+++ b/app/client/src/sagas/WidgetAdditionSagas.ts
@@ -53,6 +53,7 @@ import {
 import { getPropertiesToUpdate } from "./WidgetOperationSagas";
 import { getWidget, getWidgets } from "./selectors";
 import { addBuildingBlockToCanvasSaga } from "./BuildingBlockSagas/BuildingBlockAdditionSagas";
+import { handleModuleWidgetCreationSaga } from "ee/sagas/moduleInterfaceSaga";
 
 const WidgetTypes = WidgetFactory.widgetTypes;
 
@@ -378,12 +379,17 @@ export function* getUpdateDslAfterCreatingChild(
   // some widgets need to update property of parent if the parent have CHILD_OPERATIONS
   // so here we are traversing up the tree till we get to MAIN_CONTAINER_WIDGET_ID
   // while traversing, if we find any widget which has CHILD_OPERATION, we will call the fn in it
-  const updatedWidgets: CanvasWidgetsReduxState = yield call(
+  let updatedWidgets: CanvasWidgetsReduxState = yield call(
     traverseTreeAndExecuteBlueprintChildOperations,
     parent,
     [addChildPayload.newWidgetId],
     widgets,
   );
+
+  updatedWidgets = yield call(handleModuleWidgetCreationSaga, {
+    addChildPayload,
+    widgets: updatedWidgets,
+  });
 
   return updatedWidgets;
 }

--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -29,7 +29,8 @@ const StyledContainerComponent = styled.div<
 
   ${(props) =>
     props.shouldScrollContents && !props.$noScroll ? scrollCSS : ``}
-  opacity: ${(props) => (props.resizeDisabled ? "0.8" : "1")};
+  opacity: ${(props) =>
+    props.resizeDisabled && !props.forceFullOpacity ? "0.8" : "1"};
 
   background: ${(props) => props.backgroundColor};
   &:hover {
@@ -53,6 +54,7 @@ interface ContainerWrapperProps {
   type: WidgetType;
   dropDisabled?: boolean;
   $noScroll: boolean;
+  forceFullOpacity?: boolean;
 }
 
 function ContainerComponentWrapper(
@@ -133,6 +135,7 @@ function ContainerComponentWrapper(
           : ""
       }`}
       dropDisabled={props.dropDisabled}
+      forceFullOpacity={props.forceFullOpacity}
       onClick={props.onClick}
       onClickCapture={props.onClickCapture}
       onMouseOver={onMouseOver}
@@ -153,6 +156,7 @@ function ContainerComponent(props: ContainerComponentProps) {
       <ContainerComponentWrapper
         $noScroll={!!props.noScroll}
         dropDisabled={props.dropDisabled}
+        forceFullOpacity={props.forceFullOpacity}
         onClick={props.onClick}
         onClickCapture={props.onClickCapture}
         resizeDisabled={props.resizeDisabled}
@@ -184,6 +188,7 @@ function ContainerComponent(props: ContainerComponentProps) {
         $noScroll={!!props.noScroll}
         backgroundColor={props.backgroundColor}
         dropDisabled={props.dropDisabled}
+        forceFullOpacity={props.forceFullOpacity}
         onClick={props.onClick}
         onClickCapture={props.onClickCapture}
         resizeDisabled={props.resizeDisabled}
@@ -223,6 +228,7 @@ export interface ContainerComponentProps extends WidgetStyleContainerProps {
   justifyContent?: string;
   alignItems?: string;
   dropDisabled?: boolean;
+  forceFullOpacity?: boolean;
   layoutSystemType?: LayoutSystemTypes;
   isListItemContainer?: boolean;
 }

--- a/app/client/src/widgets/ContainerWidget/widget/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/widget/index.tsx
@@ -416,6 +416,7 @@ export interface ContainerWidgetProps<T extends WidgetProps>
   shouldScrollContents?: boolean;
   noPad?: boolean;
   positioning?: Positioning;
+  forceFullOpacity?: boolean; // used to force full opacity for ui module instance meta widgets
 }
 
 export default ContainerWidget;


### PR DESCRIPTION
## Description
Adds a saga call in widgetAdditionSaga; this saga would detect if the dragged widget is a module widget and trigger module instance creation or not.
In the CE codebase; it would just return the widgets untouched.

PR for https://github.com/appsmithorg/appsmith-ee/pull/6447

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13696508503>
> Commit: 9a3bff430d3c1b6301574c5439015be7ceaabd40
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13696508503&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 06 Mar 2025 11:42:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced integration between editions to streamline widget creation and updates.
	- Improved processing flow for applying module-specific widget configurations.
	- Introduced an optional opacity control setting for container widgets, allowing for more flexible visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->