### PR TITLE
fix: First time user experience for org admin

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserSignupHelperCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserSignupHelperCE.java
@@ -52,7 +52,7 @@ public class UserSignupHelperCE {
         workspace.setName(user.getName() != null ? user.getName() + "'s workspace" : "Default workspace");
 
         return workspaceService
-                .create(workspace, user, Boolean.FALSE)
+                .createDefault(workspace, user)
                 .flatMap(createdWorkspace ->
                         createDefaultApplication(createdWorkspace.getId()).then())
                 .doOnError(error -> log.error("Error creating workspace or application: {}", error.getMessage()))


### PR DESCRIPTION
## Description
This fixes the first time user experience for org admins. For Google OAuth I'm seeing expected behaviour for subsequent users as well, but for form signups even if the verification url contains `enableFirstTimeUserExperience=true` user ends up in the default application but not seeing the screen for signup success or datasource screen. 

```
https://appsmith-5.dev.appsmith.com/user/verify?token=6c7e1033423dae*********a6ca8ec8749fbf94&email=abhijeet%2B11%40appsmith.com&organizationId=67eeea6ddd9c8b37491d5abd&redirectUrl=https://appsmith-5.dev.appsmith.com/applications/67eeec9d2b9b0244ea362dca/pages/67eeec9d2b9b0244ea362dcc/edit&enableFirstTimeUserExperience=true
```

/test Authentication

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14252053392>
> Commit: 95d50b8f9b232d4d7b3d69f45d841acbefe21859
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14252053392&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Authentication`
> Spec:
> <hr>Thu, 03 Apr 2025 20:40:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the default workspace creation during user sign-up, enhancing the onboarding setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->