### PR TITLE
chore: do not fail client build on warnings

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -171,10 +171,14 @@ jobs:
           REACT_APP_FARO_SOURCEMAP_UPLOAD_API_KEY=${{ secrets.REACT_APP_FARO_SOURCEMAP_UPLOAD_API_KEY }} \
           REACT_APP_FARO_SOURCEMAP_UPLOAD_ENDPOINT=${{ secrets.REACT_APP_FARO_SOURCEMAP_UPLOAD_ENDPOINT }} \
           REACT_APP_FARO_STACK_ID=${{ secrets.REACT_APP_FARO_STACK_ID }} \
-            REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
-            REACT_APP_VERSION_EDITION="Community" \
-            yarn build
+          REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \
+          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
+          REACT_APP_VERSION_EDITION="Community" \
+          yarn build || EXIT_CODE=$?
+
+          if [ -n "$EXIT_CODE" ] && [ "$EXIT_CODE" -gt 1 ]; then
+            exit $EXIT_CODE
+          fi
 
       # Saving the cache to use it in subsequent runs
       - name: Save Yarn cache

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -156,7 +156,8 @@ jobs:
           fi
 
       # We burn React environment & the Segment analytics key into the build itself.
-      # This is to ensure that we don't need to configure it in each installation
+      # This is to ensure that we don't need to configure it in each installation.
+      # Client build fails only on errors (EXIT_CODE > 1); warnings (EXIT_CODE <= 1) don’t affect it.
       - name: Create the bundle
         if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         run: |


### PR DESCRIPTION
## Description
An adjustment to client build that will allow it to pass in case there are warnings. Current behavior is strict and fails build if there is a warning. We could suppress warnings, but would rather be aware that there is a potential problem.

This relates to a problem described in the following [Slack thread](https://theappsmith.slack.com/archives/CPG2ZTXEY/p1741188291297589). Adjusting the build behavior seems like the best option.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13709134043>
> Commit: 223772797d57326f8c1d4a022c6fb17bbbccb991
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13709134043&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 06 Mar 2025 22:42:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved the client application build process with enhanced error handling to capture and respond to issues more effectively, ensuring that significant build failures are promptly addressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->