### PR TITLE
fix: Fixes property pane behavior when infinite scroll is enabled.

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/__tests__/propertyUtils.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/__tests__/propertyUtils.test.ts
@@ -1087,15 +1087,6 @@ describe("Infinite Scroll Update Hooks - ", () => {
         propertyValue: true,
       },
     ]);
-
-    // When some other value is passed
-    expect(
-      updateAllowAddNewRowOnInfiniteScrollChange(
-        props,
-        "infiniteScrollEnabled",
-        "some-other-value",
-      ),
-    ).toBeUndefined();
   });
 
   it("updateSearchSortFilterOnInfiniteScrollChange - should disable/enable search, filter, sort when infinite scroll is toggled", () => {
@@ -1132,11 +1123,11 @@ describe("Infinite Scroll Update Hooks - ", () => {
       ),
     ).toEqual([
       {
-        propertyPath: "isVisibleFilters",
+        propertyPath: "isVisibleSearch",
         propertyValue: true,
       },
       {
-        propertyPath: "isVisibleSearch",
+        propertyPath: "isVisibleFilters",
         propertyValue: true,
       },
       {
@@ -1144,15 +1135,6 @@ describe("Infinite Scroll Update Hooks - ", () => {
         propertyValue: true,
       },
     ]);
-
-    // When some other value is passed
-    expect(
-      updateSearchSortFilterOnInfiniteScrollChange(
-        props,
-        "infiniteScrollEnabled",
-        "some-other-value",
-      ),
-    ).toBeUndefined();
   });
 
   it("updateCellEditabilityOnInfiniteScrollChange - should disable cell editability when infinite scroll is enabled", () => {
@@ -1234,15 +1216,6 @@ describe("Infinite Scroll Update Hooks - ", () => {
         propsWithoutColumns,
         "infiniteScrollEnabled",
         true,
-      ),
-    ).toBeUndefined();
-
-    // When some other value is passed
-    expect(
-      updateCellEditabilityOnInfiniteScrollChange(
-        props,
-        "infiniteScrollEnabled",
-        "some-other-value",
       ),
     ).toBeUndefined();
   });

--- a/app/client/src/widgets/TableWidgetV2/widget/__tests__/propertyUtils.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/__tests__/propertyUtils.test.ts
@@ -1,4 +1,7 @@
-import { updateAllowAddNewRowOnInfiniteScrollChange } from "../propertyUtils";
+import {
+  updateAllowAddNewRowOnInfiniteScrollChange,
+  updateServerSidePaginationOnInfiniteScrollChange,
+} from "../propertyUtils";
 import {
   totalRecordsCountValidation,
   uniqueColumnNameValidation,
@@ -1242,5 +1245,22 @@ describe("Infinite Scroll Update Hooks - ", () => {
         "some-other-value",
       ),
     ).toBeUndefined();
+  });
+
+  it("updateServerSidePaginationOnInfiniteScrollChange - should enable server side pagination when infinite scroll is enabled", () => {
+    const props = {} as TableWidgetProps;
+
+    expect(
+      updateServerSidePaginationOnInfiniteScrollChange(
+        props,
+        "infiniteScrollEnabled",
+        true,
+      ),
+    ).toEqual([
+      {
+        propertyPath: "serverSidePaginationEnabled",
+        propertyValue: true,
+      },
+    ]);
   });
 });

--- a/app/client/src/widgets/TableWidgetV2/widget/__tests__/propertyUtils.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/__tests__/propertyUtils.test.ts
@@ -1,7 +1,4 @@
-import {
-  updateAllowAddNewRowOnInfiniteScrollChange,
-  updateServerSidePaginationOnInfiniteScrollChange,
-} from "../propertyUtils";
+import { updateAllowAddNewRowOnInfiniteScrollChange } from "../propertyUtils";
 import {
   totalRecordsCountValidation,
   uniqueColumnNameValidation,
@@ -1218,22 +1215,5 @@ describe("Infinite Scroll Update Hooks - ", () => {
         true,
       ),
     ).toBeUndefined();
-  });
-
-  it("updateServerSidePaginationOnInfiniteScrollChange - should enable server side pagination when infinite scroll is enabled", () => {
-    const props = {} as TableWidgetProps;
-
-    expect(
-      updateServerSidePaginationOnInfiniteScrollChange(
-        props,
-        "infiniteScrollEnabled",
-        true,
-      ),
-    ).toEqual([
-      {
-        propertyPath: "serverSidePaginationEnabled",
-        propertyValue: true,
-      },
-    ]);
   });
 });

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -28,6 +28,7 @@ import {
   updateInlineEditingOptionDropdownVisibilityHook,
   updateInlineEditingSaveOptionHook,
   updateSearchSortFilterOnInfiniteScrollChange,
+  updateServerSidePaginationOnInfiniteScrollChange,
 } from "../propertyUtils";
 import panelConfig from "./PanelConfig";
 
