### PR TITLE
chore: UI Module instances support broken references in widgets entity explorer

### DIFF
--- a/app/client/src/ce/pages/AppIDE/components/UIEntityListTree/OrphanUIModuleInstancesEntityList.tsx
+++ b/app/client/src/ce/pages/AppIDE/components/UIEntityListTree/OrphanUIModuleInstancesEntityList.tsx
@@ -1,0 +1,14 @@
+/**
+ * This component is used to display the orphan UIModuleInstances in the EntityListTree.
+ * An orphan UIModuleInstance is a UIModuleInstance that has an instance of a module
+ * but the module instance's widget is not present in the canvas.
+ *
+ *  This function is extended in EE
+ * @returns
+ */
+
+function OrphanUIModuleInstancesEntityList() {
+  return null;
+}
+
+export default OrphanUIModuleInstancesEntityList;

--- a/app/client/src/ee/pages/AppIDE/components/UIEntityListTree/OrphanUIModuleInstancesEntityList.tsx
+++ b/app/client/src/ee/pages/AppIDE/components/UIEntityListTree/OrphanUIModuleInstancesEntityList.tsx
@@ -1,0 +1,1 @@
+export { default } from "ce/pages/AppIDE/components/UIEntityListTree/OrphanUIModuleInstancesEntityList";

--- a/app/client/src/pages/AppIDE/components/UIEntityListTree/UIEntityListTree.tsx
+++ b/app/client/src/pages/AppIDE/components/UIEntityListTree/UIEntityListTree.tsx
@@ -6,7 +6,7 @@ import { getSelectedWidgets } from "selectors/ui";
 import { useWidgetTreeState } from "./hooks/useWidgetTreeExpandedState";
 import { enhanceItemsTree } from "./utils/enhanceTree";
 import { WidgetTreeItem } from "./WidgetTreeItem";
-
+import OrphanUIModuleInstancesEntityList from "ee/pages/AppIDE/components/UIEntityListTree/OrphanUIModuleInstancesEntityList";
 export const UIEntityListTree = () => {
   const widgets = useSelector(selectWidgetsForCurrentPage);
   const selectedWidgets = useSelector(getSelectedWidgets);
@@ -19,13 +19,17 @@ export const UIEntityListTree = () => {
     isSelected: selectedWidgets.includes(widget.widgetId),
     isExpanded: expandedWidgets.includes(widget.widgetId),
     type: widget.type,
+    hasError: widget.hasError,
   }));
 
   return (
-    <EntityListTree
-      ItemComponent={WidgetTreeItem}
-      items={items}
-      onItemExpand={handleExpand}
-    />
+    <>
+      <EntityListTree
+        ItemComponent={WidgetTreeItem}
+        items={items}
+        onItemExpand={handleExpand}
+      />
+      <OrphanUIModuleInstancesEntityList />
+    </>
   );
 };

--- a/app/client/src/pages/AppIDE/components/UIEntityListTree/WidgetTreeItem.tsx
+++ b/app/client/src/pages/AppIDE/components/UIEntityListTree/WidgetTreeItem.tsx
@@ -93,6 +93,7 @@ export const WidgetTreeItem = ({ item }: { item: EntityListTreeItem }) => {
 
   return (
     <EntityItem
+      hasError={item.hasError}
       id={item.id}
       isSelected={item.isSelected}
       nameEditorConfig={nameEditorConfig}

--- a/app/client/src/reducers/uiReducers/pageCanvasStructureReducer.ts
+++ b/app/client/src/reducers/uiReducers/pageCanvasStructureReducer.ts
@@ -13,6 +13,7 @@ export interface CanvasStructure {
   widgetId: string;
   type: WidgetType;
   children?: CanvasStructure[];
+  hasError?: boolean;
 }
 
 export interface DSL extends WidgetProps {


### PR DESCRIPTION
## Description
- Create orphan UI Module instances component for displaying UI modules not present on canvas
- Add error indication for widgets in the tree view
- Update widget tree data structure to support error state

Changes for https://github.com/appsmithorg/appsmith-ee/pull/7274

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14682236408>
> Commit: b65ec1538913ad9327c65f97e8f161707f271014
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14682236408&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Sat, 26 Apr 2025 15:49:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced display of orphan module instances in the entity list tree, allowing users to view modules not currently present on the canvas.

- **Enhancements**
  - Entity list items now indicate error status, improving visibility of issues within widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->