### PR TITLE
chore: add tooltip in slider

### DIFF
--- a/app/client/packages/design-system/ads/src/Slider/Slider.styles.tsx
+++ b/app/client/packages/design-system/ads/src/Slider/Slider.styles.tsx
@@ -28,11 +28,20 @@ export const StyledSlider = styled.div<{
   }
 `;
 
-export const SliderLabel = styled.div`
+export const SliderLabel = styled.div<{
+  hasTooltip?: boolean;
+}>`
   display: flex;
   align-self: stretch;
   justify-content: space-between;
   margin: 0 calc(var(--ads-v2-spaces-5) / 2 * -1) var(--ads-v2-spaces-3);
+  ${({ hasTooltip }) =>
+    hasTooltip &&
+    `label {
+      cursor: help;
+      text-decoration: underline dashed var(--ads-v2-color-border) from-font;
+      text-underline-position: under;
+    }`}
 
   span {
     flex-grow: 1;

--- a/app/client/packages/design-system/ads/src/Slider/Slider.tsx
+++ b/app/client/packages/design-system/ads/src/Slider/Slider.tsx
@@ -16,6 +16,7 @@ import {
   Track,
   TrackContainer,
 } from "./Slider.styles";
+import { Tooltip } from "../Tooltip";
 import type { SliderProps } from "./Slider.types";
 
 export function Slider(props: SliderProps) {
@@ -65,12 +66,14 @@ export function Slider(props: SliderProps) {
 
   return (
     <StyledSlider {...groupProps} disabled={props.isDisabled}>
-      <SliderLabel>
+      <SliderLabel hasTooltip={!!props.tooltipText}>
         {props.label && (
-          // @ts-expect-error incompatible types for Text and labelProps
-          <Text renderAs="label" {...labelProps}>
-            {props.label}
-          </Text>
+          <Tooltip content={props.tooltipText} isDisabled={!props.tooltipText}>
+            {/* @ts-expect-error incompatible types for Text and labelProps */}
+            <Text renderAs="label" {...labelProps}>
+              {props.label}
+            </Text>
+          </Tooltip>
         )}
         {/*@ts-expect-error incompatible types for Text and outputProps**/}
         <Text {...outputProps}>{getDisplayValue()}</Text>

--- a/app/client/packages/design-system/ads/src/Slider/Slider.types.ts
+++ b/app/client/packages/design-system/ads/src/Slider/Slider.types.ts
@@ -8,4 +8,6 @@ export interface SliderProps
   formatOptions?: Intl.NumberFormatOptions;
   /** A function that returns the content to display as the value's label. Overrides default formatted number. */
   getValueLabel?: (value: number) => string;
+  /** The text to display in the tooltip. */
+  tooltipText?: string;
 }

--- a/app/client/src/components/formControls/HybridSearch.tsx
+++ b/app/client/src/components/formControls/HybridSearch.tsx
@@ -6,7 +6,11 @@ import { Slider, type SliderProps, Flex, Switch, Text } from "@appsmith/ads";
 
 export interface HybridSearchControlProps
   extends ControlProps,
-    Omit<SliderProps, "id" | "label"> {}
+    Omit<SliderProps, "id" | "label"> {
+  // tooltipText also exists in ControlProps, but it has type of  of `string | Record<string, string>`
+  // and we only need it to be a string, so we override it here
+  tooltipText?: string;
+}
 
 export class HybridSearchControl extends BaseControl<HybridSearchControlProps> {
   render() {

--- a/app/client/src/components/formControls/SliderControl.tsx
+++ b/app/client/src/components/formControls/SliderControl.tsx
@@ -6,7 +6,11 @@ import { Slider, type SliderProps } from "@appsmith/ads";
 
 export interface SliderControlProps
   extends ControlProps,
-    Omit<SliderProps, "id" | "label"> {}
+    Omit<SliderProps, "id" | "label"> {
+  // tooltipText also exists in ControlProps, but it has type of  of `string | Record<string, string>`
+  // and we only need it to be a string, so we override it here
+  tooltipText?: string;
+}
 
 export class SliderControl extends BaseControl<SliderControlProps> {
   render() {
@@ -31,7 +35,7 @@ const renderSliderControl = (
     input?: WrappedFieldInputProps;
   } & SliderControlProps,
 ) => {
-  const { input, maxValue, minValue, step, title } = props;
+  const { input, maxValue, minValue, step, title, tooltipText } = props;
 
   return (
     <Slider
@@ -42,6 +46,7 @@ const renderSliderControl = (
       minValue={minValue}
       onChangeEnd={input?.onChange}
       step={step}
+      tooltipText={tooltipText}
     />
   );
 };


### PR DESCRIPTION
/ok-to-test tags="@tag.Anvil"

Adds tooltip support in slider component in ads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Interactive Tooltips:** Slider labels now offer customizable tooltip support. When enabled, users will see enhanced visual cues (e.g., underlined text with a help cursor) that provide additional context.
  - **Enhanced Form Controls:** Slider and hybrid search components have been updated to support tooltip text, allowing for clearer, context-specific guidance during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13833113756>
> Commit: 1012e57f58f6edafd8c3d1c342448455e6bcc254
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13833113756&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`
> Spec:
> <hr>Thu, 13 Mar 2025 11:29:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->
