### PR TITLE
chore: Introduce action isDirty map

### DIFF
--- a/app/client/src/PluginActionEditor/transformers/RestActionTransformers.test.ts
+++ b/app/client/src/PluginActionEditor/transformers/RestActionTransformers.test.ts
@@ -40,6 +40,9 @@ const BASE_ACTION: ApiAction = {
     },
     timeoutInMillisecond: 5000,
   },
+  isDirtyMap: {
+    SCHEMA_GENERATION: false,
+  },
   jsonPathKeys: [],
   messages: [],
 };

--- a/app/client/src/ce/selectors/entitiesSelector.ts
+++ b/app/client/src/ce/selectors/entitiesSelector.ts
@@ -834,6 +834,20 @@ export const getJsCollectionByBaseId = (
   return jsaction && jsaction.config;
 };
 
+export const getJSCollectionAction = (
+  state: AppState,
+  collectionId: string,
+  actionId: string,
+) => {
+  const jsCollection = getJSCollection(state, collectionId);
+
+  if (jsCollection) {
+    return jsCollection.actions.find((action) => action.id === actionId);
+  }
+
+  return null;
+};
+
 /**
  *
  * getJSCollectionFromAllEntities is used to get the js collection from all jsAction entities (including module instance entities) )

--- a/app/client/src/components/editorComponents/utils.test.ts
+++ b/app/client/src/components/editorComponents/utils.test.ts
@@ -47,6 +47,9 @@ const TEST_JS_FUNCTION = {
   userPermissions: ["read:actions", "execute:actions", "manage:actions"],
   validName: "JSObject1.myFun234y",
   cacheResponse: "",
+  isDirtyMap: {
+    SCHEMA_GENERATION: false,
+  },
 };
 
 describe("GetJSResponseViewState", () => {

--- a/app/client/src/entities/Action/actionProperties.test.ts
+++ b/app/client/src/entities/Action/actionProperties.test.ts
@@ -23,6 +23,9 @@ const DEFAULT_ACTION: Action = {
   pluginId: "",
   messages: [],
   pluginType: PluginType.DB,
+  isDirtyMap: {
+    SCHEMA_GENERATION: false,
+  },
 };
 
 describe("getReactivePathsOfAction", () => {

--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -166,6 +166,9 @@ export interface BaseAction {
   visualization?: {
     result: VisualizationElements;
   };
+  isDirtyMap: {
+    SCHEMA_GENERATION: boolean;
+  };
 }
 
 interface BaseApiAction extends BaseAction {

--- a/app/client/src/pages/Editor/JSEditor/utils.test.ts
+++ b/app/client/src/pages/Editor/JSEditor/utils.test.ts
@@ -61,6 +61,9 @@ const BASE_JS_ACTION = (useLiterals = false) => {
       timeoutInMillisecond: 1000,
       jsArguments: [],
     },
+    isDirtyMap: {
+      SCHEMA_GENERATION: false,
+    },
   };
 };
 

--- a/app/client/src/sagas/BuildingBlockSagas/tests/fixtures.ts
+++ b/app/client/src/sagas/BuildingBlockSagas/tests/fixtures.ts
@@ -152,5 +152,8 @@ export const newlyCreatedActions: Action[] = [
       "execute:actions",
       "manage:actions",
     ],
+    isDirtyMap: {
+      SCHEMA_GENERATION: false,
+    },
   },
 ];

--- a/app/client/test/factories/Actions/API.ts
+++ b/app/client/test/factories/Actions/API.ts
@@ -75,4 +75,7 @@ export const APIFactory = Factory.Sync.makeFactory<ApiAction>({
     "manage:actions",
   ],
   confirmBeforeExecute: false,
+  isDirtyMap: {
+    SCHEMA_GENERATION: false,
+  },
 });

--- a/app/client/test/factories/Actions/GoogleSheetFactory.ts
+++ b/app/client/test/factories/Actions/GoogleSheetFactory.ts
@@ -4,8 +4,12 @@ import { PluginPackageName, PluginType } from "entities/Plugin";
 import { PluginIDs } from "test/factories/MockPluginsState";
 
 const pageId = "0123456789abcdef00000000";
+
 export const GoogleSheetFactory = Factory.Sync.makeFactory<SaaSAction>({
   dynamicBindingPathList: [],
+  isDirtyMap: {
+    SCHEMA_GENERATION: false,
+  },
   id: "api_id",
   baseId: "api_base_id",
   workspaceId: "workspaceID",

--- a/app/client/test/factories/Actions/JSObject.ts
+++ b/app/client/test/factories/Actions/JSObject.ts
@@ -51,6 +51,9 @@ export const JSObjectFactory = Factory.Sync.makeFactory<JSCollection>({
         "manage:actions",
       ],
       cacheResponse: "",
+      isDirtyMap: {
+        SCHEMA_GENERATION: false,
+      },
     },
     {
       id: "myFunc2_id",
@@ -88,6 +91,9 @@ export const JSObjectFactory = Factory.Sync.makeFactory<JSCollection>({
         "manage:actions",
       ],
       cacheResponse: "",
+      isDirtyMap: {
+        SCHEMA_GENERATION: false,
+      },
     },
   ],
   body: "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1 () {\n\t\t//\twrite code here\n\t\t//\tthis.myVar1 = [1,2,3]\n\t},\n\tasync myFun2 () {\n\t\t//\tuse async-await or promises\n\t\t//\tawait storeValue('varName', 'hello world')\n\t}\n}",

--- a/app/client/test/factories/Actions/Postgres.ts
+++ b/app/client/test/factories/Actions/Postgres.ts
@@ -44,4 +44,7 @@ export const PostgresFactory = Factory.Sync.makeFactory<QueryAction>({
     "execute:actions",
     "manage:actions",
   ],
+  isDirtyMap: {
+    SCHEMA_GENERATION: false,
+  },
 });


### PR DESCRIPTION
## Description

The server now adds a isDirty map in the action object to signify if any aspect of the action is not saved (is dirty)

This is needed for the EE change https://github.com/appsmithorg/appsmith-ee/pull/6713

https://www.notion.so/appsmith/Implement-save-button-for-AI-Query-1b9fe271b0e2808285dcc797ad281141?pvs=4

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14029254723>
> Commit: 4321d95d427a1dfd07aedecd3731390ed0a4688e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14029254723&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Mon, 24 Mar 2025 07:51:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a capability that improves how the app retrieves a specific action from a collection based on unique identifiers, ensuring smoother interaction.
  - Enhanced state management in actions by introducing a new property to track the update status of schema generation, supporting more robust workflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->