### PR TITLE
chore: filter out AI Datasource during import

### DIFF
--- a/app/client/src/sagas/TemplatesSagas.ts
+++ b/app/client/src/sagas/TemplatesSagas.ts
@@ -48,6 +48,7 @@ import { failFastApiCalls } from "./InitSagas";
 import { getAllPageIdentities } from "./selectors";
 
 const isAirgappedInstance = isAirgapped();
+const AI_DATASOURCE_NAME = "AI Datasource";
 
 function* getAllTemplatesSaga() {
   try {
@@ -96,12 +97,20 @@ function* importTemplateToWorkspaceSaga(
         payload: response.data.application,
       });
 
-      if (response.data.isPartialImport) {
+      // Temporary fix to remove AI Datasource from the unConfiguredDatasourceList
+      // so we can avoid showing the AI Datasource in reconnect datasource modal
+      const filteredUnConfiguredDatasourceList = (
+        response.data.unConfiguredDatasourceList || []
+      ).filter((datasource) => datasource.name !== AI_DATASOURCE_NAME);
+
+      if (
+        response.data.isPartialImport &&
+        filteredUnConfiguredDatasourceList.length > 0
+      ) {
         yield put(
           showReconnectDatasourceModal({
             application: response.data.application,
-            unConfiguredDatasourceList:
-              response.data.unConfiguredDatasourceList,
+            unConfiguredDatasourceList: filteredUnConfiguredDatasourceList,
             workspaceId: action.payload.workspaceId,
           }),
         );


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/2954a270-b4e9-4871-b2f6-b9967f997d26

After:

https://github.com/user-attachments/assets/b83762e3-7e21-4fff-bdc6-708412d3d3b3

/ok-to-test tags="@tag.Templates"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14509874809>
> Commit: a3d4aa2d68f39deb5767936521c09a2d579dfbeb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14509874809&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Templates`
> Spec:
> <hr>Thu, 17 Apr 2025 07:16:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "AI Datasource" will no longer appear in the reconnect datasource modal during partial application or template imports, improving clarity for users when reconnecting datasources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->