### PR TITLE
chore: Add `organizationId` in MDC logs to ease debugging in multi-org setup

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/MDCFilter.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/filters/MDCFilter.java
@@ -4,11 +4,11 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.LogHelper;
 import com.appsmith.server.helpers.UserOrganizationHelper;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -50,7 +50,9 @@ public class MDCFilter implements WebFilter {
         try {
             return ReactiveSecurityContextHolder.getContext()
                     .map(ctx -> ctx.getAuthentication().getPrincipal())
-                    .zipWith(userOrganizationHelper.getCurrentUserOrganizationId())
+                    .zipWith(userOrganizationHelper
+                            .getCurrentUserOrganizationId()
+                            .defaultIfEmpty(""))
                     .flatMap(tuple2 -> {
                         final Object principal = tuple2.getT1();
                         final String organizationId = tuple2.getT2();
@@ -74,7 +76,7 @@ public class MDCFilter implements WebFilter {
             contextMap.put(USER_EMAIL, user.getEmail());
         }
 
-        if (organizationId != null) {
+        if (StringUtils.hasLength(organizationId)) {
             contextMap.put(ORGANIZATION_ID, organizationId);
         }
 

--- a/app/server/appsmith-server/src/main/resources/application-ce.properties
+++ b/app/server/appsmith-server/src/main/resources/application-ce.properties
@@ -32,7 +32,7 @@ appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:150}
 logging.level.root=info
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
-logging.pattern.console=[%d{ISO8601, UTC}] [%t] requestId=%X{X-Appsmith-Request-Id} userEmail=%X{userEmail} traceId=%X{traceId} spanId=%X{spanId} - %m%n
+logging.pattern.console=[%d{ISO8601, UTC}] [%t] requestId=%X{X-Appsmith-Request-Id} userEmail=%X{userEmail} orgId=%X{organizationId} traceId=%X{traceId} spanId=%X{spanId} - %m%n
 
 #Spring security
 spring.security.oauth2.client.registration.google.client-id=${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:missing_value_sentinel}


### PR DESCRIPTION
## Description


Sample log: 
```
[2025-04-10 18:19:30,460] [nioEventLoopGroup-3-4] requestId= userEmail=anonymousUser orgId=67e293c5428efb42aed44e11 traceId=6141b52a410b60168b68a6ce72e4d601 spanId=45c1771528e79d6d - Going to fetch consolidatedAPI response for applicationId: null, defaultPageId: null, branch: null, mode: PUBLISHED
```

/test Sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14387773115>
> Commit: e345a8d98448afd176be2504983ca3d95d04200c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14387773115&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 10 Apr 2025 19:11:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging output now includes an organization identifier alongside request and user details, improving traceability and contextual insight for server events.  
	- Server-side processes now capture additional organization context with each request, providing richer and more informative log entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->