### PR TITLE
refactor: Remove strong dependency from feature flag enum to (de)serialise organization object

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/OrganizationConfigurationCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/OrganizationConfigurationCE.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.domains.ce;
 
-import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.server.constants.FeatureMigrationType;
 import com.appsmith.server.constants.LicensePlan;
 import com.appsmith.server.constants.MigrationStatus;
@@ -58,7 +57,7 @@ public class OrganizationConfigurationCE implements Serializable {
     // the feature flags. This can happen for 2 reasons:
     // 1. The license plan changes
     // 2. Because of grandfathering via cron where organization level feature flags are fetched
-    Map<FeatureFlagEnum, FeatureMigrationType> featuresWithPendingMigration;
+    Map<String, FeatureMigrationType> featuresWithPendingMigration;
 
     Boolean isStrongPasswordPolicyEnabled;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/FeatureFlagMigrationHelperCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/FeatureFlagMigrationHelperCE.java
@@ -9,10 +9,9 @@ import java.util.Map;
 
 public interface FeatureFlagMigrationHelperCE {
 
-    Mono<Map<FeatureFlagEnum, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration(
-            Organization defaultOrganization);
+    Mono<Map<String, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration(Organization defaultOrganization);
 
-    Mono<Map<FeatureFlagEnum, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration(
+    Mono<Map<String, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration(
             Organization organization, boolean forceUpdate);
 
     Mono<Boolean> checkAndExecuteMigrationsForFeatureFlag(Organization organization, FeatureFlagEnum featureFlagEnum);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/FeatureFlagMigrationHelperTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/FeatureFlagMigrationHelperTest.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.helpers;
 
-import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.server.constants.FeatureMigrationType;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.OrganizationConfiguration;
@@ -65,14 +64,14 @@ class FeatureFlagMigrationHelperTest {
         Mockito.when(cacheableFeatureFlagHelper.evictCachedOrganizationFeatures(any()))
                 .thenReturn(Mono.empty());
 
-        Mono<Map<FeatureFlagEnum, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
+        Mono<Map<String, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
                 featureFlagMigrationHelper.getUpdatedFlagsWithPendingMigration(defaultOrganization);
 
         StepVerifier.create(getUpdatedFlagsWithPendingMigration)
                 .assertNext(featureFlagEnumFeatureMigrationTypeMap -> {
                     assertThat(featureFlagEnumFeatureMigrationTypeMap).isNotEmpty();
                     assertThat(featureFlagEnumFeatureMigrationTypeMap).hasSize(1);
-                    assertThat(featureFlagEnumFeatureMigrationTypeMap.get(ORGANIZATION_TEST_FEATURE))
+                    assertThat(featureFlagEnumFeatureMigrationTypeMap.get(ORGANIZATION_TEST_FEATURE.name()))
                             .isEqualTo(DISABLE);
                 })
                 .verifyComplete();
@@ -103,14 +102,14 @@ class FeatureFlagMigrationHelperTest {
         Mockito.when(cacheableFeatureFlagHelper.evictCachedOrganizationFeatures(any()))
                 .thenReturn(Mono.empty());
 
-        Mono<Map<FeatureFlagEnum, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
+        Mono<Map<String, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
                 featureFlagMigrationHelper.getUpdatedFlagsWithPendingMigration(defaultOrganization);
 
         StepVerifier.create(getUpdatedFlagsWithPendingMigration)
                 .assertNext(featureFlagEnumFeatureMigrationTypeMap -> {
                     assertThat(featureFlagEnumFeatureMigrationTypeMap).isNotEmpty();
                     assertThat(featureFlagEnumFeatureMigrationTypeMap).hasSize(1);
-                    assertThat(featureFlagEnumFeatureMigrationTypeMap.get(ORGANIZATION_TEST_FEATURE))
+                    assertThat(featureFlagEnumFeatureMigrationTypeMap.get(ORGANIZATION_TEST_FEATURE.name()))
                             .isEqualTo(ENABLE);
                 })
                 .verifyComplete();
@@ -134,7 +133,7 @@ class FeatureFlagMigrationHelperTest {
         Mockito.when(cacheableFeatureFlagHelper.evictCachedOrganizationFeatures(any()))
                 .thenReturn(Mono.empty());
 
-        Mono<Map<FeatureFlagEnum, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
+        Mono<Map<String, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
                 featureFlagMigrationHelper.getUpdatedFlagsWithPendingMigration(defaultOrganization);
 
         StepVerifier.create(getUpdatedFlagsWithPendingMigration)
@@ -172,7 +171,7 @@ class FeatureFlagMigrationHelperTest {
         Mockito.when(cacheableFeatureFlagHelper.evictCachedOrganizationFeatures(any()))
                 .thenReturn(Mono.empty());
 
-        Mono<Map<FeatureFlagEnum, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
+        Mono<Map<String, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
                 featureFlagMigrationHelper.getUpdatedFlagsWithPendingMigration(defaultOrganization);
 
         StepVerifier.create(getUpdatedFlagsWithPendingMigration)
@@ -198,7 +197,7 @@ class FeatureFlagMigrationHelperTest {
     void checkAndExecuteMigrationsForFeatureFlag_validFeatureFlag_success() {
         Organization defaultOrganization = new Organization();
         OrganizationConfiguration organizationConfiguration = new OrganizationConfiguration();
-        organizationConfiguration.setFeaturesWithPendingMigration(Map.of(ORGANIZATION_TEST_FEATURE, ENABLE));
+        organizationConfiguration.setFeaturesWithPendingMigration(Map.of(ORGANIZATION_TEST_FEATURE.name(), ENABLE));
         organizationConfiguration.setMigrationStatus(PENDING);
         defaultOrganization.setOrganizationConfiguration(organizationConfiguration);
 
@@ -231,7 +230,7 @@ class FeatureFlagMigrationHelperTest {
         Organization defaultOrganization = new Organization();
         defaultOrganization.setId(UUID.randomUUID().toString());
         OrganizationConfiguration organizationConfiguration = new OrganizationConfiguration();
-        organizationConfiguration.setFeaturesWithPendingMigration(Map.of(ORGANIZATION_TEST_FEATURE, DISABLE));
+        organizationConfiguration.setFeaturesWithPendingMigration(Map.of(ORGANIZATION_TEST_FEATURE.name(), DISABLE));
         defaultOrganization.setOrganizationConfiguration(organizationConfiguration);
 
         // Mock CS calls to fetch the feature flags to have the feature flag in pending migration list with ENABLE
@@ -256,7 +255,7 @@ class FeatureFlagMigrationHelperTest {
         Mockito.when(cacheableFeatureFlagHelper.evictCachedOrganizationFeatures(any()))
                 .thenReturn(Mono.empty());
 
-        Mono<Map<FeatureFlagEnum, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
+        Mono<Map<String, FeatureMigrationType>> getUpdatedFlagsWithPendingMigration =
                 featureFlagMigrationHelper.getUpdatedFlagsWithPendingMigration(defaultOrganization);
 
         StepVerifier.create(getUpdatedFlagsWithPendingMigration)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/FeatureFlagServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/FeatureFlagServiceCETest.java
@@ -226,7 +226,7 @@ public class FeatureFlagServiceCETest {
             getAllRemoteFeaturesForOrganizationAndUpdateFeatureFlagsWithPendingMigrations_disableMigration_statesUpdate() {
 
         Mockito.when(featureFlagMigrationHelper.getUpdatedFlagsWithPendingMigration(any()))
-                .thenReturn(Mono.just(Map.of(ORGANIZATION_TEST_FEATURE, DISABLE)));
+                .thenReturn(Mono.just(Map.of(ORGANIZATION_TEST_FEATURE.name(), DISABLE)));
 
         organizationService
                 .retrieveAll()
@@ -237,7 +237,7 @@ public class FeatureFlagServiceCETest {
         StepVerifier.create(organizationService.getCurrentUserOrganization())
                 .assertNext(organization -> {
                     assertThat(organization.getOrganizationConfiguration().getFeaturesWithPendingMigration())
-                            .isEqualTo(Map.of(ORGANIZATION_TEST_FEATURE, DISABLE));
+                            .isEqualTo(Map.of(ORGANIZATION_TEST_FEATURE.name(), DISABLE));
                     assertThat(organization.getOrganizationConfiguration().getMigrationStatus())
                             .isEqualTo(PENDING);
                 })
@@ -249,7 +249,7 @@ public class FeatureFlagServiceCETest {
             getAllRemoteFeaturesForOrganizationAndUpdateFeatureFlagsWithPendingMigrations_enableMigration_statesUpdate() {
 
         Mockito.when(featureFlagMigrationHelper.getUpdatedFlagsWithPendingMigration(any()))
-                .thenReturn(Mono.just(Map.of(ORGANIZATION_TEST_FEATURE, ENABLE)));
+                .thenReturn(Mono.just(Map.of(ORGANIZATION_TEST_FEATURE.name(), ENABLE)));
 
         organizationService
                 .retrieveAll()
@@ -260,7 +260,7 @@ public class FeatureFlagServiceCETest {
         StepVerifier.create(organizationService.getCurrentUserOrganization())
                 .assertNext(organization -> {
                     assertThat(organization.getOrganizationConfiguration().getFeaturesWithPendingMigration())
-                            .isEqualTo(Map.of(ORGANIZATION_TEST_FEATURE, ENABLE));
+                            .isEqualTo(Map.of(ORGANIZATION_TEST_FEATURE.name(), ENABLE));
                     assertThat(organization.getOrganizationConfiguration().getMigrationStatus())
                             .isEqualTo(PENDING);
                 })

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.services.ce;
 
 import com.appsmith.caching.components.CacheManager;
-import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.server.constants.FeatureMigrationType;
 import com.appsmith.server.constants.LicensePlan;
 import com.appsmith.server.domains.Organization;
@@ -339,10 +338,10 @@ class OrganizationServiceCETest {
         organization.setId(UUID.randomUUID().toString());
         organization.setSlug(UUID.randomUUID().toString());
         OrganizationConfiguration config = new OrganizationConfiguration();
-        Map<FeatureFlagEnum, FeatureMigrationType> featureMigrationTypeMap = new HashMap<>();
+        Map<String, FeatureMigrationType> featureMigrationTypeMap = new HashMap<>();
         config.setFeaturesWithPendingMigration(featureMigrationTypeMap);
-        featureMigrationTypeMap.put(ORGANIZATION_TEST_FEATURE, FeatureMigrationType.ENABLE);
-        featureMigrationTypeMap.put(TEST_FEATURE_2, FeatureMigrationType.DISABLE);
+        featureMigrationTypeMap.put(ORGANIZATION_TEST_FEATURE.name(), FeatureMigrationType.ENABLE);
+        featureMigrationTypeMap.put(TEST_FEATURE_2.name(), FeatureMigrationType.DISABLE);
         organization.setOrganizationConfiguration(config);
         final Mono<Organization> resultMono =
                 organizationService.checkAndExecuteMigrationsForOrganizationFeatureFlags(organization);
@@ -368,10 +367,10 @@ class OrganizationServiceCETest {
         organization.setId(UUID.randomUUID().toString());
         organization.setSlug(UUID.randomUUID().toString());
         OrganizationConfiguration config = new OrganizationConfiguration();
-        Map<FeatureFlagEnum, FeatureMigrationType> featureMigrationTypeMap = new HashMap<>();
+        Map<String, FeatureMigrationType> featureMigrationTypeMap = new HashMap<>();
         config.setFeaturesWithPendingMigration(featureMigrationTypeMap);
-        featureMigrationTypeMap.put(ORGANIZATION_TEST_FEATURE, FeatureMigrationType.DISABLE);
-        featureMigrationTypeMap.put(TEST_FEATURE_2, FeatureMigrationType.ENABLE);
+        featureMigrationTypeMap.put(ORGANIZATION_TEST_FEATURE.name(), FeatureMigrationType.DISABLE);
+        featureMigrationTypeMap.put(TEST_FEATURE_2.name(), FeatureMigrationType.ENABLE);
         organization.setOrganizationConfiguration(config);
         final Mono<Organization> resultMono =
                 organizationService.checkAndExecuteMigrationsForOrganizationFeatureFlags(organization);


### PR DESCRIPTION
## Description
- **Refactor**
  - Updated internal handling of feature flags for pending migrations to use string keys instead of enum values, improving consistency and error handling.

- **Tests**
  - Adjusted test cases to align with the new string-based feature flag keys, ensuring continued reliability of migration-related features.

/test Settings

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14657519125>
> Commit: ab4973c9ed3fe039ba01f68adaa451ee5d7536b6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14657519125&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Fri, 25 Apr 2025 05:39:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of feature flags for pending migrations to use string keys instead of enum values, improving consistency and error handling.

- **Tests**
  - Adjusted test cases to align with the new string-based feature flag keys, ensuring continued reliability of migration-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->