### PR TITLE
chore: Changes to support fixes in UI packages

### DIFF
--- a/app/client/src/ce/sagas/moduleInterfaceSagas.ts
+++ b/app/client/src/ce/sagas/moduleInterfaceSagas.ts
@@ -28,3 +28,10 @@ export function* waitForPackageInitialization(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   action: ReduxAction<unknown>,
 ) {}
+
+export function* handleUIModuleWidgetReplay(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  toasts: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  widgets: CanvasWidgetsReduxState,
+) {}

--- a/app/client/src/ce/selectors/modulesSelector.ts
+++ b/app/client/src/ce/selectors/modulesSelector.ts
@@ -10,4 +10,6 @@ export const getAllModules = (
 
 export const getCurrentModuleId = (state: AppState) => "";
 
+export const getCurrentBaseModuleId = (state: AppState) => "";
+
 export const showUIModulesList = (state: AppState) => false;

--- a/app/client/src/pages/AppIDE/components/WidgetAdd/WidgetsList.tsx
+++ b/app/client/src/pages/AppIDE/components/WidgetAdd/WidgetsList.tsx
@@ -2,6 +2,10 @@ import React from "react";
 
 import { useUIExplorerItems } from "pages/Editor/widgetSidebar/hooks";
 import UIEntitySidebar from "pages/Editor/widgetSidebar/UIEntitySidebar";
+import {
+  createMessage,
+  UI_ELEMENT_PANEL_SEARCH_TEXT,
+} from "ee/constants/messages";
 
 interface WidgetsListProps {
   focusSearchInput?: boolean;
@@ -17,6 +21,7 @@ function WidgetsList({ focusSearchInput }: WidgetsListProps) {
       focusSearchInput={focusSearchInput}
       groupedCards={groupedCards}
       isActive
+      searchPlaceholderText={createMessage(UI_ELEMENT_PANEL_SEARCH_TEXT)}
     />
   );
 }

--- a/app/client/src/pages/Editor/PropertyPane/ConnectDataCTA.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/ConnectDataCTA.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Button, Text } from "@appsmith/ads";
 import type { AppState } from "ee/reducers";
 import styled from "styled-components";
@@ -11,6 +11,7 @@ import { integrationEditorURL } from "ee/RouteBuilder";
 import { getCurrentBasePageId } from "selectors/editorSelectors";
 import { DocsLink, openDoc } from "../../../constants/DocumentationLinks";
 import { DatasourceCreateEntryPoints } from "constants/Datasource";
