### PR TITLE
fix: Appsmith Icon open in new tab does not work

### DIFF
--- a/app/client/src/pages/Editor/AppsmithLink.tsx
+++ b/app/client/src/pages/Editor/AppsmithLink.tsx
@@ -24,9 +24,18 @@ export const StyledLink = styled((props) => {
 `;
 
 export const AppsmithLink = () => {
-  const handleOnClick = useCallback(() => {
-    history.push(APPLICATIONS_URL);
-  }, []);
+  const handleOnClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      e.stopPropagation();
+
+      if (e.ctrlKey || e.metaKey) {
+        window.open(APPLICATIONS_URL, "_blank");
+      } else {
+        history.push(APPLICATIONS_URL);
+      }
+    },
+    [],
+  );
 
   return (
     <Tooltip content={createMessage(LOGO_TOOLTIP)} placement="bottomLeft">


### PR DESCRIPTION
## Description

Updates AppsmithLink component to handle cmd / ctrl click to open link in new tab

Fixes #39603

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13714082542>
> Commit: cc1fbe50a56b4e6e3471976060a20961489ef1d7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13714082542&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 07 Mar 2025 05:41:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced link behavior now allows you to open the related page in a new tab when you hold Ctrl (or Command on Mac) while clicking. A normal click will navigate in the current view. This enhancement offers more intuitive navigation and improved browsing flexibility within the application. Users will benefit from this smarter navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->