### PR TITLE
refactor: update terminology for new row options in select widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -344,8 +344,8 @@ describe(
 
     it("11. should check that 'new row select options' is working", () => {
       const checkNewRowOptions = () => {
-        // New row select options should be visible when "Same options in new row" is turned off
-        _.propPane.TogglePropertyState("Same options in new row", "Off");
+        // New row select options should be visible when "Use top row values in new rows" is turned off
+        _.propPane.TogglePropertyState("Use top row values in new rows", "Off");
         cy.get(".t--property-control-newrowoptions").should("exist");
 
         // New row select options should appear in table

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -279,7 +279,8 @@ describe(
         _.propPane.OpenTableColumnSettings("step");
         _.propPane.AssertPropertySwitchState(
           "Use top row values in new rows",
-          "enabled",);
+          "enabled",
+        );
 
         cy.get(".t--property-control-newrowoptions").should("not.exist");
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/Select1_spec.ts
@@ -277,13 +277,10 @@ describe(
         _.propPane.TogglePropertyState("Allow adding a row", "On");
 
         _.propPane.OpenTableColumnSettings("step");
+        _.propPane.AssertPropertySwitchState(
+          "Use top row values in new rows",
+          "enabled",);
 
-        cy.get(".t--property-control-sameoptionsinnewrow input").should(
-          "have.attr",
-          "checked",
-        );
-
-        // Check if newrowoption is invisible when sameoptionsinnewrow is true
         cy.get(".t--property-control-newrowoptions").should("not.exist");
 
         cy.updateCodeInput(

--- a/app/client/src/widgets/TableWidgetV2/widget/__tests__/utilities.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/__tests__/utilities.test.ts
@@ -2712,7 +2712,7 @@ describe("getSelectOptions", () => {
     ]);
   });
 
-  it("Should return select options while adding a new row and when 'Same options in new row' option is turned on", () => {
+  it("Should return select options while adding a new row and when 'Use top row values in new rows' option is turned on", () => {
     const columnProperties = {
       allowSameOptionsInNewRow: true,
       selectOptions: [

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Select.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/Select.ts
@@ -72,7 +72,7 @@ export default {
       defaultValue: true,
       helpText:
         "Toggle to display same choices for new row and editing existing row in column",
-      label: "Same options in new row",
+      label: "Use top row values in new rows",
       controlType: "SWITCH",
       isBindProperty: true,
       isJSConvertible: true,


### PR DESCRIPTION
## Description

Adhering to user recommendation: https://github.com/appsmithorg/appsmith/issues/20230#issuecomment-2785940800

Updated the label to clarify the meaning of config.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14375355147>
> Commit: 7b0f939203b3d3efa7c0795bf7855bd553ecf430
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14375355147&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Thu, 10 Apr 2025 09:18:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the Table widget’s configuration label from “Same options in new row” to “Use top row values in new rows” to provide clearer guidance on how select options work when adding rows.
  - Enhanced test descriptions to reflect the updated terminology, ensuring clarity in functionality related to select options when adding new rows.
  
- **Bug Fixes**
  - Adjusted test logic to ensure correct visibility of new row select options based on the updated configuration setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->