### PR TITLE
chore: Add code-split for hydrating the latest tag during git import

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -322,10 +322,12 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                 },
                 baseArtifact -> {
                     // on success send analytics
-                    return gitAnalyticsUtils.addAnalyticsForGitOperation(
-                            AnalyticsEvents.GIT_IMPORT,
-                            baseArtifact,
-                            baseArtifact.getGitArtifactMetadata().getIsRepoPrivate());
+
+                    return Mono.defer(() -> hydrateLatest(baseArtifact))
+                            .then(gitAnalyticsUtils.addAnalyticsForGitOperation(
+                                    AnalyticsEvents.GIT_IMPORT,
+                                    baseArtifact,
+                                    baseArtifact.getGitArtifactMetadata().getIsRepoPrivate()));
                 },
                 (baseArtifact, throwableError) -> {
                     // on error
@@ -338,6 +340,10 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
 
         return Mono.create(
                 sink -> importGitArtifactMono.subscribe(sink::success, sink::error, null, sink.currentContext()));
+    }
+
+    protected Mono<Artifact> hydrateLatest(Artifact artifact) {
+        return Mono.just(artifact);
     }
 
     @Override
@@ -919,7 +925,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                                 newImportedArtifact,
                                 newImportedArtifact.getGitArtifactMetadata().getIsRepoPrivate())))
                 .onErrorResume(error -> {
-                    log.error("An error occurred while creating reference. error {}", error.getMessage());
+                    log.error("An error occurred while creating reference. error {}", error.getMessage(), error);
                     return gitRedisUtils
                             .releaseFileLock(artifactType, baseArtifactId, TRUE)
                             .then(Mono.error(new AppsmithException(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportServiceCEImpl.java
@@ -541,7 +541,11 @@ public class ImportServiceCEImpl implements ImportServiceCE {
 
             return importMono
                     .flatMap(importableArtifact -> {
-                        return postImportHook(importableArtifact)
+                        return Mono.defer(
+                                        () -> postImportHook(importableArtifact).onErrorResume(error -> {
+                                            log.error("Post import hook failed: {}", error.getMessage(), error);
+                                            return Mono.empty();
+                                        }))
                                 .then(sendImportedContextAnalyticsEvent(
                                         artifactBasedImportService, importableArtifact, AnalyticsEvents.IMPORT));
                     })


### PR DESCRIPTION
## Description
EE Counterpart: https://github.com/appsmithorg/appsmith-ee/pull/6808

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14178760090>
> Commit: 31d0486f6946445fca36365c1f58f913afc8dea9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14178760090&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Mon, 31 Mar 2025 19:25:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during the post-import process to ensure a smoother and uninterrupted workflow.
  
- **Refactor**
	- Optimized the sequence of operations to incorporate the most up-to-date information before analytics logging, enhancing overall data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->