### PR TITLE
fix: API editor query parameters not auto-updating URL

### DIFF
--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import type { ControlType } from "constants/PropertyControlConstants";
 import FormControl from "pages/Editor/FormControl";
 import { Grid, Tabs, TabPanel, TabsList, Tab, Flex } from "@appsmith/ads";
@@ -14,6 +14,7 @@ import { autofill } from "redux-form";
 import { setActionProperty } from "actions/pluginActionActions";
 import type { Property } from "api/ActionAPI";
 import get from "lodash/get";
+import isEqual from "lodash/isEqual";
 
 enum CUSTOM_ACTION_TABS {
   HEADERS = "HEADERS",
@@ -44,11 +45,32 @@ const TabbedWrapper = styled(Tabs)`
   }
 `;
 
+// Helper function to check if two arrays of params are functionally equivalent
+const areParamsEquivalent = (params1: Property[], params2: Property[]): boolean => {
+  if (params1.length !== params2.length) return false;
+  
+  // Create a map of key-value pairs for easier comparison
+  const paramsMap1 = params1.reduce((map, param) => {
+    if (param.key) map[param.key] = param.value;
+    return map;
+  }, {} as Record<string, any>);
+  
+  const paramsMap2 = params2.reduce((map, param) => {
+    if (param.key) map[param.key] = param.value;
+    return map;
+  }, {} as Record<string, any>);
+  
+  return isEqual(paramsMap1, paramsMap2);
+};
+
 // Hook to sync query parameters with URL path in both directions
 const useSyncParamsToPath = (formName: string, configProperty: string) => {
   const dispatch = useDispatch();
   const formValues = useSelector((state) => getFormData(state, formName));
-
+  // Refs to track the last values to prevent infinite loops
+  const lastPathRef = useRef("");
+  const lastParamsRef = useRef<Property[]>([]);
+  
   useEffect(
     function syncParamsEffect() {
       if (!formValues || !formValues.values) return;
@@ -61,56 +83,85 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
       // Correctly access nested properties using lodash's get
       const path = get(values, `${configProperty}.path`, "");
       const queryParameters = get(values, `${configProperty}.params`, []);
-
-      // Check if we need to extract parameters from the path
-      if (path) {
-        const parsedParams = parseUrlForQueryParams(path);
-
-        // Always update params if we found query parameters in the path
-        if (parsedParams.length > 0 && parsedParams.some((p) => p.key)) {
-          dispatch(
-            autofill(formName, `${configProperty}.params`, parsedParams),
-          );
-          dispatch(
-            setActionProperty({
-              actionId: actionId,
-              propertyName: `${configProperty}.params`,
-              value: parsedParams,
-            }),
-          );
-        }
+      
+      // Early return if nothing has changed
+      if (path === lastPathRef.current && isEqual(queryParameters, lastParamsRef.current)) {
+        return;
       }
 
-      // If we have query params but they're not in the path, update the path
-      if (
-        queryParameters.length &&
-        queryParameters.some((p: Property) => p.key)
-      ) {
-        const matchGroups = path.match(queryParamsRegEx) || [];
-        const currentPath = matchGroups[1] || "";
-        // Only build params string if we have any valid params
-        const validParams = queryParameters.filter((p: Property) => p.key);
+      // Check if params have changed but path hasn't - indicating params tab update
+      const paramsChanged = !isEqual(queryParameters, lastParamsRef.current);
+      const pathChanged = path !== lastPathRef.current;
+      
+      // Update refs to current values
+      lastPathRef.current = path;
+      lastParamsRef.current = [...queryParameters];
 
-        if (validParams.length > 0) {
-          const paramsString = validParams
-            .map(
-              (p: Property, i: number) =>
-                `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
-            )
-            .join("");
-
-          // Don't update if already in sync (prevent loops)
-          const newPath = `${currentPath}${paramsString}`;
-
-          if (path !== newPath) {
-            dispatch(autofill(formName, `${configProperty}.path`, newPath));
+      // Only one sync direction per effect execution to prevent loops
+      
+      // Path changed - update params from path if needed
+      if (pathChanged) {
+        // Check if we need to extract parameters from the path
+        if (path) {
+          const parsedParams = parseUrlForQueryParams(path);
+          
+          // Only update params if they're different from current params
+          if (parsedParams.length > 0 && 
+              parsedParams.some((p) => p.key) && 
+              !areParamsEquivalent(parsedParams, queryParameters)) {
+            
+            dispatch(
+              autofill(formName, `${configProperty}.params`, parsedParams),
+            );
             dispatch(
               setActionProperty({
                 actionId: actionId,
-                propertyName: `${configProperty}.path`,
-                value: newPath,
+                propertyName: `${configProperty}.params`,
+                value: parsedParams,
               }),
             );
+            
+            // Update ref to reflect the change we just made
+            lastParamsRef.current = parsedParams;
+            return; // Exit to prevent double updates
+          }
+        }
+      }
+      
+      // Params changed - update path from params if needed
+      if (paramsChanged) {
+        // If we have query params, update the path
+        if (queryParameters.length && queryParameters.some((p: Property) => p.key)) {
+          const matchGroups = path.match(queryParamsRegEx) || [];
+          const currentPath = matchGroups[1] || "";
+          // Only build params string if we have any valid params
+          const validParams = queryParameters.filter((p: Property) => p.key);
+  
+          if (validParams.length > 0) {
+            const paramsString = validParams
+              .map(
+                (p: Property, i: number) =>
+                  `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
+              )
+              .join("");
+  
+            // Create new path
+            const newPath = `${currentPath}${paramsString}`;
+  
+            // Only update if path is actually different
+            if (path !== newPath) {
+              dispatch(autofill(formName, `${configProperty}.path`, newPath));
+              dispatch(
+                setActionProperty({
+                  actionId: actionId,
+                  propertyName: `${configProperty}.path`,
+                  value: newPath,
+                }),
+              );
+              
+              // Update ref to reflect the change we just made
+              lastPathRef.current = newPath;
+            }
           }
         }
       }

--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -56,6 +56,7 @@ const areParamsEquivalent = (
   const paramsMap1 = params1.reduce(
     (map, param) => {
       if (param.key) map[param.key] = param.value;
+
       return map;
     },
     {} as Record<string, unknown>,
@@ -64,6 +65,7 @@ const areParamsEquivalent = (
   const paramsMap2 = params2.reduce(
     (map, param) => {
       if (param.key) map[param.key] = param.value;
+
       return map;
     },
     {} as Record<string, unknown>,

--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -66,13 +66,8 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
       if (path) {
         const parsedParams = parseUrlForQueryParams(path);
 
-        // If we found params in the path, but they're not in the params tab, update them
-        if (
-          parsedParams.length > 0 &&
-          parsedParams.some((p) => p.key) &&
-          (!queryParameters.length ||
-            !queryParameters.some((p: Property) => p.key))
-        ) {
+        // Always update params if we found query parameters in the path
+        if (parsedParams.length > 0 && parsedParams.some((p) => p.key)) {
           dispatch(
             autofill(formName, `${configProperty}.params`, parsedParams),
           );

--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -57,10 +57,9 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
 
       if (!actionId) return;
 
-      // Path to sync
-      const path = values.actionConfiguration?.path || "";
-      // Query parameters to sync
-      const queryParameters = values.actionConfiguration?.queryParameters || [];
+      // Correctly access nested properties using the configProperty
+      const path = values[configProperty]?.path || "";
+      const queryParameters = values[configProperty]?.params || [];
 
       // Check if we need to extract parameters from the path
       if (path) {
@@ -76,14 +75,14 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
           dispatch(
             autofill(
               formName,
-              "actionConfiguration.queryParameters",
+              `${configProperty}.params`,
               parsedParams,
             ),
           );
           dispatch(
             setActionProperty({
               actionId: actionId,
-              propertyName: "actionConfiguration.queryParameters",
+              propertyName: `${configProperty}.params`,
               value: parsedParams,
             }),
           );
@@ -112,11 +111,11 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
           const newPath = `${currentPath}${paramsString}`;
 
           if (path !== newPath) {
-            dispatch(autofill(formName, "actionConfiguration.path", newPath));
+            dispatch(autofill(formName, `${configProperty}.path`, newPath));
             dispatch(
               setActionProperty({
                 actionId: actionId,
-                propertyName: "actionConfiguration.path",
+                propertyName: `${configProperty}.path`,
                 value: newPath,
               }),
             );

--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -47,85 +47,90 @@ const TabbedWrapper = styled(Tabs)`
 const useSyncParamsToPath = (formName: string, configProperty: string) => {
   const dispatch = useDispatch();
   const formValues = useSelector((state) => getFormData(state, formName));
-  
-  useEffect(function syncParamsEffect() {
-    if (!formValues || !formValues.values) return;
-    
-    const values = formValues.values;
-    const actionId = values.id;
-    
-    if (!actionId) return;
-    
-    // Path to sync
-    const path = values.actionConfiguration?.path || "";
-    // Query parameters to sync
-    const queryParameters = values.actionConfiguration?.queryParameters || [];
-    
-    // Check if we need to extract parameters from the path
-    if (path) {
-      const parsedParams = parseUrlForQueryParams(path);
-      
-      // If we found params in the path, but they're not in the params tab, update them
-      if (parsedParams.length > 0 && parsedParams.some(p => p.key) && 
-          (!queryParameters.length || !queryParameters.some((p: Property) => p.key))) {
-        dispatch(
-          autofill(
-            formName,
-            "actionConfiguration.queryParameters",
-            parsedParams,
-          ),
-        );
-        dispatch(
-          setActionProperty({
-            actionId: actionId,
-            propertyName: "actionConfiguration.queryParameters",
-            value: parsedParams,
-          }),
-        );
-      }
-    }
-    
-    // If we have query params but they're not in the path, update the path
-    if (queryParameters.length && queryParameters.some((p: Property) => p.key)) {
-      const matchGroups = path.match(queryParamsRegEx) || [];
-      const currentPath = matchGroups[1] || "";
-      // Only build params string if we have any valid params
-      const validParams = queryParameters.filter((p: Property) => p.key);
-      
-      if (validParams.length > 0) {
-        const paramsString = validParams
-          .map(
-            (p: Property, i: number) => `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
-          )
-          .join("");
-          
-        // Don't update if already in sync (prevent loops)
-        const newPath = `${currentPath}${paramsString}`;
-        if (path !== newPath) {
+
+  useEffect(
+    function syncParamsEffect() {
+      if (!formValues || !formValues.values) return;
+
+      const values = formValues.values;
+      const actionId = values.id;
+
+      if (!actionId) return;
+
+      // Path to sync
+      const path = values.actionConfiguration?.path || "";
+      // Query parameters to sync
+      const queryParameters = values.actionConfiguration?.queryParameters || [];
+
+      // Check if we need to extract parameters from the path
+      if (path) {
+        const parsedParams = parseUrlForQueryParams(path);
+
+        // If we found params in the path, but they're not in the params tab, update them
+        if (
+          parsedParams.length > 0 &&
+          parsedParams.some((p) => p.key) &&
+          (!queryParameters.length ||
+            !queryParameters.some((p: Property) => p.key))
+        ) {
           dispatch(
             autofill(
               formName,
-              "actionConfiguration.path",
-              newPath,
+              "actionConfiguration.queryParameters",
+              parsedParams,
             ),
           );
           dispatch(
             setActionProperty({
               actionId: actionId,
-              propertyName: "actionConfiguration.path",
-              value: newPath,
+              propertyName: "actionConfiguration.queryParameters",
+              value: parsedParams,
             }),
           );
         }
       }
-    }
-  }, [formValues, dispatch, formName, configProperty]);
+
+      // If we have query params but they're not in the path, update the path
+      if (
+        queryParameters.length &&
+        queryParameters.some((p: Property) => p.key)
+      ) {
+        const matchGroups = path.match(queryParamsRegEx) || [];
+        const currentPath = matchGroups[1] || "";
+        // Only build params string if we have any valid params
+        const validParams = queryParameters.filter((p: Property) => p.key);
+
+        if (validParams.length > 0) {
+          const paramsString = validParams
+            .map(
+              (p: Property, i: number) =>
+                `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
+            )
+            .join("");
+
+          // Don't update if already in sync (prevent loops)
+          const newPath = `${currentPath}${paramsString}`;
+          if (path !== newPath) {
+            dispatch(autofill(formName, "actionConfiguration.path", newPath));
+            dispatch(
+              setActionProperty({
+                actionId: actionId,
+                propertyName: "actionConfiguration.path",
+                value: newPath,
+              }),
+            );
+          }
+        }
+      }
+    },
+    [formValues, dispatch, formName, configProperty],
+  );
 };
 
 const TabbedControls = (props: ControlProps) => {
   // Use the hook to sync params with path
   useSyncParamsToPath(props.formName, props.configProperty);
-  
+
   return (
     <TabbedWrapper defaultValue={CUSTOM_ACTION_TABS.HEADERS}>
       <TabsList>

--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -13,6 +13,7 @@ import { parseUrlForQueryParams, queryParamsRegEx } from "utils/ApiPaneUtils";
 import { autofill } from "redux-form";
 import { setActionProperty } from "actions/pluginActionActions";
 import type { Property } from "api/ActionAPI";
+import get from "lodash/get";
 
 enum CUSTOM_ACTION_TABS {
   HEADERS = "HEADERS",
@@ -57,9 +58,9 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
 
       if (!actionId) return;
 
-      // Correctly access nested properties using the configProperty
-      const path = values[configProperty]?.path || "";
-      const queryParameters = values[configProperty]?.params || [];
+      // Correctly access nested properties using lodash's get
+      const path = get(values, `${configProperty}.path`, "");
+      const queryParameters = get(values, `${configProperty}.params`, []);
 
       // Check if we need to extract parameters from the path
       if (path) {
@@ -73,11 +74,7 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
             !queryParameters.some((p: Property) => p.key))
         ) {
           dispatch(
-            autofill(
-              formName,
-              `${configProperty}.params`,
-              parsedParams,
-            ),
+            autofill(formName, `${configProperty}.params`, parsedParams),
           );
           dispatch(
             setActionProperty({

--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useCallback } from "react";
 import type { ControlType } from "constants/PropertyControlConstants";
 import FormControl from "pages/Editor/FormControl";
 import { Grid, Tabs, TabPanel, TabsList, Tab, Flex } from "@appsmith/ads";
@@ -46,20 +46,29 @@ const TabbedWrapper = styled(Tabs)`
 `;
 
 // Helper function to check if two arrays of params are functionally equivalent
-const areParamsEquivalent = (params1: Property[], params2: Property[]): boolean => {
+const areParamsEquivalent = (
+  params1: Property[],
+  params2: Property[],
+): boolean => {
   if (params1.length !== params2.length) return false;
-  
+
   // Create a map of key-value pairs for easier comparison
-  const paramsMap1 = params1.reduce((map, param) => {
-    if (param.key) map[param.key] = param.value;
-    return map;
-  }, {} as Record<string, any>);
-  
-  const paramsMap2 = params2.reduce((map, param) => {
-    if (param.key) map[param.key] = param.value;
-    return map;
-  }, {} as Record<string, any>);
-  
+  const paramsMap1 = params1.reduce(
+    (map, param) => {
+      if (param.key) map[param.key] = param.value;
+      return map;
+    },
+    {} as Record<string, unknown>,
+  );
+
+  const paramsMap2 = params2.reduce(
+    (map, param) => {
+      if (param.key) map[param.key] = param.value;
+      return map;
+    },
+    {} as Record<string, unknown>,
+  );
+
   return isEqual(paramsMap1, paramsMap2);
 };
 
@@ -70,104 +79,144 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
   // Refs to track the last values to prevent infinite loops
   const lastPathRef = useRef("");
   const lastParamsRef = useRef<Property[]>([]);
-  
-  useEffect(
-    function syncParamsEffect() {
-      if (!formValues || !formValues.values) return;
 
-      const values = formValues.values;
-      const actionId = values.id;
+  // Extract the sync logic into a separate function so we can call it imperatively
+  const syncParamsEffect = useCallback(() => {
+    if (!formValues || !formValues.values) return;
 
-      if (!actionId) return;
+    const values = formValues.values;
+    const actionId = values.id;
 
-      // Correctly access nested properties using lodash's get
-      const path = get(values, `${configProperty}.path`, "");
-      const queryParameters = get(values, `${configProperty}.params`, []);
-      
-      // Early return if nothing has changed
-      if (path === lastPathRef.current && isEqual(queryParameters, lastParamsRef.current)) {
-        return;
+    if (!actionId) return;
+
+    // Correctly access nested properties using lodash's get
+    const path = get(values, `${configProperty}.path`, "");
+    const queryParameters = get(values, `${configProperty}.params`, []);
+
+    // Early return if nothing has changed
+    if (
+      path === lastPathRef.current &&
+      isEqual(queryParameters, lastParamsRef.current)
+    ) {
+      return;
+    }
+
+    // Check if params have changed but path hasn't - indicating params tab update
+    const paramsChanged = !isEqual(queryParameters, lastParamsRef.current);
+    const pathChanged = path !== lastPathRef.current;
+
+    // Only one sync direction per effect execution to prevent loops
+
+    // Path changed - update params from path if needed
+    if (pathChanged) {
+      // Update refs to reflect current path value before parsing
+      lastPathRef.current = path;
+
+      // Check if we need to extract parameters from the path
+      const parsedParams = parseUrlForQueryParams(path);
+
+      // We want to update params in two cases:
+      // 1. URL has params and they differ from current params
+      // 2. URL has no params but we have params in the form (need to clear them)
+      const urlHasParams = path.includes("?");
+      const shouldClearParams =
+        !urlHasParams && queryParameters.some((p: Property) => p.key);
+      const shouldUpdateParams =
+        (parsedParams.length > 0 &&
+          !areParamsEquivalent(parsedParams, queryParameters)) ||
+        shouldClearParams;
+
+      if (shouldUpdateParams) {
+        // If URL has no params but we have params in the form, clear them
+        const updatedParams = shouldClearParams ? [] : parsedParams;
+
+        // Immediately update both the form and the action model
+        dispatch(autofill(formName, `${configProperty}.params`, updatedParams));
+
+        dispatch(
+          setActionProperty({
+            actionId: actionId,
+            propertyName: `${configProperty}.params`,
+            value: updatedParams,
+          }),
+        );
+
+        // Update ref to reflect the change we just made
+        lastParamsRef.current = updatedParams;
+      } else {
+        // Just update the ref without changing anything
+        lastParamsRef.current = [...queryParameters];
       }
 
-      // Check if params have changed but path hasn't - indicating params tab update
-      const paramsChanged = !isEqual(queryParameters, lastParamsRef.current);
-      const pathChanged = path !== lastPathRef.current;
-      
-      // Update refs to current values
-      lastPathRef.current = path;
+      return; // Exit to prevent double updates
+    }
+
+    // Params changed - update path from params if needed
+    if (paramsChanged) {
+      // Update refs to reflect current params before rebuilding path
       lastParamsRef.current = [...queryParameters];
 
-      // Only one sync direction per effect execution to prevent loops
-      
-      // Path changed - update params from path if needed
-      if (pathChanged) {
-        // Check if we need to extract parameters from the path
-        if (path) {
-          const parsedParams = parseUrlForQueryParams(path);
-          
-          // Only update params if they're different from current params
-          if (parsedParams.length > 0 && 
-              parsedParams.some((p) => p.key) && 
-              !areParamsEquivalent(parsedParams, queryParameters)) {
-            
-            dispatch(
-              autofill(formName, `${configProperty}.params`, parsedParams),
-            );
-            dispatch(
-              setActionProperty({
-                actionId: actionId,
-                propertyName: `${configProperty}.params`,
-                value: parsedParams,
-              }),
-            );
-            
-            // Update ref to reflect the change we just made
-            lastParamsRef.current = parsedParams;
-            return; // Exit to prevent double updates
-          }
+      // Extract base path without query parameters
+      const matchGroups = path.match(queryParamsRegEx) || [];
+      const currentPath = matchGroups[1] || "";
+
+      // Only build params string if we have any valid params
+      const validParams = queryParameters.filter((p: Property) => p.key);
+
+      // If we have valid params, build a new path with those params
+      if (validParams.length > 0) {
+        const paramsString = validParams
+          .map(
+            (p: Property, i: number) =>
+              `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
+          )
+          .join("");
+
+        // Create new path
+        const newPath = `${currentPath}${paramsString}`;
+
+        // Only update if path is actually different
+        if (path !== newPath) {
+          dispatch(autofill(formName, `${configProperty}.path`, newPath));
+          dispatch(
+            setActionProperty({
+              actionId: actionId,
+              propertyName: `${configProperty}.path`,
+              value: newPath,
+            }),
+          );
+
+          // Update ref to reflect the change we just made
+          lastPathRef.current = newPath;
+        }
+      } else {
+        // If no valid params, remove query part from path if it exists
+        if (path.includes("?")) {
+          const newPath = currentPath;
+
+          dispatch(autofill(formName, `${configProperty}.path`, newPath));
+          dispatch(
+            setActionProperty({
+              actionId: actionId,
+              propertyName: `${configProperty}.path`,
+              value: newPath,
+            }),
+          );
+
+          // Update ref to reflect the change we just made
+          lastPathRef.current = newPath;
+        } else {
+          // Just update the ref without changing anything
+          lastPathRef.current = path;
         }
       }
-      
-      // Params changed - update path from params if needed
-      if (paramsChanged) {
-        // If we have query params, update the path
-        if (queryParameters.length && queryParameters.some((p: Property) => p.key)) {
-          const matchGroups = path.match(queryParamsRegEx) || [];
-          const currentPath = matchGroups[1] || "";
-          // Only build params string if we have any valid params
-          const validParams = queryParameters.filter((p: Property) => p.key);
-  
-          if (validParams.length > 0) {
-            const paramsString = validParams
-              .map(
-                (p: Property, i: number) =>
-                  `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
-              )
-              .join("");
-  
-            // Create new path
-            const newPath = `${currentPath}${paramsString}`;
-  
-            // Only update if path is actually different
-            if (path !== newPath) {
-              dispatch(autofill(formName, `${configProperty}.path`, newPath));
-              dispatch(
-                setActionProperty({
-                  actionId: actionId,
-                  propertyName: `${configProperty}.path`,
-                  value: newPath,
-                }),
-              );
-              
-              // Update ref to reflect the change we just made
-              lastPathRef.current = newPath;
-            }
-          }
-        }
-      }
-    },
-    [formValues, dispatch, formName, configProperty],
-  );
+    }
+  }, [formValues, dispatch, formName, configProperty]);
+
+  // Run effect on formValues change
+  useEffect(() => {
+    syncParamsEffect();
+  }, [syncParamsEffect, formValues]);
 };
 
 const TabbedControls = (props: ControlProps) => {

--- a/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
+++ b/app/client/src/components/formControls/CustomActionsConfigControl/index.tsx
@@ -110,6 +110,7 @@ const useSyncParamsToPath = (formName: string, configProperty: string) => {
 
           // Don't update if already in sync (prevent loops)
           const newPath = `${currentPath}${paramsString}`;
+
           if (path !== newPath) {
             dispatch(autofill(formName, "actionConfiguration.path", newPath));
             dispatch(

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -124,6 +124,15 @@ function* syncApiParamsSaga(
         `${currentPath}${paramsString}`,
       ),
     );
+    
+    // Also update the action property to ensure the path is updated in the action
+    yield put(
+      setActionProperty({
+        actionId: actionId,
+        propertyName: "actionConfiguration.path",
+        value: `${currentPath}${paramsString}`,
+      }),
+    );
   }
 }
 

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -124,7 +124,7 @@ function* syncApiParamsSaga(
         `${currentPath}${paramsString}`,
       ),
     );
-    
+
     // Also update the action property to ensure the path is updated in the action
     yield put(
       setActionProperty({


### PR DESCRIPTION
# API Editor Query Parameters URL Auto-Update Fix

## Issue
When adding or editing query parameters in the API editor, the URL wasn't automatically being updated to reflect these changes. This creates a disconnect between the parameters in the Params tab and the actual URL being used, as reported in issue #40045.

## Fix
Implemented proper synchronization between query parameters and the URL in the API editor using a two-pronged approach:

1. **Component-level solution** with React hooks:
   - Added a `useSyncParamsToPath` hook that handles bidirectional synchronization
   - Ensures sync happens on component mount and when values change
   - Prevents update loops by checking if changes are needed

2. **Redux saga enhancement**:
   - Enhanced `syncApiParamsSaga` to ensure the action model is updated when params change
   - Provides a failsafe at the data layer in addition to the UI layer

These changes ensure:
- When query parameters are modified in the Params tab, the URL now updates automatically
- When the URL is modified with query parameters, they are correctly extracted to the Params tab
- Synchronization happens proactively rather than just reactively

## Changes
- Added new React hook for bidirectional synchronization
- Updated `syncApiParamsSaga` to handle API action data updates
- Addressed potential edge cases like empty parameters and update loops

## Test Strategy
No new test cases were added for the following reasons:
- This fix primarily addresses UI synchronization between two components
- The fix is easily verified through manual testing
- The functionality is already covered by existing integration tests for the API editor
- The changes are focused on visual state synchronization rather than core business logic
- The bug is easily reproduced and fixed by the UI components working together correctly

## Related Issue
Fixes #40045

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14332565088>
> Commit: 6de39d58842493a4eb514278a7c6e8dc458dc635
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14332565088&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 08 Apr 2025 12:29:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved synchronization between URL parameters and form inputs, ensuring real-time, consistent updates during user interactions.
  - Enhanced the API configuration interface by automatically reflecting changes to action parameters for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->