### PR TITLE
chore: Remove JS Visualisation

### DIFF
--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -42,8 +42,6 @@ import { StateInspector } from "./Debugger/StateInspector";
 import { getErrorCount } from "selectors/debuggerSelectors";
 import { getIDETypeByUrl } from "ee/entities/IDE/utils";
 import { useLocation } from "react-router";
-import { getIsAnvilEnabledInCurrentApplication } from "layoutSystems/anvil/integrations/selectors";
-import { Visualization } from "PluginActionEditor/components/PluginActionResponse/components/Visualization";
 
 const ResponseTabWrapper = styled.div`
   display: flex;
@@ -214,7 +212,6 @@ function JSResponseView(props: Props) {
 
   const ideViewMode = useSelector(getIDEViewMode);
   const location = useLocation();
-  const isAnvilEnabled = useSelector(getIsAnvilEnabledInCurrentApplication);
 
   const ideType = getIDETypeByUrl(location.pathname);
 
@@ -226,20 +223,6 @@ function JSResponseView(props: Props) {
         panelComponent: JSResponseTab,
       },
     ];
-
-    if (isAnvilEnabled) {
-      responseTabs.push({
-        key: DEBUGGER_TAB_KEYS.VISUALIZATION_TAB,
-        title: "AI Response Visualizer",
-        panelComponent: currentFunction && (
-          <Visualization
-            entityId={currentFunction.id}
-            response={response.value}
-            visualizationElements={currentFunction.visualization?.result}
-          />
-        ),
-      });
-    }
 
     const jsTabs: BottomTab[] = [
       ...responseTabs,


### PR DESCRIPTION
## Description

Remove Visualisation tab fro JS Editor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the response view interface by removing the legacy visualizer tab, streamlining the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->