### PR TITLE
fix: updated all the downstream actions connected to a datasource on datasource update

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
@@ -50,6 +50,8 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
 
     Mono<Long> countByDatasourceId(String datasourceId);
 
+    Flux<NewAction> findUnpublishedActionsByDatasourceId(String datasourceId);
+
     Flux<NewAction> findByPageIds(List<String> pageIds, AclPermission permission);
 
     Flux<NewAction> findByPageIds(List<String> pageIds, Optional<AclPermission> permission);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -276,6 +276,17 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     }
 
     @Override
+    public Flux<NewAction> findUnpublishedActionsByDatasourceId(String datasourceId) {
+        BridgeQuery<NewAction> q = Bridge.<NewAction>equal(
+                        NewAction.Fields.unpublishedAction + ".datasource._id", new ObjectId(datasourceId))
+                // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object
+                // would exist. To handle this, only fetch non-deleted actions
+                .isNull(NewAction.Fields.unpublishedAction_deletedAt);
+
+        return queryBuilder().criteria(q).all();
+    }
+
+    @Override
     public Flux<NewAction> findByPageIds(List<String> pageIds, AclPermission permission) {
         return queryBuilder()
                 .criteria(Bridge.in(NewAction.Fields.unpublishedAction_pageId, pageIds))


### PR DESCRIPTION
## Description
> This PR updates all downstream actions connected to a datasource on datasource update but since a datasource is a workspace level entity and it can be used across multiple applications and hence have a lot of actions connected to it. This approach could be non-performant. Since at the moment the current issue at hand is not high severity and the functional use case has already been resolved by handling this on [the client side](https://github.com/appsmithorg/appsmith/issues/40287), considering this a tech debt to be taken up later. 

The PR here is just an attempt for one of the approach to solve this issue but we can try other approaches to see if they are performant and also resolves this tech-debt. 
Ref: https://theappsmith.slack.com/archives/C040LHZN03V/p1744876988890589?thread_ts=1744816907.975709&cid=C040LHZN03V

Fixes #40292 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
