### PR TITLE
chore: FS layer has additional reset responsibility before reconstruction 

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -1414,6 +1414,18 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                 .subscribeOn(scheduler);
     }
 
+    /**
+     * reset to last commit on the current branch itself but doesn't checkout to any specific branch
+     * @param repoSuffix suffixedPath used to generate the base repo path this includes workspaceId, defaultAppId, repoName
+     * @return a boolean whether the operation was successfull or not
+     */
+    public Mono<Boolean> resetToLastCommit(Path repoSuffix) {
+        return Mono.using(
+                () -> Git.open(createRepoPath(repoSuffix).toFile()),
+                git -> this.resetToLastCommit(git).thenReturn(true).onErrorReturn(false),
+                Git::close);
+    }
+
     public Mono<Boolean> resetToLastCommit(Path repoSuffix, String branchName) {
         return Mono.using(
                 () -> Git.open(createRepoPath(repoSuffix).toFile()),

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/handler/FSGitHandler.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/handler/FSGitHandler.java
@@ -204,6 +204,13 @@ public interface FSGitHandler {
     Mono<Boolean> resetToLastCommit(Path repoSuffix, String branchName) throws GitAPIException, IOException;
 
     /**
+     * This method will reset the repo to last commit for the current branch on which it's present
+     * @param repoSuffix suffixedPath used to generate the base repo path this includes workspaceId, defaultAppId, repoName
+     * @return success status
+     */
+    Mono<Boolean> resetToLastCommit(Path repoSuffix);
+
+    /**
      *
      * @param repoSuffix suffixedPath used to generate the base repo path this includes workspaceId, defaultAppId, repoName
      * @param branchName Name of the remote branch

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -869,7 +869,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                                                 new AppsmithException(
                                                         AppsmithError.GIT_ACTION_FAILED,
                                                         "ref creation",
-                                                        "either ref name is already exists or it doesn't meet naming criteria, or the artifact is not in a publishable state"));
+                                                        "either ref name already exists or it doesn't meet naming criteria, or the artifact is not in a publishable state"));
                                     }
 
                                     Mono<? extends Artifact> newArtifactFromSourceMono = generateArtifactForRefCreation(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -275,8 +275,18 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
     @Override
     public Mono<? extends ArtifactExchangeJson> reconstructArtifactJsonFromGitRepository(
             ArtifactJsonTransformationDTO artifactJsonTransformationDTO) {
-        return commonGitFileUtils.constructArtifactExchangeJsonFromGitRepositoryWithAnalytics(
-                artifactJsonTransformationDTO);
+        GitArtifactHelper<?> gitArtifactHelper =
+                gitArtifactHelperResolver.getArtifactHelper(artifactJsonTransformationDTO.getArtifactType());
+
+        Path repoSuffix = gitArtifactHelper.getRepoSuffixPath(
+                artifactJsonTransformationDTO.getWorkspaceId(),
+                artifactJsonTransformationDTO.getBaseArtifactId(),
+                artifactJsonTransformationDTO.getRepoName());
+
+        return fsGitHandler
+                .resetToLastCommit(repoSuffix)
+                .then(commonGitFileUtils.constructArtifactExchangeJsonFromGitRepositoryWithAnalytics(
+                        artifactJsonTransformationDTO));
     }
 
     @Override


### PR DESCRIPTION
## Description
### This helps in resetting the file system to last commit in the following flows
- Import
- Checkout ref (Branch/tag)
- pull
- merge
- discard

Fixes https://github.com/appsmithorg/appsmith/issues/39934  


## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14176842029>
> Commit: a8202cb9d34b24ff33b3bd5d55fb090123102760
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14176842029&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Mon, 31 Mar 2025 17:39:11 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a repository reset option allowing users to revert to the latest commit on the current branch without needing to specify extra details.
  - Enhanced the artifact restoration process by applying this reset step to ensure a consistent repository state before rebuilding data.
- **Bug Fixes**
  - Updated error notifications during reference creation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->