### PR TITLE
fix: fixed support for IPV6 connections in the Postgres plugin

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/BasePluginErrorMessages.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/BasePluginErrorMessages.java
@@ -16,8 +16,7 @@ public abstract class BasePluginErrorMessages {
     public static final String DS_MISSING_SSH_USERNAME_ERROR_MSG = "Missing SSH username for authentication.";
     public static final String DS_MISSING_SSH_KEY_ERROR_MSG = "Missing SSH key for authentication.";
     public static final String DS_MISSING_SSH_HOSTNAME_ERROR_MSG = "SSH host value cannot be empty";
-    public static final String DS_INVALID_SSH_HOSTNAME_ERROR_MSG =
-            "SSH host value cannot contain `/` or `:` " + "characters.";
+    public static final String DS_INVALID_SSH_HOSTNAME_ERROR_MSG = "SSH host value cannot contain `/` characters.";
     public static final String INVALID_SSH_KEY_FORMAT_ERROR_MSG =
             "Invalid SSH key format. Supported formats: OpenSSH, PKCS#8, or RSA PEM.";
     public static final String SSH_KEY_PARSING_ERROR_MSG = "The provided SSH key could not be parsed.";

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -710,8 +710,7 @@ public class PostgresPlugin extends BasePlugin {
                 for (final Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
                     if (StringUtils.isEmpty(endpoint.getHost())) {
                         invalids.add(PostgresErrorMessages.DS_MISSING_HOSTNAME_ERROR_MSG);
-                    } else if (endpoint.getHost().contains("/")
-                            || endpoint.getHost().contains(":")) {
+                    } else if (!isValidHostname(endpoint.getHost())) {
                         invalids.add(
                                 String.format(PostgresErrorMessages.DS_INVALID_HOSTNAME_ERROR_MSG, endpoint.getHost()));
                     }
@@ -757,7 +756,7 @@ public class PostgresPlugin extends BasePlugin {
                     invalids.add(DS_MISSING_SSH_HOSTNAME_ERROR_MSG);
                 } else {
                     String sshHost = datasourceConfiguration.getSshProxy().getHost();
-                    if (sshHost.contains("/") || sshHost.contains(":")) {
+                    if (sshHost.contains("/")) {
                         invalids.add(DS_INVALID_SSH_HOSTNAME_ERROR_MSG);
                     }
                 }
@@ -1168,6 +1167,24 @@ public class PostgresPlugin extends BasePlugin {
                     throw new IllegalArgumentException(
                             "Unable to map the computed data type to primitive Postgresql type");
             }
+        }
+
+        private static boolean isValidHostname(String hostname) {
+            if (hostname == null) {
+                return false;
+            }
+
+            // Check for forward slashes
+            if (hostname.contains("/")) {
+                return false;
+            }
+
+            // Check for jdbc: prefix which is not allowed
+            if (hostname.startsWith("jdbc:")) {
+                return false;
+            }
+
+            return true;
         }
     }
 

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/exceptions/PostgresErrorMessages.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/exceptions/PostgresErrorMessages.java
@@ -38,7 +38,7 @@ public class PostgresErrorMessages extends BasePluginErrorMessages {
     public static final String DS_MISSING_HOSTNAME_ERROR_MSG = "Missing hostname.";
 
     public static final String DS_INVALID_HOSTNAME_ERROR_MSG =
-            "Host value cannot contain `/` or `:` characters. Found `%s`.";
+            "Host value cannot contain `/` characters or start with `jdbc:`. Found `%s`.";
 
     public static final String DS_MISSING_CONNECTION_MODE_ERROR_MSG = "Missing connection mode.";
 

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/form.json
@@ -51,7 +51,7 @@
               "configProperty": "datasourceConfiguration.endpoints[*].host",
               "controlType": "KEYVALUE_ARRAY",
               "validationMessage": "Please enter a valid host",
-              "validationRegex": "^((?![/:]).)*$",
+              "validationRegex": "^((?![/]).)*$",
               "placeholderText": "myapp.abcde.postgres.net"
             },
             {
@@ -72,7 +72,7 @@
               "configProperty": "datasourceConfiguration.sshProxy.endpoints[*].host",
               "controlType": "KEYVALUE_ARRAY",
               "validationMessage": "Please enter a valid host",
-              "validationRegex": "^((?![/:]).)*$",
+              "validationRegex": "^((?![/]).)*$",
               "placeholderText": "myapp.abcde.sshHost.net"
             },
             {

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -55,10 +55,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
+import static org.bson.assertions.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
@@ -601,10 +601,9 @@ public class PostgresPluginTest {
 
     @Test
     public void itShouldValidateDatasourceWithInvalidHostname() {
-
         String hostname = "jdbc://localhost";
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        dsConfig.getEndpoints().get(0).setHost("jdbc://localhost");
+        dsConfig.getEndpoints().get(0).setHost(hostname);
 
         assertEquals(
                 Set.of(String.format(PostgresErrorMessages.DS_INVALID_HOSTNAME_ERROR_MSG, hostname)),


### PR DESCRIPTION
## Description
> This PR fixes the support for IPV6 connections in the Postgres Plugin. Earlier only IPV4 connections were supported due to a bug in the plugin implementation. 

Fixes #40082 

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14328937437>
> Commit: 623ac8e3fc02265305a349ebf2bfe5593f092e93
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14328937437&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 08 Apr 2025 09:16:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clarified error messaging for invalid host entries, ensuring that host values now correctly reject entries containing the forward slash and those starting with a prohibited prefix.
  - Refined hostname validation for both standard and SSH configurations for more consistent error feedback.

- **Tests**
  - Expanded test coverage to validate various hostname formats, including IPv6 scenarios, ensuring that invalid inputs trigger the appropriate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->