### PR TITLE
chore: Enable the form login by default

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/OrganizationConfigurationCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/OrganizationConfigurationCE.java
@@ -81,7 +81,7 @@ public class OrganizationConfigurationCE implements Serializable {
 
         googleMapsKey = ObjectUtils.defaultIfNull(organizationConfiguration.getGoogleMapsKey(), googleMapsKey);
         isFormLoginEnabled =
-                ObjectUtils.defaultIfNull(organizationConfiguration.getIsFormLoginEnabled(), isFormLoginEnabled);
+                getComputedValue(true, organizationConfiguration.getIsFormLoginEnabled(), isFormLoginEnabled);
         isSignupDisabled = ObjectUtils.defaultIfNull(organizationConfiguration.getIsSignupDisabled(), isSignupDisabled);
         instanceName = ObjectUtils.defaultIfNull(organizationConfiguration.getInstanceName(), instanceName);
         emailVerificationEnabled = ObjectUtils.defaultIfNull(
@@ -91,6 +91,13 @@ public class OrganizationConfigurationCE implements Serializable {
         migrationStatus = organizationConfiguration.getMigrationStatus();
         isStrongPasswordPolicyEnabled = organizationConfiguration.getIsStrongPasswordPolicyEnabled();
         isAtomicPushAllowed = organizationConfiguration.getIsAtomicPushAllowed();
+    }
+
+    protected static <T> T getComputedValue(T defaultValue, T updatedValue, T currentValue) {
+        if (currentValue == null && updatedValue == null) {
+            return defaultValue;
+        }
+        return ObjectUtils.defaultIfNull(updatedValue, currentValue);
     }
 
     public static class Fields {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
@@ -173,6 +173,49 @@ class OrganizationServiceCETest {
     }
 
     @Test
+    @WithUserDetails("api_user")
+    void updateOrganizationConfiguration_updateFormLoginEnabled_success() {
+
+        // Ensure that default value for form login is enabled
+        Mono<Organization> organizationMono = organizationService.getOrganizationConfiguration();
+        StepVerifier.create(organizationMono)
+                .assertNext(organization -> {
+                    assertThat(organization.getOrganizationConfiguration().getIsFormLoginEnabled())
+                            .isTrue();
+                })
+                .verifyComplete();
+
+        // Ensure that the form login is disabled after the update
+        final OrganizationConfiguration changes = new OrganizationConfiguration();
+        changes.setIsFormLoginEnabled(FALSE);
+        Mono<OrganizationConfiguration> resultMono = organizationService
+                .updateOrganizationConfiguration(changes)
+                .then(organizationService.getOrganizationConfiguration())
+                .map(Organization::getOrganizationConfiguration);
+
+        StepVerifier.create(resultMono)
+                .assertNext(organizationConfiguration -> {
+                    assertThat(organizationConfiguration.getIsFormLoginEnabled())
+                            .isFalse();
+                })
+                .verifyComplete();
+
+        // Ensure that the form login is enabled after the update
+        changes.setIsFormLoginEnabled(TRUE);
+        resultMono = organizationService
+                .updateOrganizationConfiguration(changes)
+                .then(organizationService.getOrganizationConfiguration())
+                .map(Organization::getOrganizationConfiguration);
+
+        StepVerifier.create(resultMono)
+                .assertNext(organizationConfiguration -> {
+                    assertThat(organizationConfiguration.getIsFormLoginEnabled())
+                            .isTrue();
+                })
+                .verifyComplete();
+    }
+
+    @Test
     @WithUserDetails("anonymousUser")
     void getOrganizationConfig_Valid_AnonymousUser() {
         StepVerifier.create(organizationService.getOrganizationConfiguration())


### PR DESCRIPTION
## Description

PR to provide fallback for form login state when it's not explicitly set by the user.Enable the form login by default

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14326905886>
> Commit: 58ecbe074e2f8b371b55542a273be80379adfc6d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14326905886&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Tue, 08 Apr 2025 07:02:34 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the behavior for updating organization login settings so that the correct default is consistently applied, ensuring a more reliable configuration update.
  
- **Tests**
  - Added tests to verify that changes to the login setting are applied as expected, enhancing confidence in the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->