### PR TITLE
chore: add unique index on organization slug in MongoDB

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Organization.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Organization.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
-import org.checkerframework.common.aliasing.qual.Unique;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -20,7 +19,7 @@ import java.io.Serializable;
 @FieldNameConstants
 public class Organization extends BaseDomain implements Serializable {
 
-    @Unique String slug;
+    String slug;
 
     String displayName;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration073_AddUniqueIndexOnOrganizationSlug.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration073_AddUniqueIndexOnOrganizationSlug.java
@@ -1,0 +1,48 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.server.domains.Organization;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+
+import static com.appsmith.server.migrations.DatabaseChangelog1.dropIndexIfExists;
+import static com.appsmith.server.migrations.DatabaseChangelog1.ensureIndexes;
+import static com.appsmith.server.migrations.DatabaseChangelog1.makeIndex;
+
+@Slf4j
+@ChangeUnit(order = "073", id = "add-unique-index-on-organization-slug", author = "")
+public class Migration073_AddUniqueIndexOnOrganizationSlug {
+
+    private final MongoTemplate mongoTemplate;
+
+    public Migration073_AddUniqueIndexOnOrganizationSlug(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void rollbackExecution() {
+        // No rollback necessary
+    }
+
+    @Execution
+    public void addUniqueIndexOnOrganizationSlug() {
+        log.info("Adding unique index on organization slug field");
+        try {
+            // First drop the index if it exists (to ensure idempotence)
+            dropIndexIfExists(mongoTemplate, Organization.class, "slug");
+
+            // Create unique index on the slug field
+            Index slugIndex = makeIndex("slug").named("slug").unique().background();
+
+            ensureIndexes(mongoTemplate, Organization.class, slugIndex);
+
+            log.info("Successfully added unique index on organization slug field");
+        } catch (Exception e) {
+            log.error("Error adding unique index on organization slug field", e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Introduced a new migration to add a unique index on the 'slug' field of the Organization collection.
- Ensured idempotence by dropping the existing index before creating the new one.
- Added logging for successful index creation and error handling for potential issues during the process.

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated how organization identifiers are validated to ensure each remains unique.
- **Chores**
  - Introduced a database update that enforces uniqueness for organization identifiers, enhancing data consistency and preventing duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->