### PR TITLE
test: fix failing Rich text editor

### DIFF
--- a/app/client/.husky/check-staged-files.sh
+++ b/app/client/.husky/check-staged-files.sh
@@ -2,14 +2,26 @@
 
 is_server_change=$(git diff --cached --name-only | grep -c "app/server")
 is_client_change=$(git diff --cached --name-only | grep -c "app/client")
+is_package_json_change=$(git diff --cached --name-only | grep -c "app/client/package.json")
 
 is_merge_commit=$(git rev-parse -q --verify MERGE_HEAD)
 
+# Function to check TinyMCE version changes
+check_tinymce_version() {
+  # Check if TinyMCE version is being changed
+  if git diff --cached app/client/package.json | grep -q '^-.*"tinymce": "6\.8\.3"' &&
+    git diff --cached app/client/package.json | grep -q '^+.*"tinymce": "[^"]*"'; then
+    echo "❌ Error: Attempting to change TinyMCE version. This is not allowed as per team decision."
+    echo "Please keep TinyMCE at version 6.8.3"
+    exit 1
+  fi
+}
+
 # Function to apply Spotless and only commit staged files
 apply_spotless_and_commit_staged_files() {
-  staged_server_files=$(git diff --cached --name-only | grep "app/server"| sed 's|app/server/||')
+  staged_server_files=$(git diff --cached --name-only | grep "app/server" | sed 's|app/server/||')
   mvn spotless:apply
-   # Check if Spotless succeeded
+  # Check if Spotless succeeded
   if [ $? -ne 0 ]; then
     echo "Spotless apply failed, Please run mvn spotless:apply"
     exit 1
@@ -21,11 +33,16 @@ apply_spotless_and_commit_staged_files() {
 if [ "$is_merge_commit" ]; then
   echo "Skipping server and client checks for merge commit"
 else
+  if [ "$is_package_json_change" -ge 1 ]; then
+    echo "Checking package.json changes..."
+    check_tinymce_version
+  fi
+
   if [ "$is_server_change" -ge 1 ]; then
     echo "Applying Spotless to server files..."
-    pushd app/server > /dev/null
+    pushd app/server >/dev/null
     apply_spotless_and_commit_staged_files
-    popd > /dev/null
+    popd >/dev/null
   else
     echo "Skipping server side check..."
   fi

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -315,11 +315,11 @@ export class CommonLocators {
   _fileUploadAddMore = ".uppy-DashboardContent-addMore";
   _buttonText = ".bp3-button-text";
   _richText_TitleBlock = "[aria-label='Block Paragraph']";
-  _richText_Heading = "[aria-label='Heading 1']";
+  _richText_Heading = "[title='Heading 1']";
   _richText_Label_Text = ".tox-tbtn__select-label";
   _richText_Text_Color = (color: string) =>
     `[aria-label="Text color ${color}"] .tox-split-button__chevron`;
-  _richText_color = (value: string) => `[aria-label="${value}"]`;
+  _richText_color = (value: string) => `[title="${value}"]`;
   _richText_line = "#tinymce p span";
   _treeSelectedContent = ".rc-tree-select-selection-item-content";
   _switcherIcon = ".switcher-icon";


### PR DESCRIPTION
## Description
* In addition, added a check on the pre-commit hook to prevent anyone from updating TinyMCE from 6. 8. 3 again. 

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.TextEditor"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14735650279>
> Commit: 2fb46c6675b18e735dca766083dd78469722ebb5
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14735650279&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.TextEditor`
> Spec:
> <hr>Tue, 29 Apr 2025 16:12:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated selectors for rich text editor elements to use the `title` attribute instead of `aria-label`, improving compatibility with recent changes.

- **Chores**
  - Added a pre-commit check to prevent changes to the TinyMCE dependency version in `package.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->