### PR TITLE
feat: Dummy Generate Prompt Button 

### DIFF
--- a/app/client/src/ce/components/GeneratePromptButton.tsx
+++ b/app/client/src/ce/components/GeneratePromptButton.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const GeneratePromptButton = () => {
+  return <div />;
+};

--- a/app/client/src/ce/components/GeneratePromptButton.tsx
+++ b/app/client/src/ce/components/GeneratePromptButton.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
-export const GeneratePromptButton = () => {
+export interface GeneratePromptButtonProps {
+  existingPrompt: string;
+  onSubmit: (prompt: string) => void;
+}
+
+// Implementation is in ee
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const GeneratePromptButton = (props: GeneratePromptButtonProps) => {
   return <div />;
 };

--- a/app/client/src/components/formControls/FormTemplateControl.tsx
+++ b/app/client/src/components/formControls/FormTemplateControl.tsx
@@ -1,25 +1,16 @@
-import React, { useState } from "react";
+import React from "react";
 import type { ControlProps } from "./BaseControl";
 import BaseControl from "./BaseControl";
 import type { ControlType } from "constants/PropertyControlConstants";
 import styled from "styled-components";
-import {
-  Button,
-  Flex,
-  Input,
-  Popover,
-  PopoverBody,
-  PopoverContent,
-  PopoverHeader,
-  PopoverTrigger,
-  ToggleButton,
-} from "@appsmith/ads";
+import { Button, Flex } from "@appsmith/ads";
 import type { ButtonProps } from "@appsmith/ads";
 import { change, getFormValues } from "redux-form";
 import { connect } from "react-redux";
 import { get, omit } from "lodash";
 import type { AppState } from "ee/reducers";
 import type { Action } from "entities/Action";
+import { GeneratePromptButton } from "ee/components/GeneratePromptButton";
 
 const StyledButton = styled((props: ButtonProps & { isActive: boolean }) => (
   <Button {...omit(props, ["isActive"])} />
@@ -87,10 +78,11 @@ type FormTemplateProps = FormTemplatePartialProps &
   ReduxDispatchProps &
   ReduxStateProps;
 
+const SYSTEM_INSTRUCTIONS_FIELD =
+  "actionConfiguration.formData.aiChatAssistant.input.instructions";
+
 export function FormTemplate(props: FormTemplateProps) {
   const { formName, formValues, options, updateFormProperty } = props;
-
-  const [isOpen, setIsOpen] = useState(false);
 
   const isActive = (option: FormTemplateOption) => {
     // Checks if the option is active
@@ -100,6 +92,12 @@ export function FormTemplate(props: FormTemplateProps) {
     return Object.keys(value).every((key) => {
       return get(formValues, key) === value[key];
     });
+  };
+
+  const existingPrompt = get(formValues, SYSTEM_INSTRUCTIONS_FIELD, "");
+
+  const onGeneratedPrompt = (prompt: string) => {
+    updateFormProperty(formName, SYSTEM_INSTRUCTIONS_FIELD, prompt);
   };
 
   const onClick = (option: FormTemplateOption) => {
@@ -125,34 +123,10 @@ export function FormTemplate(props: FormTemplateProps) {
           {option.label}
         </StyledButton>
       ))}
-      <Popover onOpenChange={setIsOpen} open={isOpen}>
-        <PopoverTrigger>
-          <ToggleButton
-            icon="star-fill"
-            isSelected={isOpen}
-            onClick={() => setIsOpen(true)}
-            size="md"
-          >
-            Generate prompt
-          </ToggleButton>
-        </PopoverTrigger>
-        <PopoverContent
-          align="end"
-          avoidCollisions={false}
-          showArrow
-          side="bottom"
-        >
-          <PopoverHeader>Generate prompt</PopoverHeader>
-          <PopoverBody>
-            <Flex flexDirection="column" gap="spaces-2">
-              <Input autoFocus renderAs="textarea" />
-              <Button kind="primary" size="sm">
-                Generate
-              </Button>
-            </Flex>
-          </PopoverBody>
-        </PopoverContent>
-      </Popover>
+      <GeneratePromptButton
+        existingPrompt={existingPrompt}
+        onSubmit={onGeneratedPrompt}
+      />
     </Flex>
   );
 }

--- a/app/client/src/components/formControls/FormTemplateControl.tsx
+++ b/app/client/src/components/formControls/FormTemplateControl.tsx
@@ -1,9 +1,19 @@
-import React from "react";
+import React, { useState } from "react";
 import type { ControlProps } from "./BaseControl";
 import BaseControl from "./BaseControl";
 import type { ControlType } from "constants/PropertyControlConstants";
 import styled from "styled-components";
-import { Button, Flex } from "@appsmith/ads";
+import {
+  Button,
+  Flex,
+  Input,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  ToggleButton,
+} from "@appsmith/ads";
 import type { ButtonProps } from "@appsmith/ads";
 import { change, getFormValues } from "redux-form";
 import { connect } from "react-redux";
@@ -80,6 +90,8 @@ type FormTemplateProps = FormTemplatePartialProps &
 export function FormTemplate(props: FormTemplateProps) {
   const { formName, formValues, options, updateFormProperty } = props;
 
+  const [isOpen, setIsOpen] = useState(false);
+
   const isActive = (option: FormTemplateOption) => {
     // Checks if the option is active
     // An option is active if all the values in the option value are equal to the form values
@@ -113,6 +125,34 @@ export function FormTemplate(props: FormTemplateProps) {
           {option.label}
         </StyledButton>
       ))}
+      <Popover onOpenChange={setIsOpen} open={isOpen}>
+        <PopoverTrigger>
+          <ToggleButton
+            icon="star-fill"
+            isSelected={isOpen}
+            onClick={() => setIsOpen(true)}
+            size="md"
+          >
+            Generate prompt
+          </ToggleButton>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          avoidCollisions={false}
+          showArrow
+          side="bottom"
+        >
+          <PopoverHeader>Generate prompt</PopoverHeader>
+          <PopoverBody>
+            <Flex flexDirection="column" gap="spaces-2">
+              <Input autoFocus renderAs="textarea" />
+              <Button kind="primary" size="sm">
+                Generate
+              </Button>
+            </Flex>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
     </Flex>
   );
 }

--- a/app/client/src/ee/components/GeneratePromptButton.tsx
+++ b/app/client/src/ee/components/GeneratePromptButton.tsx
@@ -1,0 +1,1 @@
+export { GeneratePromptButton } from "ce/components/GeneratePromptButton";


### PR DESCRIPTION
## Description

https://github.com/appsmithorg/appsmith-ee/pull/6813


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14126942963>
> Commit: 8fc65a57e1a3daa89cd44e43a5e399fbb26c9b6c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14126942963&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 28 Mar 2025 11:09:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a prompt generation button in the form interface, allowing users to view the current prompt and update it interactively.
  - Added a new component, `GeneratePromptButton`, to facilitate prompt generation based on existing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->