### PR TITLE
chore: Showing admin setting categories based on feature flags

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/index.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/index.ts
@@ -11,11 +11,23 @@ import { config as ProvisioningConfig } from "ee/pages/AdminSettings/config/prov
 import { config as UserListing } from "ee/pages/AdminSettings/config//userlisting";
 import { config as AuditLogsConfig } from "ee/pages/AdminSettings/config/auditlogs";
 
+import { selectFeatureFlags } from "ee/selectors/featureFlagsSelectors";
+import store from "store";
+
+const featureFlags = selectFeatureFlags(store.getState());
+
+const isMultiOrgEnabled = featureFlags?.license_multi_org_enabled;
+
 ConfigFactory.register(GeneralConfig);
-ConfigFactory.register(EmailConfig);
-ConfigFactory.register(DeveloperSettings);
+
+if (!isMultiOrgEnabled) ConfigFactory.register(EmailConfig);
+
+if (!isMultiOrgEnabled) ConfigFactory.register(DeveloperSettings);
+
 ConfigFactory.register(Authentication);
-ConfigFactory.register(AdvancedConfig);
+
+if (!isMultiOrgEnabled) ConfigFactory.register(AdvancedConfig);
+
 ConfigFactory.register(VersionConfig);
 ConfigFactory.register(BrandingConfig);
 ConfigFactory.register(ProvisioningConfig);

--- a/app/client/src/ce/utils/adminSettingsHelpers.ts
+++ b/app/client/src/ce/utils/adminSettingsHelpers.ts
@@ -65,11 +65,7 @@ export const getWrapperCategory = (
   return categories[subCategory || category];
 };
 
-export const getFilteredGeneralCategories = (
-  categories: Category[],
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  featureFlags?: Record<string, boolean>,
-) => {
+export const getFilteredGeneralCategories = (categories: Category[]) => {
   return categories
     ?.map((category: Category) => {
       return category;

--- a/app/client/src/pages/AdminSettings/LeftPane.tsx
+++ b/app/client/src/pages/AdminSettings/LeftPane.tsx
@@ -202,17 +202,12 @@ export default function LeftPane() {
   const isSuperUser = user?.isSuperUser;
   const organizationPermissions = useSelector(getOrganizationPermissions);
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
-  const isMultiOrgEnabled = useFeatureFlag(
-    FEATURE_FLAG.license_multi_org_enabled,
-  );
   const isAuditLogsEnabled = getHasAuditLogsReadPermission(
     isFeatureEnabled,
     organizationPermissions,
   );
 
-  const filteredGeneralCategories = getFilteredGeneralCategories(categories, {
-    license_multi_org_enabled: isMultiOrgEnabled,
-  });
+  const filteredGeneralCategories = getFilteredGeneralCategories(categories);
 
   const filteredAclCategories = getFilteredAclCategories(
     aclCategories,

--- a/app/client/src/utils/dayJsUtils.ts
+++ b/app/client/src/utils/dayJsUtils.ts
@@ -30,3 +30,5 @@ export function getReadableDateInFormat(
 ): string {
   return dayjs(date).format(formatString);
 }
+
+export { dayjs };


### PR DESCRIPTION
## Description

Showing admin setting categories based on feature flags

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14232885915>
> Commit: 762de563956fd870340990244ba9bef0ca2eaa32
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14232885915&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Thu, 03 Apr 2025 01:45:37 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The admin settings interface now dynamically adjusts available configuration options based on your organization’s multi-tenant setup, ensuring you see only the relevant settings.

- **Refactor**
  - The filtering process for configuration categories has been streamlined, resulting in a cleaner and more intuitive settings display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->