### PR TITLE
chore: Remove Navigation Settings in AI apps

### DIFF
--- a/app/client/src/pages/AppIDE/components/AppSettings/AppSettings.tsx
+++ b/app/client/src/pages/AppIDE/components/AppSettings/AppSettings.tsx
@@ -34,6 +34,7 @@ import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import { Divider } from "@appsmith/ads";
 import { ImportAppSettings } from "./components/ImportAppSettings";
 import { getIsAnvilLayout } from "layoutSystems/anvil/integrations/selectors";
+import { getIsAiAgentFlowEnabled } from "ee/selectors/aiAgentSelectors";
 
 export enum AppSettingsTabs {
   General,
@@ -125,7 +126,7 @@ function AppSettings() {
     };
   }, [selectedTab]);
 
-  const SectionHeadersConfig: SectionHeaderProps[] = [
+  let SectionHeadersConfig: SectionHeaderProps[] = [
     {
       id: "t--general-settings-header",
       icon: "settings-v3",
@@ -192,6 +193,14 @@ function AppSettings() {
       subText: createMessage(UPDATE_VIA_IMPORT_SETTING.settingDesc),
     },
   ];
+
+  const isAiAgentFlowEnabled = useSelector(getIsAiAgentFlowEnabled);
+
+  if (isAiAgentFlowEnabled) {
+    SectionHeadersConfig = SectionHeadersConfig.filter(
+      (config) => config.id !== "t--navigation-settings-header",
+    );
+  }
 
   // 50 px height of the sectionHeader item
   // 41px height of pages title


### PR DESCRIPTION
## Description

Hide the Navigation settings in AI datasources


## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14515902754>
> Commit: edb032e087d77ebe955e4fa34af74eaf7954b02d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14515902754&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Thu, 17 Apr 2025 13:14:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Navigation settings tab is now automatically hidden when the AI agent flow feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->