### PR TITLE
feat: Add isWithinAnOrganization state to organization reducer

### DIFF
--- a/app/client/src/ce/reducers/organizationReducer.ts
+++ b/app/client/src/ce/reducers/organizationReducer.ts
@@ -18,6 +18,7 @@ export interface OrganizationReduxState<T> {
   isLoading: boolean;
   instanceId: string;
   tenantId: string;
+  isWithinAnOrganization: boolean;
 }
 
 export const defaultBrandingConfig = {
@@ -39,6 +40,7 @@ export const initialState: OrganizationReduxState<any> = {
   isLoading: true,
   instanceId: "",
   tenantId: "",
+  isWithinAnOrganization: false,
 };
 
 export const handlers = {
@@ -73,6 +75,7 @@ export const handlers = {
     isLoading: false,
     instanceId: action.payload.instanceId,
     tenantId: action.payload.tenantId,
+    isWithinAnOrganization: action.payload.isWithinAnOrganization,
   }),
   [ReduxActionErrorTypes.FETCH_CURRENT_ORGANIZATION_CONFIG_ERROR]: (
     // TODO: Fix this the next time the file is edited


### PR DESCRIPTION
- Introduced a new state property `isWithinAnOrganization` to the OrganizationReduxState interface.
- Initialized `isWithinAnOrganization` to false in the initial state.
- Updated the reducer to handle the new property when fetching current organization configuration.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14333864526>
> Commit: 4550ddeea26f0c4a8cc8fdf34c5212a734e59f25
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14333864526&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 08 Apr 2025 13:40:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the application’s ability to detect your organizational context, ensuring that your experience adapts appropriately when you’re operating within an organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->