### PR TITLE
chore: add a dummy test for aiagents

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/AIAgents/AgentsDummy_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/AIAgents/AgentsDummy_spec.ts
@@ -1,9 +1,4 @@
-
 import { AI_AGENTS_TEST } from "../../../../support/Constants";
-import {
-  agHelper,
-} from "../../../../support/Objects/ObjectsCore";
-import { featureFlagIntercept } from "../../../../support/Objects/FeatureFlags";
 
 describe(
   `${AI_AGENTS_TEST}: This is a dummy test`,

--- a/app/client/cypress/e2e/Regression/ClientSide/AIAgents/AgentsDummy_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/AIAgents/AgentsDummy_spec.ts
@@ -1,0 +1,16 @@
+
+import { AI_AGENTS_TEST } from "../../../../support/Constants";
+import {
+  agHelper,
+} from "../../../../support/Objects/ObjectsCore";
+import { featureFlagIntercept } from "../../../../support/Objects/FeatureFlags";
+
+describe(
+  `${AI_AGENTS_TEST}: This is a dummy test`,
+  { tags: ["@tag.AIAgents"] },
+  function () {
+    it("1. This is a dummy test to check if the tag is working.", () => {
+      expect(true).to.equal(true);
+    });
+  },
+);


### PR DESCRIPTION
/ok-to-test tags="@tag.AIAgents"

Context for this PR - https://theappsmith.slack.com/archives/C06CG2HNUKB/p1742291871620149

There are no cypress tests for AIAgent on CE repo. Not sure about the root cause, but because of this cypress is running the tests that are marked as skip. So just adding a dummy spec so that cypress don't act weird.

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13963612254>
> Commit: 3a79f55e25f3ec59b0394f95569db1b99dfeccf7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13963612254&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.AIAgents`
> Spec:
> <hr>Thu, 20 Mar 2025 07:13:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a new automated end-to-end test suite for dummy assertions to enhance regression testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->