### PR TITLE
chore: Update selector to just form values 

### DIFF
--- a/app/client/src/components/formControls/FunctionCallingConfigControl/components/selectors.ts
+++ b/app/client/src/components/formControls/FunctionCallingConfigControl/components/selectors.ts
@@ -3,7 +3,7 @@ import {
   getJSCollections,
   getPlugins,
 } from "ee/selectors/entitiesSelector";
-import { createSelector, type ParametricSelector } from "reselect";
+import { createSelector } from "reselect";
 import { getCurrentPageId } from "selectors/editorSelectors";
 import type {
   FunctionCallingEntityType,
@@ -20,11 +20,7 @@ import { getFormValues } from "redux-form";
 import type { Action } from "entities/Action";
 
 export const selectEntityOptions = createSelector(
-  getFormValues(QUERY_EDITOR_FORM_NAME) as unknown as ParametricSelector<
-    object,
-    Action,
-    Action
-  >,
+  (state) => getFormValues(QUERY_EDITOR_FORM_NAME)(state) as Action,
   getActions,
   getJSCollections,
   getCurrentPageId,


### PR DESCRIPTION
## Description

Update form selector to accept redux form values instead of entities state

EE: https://github.com/appsmithorg/appsmith-ee/pull/6842


## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14171502400>
> Commit: 261563026477b420a965cb6a7e0fd038bbe21c5d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14171502400&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 31 Mar 2025 12:58:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved how form input values are processed for configuration, ensuring that available options are filtered and displayed more reliably. This update enhances the integration of form data into the selection process, resulting in a smoother user experience when managing function-related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->