### PR TITLE
feat: Add user-defined column order to TableWidgetV2

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/constants.ts
@@ -75,6 +75,7 @@ export interface TableWidgetProps
   enableClientSideSearch?: boolean;
   hiddenColumns?: string[];
   columnOrder?: string[];
+  userColumnOrder?: string[];
   frozenColumnIndices: Record<string, number>;
   canFreezeColumn?: boolean;
   columnNameMap?: { [key: string]: string };

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -231,6 +231,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
       customIsLoadingValue: "",
       cachedTableData: {},
       endOfData: false,
+      userColumnOrder: [],
     };
   }
 
@@ -1350,6 +1351,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
           triggerRowSelection={this.props.triggerRowSelection}
           unSelectAllRow={this.unSelectAllRow}
           updatePageNo={this.updatePageNumber}
+          userColumnOrder={this.props.userColumnOrder}
           variant={this.props.variant}
           widgetId={this.props.widgetId}
           widgetName={this.props.widgetName}

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -72,6 +72,24 @@ export default [
         ) => triggerFlag && isDynamic && !isToggleDisabled,
       },
       {
+        propertyName: "userColumnOrder",
+        helpText:
+          "Define the order of columns to display. Provide an array of column names.",
+        label: "Column order",
+        controlType: "INPUT_TEXT",
+        placeholderText: '["column1", "column2", "column3"]',
+        isBindProperty: true,
+        isTriggerProperty: false,
+        isJSConvertible: true,
+        validation: {
+          type: ValidationTypes.ARRAY,
+          params: {
+            default: [],
+            unique: true,
+          },
+        },
+      },
+      {
         propertyName: "primaryColumns",
         controlType: "PRIMARY_COLUMNS_V2",
         label: "Columns",


### PR DESCRIPTION
- Introduced `userColumnOrder` prop to allow users to specify the order of columns displayed in the table.
- Updated `ReactTableComponent` to reorder columns based on the `userColumnOrder` if provided.
- Enhanced property configuration to include help text and validation for the new `userColumnOrder` property.

This feature improves the customization options for users, enabling a more tailored table display.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
