### PR TITLE
chore: Adjust nested paddings in markdown

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
@@ -79,9 +79,14 @@
 
   li {
     margin-bottom: var(--inner-spacing-2);
+    margin-left: 0.5em;
     position: relative;
     list-style-type: auto;
     letter-spacing: -0.02em;
+  }
+
+  > :is(ul, ol) > li {
+    margin-left: 1em;
   }
 
   a {


### PR DESCRIPTION
## Description

Part of https://github.com/appsmithorg/appsmith-ee/pull/7148

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14471353200>
> Commit: 08688d97af60ec7a816128844b34e3868dba7911
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14471353200&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 15 Apr 2025 14:42:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved indentation for list items in markdown content, increasing left margin for nested lists to enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->