### PR TITLE
fix: Bad mixpanel config arising from env

### DIFF
--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -213,7 +213,7 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
       apiKey: googleRecaptchaSiteKey.value,
     },
     mixpanel: {
-      enabled: segment.enabled,
+      enabled: segment.enabled && mixpanel.enabled,
       apiKey: mixpanel.value,
     },
     cloudHosting:


### PR DESCRIPTION
## Description

Earlier we were only checking for segment enabled to turn on mixpanel. But an error happened when segment was enabled on a deployment but mixpanel key was not present. This cause mixpanel config to be true but without a key

To avoid this, we will also confirm mixpanel key exists and not just segment

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14474665480>
> Commit: 2edc7ceece29ea7136d0a14f5f756f8a778b8bd0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14474665480&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 15 Apr 2025 17:18:28 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of Mixpanel tracking settings, ensuring Mixpanel is only enabled when both Segment and Mixpanel tracking are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->