### PR TITLE
chore: Removes highlighting from JSEditor

### DIFF
--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -57,7 +57,6 @@ import {
   getJSActionOption,
   type OnUpdateSettingsProps,
 } from "./JSEditorToolbar";
-import { getHighlightedLines } from "ee/pages/Editor/JSEditor/utils/getHighlightedLines";
 
 interface JSFormProps {
   jsCollectionData: JSCollectionData;
@@ -288,8 +287,6 @@ function JSEditorForm({
     }
   };
 
-  const highlightedLines = getHighlightedLines(currentJSCollection);
-
   useEffect(() => {
     if (parseErrors.length || isEmpty(jsActions)) {
       setDisableRunFunctionality(true);
@@ -376,7 +373,6 @@ function JSEditorForm({
                   currentJSCollection={currentJSCollection}
                   customGutter={JSGutters}
                   executing={isExecutingCurrentJSAction}
-                  highlightedLines={highlightedLines}
                   onChange={handleEditorChange}
                   onUpdateSettings={onUpdateSettings}
                   onValueChange={(string) =>


### PR DESCRIPTION
## Description

Removes the line highlight in JS Editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the code editor by removing the highlighted lines feature. The editor now presents a cleaner, uniform display while maintaining its existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->