### PR TITLE
chore: Remove AI quote from login

### DIFF
--- a/app/client/src/pages/UserAuth/Container.tsx
+++ b/app/client/src/pages/UserAuth/Container.tsx
@@ -7,6 +7,8 @@ import LeftSideContent from "./LeftSideContent";
 import { getAppsmithConfigs } from "ee/configs";
 import { useIsMobileDevice } from "utils/hooks/useDeviceDetect";
 import styled from "styled-components";
+import { getIsAiAgentFlowEnabled } from "ee/selectors/aiAgentSelectors";
+import clsx from "clsx";
 
 interface ContainerProps {
   title: string;
@@ -43,10 +45,15 @@ function Container(props: ContainerProps) {
   const organizationConfig = useSelector(getOrganizationConfig);
   const { cloudHosting } = getAppsmithConfigs();
   const isMobileDevice = useIsMobileDevice();
+  const isAiAgentFlowEnabled = useSelector(getIsAiAgentFlowEnabled);
 
   return (
     <ContainerWrapper
-      className={`gap-14 my-auto flex items-center justify-center min-w-min`}
+      className={clsx({
+        "my-auto flex items-center justify-center min-w-min": true,
+        "flex-col-reverse gap-4": isAiAgentFlowEnabled,
+        "flex-row gap-14": !isAiAgentFlowEnabled,
+      })}
       data-testid={testId}
     >
       {cloudHosting && !isMobileDevice && <LeftSideContent />}

--- a/app/client/src/pages/UserAuth/LeftSideContent.tsx
+++ b/app/client/src/pages/UserAuth/LeftSideContent.tsx
@@ -71,33 +71,30 @@ const QUOTE = {
   authorImage: `${getAssetUrl(`${ASSETS_CDN_URL}/thomas-zwick.png`)}`,
 };
 
-const QUOTE_FOR_AGENTS = {
-  quote: `Our goal was to have an omni-channel AI system that could help our usersin every step of the journey. Appsmith serves as a command center for us to control the behavior of the agent. This is a competitive advantage. We're able to serve our customers much faster than our competitors`,
-  author: "Shawn Lim",
-  authorTitle: "VP, Platform & AI, Funding Societies",
-  authorImage: "https://assets.appsmith.com/fundingsocieties-logo.svg",
-};
-
 function LeftSideContent() {
   const isAiAgentFlowEnabled = useSelector(getIsAiAgentFlowEnabled);
 
-  const quote = isAiAgentFlowEnabled ? QUOTE_FOR_AGENTS : QUOTE;
-
   return (
     <Wrapper>
-      <div className="left-description">
-        <div className="left-description-container">
-          &quot;{quote.quote}&quot;
+      {!isAiAgentFlowEnabled && (
+        <div className="left-description">
+          <div className="left-description-container">
+            &quot;{QUOTE.quote}&quot;
+          </div>
+          <div className="left-description-author">
+            {QUOTE.authorImage && (
+              <Avatar
+                image={QUOTE.authorImage}
+                label={QUOTE.author}
+                size="sm"
+              />
+            )}
+            <div>{QUOTE.author}</div>
+            <div className="dot">&#183;</div>
+            <div>{QUOTE.authorTitle}</div>
+          </div>
         </div>
-        <div className="left-description-author">
-          {quote.authorImage && (
-            <Avatar image={quote.authorImage} label={quote.author} size="sm" />
-          )}
-          <div>{quote.author}</div>
-          <div className="dot">&#183;</div>
-          <div>{quote.authorTitle}</div>
-        </div>
-      </div>
+      )}
 
       <div className="client-logo-container">
         <div className="client-heading">


### PR DESCRIPTION
## Description
 
Removes the Quote for AI flow 

## Automation

/ok-to-test tags="@tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14659035348>
> Commit: 2aea340a5ee07762644945c0e5732771e4329235
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14659035348&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.IDE`
> Spec:
> <hr>Fri, 25 Apr 2025 07:44:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The layout and spacing of the authentication container now adjust dynamically based on whether the AI agent flow is enabled.
- **Style**
  - Updated the appearance of the container and client logos to reflect the AI agent flow status.
- **Bug Fixes**
  - When the AI agent flow is enabled, motivational quotes and author details are no longer displayed on the authentication page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->