### PR TITLE
fix: Skip CSRF check if there's JSON content type

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ce/CsrfConfigCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ce/CsrfConfigCE.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
@@ -84,6 +85,11 @@ public class CsrfConfigCE implements Customizer<ServerHttpSecurity.CsrfSpec>, Se
         }
 
         final HttpHeaders headers = request.getHeaders();
+
+        if (MediaType.APPLICATION_JSON.equalsTypeAndSubtype(headers.getContentType())) {
+            // HTML form submissions never send a JSON content type.
+            return ServerWebExchangeMatcher.MatchResult.notMatch();
+        }
 
         if (headers.containsKey(VERSION_HEADER)) {
             // If `X-Appsmith-Version` header is present, CSRF check isn't needed.


### PR DESCRIPTION
## Description


## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This update enhances the handling of API interactions involving JSON data, resulting in a more seamless integration experience. The system now applies streamlined processing for JSON requests, reducing unnecessary verifications and improving overall performance and responsiveness for API-based communications.

- **New Features**
  - Improved processing for JSON API requests for smoother and more efficient communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->