### PR TITLE
chore: Hiding the embedding restricted field in share modal for cloud billing

### DIFF
--- a/app/client/src/ce/pages/Applications/EmbedSnippetTab.tsx
+++ b/app/client/src/ce/pages/Applications/EmbedSnippetTab.tsx
@@ -140,6 +140,7 @@ export function AppSettings() {
     isPublicApp,
     selectedMethod,
   );
+  const isCloudBillingEnabled = useIsCloudBillingEnabled();
 
   return (
     <EmbedWrapper className="px-4">
@@ -148,7 +149,7 @@ export function AppSettings() {
       </Text>
 
       <div className="flex flex-col gap-6">
-        {embedSnippet.isSuperUser && (
+        {embedSnippet.isSuperUser && !isCloudBillingEnabled && (
           <div className="flex justify-between">
             <div className="flex gap-1" data-testid="frame-ancestors-setting">
               <Icon

--- a/app/client/src/ce/pages/Applications/EmbedSnippetTab.tsx
+++ b/app/client/src/ce/pages/Applications/EmbedSnippetTab.tsx
@@ -14,6 +14,7 @@ import { ADMIN_SETTINGS_PATH } from "constants/routes";
 import { defaultOptionSelected, to, getSnippetUrl } from "ee/utils";
 import { PrivateEmbedSettings } from "ee/pages/Applications/PrivateEmbedSettings";
 import { getCurrentApplication } from "ee/selectors/applicationSelectors";
+import { useIsCloudBillingEnabled } from "hooks";
 
 export const StyledPropertyHelpLabel = styled(PropertyHelpLabel)`
   .bp3-popover-content > div {
@@ -54,10 +55,11 @@ export function ShareModal() {
     isPublicApp,
     selectedMethod,
   );
+  const isCloudBillingEnabled = useIsCloudBillingEnabled();
 
   return (
     <div className="flex flex-col gap-6">
-      {embedSnippet.isSuperUser && (
+      {embedSnippet.isSuperUser && !isCloudBillingEnabled && (
         <div className="flex justify-between">
           <div className="flex gap-1" data-testid="frame-ancestors-setting">
             <Icon


### PR DESCRIPTION
## Description

Hiding the embedding restricted field in share modal for cloud billing

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.AccessControl, @tag.Workspace"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14325375580>
> Commit: 5ce5d50ab6f6fd8a13a09e1bc01f5d92a2bef7bc
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14325375580&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.AccessControl, @tag.Workspace`
> Spec:
> <hr>Tue, 08 Apr 2025 05:42:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the display logic in the share interface so that administrative settings now appear only when the user has the required privileges and the cloud billing feature is not enabled. This update ensures that relevant options are shown accurately based on the billing status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->