### PR TITLE
chore: remove anvil flag for git

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -682,8 +682,6 @@ export const ERROR_IMPORTING_APPLICATION_TO_WORKSPACE = () =>
 export const IMPORT_APPLICATION_MODAL_TITLE = () => "Import application";
 export const IMPORT_APPLICATION_MODAL_LABEL = () =>
   "Where would you like to import your application from?";
-export const IMPORT_FROM_GIT_DISABLED_IN_ANVIL = () =>
-  "Importing from Git repositories is not yet supported in Anvil α";
 export const IMPORT_APP_FROM_FILE_TITLE = () => "Import from file";
 export const UPLOADING_JSON = () => "Uploading JSON file";
 export const UPLOADING_APPLICATION = () => "Uploading application";

--- a/app/client/src/pages/common/ImportModal.tsx
+++ b/app/client/src/pages/common/ImportModal.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import React, { useCallback, useEffect } from "react";
 import styled, { useTheme, css } from "styled-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { setWorkspaceIdForImport } from "ee/actions/applicationActions";
 import {
   createMessage,
@@ -9,7 +9,6 @@ import {
   IMPORT_APP_FROM_FILE_TITLE,
   IMPORT_APP_FROM_GIT_MESSAGE,
   IMPORT_APP_FROM_GIT_TITLE,
-  IMPORT_FROM_GIT_DISABLED_IN_ANVIL,
   UPLOADING_JSON,
 } from "ee/constants/messages";
 import { FilePickerV2, FileType } from "@appsmith/ads-old";
@@ -19,17 +18,9 @@ import { ReduxActionTypes } from "ee/constants/ReduxActionConstants";
 import Statusbar from "pages/Editor/gitSync/components/Statusbar";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import type { Theme } from "constants/DefaultTheme";
-import {
-  Callout,
-  Icon,
-  Modal,
-  ModalContent,
-  ModalHeader,
-  Text,
-} from "@appsmith/ads";
+import { Icon, Modal, ModalContent, ModalHeader, Text } from "@appsmith/ads";
 import useMessages from "ee/hooks/importModal/useMessages";
 import useMethods from "ee/hooks/importModal/useMethods";
-import { getIsAnvilLayoutEnabled } from "layoutSystems/anvil/integrations/selectors";
 import { useGitModEnabled } from "pages/Editor/gitSync/hooks/modHooks";
 import { gitToggleImportModal } from "git/store";
 
@@ -215,8 +206,6 @@ function ImportModal(props: ImportModalProps) {
     resetAppFileToBeUploaded,
     uploadingText,
   } = useMethods({ editorId, workspaceId });
-
-  const isAnvilEnabled = useSelector(getIsAnvilLayoutEnabled);
   const dispatch = useDispatch();
   const onGitImport = useCallback(() => {
     onClose && onClose();
@@ -281,15 +270,6 @@ function ImportModal(props: ImportModalProps) {
                 ? createMessage(UPLOADING_JSON)
                 : mainDescription}
           </Text>
-          {
-            // If Anvil is enabled, we disable the import via Git option.
-            // This callout informs the user of this.
-            isAnvilEnabled && (
-              <Callout kind="warning" onClose={() => {}}>
-                {createMessage(IMPORT_FROM_GIT_DISABLED_IN_ANVIL)}
-              </Callout>
-            )
-          }
         </TextWrapper>
 
         {!isImporting && (
@@ -309,9 +289,7 @@ function ImportModal(props: ImportModalProps) {
                 uploadIcon="file-line"
               />
             </FileImportCard>
-            {!toEditor && !isAnvilEnabled && (
-              <GitImportCard handler={onGitImport} />
-            )}
+            {!toEditor && <GitImportCard handler={onGitImport} />}
           </Row>
         )}
         {isImporting && (


### PR DESCRIPTION
## Description
Removed anvil feature flag check for Git import. 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13925483139>
> Commit: 1b7663f2decef17ee8a93599ccf3c3a8d6c75ba0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13925483139&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 18 Mar 2025 15:00:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed an outdated warning message related to Git import limitations.
  - Streamlined the import interface so that Git import options display consistently without conditional warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->