### PR TITLE
fix: WDS neutral foregrounds

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -763,7 +763,12 @@ export class DarkModeTheme implements ColorModeTheme {
     // Neutral foreground. Slightly less prominent than main fg
     const color = this.fg.clone();
 
-    color.oklch.c = 0;
+    color.oklch.l -= 0.05;
+    color.oklch.c -= 0.04;
+
+    if (color.oklch.c < 0) {
+      color.oklch.c = 0;
+    }
 
     return color;
   }
@@ -771,7 +776,7 @@ export class DarkModeTheme implements ColorModeTheme {
   private get fgNeutralSubtle() {
     const color = this.fgNeutral.clone();
 
-    color.oklch.l -= 0.3;
+    color.oklch.l -= 0.2;
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -767,7 +767,12 @@ export class LightModeTheme implements ColorModeTheme {
     // Neutral foreground. Slightly less prominent than main fg
     const color = this.fg.clone();
 
-    color.oklch.c -= 0.09;
+    color.oklch.l += 0.05;
+    color.oklch.c -= 0.02;
+
+    if (color.oklch.c < 0) {
+      color.oklch.c = 0;
+    }
 
     return color;
   }
@@ -775,7 +780,7 @@ export class LightModeTheme implements ColorModeTheme {
   private get fgNeutralSubtle() {
     const color = this.fgNeutral.clone();
 
-    color.oklch.l += 0.22;
+    color.oklch.l += 0.12;
 
     return color;
   }

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -638,19 +638,19 @@ describe("fgNeutral color", () => {
   it("should return correct color when chroma < 0.04", () => {
     const { fgNeutral } = new DarkModeTheme("oklch(0.45 0.03 60)").getColors();
 
-    expect(fgNeutral).toEqual("rgb(88.268% 88.268% 88.268%)");
+    expect(fgNeutral).toEqual("rgb(81.873% 81.873% 81.873%)");
   });
 
   it("should return correct color when chroma > 0.04 and hue is between 120 and 300", () => {
     const { fgNeutral } = new DarkModeTheme("oklch(0.45 0.1 150)").getColors();
 
-    expect(fgNeutral).toEqual("rgb(88.268% 88.268% 88.268%)");
+    expect(fgNeutral).toEqual("rgb(77.671% 83.881% 78.629%)");
   });
 
   it("should return correct color when chroma > 0.04 and hue is not between 120 and 300", () => {
     const { fgNeutral } = new DarkModeTheme("oklch(0.45 0.1 110)").getColors();
 
-    expect(fgNeutral).toEqual("rgb(88.268% 88.268% 88.268%)");
+    expect(fgNeutral).toEqual("rgb(82.157% 82.637% 75.397%)");
   });
 });
 
@@ -660,7 +660,7 @@ describe("fgNeutralSubtle color", () => {
       "oklch(0.45 0.03 60)",
     ).getColors();
 
-    expect(fgNeutralSubtle).toEqual("rgb(51.374% 51.374% 51.374%)");
+    expect(fgNeutralSubtle).toEqual("rgb(57.26% 57.26% 57.26%)");
   });
 });
 

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -670,19 +670,19 @@ describe("fgNeutral color", () => {
   it("should return correct color when chroma < 0.04", () => {
     const { fgNeutral } = new LightModeTheme("oklch(0.45 0.03 60)").getColors();
 
-    expect(fgNeutral).toEqual("rgb(0% 26.839% 41.548%)");
+    expect(fgNeutral).toEqual("rgb(30.171% 30.171% 30.171%)");
   });
 
   it("should return correct color when chroma >  0.04 and hue is between 120 and 300", () => {
     const { fgNeutral } = new LightModeTheme("oklch(0.45 0.1 150)").getColors();
 
-    expect(fgNeutral).toEqual("rgb(31.034% 21.083% 30.044%)");
+    expect(fgNeutral).toEqual("rgb(27.457% 31.431% 28.097%)");
   });
 
   it("should return correct color when chroma >  0.04 and hue is not between 120 and 300", () => {
     const { fgNeutral } = new LightModeTheme("oklch(0.45 0.1 110)").getColors();
 
-    expect(fgNeutral).toEqual("rgb(24.783% 23.161% 34.901%)");
+    expect(fgNeutral).toEqual("rgb(30.362% 30.64% 26.009%)");
   });
 });
 
@@ -692,7 +692,7 @@ describe("fgNeutralSubtle color", () => {
       "oklch(0.45 0.03 60)",
     ).getColors();
 
-    expect(fgNeutralSubtle).toEqual("rgb(27.658% 51.819% 68%)");
+    expect(fgNeutralSubtle).toEqual("rgb(43.337% 43.337% 43.337%)");
   });
 });
 


### PR DESCRIPTION
## Description

Fixes brown-ish neutrals.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14222219250>
> Commit: 98dd30c7173da29cf4c1d97422bba18bacd0b7f8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14222219250&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 02 Apr 2025 15:13:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Changes**
  - Adjusted the neutral foreground color calculations in both dark and light modes to improve contrast and visual consistency.
- **Tests**
  - Updated the color verification tests to ensure the revised color adjustments perform as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->