### PR TITLE
fix: updated the code to fetch all workspaces without the user session context

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/base/PluginServiceCEImpl.java
@@ -159,8 +159,8 @@ public class PluginServiceCEImpl extends BaseService<PluginRepository, Plugin, S
         if (newWorkspacePlugins.isEmpty()) {
             return Flux.empty();
         }
-
-        return workspaceService.getAll().flatMap(workspace -> {
+        // used retrieveAll() as it does not need user session context
+        return workspaceService.retrieveAll().flatMap(workspace -> {
             // Only perform a DB op if plugins associated to this org have changed
             if (workspace.getPlugins().containsAll(newWorkspacePlugins)) {
                 return Mono.just(workspace);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
@@ -43,4 +43,6 @@ public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
     Mono<Workspace> archiveById(String s);
 
     Mono<String> getDefaultEnvironmentId(String workspaceId, AclPermission aclPermission);
+
+    Flux<Workspace> retrieveAll();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -618,4 +618,9 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
     public Flux<Workspace> getAll(AclPermission permission) {
         return repository.findAll(permission);
     }
+
+    @Override
+    public Flux<Workspace> retrieveAll() {
+        return repository.retrieveAll();
+    }
 }


### PR DESCRIPTION
## Description
> This PR fixes the cron for fetching and storing all EXTERNAL_SAAS and REMOTE type plugins by updating the service class method to use the one which does not need user session context. As this function is triggered by a cron, the user session context cannot be maintained.


Fixes #39769 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
