### PR TITLE
chore: git pkg - hiding cd for packages

### DIFF
--- a/app/client/src/git/components/OpsModal/OpsModalView.tsx
+++ b/app/client/src/git/components/OpsModal/OpsModalView.tsx
@@ -15,7 +15,7 @@ import styled from "styled-components";
 // import ReconnectSSHError from "../components/ReconnectSSHError";
 import { GitOpsTab } from "git/constants/enums";
 import noop from "lodash/noop";
-import isGitTaggingEnabled from "git/helpers/isGitTaggingEnabled";
+import isTaggingEnabled from "git/helpers/isTaggingEnabled";
 import type { GitArtifactDef } from "git/types";
 import TabRelease from "./TabRelease";
 import { OPS_MODAL } from "git/ee/constants/messages";
@@ -49,7 +49,7 @@ function OpsModalView({
   repoName = null,
   toggleOpsModal = noop,
 }: OpsModalViewProps) {
-  const isTaggingEnabled = isGitTaggingEnabled(artifactDef);
+  const showReleaseTab = isTaggingEnabled(artifactDef);
 
   useEffect(
     function fetchStatusOnMountEffect() {
@@ -99,7 +99,7 @@ function OpsModalView({
               >
                 {createMessage(MERGE)}
               </Tab>
-              {isTaggingEnabled && (
+              {showReleaseTab && (
                 <Tab
                   data-testid={"t--git-ops-tab-tag"}
                   disabled={isProtectedMode}
@@ -112,7 +112,7 @@ function OpsModalView({
           </Tabs>
           {opsModalTab === GitOpsTab.Deploy && <TabDeploy />}
           {opsModalTab === GitOpsTab.Merge && <TabMerge />}
-          {isTaggingEnabled && opsModalTab === GitOpsTab.Release && (
+          {showReleaseTab && opsModalTab === GitOpsTab.Release && (
             <TabRelease />
           )}
         </StyledModalContent>

--- a/app/client/src/git/components/SettingsModal/SettingsModalView.tsx
+++ b/app/client/src/git/components/SettingsModal/SettingsModalView.tsx
@@ -40,6 +40,8 @@ interface SettingsModalViewProps {
   isManageProtectedBranchesPermitted: boolean;
   isSettingsModalOpen: boolean;
   settingsModalTab: keyof typeof GitSettingsTab;
+  showBranchTab: boolean;
+  showCDTab: boolean;
   toggleSettingsModal: (
     open: boolean,
     tab?: keyof typeof GitSettingsTab,
@@ -53,11 +55,10 @@ function SettingsModalView({
   isManageProtectedBranchesPermitted = false,
   isSettingsModalOpen = false,
   settingsModalTab = GitSettingsTab.General,
+  showBranchTab = false,
+  showCDTab = false,
   toggleSettingsModal = noop,
 }: SettingsModalViewProps) {
-  const showBranchTab =
-    isManageDefaultBranchPermitted || isManageProtectedBranchesPermitted;
-
   const handleTabKeyChange = useCallback(
     (tabKey: string) => {
       toggleSettingsModal(true, tabKey as GitSettingsTab);
@@ -85,12 +86,14 @@ function SettingsModalView({
                 {createMessage(BRANCH)}
               </Tab>
             )}
-            <Tab
-              data-testid={"t--git-settings-tab-cd"}
-              value={GitSettingsTab.ContinuousDelivery}
-            >
-              {createMessage(CONTINUOUS_DELIVERY)}
-            </Tab>
+            {showCDTab && (
+              <Tab
+                data-testid={"t--git-settings-tab-cd"}
+                value={GitSettingsTab.ContinuousDelivery}
+              >
+                {createMessage(CONTINUOUS_DELIVERY)}
+              </Tab>
+            )}
           </TabsList>
         </Tabs>
         <ModalBody>

--- a/app/client/src/git/components/SettingsModal/index.tsx
+++ b/app/client/src/git/components/SettingsModal/index.tsx
@@ -3,8 +3,10 @@ import SettingsModalView from "./SettingsModalView";
 import useSettings from "git/hooks/useSettings";
 import { GitSettingsTab } from "git/constants/enums";
 import { useGitContext } from "../GitContextProvider";
+import isContinuousDeliveryEnabled from "git/helpers/isContinuousDeliveryEnabled";
 
 function SettingsModal() {
+  const { artifactDef } = useGitContext();
   const {
     isConnectPermitted,
 
@@ -15,6 +17,12 @@ function SettingsModal() {
   const { isSettingsModalOpen, settingsModalTab, toggleSettingsModal } =
     useSettings();
 
+  const showBranchTab =
+    isManageDefaultBranchPermitted || isManageProtectedBranchesPermitted;
+  const showCDTab = artifactDef
+    ? isContinuousDeliveryEnabled(artifactDef)
+    : false;
+
   return (
     <SettingsModalView
       isConnectPermitted={isConnectPermitted}
@@ -23,6 +31,8 @@ function SettingsModal() {
       isManageProtectedBranchesPermitted={isManageProtectedBranchesPermitted}
       isSettingsModalOpen={isSettingsModalOpen}
       settingsModalTab={settingsModalTab ?? GitSettingsTab.General}
+      showBranchTab={showBranchTab}
+      showCDTab={showCDTab}
       toggleSettingsModal={toggleSettingsModal}
     />
   );

--- a/app/client/src/git/helpers/isAutocommitEnabled.ts
+++ b/app/client/src/git/helpers/isAutocommitEnabled.ts
@@ -1,7 +1,6 @@
 import { GitArtifactType } from "git/constants/enums";
 import type { GitArtifactDef } from "git/types";
 
-// ? Temporary, will be removed when the feature is supported in packages
 function isAutocommitEnabled(artifactDef: GitArtifactDef) {
   if (artifactDef.artifactType === GitArtifactType.Application) {
     return true;

--- a/app/client/src/git/helpers/isContinuousDeliveryEnabled.ts
+++ b/app/client/src/git/helpers/isContinuousDeliveryEnabled.ts
@@ -1,7 +1,7 @@
 import { GitArtifactType } from "git/constants/enums";
 import type { GitArtifactDef } from "git/types";
 
-function isProtectedBranchesEnabled(artifactDef: GitArtifactDef) {
+function isContinuousDeliveryEnabled(artifactDef: GitArtifactDef) {
   if (artifactDef.artifactType === GitArtifactType.Application) {
     return true;
   }
@@ -9,4 +9,4 @@ function isProtectedBranchesEnabled(artifactDef: GitArtifactDef) {
   return false;
 }
 
-export default isProtectedBranchesEnabled;
+export default isContinuousDeliveryEnabled;

--- a/app/client/src/git/helpers/isTaggingEnabled.ts
+++ b/app/client/src/git/helpers/isTaggingEnabled.ts
@@ -1,7 +1,7 @@
 import { GitArtifactType } from "git/constants/enums";
 import type { GitArtifactDef } from "git/types";
 
-function isGitTaggingEnabled(artifactDef: GitArtifactDef | null) {
+function isTaggingEnabled(artifactDef: GitArtifactDef | null) {
   if (artifactDef?.artifactType === GitArtifactType.Package) {
     return true;
   }
@@ -9,4 +9,4 @@ function isGitTaggingEnabled(artifactDef: GitArtifactDef | null) {
   return false;
 }
 
-export default isGitTaggingEnabled;
+export default isTaggingEnabled;


### PR DESCRIPTION
## Description
- Adds logic to hide CD for packages
- General cleanup for consistency

Fixes https://github.com/appsmithorg/appsmith/issues/40505

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14754219588>
> Commit: f44c9f039b0a8168a66038f1ca8abb28f80b5df1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14754219588&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Wed, 30 Apr 2025 13:12:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Continuous Delivery tab in the Git settings modal is now shown only when supported for the current artifact.
- **Refactor**
	- Improved control over the visibility of Branch and Continuous Delivery tabs in the Git settings modal.
	- Renamed and clarified internal logic for displaying the Release tab in the Git operations modal.
- **Chores**
	- Minor cleanup of comments and naming in helper utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->