### PR TITLE
fix: simplify table reset logic in TableWidgetV2

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -140,6 +140,7 @@ import {
   isColumnTypeEditable,
   updateAndSyncTableLocalColumnOrders,
 } from "./utilities";
+import resetWidget from "workers/Evaluation/fns/resetWidget";
 
 const ReactTableComponent = lazy(async () =>
   retryPromise(async () => import("../component")),
@@ -3064,46 +3065,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
   }
 
   resetTableForInfiniteScroll = () => {
-    const {
-      infiniteScrollEnabled,
-      pushBatchMetaUpdates,
-      updateWidgetMetaProperty,
-    } = this.props;
-
-    if (infiniteScrollEnabled) {
-      // reset the cachedRows
-      const isAlreadyOnFirstPage = this.props.pageNo === 1;
-      const data = isAlreadyOnFirstPage ? { 1: this.props.tableData } : {};
-
-      pushBatchMetaUpdates("cachedTableData", data);
-      pushBatchMetaUpdates("endOfData", false);
-
-      // Explicitly reset specific meta properties
-      updateWidgetMetaProperty("selectedRowIndex", undefined);
-      updateWidgetMetaProperty("selectedRowIndices", undefined);
-      updateWidgetMetaProperty("searchText", undefined);
-      updateWidgetMetaProperty("triggeredRowIndex", undefined);
-      updateWidgetMetaProperty("filters", []);
-      updateWidgetMetaProperty("sortOrder", {
-        column: "",
-        order: null,
-      });
-      updateWidgetMetaProperty("transientTableData", {});
-      updateWidgetMetaProperty("updatedRowIndex", -1);
-      updateWidgetMetaProperty("editableCell", defaultEditableCell);
-      updateWidgetMetaProperty("columnEditableCellValue", {});
-      updateWidgetMetaProperty("selectColumnFilterText", {});
-      updateWidgetMetaProperty("isAddRowInProgress", false);
-      updateWidgetMetaProperty("newRowContent", undefined);
-      updateWidgetMetaProperty("newRow", undefined);
-      updateWidgetMetaProperty("previousPageVisited", false);
-      updateWidgetMetaProperty("nextPageVisited", false);
-
-      // reset and reload page
-      if (!isAlreadyOnFirstPage) {
-        this.updatePageNumber(1, EventType.ON_NEXT_PAGE);
-      }
-    }
+    resetWidget(this.props.widgetId, false);
   };
 }
 


### PR DESCRIPTION
## Description
<ins>Problem</ins>

The table state wasn't being reset automatically, causing issues with individual page numbers and data properties.

<ins>Root cause</ins>

Using manual page number handling led to unexpected outcomes due to not having an automatic reset mechanism for the table state when infinite scroll was enabled or disabled.

<ins>Solution</ins>
To mitigate this issue, we have utilized in-built evaluations and the reset widget method to properly reset the widget.

Fixes: #40452 

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14747978041>
> Commit: 32f17cca1ab2c8c735fd9a10d359ae5a95e9f6c9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14747978041&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Wed, 30 Apr 2025 07:28:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the table reset process for infinite scroll by streamlining internal logic, resulting in a more efficient reset experience for users. No visible changes to the interface or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->