### PR TITLE
chore: Remove dirty check dots from Entity Item and Tab

### DIFF
--- a/app/client/src/pages/AppIDE/components/JSEntityItem/JSEntityItem.tsx
+++ b/app/client/src/pages/AppIDE/components/JSEntityItem/JSEntityItem.tsx
@@ -1,10 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { EntityItem, EntityContextMenu } from "@appsmith/ads";
 import type { AppState } from "ee/reducers";
-import {
-  getJsCollectionByBaseId,
-  getJSCollectionSchemaDirtyState,
-} from "ee/selectors/entitiesSelector";
+import { getJsCollectionByBaseId } from "ee/selectors/entitiesSelector";
 import { useDispatch, useSelector } from "react-redux";
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
@@ -108,10 +105,6 @@ export const JSEntityItem = ({ item }: { item: EntityItemProps }) => {
     validateName,
   ]);
 
-  const isJSActionSchemaDirty = useSelector((state: AppState) =>
-    getJSCollectionSchemaDirtyState(state, item.key),
-  );
-
   return (
     <EntityItem
       className={clsx("t--jsaction", {
@@ -125,7 +118,6 @@ export const JSEntityItem = ({ item }: { item: EntityItemProps }) => {
       onDoubleClick={() => enterEditMode(jsAction.id)}
       rightControl={contextMenu}
       rightControlVisibility="hover"
-      showUnsavedChanges={isJSActionSchemaDirty}
       startIcon={JsFileIconV2(16, 16)}
       title={item.title}
     />

--- a/app/client/src/pages/AppIDE/components/QueryEntityItem/QueryEntityItem.tsx
+++ b/app/client/src/pages/AppIDE/components/QueryEntityItem/QueryEntityItem.tsx
@@ -3,7 +3,6 @@ import { EntityItem, EntityContextMenu } from "@appsmith/ads";
 import type { AppState } from "ee/reducers";
 import {
   getActionByBaseId,
-  getActionSchemaDirtyState,
   getDatasource,
   getPlugins,
 } from "ee/selectors/entitiesSelector";
@@ -118,10 +117,6 @@ export const QueryEntityItem = ({ item }: { item: EntityItemProps }) => {
     validateName,
   ]);
 
-  const isActionSchemaDirty = useSelector((state: AppState) =>
-    getActionSchemaDirtyState(state, action.id),
-  );
-
   return (
     <EntityItem
       className="action t--action-entity"
@@ -133,7 +128,6 @@ export const QueryEntityItem = ({ item }: { item: EntityItemProps }) => {
       onDoubleClick={() => enterEditMode(action.id)}
       rightControl={contextMenu}
       rightControlVisibility="hover"
-      showUnsavedChanges={isActionSchemaDirty}
       startIcon={icon}
       title={item.title}
     />

--- a/app/client/src/pages/AppIDE/layouts/components/EditorTabs/EditableTab.tsx
+++ b/app/client/src/pages/AppIDE/layouts/components/EditorTabs/EditableTab.tsx
@@ -6,11 +6,7 @@ import { EditableDismissibleTab } from "@appsmith/ads";
 
 import { type EntityItem } from "ee/IDE/Interfaces/EntityItem";
 import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
-import {
-  getActionSchemaDirtyState,
-  getIsSavingEntityName,
-  getJSCollectionSchemaDirtyState,
-} from "ee/selectors/entitiesSelector";
+import { getIsSavingEntityName } from "ee/selectors/entitiesSelector";
 
 import { useFeatureFlag } from "utils/hooks/useFeatureFlag";
 import { sanitizeString } from "utils/URLUtils";
@@ -65,16 +61,6 @@ export function EditableTab(props: EditableTabProps) {
     [dispatch, entity, id, segment],
   );
 
-  const isJSActionSchemaDirty = useSelector((state) =>
-    getJSCollectionSchemaDirtyState(state, id),
-  );
-
-  const isActionSchemaDirty = useSelector((state) =>
-    getActionSchemaDirtyState(state, id),
-  );
-
-  const isSchemaDirty = isJSActionSchemaDirty || isActionSchemaDirty;
-
   return (
     <EditableDismissibleTab
       dataTestId={`t--ide-tab-${sanitizeString(title)}`}
@@ -89,7 +75,6 @@ export function EditableTab(props: EditableTabProps) {
       onEnterEditMode={enterEditMode}
       onExitEditMode={exitEditMode}
       onNameSave={handleNameSave}
-      showUnsavedChanges={isSchemaDirty}
       validateName={validateName}
     />
   );


### PR DESCRIPTION
## Description

Removes the dots shown on entity items when the schema was dirty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed unsaved change indicators from several views. Users will no longer see notifications for pending modifications in action items, JavaScript entries, and editing tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->