### PR TITLE
chore: Adding postfix prop to input field used on admin settings

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/index.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/index.ts
@@ -13,10 +13,10 @@ import { config as AuditLogsConfig } from "ee/pages/AdminSettings/config/auditlo
 
 import { selectFeatureFlags } from "ee/selectors/featureFlagsSelectors";
 import store from "store";
+import { isMultiOrgFFEnabled } from "ee/utils/planHelpers";
 
 const featureFlags = selectFeatureFlags(store.getState());
-
-const isMultiOrgEnabled = featureFlags?.license_multi_org_enabled;
+const isMultiOrgEnabled = isMultiOrgFFEnabled(featureFlags);
 
 ConfigFactory.register(GeneralConfig);
 

--- a/app/client/src/ce/pages/AdminSettings/config/types.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/types.ts
@@ -103,6 +103,7 @@ export type Setting = ControlType & {
   isFeatureEnabled?: boolean;
   tooltip?: string;
   isEnterprise?: boolean;
+  postfix?: string;
 };
 
 export interface Category {

--- a/app/client/src/components/utils/ReduxFormTextField.tsx
+++ b/app/client/src/components/utils/ReduxFormTextField.tsx
@@ -40,6 +40,7 @@ const renderComponent = (
         componentProps.meta.error
       }
       isDisabled={componentProps.disabled}
+      postfix={componentProps.postfix}
       renderAs={componentProps.type === "textarea" ? "textarea" : "input"}
       size="md"
       value={value}

--- a/app/client/src/pages/AdminSettings/FormGroup/TextInput.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/TextInput.tsx
@@ -19,6 +19,7 @@ export default function TextInput({ setting }: SettingComponentProps) {
         name={setting.name || setting.id || ""}
         parse={setting.parse}
         placeholder={createMessage(() => setting.placeholder || "")}
+        postfix={setting.postfix}
         type={setting.controlSubType}
       />
     </FormGroup>

--- a/app/client/src/pages/AdminSettings/FormGroup/group.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/group.tsx
@@ -90,6 +90,10 @@ const GroupBody = styled.div`
   label {
     user-select: none;
   }
+
+  .ads-v2-input-postfix {
+    font-weight: 500;
+  }
 `;
 
 const formValuesSelector = getFormValues(SETTINGS_FORM_NAME);


### PR DESCRIPTION
## Description

Adding postfix prop to input field used on admin settings

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14267276463>
> Commit: 394946baf2016088a4274da58d228c73c5f7f611
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14267276463&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Fri, 04 Apr 2025 14:37:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the logic for determining multi-organization support.
  - Enabled an optional addition of custom postfix text in settings and input fields for enhanced customization.

- **Style**
  - Enhanced the visual emphasis of appended text by applying a distinct typographic style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->