### PR TITLE
feat(helm): add option to specifiy extra env and envFrom for the appsmith container

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -144,6 +144,9 @@ spec:
               value: kubernetes.KUBE_PING
             - name: APPSMITH_HEADLESS_SVC
               value: {{ include "appsmith.fullname" . }}-headless
+            {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "appsmith.fullname" . }}
@@ -159,6 +162,9 @@ spec:
             - secretRef:
                 name: "{{ include "appsmith.fullname" . }}-external-secret"
             {{- end }}
+            {{- if .Values.extraEnvFrom }}
+            {{- toYaml .Values.extraEnvFrom | nindent 12 }}
+            {{- end }}
       {{- if .Values.image.pullSecrets}}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecrets }}
@@ -166,7 +172,7 @@ spec:
       volumes:
       {{- if .Values.customCAcert }}
       - name: ca-cert
-        configMap: 
+        configMap:
           name: {{ $releaseName }}-trustedca
           items:
           {{- range $key, $value := .Values.customCAcert }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -444,3 +444,18 @@ applicationConfig:
   APPSMITH_KEYCLOAK_DB_USERNAME: ""
   APPSMITH_KEYCLOAK_DB_PASSWORD: ""
   APPSMITH_KEYCLOAK_DB_URL: ""
+
+# -- Additional environment variables to add to the appsmith container
+extraEnv: []
+# - name: DEMO_GREETING
+#   value: "Hello from the environment"
+# - name: SECRET_USERNAME
+#   valueFrom:
+#     secretKeyRef:
+#       name: backend-user
+#       key: backend-username
+
+# -- Additional secrets or configmaps to reference in envFrom in the appsmith container
+extraEnvFrom: []
+# - secretRef:
+#     name: test-secret


### PR DESCRIPTION
## Description

This PR adds two additional options to allow additional environment variables (with env and envFrom) to be added to the appsmith container.

We use this to add additional secrets generated by our controllers (e.g. crossplane aws-provider) as environment variables into the appsmith container.

An example values.yaml could look like this:

```yaml
extraEnv:
- name: APPSMITH_MAIL_USERNAME
  valueFrom:
    secretKeyRef:
      name: smtp-credentials
      key: username
- name: APPSMITH_MAIL_PASSWORD
  valueFrom:
    secretKeyRef:
      name: smtp-credentials
      key: password
```

If you have any suggestions or questions please let me know.

Best regards,
Florian.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new configuration options that enable users to include supplementary environment variables and external sources during deployment for enhanced application flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->