### PR TITLE
chore: open carbon modal when creating agent from scratch

### DIFF
--- a/app/client/src/ee/actions/aiAgentActions.ts
+++ b/app/client/src/ee/actions/aiAgentActions.ts
@@ -7,3 +7,17 @@ export const setCreateAgentModalOpen = ({ isOpen }: { isOpen: boolean }) => ({
   type: "",
   payload: { isOpen },
 });
+
+export const openCarbonModal = ({ shouldOpen }: { shouldOpen: boolean }) => ({
+  type: "",
+  payload: { shouldOpen },
+});
+
+export const toggleFCIntegrations = ({
+  isEnabled,
+}: {
+  isEnabled: boolean;
+}) => ({
+  type: "",
+  payload: { isEnabled },
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Carbon" modal now opens automatically when importing certain templates.
  - Feature-flagged integrations can be enabled during template import if applicable.

- **Bug Fixes**
  - No bug fixes included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->