### PR TITLE
chore: Adjust WDS fg negative

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -805,7 +805,7 @@ export class DarkModeTheme implements ColorModeTheme {
 
     color.oklch.l += 0.05;
     color.oklch.c += 0.1;
-    color.oklch.h -= 10;
+    color.oklch.h += 5;
 
     if (
       this.seedIsRed &&
@@ -815,7 +815,7 @@ export class DarkModeTheme implements ColorModeTheme {
     ) {
       color.oklch.l += 0.05;
       color.oklch.c += 0.05;
-      color.oklch.h -= 15;
+      color.oklch.h -= 20;
     }
 
     return color;

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -806,10 +806,10 @@ export class LightModeTheme implements ColorModeTheme {
     // Negative foreground is produced from the initially adjusted background color (see above). Additional tweaks are applied to make sure it's distinct from fgAccent when seed is red.
     const color = this.bgNegative.clone();
 
-    // Red hue interval bgNegativein OKLCh is less symmetrical than green, compensation is applied to results of bgNegative
-    color.oklch.l += 0.1;
+    // Red hue interval in OKLCh is less symmetrical than green, compensation is applied to results of bgNegative
+    color.oklch.l += 0.05;
     color.oklch.c += 0.1;
-    color.oklch.h -= 10;
+    color.oklch.h += 5;
 
     if (
       this.seedIsRed &&
@@ -818,7 +818,7 @@ export class LightModeTheme implements ColorModeTheme {
       this.fgAccent.oklch.h < 27
     ) {
       color.oklch.c += 0.05;
-      color.oklch.h -= 10;
+      color.oklch.h -= 20;
     }
 
     return color;

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -694,25 +694,25 @@ describe("fgNegative color", () => {
   it("should return correct color when chroma < 0.04", () => {
     const { fgNegative } = new DarkModeTheme("oklch(0.45 0.03 60)").getColors();
 
-    expect(fgNegative).toEqual("rgb(95.583% 0% 26.685%)");
+    expect(fgNegative).toEqual("rgb(96.363% 0% 0%)");
   });
 
   it("should return correct color when chroma > 0.04", () => {
     const { fgNegative } = new DarkModeTheme("oklch(0.45 0.1 60)").getColors();
 
-    expect(fgNegative).toEqual("rgb(95.583% 0% 26.685%)");
+    expect(fgNegative).toEqual("rgb(96.363% 0% 0%)");
   });
 
   it("should return correct color hue is between 5 and 49", () => {
     const { fgNegative } = new DarkModeTheme("oklch(0.45 0.1 30)").getColors();
 
-    expect(fgNegative).toEqual("rgb(94.917% 0% 33.564%)");
+    expect(fgNegative).toEqual("rgb(96.738% 0% 0.56564%)");
   });
 
   it("should return correct color hue is not between 5 and 49", () => {
     const { fgNegative } = new DarkModeTheme("oklch(0.45 0.1 120)").getColors();
 
-    expect(fgNegative).toEqual("rgb(95.583% 0% 26.685%)");
+    expect(fgNegative).toEqual("rgb(96.363% 0% 0%)");
   });
 });
 

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -732,19 +732,19 @@ describe("fgNegative color", () => {
       "oklch(0.45 0.03 60)",
     ).getColors();
 
-    expect(fgNegative).toEqual("rgb(100% 0% 31.57%)");
+    expect(fgNegative).toEqual("rgb(96.363% 0% 0%)");
   });
 
   it("should return correct color when chroma >  0.04", () => {
     const { fgNegative } = new LightModeTheme("oklch(0.45 0.1 60)").getColors();
 
-    expect(fgNegative).toEqual("rgb(100% 0% 31.57%)");
+    expect(fgNegative).toEqual("rgb(96.363% 0% 0%)");
   });
 
   it("should return correct color hue is between 5 and 49", () => {
     const { fgNegative } = new LightModeTheme("oklch(0.45 0.1 30)").getColors();
 
-    expect(fgNegative).toEqual("rgb(100% 0% 31.57%)");
+    expect(fgNegative).toEqual("rgb(96.363% 0% 0%)");
   });
 
   it("should return correct color hue is not between 5 and 49", () => {
@@ -752,7 +752,7 @@ describe("fgNegative color", () => {
       "oklch(0.45 0.1 120)",
     ).getColors();
 
-    expect(fgNegative).toEqual("rgb(100% 0% 31.57%)");
+    expect(fgNegative).toEqual("rgb(96.363% 0% 0%)");
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #39743 

| Before | After |
|--------|--------|
| <img width="656" alt="Screenshot 2025-04-17 at 12 10 57" src="https://github.com/user-attachments/assets/9d684160-6368-417e-a2e1-3e1378f85006" /> | <img width="659" alt="Screenshot 2025-04-17 at 12 10 05" src="https://github.com/user-attachments/assets/d53136ec-6bdc-4d26-9843-8c68d8695c98" /> | 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14513262899>
> Commit: cb548296b06fcb3d5598233ab572d72b5802a80f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14513262899&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 17 Apr 2025 10:50:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted color tones for negative foreground elements in both dark and light modes, resulting in updated visual appearance for certain UI elements.
- **Tests**
	- Updated test cases to reflect the new color values for negative foreground elements in both dark and light modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->