### PR TITLE
ci: Fixing the page actions spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/PartialImportExport/PageActions_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/PartialImportExport/PageActions_spec.ts
@@ -15,7 +15,7 @@ import {
 import PageList from "../../../../support/Pages/PageList";
 import { EntityItems } from "../../../../support/Pages/AssertHelper";
 
-describe("Check Page Actions Menu", {}, function () {
+describe("Check Page Actions Menu", { tags: ["@tag.IDE"] }, function () {
   it("1. Verify Page Actions when a page is selected", function () {
     homePage.RenameApplication("PageActions");
     PageList.AddNewPage("New blank page");
@@ -32,7 +32,7 @@ describe("Check Page Actions Menu", {}, function () {
     PageList.ShowList();
     agHelper.AssertAttribute(
       locators._entityTestId("NewPage Copy"),
-      "data-disabled",
+      "data-subtle",
       "true",
     );
     PageList.DeletePage("NewPage Copy");
@@ -93,7 +93,7 @@ describe("Check Page Actions Menu", {}, function () {
     PageList.ShowList();
     agHelper.AssertAttribute(
       locators._entityTestId("Page2 Copy"),
-      "data-disabled",
+      "data-subtle",
       "true",
     );
     PageList.DeletePage("Page2 Copy");
@@ -115,7 +115,7 @@ describe("Check Page Actions Menu", {}, function () {
     PageList.ShowList();
     agHelper.AssertAttribute(
       locators._entityTestId("HomePage Copy"),
-      "data-disabled",
+      "data-subtle",
       "true",
     );
     PageList.DeletePage("HomePage Copy");


### PR DESCRIPTION
## Description

Fixing the page actions spec that was failing after [#40322](https://github.com/appsmithorg/appsmith/pull/40322) merge

Fixes #

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14587020719>
> Commit: d46229ad5cef61fdfa1eaee3adc38d38faac2b3a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14587020719&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Tue, 22 Apr 2025 05:28:28 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test assertions to check the "data-subtle" attribute instead of "data-disabled" when verifying the UI state of hidden pages.
  - Added a tag to the test suite for improved categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->