### PR TITLE
fix(helm): spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy  is 'Recreate'

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -18,9 +18,11 @@ spec:
   {{- else }}
   strategy:
     type: {{ .Values.strategyType | default "RollingUpdate" }}
+  {{- if eq .Values.strategyType "RollingUpdate" }}
     rollingUpdate:
       maxSurge: {{ dig "maxSurge" 1 $updateStrategy }}
       maxUnavailable: {{ dig "maxUnavailable" "0" $updateStrategy }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
@@ -166,7 +168,7 @@ spec:
       volumes:
       {{- if .Values.customCAcert }}
       - name: ca-cert
-        configMap: 
+        configMap:
           name: {{ $releaseName }}-trustedca
           items:
           {{- range $key, $value := .Values.customCAcert }}


### PR DESCRIPTION


## Description

When setting `.Values.strategyType: Recreate` during Helm install or upgrade, the installation fails with the following error message:

```
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy  is 'Recreate'
```

This is because the Helm Chart still renders the `rollingUpdate` even though the strategy is not set to `RollingUpdate`.

See the [Kubernetes API Reference Docs for Deployments](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#deploymentstrategy-v1-apps) for reference.

In case you have any suggestions or improvements, let me know.

Best regards,
Florian.