### PR TITLE
chore: update openai node module to 4.87.3

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -159,7 +159,7 @@
     "nanoid": "^2.0.4",
     "node-forge": "^1.3.0",
     "object-hash": "^3.0.0",
-    "openai": "^4.64.0",
+    "openai": "4.87.3",
     "path-to-regexp": "^6.3.0",
     "pluralize": "^8.0.0",
     "popper.js": "^1.15.0",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -13685,7 +13685,7 @@ __metadata:
     nanoid: ^2.0.4
     node-forge: ^1.3.0
     object-hash: ^3.0.0
-    openai: ^4.64.0
+    openai: 4.87.3
     path-to-regexp: ^6.3.0
     pg: ^8.11.3
     plop: ^3.1.1
@@ -26546,9 +26546,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^4.64.0, openai@npm:^4.83.0":
-  version: 4.85.2
-  resolution: "openai@npm:4.85.2"
+"openai@npm:4.87.3, openai@npm:^4.83.0":
+  version: 4.87.3
+  resolution: "openai@npm:4.87.3"
   dependencies:
     "@types/node": ^18.11.18
     "@types/node-fetch": ^2.6.4
@@ -26567,7 +26567,7 @@ __metadata:
       optional: true
   bin:
     openai: bin/cli
-  checksum: 44686ce3e6b67a6374a8e30e65c638bff901f48f2df539c862f3bb86e6f079e4c30804f0141c2dfe91fc4714cd37cbe67900c0de1476ecb950db8b78fe8f69b7
+  checksum: 2cbb548c5b6dfa21c87b012fee81010925d8106626e4adc0ba86e2a5974aca3b5ec29e3ddc2f354d8c95e1d64da8d384f1495ceabbbf2948269fc2dab34bb3fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
> Update openai node module to 4.87.3

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13892386825>
> Commit: 3fec7b0115a306bec99ebbfe45f780995ad38108
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13892386825&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 17 Mar 2025 06:21:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Locked the version of the AI service integration to 4.87.3, ensuring consistent and stable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->