### PR TITLE
chore: Updating google authentication config to support Multi Org flow on EE

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1492,15 +1492,15 @@ export const DISCONNECT_AUTH_ERROR = () =>
   "Cannot disconnect the only connected authentication method.";
 export const MANDATORY_FIELDS_ERROR = () => "Mandatory fields cannot be empty";
 export const FORM_LOGIN_DESC = () =>
-  "Enable your workspace to sign in with Appsmith Form.";
+  "Enable your organization to sign in with Appsmith Form.";
 export const GOOGLE_AUTH_DESC = () =>
-  "Enable your workspace to sign in with Google (OAuth 2.0) single sign-on (SSO).";
+  "Enable your organization to sign in with Google (OAuth 2.0) single sign-on (SSO).";
 export const GITHUB_AUTH_DESC = () =>
-  "Enable your workspace to sign in with GitHub (OAuth 2.0) single sign-on (SSO).";
+  "Enable your organization to sign in with GitHub (OAuth 2.0) single sign-on (SSO).";
 export const SAML_AUTH_DESC = () =>
-  "Enable your workspace to sign in with your preferred SAML2 compliant provider.";
+  "Enable your organization to sign in with your preferred SAML2 compliant provider.";
 export const OIDC_AUTH_DESC = () =>
-  "Enable your workspace to sign in with your preferred OIDC compliant provider.";
+  "Enable your organization to sign in with your preferred OIDC compliant provider.";
 export const SAVE_BUTTON = () => "Save";
 export const SAVE_AND_RESTART_BUTTON = () => "Save & Restart";
 export const SAVE_AND_REFRESH_BUTTON = () => "Save & Refresh";

--- a/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
@@ -37,9 +37,10 @@ import store from "store";
 const featureFlags = selectFeatureFlags(store.getState());
 
 import { getAppsmithConfigs } from "ee/configs";
+import type { Setting } from "./types";
 const { mailEnabled } = getAppsmithConfigs();
 
