### PR TITLE
feat: Remove email verification setting for Multi organization flow

### DIFF
--- a/app/client/cypress/support/Objects/FeatureFlags.ts
+++ b/app/client/cypress/support/Objects/FeatureFlags.ts
@@ -4,7 +4,6 @@ import { ObjectsRegistry } from "./Registry";
 const defaultFlags = {
   rollout_remove_feature_walkthrough_enabled: false, // remove this flag from here when it's removed from code
   release_git_modularisation_enabled: true,
-  release_ads_entity_item_enabled: true,
 };
 
 export const featureFlagIntercept = (

--- a/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
@@ -34,10 +34,12 @@ import {
 import { isSAMLEnabled, isOIDCEnabled } from "ee/utils/planHelpers";
 import { selectFeatureFlags } from "ee/selectors/featureFlagsSelectors";
 import store from "store";
-const featureFlags = selectFeatureFlags(store.getState());
-
+import { isMultiOrgFFEnabled } from "ee/utils/planHelpers";
 import { getAppsmithConfigs } from "ee/configs";
 import type { Setting } from "./types";
+
+const featureFlags = selectFeatureFlags(store.getState());
+const isMultiOrgEnabled = isMultiOrgFFEnabled(featureFlags);
 const { mailEnabled } = getAppsmithConfigs();
 
 export const FormAuth: AdminConfigType = {
@@ -69,6 +71,9 @@ export const FormAuth: AdminConfigType = {
       category: SettingCategories.FORM_AUTH,
       controlType: SettingTypes.TOGGLE,
       label: "email verification",
+      isVisible: () => {
+        return !isMultiOrgEnabled;
+      },
       isDisabled: (settings) => {
         // Disabled when mail is not enabled, unless setting already enabled then enabled
         if (!settings) {
@@ -85,7 +90,7 @@ export const FormAuth: AdminConfigType = {
     {
       id: "APPSMITH_FORM_DISABLED_BANNER",
       category: SettingCategories.FORM_AUTH,
-      controlType: SettingTypes.LINK,
+      controlType: SettingTypes.CALLOUT,
       label:
         "To enable email verification for form login, you must enable SMTP server from email settings",
       url: EMAIL_SETUP_DOC,
@@ -100,7 +105,7 @@ export const FormAuth: AdminConfigType = {
           return false;
         }
 
-        return !mailEnabled;
+        return !mailEnabled && !isMultiOrgEnabled;
       },
     },
     {
@@ -122,7 +127,7 @@ export const FormAuth: AdminConfigType = {
     {
       id: "APPSMITH_FORM_ERROR_BANNER",
       category: SettingCategories.FORM_AUTH,
-      controlType: SettingTypes.LINK,
+      controlType: SettingTypes.CALLOUT,
       label:
         "Valid SMTP settings not found. Signup with email verification will not work without SMTP configuration",
       calloutType: "error",

--- a/app/client/src/ce/utils/planHelpers.ts
+++ b/app/client/src/ce/utils/planHelpers.ts
@@ -26,3 +26,8 @@ export const isBranchProtectionLicenseEnabled = (
 ) => {
   return !!featureFlags?.license_git_branch_protection_enabled;
 };
+
+export const isMultiOrgFFEnabled = (featureFlags: FeatureFlags) => {
+  // add cloudHosting check later: Ankita
+  return featureFlags?.license_multi_org_enabled;
+};

--- a/app/client/src/pages/AdminSettings/config/email.ts
+++ b/app/client/src/pages/AdminSettings/config/email.ts
@@ -34,7 +34,7 @@ export const config: AdminConfigType = {
     {
       id: "APPSMITH_MAIL_WARNING",
       category: SettingCategories.EMAIL,
-      controlType: SettingTypes.LINK,
+      controlType: SettingTypes.CALLOUT,
       calloutType: "warning",
       label: createMessage(ADMIN_SETTINGS_EMAIL_WARNING),
     },


### PR DESCRIPTION
## Description

Removing email verification setting for Multi organization flow

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14249110861>
> Commit: 0d9eaeb7b000123871fada897c346729f3751757
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14249110861&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Thu, 03 Apr 2025 17:52:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an outdated configuration flag from the default settings.

- **New Features**
  - Enhanced multi-organization support for admin settings, with certain configurations (e.g., email verification) now conditionally hidden.
  - Updated the presentation of notification and warning messages, switching from link-based displays to more prominent callout styles for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->