### PR TITLE
Adjust citation paddings

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Button/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Button/src/styles.module.css
@@ -248,23 +248,23 @@
   &[data-icon-position="start"][data-size="small"]:has([data-icon]):has(
       [data-text]
     ) {
-    padding-inline: var(--inner-spacing-1) var(--inner-spacing-2);
+    padding-inline: var(--inner-spacing-1) var(--inner-spacing-3);
   }
 
   &[data-icon-position="start"][data-size="small"]
     [data-content]:has([data-icon]):has([data-text]) {
-    padding-inline-start: calc(var(--icon-size-2) + var(--inner-spacing-1));
+    padding-inline-start: calc(var(--icon-size-1) + var(--inner-spacing-1));
   }
 
   &[data-icon-position="end"][data-size="small"]:has([data-icon]):has(
       [data-text]
     ) {
-    padding-inline: var(--inner-spacing-2) var(--inner-spacing-1);
+    padding-inline: var(--inner-spacing-3) var(--inner-spacing-1);
   }
 
   &[data-icon-position="end"][data-size="small"]
     [data-content]:has([data-icon]):has([data-text]) {
-    padding-inline-end: calc(var(--icon-size-2) + var(--inner-spacing-1));
+    padding-inline-end: calc(var(--icon-size-1) + var(--inner-spacing-1));
   }
 
   &[data-size="medium"] {


### PR DESCRIPTION
## Description

Fixes #39921

| Before | After |
|--------|--------|
| <img width="391" alt="Screenshot 2025-03-31 at 13 44 21" src="https://github.com/user-attachments/assets/a0d55fb9-8057-4cf0-a0a6-2402a4d64c78" /> | <img width="398" alt="Screenshot 2025-03-31 at 13 43 35" src="https://github.com/user-attachments/assets/4482a7d3-a22e-4fd4-8220-801adb2b4959" /> |

## Automation\

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