-const FormAuth: AdminConfigType = {
+export const FormAuth: AdminConfigType = {
   type: SettingCategories.FORM_AUTH,
   categoryType: CategoryType.GENERAL,
   controlType: SettingTypes.GROUP,
@@ -141,6 +142,62 @@ const FormAuth: AdminConfigType = {
   ],
 };
 
+export const SingleOrgGoogleAuthSettings: Setting[] = [
+  {
+    id: "APPSMITH_OAUTH2_GOOGLE_READ_MORE",
+    category: SettingCategories.GOOGLE_AUTH,
+    controlType: SettingTypes.CALLOUT,
+    label: "How to configure?",
+    url: GOOGLE_SIGNUP_SETUP_DOC,
+  },
+  {
+    id: "APPSMITH_OAUTH2_GOOGLE_JS_ORIGIN_URL",
+    category: SettingCategories.GOOGLE_AUTH,
+    controlType: SettingTypes.UNEDITABLEFIELD,
+    label: "JavaScript origin URL",
+    fieldName: "js-origin-url-form",
+    value: "",
+    tooltip:
+      "This URL will be used while configuring the Google OAuth Client ID's authorized JavaScript origins",
+    helpText: "Paste this URL in your Google developer console.",
+  },
+  {
+    id: "APPSMITH_OAUTH2_GOOGLE_REDIRECT_URL",
+    category: SettingCategories.GOOGLE_AUTH,
+    controlType: SettingTypes.UNEDITABLEFIELD,
+    label: "Redirect URL",
+    fieldName: "redirect-url-form",
+    value: "/login/oauth2/code/google",
+    tooltip:
+      "This URL will be used while configuring the Google OAuth Client ID's authorized redirect URIs",
+    helpText: "Paste this URL in your Google developer console.",
+  },
+  {
+    id: "APPSMITH_OAUTH2_GOOGLE_CLIENT_ID",
+    category: SettingCategories.GOOGLE_AUTH,
+    controlType: SettingTypes.TEXTINPUT,
+    controlSubType: SettingSubtype.TEXT,
+    label: "Client ID",
+    isRequired: true,
+  },
+  {
+    id: "APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET",
+    category: SettingCategories.GOOGLE_AUTH,
+    controlType: SettingTypes.TEXTINPUT,
+    controlSubType: SettingSubtype.TEXT,
+    label: "Client secret",
+    isRequired: true,
+  },
+  {
+    id: "APPSMITH_SIGNUP_ALLOWED_DOMAINS",
+    category: SettingCategories.GOOGLE_AUTH,
+    controlType: SettingTypes.TEXTINPUT,
+    controlSubType: SettingSubtype.TEXT,
+    label: "Allowed domains",
+    placeholder: "domain1.com, domain2.com",
+  },
+];
+
 export const GoogleAuth: AdminConfigType = {
   type: SettingCategories.GOOGLE_AUTH,
   categoryType: CategoryType.GENERAL,
@@ -148,61 +205,7 @@ export const GoogleAuth: AdminConfigType = {
   title: "Google authentication",
   subText: createMessage(GOOGLE_AUTH_DESC),
   canSave: true,
-  settings: [
-    {
-      id: "APPSMITH_OAUTH2_GOOGLE_READ_MORE",
-      category: SettingCategories.GOOGLE_AUTH,
-      controlType: SettingTypes.CALLOUT,
-      label: "How to configure?",
-      url: GOOGLE_SIGNUP_SETUP_DOC,
-    },
-    {
-      id: "APPSMITH_OAUTH2_GOOGLE_JS_ORIGIN_URL",
-      category: SettingCategories.GOOGLE_AUTH,
-      controlType: SettingTypes.UNEDITABLEFIELD,
-      label: "JavaScript origin URL",
-      fieldName: "js-origin-url-form",
-      value: "",
-      tooltip:
-        "This URL will be used while configuring the Google OAuth Client ID's authorized JavaScript origins",
-      helpText: "Paste this URL in your Google developer console.",
-    },
-    {
-      id: "APPSMITH_OAUTH2_GOOGLE_REDIRECT_URL",
-      category: SettingCategories.GOOGLE_AUTH,
-      controlType: SettingTypes.UNEDITABLEFIELD,
-      label: "Redirect URL",
-      fieldName: "redirect-url-form",
-      value: "/login/oauth2/code/google",
-      tooltip:
-        "This URL will be used while configuring the Google OAuth Client ID's authorized redirect URIs",
-      helpText: "Paste this URL in your Google developer console.",
-    },
-    {
-      id: "APPSMITH_OAUTH2_GOOGLE_CLIENT_ID",
-      category: SettingCategories.GOOGLE_AUTH,
-      controlType: SettingTypes.TEXTINPUT,
-      controlSubType: SettingSubtype.TEXT,
-      label: "Client ID",
-      isRequired: true,
-    },
-    {
-      id: "APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET",
-      category: SettingCategories.GOOGLE_AUTH,
-      controlType: SettingTypes.TEXTINPUT,
-      controlSubType: SettingSubtype.TEXT,
-      label: "Client secret",
-      isRequired: true,
-    },
-    {
-      id: "APPSMITH_SIGNUP_ALLOWED_DOMAINS",
-      category: SettingCategories.GOOGLE_AUTH,
-      controlType: SettingTypes.TEXTINPUT,
-      controlSubType: SettingSubtype.TEXT,
-      label: "Allowed domains",
-      placeholder: "domain1.com, domain2.com",
-    },
-  ],
+  settings: SingleOrgGoogleAuthSettings,
 };
 
 export const GithubAuth: AdminConfigType = {

--- a/app/client/src/hooks/useIsCloudBillingEnabled.ts
+++ b/app/client/src/hooks/useIsCloudBillingEnabled.ts
@@ -1,15 +1,13 @@
 import { useSelector } from "react-redux";
-
-import { getAppsmithConfigs } from "ee/configs";
 import { getIsCloudBillingFeatureFlagEnabled } from "selectors/cloudBillingSelectors";
 
 const useIsCloudBillingEnabled = () => {
-  const { cloudHosting } = getAppsmithConfigs();
   const isCloudBillingFeatureFlagEnabled = useSelector(
     getIsCloudBillingFeatureFlagEnabled,
   );
 
-  return isCloudBillingFeatureFlagEnabled && cloudHosting;
+  return isCloudBillingFeatureFlagEnabled;
 };
 
+// add cloudHosting check later: Ankita
 export { useIsCloudBillingEnabled };

--- a/app/client/src/pages/AdminSettings/SettingsForm.tsx
+++ b/app/client/src/pages/AdminSettings/SettingsForm.tsx
@@ -50,6 +50,7 @@ import {
 } from "ee/selectors/organizationSelectors";
 import { updateOrganizationConfig } from "ee/actions/organizationActions";
 import { organizationConfigConnection } from "ee/constants/organizationConstants";
+import { useIsCloudBillingEnabled } from "hooks";
 
 interface FormProps {
   settings: Record<string, string>;
@@ -91,6 +92,7 @@ export function SettingsForm(
   const socialLoginList = useSelector(getThirdPartyAuths);
   const [initialFormLoginEnabled, setInitialFormLoginEnabled] =
     useState(isFormLoginEnabled);
+  const isMultiOrgEnabled = useIsCloudBillingEnabled();
 
   const updatedOrganizationSettings = useMemo(
     () => Object.keys(props.settings).filter((s) => isOrganizationConfig(s)),
@@ -339,7 +341,7 @@ export function SettingsForm(
             valid={props.valid}
           />
         )}
-        {details?.isConnected && (
+        {details?.isConnected && !isMultiOrgEnabled && (
           <DisconnectService
             disconnect={() => disconnect(settingsDetails)}
             subHeader={createMessage(DISCONNECT_SERVICE_SUBHEADER)}


### PR DESCRIPTION
## Description

Updating google authentication config to support Multi Organization flow on EE for an instance.

Fixes #

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14170970472>
> Commit: 006c20438f26bbc2015dab51be610f42c4b9f0c3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14170970472&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Mon, 31 Mar 2025 12:22:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated authentication messaging to use “organization” instead of “workspace” for clearer communication.
  
- **New Features**
  - Streamlined Google authentication configuration in the admin settings for a more modular setup.
  - Adjusted the admin interface to conditionally display disconnect options based on the current billing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->