### PR TITLE
chore: spans added in ast service for RTS calls

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/OnLoadSpanCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/spans/ce/OnLoadSpanCE.java
@@ -16,4 +16,8 @@ public class OnLoadSpanCE {
             APPSMITH_SPAN_PREFIX + "addExplicitUserSetOnLoadExecutablesToGraph";
     public static final String GET_UNPUBLISHED_ON_LOAD_EXECUTABLES_EXPLICIT_SET_BY_USER_IN_CREATOR_CONTEXT =
             APPSMITH_SPAN_PREFIX + "getUnpublishedOnLoadExecutablesExplicitSetByUserInCreatorContext";
+    public static final String GET_POSSIBLE_REFERENCES_FROM_DYNAMIC_BINDING =
+            APPSMITH_SPAN_PREFIX + "getPossibleReferencesFromDynamicBinding";
+    public static final String AST_SERVICE_CALLING_RTS_API =
+            APPSMITH_SPAN_PREFIX + "astService.getPossibleReferencesFromDynamicBinding";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
@@ -58,6 +58,7 @@ import static com.appsmith.external.constants.spans.OnLoadSpan.EXECUTABLE_NAME_T
 import static com.appsmith.external.constants.spans.OnLoadSpan.GET_ALL_EXECUTABLES_BY_CREATOR_ID;
 import static com.appsmith.external.constants.spans.OnLoadSpan.GET_UNPUBLISHED_ON_LOAD_EXECUTABLES_EXPLICIT_SET_BY_USER_IN_CREATOR_CONTEXT;
 import static com.appsmith.external.constants.spans.OnLoadSpan.UPDATE_EXECUTABLE_SELF_REFERENCING_PATHS;
+import static com.appsmith.external.constants.spans.ce.OnLoadSpanCE.GET_POSSIBLE_REFERENCES_FROM_DYNAMIC_BINDING;
 import static com.appsmith.external.helpers.MustacheHelper.EXECUTABLE_ENTITY_REFERENCES;
 import static com.appsmith.external.helpers.MustacheHelper.WIDGET_ENTITY_REFERENCES;
 import static com.appsmith.external.helpers.MustacheHelper.getPossibleParents;
@@ -667,8 +668,10 @@ public class OnLoadExecutablesUtilCEImpl implements OnLoadExecutablesUtilCE {
      */
     private Mono<Map<String, Set<EntityDependencyNode>>> getPossibleEntityParentsMap(
             List<String> bindings, int types, int evalVersion) {
-        Flux<Tuple2<String, Set<String>>> findingToReferencesFlux =
-                astService.getPossibleReferencesFromDynamicBinding(bindings, evalVersion);
+        Flux<Tuple2<String, Set<String>>> findingToReferencesFlux = astService
+                .getPossibleReferencesFromDynamicBinding(bindings, evalVersion)
+                .name(GET_POSSIBLE_REFERENCES_FROM_DYNAMIC_BINDING)
+                .tap(Micrometer.observation(observationRegistry));
         return MustacheHelper.getPossibleEntityParentsMap(findingToReferencesFlux, types);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AstServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AstServiceImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.external.services.RTSCaller;
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.InstanceConfig;
 import com.appsmith.server.services.ce.AstServiceCEImpl;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class AstServiceImpl extends AstServiceCEImpl implements AstService {
 
-    public AstServiceImpl(CommonConfig commonConfig, InstanceConfig instanceConfig, RTSCaller rtsCaller) {
-        super(commonConfig, instanceConfig, rtsCaller);
+    public AstServiceImpl(
+            CommonConfig commonConfig,
+            InstanceConfig instanceConfig,
+            RTSCaller rtsCaller,
+            ObservationRegistry observationRegistry) {
+        super(commonConfig, instanceConfig, rtsCaller, observationRegistry);
     }
 }


### PR DESCRIPTION
## Description
> Spans added in AST service for RTS calls, this is done to help us debug SLO alerts for JS object update API


Fixes #39799   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
