### PR TITLE
chore: add feature flag to the git reset optimisation

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
@@ -246,14 +246,15 @@ public class FileUtilsCEImpl implements FileInterface {
     }
 
     @Override
-    public Mono<Path> saveArtifactToGitRepo(Path baseRepoSuffix, GitResourceMap gitResourceMap, String branchName)
+    public Mono<Path> saveArtifactToGitRepo(
+            Path baseRepoSuffix, GitResourceMap gitResourceMap, String branchName, boolean keepWorkingDirChanges)
             throws GitAPIException, IOException {
 
         // Repo path will be:
         // baseRepo : root/workspaceId/defaultAppId/repoName/{applicationData}
         // Checkout to mentioned branch if not already checked-out
         return fsGitHandler
-                .resetToLastCommit(baseRepoSuffix, branchName)
+                .resetToLastCommit(baseRepoSuffix, branchName, keepWorkingDirChanges)
                 .flatMap(isSwitched -> {
                     Path baseRepo = Paths.get(gitServiceConfig.getGitRootPath()).resolve(baseRepoSuffix);
 

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -1149,7 +1149,7 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                         return resetToLastCommit(repoSuffix, destinationBranch, keepWorkingDirChanges)
                                                 .thenReturn(error.getMessage());
                                     } catch (Exception e) {
-                                        log.error("Error while hard resetting to latest commit {0}", e);
+                                        log.error("Error while hard resetting to latest commit", e);
                                         return Mono.error(e);
                                     }
                                 })
@@ -1348,7 +1348,7 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                                     return status;
                                                 });
                                     } catch (Exception e) {
-                                        log.error("Error for hard resetting to latest commit {0}", e);
+                                        log.error("Error for hard resetting to latest commit", e);
                                         return Mono.error(e);
                                     }
                                 })
@@ -1366,7 +1366,7 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                         return resetToLastCommit(repoSuffix, destinationBranch, keepWorkingDirChanges)
                                                 .thenReturn(mergeStatusDTO);
                                     } catch (Exception e) {
-                                        log.error("Error while hard resetting to latest commit {0}", e);
+                                        log.error("Error while hard resetting to latest commit", e);
                                         return Mono.error(e);
                                     }
                                 })

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -571,7 +571,12 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
 
     @Override
     public Mono<MergeStatusDTO> pullArtifactWithoutCheckout(
-            Path repoSuffix, String remoteUrl, String branchName, String privateKey, String publicKey)
+            Path repoSuffix,
+            String remoteUrl,
+            String branchName,
+            String privateKey,
+            String publicKey,
+            boolean keepWorkingDirChanges)
             throws IOException {
 
         TransportConfigCallback transportConfigCallback = new SshTransportConfigCallback(privateKey, publicKey);
@@ -629,7 +634,13 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                         }
                                     }
                                 })
-                                .onErrorResume(error -> Mono.error(error))
+                                .onErrorResume(error -> {
+                                    if (keepWorkingDirChanges) {
+                                        return Mono.error(error);
+                                    }
+
+                                    return resetToLastCommit(git).flatMap(ignore -> Mono.error(error));
+                                })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
                                 .name(GitSpan.FS_PULL)
                                 .tap(Micrometer.observation(observationRegistry)),
@@ -848,7 +859,7 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
      * @return Map of file names those are modified, conflicted etc.
      */
     @Override
