### PR TITLE
fix: Rename Error effect in ADS

### DIFF
--- a/app/client/packages/design-system/ads/src/__hooks__/useEditableText/useEditableText.ts
+++ b/app/client/packages/design-system/ads/src/__hooks__/useEditableText/useEditableText.ts
@@ -8,7 +8,6 @@ import {
   type RefObject,
 } from "react";
 
-import { usePrevious } from "@mantine/hooks";
 import { useEventCallback, useEventListener } from "usehooks-ts";
 
 import { normaliseName } from "./utils";
@@ -27,7 +26,6 @@ export function useEditableText(
   (e: KeyboardEvent<HTMLInputElement>) => void,
   (e: ChangeEvent<HTMLInputElement>) => void,
 ] {
-  const previousName = usePrevious(name);
   const [editableName, setEditableName] = useState(name);
   const [validationError, setValidationError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -111,11 +109,11 @@ export function useEditableText(
 
   useEffect(
     function syncEditableTitle() {
-      if (!isEditing && previousName !== name) {
+      if (!isEditing && editableName !== name) {
         setEditableName(name);
       }
     },
-    [name, previousName, isEditing],
+    [name, editableName, isEditing],
   );
 
   return [


### PR DESCRIPTION
## Description

Updates the ADS `useEditbaleText`.

It was seen that the syncEditableTitle hook was not checking the correct variables. Because of the bad check, errors in editing name was not reflected in the Entity Explorer or Tabs and the old invalid name was displayed.

Fixes #39589 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
