### PR TITLE
chore: added tag to exclude from map widget spec from airgap

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Map/MapWidget_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Map/MapWidget_Spec.ts
@@ -31,7 +31,15 @@ const location = [
 
 describe(
   "Map Widget",
-  { tags: ["@tag.Widget", "@tag.Maps", "@tag.Visual", "@tag.Binding"] },
+  {
+    tags: [
+      "@tag.Widget",
+      "@tag.Maps",
+      "@tag.Visual",
+      "@tag.Binding",
+      "@tag.excludeForAirgap",
+    ],
+  },
   function () {
     it("1.Drag Map Widget and Verify the Map Widget with Initial Location", () => {
       //Add map and verify


### PR DESCRIPTION
## Description
Added tag to exclude from map widget spec from airgap


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13759569874>
> Commit: 7bd6cac649ac715267c5149f15f6f85bddbc0ff2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13759569874&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 10 Mar 2025 08:38:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test suite configuration by adding an environment-specific tag to allow selective exclusion of certain tests, improving flexibility in managing test execution across different deployment contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->