### PR TITLE
fix: Adjust markdown lists margin

### DIFF
--- a/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
+++ b/app/client/packages/design-system/widgets/src/components/Markdown/src/styles.module.css
@@ -79,14 +79,14 @@
 
   li {
     margin-bottom: var(--inner-spacing-2);
-    margin-left: 0.5em;
+    margin-left: 1em;
     position: relative;
     list-style-type: auto;
     letter-spacing: -0.02em;
   }
 
   > :is(ul, ol) > li {
-    margin-left: 1em;
+    margin-left: 2em;
   }
 
   a {


### PR DESCRIPTION
## Description

Prevents overflowing up to hundreds.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14489373046>
> Commit: eb22618f3c269fb34711555d5c8e2b1312ead7b6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14489373046&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 16 Apr 2025 10:10:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved indentation for list items in markdown content for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->