### PR TITLE
remove duplicate helm value

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -44,10 +44,6 @@ mongodb:
     nodeSelector: {}
     affinity: {}
     tolerations: []
-  image:
-    registry: docker.io
-    repository: bitnami/mongodb
-    tag: 6.0.13
 
 ## postgresql parameters
 postgresql:


### PR DESCRIPTION
## Description
Encountered error
```
Error: could not parse merged values into map: received error yaml: unmarshal errors:
  line 47: mapping key "image" already defined at line 35 for the following resource:
...
mongodb:
...
  image:
    registry: 1234.dkr.ecr.us-east-1.amazonaws.com/docker-hub
    repository: bitnami/mongodb
    tag: 6.0.13
  ...
  image:
    registry: docker.io
    repository: bitnami/mongodb
```

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Revised the database service deployment by removing explicit Docker image settings, allowing it to use default configurations for image selection during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->