### PR TITLE
chore: reduced critical path to not include populatedExecuteActionDTOMono

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -205,12 +205,8 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
 
         Mono<ExecuteActionDTO> populatedExecuteActionDTOMono =
                 newActionMono.flatMap(newAction -> populateExecuteActionDTO(executeActionDTO, newAction));
-        Mono<String> environmentIdMono = Mono.zip(newActionMono, populatedExecuteActionDTOMono)
-                .flatMap(tuple -> {
-                    NewAction newAction = tuple.getT1();
-                    ExecuteActionDTO populatedExecuteActionDTO = tuple.getT2();
-                    return getTrueEnvironmentId(newAction, populatedExecuteActionDTO, executeActionMetaDTO);
-                });
+        Mono<String> environmentIdMono = newActionMono.flatMap(
+                newAction -> getTrueEnvironmentId(newAction, executeActionDTO, executeActionMetaDTO));
 
         return Mono.zip(populatedExecuteActionDTOMono, environmentIdMono).flatMap(pair -> {
             ExecuteActionDTO populatedExecuteActionDTO = pair.getT1();


### PR DESCRIPTION
## Description
Reduced critical path of populateAndExecuteAction to not include populatedExecuteActionDTOMono.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13828479927>
> Commit: d035dfc1a4bce4ac6e1cb1c34d771f679c91e8e5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13828479927&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 13 Mar 2025 07:59:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal process for determining environment settings during action execution for improved clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->