### PR TITLE
fix: update visibility condition for infinite scroll in TableWidgetV2

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/InfiniteScrollVariableHeightRows_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/InfiniteScrollVariableHeightRows_spec.ts
@@ -43,6 +43,7 @@ describe(
 
       propPane.EnterJSContext("Table data", JSON.stringify(testData));
 
+      propPane.TogglePropertyState("Server side pagination", "On");
       propPane.TogglePropertyState("Infinite scroll", "On");
     });
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Table_InfiniteScroll_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/Table_InfiniteScroll_spec.ts
@@ -48,6 +48,7 @@ describe(
 
     it("1. should enable infinite scroll and verify records are loaded automatically when scrolling", () => {
       // Enable infinite scroll in the property pane
+      propPane.TogglePropertyState("Server side pagination", "On");
       propPane.TogglePropertyState("Infinite scroll", "On");
 
       // Wait for network call to complete

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -201,7 +201,9 @@ export default [
           updateSearchSortFilterOnInfiniteScrollChange,
         ]),
         dependencies: ["primaryColumns"],
-        hidden: () => !Widget.getFeatureFlag(INFINITE_SCROLL_ENABLED),
+        hidden: (props: TableWidgetProps) =>
+          !Widget.getFeatureFlag(INFINITE_SCROLL_ENABLED) ||
+          !props.serverSidePaginationEnabled,
       },
       {
         helpText: createMessage(TABLE_WIDGET_TOTAL_RECORD_TOOLTIP),

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -200,7 +200,7 @@ export default [
           updateCellEditabilityOnInfiniteScrollChange,
           updateSearchSortFilterOnInfiniteScrollChange,
         ]),
-        dependencies: ["primaryColumns"],
+        dependencies: ["primaryColumns", "serverSidePaginationEnabled"],
         hidden: (props: TableWidgetProps) =>
           !Widget.getFeatureFlag(INFINITE_SCROLL_ENABLED) ||
           !props.serverSidePaginationEnabled,


### PR DESCRIPTION

## Description
Updated the 'hidden' property in the TableWidgetV2 configuration to account for both the INFINITE_SCROLL_ENABLED feature flag and the serverSidePaginationEnabled prop, ensuring proper visibility control based on these conditions.


Fixes #40409
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14733305658>
> Commit: cba8275ab184bc9c3c8e0a54c54994e3409b9c98
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14733305658&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Tue, 29 Apr 2025 16:01:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the visibility logic for the infinite scroll option in table pagination settings to better reflect feature availability and widget configuration.  
- **Tests**
  - Enhanced test coverage by enabling server-side pagination alongside infinite scroll in table widget scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->