### PR TITLE
chore: optimise sort when developing the dependencyMap

### DIFF
--- a/app/client/src/entities/DependencyMap/index.ts
+++ b/app/client/src/entities/DependencyMap/index.ts
@@ -1,6 +1,5 @@
 import { difference } from "lodash";
 import { isChildPropertyPath } from "utils/DynamicBindingUtils";
-import { sort } from "fast-sort";
 
 export type TDependencies = Map<string, Set<string>>;
 export default class DependencyMap {
@@ -161,6 +160,26 @@ export default class DependencyMap {
   };
 
   /**
+   * Sorts nodes by their depth in descending order (deeper paths first)
+   * @param nodes Record of nodes to sort
+   * @returns Array of node keys sorted by depth
+   */
+  private sortNodesByDepth = (nodes: Record<string, true>): string[] => {
+    // Pre-compute depths for all nodes
+    const nodeKeys = Object.keys(nodes);
+    const nodeDepths = nodeKeys.map((node) => ({
+      node,
+      depth: node.split(".").length,
+    }));
+
+    // Sort by pre-computed depths in descending order
+    nodeDepths.sort((a, b) => b.depth - a.depth);
+
+    // Return just the node keys in sorted order
+    return nodeDepths.map((item) => item.node);
+  };
+
+  /**
    * Adds new nodes to the graph. Should be called when a new node is added to the graph.
    * Iterates over the nodes and checks in the invalid dependency map, to see if it was used earlier.
    * If it was used earlier, it is added to the valid dependencies and removed from the invalid dependencies.
@@ -170,7 +189,7 @@ export default class DependencyMap {
   addNodes = (nodes: Record<string, true>, strict = true) => {
     const nodesToAdd = strict
       ? Object.keys(nodes)
-      : sort(Object.keys(nodes)).desc((node) => node.split(".").length);
+      : this.sortNodesByDepth(nodes);
 
     let didUpdateGraph = false;
 


### PR DESCRIPTION
## Description
In the sort comparator, we were repeatedly computing the lengths of the paths for two nodes, which contributed approximately 0.87 seconds to the LCP on a Windows machine. We've now optimized this by precomputing the paths beforehand and then sorting the collection. This change has reduced the time to around 70ms, effectively eliminating the redundant computation.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14592179498>
> Commit: d552730a6606b425a8ee33dbe7d8160e78cd0f80
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14592179498&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 22 Apr 2025 11:29:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal sorting of dependency nodes for better performance and maintainability. No visible changes to user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->