### PR TITLE
fix: Remove default value of IDE tabs focus retention

### DIFF
--- a/app/client/src/ce/navigation/FocusElements/AppIDE.ts
+++ b/app/client/src/ce/navigation/FocusElements/AppIDE.ts
@@ -249,7 +249,6 @@ export const AppIDEFocusElements: FocusElementsConfigList = {
       name: FocusElement.IDETabs,
       selector: getIDETabs,
       setter: setIDETabs,
-      defaultValue: {},
     },
   ],
 };


### PR DESCRIPTION
## Description

It was found that the default value added not real purpose but always caused a reset of tabs for new apps. This avoided us to have new apps with deep links to specific urls

fixes #39845 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/13986189070>
> Commit: 57217a68f07a53644c4c2703abdcf3cbf0f8e99d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=13986189070&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Fri, 21 Mar 2025 07:16:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Adjusted IDE tab initialization so that no preset option is provided, requiring explicit user selection for improved interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->