### PR TITLE
fix: Updating the logic to show the updated Datasource group name in the Entity explorer

### DIFF
--- a/app/client/src/ce/PluginActionEditor/hooks/useBlockExecution.ts
+++ b/app/client/src/ce/PluginActionEditor/hooks/useBlockExecution.ts
@@ -7,7 +7,7 @@ import { SQL_DATASOURCES } from "constants/QueryEditorConstants";
 import { usePluginActionContext } from "PluginActionEditor/PluginActionContext";
 
 const useBlockExecution = () => {
-  const { action, plugin } = usePluginActionContext();
+  const { action, datasource, plugin } = usePluginActionContext();
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
   const isExecutePermitted = getHasExecuteActionPermission(
     isFeatureEnabled,
@@ -23,7 +23,8 @@ const useBlockExecution = () => {
     action.datasource.datasourceConfiguration?.url || "";
   const actionDatasourceUrlPath = action.actionConfiguration?.path || "";
   // this gets the name of the current action's datasource
-  const actionDatasourceName = action.datasource.name || "";
+  const actionDatasourceName =
+    datasource?.name || action?.datasource?.name || "";
 
   // Query Editor Constants
   if (!!action.actionConfiguration) {

--- a/app/client/src/ce/selectors/entitiesSelector.ts
+++ b/app/client/src/ce/selectors/entitiesSelector.ts
@@ -1689,8 +1689,8 @@ export const getQuerySegmentItems = createSelector(
           : datasourceIdToNameMap[action.config.datasource.id] ?? "AI Queries";
       } else {
         group =
-          action.config.datasource?.name ??
-          datasourceIdToNameMap[action.config.datasource?.id];
+          datasourceIdToNameMap[action.config.datasource?.id] ??
+          action.config.datasource?.name;
       }
 
       return {


### PR DESCRIPTION
## Description

Updating the logic to show the updated Datasource group name in the Entity explorer when the datasource name is changed.

Fixes [#40287](https://github.com/appsmithorg/appsmith/issues/40287)

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
