### PR TITLE
chore: downgrade tinymce from 7.7.1 to 6.8.3 in package.json

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -226,7 +226,7 @@
     "tailwindcss": "^3.3.3",
     "tern": "^0.21.0",
     "tinycolor2": "^1.4.2",
-    "tinymce": "7.7.1",
+    "tinymce": "6.8.3",
     "toposort": "^2.0.2",
     "tslib": "^2.3.1",
     "typescript": "^5.5.4",

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -460,13 +460,13 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
             ],
             // Configure text patterns to use space key trigger for markdown-style formatting
             text_patterns: [
-              { start: "#", format: "h1", trigger: "space" },
-              { start: "##", format: "h2", trigger: "space" },
-              { start: "###", format: "h3", trigger: "space" },
-              { start: "1.", cmd: "InsertOrderedList", trigger: "space" },
-              { start: "*", cmd: "InsertUnorderedList", trigger: "space" },
-              { start: "-", cmd: "InsertUnorderedList", trigger: "space" },
-              { start: ">", cmd: "mceBlockQuote", trigger: "space" },
+              { start: "#", format: "h1" },
+              { start: "##", format: "h2" },
+              { start: "###", format: "h3" },
+              { start: "1.", cmd: "InsertOrderedList" },
+              { start: "*", cmd: "InsertUnorderedList" },
+              { start: "-", cmd: "InsertUnorderedList" },
+              { start: ">", cmd: "mceBlockQuote" },
             ],
             contextmenu: "link useBrowserSpellcheck image table",
             setup: function (editor) {

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -13878,7 +13878,7 @@ __metadata:
     tern: ^0.21.0
     terser-webpack-plugin: ^5.2.5
     tinycolor2: ^1.4.2
-    tinymce: 7.7.1
+    tinymce: 6.8.3
     toposort: ^2.0.2
     ts-jest: ^29.1.0
     ts-jest-mock-import-meta: ^0.12.0
@@ -33361,10 +33361,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinymce@npm:7.7.1":
-  version: 7.7.1
-  resolution: "tinymce@npm:7.7.1"
-  checksum: e5deb0ee798c4af3d5c1ed4887e4b9541ec0355704731623f1fbb9f9afad09938e6d397c003cc82424aca381f252d4b324a6cac33fcdb79771daea23c5d8f8f7
+"tinymce@npm:6.8.3":
+  version: 6.8.3
+  resolution: "tinymce@npm:6.8.3"
+  checksum: 2ce922ceb60636778afb21a493e99d561e73f82c5fb331a4f666d973129ca27277bc1b6332d6932ab8fe0a379b1f201285f143a2d72646a813fda88a0dec5312
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Following the first proposed option, this PR downgrades the tinymce dependency back to the latest available 6.x version, which is still covered under the MIT license.
This ensures Appsmith remains compliant with its Apache-2.0 licensing terms without needing to replace the editor entirely.


### Implementation Details
	•	Reverted the tinymce dependency to ^6.8.3.
	•	Confirmed editor functionality remains intact after the downgrade.
	•	Updated any lockfiles as necessary.

### Additional Notes
	•	If/when Appsmith decides to upgrade or swap editors in the future, alternatives that are Apache-2.0-compatible should be considered.
	•	No user-facing changes are expected from this downgrade.

Fixes #40365
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity, @tag.RichTextEditor"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14723044727>
> Commit: 9def4598f287830bbcc14c467826be6f4303f494
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14723044727&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.RichTextEditor`
> Spec:
> <hr>Tue, 29 Apr 2025 04:43:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Downgraded the "tinymce" editor dependency to version 6.8.3.
  - Improved text formatting behavior in the rich text editor for a smoother editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->