### PR TITLE
fix: sidebar showing when page is hidden

### DIFF
--- a/app/client/src/ce/selectors/applicationSelectors.tsx
+++ b/app/client/src/ce/selectors/applicationSelectors.tsx
@@ -9,12 +9,7 @@ import type { ApplicationPayload } from "entities/Application";
 import Fuse from "fuse.js";
 import type { GitApplicationMetadata } from "ee/api/ApplicationApi";
 import { getApplicationsOfWorkspace } from "ee/selectors/selectedWorkspaceSelectors";
-import {
-  NAVIGATION_SETTINGS,
-  SIDEBAR_WIDTH,
-  type ThemeSetting,
-  defaultThemeSetting,
-} from "constants/AppConstants";
+import { type ThemeSetting, defaultThemeSetting } from "constants/AppConstants";
 import { DEFAULT_EVALUATION_VERSION } from "constants/EvalConstants";
 
 const fuzzySearchOptions = {
@@ -146,31 +141,6 @@ export const getImportedApplication = (state: AppState) =>
 
 export const getAppSidebarPinned = (state: AppState) => {
   return state.ui.applications.isAppSidebarPinned;
-};
-
-/**
- * Return the width of the sidbar depending on the sidebar style.
- * If there isn't any sidebar or it is unpinned, return 0.
- */
-export const getSidebarWidth = (state: AppState) => {
-  const navigationSetting =
-    state.ui.applications.currentApplication?.applicationDetail
-      ?.navigationSetting;
-  const isAppSidebarPinned = state.ui.applications.isAppSidebarPinned;
-
-  if (
-    navigationSetting?.showNavbar !== false &&
-    navigationSetting?.orientation === NAVIGATION_SETTINGS.ORIENTATION.SIDE &&
-    isAppSidebarPinned
-  ) {
-    if (navigationSetting?.navStyle === NAVIGATION_SETTINGS.NAV_STYLE.MINIMAL) {
-      return SIDEBAR_WIDTH.MINIMAL;
-    } else {
-      return SIDEBAR_WIDTH.REGULAR;
-    }
-  }
-
-  return 0;
 };
 
 export const getIsUploadingNavigationLogo = (state: AppState) => {

--- a/app/client/src/pages/AppViewer/Navigation/index.tsx
+++ b/app/client/src/pages/AppViewer/Navigation/index.tsx
@@ -1,108 +1,111 @@
-import React, { useEffect, useRef, useState } from "react";
+// React and core libraries
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { ThemeProvider } from "styled-components";
-import type { ApplicationPayload } from "entities/Application";
+
+// Third-party libraries
 import { useDispatch, useSelector } from "react-redux";
+import { ThemeProvider } from "styled-components";
+
+// Type imports
 import type { AppState } from "ee/reducers";
-import {
-  getCurrentBasePageId,
-  getViewModePageList,
-} from "selectors/editorSelectors";
-import { getCurrentWorkspaceId } from "ee/selectors/selectedWorkspaceSelectors";
-import { getCurrentUser } from "selectors/usersSelectors";
-import type { User } from "constants/userConstants";
-import type { Theme } from "constants/DefaultTheme";
-import { getThemeDetails, ThemeMode } from "selectors/themeSelectors";
-import HtmlTitle from "../AppViewerHtmlTitle";
+import type { ApplicationPayload } from "entities/Application";
+
+// Application-specific imports
+import { setAppViewHeaderHeight } from "actions/appViewActions";
 import { NAVIGATION_SETTINGS } from "constants/AppConstants";
+import { builderURL } from "ee/RouteBuilder";
+import { getCurrentApplication } from "ee/selectors/applicationSelectors";
+import { getCurrentWorkspaceId } from "ee/selectors/selectedWorkspaceSelectors";
+import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import PageMenu from "pages/AppViewer/PageMenu";
 import { useHref } from "pages/Editor/utils";
-import { builderURL } from "ee/RouteBuilder";
-import TopHeader from "./components/TopHeader";
-import Sidebar from "./Sidebar";
-import { getCurrentApplication } from "ee/selectors/applicationSelectors";
+import {
+  getCurrentBasePageId,
+  getCurrentPageId,
+  getViewModePageList,
+} from "selectors/editorSelectors";
+import { getThemeDetails, ThemeMode } from "selectors/themeSelectors";
+import { getCurrentUser } from "selectors/usersSelectors";
 import { useIsMobileDevice } from "utils/hooks/useDeviceDetect";
-import { setAppViewHeaderHeight } from "actions/appViewActions";
-import AnalyticsUtil from "ee/utils/AnalyticsUtil";
+
+// Relative imports
+import HtmlTitle from "../AppViewerHtmlTitle";
+import Sidebar from "./Sidebar";
+import TopHeader from "./components/TopHeader";
 
 export function Navigation() {
+  const dispatch = useDispatch();
   const { search } = useLocation();
-  const queryParams = new URLSearchParams(search);
-  const isEmbed = queryParams.get("embed") === "true";
-  const showNavBar = queryParams.get("navbar") === "true";
-  const hideHeader = isEmbed && !showNavBar;
   const [isMenuOpen, setMenuOpen] = useState(false);
   const headerRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobileDevice();
   const basePageId = useSelector(getCurrentBasePageId);
+  const pageId = useSelector(getCurrentPageId);
   const editorURL = useHref(builderURL, { basePageId });
-  const currentWorkspaceId: string = useSelector(getCurrentWorkspaceId);
-  const currentUser: User | undefined = useSelector(getCurrentUser);
-  const lightTheme: Theme = useSelector((state: AppState) =>
+
+  const currentWorkspaceId = useSelector(getCurrentWorkspaceId);
+  const currentUser = useSelector(getCurrentUser);
+  const lightTheme = useSelector((state: AppState) =>
     getThemeDetails(state, ThemeMode.LIGHT),
   );
   const currentApplicationDetails: ApplicationPayload | undefined = useSelector(
     getCurrentApplication,
   );
   const pages = useSelector(getViewModePageList);
-  const isMobile = useIsMobileDevice();
-  const dispatch = useDispatch();
 
-  useEffect(() => {
-    const header = document.querySelector(".js-appviewer-header");
+  const queryParams = new URLSearchParams(search);
+  const isEmbed = queryParams.get("embed") === "true";
+  const forceShowNavBar = queryParams.get("navbar") === "true";
+  const hideHeader = isEmbed && !forceShowNavBar;
 
-    dispatch(setAppViewHeaderHeight(header?.clientHeight || 0));
-
-    return () => {
-      dispatch(setAppViewHeaderHeight(0));
-    };
-  }, [
-    currentApplicationDetails?.applicationDetail?.navigationSetting?.navStyle,
+  const navStyle =
+    currentApplicationDetails?.applicationDetail?.navigationSetting?.navStyle;
+  const orientation =
     currentApplicationDetails?.applicationDetail?.navigationSetting
-      ?.orientation,
-  ]);
-  useEffect(() => {
-    if (showNavBar && currentApplicationDetails) {
-      AnalyticsUtil.logEvent("APP_VIEWED_WITH_NAVBAR", {
-        id: currentApplicationDetails.id,
-      });
-    }
-  }, [showNavBar, currentApplicationDetails]);
+      ?.orientation;
+  const applicationId = currentApplicationDetails?.id;
 
-  const renderNavigation = () => {
-    if (
-      currentApplicationDetails?.applicationDetail?.navigationSetting
-        ?.orientation === NAVIGATION_SETTINGS.ORIENTATION.SIDE
-    ) {
-      return (
-        <>
-          {/*
-           * We need to add top header since we want the current mobile
-           * navigation experience until we create the new sidebar for mobile.
-           */}
-          {isMobile ? (
-            <TopHeader
-              currentApplicationDetails={currentApplicationDetails}
-              currentUser={currentUser}
-              currentWorkspaceId={currentWorkspaceId}
-              isMenuOpen={isMenuOpen}
-              pages={pages}
-              setMenuOpen={setMenuOpen}
-              showUserSettings={!isEmbed}
-            />
-          ) : (
-            <Sidebar
-              currentApplicationDetails={currentApplicationDetails}
-              currentUser={currentUser}
-              currentWorkspaceId={currentWorkspaceId}
-              pages={pages}
-              showUserSettings={!isEmbed}
-            />
-          )}
-        </>
-      );
-    }
+  const currentPage = pages.find((page) => page.pageId === pageId);
+  const showNavbar = !(
+    currentApplicationDetails?.applicationDetail?.navigationSetting
+      ?.showNavbar === false || currentPage?.isHidden
+  );
 
-    return (
+  // TODO: refactor this to not directly reference a DOM element by class defined elsewhere
+  useEffect(
+    function adjustHeaderHeightEffect() {
+      const header = document.querySelector(".js-appviewer-header");
+
+      dispatch(setAppViewHeaderHeight(header?.clientHeight || 0));
+
+      return () => {
+        dispatch(setAppViewHeaderHeight(0));
+      };
+    },
+    [navStyle, orientation, dispatch],
+  );
+
+  useEffect(
+    function trackNavbarAnalyticsEffect() {
+      if (forceShowNavBar && applicationId) {
+        AnalyticsUtil.logEvent("APP_VIEWED_WITH_NAVBAR", {
+          id: applicationId,
+        });
+      }
+    },
+    [forceShowNavBar, applicationId],
+  );
+
+  const navigation = useMemo(() => {
+    return orientation === NAVIGATION_SETTINGS.ORIENTATION.SIDE && !isMobile ? (
+      <Sidebar
+        currentApplicationDetails={currentApplicationDetails}
+        currentUser={currentUser}
+        currentWorkspaceId={currentWorkspaceId}
+        pages={pages}
+        showUserSettings={!isEmbed}
+      />
+    ) : (
       <TopHeader
         currentApplicationDetails={currentApplicationDetails}
         currentUser={currentUser}
@@ -113,7 +116,16 @@ export function Navigation() {
         showUserSettings={!isEmbed}
       />
     );
-  };
+  }, [
+    currentApplicationDetails,
+    currentUser,
+    currentWorkspaceId,
+    isEmbed,
+    isMenuOpen,
+    isMobile,
+    orientation,
+    pages,
+  ]);
 
   if (hideHeader) return <HtmlTitle />;
 
@@ -124,8 +136,7 @@ export function Navigation() {
         and we are creating the default values only when any nav settings via the
         settings pane has changed, we need to hide the navbar ONLY when the showNavbar
         setting is explicitly set to false by the user via the settings pane. */}
-        {currentApplicationDetails?.applicationDetail?.navigationSetting
-          ?.showNavbar !== false && renderNavigation()}
+        {showNavbar && navigation}
 
         {/* Mobile Sidebar */}
         <PageMenu

--- a/app/client/src/pages/Editor/WidgetsEditor/components/NavigationAdjustedPageViewer.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/components/NavigationAdjustedPageViewer.tsx
@@ -1,23 +1,32 @@
-import type { ReactNode } from "react";
+// React and core libraries
 import React from "react";
+
+// Third-party libraries
+import classNames from "classnames";
+import { useSelector } from "react-redux";
+
+// Application-specific imports
+import { APP_MODE } from "entities/App";
 import { EditorState } from "IDE/enums";
 import { useCurrentAppState } from "IDE/hooks/useCurrentAppState";
-import { getIsAppSettingsPaneWithNavigationTabOpen } from "selectors/appSettingsPaneSelectors";
-import { useSelector } from "react-redux";
-import { selectCombinedPreviewMode } from "selectors/gitModSelectors";
-import { PageViewWrapper } from "pages/AppViewer/AppPage";
-import classNames from "classnames";
-import { APP_MODE } from "entities/App";
+import { CANVAS_VIEWPORT } from "constants/componentClassNameConstants";
+import { NAVIGATION_SETTINGS } from "constants/AppConstants";
 import { getAppMode } from "ee/selectors/entitiesSelector";
 import {
   getAppSidebarPinned,
   getCurrentApplication,
-  getSidebarWidth,
 } from "ee/selectors/applicationSelectors";
-import { useIsMobileDevice } from "utils/hooks/useDeviceDetect";
-import { CANVAS_VIEWPORT } from "constants/componentClassNameConstants";
-import { NAVIGATION_SETTINGS } from "constants/AppConstants";
 import { getIsAnvilLayout } from "layoutSystems/anvil/integrations/selectors";
+import { PageViewWrapper } from "pages/AppViewer/AppPage";
+import { getIsAppSettingsPaneWithNavigationTabOpen } from "selectors/appSettingsPaneSelectors";
+import { selectCombinedPreviewMode } from "selectors/gitModSelectors";
+
+// Type imports
+import type { ReactNode } from "react";
+
+// Utility/Helper functions
+import { useIsMobileDevice } from "utils/hooks/useDeviceDetect";
+import { useSidebarWidth } from "utils/hooks/useSidebarWidth";
 
 /**
  * NavigationAdjustedPageViewer
@@ -30,7 +39,7 @@ export const NavigationAdjustedPageViewer = (props: {
   const isPreview = useSelector(selectCombinedPreviewMode);
   const currentApplicationDetails = useSelector(getCurrentApplication);
   const isAppSidebarPinned = useSelector(getAppSidebarPinned);
-  const sidebarWidth = useSelector(getSidebarWidth);
+  const sidebarWidth = useSidebarWidth();
   const isNavigationSelectedInSettings = useSelector(
     getIsAppSettingsPaneWithNavigationTabOpen,
   );

--- a/app/client/src/utils/hooks/useAppViewerSidebarProperties.ts
+++ b/app/client/src/utils/hooks/useAppViewerSidebarProperties.ts
@@ -1,19 +1,27 @@
-import { useSelector } from "react-redux";
+// React and core libraries
 import { useLocation } from "react-router";
 
+// Third-party libraries
+import { useSelector } from "react-redux";
+
+// Application-specific imports
 import {
   getAppSidebarPinned,
   getCurrentApplication,
-  getSidebarWidth,
 } from "ee/selectors/applicationSelectors";
 import { NAVIGATION_SETTINGS } from "constants/AppConstants";
+
+// Utility/Helper functions
+import { useSidebarWidth } from "utils/hooks/useSidebarWidth";
+
+// Imports with relative paths
 import { useIsMobileDevice } from "./useDeviceDetect";
 
 export const useAppViewerSidebarProperties = () => {
   const currentApplicationDetails = useSelector(getCurrentApplication);
   const isAppSidebarPinned = useSelector(getAppSidebarPinned);
   const isMobile = useIsMobileDevice();
-  const _sidebarWidth = useSelector(getSidebarWidth);
+  const _sidebarWidth = useSidebarWidth();
 
   const { search } = useLocation();
   const queryParams = new URLSearchParams(search);

--- a/app/client/src/utils/hooks/useSidebarWidth.ts
+++ b/app/client/src/utils/hooks/useSidebarWidth.ts
@@ -1,0 +1,36 @@
+// React and core libraries
+import { useSelector } from "react-redux";
+
+// Application-specific imports
+import { getApplicationsState } from "ee/selectors/applicationSelectors";
+import { NAVIGATION_SETTINGS, SIDEBAR_WIDTH } from "constants/AppConstants";
+import { getCurrentPageId, getPageById } from "selectors/editorSelectors";
+
+/**
+ * Return the width of the sidebar depending on the sidebar style.
+ * If there isn't any sidebar or it is unpinned, return 0.
+ */
+export const useSidebarWidth = () => {
+  const applications = useSelector(getApplicationsState);
+  const navigationSetting =
+    applications.currentApplication?.applicationDetail?.navigationSetting;
+  const isAppSidebarPinned = applications.isAppSidebarPinned;
+
+  const currentPageId = useSelector(getCurrentPageId);
+  const currentPage = useSelector(getPageById(currentPageId));
+
+  if (
+    navigationSetting?.showNavbar !== false &&
+    currentPage?.isHidden === false &&
+    navigationSetting?.orientation === NAVIGATION_SETTINGS.ORIENTATION.SIDE &&
+    isAppSidebarPinned
+  ) {
+    if (navigationSetting?.navStyle === NAVIGATION_SETTINGS.NAV_STYLE.MINIMAL) {
+      return SIDEBAR_WIDTH.MINIMAL;
+    } else {
+      return SIDEBAR_WIDTH.REGULAR;
+    }
+  }
+
+  return 0;
+};


### PR DESCRIPTION
## Description
Fixes an issue, when the "Show Page Navigation" option is disabled in the page settings, the sidebar should not appear when navigating to that page. However, even after turning off navigation, the sidebar is still visible.

Fixes #39580

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
