### PR TITLE
fix: Updating the UX for hidden pages

### DIFF
--- a/app/client/packages/design-system/ads/src/List/List.styles.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.styles.tsx
@@ -145,6 +145,16 @@ export const StyledListItem = styled.div<{
     background-color: var(--ads-v2-colors-content-surface-default-bg);
   }
 
+  &[data-hidden="true"] {
+    .t--entity-name {
+      color: var(--ads-v2-color-fg-subtle);
+    }
+
+    .ads-v2-icon {
+      color: var(--ads-v2-color-fg-subtle);
+    }
+  }
+
   &:hover {
     background-color: var(--ads-v2-colors-content-surface-hover-bg);
   }

--- a/app/client/packages/design-system/ads/src/List/List.styles.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.styles.tsx
@@ -145,7 +145,7 @@ export const StyledListItem = styled.div<{
     background-color: var(--ads-v2-colors-content-surface-default-bg);
   }
 
-  &[data-hidden="true"] {
+  &[data-subtle="true"] {
     .t--entity-name {
       color: var(--ads-v2-color-fg-subtle);
     }

--- a/app/client/packages/design-system/ads/src/List/List.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.tsx
@@ -124,10 +124,10 @@ function ListItem(props: ListItemProps) {
     <StyledListItem
       className={clsx(ListItemClassName, props.className, "t--ide-list-item")}
       data-disabled={props.isDisabled || false}
-      data-hidden={props.isHidden || false}
       data-isblockdescription={isBlockDescription}
       data-rightcontrolvisibility={rightControlVisibility}
       data-selected={props.isSelected}
+      data-subtle={props.isSubtle || false}
       data-testid={props.dataTestId}
       id={props.id}
       onClick={handleOnClick}

--- a/app/client/packages/design-system/ads/src/List/List.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.tsx
@@ -124,6 +124,7 @@ function ListItem(props: ListItemProps) {
     <StyledListItem
       className={clsx(ListItemClassName, props.className, "t--ide-list-item")}
       data-disabled={props.isDisabled || false}
+      data-hidden={props.isHidden || false}
       data-isblockdescription={isBlockDescription}
       data-rightcontrolvisibility={rightControlVisibility}
       data-selected={props.isSelected}

--- a/app/client/packages/design-system/ads/src/List/List.types.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.types.tsx
@@ -16,6 +16,8 @@ export interface ListItemProps {
   onDoubleClick?: () => void;
   /** Whether the list item is disabled. */
   isDisabled?: boolean;
+  /** Whether the list item is hidden, but not disabled. */
+  isHidden?: boolean;
   /** Whether the list item is selected. */
   isSelected?: boolean;
   /** The size of the list item. */

--- a/app/client/packages/design-system/ads/src/List/List.types.tsx
+++ b/app/client/packages/design-system/ads/src/List/List.types.tsx
@@ -16,8 +16,8 @@ export interface ListItemProps {
   onDoubleClick?: () => void;
   /** Whether the list item is disabled. */
   isDisabled?: boolean;
-  /** Whether the list item is hidden, but not disabled. */
-  isHidden?: boolean;
+  /** Whether the list item should be subtle styled, but not disabled. */
+  isSubtle?: boolean;
   /** Whether the list item is selected. */
   isSelected?: boolean;
   /** The size of the list item. */

--- a/app/client/src/pages/AppIDE/components/PageList/PageEntity.tsx
+++ b/app/client/src/pages/AppIDE/components/PageList/PageEntity.tsx
@@ -155,8 +155,8 @@ export const PageEntity = ({
     <EntityItem
       className={`page fullWidth ${isCurrentPage && "activePage"}`}
       id={page.pageId}
-      isHidden={page.isHidden}
       isSelected={isCurrentPage}
+      isSubtle={page.isHidden}
       key={page.pageId}
       nameEditorConfig={nameEditorConfig}
       onClick={!isCurrentPage ? switchPage : noop}

--- a/app/client/src/pages/AppIDE/components/PageList/PageEntity.tsx
+++ b/app/client/src/pages/AppIDE/components/PageList/PageEntity.tsx
@@ -155,7 +155,7 @@ export const PageEntity = ({
     <EntityItem
       className={`page fullWidth ${isCurrentPage && "activePage"}`}
       id={page.pageId}
-      isDisabled={page.isHidden}
+      isHidden={page.isHidden}
       isSelected={isCurrentPage}
       key={page.pageId}
       nameEditorConfig={nameEditorConfig}


### PR DESCRIPTION
## Description

Updating the UX for hidden pages which is breaking on v1.68. The user is no longer able to select the hidden pages, to edit the same in edit mode. This is being fixed in this PR.

Fixes [#40321](https://github.com/appsmithorg/appsmith/issues/40321)

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14569833575>
> Commit: 76d359c04ccc216abfbec34952373ea370bdb3e9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14569833575&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Mon, 21 Apr 2025 08:31:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for visually dimming list items marked as subtle, making entity names and icons appear subdued.

- **Style**
  - Updated styling to apply a subtle visual treatment to list items flagged as subtle, enhancing UI clarity.

- **Refactor**
  - Replaced the disabled state indicator with a subtle style indicator for representing hidden pages in the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->