### PR TITLE
chore: Updating upgrade link for cloud billing

### DIFF
--- a/app/client/src/utils/hooks/useOnUpgrade.ts
+++ b/app/client/src/utils/hooks/useOnUpgrade.ts
@@ -12,6 +12,8 @@ import type {
   RampFeature,
   RampSection,
 } from "utils/ProductRamps/RampsControlList";
+import { useIsCloudBillingEnabled } from "hooks";
+import { WORKSPACE_SETTINGS_LICENSE_PAGE_URL } from "constants/routes";
 
 interface Props {
   logEventName?: EventName;
@@ -28,6 +30,7 @@ const useOnUpgrade = (props: Props) => {
     props;
   const instanceId = useSelector(getInstanceId);
   const appsmithConfigs = getAppsmithConfigs();
+  const isCloudBillingEnabled = useIsCloudBillingEnabled();
 
   const onUpgrade = () => {
     AnalyticsUtil.logEvent(
@@ -45,6 +48,8 @@ const useOnUpgrade = (props: Props) => {
           sectionName,
         ),
       );
+    } else if (isCloudBillingEnabled) {
+      window.open(WORKSPACE_SETTINGS_LICENSE_PAGE_URL, "_blank");
     } else {
       window.open(
         CUSTOMER_PORTAL_URL_WITH_PARAMS(


### PR DESCRIPTION
## Description

Updating upgrade link for cloud billing

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14328221969>
> Commit: 7502e28220824eba1461cb9f981be9392f3efea8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14328221969&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Tue, 08 Apr 2025 08:22:33 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Adjusted link behavior so that when multi-organization features are active, users are directed to a dedicated settings page.
  - Enhanced the upgrade process to detect cloud billing activation and open the appropriate licensing page for a more seamless experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->