### PR TITLE
feat: Replacing `executeOnLoad` with `runBehavior` in all action config settings

### DIFF
--- a/app/client/src/PluginActionEditor/constants/PluginActionConstants.ts
+++ b/app/client/src/PluginActionEditor/constants/PluginActionConstants.ts
@@ -3,17 +3,11 @@ import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig
 export const THEME = EditorTheme.LIGHT;
 
 export enum ActionRunBehaviour {
-  AUTOMATIC = "AUTOMATIC",
   PAGE_LOAD = "PAGE_LOAD",
   MANUAL = "MANUAL",
 }
 
 export const RUN_BEHAVIOR = {
-  AUTOMATIC: {
-    label: "Automatic",
-    subText: "Query runs on page load or when a variable it depends on changes",
-    value: ActionRunBehaviour.AUTOMATIC,
-  },
   PAGE_LOAD: {
     label: "On page load",
     subText: "Query runs when the page loads or when manually triggered",

--- a/app/client/src/PluginActionEditor/constants/PluginActionConstants.ts
+++ b/app/client/src/PluginActionEditor/constants/PluginActionConstants.ts
@@ -1,3 +1,29 @@
 import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
 
 export const THEME = EditorTheme.LIGHT;
+
+export enum ActionRunBehaviour {
+  AUTOMATIC = "AUTOMATIC",
+  PAGE_LOAD = "PAGE_LOAD",
+  MANUAL = "MANUAL",
+}
+
+export const RUN_BEHAVIOR = {
+  AUTOMATIC: {
+    label: "Automatic",
+    subText: "Query runs on page load or when a variable it depends on changes",
+    value: ActionRunBehaviour.AUTOMATIC,
+  },
+  PAGE_LOAD: {
+    label: "On page load",
+    subText: "Query runs when the page loads or when manually triggered",
+    value: ActionRunBehaviour.PAGE_LOAD,
+  },
+  MANUAL: {
+    label: "Manual",
+    subText: "Query only runs when called in an event or JS with .run()",
+    value: ActionRunBehaviour.MANUAL,
+  },
+};
+
+export const RUN_BEHAVIOR_VALUES = Object.values(RUN_BEHAVIOR);

--- a/app/client/src/PluginActionEditor/transformers/RestActionTransformers.test.ts
+++ b/app/client/src/PluginActionEditor/transformers/RestActionTransformers.test.ts
@@ -9,6 +9,7 @@ import {
   MultiPartOptionTypes,
   POST_BODY_FORMAT_OPTIONS,
 } from "../constants/CommonApiConstants";
+import { ActionRunBehaviour } from "PluginActionEditor/constants/PluginActionConstants";
 
 // jest.mock("POST_");
 
@@ -16,6 +17,7 @@ const BASE_ACTION: ApiAction = {
   dynamicBindingPathList: [],
   cacheResponse: "",
   executeOnLoad: false,
+  runBehavior: ActionRunBehaviour.MANUAL,
   invalids: [],
   isValid: false,
   workspaceId: "",

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -2583,7 +2583,7 @@ export const PREPARED_STATEMENT_WARNING = {
 
 export const JS_EDITOR_SETTINGS = {
   TITLE: () => "Settings",
-  ON_LOAD_TITLE: () => "Choose the functions to run on page load",
+  ON_LOAD_TITLE: () => "Choose functions run behavior",
 };
 
 export const CUSTOM_WIDGET_BUILDER_TAB_TITLE = {

--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -10046,12 +10046,6 @@ export const defaultAppState = {
                 initialValue: "MANUAL",
                 options: [
                   {
-                    label: "Automatic",
-                    subText:
-                      "Query runs on page load or when a variable it depends on changes",
-                    value: "AUTOMATIC",
-                  },
-                  {
                     label: "On page load",
                     subText:
                       "Query runs when the page loads or when manually triggered",
@@ -10103,12 +10097,6 @@ export const defaultAppState = {
                 initialValue: "MANUAL",
                 options: [
                   {
-                    label: "Automatic",
-                    subText:
-                      "Query runs on page load or when a variable it depends on changes",
-                    value: "AUTOMATIC",
-                  },
-                  {
                     label: "On page load",
                     subText:
                       "Query runs when the page loads or when manually triggered",
@@ -10159,12 +10147,6 @@ export const defaultAppState = {
                 controlType: "DROP_DOWN",
                 initialValue: "MANUAL",
                 options: [
-                  {
-                    label: "Automatic",
-                    subText:
-                      "Query runs on page load or when a variable it depends on changes",
-                    value: "AUTOMATIC",
-                  },
                   {
                     label: "On page load",
                     subText:
@@ -10245,12 +10227,6 @@ export const defaultAppState = {
                 controlType: "DROP_DOWN",
                 initialValue: "MANUAL",
                 options: [
-                  {
-                    label: "Automatic",
-                    subText:
-                      "Query runs on page load or when a variable it depends on changes",
-                    value: "AUTOMATIC",
-                  },
                   {
                     label: "On page load",
                     subText:

--- a/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
+++ b/app/client/src/components/editorComponents/PartialImportExport/PartialExportModal/unitTestUtils.ts
@@ -2308,6 +2308,7 @@ export const defaultAppState = {
             ],
           },
           executeOnLoad: true,
+          runBehavior: "PAGE_LOAD",
           dynamicBindingPathList: [],
           isValid: true,
           invalids: [],
@@ -2392,6 +2393,7 @@ export const defaultAppState = {
             },
           },
           executeOnLoad: false,
+          runBehavior: "MANUAL",
           isValid: true,
           invalids: [],
           messages: [],
@@ -10038,9 +10040,30 @@ export const defaultAppState = {
             id: 1,
             children: [
               {
-                label: "Run the query on page load",
-                configProperty: "executeOnLoad",
-                controlType: "SWITCH",
+                label: "Run behavior",
+                configProperty: "runBehavior",
+                controlType: "DROP_DOWN",
+                initialValue: "MANUAL",
+                options: [
+                  {
+                    label: "Automatic",
+                    subText:
+                      "Query runs on page load or when a variable it depends on changes",
+                    value: "AUTOMATIC",
+                  },
+                  {
+                    label: "On page load",
+                    subText:
+                      "Query runs when the page loads or when manually triggered",
+                    value: "PAGE_LOAD",
+                  },
+                  {
+                    label: "Manual",
+                    subText:
+                      "Query only runs when called in an event or JS with .run()",
+                    value: "MANUAL",
+                  },
+                ],
               },
               {
                 label: "Request confirmation before running this query",
@@ -10074,9 +10097,30 @@ export const defaultAppState = {
             id: 1,
             children: [
               {
-                label: "Run the query on page load",
-                configProperty: "executeOnLoad",
-                controlType: "SWITCH",
+                label: "Run behavior",
+                configProperty: "runBehavior",
+                controlType: "DROP_DOWN",
+                initialValue: "MANUAL",
+                options: [
+                  {
+                    label: "Automatic",
+                    subText:
+                      "Query runs on page load or when a variable it depends on changes",
+                    value: "AUTOMATIC",
+                  },
+                  {
+                    label: "On page load",
+                    subText:
+                      "Query runs when the page loads or when manually triggered",
+                    value: "PAGE_LOAD",
+                  },
+                  {
+                    label: "Manual",
+                    subText:
+                      "Query only runs when called in an event or JS with .run()",
+                    value: "MANUAL",
+                  },
+                ],
               },
               {
                 label: "Request confirmation before running this query",
@@ -10110,9 +10154,30 @@ export const defaultAppState = {
             id: 1,
             children: [
               {
-                label: "Run the API on page load",
-                configProperty: "executeOnLoad",
-                controlType: "SWITCH",
+                label: "Run behavior",
+                configProperty: "runBehavior",
+                controlType: "DROP_DOWN",
+                initialValue: "MANUAL",
+                options: [
+                  {
+                    label: "Automatic",
+                    subText:
+                      "Query runs on page load or when a variable it depends on changes",
+                    value: "AUTOMATIC",
+                  },
+                  {
+                    label: "On page load",
+                    subText:
+                      "Query runs when the page loads or when manually triggered",
+                    value: "PAGE_LOAD",
+                  },
+                  {
+                    label: "Manual",
+                    subText:
+                      "Query only runs when called in an event or JS with .run()",
+                    value: "MANUAL",
+                  },
+                ],
               },
               {
                 label: "Request confirmation before running this API",
@@ -10175,9 +10240,30 @@ export const defaultAppState = {
             id: 1,
             children: [
               {
-                label: "Run the API on page load",
-                configProperty: "executeOnLoad",
-                controlType: "SWITCH",
+                label: "Run behavior",
+                configProperty: "runBehavior",
+                controlType: "DROP_DOWN",
+                initialValue: "MANUAL",
+                options: [
+                  {
+                    label: "Automatic",
+                    subText:
+                      "Query runs on page load or when a variable it depends on changes",
+                    value: "AUTOMATIC",
+                  },
+                  {
+                    label: "On page load",
+                    subText:
+                      "Query runs when the page loads or when manually triggered",
+                    value: "PAGE_LOAD",
+                  },
+                  {
+                    label: "Manual",
+                    subText:
+                      "Query only runs when called in an event or JS with .run()",
+                    value: "MANUAL",
+                  },
+                ],
               },
               {
                 label: "Request confirmation before running this API",
@@ -10353,6 +10439,7 @@ export const defaultAppState = {
                 jsArguments: [],
               },
               executeOnLoad: false,
+              runBehavior: "MANUAL",
               clientSideExecution: true,
               dynamicBindingPathList: [
                 {
@@ -10403,6 +10490,7 @@ export const defaultAppState = {
                 jsArguments: [],
               },
               executeOnLoad: false,
+              runBehavior: "MANUAL",
               clientSideExecution: true,
               dynamicBindingPathList: [
                 {
@@ -10487,6 +10575,7 @@ export const defaultAppState = {
                 jsArguments: [],
               },
               executeOnLoad: false,
+              runBehavior: "MANUAL",
               clientSideExecution: true,
               dynamicBindingPathList: [
                 {
@@ -10537,6 +10626,7 @@ export const defaultAppState = {
                 jsArguments: [],
               },
               executeOnLoad: false,
+              runBehavior: "MANUAL",
               clientSideExecution: true,
               dynamicBindingPathList: [
                 {

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -20,7 +20,7 @@ import {
 } from "workers/Evaluation/formEval";
 import type { Action } from "entities/Action";
 import type { SelectOptionProps } from "@appsmith/ads";
-import { Icon, Option, OptGroup, Select } from "@appsmith/ads";
+import { Icon, Option, OptGroup, Select, Flex, Text } from "@appsmith/ads";
 import { getFormConfigConditionalOutput } from "selectors/formSelectors";
 import { fetchFormDynamicValNextPage } from "actions/evaluationActions";
 import { objectKeys } from "@appsmith/utils";
@@ -29,6 +29,18 @@ import type {
   DynamicValues,
 } from "reducers/evaluationReducers/formEvaluationReducer";
 import NoSearchCommandFound from "./CustomActionsConfigControl/NoSearchCommandFound";
+import styled from "styled-components";
+
+const OptionLabel = styled(Text)`
+  color: var(--ads-v2-color-fg);
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+const OptionSubText = styled(Text)`
+  color: var(--ads-v2-color-fg-muted);
+  font-size: 12px;
+`;
 
 export interface DropDownGroupedOptions {
   label: string;
@@ -495,7 +507,24 @@ function renderDropdown(
 }
 
 function renderOptionWithIcon(option: SelectOptionProps) {
-  return (
+  return option.subText ? (
+    <Option
+      aria-label={option.label}
+      disabled={option.disabled}
+      isDisabled={option.isDisabled}
+      key={option.value}
+      label={option.label}
+      value={option.value}
+    >
+      <Flex flexDirection="column">
+        <Flex>
+          {option.icon && <Icon color={option.color} name={option.icon} />}
+          <OptionLabel>{option.label}</OptionLabel>
+        </Flex>
+        <OptionSubText>{option.subText}</OptionSubText>
+      </Flex>
+    </Option>
+  ) : (
     <Option
       aria-label={option.label}
       disabled={option.disabled}

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -474,6 +474,7 @@ function renderDropdown(
       isDisabled={props.disabled}
       isLoading={props.isLoading}
       isMultiSelect={isMultiSelect}
+      listHeight={240}
       maxTagCount={props.maxTagCount}
       notFoundContent={
         <NoSearchCommandFound

--- a/app/client/src/constants/AppsmithActionConstants/formConfig/ApiSettingsConfig.ts
+++ b/app/client/src/constants/AppsmithActionConstants/formConfig/ApiSettingsConfig.ts
@@ -6,6 +6,10 @@ import {
   HTTP_PROTOCOL,
   HTTP_PROTOCOL_VERSIONS,
 } from "PluginActionEditor/constants/CommonApiConstants";
+import {
+  RUN_BEHAVIOR,
+  RUN_BEHAVIOR_VALUES,
+} from "PluginActionEditor/constants/PluginActionConstants";
 
 export default [
   {
@@ -13,9 +17,11 @@ export default [
     id: 1,
     children: [
       {
-        label: "Run the API on page load",
-        configProperty: "executeOnLoad",
-        controlType: "SWITCH",
+        label: "Run behavior",
+        configProperty: "runBehavior",
+        controlType: "DROP_DOWN",
+        initialValue: RUN_BEHAVIOR.MANUAL.label,
+        options: RUN_BEHAVIOR_VALUES,
       },
       {
         label: "Request confirmation before running this API",

--- a/app/client/src/constants/AppsmithActionConstants/formConfig/GoogleSheetsSettingsConfig.ts
+++ b/app/client/src/constants/AppsmithActionConstants/formConfig/GoogleSheetsSettingsConfig.ts
@@ -1,12 +1,19 @@
+import {
+  RUN_BEHAVIOR,
+  RUN_BEHAVIOR_VALUES,
+} from "PluginActionEditor/constants/PluginActionConstants";
+
 export default [
   {
     sectionName: "",
     id: 1,
     children: [
       {
-        label: "Run the API on page load",
-        configProperty: "executeOnLoad",
-        controlType: "SWITCH",
+        label: "Run behavior",
+        configProperty: "runBehavior",
+        controlType: "DROP_DOWN",
+        initialValue: RUN_BEHAVIOR.MANUAL.label,
+        options: RUN_BEHAVIOR_VALUES,
       },
       {
         label: "Request confirmation before running this API",

--- a/app/client/src/constants/AppsmithActionConstants/formConfig/QuerySettingsConfig.ts
+++ b/app/client/src/constants/AppsmithActionConstants/formConfig/QuerySettingsConfig.ts
@@ -1,12 +1,19 @@
+import {
+  RUN_BEHAVIOR,
+  RUN_BEHAVIOR_VALUES,
+} from "PluginActionEditor/constants/PluginActionConstants";
+
 export default [
   {
     sectionName: "",
     id: 1,
     children: [
       {
-        label: "Run the query on page load",
-        configProperty: "executeOnLoad",
-        controlType: "SWITCH",
+        label: "Run behavior",
+        configProperty: "runBehavior",
+        controlType: "DROP_DOWN",
+        initialValue: RUN_BEHAVIOR.MANUAL.label,
+        options: RUN_BEHAVIOR_VALUES,
       },
       {
         label: "Request confirmation before running this query",

--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -10,6 +10,7 @@ import {
   type Plugin,
   type PluginName,
 } from "../Plugin";
+import type { ActionRunBehaviour } from "PluginActionEditor/constants/PluginActionConstants";
 
 export enum PaginationType {
   NONE = "NONE",
@@ -140,6 +141,7 @@ export interface BaseAction {
   collectionId?: string;
   pluginId: string;
   executeOnLoad: boolean;
+  runBehavior: ActionRunBehaviour;
   dynamicBindingPathList: DynamicPath[];
   isValid: boolean;
   invalids: string[];

--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -141,7 +141,7 @@ export interface BaseAction {
   collectionId?: string;
   pluginId: string;
   executeOnLoad: boolean;
-  runBehavior: ActionRunBehaviour;
+  runBehavior?: ActionRunBehaviour;
   dynamicBindingPathList: DynamicPath[];
   isValid: boolean;
   invalids: string[];

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useState } from "react";
-import { Flex, Switch, Text } from "@appsmith/ads";
+import {
+  Flex,
+  Option,
+  Select,
+  Text,
+  type SelectOptionProps,
+} from "@appsmith/ads";
 import type { JSAction } from "entities/JSCollection";
 import {
   createMessage,
@@ -8,6 +14,27 @@ import {
 } from "ee/constants/messages";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import type { OnUpdateSettingsProps } from "../types";
+import type { ActionRunBehaviour } from "PluginActionEditor/constants/PluginActionConstants";
+import {
+  RUN_BEHAVIOR,
+  RUN_BEHAVIOR_VALUES,
+} from "PluginActionEditor/constants/PluginActionConstants";
+import styled from "styled-components";
+
+const OptionLabel = styled(Text)`
+  color: var(--ads-v2-color-fg);
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+const OptionSubText = styled(Text)`
+  color: var(--ads-v2-color-fg-muted);
+  font-size: 12px;
+`;
+
+const StyledSelect = styled(Select)`
+  width: fit-content;
+`;
 
 interface Props {
   disabled: boolean;
@@ -20,24 +47,21 @@ interface FunctionSettingsRowProps extends Omit<Props, "actions"> {
 }
 
 const FunctionSettingRow = (props: FunctionSettingsRowProps) => {
-  const [executeOnPageLoad, setExecuteOnPageLoad] = useState(
-    String(props.action.executeOnLoad),
-  );
+  const [runBehavior, setRunBehavior] = useState(props.action.runBehavior);
+  const options = RUN_BEHAVIOR_VALUES as Omit<SelectOptionProps, "children">[];
 
-  const onChange = useCallback(
-    (isSelected: boolean) => {
-      const value = String(isSelected);
-
-      setExecuteOnPageLoad(value);
+  const onSelectOptions = useCallback(
+    (newRunBehavior: ActionRunBehaviour) => {
+      setRunBehavior(newRunBehavior);
       props.onUpdateSettings?.({
-        value: value === "true",
-        propertyName: "executeOnLoad",
+        value: newRunBehavior,
+        propertyName: "runBehavior",
         action: props.action,
       });
 
       AnalyticsUtil.logEvent("JS_OBJECT_SETTINGS_CHANGED", {
         toggleSetting: "ON_PAGE_LOAD",
-        toggleValue: value,
+        toggleValue: newRunBehavior,
       });
     },
     [props],
@@ -45,21 +69,43 @@ const FunctionSettingRow = (props: FunctionSettingsRowProps) => {
 
   return (
     <Flex
+      alignItems="center"
       className={`t--async-js-function-settings ${props.action.name}-on-page-load-setting`}
-      gap="spaces-4"
       id={`${props.action.name}-settings`}
+      justifyContent="space-between"
       key={props.action.id}
       w="100%"
     >
-      <Switch
-        defaultSelected={JSON.parse(executeOnPageLoad)}
+      <Text>{props.action.name}</Text>
+      <StyledSelect
+        data-testid={`execute-on-page-load-${props.action.id}`}
+        defaultValue={RUN_BEHAVIOR.MANUAL.label}
         isDisabled={props.disabled}
-        isSelected={JSON.parse(executeOnPageLoad)}
-        name={`execute-on-page-load-${props.action.id}`}
-        onChange={onChange}
+        listHeight={240}
+        onSelect={onSelectOptions}
+        // Default value of optionFilterProp prop is `value` which searches the dropdown based on value and not label,
+        // hence explicitly setting this to label to search based on label.
+        // For eg. If value is `Create_ticket` and label is `Create ticket`, we should be able to search using `Create ticket`.
+        optionFilterProp="label"
+        size="sm"
+        value={runBehavior}
       >
-        {props.action.name}
-      </Switch>
+        {options.map((option) => (
+          <Option
+            aria-label={option.label}
+            disabled={option.disabled}
+            isDisabled={option.isDisabled}
+            key={option.value}
+            label={option.label}
+            value={option.value}
+          >
+            <Flex flexDirection="column">
+              <OptionLabel>{option.label}</OptionLabel>
+              <OptionSubText>{option.subText}</OptionSubText>
+            </Flex>
+          </Option>
+        ))}
+      </StyledSelect>
     </Flex>
   );
 };

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/types.ts
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/types.ts
@@ -2,7 +2,7 @@ import type { JSAction } from "entities/JSCollection";
 import type { DropdownOption } from "@appsmith/ads-old";
 
 export interface OnUpdateSettingsProps {
-  value: boolean | number;
+  value: boolean | number | string;
   propertyName: string;
   action: JSAction;
 }

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
@@ -84,6 +84,7 @@
             ]
           },
           "executeOnLoad": false,
+          "runBehavior": "MANUAL",
           "dynamicBindingPathList": [],
           "isValid": true,
           "invalids": [],
@@ -2543,9 +2544,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2576,9 +2595,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2609,9 +2646,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the API on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "CHECKBOX"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this API",
@@ -2648,9 +2703,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2674,9 +2747,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2707,9 +2798,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2740,9 +2849,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/FinalState.json
@@ -2550,11 +2550,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2601,11 +2596,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2651,11 +2641,6 @@
                 "controlType": "DROP_DOWN",
                 "initialValue": "MANUAL",
                 "options": [
-                  {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
                   {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
@@ -2709,11 +2694,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2752,11 +2732,6 @@
                 "controlType": "DROP_DOWN",
                 "initialValue": "MANUAL",
                 "options": [
-                  {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
                   {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
@@ -2804,11 +2779,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2854,11 +2824,6 @@
                 "controlType": "DROP_DOWN",
                 "initialValue": "MANUAL",
                 "options": [
-                  {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
                   {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
@@ -2549,11 +2549,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2600,11 +2595,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2650,11 +2640,6 @@
                 "controlType": "DROP_DOWN",
                 "initialValue": "MANUAL",
                 "options": [
-                  {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
                   {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
@@ -2708,11 +2693,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2751,11 +2731,6 @@
                 "controlType": "DROP_DOWN",
                 "initialValue": "MANUAL",
                 "options": [
-                  {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
                   {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
@@ -2803,11 +2778,6 @@
                 "initialValue": "MANUAL",
                 "options": [
                   {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
-                  {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",
                     "value": "PAGE_LOAD"
@@ -2853,11 +2823,6 @@
                 "controlType": "DROP_DOWN",
                 "initialValue": "MANUAL",
                 "options": [
-                  {
-                    "label": "Automatic",
-                    "subText": "Query runs on page load or when a variable it depends on changes",
-                    "value": "AUTOMATIC"
-                  },
                   {
                     "label": "On page load",
                     "subText": "Query runs when the page loads or when manually triggered",

--- a/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
+++ b/app/client/src/pages/Editor/SaaSEditor/__data__/InitialState.json
@@ -83,6 +83,7 @@
             ]
           },
           "executeOnLoad": false,
+          "runBehavior": "MANUAL",
           "dynamicBindingPathList": [],
           "isValid": true,
           "invalids": [],
@@ -2542,9 +2543,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2575,9 +2594,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2608,9 +2645,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the API on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "CHECKBOX"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this API",
@@ -2647,9 +2702,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2673,9 +2746,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2706,9 +2797,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",
@@ -2739,9 +2848,27 @@
             "id": 1,
             "children": [
               {
-                "label": "Run the query on page load",
-                "configProperty": "executeOnLoad",
-                "controlType": "SWITCH"
+                "label": "Run behavior",
+                "configProperty": "runBehavior",
+                "controlType": "DROP_DOWN",
+                "initialValue": "MANUAL",
+                "options": [
+                  {
+                    "label": "Automatic",
+                    "subText": "Query runs on page load or when a variable it depends on changes",
+                    "value": "AUTOMATIC"
+                  },
+                  {
+                    "label": "On page load",
+                    "subText": "Query runs when the page loads or when manually triggered",
+                    "value": "PAGE_LOAD"
+                  },
+                  {
+                    "label": "Manual",
+                    "subText": "Query only runs when called in an event or JS with .run()",
+                    "value": "MANUAL"
+                  }
+                ]
               },
               {
                 "label": "Request confirmation before running this query",

--- a/app/client/test/factories/MockPluginsState.ts
+++ b/app/client/test/factories/MockPluginsState.ts
@@ -6958,12 +6958,6 @@ export default {
             initialValue: "MANUAL",
             options: [
               {
-                label: "Automatic",
-                subText:
-                  "Query runs on page load or when a variable it depends on changes",
-                value: "AUTOMATIC",
-              },
-              {
                 label: "On page load",
                 subText:
                   "Query runs when the page loads or when manually triggered",
@@ -7043,12 +7037,6 @@ export default {
             controlType: "DROP_DOWN",
             initialValue: "MANUAL",
             options: [
-              {
-                label: "Automatic",
-                subText:
-                  "Query runs on page load or when a variable it depends on changes",
-                value: "AUTOMATIC",
-              },
               {
                 label: "On page load",
                 subText:
@@ -7130,12 +7118,6 @@ export default {
             initialValue: "MANUAL",
             options: [
               {
-                label: "Automatic",
-                subText:
-                  "Query runs on page load or when a variable it depends on changes",
-                value: "AUTOMATIC",
-              },
-              {
                 label: "On page load",
                 subText:
                   "Query runs when the page loads or when manually triggered",
@@ -7179,12 +7161,6 @@ export default {
             controlType: "DROP_DOWN",
             initialValue: "MANUAL",
             options: [
-              {
-                label: "Automatic",
-                subText:
-                  "Query runs on page load or when a variable it depends on changes",
-                value: "AUTOMATIC",
-              },
               {
                 label: "On page load",
                 subText:

--- a/app/client/test/factories/MockPluginsState.ts
+++ b/app/client/test/factories/MockPluginsState.ts
@@ -6952,9 +6952,30 @@ export default {
         id: 1,
         children: [
           {
-            label: "Run the API on page load",
-            configProperty: "executeOnLoad",
-            controlType: "SWITCH",
+            label: "Run behavior",
+            configProperty: "runBehavior",
+            controlType: "DROP_DOWN",
+            initialValue: "MANUAL",
+            options: [
+              {
+                label: "Automatic",
+                subText:
+                  "Query runs on page load or when a variable it depends on changes",
+                value: "AUTOMATIC",
+              },
+              {
+                label: "On page load",
+                subText:
+                  "Query runs when the page loads or when manually triggered",
+                value: "PAGE_LOAD",
+              },
+              {
+                label: "Manual",
+                subText:
+                  "Query only runs when called in an event or JS with .run()",
+                value: "MANUAL",
+              },
+            ],
           },
           {
             label: "Request confirmation before running this API",
@@ -7017,9 +7038,30 @@ export default {
         id: 1,
         children: [
           {
-            label: "Run the API on page load",
-            configProperty: "executeOnLoad",
-            controlType: "SWITCH",
+            label: "Run behavior",
+            configProperty: "runBehavior",
+            controlType: "DROP_DOWN",
+            initialValue: "MANUAL",
+            options: [
+              {
+                label: "Automatic",
+                subText:
+                  "Query runs on page load or when a variable it depends on changes",
+                value: "AUTOMATIC",
+              },
+              {
+                label: "On page load",
+                subText:
+                  "Query runs when the page loads or when manually triggered",
+                value: "PAGE_LOAD",
+              },
+              {
+                label: "Manual",
+                subText:
+                  "Query only runs when called in an event or JS with .run()",
+                value: "MANUAL",
+              },
+            ],
           },
           {
             label: "Request confirmation before running this API",
@@ -7082,9 +7124,30 @@ export default {
         id: 1,
         children: [
           {
-            label: "Run the query on page load",
-            configProperty: "executeOnLoad",
-            controlType: "SWITCH",
+            label: "Run behavior",
+            configProperty: "runBehavior",
+            controlType: "DROP_DOWN",
+            initialValue: "MANUAL",
+            options: [
+              {
+                label: "Automatic",
+                subText:
+                  "Query runs on page load or when a variable it depends on changes",
+                value: "AUTOMATIC",
+              },
+              {
+                label: "On page load",
+                subText:
+                  "Query runs when the page loads or when manually triggered",
+                value: "PAGE_LOAD",
+              },
+              {
+                label: "Manual",
+                subText:
+                  "Query only runs when called in an event or JS with .run()",
+                value: "MANUAL",
+              },
+            ],
           },
           {
             label: "Request confirmation before running this query",
@@ -7111,9 +7174,30 @@ export default {
         id: 1,
         children: [
           {
-            label: "Run the query on page load",
-            configProperty: "executeOnLoad",
-            controlType: "SWITCH",
+            label: "Run behavior",
+            configProperty: "runBehavior",
+            controlType: "DROP_DOWN",
+            initialValue: "MANUAL",
+            options: [
+              {
+                label: "Automatic",
+                subText:
+                  "Query runs on page load or when a variable it depends on changes",
+                value: "AUTOMATIC",
+              },
+              {
+                label: "On page load",
+                subText:
+                  "Query runs when the page loads or when manually triggered",
+                value: "PAGE_LOAD",
+              },
+              {
+                label: "Manual",
+                subText:
+                  "Query only runs when called in an event or JS with .run()",
+                value: "MANUAL",
+              },
+            ],
           },
           {
             label: "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/appsmithAiPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/appsmithAiPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/oraclePlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/oraclePlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/oraclePlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/oraclePlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
@@ -11,11 +11,6 @@
           "initialValue": "MANUAL",
           "options": [
             {
-              "label": "Automatic",
-              "subText": "Query runs on page load or when a variable it depends on changes",
-              "value": "AUTOMATIC"
-            },
-            {
               "label": "On page load",
               "subText": "Query runs when the page loads or when manually triggered",
               "value": "PAGE_LOAD"

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
@@ -5,9 +5,27 @@
       "id": 1,
       "children": [
         {
-          "label": "Run the query on page load",
-          "configProperty": "executeOnLoad",
-          "controlType": "SWITCH"
+          "label": "Run behavior",
+          "configProperty": "runBehavior",
+          "controlType": "DROP_DOWN",
+          "initialValue": "MANUAL",
+          "options": [
+            {
+              "label": "Automatic",
+              "subText": "Query runs on page load or when a variable it depends on changes",
+              "value": "AUTOMATIC"
+            },
+            {
+              "label": "On page load",
+              "subText": "Query runs when the page loads or when manually triggered",
+              "value": "PAGE_LOAD"
+            },
+            {
+              "label": "Manual",
+              "subText": "Query only runs when called in an event or JS with .run()",
+              "value": "MANUAL"
+            }
+          ]
         },
         {
           "label": "Request confirmation before running this query",


### PR DESCRIPTION
## Description

Replacing `executeOnLoad` with `runBehavior` in all action config settings

Figma: https://www.figma.com/design/qFXimqMSH45aviBOdTfDXu/Reactive-Queries-JS?node-id=61-16773&t=rv594VlMSm75Bvcb-0

Fixes [#39831](https://github.com/appsmithorg/appsmith/issues/39831)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