+import { getCurrentBaseModuleId } from "ee/selectors/modulesSelector";
 
 const Container = styled.div`
   height: 75px;
@@ -34,17 +35,25 @@ interface ConnectDataCTAProps {
 
 function ConnectDataCTA(props: ConnectDataCTAProps) {
   const basePageId: string = useSelector(getCurrentBasePageId);
+  const baseModuleId: string = useSelector(getCurrentBaseModuleId);
 
-  const onClick = () => {
+  const onClick = useCallback(() => {
     const { widgetId, widgetTitle, widgetType } = props;
+    const refirectionProps: Parameters<typeof integrationEditorURL>[0] & {
+      baseModuleId?: string;
+    } = {
+      selectedTab: INTEGRATION_TABS.NEW,
+      params: { mode: INTEGRATION_EDITOR_MODES.AUTO },
+    };
 
-    history.push(
-      integrationEditorURL({
-        basePageId,
-        selectedTab: INTEGRATION_TABS.NEW,
-        params: { mode: INTEGRATION_EDITOR_MODES.AUTO },
-      }),
-    );
+    if (baseModuleId) {
+      refirectionProps.baseModuleId = baseModuleId;
+    } else {
+      refirectionProps.basePageId = basePageId;
+    }
+
+    history.push(integrationEditorURL(refirectionProps));
+
     AnalyticsUtil.logEvent("CONNECT_DATA_CLICK", {
       widgetTitle,
       widgetId,
@@ -57,7 +66,7 @@ function ConnectDataCTA(props: ConnectDataCTAProps) {
     AnalyticsUtil.logEvent("NAVIGATE_TO_CREATE_NEW_DATASOURCE_PAGE", {
       entryPoint,
     });
-  };
+  }, [baseModuleId, basePageId, props]);
 
   return (
     <Container className="flex flex-col t--propertypane-connect-cta">

--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneView.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneView.tsx
@@ -73,6 +73,7 @@ export const excludeList: WidgetType[] = [
   "WDS_MODAL_WIDGET",
   "WDS_BUTTON_WIDGET",
   "WDS_TABLE_WIDGET",
+  "MODULE_CONTAINER_WIDGET",
 ];
 
 function PropertyPaneView(

--- a/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/UIEntitySidebar.tsx
@@ -1,5 +1,4 @@
 import {
-  UI_ELEMENT_PANEL_SEARCH_TEXT,
   WIDGET_PANEL_EMPTY_MESSAGE,
   createMessage,
 } from "ee/constants/messages";
@@ -23,6 +22,7 @@ interface UIEntitySidebarProps {
   cards: WidgetCardProps[];
   entityLoading?: Partial<Record<WidgetTags, boolean>>;
   groupedCards: WidgetCardsGroupedByTags;
+  searchPlaceholderText?: string;
 }
 
 function UIEntitySidebar({
@@ -31,6 +31,7 @@ function UIEntitySidebar({
   focusSearchInput,
   groupedCards,
   isActive,
+  searchPlaceholderText,
 }: UIEntitySidebarProps) {
   const [filteredCards, setFilteredCards] =
     useState<WidgetCardsGroupedByTags>(groupedCards);
@@ -115,7 +116,7 @@ function UIEntitySidebar({
           autoComplete="off"
           id={ENTITY_EXPLORER_SEARCH_ID}
           onChange={search}
-          placeholder={createMessage(UI_ELEMENT_PANEL_SEARCH_TEXT)}
+          placeholder={searchPlaceholderText}
           ref={searchInputRef}
           type="text"
         />

--- a/app/client/src/pages/Editor/widgetSidebar/tests/UIEntitySidebar.test.tsx
+++ b/app/client/src/pages/Editor/widgetSidebar/tests/UIEntitySidebar.test.tsx
@@ -43,6 +43,7 @@ describe("UIEntitySidebar", () => {
         focusSearchInput={focusSearchInput}
         groupedCards={mockItems.groupedCards}
         isActive={isActive}
+        searchPlaceholderText={createMessage(UI_ELEMENT_PANEL_SEARCH_TEXT)}
       />,
       {
         initialState: getIDETestState({}),
@@ -98,6 +99,7 @@ describe("UIEntitySidebar", () => {
         focusSearchInput
         groupedCards={emptyGroupedCards}
         isActive
+        searchPlaceholderText={createMessage(UI_ELEMENT_PANEL_SEARCH_TEXT)}
       />,
       {
         initialState: getIDETestState({}),

--- a/app/client/src/sagas/ReplaySaga.ts
+++ b/app/client/src/sagas/ReplaySaga.ts
@@ -83,6 +83,7 @@ import { getCurrentEnvironmentId } from "ee/selectors/environmentSelectors";
 import { updateAndSaveAnvilLayout } from "layoutSystems/anvil/utils/anvilChecksUtils";
 import type { ReplayOperation } from "entities/Replay/ReplayEntity/ReplayOperations";
 import { objectKeys } from "@appsmith/utils";
+import { handleUIModuleWidgetReplay } from "ee/sagas/moduleInterfaceSaga";
 
 export interface UndoRedoPayload {
   operation: ReplayOperation;
@@ -225,6 +226,8 @@ export function* undoRedoSaga(action: ReduxAction<UndoRedoPayload>) {
           paths,
           timeTaken: endTime - startTime,
         });
+
+        yield call(handleUIModuleWidgetReplay, replay, replayEntity.widgets);
 
         yield call(updateAndSaveAnvilLayout, replayEntity.widgets, {
           isRetry: false,


### PR DESCRIPTION
## Description
#### UI Module Integrations Enhancement

This PR adds support for UI Modules across several components:

- Adds `getCurrentBaseModuleId` selector to retrieve the current base module ID
- Implements module-aware redirection in `ConnectDataCTA` component
- Adds `handleUIModuleWidgetReplay` function for module widget replay support
- Improves `UIEntitySidebar` to accept custom search placeholder text
- Excludes `MODULE_CONTAINER_WIDGET` from the property pane exclusion list

These changes enable proper navigation and functionality when working with UI modules in the application.


PR for https://github.com/appsmithorg/appsmith-ee/pull/7190

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14530037275>
> Commit: 35573170fe705a25e0b2a0d26b8729edcfd64c8e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14530037275&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 18 Apr 2025 06:26:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizable search placeholder text in the widget sidebar for improved localization and flexibility.
  - Navigation from the "Connect Data" call-to-action now conditionally uses module or page identifiers, enhancing navigation accuracy.

- **Improvements**
  - The "Connect Data" option is now hidden for module container widgets in the property pane for a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->