@@ -196,6 +197,7 @@ export default [
         isBindProperty: false,
         isTriggerProperty: false,
         updateHook: composePropertyUpdateHook([
+          updateServerSidePaginationOnInfiniteScrollChange,
           updateAllowAddNewRowOnInfiniteScrollChange,
           updateCellEditabilityOnInfiniteScrollChange,
           updateSearchSortFilterOnInfiniteScrollChange,

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -28,7 +28,6 @@ import {
   updateInlineEditingOptionDropdownVisibilityHook,
   updateInlineEditingSaveOptionHook,
   updateSearchSortFilterOnInfiniteScrollChange,
-  updateServerSidePaginationOnInfiniteScrollChange,
 } from "../propertyUtils";
 import panelConfig from "./PanelConfig";
 
@@ -197,13 +196,14 @@ export default [
         isBindProperty: false,
         isTriggerProperty: false,
         updateHook: composePropertyUpdateHook([
-          updateServerSidePaginationOnInfiniteScrollChange,
           updateAllowAddNewRowOnInfiniteScrollChange,
           updateCellEditabilityOnInfiniteScrollChange,
           updateSearchSortFilterOnInfiniteScrollChange,
         ]),
-        dependencies: ["primaryColumns"],
-        hidden: () => !Widget.getFeatureFlag(INFINITE_SCROLL_ENABLED),
+        dependencies: ["primaryColumns", "serverSidePaginationEnabled"],
+        hidden: (props: TableWidgetProps) =>
+          !Widget.getFeatureFlag(INFINITE_SCROLL_ENABLED) ||
+          !props.serverSidePaginationEnabled,
       },
       {
         helpText: createMessage(TABLE_WIDGET_TOTAL_RECORD_TOOLTIP),

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -1556,3 +1556,18 @@ export const updateCellEditabilityOnInfiniteScrollChange = (
 
   return updates.length > 0 ? updates : undefined;
 };
+
+export const updateServerSidePaginationOnInfiniteScrollChange = (
+  props: TableWidgetProps,
+  propertyPath: string,
+  propertyValue: unknown,
+): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
+  if (propertyValue === true) {
+    return [
+      {
+        propertyPath: "serverSidePaginationEnabled",
+        propertyValue: true,
+      },
+    ];
+  }
+};

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -1454,23 +1454,12 @@ export const updateAllowAddNewRowOnInfiniteScrollChange = (
   propertyPath: string,
   propertyValue: unknown,
 ): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
-  if (propertyValue === true) {
-    return [
-      {
-        propertyPath: "allowAddNewRow",
-        propertyValue: false,
-      },
-    ];
-  } else if (propertyValue === false) {
-    return [
-      {
-        propertyPath: "allowAddNewRow",
-        propertyValue: true,
-      },
-    ];
-  }
-
-  return;
+  return [
+    {
+      propertyPath: "allowAddNewRow",
+      propertyValue: !propertyValue,
+    },
+  ];
 };
 
 // Infinite scroll not supported for search, sort and filters yet
@@ -1479,39 +1468,20 @@ export const updateSearchSortFilterOnInfiniteScrollChange = (
   propertyPath: string,
   propertyValue: unknown,
 ): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
-  if (propertyValue === true) {
-    return [
-      {
-        propertyPath: "isVisibleSearch",
-        propertyValue: false,
-      },
-      {
-        propertyPath: "isVisibleFilters",
-        propertyValue: false,
-      },
-      {
-        propertyPath: "isSortable",
-        propertyValue: false,
-      },
-    ];
-  } else if (propertyValue === false) {
-    return [
-      {
-        propertyPath: "isVisibleFilters",
-        propertyValue: true,
-      },
-      {
-        propertyPath: "isVisibleSearch",
-        propertyValue: true,
-      },
-      {
-        propertyPath: "isSortable",
-        propertyValue: true,
-      },
-    ];
-  }
-
-  return;
+  return [
+    {
+      propertyPath: "isVisibleSearch",
+      propertyValue: !propertyValue,
+    },
+    {
+      propertyPath: "isVisibleFilters",
+      propertyValue: !propertyValue,
+    },
+    {
+      propertyPath: "isSortable",
+      propertyValue: !propertyValue,
+    },
+  ];
 };
 
 // Disable cell editability when infinite scroll is enabled
@@ -1524,35 +1494,19 @@ export const updateCellEditabilityOnInfiniteScrollChange = (
 
   const updates: Array<{ propertyPath: string; propertyValue: unknown }> = [];
 
-  if (propertyValue === true) {
-    Object.entries(props.primaryColumns).forEach(([, column]) => {
-      const columnName = column.alias;
+  Object.entries(props.primaryColumns).forEach(([, column]) => {
+    const columnName = column.alias;
 
-      updates.push({
-        propertyPath: `primaryColumns.${columnName}.isCellEditable`,
-        propertyValue: false,
-      });
-
-      updates.push({
-        propertyPath: `primaryColumns.${columnName}.isEditable`,
-        propertyValue: false,
-      });
+    updates.push({
+      propertyPath: `primaryColumns.${columnName}.isCellEditable`,
+      propertyValue: !propertyValue,
     });
-  } else if (propertyValue === false) {
-    Object.entries(props.primaryColumns).forEach(([, column]) => {
-      const columnName = column.alias;
 
-      updates.push({
-        propertyPath: `primaryColumns.${columnName}.isCellEditable`,
-        propertyValue: true,
-      });
-
-      updates.push({
-        propertyPath: `primaryColumns.${columnName}.isEditable`,
-        propertyValue: true,
-      });
+    updates.push({
+      propertyPath: `primaryColumns.${columnName}.isEditable`,
+      propertyValue: !propertyValue,
     });
-  }
+  });
 
   return updates.length > 0 ? updates : undefined;
 };

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -1452,7 +1452,7 @@ export function colorForEachRowValidation(
 export const updateAllowAddNewRowOnInfiniteScrollChange = (
   props: TableWidgetProps,
   propertyPath: string,
-  propertyValue: unknown,
+  propertyValue: boolean,
 ): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
   return [
     {
@@ -1466,7 +1466,7 @@ export const updateAllowAddNewRowOnInfiniteScrollChange = (
 export const updateSearchSortFilterOnInfiniteScrollChange = (
   props: TableWidgetProps,
   propertyPath: string,
-  propertyValue: unknown,
+  propertyValue: boolean,
 ): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
   return [
     {
@@ -1488,7 +1488,7 @@ export const updateSearchSortFilterOnInfiniteScrollChange = (
 export const updateCellEditabilityOnInfiniteScrollChange = (
   props: TableWidgetProps,
   propertyPath: string,
-  propertyValue: unknown,
+  propertyValue: boolean,
 ): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
   if (!props.primaryColumns) return;
 
@@ -1514,13 +1514,13 @@ export const updateCellEditabilityOnInfiniteScrollChange = (
 export const updateServerSidePaginationOnInfiniteScrollChange = (
   props: TableWidgetProps,
   propertyPath: string,
-  propertyValue: unknown,
-): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
+  propertyValue: boolean,
+): Array<{ propertyPath: string; propertyValue: boolean }> | undefined => {
   if (propertyValue === true && !props.serverSidePaginationEnabled) {
     return [
       {
         propertyPath: "serverSidePaginationEnabled",
-        propertyValue: true,
+        propertyValue,
       },
     ];
   }

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -1516,7 +1516,7 @@ export const updateServerSidePaginationOnInfiniteScrollChange = (
   propertyPath: string,
   propertyValue: unknown,
 ): Array<{ propertyPath: string; propertyValue: unknown }> | undefined => {
-  if (propertyValue === true) {
+  if (propertyValue === true && !props.serverSidePaginationEnabled) {
     return [
       {
         propertyPath: "serverSidePaginationEnabled",
@@ -1524,4 +1524,6 @@ export const updateServerSidePaginationOnInfiniteScrollChange = (
       },
     ];
   }
+
+  return undefined;
 };

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -1510,20 +1510,3 @@ export const updateCellEditabilityOnInfiniteScrollChange = (
 
   return updates.length > 0 ? updates : undefined;
 };
-
-export const updateServerSidePaginationOnInfiniteScrollChange = (
-  props: TableWidgetProps,
-  propertyPath: string,
-  propertyValue: boolean,
-): Array<{ propertyPath: string; propertyValue: boolean }> | undefined => {
-  if (propertyValue === true && !props.serverSidePaginationEnabled) {
-    return [
-      {
-        propertyPath: "serverSidePaginationEnabled",
-        propertyValue,
-      },
-    ];
-  }
-
-  return undefined;
-};


### PR DESCRIPTION
## Description
<ins>Problem</ins>

When enabling infinite scrolling without previously having server-side pagination enabled, the property for server-side pagination remains false.

<ins>Root cause</ins>

The issue lies in the fact that setting up infinite scrolling automatically enables server-side pagination, but doesn't update the property to reflect this change.

<ins>Solution</ins>

This PR addresses this issue by adding a property update hook that enables server-side pagination as soon as the user enables infinite scroll.

Fixes #40409
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14730894730>
> Commit: 8a4fc351c0e960a7d2e3b5b87fbfa8eb5d141e51
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14730894730&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.Table
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/InfiniteScrollVariableHeightRows_spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Tue, 29 Apr 2025 12:53:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and improved the logic for toggling related Table widget settings when infinite scroll is enabled or disabled.
  - Updated the visibility of the infinite scroll toggle to depend on server-side pagination being enabled and the relevant feature flag.

- **Tests**
  - Removed obsolete test assertions related to infinite scroll property handling and corrected test output expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->