### PR TITLE
fix: added null checks for accessing published actionDTO before export

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
@@ -719,7 +719,6 @@ public class FileUtilsCEImpl implements FileInterface {
 
     @Override
     public Mono<GitResourceMap> constructGitResourceMapFromGitRepo(Path repositorySuffix, String refName) {
-        // TODO: check that we need to checkout to the ref
         Path repositoryPath = Paths.get(gitServiceConfig.getGitRootPath()).resolve(repositorySuffix);
         return Mono.fromCallable(() -> fetchGitResourceMap(repositoryPath)).subscribeOn(scheduler);
     }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/RefAwareDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/RefAwareDomain.java
@@ -55,6 +55,8 @@ public abstract class RefAwareDomain extends GitSyncedDomain {
     public void sanitiseToExportDBObject() {
         this.setBaseId(null);
         this.setBranchName(null);
+        this.setRefType(null);
+        this.setRefName(null);
         super.sanitiseToExportDBObject();
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -288,7 +288,7 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
 
         return fsGitHandler
                 .resetToLastCommit(repoSuffix)
-                .then(commonGitFileUtils.constructArtifactExchangeJsonFromGitRepositoryWithAnalytics(
+                .flatMap(resetFlag -> commonGitFileUtils.constructArtifactExchangeJsonFromGitRepositoryWithAnalytics(
                         artifactJsonTransformationDTO));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -1480,7 +1480,9 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
             List<String> unpublishedPages, Optional<AclPermission> optionalPermission) {
         return repository.findByPageIds(unpublishedPages, optionalPermission).doOnNext(newAction -> {
             this.setCommonFieldsFromNewActionIntoAction(newAction, newAction.getUnpublishedAction());
-            this.setCommonFieldsFromNewActionIntoAction(newAction, newAction.getPublishedAction());
+            if (newAction.getPublishedAction() != null) {
+                this.setCommonFieldsFromNewActionIntoAction(newAction, newAction.getPublishedAction());
+            }
         });
     }
 


### PR DESCRIPTION
## Description

Fixes #https://github.com/appsmithorg/appsmith/issues/40159

## Automation

/ok-to-test tags="@tag.Git, @tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14396287758>
> Commit: 42379619c5e7b6ca6761688d510cafb37991df87
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14396287758&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git, @tag.ImportExport`
> Spec:
> <hr>Fri, 11 Apr 2025 06:25:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data export to ensure all relevant fields are correctly sanitized.
  - Added safety checks to prevent potential runtime errors during action processing.
  
- **Refactor**
  - Enhanced asynchronous processing flow for more robust operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->