### PR TITLE
chore: remove redundant flag

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -31,7 +31,6 @@ export const FEATURE_FLAG = {
   release_drag_drop_building_blocks_enabled:
     "release_drag_drop_building_blocks_enabled",
   release_layout_conversion_enabled: "release_layout_conversion_enabled",
-  release_anvil_toggle_enabled: "release_anvil_toggle_enabled",
   release_git_persist_branch_enabled: "release_git_persist_branch_enabled",
   release_ide_animations_enabled: "release_ide_animations_enabled",
   release_ide_datasource_selector_enabled:
@@ -83,7 +82,6 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   rollout_remove_feature_walkthrough_enabled: true,
   rollout_eslint_enabled: false,
   release_layout_conversion_enabled: false,
-  release_anvil_toggle_enabled: false,
   release_git_persist_branch_enabled: false,
   release_ide_animations_enabled: false,
   release_ide_datasource_selector_enabled: false,

--- a/app/client/src/pages/common/PageHeader.tsx
+++ b/app/client/src/pages/common/PageHeader.tsx
@@ -12,12 +12,6 @@ import { shouldShowLicenseBanner } from "ee/selectors/organizationSelectors";
 import { Banner } from "ee/utils/licenseHelpers";
 import bootIntercom from "utils/bootIntercom";
 import EntitySearchBar from "pages/common/SearchBar/EntitySearchBar";
-import { Switch, Tooltip } from "@appsmith/ads";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
-import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
-import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
-import { setFeatureFlagOverrideValues } from "utils/storage";
-import { updateFeatureFlagOverrideAction } from "actions/featureFlagActions";
 
 const StyledPageHeader = styled(StyledHeader)<{
   hideShadow?: boolean;
@@ -41,20 +35,6 @@ const StyledPageHeader = styled(StyledHeader)<{
     `};
   ${({ isBannerVisible, isMobile }) =>
     isBannerVisible ? (isMobile ? `top: 70px;` : `top: 40px;`) : ""};
-
-  /* intentionally "hacky" approach to show the Anvil toggle in the header. This will be removed once all features work well with Anvil */
-  & .ads-v2-switch {
-    display: block;
-    width: 100%;
-    position: absolute;
-    left: 175px;
-    top: 12px;
-    width: 30px;
-    & > label {
-      min-width: 0;
-      flex-direction: row-reverse;
-    }
-  }
 `;
 
 interface PageHeaderProps {
@@ -81,25 +61,6 @@ export function PageHeader(props: PageHeaderProps) {
   const showBanner = useSelector(shouldShowLicenseBanner);
   const isHomePage = useRouteMatch("/applications")?.isExact;
   const isLicensePage = useRouteMatch("/license")?.isExact;
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
-  const shouldShowAnvilToggle = useFeatureFlag(
-    FEATURE_FLAG.release_anvil_toggle_enabled,
-  );
-
-  /*
-    If Anvil toggle is enabled, the switch allows us to enable or disable Anvil
-    We pass the anvil feature's value via the toggle. We also passthrough the original
-    anvil toggle feature flag value as-is.
-  */
-  function handleAnvilToggle(isSelected: boolean) {
-    const featureFlags = {
-      release_anvil_enabled: isSelected,
-      release_anvil_toggle_enabled: shouldShowAnvilToggle,
-    };
-
-    dispatch(updateFeatureFlagOverrideAction(featureFlags));
-    setFeatureFlagOverrideValues(featureFlags);
-  }
 
   return (
     <>
@@ -111,16 +72,6 @@ export function PageHeader(props: PageHeaderProps) {
         isMobile={isMobile}
         showSeparator={props.showSeparator || false}
       >
-        {
-          // Based on a feature flag, show the switch that enables/disables Anvil
-          shouldShowAnvilToggle && (
-            <Switch isSelected={isAnvilEnabled} onChange={handleAnvilToggle}>
-              <Tooltip content="Toggles Anvil Layout System" trigger="hover">
-                <b>&alpha;</b>
-              </Tooltip>
-            </Switch>
-          )
-        }
         <EntitySearchBar user={user} />
       </StyledPageHeader>
     </>

--- a/app/client/src/utils/hooks/useFeatureFlagOverride.ts
+++ b/app/client/src/utils/hooks/useFeatureFlagOverride.ts
@@ -15,7 +15,6 @@ import {
 export const AvailableFeaturesToOverride: FeatureFlag[] = [
   "release_anvil_enabled",
   "release_layout_conversion_enabled",
-  "release_anvil_toggle_enabled",
   "release_fn_calling_enabled",
 ];
 export type OverriddenFeatureFlags = Partial<Record<FeatureFlag, boolean>>;


### PR DESCRIPTION
## Description
Just remove flag that we don't need anymore.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
