### PR TITLE
chore: fixes issue with disabled branch button

### DIFF
--- a/app/client/src/git/sagas/triggerAutocommitSaga.ts
+++ b/app/client/src/git/sagas/triggerAutocommitSaga.ts
@@ -1,4 +1,3 @@
-import { triggerAutocommitSuccessAction } from "actions/gitSyncActions";
 import { AutocommitStatusState } from "git/constants/enums";
 import fetchAutocommitProgressRequest from "git/requests/fetchAutocommitProgressRequest";
 import type {
@@ -151,6 +150,6 @@ export default function* triggerAutocommitSaga(
     yield take(gitArtifactActions.pollAutocommitProgressStop.type);
     yield cancel(pollTask);
   } else {
-    yield put(triggerAutocommitSuccessAction());
+    yield put(gitArtifactActions.triggerAutocommitSuccess({ artifactDef }));
   }
 }


### PR DESCRIPTION
## Description
- Users with "developer" access to an app were finding the branch switch button disabled
- The issue is occurring due to a bug in the autocommit flow. This PR fixes it 

Fixes https://github.com/appsmithorg/appsmith/issues/40162

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14337186264>
> Commit: 5803065bc71df9f9c36aa7a14fdac9ed94e7d0f5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14337186264&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Tue, 08 Apr 2025 16:13:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the autocommit process by enhancing the success-handling logic with additional context details. This change refines how commit actions are processed, ensuring more precise state updates during the commit workflow while preserving the existing functional flow. These modifications help significantly streamline internal operations without affecting the overall seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->