### PR TITLE
fix: Enforce lodash >=4.17.21 to mitigate CVE-2019-10744 (Critical vulnerability)

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -144,7 +144,7 @@
     "libphonenumber-js": "^1.9.44",
     "linkedom": "^0.14.20",
     "localforage": "^1.7.3",
-    "lodash": "^4.17.21",
+    "lodash": ">=4.17.21",
     "lodash-es": "4.17.21",
     "loglevel": "^1.7.1",
     "lottie-web": "^5.7.4",

--- a/app/client/packages/design-system/theming/package.json
+++ b/app/client/packages/design-system/theming/package.json
@@ -18,6 +18,6 @@
     "@capsizecss/metrics": "^1.2.0",
     "@emotion/css": "^11.13.0",
     "colorjs.io": "^0.5.2",
-    "lodash": "*"
+    "lodash": ">=4.17.21"
   }
 }

--- a/app/client/packages/design-system/widgets/package.json
+++ b/app/client/packages/design-system/widgets/package.json
@@ -30,7 +30,7 @@
     "@react-types/shared": "^3.23.1",
     "@tabler/icons-react": "^3.10.0",
     "clsx": "^2.0.0",
-    "lodash": "*",
+    "lodash": ">=4.17.21",
     "react-aria-components": "^1.6.0",
     "react-markdown": "^9.0.1",
     "react-syntax-highlighter": "^15.5.0",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -126,7 +126,7 @@ __metadata:
     "@capsizecss/metrics": ^1.2.0
     "@emotion/css": ^11.13.0
     colorjs.io: ^0.5.2
-    lodash: "*"
+    lodash: ">=4.17.21"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   languageName: unknown
@@ -169,7 +169,7 @@ __metadata:
     browserslist: ^4.24.4
     clsx: ^2.0.0
     eslint-plugin-storybook: ^0.11.3
-    lodash: "*"
+    lodash: ">=4.17.21"
     postcss-import: ^16.1.0
     react-aria-components: ^1.6.0
     react-markdown: ^9.0.1
@@ -13669,7 +13669,7 @@ __metadata:
     linkedom: ^0.14.20
     lint-staged: ^14.0.1
     localforage: ^1.7.3
-    lodash: ^4.17.21
+    lodash: ">=4.17.21"
     lodash-es: 4.17.21
     loglevel: ^1.7.1
     lottie-web: ^5.7.4
@@ -24261,7 +24261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:*, lodash@npm:^4, lodash@npm:^4.17.10, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:~4.17.21":
+"lodash@npm:>=4.17.21, lodash@npm:^4, lodash@npm:^4.17.10, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:~4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7


### PR DESCRIPTION
## Description
This PR enforces lodash version 4.17.21 or above, mitigating the **Critical severity**  vulnerability [CVE-2019-10744](https://github.com/advisories/GHSA-jf85-cpcp-j695).

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version constraints for the lodash library across multiple packages. This ensures a minimum version of 4.17.21 while allowing a broader range of updates, including potential major releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->