### PR TITLE
chore: remove klona from evalTreeWithChanges cycles becauses we aren't doing…

### DIFF
--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -648,9 +648,8 @@ export default class DataTreeEvaluator {
   } {
     this.setConfigTree(configTree);
 
-    const localUnEvalTree = Object.assign({}, unEvalTree);
     const updatedUnEvalTreeJSFunction = this.updateUnEvalTreeJSFunction(
-      localUnEvalTree,
+      unEvalTree,
       configTree,
     );
 
@@ -813,10 +812,12 @@ export default class DataTreeEvaluator {
       removedPaths?: Array<{ entityId: string; fullpath: string }>;
       translatedDiffs?: DataTreeDiff[];
       pathsToSkipFromEval?: string[];
+      isEvalTreeWithChanges?: boolean;
     },
   ) {
     const {
       dependenciesOfRemovedPaths = [],
+      isEvalTreeWithChanges,
       pathsToSkipFromEval = [],
       removedPaths = [],
       translatedDiffs = [],
@@ -855,7 +856,10 @@ export default class DataTreeEvaluator {
 
     // TODO: For some reason we are passing some reference which are getting mutated.
     // Need to check why big api responses are getting split between two eval runs
-    this.oldUnEvalTree = klona(updatedUnEvalTree);
+    if (!isEvalTreeWithChanges) {
+      this.oldUnEvalTree = klona(updatedUnEvalTree);
+    }
+
     this.oldConfigTree = Object.assign({}, this.getConfigTree());
     const cloneEndTime = performance.now();
 
@@ -886,7 +890,7 @@ export default class DataTreeEvaluator {
     updatedValuePaths: string[][],
     pathsToSkipFromEval: string[] = [],
   ): ReturnType<typeof DataTreeEvaluator.prototype.setupUpdateTree> {
-    const updatedUnEvalTree = Object.assign({}, this.oldUnEvalTree);
+    const updatedUnEvalTree = this.oldUnEvalTree;
 
     // skipped update local unEvalTree
     if (updatedValuePaths.length === 0) {
@@ -902,6 +906,7 @@ export default class DataTreeEvaluator {
     return {
       ...this.setupTree(updatedUnEvalTree, updatedValuePaths, {
         pathsToSkipFromEval,
+        isEvalTreeWithChanges: true,
       }),
       jsUpdates: {},
     };


### PR DESCRIPTION
… any mutation

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14194432099>
> Commit: 48bda945ed4378a7eabb2ffea54a013990d1ea76
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14194432099&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 01 Apr 2025 12:46:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal state update processes for a more efficient handling of dynamic changes.
  - Introduced enhanced configuration options to better track and manage updates, ensuring smoother performance during ongoing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->