### PR TITLE
fix: Avoid excessive API saves

### DIFF
--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -129,7 +129,7 @@ import { convertToBaseParentEntityIdSelector } from "selectors/pageListSelectors
 import AppsmithConsole from "utils/AppsmithConsole";
 import { getDynamicBindingsChangesSaga } from "utils/DynamicBindingUtils";
 import { getDefaultTemplateActionConfig } from "utils/editorContextUtils";
-import { shouldBeDefined } from "utils/helpers";
+import { isEmptyKeyValue, shouldBeDefined } from "utils/helpers";
 import history from "utils/history";
 import { setAIPromptTriggered } from "utils/storage";
 import { sendAnalyticsEventSaga } from "./AnalyticsSaga";
@@ -1026,6 +1026,12 @@ export function* setActionPropertySaga(
       },
     });
 
+    return;
+  }
+
+  // The Rest Api editor adds empty key value pairs in the form for display.
+  // We don't need to save those empty key value pairs.
+  if (actionObj?.pluginType === PluginType.API && isEmptyKeyValue(value)) {
     return;
   }
 

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -1309,7 +1309,7 @@ export function isEmptyKeyValue(value: Property | Property[]): boolean {
   }
 
   if (typeof value === "object") {
-    return !value.key && !value.value;
+    if (value.key === "" && value.value === "") return true;
   }
 
   return false;

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -44,6 +44,7 @@ import { klona as klonaLite } from "klona/lite";
 import { klona as klonaJson } from "klona/json";
 
 import { startAndEndSpanForFn } from "instrumentation/generateTraces";
+import type { Property } from "entities/Action";
 
 export const snapToGrid = (
   columnWidth: number,
@@ -1300,4 +1301,16 @@ export function getDomainFromEmail(email: string) {
   const final_domain = email_string_array[domain_string_location];
 
   return final_domain;
+}
+
+export function isEmptyKeyValue(value: Property | Property[]): boolean {
+  if (Array.isArray(value)) {
+    return value.every((item) => isEmptyKeyValue(item));
+  }
+
+  if (typeof value === "object") {
+    return !value.key && !value.value;
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Description

When we load API editor, we notice an update call without any changes. This happens because of the Headers and Params of the API editor adding empty key value fields. These fields are removed by the RestAPITransformer but the save keeps happening and we update the action state without the empty fields. When we load the API again, the API editor notices that no fields exists and adds them back again. This thus lead to excessive saves of the API to the server without any benefit.

We will now check for this case before hand and avoid starting a save when form adds these empty key value fields


## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14075955172>
> Commit: b11f85f3ee716b2042331a55b670e292516755d6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14075955172&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Wed, 26 Mar 2025 05:59:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined API action updates by filtering out empty entries during save operations, ensuring only valid data is processed and improving overall data integrity.
  
- **New Features**
  - Introduced a utility function to check for empty key-value pairs, enhancing the logic for action property updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->