### PR TITLE
fix: Placeholder for Anvil Application deploy

### DIFF
--- a/app/client/src/ce/sagas/ApplicationSagas.tsx
+++ b/app/client/src/ce/sagas/ApplicationSagas.tsx
@@ -54,6 +54,7 @@ import {
   updateCurrentApplicationForkingEnabled,
   updateApplicationThemeSettingAction,
   fetchAllApplicationsOfWorkspace,
+  publishApplication,
 } from "ee/actions/applicationActions";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import {
@@ -1126,6 +1127,21 @@ export function* deleteNavigationLogoSaga(
   } catch (error) {
     yield put({
       type: ReduxActionErrorTypes.DELETE_NAVIGATION_LOGO_ERROR,
+      payload: {
+        error,
+      },
+    });
+  }
+}
+
+export function* publishAnvilApplicationSaga(
+  action: ReduxAction<PublishApplicationRequest>,
+) {
+  try {
+    yield put(publishApplication(action.payload.applicationId));
+  } catch (error) {
+    yield put({
+      type: ReduxActionErrorTypes.PUBLISH_ANVIL_APPLICATION_ERROR,
       payload: {
         error,
       },

--- a/app/client/src/ee/sagas/ApplicationSagas.tsx
+++ b/app/client/src/ee/sagas/ApplicationSagas.tsx
@@ -17,6 +17,7 @@ import {
   uploadNavigationLogoSaga,
   deleteNavigationLogoSaga,
   fetchAllApplicationsOfWorkspaceSaga,
+  publishAnvilApplicationSaga,
 } from "ce/sagas/ApplicationSagas";
 import { ReduxActionTypes } from "ee/constants/ReduxActionConstants";
 import { all, takeLatest } from "redux-saga/effects";
@@ -66,6 +67,10 @@ export default function* applicationSagas() {
     takeLatest(
       ReduxActionTypes.FETCH_UNCONFIGURED_DATASOURCE_LIST,
       fetchUnconfiguredDatasourceList,
+    ),
+    takeLatest(
+      ReduxActionTypes.PUBLISH_ANVIL_APPLICATION_INIT,
+      publishAnvilApplicationSaga,
     ),
   ]);
 }


### PR DESCRIPTION
## Description

Adds a CE version for Anvil Application deploy flow


## Automation

/ok-to-test tags="@tag.Anvil"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14076064490>
> Commit: 507843d7fdf1df605020f41b3351da65636b2184
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14076064490&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Anvil`
> Spec:
> <hr>Wed, 26 Mar 2025 05:42:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the application publishing process for a more reliable experience. Now, when you publish an application, the system manages the process with improved error handling to ensure smoother and more resilient operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->