### PR TITLE
fix: fix axis label configuration for ECharts with additional properties

### DIFF
--- a/app/client/src/widgets/ChartWidget/component/LayoutBuilders/EChartsXAxisLayoutBuilder.ts
+++ b/app/client/src/widgets/ChartWidget/component/LayoutBuilders/EChartsXAxisLayoutBuilder.ts
@@ -32,7 +32,12 @@ export class EChartsXAxisLayoutBuilder {
 
   axisLabelConfig = (allocatedXAxisHeight: number) => {
     if (this.props.labelOrientation == LabelOrientation.AUTO) {
-      return {};
+      return {
+        width: allocatedXAxisHeight,
+        overflow: "truncate",
+        hideOverlap: true,
+        interval: 0,
+      };
     } else {
       return {
         width:
@@ -40,6 +45,8 @@ export class EChartsXAxisLayoutBuilder {
           this.defaultHeightForXAxisName -
           this.gapBetweenLabelAndName,
         overflow: "truncate",
+        hideOverlap: true,
+        interval: 0,
       };
     }
   };

--- a/app/client/src/widgets/ChartWidget/component/LayoutBuilders/EChartsYAxisLayoutBuilder.ts
+++ b/app/client/src/widgets/ChartWidget/component/LayoutBuilders/EChartsYAxisLayoutBuilder.ts
@@ -45,7 +45,6 @@ export class EChartsYAxisLayoutBuilder {
       nameGap: this.nameGap,
       axisLabel: {
         width: this.labelsWidth,
-        overflow: "truncate",
       },
     };
   };


### PR DESCRIPTION
Fixes #38974   
Fixes the issue where Y-axis labels were getting truncated, as mentioned in the issue.

Also resolves the problem of X-axis labels not being truncated when displaying large values. The fix ensures that truncation occurs in two cases:
When the orientation is set to "auto," truncation happens for relatively larger values.
For other orientations, truncation follows the same width constraints as before. 
## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced X-axis label display for charts, offering improved control over label spacing, width, and overlap when using automatic orientation.
  - Adjusted Y-axis label rendering by removing explicit truncation, resulting in a modified display behavior when labels exceed allocated space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->