-    public Mono<GitStatusDTO> getStatus(Path repoPath, String branchName) {
+    public Mono<GitStatusDTO> getStatus(Path repoPath, String branchName, boolean keepWorkingDirChanges) {
         Stopwatch processStopwatch =
                 StopwatchHelpers.startStopwatch(repoPath, AnalyticsEvents.GIT_STATUS.getEventName());
         return Mono.using(
@@ -900,6 +911,16 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                         response.setAheadCount(0);
                                         response.setBehindCount(0);
                                         response.setRemoteBranch("untracked");
+                                    }
+
+                                    // Remove modified changes from current branch so that checkout to other branches
+                                    // will be clean
+                                    if (!status.isClean() && !keepWorkingDirChanges) {
+                                        return resetToLastCommit(git).map(ref -> {
+                                            processStopwatch.stopAndLogTimeInMillis();
+                                            jgitStatusSpan.end();
+                                            return response;
+                                        });
                                     }
 
                                     processStopwatch.stopAndLogTimeInMillis();
@@ -1087,7 +1108,8 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
     }
 
     @Override
-    public Mono<String> mergeBranch(Path repoSuffix, String sourceBranch, String destinationBranch) {
+    public Mono<String> mergeBranch(
+            Path repoSuffix, String sourceBranch, String destinationBranch, boolean keepWorkingDirChanges) {
         return Mono.using(
                         () -> Git.open(createRepoPath(repoSuffix).toFile()),
                         git -> Mono.fromCallable(() -> {
@@ -1119,7 +1141,17 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                     }
                                 })
                                 .onErrorResume(error -> {
-                                    return Mono.error(error);
+                                    if (keepWorkingDirChanges) {
+                                        return Mono.error(error);
+                                    }
+
+                                    try {
+                                        return resetToLastCommit(repoSuffix, destinationBranch, keepWorkingDirChanges)
+                                                .thenReturn(error.getMessage());
+                                    } catch (Exception e) {
+                                        log.error("Error while hard resetting to latest commit {0}", e);
+                                        return Mono.error(e);
+                                    }
                                 })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
                                 .name(GitSpan.FS_MERGE)
@@ -1252,7 +1284,8 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
     }
 
     @Override
-    public Mono<MergeStatusDTO> isMergeBranch(Path repoSuffix, String sourceBranch, String destinationBranch) {
+    public Mono<MergeStatusDTO> isMergeBranch(
+            Path repoSuffix, String sourceBranch, String destinationBranch, boolean keepWorkingDirChanges) {
         Stopwatch processStopwatch =
                 StopwatchHelpers.startStopwatch(repoSuffix, AnalyticsEvents.GIT_MERGE_CHECK.getEventName());
         return Mono.using(
@@ -1302,13 +1335,40 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                             mergeResult.getMergeStatus().name());
                                     return mergeStatus;
                                 })
+                                .flatMap(status -> {
+                                    if (keepWorkingDirChanges) {
+                                        return Mono.just(status);
+                                    }
+
+                                    try {
+                                        // Revert uncommitted changes if any
+                                        return resetToLastCommit(repoSuffix, destinationBranch, keepWorkingDirChanges)
+                                                .map(ignore -> {
+                                                    processStopwatch.stopAndLogTimeInMillis();
+                                                    return status;
+                                                });
+                                    } catch (Exception e) {
+                                        log.error("Error for hard resetting to latest commit {0}", e);
+                                        return Mono.error(e);
+                                    }
+                                })
                                 .onErrorResume(error -> {
                                     MergeStatusDTO mergeStatusDTO = new MergeStatusDTO();
                                     mergeStatusDTO.setMergeAble(false);
                                     mergeStatusDTO.setMessage(error.getMessage());
                                     mergeStatusDTO.setReferenceDoc(ErrorReferenceDocUrl.GIT_MERGE_CONFLICT.getDocUrl());
 
-                                    return Mono.just(mergeStatusDTO);
+                                    if (keepWorkingDirChanges) {
+                                        return Mono.just(mergeStatusDTO);
+                                    }
+
+                                    try {
+                                        return resetToLastCommit(repoSuffix, destinationBranch, keepWorkingDirChanges)
+                                                .thenReturn(mergeStatusDTO);
+                                    } catch (Exception e) {
+                                        log.error("Error while hard resetting to latest commit {0}", e);
+                                        return Mono.error(e);
+                                    }
                                 })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS)),
                         Git::close)
@@ -1414,11 +1474,17 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                 .subscribeOn(scheduler);
     }
 
-    public Mono<Boolean> resetToLastCommit(Path repoSuffix, String branchName) {
+    public Mono<Boolean> resetToLastCommit(Path repoSuffix, String branchName, boolean keepWorkingDirChanges) {
         return Mono.using(
                 () -> Git.open(createRepoPath(repoSuffix).toFile()),
                 git -> this.resetToLastCommit(git)
-                        .flatMap(ref -> checkoutToBranch(repoSuffix, branchName).thenReturn(true)),
+                        .flatMap(ref -> checkoutToBranch(repoSuffix, branchName).flatMap(aBoolean -> {
+                            if (keepWorkingDirChanges) {
+                                return Mono.just(true);
+                            }
+
+                            return resetToLastCommit(git).thenReturn(true);
+                        })),
                 Git::close);
     }
 
@@ -1447,40 +1513,41 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                 .subscribeOn(scheduler);
     }
 
