### PR TITLE
chore: Updating to logic to handle toggle changes when reverted manually should disable the save button on Admin settings

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
@@ -121,7 +121,9 @@ export const FormAuth: AdminConfigType = {
           return false;
         }
 
-        return settings.emailVerificationEnabled && mailEnabled;
+        return (
+          settings.emailVerificationEnabled && mailEnabled && !isMultiOrgEnabled
+        );
       },
     },
     {
@@ -137,7 +139,11 @@ export const FormAuth: AdminConfigType = {
           return false;
         }
 
-        if (!mailEnabled && settings.emailVerificationEnabled) {
+        if (
+          !mailEnabled &&
+          settings.emailVerificationEnabled &&
+          !isMultiOrgEnabled
+        ) {
           return true;
         }
 

--- a/app/client/src/pages/AdminSettings/SettingsForm.tsx
+++ b/app/client/src/pages/AdminSettings/SettingsForm.tsx
@@ -395,7 +395,8 @@ export default withRouter(
     _.forEach(AdminConfig.settingsMap, (setting, name) => {
       const fieldValue = selector(state, name);
       const doNotUpdate =
-        setting.controlType === SettingTypes.CHECKBOX &&
+        (setting.controlType === SettingTypes.CHECKBOX ||
+          setting.controlType === SettingTypes.TOGGLE) &&
         !settingsConfig[name] &&
         !fieldValue;
 


### PR DESCRIPTION
## Description

Updating to logic to handle toggle changes when reverted manually should disable the save button on Admin settings

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
