### PR TITLE
feat: filter fc by page

### DIFF
--- a/app/client/src/components/formControls/FunctionCallingConfigControl/components/selectors.ts
+++ b/app/client/src/components/formControls/FunctionCallingConfigControl/components/selectors.ts
@@ -5,6 +5,7 @@ import {
   getPlugins,
 } from "ee/selectors/entitiesSelector";
 import { createSelector } from "reselect";
+import { getCurrentPageId } from "selectors/editorSelectors";
 import type {
   FunctionCallingEntityType,
   FunctionCallingEntityTypeOption,
@@ -14,6 +15,7 @@ export const selectQueryEntityOptions = (
   state: AppState,
 ): FunctionCallingEntityTypeOption[] => {
   const plugins = getPlugins(state);
+  const currentPageId = getCurrentPageId(state);
 
   return (
     getActions(state)
@@ -24,6 +26,7 @@ export const selectQueryEntityOptions = (
           // @ts-expect-error No way to narrow down proper type
           action.config.pluginName !== "Appsmith AI",
       )
+      .filter((action) => action.config.pageId === currentPageId)
       .map(({ config }) => ({
         id: config.id,
         name: config.name,
@@ -47,14 +50,18 @@ export const selectQueryEntityOptions = (
 const selectJsFunctionEntityOptions = (
   state: AppState,
 ): FunctionCallingEntityTypeOption[] => {
+  const currentPageId = getCurrentPageId(state);
+
   return getJSCollections(state).flatMap((jsCollection) => {
-    return jsCollection.config.actions.map((jsFunction) => {
-      return {
-        value: jsFunction.id,
-        label: jsFunction.name,
-        optionGroupType: "JSFunction",
-      };
-    });
+    return jsCollection.config.actions
+      .filter((action) => action.pageId === currentPageId)
+      .map((jsFunction) => {
+        return {
+          value: jsFunction.id,
+          label: jsFunction.name,
+          optionGroupType: "JSFunction",
+        };
+      });
   });
 };
 


### PR DESCRIPTION
## Description

Fixes #39765

## Automation

/ok-to-test tags="@tag.AIAgents"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13964117859>
> Commit: 59a83270789e981f5cf7aeea58de5a98191b55ee
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13964117859&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.AIAgents`
> Spec:
> <hr>Thu, 20 Mar 2025 07:49:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the filtering of available actions so that only those relevant to the current page are displayed, streamlining configuration and reducing interface clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->