### PR TITLE
feat: Migrate executeOnLoad to runBehavior enum

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/RunBehaviorEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/RunBehaviorEnum.java
@@ -1,0 +1,10 @@
+package com.appsmith.external.models;
+
+/**
+ * Enum to define the behavior for running actions
+ */
+public enum RunBehaviorEnum {
+    MANUAL, // Action will only run when manually triggered
+    AUTOMATIC, // Action will run automatically based on triggers
+    ON_PAGE_LOAD // Action will run when the page loads
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ce/ActionCE_DTO.java
@@ -15,6 +15,7 @@ import com.appsmith.external.models.Executable;
 import com.appsmith.external.models.PluginType;
 import com.appsmith.external.models.Policy;
 import com.appsmith.external.models.Property;
+import com.appsmith.external.models.RunBehaviorEnum;
 import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Git;
 import com.appsmith.external.views.Views;
@@ -100,8 +101,16 @@ public class ActionCE_DTO implements Identifiable, Executable {
     @JsonView(Views.Public.class)
     List<ErrorDTO> errorReports;
 
+    /**
+     * @deprecated This field is deprecated and will be removed in a future release.
+     * Use runBehavior instead.
+     */
+    @Deprecated
     @JsonView({Views.Public.class, FromRequest.class, Git.class})
     Boolean executeOnLoad;
+
+    @JsonView({Views.Public.class, FromRequest.class, Git.class})
+    RunBehaviorEnum runBehavior = RunBehaviorEnum.MANUAL;
 
     @JsonView({Views.Public.class, FromRequest.class, Git.class})
     Boolean clientSideExecution;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ActionControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ActionControllerCE.java
@@ -2,6 +2,7 @@ package com.appsmith.server.controllers.ce;
 
 import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.ActionExecutionResult;
+import com.appsmith.external.models.RunBehaviorEnum;
 import com.appsmith.external.views.FromRequest;
 import com.appsmith.external.views.Views;
 import com.appsmith.server.constants.FieldName;
@@ -115,6 +116,20 @@ public class ActionControllerCE {
                 .map(actions -> new ResponseDTO<>(HttpStatus.OK, actions));
     }
 
+    @JsonView(Views.Public.class)
+    @PutMapping("/runBehavior/{branchedActionId}")
+    public Mono<ResponseDTO<ActionDTO>> setRunBehavior(
+            @PathVariable String branchedActionId, @RequestParam RunBehaviorEnum behavior) {
+        log.debug("Going to set run behavior for action id {} to {}", branchedActionId, behavior);
+        return layoutActionService
+                .setRunBehavior(branchedActionId, behavior)
+                .map(action -> new ResponseDTO<>(HttpStatus.OK, action));
+    }
+
+    /**
+     * @deprecated This endpoint is deprecated. Use /runBehavior/{branchedActionId} instead.
+     */
+    @Deprecated
     @JsonView(Views.Public.class)
     @PutMapping("/executeOnLoad/{branchedActionId}")
     public Mono<ResponseDTO<ActionDTO>> setExecuteOnLoad(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCE.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.services.ce;
 
 import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.RunBehaviorEnum;
 import com.appsmith.server.dtos.ActionMoveDTO;
 import com.appsmith.server.dtos.CreateActionMetaDTO;
 import reactor.core.publisher.Mono;
@@ -16,6 +17,8 @@ public interface LayoutActionServiceCE {
     Mono<ActionDTO> updateNewActionByBranchedId(String branchedId, ActionDTO actionDTO);
 
     Mono<ActionDTO> setExecuteOnLoad(String id, Boolean isExecuteOnLoad);
+
+    Mono<ActionDTO> setRunBehavior(String id, RunBehaviorEnum behavior);
 
     Mono<ActionDTO> createAction(ActionDTO actionDTO);
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -8,6 +8,7 @@ import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.PluginType;
 import com.appsmith.external.models.Property;
+import com.appsmith.external.models.RunBehaviorEnum;
 import com.appsmith.server.actioncollections.base.ActionCollectionService;
 import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.constants.ArtifactType;
@@ -1103,7 +1104,7 @@ class LayoutActionServiceTest {
         layout.setDsl(parentDsl);
 
         ActionDTO createdAction1 =
-                layoutActionService.createSingleAction(action1, Boolean.FALSE).block(); // create action1
+                layoutActionService.createSingleAction(action1, Boolean.FALSE).block();
         assertNotNull(createdAction1);
         createdAction1.setExecuteOnLoad(true); // this can only be set to true post action creation.
         NewAction newAction1 = new NewAction();
@@ -1115,7 +1116,7 @@ class LayoutActionServiceTest {
         newAction1.setPluginType(installed_plugin.getType());
 
         ActionDTO createdAction2 =
-                layoutActionService.createSingleAction(action2, Boolean.FALSE).block(); // create action2
+                layoutActionService.createSingleAction(action2, Boolean.FALSE).block();
         assertNotNull(createdAction1);
         createdAction2.setExecuteOnLoad(true); // this can only be set to true post action creation.
         NewAction newAction2 = new NewAction();
@@ -1351,5 +1352,92 @@ class LayoutActionServiceTest {
         children.add(firstWidget);
         parentDsl.put("children", children);
         return parentDsl;
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    void testSetRunBehavior_WhenRunBehaviorChanged_ValuesUpdatedCorrectly() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        // Create a new action
+        ActionDTO action = new ActionDTO();
+        action.setName("testRunBehaviorAction");
+        action.setPageId(testPage.getId());
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        action.setDatasource(datasource);
+
+        // Create the action and validate default values
+        ActionDTO createdAction =
+                layoutActionService.createSingleAction(action, Boolean.FALSE).block();
+        assertNotNull(createdAction);
+        assertEquals(RunBehaviorEnum.MANUAL, createdAction.getRunBehavior());
+        assertEquals(Boolean.FALSE, createdAction.getExecuteOnLoad());
+
+        // Test setting runBehavior to ON_PAGE_LOAD
+        ActionDTO updatedAction = layoutActionService
+                .setRunBehavior(createdAction.getId(), RunBehaviorEnum.ON_PAGE_LOAD)
+                .block();
+        assertNotNull(updatedAction);
+        assertEquals(RunBehaviorEnum.ON_PAGE_LOAD, updatedAction.getRunBehavior());
+        assertEquals(Boolean.TRUE, updatedAction.getExecuteOnLoad());
+        assertEquals(Boolean.TRUE, updatedAction.getUserSetOnLoad());
+
+        // Test setting runBehavior to AUTOMATIC
+        updatedAction = layoutActionService
+                .setRunBehavior(createdAction.getId(), RunBehaviorEnum.AUTOMATIC)
+                .block();
+        assertNotNull(updatedAction);
+        assertEquals(RunBehaviorEnum.AUTOMATIC, updatedAction.getRunBehavior());
+        assertEquals(Boolean.FALSE, updatedAction.getExecuteOnLoad());
+        assertEquals(Boolean.TRUE, updatedAction.getUserSetOnLoad());
+
+        // Ensure the changes were persisted by getting the action again
+        NewAction savedAction = actionRepository.findById(createdAction.getId()).block();
+        assertNotNull(savedAction);
+        assertEquals(
+                RunBehaviorEnum.AUTOMATIC, savedAction.getUnpublishedAction().getRunBehavior());
+        assertEquals(Boolean.FALSE, savedAction.getUnpublishedAction().getExecuteOnLoad());
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    void testSetExecuteOnLoad_AlsoUpdatesRunBehavior() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        // Create a new action
+        ActionDTO action = new ActionDTO();
+        action.setName("testExecuteLoadRunBehaviorAction");
+        action.setPageId(testPage.getId());
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        action.setDatasource(datasource);
+
+        // Create the action and validate default values
+        ActionDTO createdAction =
+                layoutActionService.createSingleAction(action, Boolean.FALSE).block();
+        assertNotNull(createdAction);
+        assertEquals(RunBehaviorEnum.MANUAL, createdAction.getRunBehavior());
+        assertEquals(Boolean.FALSE, createdAction.getExecuteOnLoad());
+
+        // Test setting executeOnLoad to TRUE
+        ActionDTO updatedAction = layoutActionService
+                .setExecuteOnLoad(createdAction.getId(), Boolean.TRUE)
+                .block();
+        assertNotNull(updatedAction);
+        assertEquals(RunBehaviorEnum.ON_PAGE_LOAD, updatedAction.getRunBehavior());
+        assertEquals(Boolean.TRUE, updatedAction.getExecuteOnLoad());
+
+        // Test setting executeOnLoad to FALSE
+        updatedAction = layoutActionService
+                .setExecuteOnLoad(createdAction.getId(), Boolean.FALSE)
+                .block();
+        assertNotNull(updatedAction);
+        assertEquals(RunBehaviorEnum.MANUAL, updatedAction.getRunBehavior());
+        assertEquals(Boolean.FALSE, updatedAction.getExecuteOnLoad());
     }
 }


### PR DESCRIPTION
## Description
This PR implements the migration from the boolean `executeOnLoad` field to a more flexible `runBehavior` enum. The changes include:

1. Created a new `RunBehaviorEnum` in the external models with values `AUTO` (equivalent to executeOnLoad=true) and `MANUAL` (equivalent to executeOnLoad=false)
2. Added `runBehavior` field to action models with default value of `MANUAL`
3. Deprecated the `executeOnLoad` field but maintained it for backward compatibility
4. Updated controller endpoints to support both the new `setRunBehavior` method and the legacy `setExecuteOnLoad` method
5. Added synchronization logic to keep the values of both fields consistent

This approach provides more semantic clarity and flexibility while maintaining backward compatibility with existing client implementations. Future enhancements can add more behavior types beyond the current binary options.


Fixes https://github.com/appsmithorg/appsmith/issues/40309
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14593882821>
> Commit: c00e0cbbd57dd02b6de860b1580bd0ca5658d356
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14593882821&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.Sanity`
> Spec:
> <hr>Tue, 22 Apr 2025 12:29:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting to control how actions are triggered, allowing selection between manual, automatic, or on-page-load execution modes.
  - Added an endpoint to update the run behavior of actions.

- **Bug Fixes**
  - Ensured synchronization between the new run behavior setting and the existing execute-on-load flag for consistent action execution.

- **Deprecation**
  - Marked the previous execute-on-load setting and its related endpoint as deprecated; users are encouraged to use the new run behavior setting.

- **Tests**
  - Added tests to verify correct synchronization between run behavior and execute-on-load settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->