### PR TITLE
fix: Updating styles for removing the horizontal scrollbar showing up in Entity lists

### DIFF
--- a/app/client/packages/design-system/ads/src/List/List.styles.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.styles.tsx
@@ -107,7 +107,7 @@ export const StyledListItem = styled.div<{
       visibility: hidden;
       width: 0;
 
-      button {
+      button.entity-context-menu {
         visibility: hidden;
         height: 100%;
         width: 100%;
@@ -118,7 +118,7 @@ export const StyledListItem = styled.div<{
       visibility: visible;
       width: auto;
 
-      button {
+      button.entity-context-menu {
         visibility: visible;
         width: 24px;
       }

--- a/app/client/packages/design-system/ads/src/List/List.styles.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.styles.tsx
@@ -42,10 +42,6 @@ export const RightControlWrapper = styled.div`
   line-height: normal;
   display: flex;
   align-items: center;
-
-  button {
-    margin-left: -4px;
-  }
 `;
 
 export const TopContentWrapper = styled.div`
@@ -110,11 +106,22 @@ export const StyledListItem = styled.div<{
     ${RightControlWrapper} {
       visibility: hidden;
       width: 0;
+
+      button {
+        visibility: hidden;
+        height: 100%;
+        width: 100%;
+      }
     }
 
     &:hover ${RightControlWrapper} {
       visibility: visible;
       width: auto;
+
+      button {
+        visibility: visible;
+        width: 24px;
+      }
     }
   }
 

--- a/app/client/packages/design-system/ads/src/Templates/EntityContextMenu/EntityContextMenu.styles.ts
+++ b/app/client/packages/design-system/ads/src/Templates/EntityContextMenu/EntityContextMenu.styles.ts
@@ -9,4 +9,6 @@ export const MenuContent = styled(ADSMenuContent)`
 
 export const ButtonContainer = styled.div`
   position: relative;
+  width: 100%;
+  height: 100%;
 `;


### PR DESCRIPTION
## Description

Updating styles for removing the horizontal scrollbar showing up in Entity lists

Fixes [#39707](https://github.com/appsmithorg/appsmith/issues/39707)

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13830889465>
> Commit: b125fdd65460b72e9ff4b5182ee2339197f64bd9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13830889465&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Thu, 13 Mar 2025 09:40:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined button behavior in list items for smoother hover interactions and consistent sizing.
  - Adjusted context menu controls to fully occupy available space for improved layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->