### PR TITLE
fix: Make isDirty map optional

### DIFF
--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -166,7 +166,7 @@ export interface BaseAction {
   visualization?: {
     result: VisualizationElements;
   };
-  isDirtyMap: {
+  isDirtyMap?: {
     SCHEMA_GENERATION: boolean;
   };
 }


### PR DESCRIPTION
## Description

fixes issue introduced in https://github.com/appsmithorg/appsmith/commit/97b374c1ef8e54e2924277dbe40b414a68692d01

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14052145641>
> Commit: 799b54d6b73ad803e5323de64886411fe2427740
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14052145641&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 25 Mar 2025 06:27:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced action configuration by making certain settings optional, which increases flexibility in how actions are handled and instantiated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->