### PR TITLE
chore: Adding permission check for the plus button in tabs list

### DIFF
--- a/app/client/src/pages/AppIDE/layouts/components/EditorTabs/index.tsx
+++ b/app/client/src/pages/AppIDE/layouts/components/EditorTabs/index.tsx
@@ -28,6 +28,10 @@ import { ScreenModeToggle } from "./ScreenModeToggle";
 import { EditableTab } from "./EditableTab";
 import { TabSelectors } from "./constants";
 import { AddTab } from "./AddTab";
+import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
+import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
+import { getPagePermissions } from "selectors/editorSelectors";
+import { getHasCreateActionPermission } from "ee/utils/BusinessFeatures/permissionPageHelpers";
 
 const EditorTabs = () => {
   const location = useLocation();
@@ -42,9 +46,19 @@ const EditorTabs = () => {
   const [showNudge, dismissNudge] = useShowSideBySideNudge();
   const { addClickHandler } = useIDETabClickHandlers();
   const isJSLoading = useIsJSAddLoading();
-  const hideAdd = segmentMode === EditorEntityTabState.Add || !files.length;
 
   const currentEntity = identifyEntityFromPath(location.pathname);
+  const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
+  const pagePermissions = useSelector(getPagePermissions);
+  const canCreateActions = getHasCreateActionPermission(
+    isFeatureEnabled,
+    pagePermissions,
+  );
+  const hideAdd =
+    segmentMode === EditorEntityTabState.Add ||
+    !files.length ||
+    !canCreateActions;
+
   const showEntityListButton =
     ideViewMode === EditorViewMode.SplitScreen && files.length > 0;
 

--- a/app/client/src/pages/Editor/gitSync/components/PushFailedWarning.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/PushFailedWarning.tsx
@@ -11,7 +11,7 @@ const Container = styled.div`
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function PushFailedWarning({ closeHandler, error }: any) {
   return (
-    <Container className="ankita">
+    <Container>
       <Callout isClosable kind="error" onClose={closeHandler}>
         <>
           <Text type={TextType.H5}>{error.errorType}</Text>


### PR DESCRIPTION
## Description

Adding permission check for the plus button in tabs list to handle the edge case in GAC where we see a new query tab with no datasource options in the page to create one.

Fixes [#39673](https://github.com/appsmithorg/appsmith/issues/39673)

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13811690526>
> Commit: 6501918837d95c646ce839dfec640f54268955dd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13811690526&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Wed, 12 Mar 2025 13:19:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the editor’s tab behavior so the "Add" button is only displayed when files are present and the user has the appropriate permissions.
- **Style**
	- Refined the display styling of push failure warnings for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->