-    public Mono<Boolean> rebaseBranch(Path repoSuffix, String branchName) {
-        return this.resetToLastCommit(repoSuffix, branchName).flatMap(isCheckedOut -> Mono.using(
-                        () -> Git.open(createRepoPath(repoSuffix).toFile()),
-                        git -> Mono.fromCallable(() -> {
-                                    Span jgitRebaseSpan = observationHelper.createSpan(GitSpan.JGIT_REBASE);
-                                    RebaseResult result = git.rebase()
-                                            .setUpstream("origin/" + branchName)
-                                            .call();
-                                    if (result.getStatus().isSuccessful()) {
-                                        jgitRebaseSpan.end();
-                                        return true;
-                                    } else {
-                                        log.error(
-                                                "Error while rebasing the branch, {}, {}",
-                                                result.getStatus().name(),
-                                                result.getConflicts());
-                                        git.rebase()
-                                                .setUpstream("origin/" + branchName)
-                                                .setOperation(RebaseCommand.Operation.ABORT)
-                                                .call();
-                                        jgitRebaseSpan.end();
-                                        throw new Exception("Error while rebasing the branch, "
-                                                + result.getStatus().name());
-                                    }
-                                })
-                                .onErrorMap(e -> {
-                                    log.error("Error while rebasing the branch, {}", e.getMessage());
-                                    return e;
-                                })
-                                .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
-                                .name(GitSpan.FS_REBASE)
-                                .tap(Micrometer.observation(observationRegistry)),
-                        Git::close)
-                .subscribeOn(scheduler));
+    public Mono<Boolean> rebaseBranch(Path repoSuffix, String branchName, boolean keepWorkingDirChanges) {
+        return this.resetToLastCommit(repoSuffix, branchName, keepWorkingDirChanges)
+                .flatMap(isCheckedOut -> Mono.using(
+                                () -> Git.open(createRepoPath(repoSuffix).toFile()),
+                                git -> Mono.fromCallable(() -> {
+                                            Span jgitRebaseSpan = observationHelper.createSpan(GitSpan.JGIT_REBASE);
+                                            RebaseResult result = git.rebase()
+                                                    .setUpstream("origin/" + branchName)
+                                                    .call();
+                                            if (result.getStatus().isSuccessful()) {
+                                                jgitRebaseSpan.end();
+                                                return true;
+                                            } else {
+                                                log.error(
+                                                        "Error while rebasing the branch, {}, {}",
+                                                        result.getStatus().name(),
+                                                        result.getConflicts());
+                                                git.rebase()
+                                                        .setUpstream("origin/" + branchName)
+                                                        .setOperation(RebaseCommand.Operation.ABORT)
+                                                        .call();
+                                                jgitRebaseSpan.end();
+                                                throw new Exception("Error while rebasing the branch, "
+                                                        + result.getStatus().name());
+                                            }
+                                        })
+                                        .onErrorMap(e -> {
+                                            log.error("Error while rebasing the branch, {}", e.getMessage());
+                                            return e;
+                                        })
+                                        .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
+                                        .name(GitSpan.FS_REBASE)
+                                        .tap(Micrometer.observation(observationRegistry)),
+                                Git::close)
+                        .subscribeOn(scheduler));
     }
 
     @Override

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
@@ -16,6 +16,10 @@ public enum FeatureFlagEnum {
     rollout_datasource_test_rate_limit_enabled,
     release_google_sheets_shared_drive_support_enabled,
     release_gs_all_sheets_options_enabled,
+    /**
+     * Feature flag to detect if the git reset optimization is enabled
+     */
+    release_git_reset_optimization_enabled,
 
     // Deprecated CE flags over here
     release_git_autocommit_feature_enabled,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/FileInterface.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/FileInterface.java
@@ -35,7 +35,8 @@ public interface FileInterface {
             Path baseRepoSuffix, ArtifactGitReference artifactGitReference, String branchName)
             throws IOException, GitAPIException;
 
-    Mono<Path> saveArtifactToGitRepo(Path baseRepoSuffix, GitResourceMap gitResourceMap, String branchName)
+    Mono<Path> saveArtifactToGitRepo(
+            Path baseRepoSuffix, GitResourceMap gitResourceMap, String branchName, boolean keepWorkingDirChanges)
             throws GitAPIException, IOException;
 
     /**

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/handler/FSGitHandler.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/handler/FSGitHandler.java
@@ -117,7 +117,12 @@ public interface FSGitHandler {
      * @return success message
      */
     Mono<MergeStatusDTO> pullArtifactWithoutCheckout(
-            Path repoSuffix, String remoteUrl, String branchName, String privateKey, String publicKey)
+            Path repoSuffix,
+            String remoteUrl,
+            String branchName,
+            String privateKey,
+            String publicKey,
+            boolean keepWorkingDirChanges)
             throws IOException;
 
     /**
@@ -153,7 +158,7 @@ public interface FSGitHandler {
      * @param branchName branch name for which the status is required
      * @return Map of file names those are added, removed, modified
      */
-    Mono<GitStatusDTO> getStatus(Path repoPath, String branchName);
+    Mono<GitStatusDTO> getStatus(Path repoPath, String branchName, boolean keepWorkingDirChanges);
 
     /**
      * This method merges source branch into destination branch for a git repository which is present on the partial
@@ -163,7 +168,8 @@ public interface FSGitHandler {
      * @param destinationBranch Merge operation is performed on this branch
      * @return Merge status
      */
-    Mono<String> mergeBranch(Path repoSuffix, String sourceBranch, String destinationBranch);
+    Mono<String> mergeBranch(
+            Path repoSuffix, String sourceBranch, String destinationBranch, boolean keepWorkingDirChanges);
 
     /**
      * @param repoSuffix suffixedPath used to generate the base repo path this includes workspaceId, defaultAppId, repoName
@@ -190,7 +196,8 @@ public interface FSGitHandler {
      * @param destinationBranch Merge operation is performed on this branch
      * @return Whether the two branches can be merged or not with list of files where the conflicts are present
      */
-    Mono<MergeStatusDTO> isMergeBranch(Path repoSuffix, String sourceBranch, String destinationBranch);
+    Mono<MergeStatusDTO> isMergeBranch(
+            Path repoSuffix, String sourceBranch, String destinationBranch, boolean keepWorkingDirChanges);
 
     /**
      * This method will reset the repo to last commit for the specific branch
@@ -201,7 +208,8 @@ public interface FSGitHandler {
      * @throws GitAPIException
      * @throws IOException
      */
-    Mono<Boolean> resetToLastCommit(Path repoSuffix, String branchName) throws GitAPIException, IOException;
+    Mono<Boolean> resetToLastCommit(Path repoSuffix, String branchName, boolean keepWorkingDirChanges)
+            throws GitAPIException, IOException;
 
     /**
      *
@@ -230,7 +238,7 @@ public interface FSGitHandler {
 
     Mono<Boolean> resetHard(Path repoSuffix, String branchName);
 
-    Mono<Boolean> rebaseBranch(Path repoSuffix, String branchName);
+    Mono<Boolean> rebaseBranch(Path repoSuffix, String branchName, boolean keepWorkingDirChanges);
 
     Path createRepoPath(Path suffix);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCECompatibleImpl.java
@@ -16,6 +16,7 @@ import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.repositories.GitDeployKeysRepository;
 import com.appsmith.server.services.AnalyticsService;
+import com.appsmith.server.services.FeatureFlagService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.services.UserService;
@@ -52,7 +53,8 @@ public class GitFSServiceCECompatibleImpl extends GitFSServiceCEImpl implements 
             GitAutoCommitHelper gitAutoCommitHelper,
             GitProfileUtils gitProfileUtils,
             GitAnalyticsUtils gitAnalyticsUtils,
-            GitArtifactHelperResolver gitArtifactHelperResolver) {
+            GitArtifactHelperResolver gitArtifactHelperResolver,
+            FeatureFlagService featureFlagService) {
         super(
                 gitDeployKeysRepository,
                 gitPrivateRepoHelper,
@@ -75,6 +77,7 @@ public class GitFSServiceCECompatibleImpl extends GitFSServiceCEImpl implements 
                 gitAutoCommitHelper,
                 gitProfileUtils,
                 gitAnalyticsUtils,
-                gitArtifactHelperResolver);
+                gitArtifactHelperResolver,
+                featureFlagService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.external.constants.AnalyticsEvents;
 import com.appsmith.external.dtos.GitRefDTO;
 import com.appsmith.external.dtos.GitStatusDTO;
 import com.appsmith.external.dtos.MergeStatusDTO;
+import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.external.git.constants.GitConstants.GitCommandConstants;
 import com.appsmith.external.git.constants.GitSpan;
 import com.appsmith.external.git.constants.ce.RefType;
@@ -38,6 +39,7 @@ import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.repositories.GitDeployKeysRepository;
 import com.appsmith.server.services.AnalyticsService;
+import com.appsmith.server.services.FeatureFlagService;
 import com.appsmith.server.services.GitArtifactHelper;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
@@ -104,6 +106,7 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
     private final GitAnalyticsUtils gitAnalyticsUtils;
 
     protected final GitArtifactHelperResolver gitArtifactHelperResolver;
+    private final FeatureFlagService featureFlagService;
 
     private static final String ORIGIN = "origin/";
     private static final String REMOTE_NAME_REPLACEMENT = "";
@@ -682,9 +685,12 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
         ArtifactType artifactType = jsonTransformationDTO.getArtifactType();
         GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
         Path repoSuffix = gitArtifactHelper.getRepoSuffixPath(workspaceId, baseArtifactId, repoName);
+        Mono<Boolean> keepWorkingDirChangesMono =
+                featureFlagService.check(FeatureFlagEnum.release_git_reset_optimization_enabled);
 
         // At this point the assumption is that the repository has already checked out the destination branch
-        return fsGitHandler.mergeBranch(repoSuffix, gitMergeDTO.getSourceBranch(), gitMergeDTO.getDestinationBranch());
+        return keepWorkingDirChangesMono.flatMap(keepWorkingDirChanges -> fsGitHandler.mergeBranch(
+                repoSuffix, gitMergeDTO.getSourceBranch(), gitMergeDTO.getDestinationBranch(), keepWorkingDirChanges));
     }
 
     @Override
@@ -693,14 +699,16 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
         String workspaceId = jsonTransformationDTO.getWorkspaceId();
         String baseArtifactId = jsonTransformationDTO.getBaseArtifactId();
         String repoName = jsonTransformationDTO.getRepoName();
+        Mono<Boolean> keepWorkingDirChangesMono =
+                featureFlagService.check(FeatureFlagEnum.release_git_reset_optimization_enabled);
 
         ArtifactType artifactType = jsonTransformationDTO.getArtifactType();
         GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
         Path repoSuffix = gitArtifactHelper.getRepoSuffixPath(workspaceId, baseArtifactId, repoName);
 
         // At this point the assumption is that the repository has already checked out the destination branch
-        return fsGitHandler.isMergeBranch(
-                repoSuffix, gitMergeDTO.getSourceBranch(), gitMergeDTO.getDestinationBranch());
+        return keepWorkingDirChangesMono.flatMap(keepWorkingDirChanges -> fsGitHandler.isMergeBranch(
+                repoSuffix, gitMergeDTO.getSourceBranch(), gitMergeDTO.getDestinationBranch(), keepWorkingDirChanges));
     }
 
     @Override
@@ -715,10 +723,14 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
         ArtifactType artifactType = jsonTransformationDTO.getArtifactType();
         GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
         Path repoSuffix = gitArtifactHelper.getRepoSuffixPath(workspaceId, baseArtifactId, repoName);
+        Mono<Boolean> keepWorkingDirChangesMono =
+                featureFlagService.check(FeatureFlagEnum.release_git_reset_optimization_enabled);
 
-        return fsGitHandler.rebaseBranch(repoSuffix, refName).flatMap(rebaseStatus -> {
-            return commonGitFileUtils.constructArtifactExchangeJsonFromGitRepository(jsonTransformationDTO);
-        });
+        return keepWorkingDirChangesMono
+                .flatMap(keepWorkingDirChanges -> fsGitHandler.rebaseBranch(repoSuffix, refName, keepWorkingDirChanges))
+                .flatMap(rebaseStatus -> {
+                    return commonGitFileUtils.constructArtifactExchangeJsonFromGitRepository(jsonTransformationDTO);
+                });
     }
 
     @Override
@@ -727,13 +739,16 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
         String baseArtifactId = jsonTransformationDTO.getBaseArtifactId();
         String repoName = jsonTransformationDTO.getRepoName();
         String refName = jsonTransformationDTO.getRefName();
+        Mono<Boolean> keepWorkingDirChangesMono =
+                featureFlagService.check(FeatureFlagEnum.release_git_reset_optimization_enabled);
 
         ArtifactType artifactType = jsonTransformationDTO.getArtifactType();
         GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
         Path repoSuffix = gitArtifactHelper.getRepoSuffixPath(workspaceId, baseArtifactId, repoName);
 
         Path repoPath = fsGitHandler.createRepoPath(repoSuffix);
-        return fsGitHandler.getStatus(repoPath, refName);
+        return keepWorkingDirChangesMono.flatMap(
+                keepWorkingDirChanges -> fsGitHandler.getStatus(repoPath, refName, keepWorkingDirChanges));
     }
 
     @Override
@@ -833,32 +848,37 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                 jsonTransformationDTO.getRepoName());
 
         String branchName = jsonTransformationDTO.getRefName();
+        Mono<Boolean> keepWorkingDirChangesMono =
+                featureFlagService.check(FeatureFlagEnum.release_git_reset_optimization_enabled);
 
         // pull remote branchName
-        try {
-            return fsGitHandler
-                    .pullArtifactWithoutCheckout(
-                            repoSuffix,
-                            baseMetadata.getRemoteUrl(),
-                            branchName,
-                            baseMetadata.getGitAuth().getPrivateKey(),
-                            baseMetadata.getGitAuth().getPublicKey())
-                    .onErrorResume(error -> {
-                        if (error.getMessage().contains("conflict")) {
-                            return Mono.error(
-                                    new AppsmithException(AppsmithError.GIT_PULL_CONFLICTS, error.getMessage()));
-                        } else if (error.getMessage().contains("Nothing to fetch")) {
-                            MergeStatusDTO mergeStatus = new MergeStatusDTO();
-                            mergeStatus.setStatus("Nothing to fetch from remote. All changes are up to date.");
-                            mergeStatus.setMergeAble(true);
-                            return Mono.just(mergeStatus);
-                        }
+        return keepWorkingDirChangesMono.flatMap(keepWorkingDirChanges -> {
+            try {
+                return fsGitHandler
+                        .pullArtifactWithoutCheckout(
+                                repoSuffix,
+                                baseMetadata.getRemoteUrl(),
+                                branchName,
+                                baseMetadata.getGitAuth().getPrivateKey(),
+                                baseMetadata.getGitAuth().getPublicKey(),
+                                keepWorkingDirChanges)
+                        .onErrorResume(error -> {
+                            if (error.getMessage().contains("conflict")) {
+                                return Mono.error(
+                                        new AppsmithException(AppsmithError.GIT_PULL_CONFLICTS, error.getMessage()));
+                            } else if (error.getMessage().contains("Nothing to fetch")) {
+                                MergeStatusDTO mergeStatus = new MergeStatusDTO();
+                                mergeStatus.setStatus("Nothing to fetch from remote. All changes are up to date.");
+                                mergeStatus.setMergeAble(true);
+                                return Mono.just(mergeStatus);
+                            }
 
-                        return Mono.error(new AppsmithException(
-                                AppsmithError.GIT_ACTION_FAILED, GitCommandConstants.PULL, error.getMessage()));
-                    });
-        } catch (IOException e) {
-            return Mono.error(new AppsmithException(AppsmithError.GIT_FILE_SYSTEM_ERROR, e.getMessage()));
-        }
+                            return Mono.error(new AppsmithException(
+                                    AppsmithError.GIT_ACTION_FAILED, GitCommandConstants.PULL, error.getMessage()));
+                        });
+            } catch (IOException e) {
+                return Mono.error(new AppsmithException(AppsmithError.GIT_FILE_SYSTEM_ERROR, e.getMessage()));
+            }
+        });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceImpl.java
@@ -16,6 +16,7 @@ import com.appsmith.server.imports.internal.ImportService;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.repositories.GitDeployKeysRepository;
 import com.appsmith.server.services.AnalyticsService;
+import com.appsmith.server.services.FeatureFlagService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.services.UserService;
@@ -52,7 +53,8 @@ public class GitFSServiceImpl extends GitFSServiceCECompatibleImpl implements Gi
             GitAutoCommitHelper gitAutoCommitHelper,
             GitProfileUtils gitProfileUtils,
             GitAnalyticsUtils gitAnalyticsUtils,
-            GitArtifactHelperResolver gitArtifactHelperResolver) {
+            GitArtifactHelperResolver gitArtifactHelperResolver,
+            FeatureFlagService featureFlagService) {
         super(
                 gitDeployKeysRepository,
                 gitPrivateRepoHelper,
@@ -75,6 +77,7 @@ public class GitFSServiceImpl extends GitFSServiceCECompatibleImpl implements Gi
                 gitAutoCommitHelper,
                 gitProfileUtils,
                 gitAnalyticsUtils,
-                gitArtifactHelperResolver);
+                gitArtifactHelperResolver,
+                featureFlagService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CommonGitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CommonGitFileUtils.java
@@ -10,6 +10,7 @@ import com.appsmith.server.helpers.ce.CommonGitFileUtilsCE;
 import com.appsmith.server.migrations.JsonSchemaVersions;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.services.AnalyticsService;
+import com.appsmith.server.services.FeatureFlagService;
 import com.appsmith.server.services.SessionUserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +32,8 @@ public class CommonGitFileUtils extends CommonGitFileUtilsCE {
             NewActionService newActionService,
             ActionCollectionService actionCollectionService,
             JsonSchemaVersions jsonSchemaVersions,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            FeatureFlagService featureFlagService) {
         super(
                 applicationGitFileUtils,
                 gitServiceConfig,
@@ -42,6 +44,7 @@ public class CommonGitFileUtils extends CommonGitFileUtilsCE {
                 newActionService,
                 actionCollectionService,
                 jsonSchemaVersions,
-                objectMapper);
+                objectMapper,
+                featureFlagService);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/ops/GitDiscardTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/ops/GitDiscardTests.java
@@ -202,7 +202,9 @@ public class GitDiscardTests {
         Mockito.doReturn(Mono.just(artifactExchangeJson))
                 .when(gitHandlingService)
                 .recreateArtifactJsonFromLastCommit(Mockito.any());
-        Mockito.doReturn(Mono.just(true)).when(fsGitHandler).rebaseBranch(any(Path.class), Mockito.anyString());
+        Mockito.doReturn(Mono.just(true))
+                .when(fsGitHandler)
+                .rebaseBranch(any(Path.class), Mockito.anyString(), Mockito.anyBoolean());
 
         Mono<Application> applicationMono = centralGitService
                 .discardChanges(application.getId(), ArtifactType.APPLICATION, GitType.FILE_SYSTEM)
@@ -255,7 +257,9 @@ public class GitDiscardTests {
                         Mockito.anyString(),
                         Mockito.anyString(),
                         Mockito.anyString());
-        Mockito.doReturn(Mono.just(gitStatusDTO)).when(fsGitHandler).getStatus(any(Path.class), Mockito.anyString());
+        Mockito.doReturn(Mono.just(gitStatusDTO))
+                .when(fsGitHandler)
+                .getStatus(any(Path.class), Mockito.anyString(), Mockito.anyBoolean());
         Mockito.doReturn(Mono.just("fetched"))
                 .when(fsGitHandler)
                 .fetchRemote(

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/resourcemap/ExchangeJsonConversionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/resourcemap/ExchangeJsonConversionTests.java
@@ -127,7 +127,9 @@ public class ExchangeJsonConversionTests {
             ExchangeJsonContext context) throws IOException, GitAPIException {
         ArtifactExchangeJson originalArtifactJson = createArtifactJson(context).block();
 
-        Mockito.doReturn(Mono.just(true)).when(fsGitHandler).resetToLastCommit(Mockito.any(), Mockito.anyString());
+        Mockito.doReturn(Mono.just(true))
+                .when(fsGitHandler)
+                .resetToLastCommit(Mockito.any(), Mockito.anyString(), Mockito.anyBoolean());
 
         Files.createDirectories(Path.of("./container-volumes/git-storage/test123"));
 


### PR DESCRIPTION
## Description
Toggle the [remove extra git resets changes](https://github.com/appsmithorg/appsmith/pull/39758) in the new git apis behind a feature flag `release_git_reset_optimization_enabled`.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14188261678>
> Commit: 5f3ce61533459f6cc47d01af718eb888e1316a9e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14188261678&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Tue, 01 Apr 2025 06:48:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a feature flag for enhanced Git reset optimization, enabling optional preservation of local changes during Git operations.

- **Refactor**
  - Updated Git workflows to offer more flexible handling of uncommitted changes and improved error management.

- **Tests**
  - Adjusted test scenarios to validate the refined Git behavior and ensure consistent operation under the new settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->