### PR TITLE
chore: redirect ai agent user to app with carbon modal open

### DIFF
--- a/app/client/src/ce/utils/signupHelpers.ts
+++ b/app/client/src/ce/utils/signupHelpers.ts
@@ -1,7 +1,4 @@
-import {
-  firstTimeUserOnboardingInit,
-  setCurrentApplicationIdForCreateNewApp,
-} from "actions/onboardingActions";
+import { setCurrentApplicationIdForCreateNewApp } from "actions/onboardingActions";
 import {
   SIGNUP_SUCCESS_URL,
   BUILDER_PATH,
@@ -19,18 +16,21 @@ import type {
   SocialLoginType,
 } from "ee/constants/SocialLogin";
 import { SocialLoginButtonPropsList } from "ee/constants/SocialLogin";
+import type { Dispatch } from "redux";
+
+export interface RedirectUserAfterSignupProps {
+  redirectUrl: string;
+  shouldEnableFirstTimeUserOnboarding: string | null;
+  validLicense?: boolean;
+  dispatch: Dispatch;
+  isAiAgentFlowEnabled: boolean;
+}
 
 export const redirectUserAfterSignup = (
-  redirectUrl: string,
-  shouldEnableFirstTimeUserOnboarding: string | null,
-  _validLicense?: boolean,
-  // TODO: Fix this the next time the file is edited
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dispatch?: any,
-  isEnabledForCreateNew?: boolean, // is Enabled for only non-invited users
-  // TODO: Fix this the next time the file is edited
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any => {
+  props: RedirectUserAfterSignupProps,
+) => {
+  const { dispatch, redirectUrl, shouldEnableFirstTimeUserOnboarding } = props;
+
   if (redirectUrl) {
     try {
       if (
@@ -65,21 +65,10 @@ export const redirectUserAfterSignup = (
          *  passing baseApplicationId as applicationId should be fine
          * **/
         if (baseApplicationId || basePageId) {
-          if (isEnabledForCreateNew) {
-            dispatch(
-              setCurrentApplicationIdForCreateNewApp(
-                baseApplicationId as string,
-              ),
-            );
-            history.replace(APPLICATIONS_URL);
-          } else {
-            dispatch(
-              firstTimeUserOnboardingInit(
-                baseApplicationId,
-                basePageId as string,
-              ),
-            );
-          }
+          dispatch(
+            setCurrentApplicationIdForCreateNewApp(baseApplicationId as string),
+          );
+          history.replace(APPLICATIONS_URL);
         } else {
           if (!urlObject) {
             try {

--- a/app/client/src/pages/setup/SignupSuccess.tsx
+++ b/app/client/src/pages/setup/SignupSuccess.tsx
@@ -12,6 +12,7 @@ import { isValidLicense } from "ee/selectors/organizationSelectors";
 import { redirectUserAfterSignup } from "ee/utils/signupHelpers";
 import { setUserSignedUpFlag } from "utils/storage";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
+import { getIsAiAgentFlowEnabled } from "ee/selectors/aiAgentSelectors";
 
 export function SignupSuccess() {
   const dispatch = useDispatch();
@@ -27,17 +28,17 @@ export function SignupSuccess() {
     user?.email && setUserSignedUpFlag(user?.email);
   }, []);
 
-  const isNonInvitedUser = shouldEnableFirstTimeUserOnboarding === "true";
+  const isAiAgentFlowEnabled = useSelector(getIsAiAgentFlowEnabled);
 
   const redirectUsingQueryParam = useCallback(
     () =>
-      redirectUserAfterSignup(
+      redirectUserAfterSignup({
         redirectUrl,
         shouldEnableFirstTimeUserOnboarding,
         validLicense,
         dispatch,
-        isNonInvitedUser,
-      ),
+        isAiAgentFlowEnabled,
+      }),
     [],
   );
 


### PR DESCRIPTION
/ok-to-test tags="@tag.Sanity"

This is the corresponding CE PR for redirecting ai agent new user to app page directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an AI-driven option during signup that tailors the post-signup experience.
  
- **Refactor**
  - Streamlined the redirection process by consolidating multiple options into a single, structured input.
  - Simplified the logic behind directing users to their respective landing pages for a smoother transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14189262440>
> Commit: 03c954c7e6bad3122f727d73fa34a50daec69b6c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14189262440&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 01 Apr 2025 07:46:41 UTC
<!-- end of auto-generated comment: Cypress test results  -->
