### PR TITLE
chore: fix the WDS button widget click bug

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
@@ -108,6 +108,7 @@
   pre {
     margin-top: var(--inner-spacing-4);
     margin-bottom: var(--inner-spacing-4);
+    font-family: unset;
   }
 
   blockquote {

--- a/app/client/src/widgets/wds/WDSButtonWidget/component/index.tsx
+++ b/app/client/src/widgets/wds/WDSButtonWidget/component/index.tsx
@@ -17,9 +17,13 @@ export interface ButtonComponentProps extends ButtonProps {
 }
 
 function ButtonComponent(props: ButtonComponentProps & UseRecaptchaProps) {
-  const { icon, text, tooltip, ...rest } = props;
+  const { icon, onClick: onClickProp, text, tooltip, ...rest } = props;
   const { isFormValid, onReset } = useWDSZoneWidgetContext();
-  const { onClick, recpatcha } = useRecaptcha({ ...props, onReset });
+  const { onClick, recpatcha } = useRecaptcha({
+    ...props,
+    onClick: onClickProp,
+    onReset,
+  });
 
   const isDisabled =
     props.isDisabled || (props.disableOnInvalidForm && isFormValid === false);


### PR DESCRIPTION
/ok-to-test tags="@tag.Anvil"

The WDS Button widget was firing onClick twice. This was because we were sending onClick + onPress to the widget. And it was firing both. We don't need onClick prop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved button click event handling for better integration with verification features.
	- Added styling changes to enhance text rendering within code blocks in markdown content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14036976365>
> Commit: 5343c7e3c9d721a2d4b0d0282ecff514855823ab
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14036976365&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`
> Spec:
> <hr>Mon, 24 Mar 2025 14:14:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->
