### PR TITLE
chore: Fix DS_Bug26941 spec error assertion

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug26941_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug26941_Spec.ts
@@ -30,7 +30,11 @@ describe(
       });
 
       cy.get("@postExecute").then((interception: any) => {
+        console.log(interception.response);
         debuggerHelper.AssertDownStreamLogError(
+          interception.response.body.data.statusCode,
+        );
+        debuggerHelper.LogStateContains(
           interception.response.body.data.pluginErrorDetails
             .downstreamErrorMessage,
         );

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug26941_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DS_Bug26941_Spec.ts
@@ -30,7 +30,6 @@ describe(
       });
 
       cy.get("@postExecute").then((interception: any) => {
-        console.log(interception.response);
         debuggerHelper.AssertDownStreamLogError(
           interception.response.body.data.statusCode,
         );


### PR DESCRIPTION
## Description

Updates the error message assertion in DS_Bug26941_Spec.ts


## Automation

/ok-to-test tags="@tag.Datasource, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13963497727>
> Commit: 143ec48d157ff1e05479106b31bf9093361eeb6f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13963497727&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.Sanity`
> Spec:
> <hr>Thu, 20 Mar 2025 07:49:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced automated test routines to improve the monitoring and verification of API error scenarios for increased reliability.
	- Added additional logging and assertions to capture detailed API response information during error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->