### PR TITLE
feat: filter fc by page

### DIFF
--- a/app/client/src/components/formControls/FunctionCallingConfigControl/components/selectors.ts
+++ b/app/client/src/components/formControls/FunctionCallingConfigControl/components/selectors.ts
@@ -5,6 +5,7 @@ import {
   getPlugins,
 } from "ee/selectors/entitiesSelector";
 import { createSelector } from "reselect";
+import { getCurrentPageId } from "selectors/editorSelectors";
 import type {
   FunctionCallingEntityType,
   FunctionCallingEntityTypeOption,
@@ -14,6 +15,7 @@ export const selectQueryEntityOptions = (
   state: AppState,
 ): FunctionCallingEntityTypeOption[] => {
   const plugins = getPlugins(state);
+  const currentPageId = getCurrentPageId(state);
 
   return (
     getActions(state)
@@ -24,6 +26,7 @@ export const selectQueryEntityOptions = (
           // @ts-expect-error No way to narrow down proper type
           action.config.pluginName !== "Appsmith AI",
       )
+      .filter((action) => action.config.pageId === currentPageId)
       .map(({ config }) => ({
         id: config.id,
         name: config.name,
@@ -47,14 +50,18 @@ export const selectQueryEntityOptions = (
 const selectJsFunctionEntityOptions = (
   state: AppState,
 ): FunctionCallingEntityTypeOption[] => {
+  const currentPageId = getCurrentPageId(state);
+
   return getJSCollections(state).flatMap((jsCollection) => {
-    return jsCollection.config.actions.map((jsFunction) => {
-      return {
-        value: jsFunction.id,
-        label: jsFunction.name,
-        optionGroupType: "JSFunction",
-      };
-    });
+    return jsCollection.config.actions
+      .filter((action) => action.pageId === currentPageId)
+      .map((jsFunction) => {
+        return {
+          value: jsFunction.id,
+          label: jsFunction.name,
+          optionGroupType: "JSFunction",
+        };
+      });
   });
 };
 


### PR DESCRIPTION
## Description

Fixes #39765

## Automation

/ok-to-test tags="@tag.AIAgents"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13946065065>
> Commit: 0065e266d75f77673d8f4232160bbabb5ac47f49
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13946065065&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.AIAgents
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ServerSide/GenerateCRUD/MySQL2_Spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Wed, 19 Mar 2025 12:37:46 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved filtering for action options: Now, available actions for queries and JavaScript functions are dynamically refined to show only those pertinent to the active page context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->