### PR TITLE
chore: Adjust default Anvil/WDS border radius

### DIFF
--- a/app/client/packages/design-system/theming/src/token/src/defaultTokens.json
+++ b/app/client/packages/design-system/theming/src/token/src/defaultTokens.json
@@ -2,7 +2,7 @@
   "seedColor": "#0080ff",
   "colorMode": "light",
   "borderRadiusElevation": {
-    "base": "0px",
+    "base": "8px",
     "1": "calc(var(--border-radius-elevation-base) + var(--outer-spacing-1) * 2)",
     "2": "calc(var(--border-radius-elevation-base) + var(--outer-spacing-1))",
     "3": "var(--border-radius-elevation-base)"

--- a/app/client/packages/storybook/src/components/ThemeSettings.tsx
+++ b/app/client/packages/storybook/src/components/ThemeSettings.tsx
@@ -98,8 +98,8 @@ export const ThemeSettings = ({
               size="100%"
               title="Border Radius"
             >
-              <option value="0px">Sharp</option>
               <option value="8px">Rounded</option>
+              <option value="0px">Sharp</option>
               <option value="20px">Pill</option>
             </StyledSelect>
           </Flex>

--- a/app/client/packages/storybook/src/components/ThemeSettings.tsx
+++ b/app/client/packages/storybook/src/components/ThemeSettings.tsx
@@ -99,7 +99,7 @@ export const ThemeSettings = ({
               title="Border Radius"
             >
               <option value="0px">Sharp</option>
-              <option value="6px">Rounded</option>
+              <option value="8px">Rounded</option>
               <option value="20px">Pill</option>
             </StyledSelect>
           </Flex>

--- a/app/client/src/constants/AppConstants.ts
+++ b/app/client/src/constants/AppConstants.ts
@@ -131,7 +131,7 @@ export const defaultThemeSetting: ThemeSetting = {
   fontFamily: "System Default",
   accentColor: "#0080ff",
   colorMode: "LIGHT",
-  borderRadius: "6px",
+  borderRadius: "8px",
   density: 1,
   sizing: 1,
   appMaxWidth: APP_MAX_WIDTH.Large,

--- a/app/client/src/pages/Editor/WDSThemePropertyPane/constants.ts
+++ b/app/client/src/pages/Editor/WDSThemePropertyPane/constants.ts
@@ -45,6 +45,12 @@ export const THEME_SETTINGS_BORDER_RADIUS_OPTIONS = [
   { label: "Pill", value: "20px" },
 ];
 
+export const THEME_SETTINGS_BORDER_RADIUS_OPTIONS_FOR_ANVIL = [
+  { label: "Sharp", value: "0px" },
+  { label: "Rounded", value: "6px" },
+  { label: "Pill", value: "20px" },
+];
+
 export const THEME_SETTING_COLOR_PRESETS = {
   LIGHT: ["#0080ff", "#6b35ff", "#d54137", "#f09326", "#02925c"],
   DARK: ["#0080ff", "#5b02ea", "#c12c26", "#e98b11", "#03854e"],

--- a/app/client/src/pages/Editor/WDSThemePropertyPane/constants.ts
+++ b/app/client/src/pages/Editor/WDSThemePropertyPane/constants.ts
@@ -47,7 +47,7 @@ export const THEME_SETTINGS_BORDER_RADIUS_OPTIONS = [
 
 export const THEME_SETTINGS_BORDER_RADIUS_OPTIONS_FOR_ANVIL = [
   { label: "Sharp", value: "0px" },
-  { label: "Rounded", value: "6px" },
+  { label: "Rounded", value: "8px" },
   { label: "Pill", value: "20px" },
 ];
 

--- a/app/client/src/pages/Editor/WDSThemePropertyPane/constants.ts
+++ b/app/client/src/pages/Editor/WDSThemePropertyPane/constants.ts
@@ -41,12 +41,6 @@ export const THEME_SETTINGS_SIZING_OPTIONS = [
 
 export const THEME_SETTINGS_BORDER_RADIUS_OPTIONS = [
   { label: "Sharp", value: "0px" },
-  { label: "Rounded", value: "6px" },
-  { label: "Pill", value: "20px" },
-];
-
-export const THEME_SETTINGS_BORDER_RADIUS_OPTIONS_FOR_ANVIL = [
-  { label: "Sharp", value: "0px" },
   { label: "Rounded", value: "8px" },
   { label: "Pill", value: "20px" },
 ];

--- a/app/client/src/pages/Editor/WDSThemePropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/WDSThemePropertyPane/index.tsx
@@ -17,7 +17,7 @@ import { SegmentedControl, Tooltip, Icon } from "@appsmith/ads";
 import styles from "./styles.module.css";
 
 import {
-  THEME_SETTINGS_BORDER_RADIUS_OPTIONS_FOR_ANVIL,
+  THEME_SETTINGS_BORDER_RADIUS_OPTIONS,
   THEME_SETTINGS_DENSITY_OPTIONS,
   THEME_SETTINGS_SIZING_OPTIONS,
   THEME_SETTINGS_COLOR_MODE_OPTIONS,
@@ -33,7 +33,7 @@ const SubText = styled.p`
   color: var(--ads-v2-color-fg);
 `;
 
-const buttonGroupOptions = THEME_SETTINGS_BORDER_RADIUS_OPTIONS_FOR_ANVIL.map(
+const buttonGroupOptions = THEME_SETTINGS_BORDER_RADIUS_OPTIONS.map(
   (optionKey) => ({
     label: (
       <Tooltip content={optionKey.label} key={optionKey.label}>

--- a/app/client/src/pages/Editor/WDSThemePropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/WDSThemePropertyPane/index.tsx
@@ -17,7 +17,7 @@ import { SegmentedControl, Tooltip, Icon } from "@appsmith/ads";
 import styles from "./styles.module.css";
 
 import {
-  THEME_SETTINGS_BORDER_RADIUS_OPTIONS,
+  THEME_SETTINGS_BORDER_RADIUS_OPTIONS_FOR_ANVIL,
   THEME_SETTINGS_DENSITY_OPTIONS,
   THEME_SETTINGS_SIZING_OPTIONS,
   THEME_SETTINGS_COLOR_MODE_OPTIONS,
@@ -33,7 +33,7 @@ const SubText = styled.p`
   color: var(--ads-v2-color-fg);
 `;
 
-const buttonGroupOptions = THEME_SETTINGS_BORDER_RADIUS_OPTIONS.map(
+const buttonGroupOptions = THEME_SETTINGS_BORDER_RADIUS_OPTIONS_FOR_ANVIL.map(
   (optionKey) => ({
     label: (
       <Tooltip content={optionKey.label} key={optionKey.label}>


### PR DESCRIPTION
## Description

Fixes #39900  

| Before | After |
|--------|--------|
| <img width="746" alt="Screenshot 2025-04-04 at 12 28 54" src="https://github.com/user-attachments/assets/8e36f87d-8340-4b83-92d4-9e3ff2525f4d" /> | <img width="707" alt="Screenshot 2025-04-04 at 12 41 51" src="https://github.com/user-attachments/assets/e786f8e8-0a7e-4a9c-8671-536962622ea2" /> | 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14264062576>
> Commit: 190183c4a62af89128dc187ef92d5d0ff4d5a4f9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14264062576&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 04 Apr 2025 11:55:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated the border radius for rounded UI elements from 6px to 8px.
	- Refined theme settings and design tokens to deliver a more modern and consistent visual experience across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->