### PR TITLE
fix: Avoid update of empty code from chat bot

### DIFF
--- a/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/ChatBot/ChatBot.tsx
+++ b/app/client/src/pages/Editor/CustomWidgetBuilder/Editor/ChatBot/ChatBot.tsx
@@ -18,7 +18,7 @@ import { isObject } from "lodash";
 export const ChatBot = (props: ContentProps) => {
   const ref = useRef<HTMLIFrameElement>(null);
   const lastUpdateFromBot = useRef<number>(0);
-  const { bulkUpdate, parentEntityId, uncompiledSrcDoc, widgetId } = useContext(
+  const { parentEntityId, uncompiledSrcDoc, update, widgetId } = useContext(
     CustomWidgetBuilderContext,
   );
 
@@ -63,19 +63,20 @@ export const ChatBot = (props: ContentProps) => {
         return;
       }
 
-      if (!bulkUpdate) return;
+      if (!update) return;
 
       if (isObject(event.data)) {
         lastUpdateFromBot.current = Date.now();
+        const { css_code, html_code, js_code } = event.data;
 
-        bulkUpdate({
-          html: event.data.html_code || "",
-          css: event.data.css_code || "",
-          js: event.data.js_code || "",
-        });
+        if (html_code && html_code !== "") update("html", html_code);
+
+        if (css_code && css_code !== "") update("css", css_code);
+
+        if (js_code && js_code !== "") update("js", js_code);
       }
     },
-    [bulkUpdate, handleSrcDocUpdates],
+    [handleSrcDocUpdates, update],
   );
 
   useEffect(


### PR DESCRIPTION
## Description

Checks each field from the chat bot and only update that field instead of a bulk update. This should avoid scenarios where a bad bulk update could while the current user code in custom widget


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14165509137>
> Commit: ec98ea0f3036f1950c978f5d475aed500167f60d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14165509137&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 31 Mar 2025 07:16:11 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the chatbot update process by switching from a bulk mechanism to individual, content-specific updates.
	- Ensured that each code segment (HTML, CSS, JS) is only updated when valid content is provided, enhancing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->