### PR TITLE
ci: Fixing cypress tests that are failing due to the change from executeOnLoad to runBehavior

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/FrameworkFunctions_ShowCloseModalFunctions_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/FrameworkFunctions_ShowCloseModalFunctions_spec.ts
@@ -46,7 +46,7 @@ describe(
         cy.wrap(jsObjectName).as("jsObjectName");
       });
 
-      apiPage.clickSettingIcon(true);
+      apiPage.clickSettingIcon("On page load");
 
       EditorNavigation.SelectEntityByName("Button1", EntityType.Widget);
       propPane.ToggleJSMode("onClick", true);

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug14987_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug14987_spec.js
@@ -32,7 +32,7 @@ describe(
       pluginActionForm.toolbar.toggleSettings();
 
       cy.get(".label-icon-wrapper")
-        .contains("Run the query on page load")
+        .contains("Run behavior")
         .parent()
         .then(($el) => {
           cy.window().then((win) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug20275_Spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug20275_Spec.js
@@ -30,7 +30,7 @@ describe(
         prettify: false,
       });
 
-      jsEditor.EnableDisableAsyncFuncSettings("myFun1", true);
+      jsEditor.EnableDisableAsyncFuncSettings("myFun1", "On page load");
 
       ee.DragDropWidgetNVerify(WIDGET.TEXT, 200, 600);
       EditorNavigation.SelectEntityByName("Text1", EntityType.Widget);

--- a/app/client/cypress/e2e/Regression/ClientSide/JSObject/JSObject_Tests_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/JSObject/JSObject_Tests_spec.ts
@@ -33,7 +33,7 @@ describe("Validate JSObj", {}, () => {
         shouldCreateNewJSObj: true,
       },
     );
-    jsEditor.EnableDisableAsyncFuncSettings("myFun1");
+    jsEditor.EnableDisableAsyncFuncSettings("myFun1", "On page load");
 
     // Add new JSObject
     PageList.AddNewPage("New blank page");

--- a/app/client/cypress/e2e/Regression/ClientSide/PublishedApps/PublishedModeToastToggle_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/PublishedApps/PublishedModeToastToggle_Spec.ts
@@ -22,14 +22,14 @@ describe.skip(
         _.dataManager.dsValues[_.dataManager.defaultEnviorment].mockApiUrl,
         "Correct_users",
       );
-      _.apiPage.ToggleOnPageLoadRun(true);
+      _.apiPage.ToggleOnPageLoadRun("On page load");
       _.apiPage.CreateAndFillApi(
         _.dataManager.dsValues[
           _.dataManager.defaultEnviorment
         ].mockApiUrl.replace("mock-api", "mock-api2err"),
         "Incorrect_users",
       );
-      _.apiPage.ToggleOnPageLoadRun(true);
+      _.apiPage.ToggleOnPageLoadRun("On page load");
       _.jsEditor.CreateJSObject(
         `export default {
         async myFun1 () {

--- a/app/client/cypress/e2e/Regression/ClientSide/SetProperty/SetOptions_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/SetProperty/SetOptions_Spec.ts
@@ -209,7 +209,7 @@ describe(
 
     it("3. Update 'setOptions' property - during onPage load", () => {
       EditorNavigation.SelectEntityByName("JSObject1", EntityType.JSObject);
-      jsEditor.EnableDisableAsyncFuncSettings("myFun1", true); //for on page load execution
+      jsEditor.EnableDisableAsyncFuncSettings("myFun1", "On page load"); //for on page load execution
       deployMode.DeployApp();
       agHelper
         .GetText(
@@ -268,7 +268,7 @@ describe(
         ])}, () => {showAlert('unable to run API')});
       }
     }`);
-      jsEditor.EnableDisableAsyncFuncSettings("myFunc1", true); //for on page load execution, since sync function is updated to async
+      jsEditor.EnableDisableAsyncFuncSettings("myFunc1", "On page load"); //for on page load execution, since sync function is updated to async
       deployMode.DeployApp();
       agHelper.WaitForCondition(
         agHelper
@@ -313,7 +313,7 @@ describe(
         Select3.setOptions(Select1.options.concat(Select2.options));
       }
     }`);
-      jsEditor.EnableDisableAsyncFuncSettings("myFunc1", true); //for on page load execution, since sync function is updated to async
+      jsEditor.EnableDisableAsyncFuncSettings("myFunc1", "On page load"); //for on page load execution, since sync function is updated to async
       EditorNavigation.SelectEntityByName("Input1", EntityType.Widget);
       propPane.UpdatePropertyFieldValue("Default value", "{{Select3.options}}");
       deployMode.DeployApp();
@@ -355,7 +355,7 @@ describe(
         setTimeout(() => {Select1.setOptions(localValue)}, 1000);
       }
     }`);
-      jsEditor.EnableDisableAsyncFuncSettings("myFun1", false); //for on page load execution
+      jsEditor.EnableDisableAsyncFuncSettings("myFun1", "Manual"); //for on page load execution
       deployMode.DeployApp();
       agHelper
         .GetText(

--- a/app/client/cypress/e2e/Regression/ClientSide/SetProperty/WidgetPropertySetters2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/SetProperty/WidgetPropertySetters2_spec.ts
@@ -177,7 +177,7 @@ describe(
       }`,
         false,
       );
-      jsEditor.EnableDisableAsyncFuncSettings("myFun1", true);
+      jsEditor.EnableDisableAsyncFuncSettings("myFun1", "On page load");
       deployMode.DeployApp(locators._widgetInDeployed(draggableWidgets.BUTTON)); //Asserting before setTimeout JS function execution, button is visible
       agHelper.Sleep(2000); //waiting for settimeout to execute
       agHelper.AssertElementAbsence(
@@ -236,7 +236,7 @@ describe(
       }`,
         false,
       );
-      jsEditor.EnableDisableAsyncFuncSettings("myFun1", false);
+      jsEditor.EnableDisableAsyncFuncSettings("myFun1", "Manual");
       deployMode.DeployApp();
       agHelper.AssertElementVisibility(
         locators._widgetInDeployed(draggableWidgets.INPUT_V2), //Asserting before setTimeout JS function execution, Input is visible

--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_MultiPart_Spec.ts
@@ -142,7 +142,7 @@ describe(
 
       EditorNavigation.SelectEntityByName("MultipartAPI", EntityType.Api);
 
-      apiPage.ToggleOnPageLoadRun(false); //Bug 12476
+      apiPage.ToggleOnPageLoadRun("Manual"); //Bug 12476
       EditorNavigation.SelectEntityByName("Page2", EntityType.Page);
       deployMode.DeployApp(locators._buttonByText("Select Files"));
       agHelper.ClickButton("Select Files");

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts
@@ -467,7 +467,7 @@ describe(
     });
 
     it("7. Tc #2365  - Query settings tab validations", () => {
-      apiPage.ToggleOnPageLoadRun(false); // All above cases validated for onpage load run with confirmation dialog set to false
+      apiPage.ToggleOnPageLoadRun("Manual"); // All above cases validated for onpage load run with confirmation dialog set to false
       pluginActionForm.toolbar.toggleSettings();
       apiPage.ToggleConfirmBeforeRunning(true);
       deployMode.DeployApp();

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/Snowflake_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/Snowflake_Basic_Spec.ts
@@ -165,7 +165,7 @@ describe.skip(
         "Select",
       );
       agHelper.RenameQuery("TemplateSelectQuery");
-      apiPage.ToggleOnPageLoadRun(true);
+      apiPage.ToggleOnPageLoadRun("On page load");
       pluginActionForm.toolbar.toggleSettings();
       apiPage.ToggleConfirmBeforeRunning(true);
       agHelper.RefreshPage();

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -505,7 +505,7 @@ return "yes";`;
       // Modify js object
       jsEditor.EditJSObj(syncJSCode, false);
       agHelper.RefreshPage();
-      jsEditor.VerifyAsyncFuncSettings("asyncToSync", true);
+      jsEditor.VerifyAsyncFuncSettings("asyncToSync", "On page load");
       agHelper.ActionContextMenuWithInPane({
         action: "Delete",
         entityType: entityItems.JSObject,

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -17,7 +17,7 @@ import PageList from "../../../../support/Pages/PageList";
 
 interface IFunctionSettingData {
   name: string;
-  onPageLoad: boolean;
+  runBehavior: "On page load" | "Manual";
   confirmBeforeExecute: boolean;
   // uses the "async" keyword
   isMarkedAsync: boolean;
@@ -35,31 +35,31 @@ describe(
     const FUNCTIONS_SETTINGS_DEFAULT_DATA: IFunctionSettingData[] = [
       {
         name: "getId",
-        onPageLoad: true,
+        runBehavior: "On page load",
         confirmBeforeExecute: false,
         isMarkedAsync: true,
       },
       {
         name: "zip",
-        onPageLoad: true,
+        runBehavior: "On page load",
         confirmBeforeExecute: true,
         isMarkedAsync: false,
       },
       {
         name: "base",
-        onPageLoad: false,
+        runBehavior: "Manual",
         confirmBeforeExecute: false,
         isMarkedAsync: true,
       },
       {
         name: "assert",
-        onPageLoad: false,
+        runBehavior: "Manual",
         confirmBeforeExecute: false,
         isMarkedAsync: false,
       },
       {
         name: "test",
-        onPageLoad: true,
+        runBehavior: "On page load",
         confirmBeforeExecute: true,
         isMarkedAsync: true,
       },
@@ -359,7 +359,7 @@ describe(
       // Number of functions set to run on page load and should also confirm before execute
       onPageLoadAndConfirmExecuteFunctionsLength =
         FUNCTIONS_SETTINGS_DEFAULT_DATA.filter(
-          (func) => func.onPageLoad && func.confirmBeforeExecute,
+          (func) => func.runBehavior && func.confirmBeforeExecute,
         ).length;
 
       getJSObject = (data: IFunctionSettingData[]) => {
@@ -404,7 +404,7 @@ describe(
         (functionSetting) => {
           jsEditor.EnableDisableAsyncFuncSettings(
             functionSetting.name,
-            functionSetting.onPageLoad,
+            functionSetting.runBehavior,
           );
         },
       );
@@ -425,31 +425,31 @@ describe(
       const FUNCTIONS_SETTINGS_RENAMED_DATA: IFunctionSettingData[] = [
         {
           name: "newGetId",
-          onPageLoad: true,
+          runBehavior: "On page load",
           confirmBeforeExecute: false,
           isMarkedAsync: false,
         },
         {
           name: "zip1",
-          onPageLoad: true,
+          runBehavior: "On page load",
           confirmBeforeExecute: true,
           isMarkedAsync: true,
         },
         {
           name: "base",
-          onPageLoad: false,
+          runBehavior: "Manual",
           confirmBeforeExecute: false,
           isMarkedAsync: true,
         },
         {
           name: "newAssert",
-          onPageLoad: true,
+          runBehavior: "On page load",
           confirmBeforeExecute: false,
           isMarkedAsync: false,
         },
         {
           name: "test",
-          onPageLoad: true,
+          runBehavior: "On page load",
           confirmBeforeExecute: true,
           isMarkedAsync: true,
         },
@@ -500,7 +500,7 @@ return "yes";`;
       });
 
       // Enable all settings
-      jsEditor.EnableDisableAsyncFuncSettings("asyncToSync", true);
+      jsEditor.EnableDisableAsyncFuncSettings("asyncToSync", "On page load");
 
       // Modify js object
       jsEditor.EditJSObj(syncJSCode, false);

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/SetTimeout_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/SetTimeout_spec.ts
@@ -227,7 +227,7 @@ describe(
           prettify: true,
         },
       );
-      jsEditor.EnableDisableAsyncFuncSettings("myFun1", true);
+      jsEditor.EnableDisableAsyncFuncSettings("myFun1", "On page load");
       deployMode.DeployApp();
       agHelper.Sleep(1000); //DeployApp already waiting 2000ms hence reducing it here to equate to 3000 timeout
       agHelper.AssertContains("Success!");

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
@@ -50,7 +50,7 @@ describe(
           "PageLoadApi2",
         );
       });
-      apiPage.ToggleOnPageLoadRun(true);
+      apiPage.ToggleOnPageLoadRun("On page load");
       EditorNavigation.SelectEntityByName("Table1", EntityType.Widget, {}, [
         "Container3",
       ]);

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
@@ -94,7 +94,7 @@ describe(
         },
       );
 
-      jsEditor.EnableDisableAsyncFuncSettings("astros", true);
+      jsEditor.EnableDisableAsyncFuncSettings("astros", "On page load");
 
       EditorNavigation.SelectEntityByName("Page1", EntityType.Page);
       agHelper.RefreshPage();

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad4_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad4_Spec.ts
@@ -34,12 +34,12 @@ describe(
         },
       );
 
-      jsEditor.VerifyAsyncFuncSettings("myFun1", false);
-      jsEditor.VerifyAsyncFuncSettings("myFun2", false);
-      jsEditor.VerifyAsyncFuncSettings("myFun3", false);
-      jsEditor.VerifyAsyncFuncSettings("myFun4", false);
-      jsEditor.VerifyAsyncFuncSettings("myFun5", false);
-      jsEditor.VerifyAsyncFuncSettings("myFun6", false);
+      jsEditor.VerifyAsyncFuncSettings("myFun1", "Manual");
+      jsEditor.VerifyAsyncFuncSettings("myFun2", "Manual");
+      jsEditor.VerifyAsyncFuncSettings("myFun3", "Manual");
+      jsEditor.VerifyAsyncFuncSettings("myFun4", "Manual");
+      jsEditor.VerifyAsyncFuncSettings("myFun5", "Manual");
+      jsEditor.VerifyAsyncFuncSettings("myFun6", "Manual");
 
       VerifyFunctionDropdown([
         "myFun1",

--- a/app/client/cypress/e2e/Regression/ServerSide/Params/PassingParams_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Params/PassingParams_Spec.ts
@@ -76,7 +76,7 @@ describe(
       propPane.EnterJSContext("Table data", "{{ParamsTest.data}}");
 
       EditorNavigation.SelectEntityByName("ParamsTest", EntityType.Query);
-      apiPage.ToggleOnPageLoadRun(false); //Bug 12476
+      apiPage.ToggleOnPageLoadRun("Manual"); //Bug 12476
 
       deployMode.DeployApp(locators._buttonByText("Submit"));
       agHelper.SelectDropDown("7");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
+cypress/e2e/Regression/ClientSide/BugTests/Bug14987_spec.js
+
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 #cypress/e2e/Regression/ClientSide/Anvil/Widgets/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/BugTests/Bug14987_spec.js
-cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
-
+cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 #cypress/e2e/Regression/ClientSide/Anvil/Widgets/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,6 @@
 # To run only limited tests - give the spec names in below format:
 cypress/e2e/Regression/ClientSide/BugTests/Bug14987_spec.js
+cypress/e2e/Regression/ServerSide/OnLoadTests/APIOnLoad_Spec.ts
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/support/Pages/ApiPage.ts
+++ b/app/client/cypress/support/Pages/ApiPage.ts
@@ -78,7 +78,6 @@ export class ApiPage {
   _noBodyMessage = "This request does not have a body";
   _imageSrc = "//img/parent::div";
   private _trashDelete = "[data-testid=t--trash-icon]";
-  private _onPageLoad = "input[name='executeOnLoad'][type='checkbox']";
   private _confirmBeforeRunning =
     "input[name='confirmBeforeExecute'][type='checkbox']";
   private _paginationTypeLabels = ".t--apiFormPaginationType label";
@@ -107,6 +106,8 @@ export class ApiPage {
   public moreActionsTrigger = "[data-testid='t--more-action-trigger']";
   private apiNameInput = this.locator._activeEntityTabInput;
   public pageList = ".ads-v2-sub-menu > .ads-v2-menu__menu-item";
+  public _runBehaviorDropdown = "[data-testid='t--dropdown-runBehavior']";
+  public _runBehaviorOption = ".rc-select-item-option-content";
 
   CreateApi(
     apiName = "",
@@ -275,10 +276,17 @@ export class ApiPage {
     this.SelectPaneTab("Headers");
   }
 
-  ToggleOnPageLoadRun(enable = true || false) {
+  ToggleOnPageLoadRun(runBehavior: "On page load" | "Manual") {
+    // Navigate to Settings tab
     this.pluginActionForm.toolbar.toggleSettings();
-    if (enable) this.agHelper.CheckUncheck(this._onPageLoad, true);
-    else this.agHelper.CheckUncheck(this._onPageLoad, false);
+    // Set runBehavior to On page load
+    this.agHelper.GetNClick(this._runBehaviorDropdown);
+    this.agHelper.GetNClickByContains(
+      this._runBehaviorOption,
+      runBehavior,
+      0,
+      true,
+    );
   }
 
   ToggleConfirmBeforeRunning(enable = true || false) {

--- a/app/client/cypress/support/Pages/ApiPage.ts
+++ b/app/client/cypress/support/Pages/ApiPage.ts
@@ -99,8 +99,6 @@ export class ApiPage {
   private curlImport = ".t--datasoucre-create-option-new_curl_import";
   private _curlTextArea =
     "//label[text()='Paste CURL Code Here']/parent::form/div";
-  private runOnPageLoadJSObject =
-    "input[name^='execute-on-page-load'][type='checkbox']";
   public settingsTriggerLocator = "[data-testid='t--js-settings-trigger']";
   public splitPaneContextMenuTrigger = ".entity-context-menu";
   public moreActionsTrigger = "[data-testid='t--more-action-trigger']";
@@ -511,16 +509,29 @@ export class ApiPage {
     this.RunAPI();
   }
 
-  ToggleOnPageLoadRunJsObject(enable = true || false) {
+  ToggleOnPageLoadRunJsObject(runBehavior: "On page load" | "Manual") {
+    // Navigate to Settings tab
     this.SelectPaneTab("Settings");
-    if (enable) this.agHelper.CheckUncheck(this.runOnPageLoadJSObject, true);
-    else this.agHelper.CheckUncheck(this.runOnPageLoadJSObject, false);
+    // Set runBehavior to On page load
+    this.agHelper.GetNClick(this._runBehaviorDropdown);
+    this.agHelper.GetNClickByContains(
+      this._runBehaviorOption,
+      runBehavior,
+      0,
+      true,
+    );
   }
 
-  public clickSettingIcon(enable: boolean) {
+  public clickSettingIcon(runBehavior: "On page load" | "Manual") {
     this.agHelper.GetNClick(this.settingsTriggerLocator);
-    if (enable) this.agHelper.CheckUncheck(this.runOnPageLoadJSObject, true);
-    else this.agHelper.CheckUncheck(this.runOnPageLoadJSObject, false);
+    // Set runBehavior to On page load
+    this.agHelper.GetNClick(this._runBehaviorDropdown);
+    this.agHelper.GetNClickByContains(
+      this._runBehaviorOption,
+      runBehavior,
+      0,
+      true,
+    );
   }
 
   public renameFromEditor(renameVal: string) {

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -54,7 +54,7 @@ export class JSEditor {
     `.${functionName}-run-behavior-setting
     input[role="combobox"]`;
   private __runBehaviourSwitchStatus = (functionName: string) =>
-    `//div[contains(@class, '${functionName}-run-behavior-setting')]//label/input`;
+    `.${functionName}-run-behavior-setting .rc-select-selection-item`;
 
   private _jsObjName = this.locator._activeEntityTab;
   public _jsObjTxt = this.locator._activeEntityTabInput;
@@ -297,11 +297,14 @@ export class JSEditor {
     cy.get(this._bindingsClose).click({ force: true });
   }
 
-  public VerifyAsyncFuncSettings(funName: string, onLoad = true) {
+  public VerifyAsyncFuncSettings(
+    funName: string,
+    runBehavior: "On page load" | "Manual",
+  ) {
     this.toolbar.toggleSettings();
-    this.agHelper.AssertExistingCheckedState(
+    this.agHelper.GetNAssertContains(
       this.__runBehaviourSwitchStatus(funName),
-      onLoad.toString(),
+      runBehavior,
     );
     this.toolbar.toggleSettings();
   }

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -56,7 +56,7 @@ export class JSEditor {
   private __runBehaviourSwitchStatus = (functionName: string) =>
     `.${functionName}-run-behavior-setting .rc-select-selection-item`;
 
-  private _jsObjName = this.locator._activeEntityTab;
+  public _jsObjName = this.locator._activeEntityTab;
   public _jsObjTxt = this.locator._activeEntityTabInput;
   public _newJSobj = "span:contains('New JS object')";
   private _bindingsClose = ".t--entity-property-close";

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -50,10 +50,10 @@ export class JSEditor {
   private _jsObjectParseErrorCallout =
     "div.t--js-response-parse-error-call-out";
 
-  private _onPageLoadSwitch = (functionName: string) =>
-    `.${functionName}-run-behavior
+  private _runBehaviourSwitch = (functionName: string) =>
+    `.${functionName}-run-behavior-setting
     input[role="combobox"]`;
-  private _onPageLoadSwitchStatus = (functionName: string) =>
+  private __runBehaviourSwitchStatus = (functionName: string) =>
     `//div[contains(@class, '${functionName}-run-behavior-setting')]//label/input`;
 
   private _jsObjName = this.locator._activeEntityTab;
@@ -95,6 +95,7 @@ export class JSEditor {
   _addJSObj = '[data-testid="t--ide-tabs-add-button"]';
   _jsPageActions = ".entity-context-menu";
   _moreActions = '[data-testid="t--more-action-trigger"]';
+  _dropdownOption = ".rc-select-item-option-content";
   //#endregion
 
   //#region constants
@@ -299,17 +300,26 @@ export class JSEditor {
   public VerifyAsyncFuncSettings(funName: string, onLoad = true) {
     this.toolbar.toggleSettings();
     this.agHelper.AssertExistingCheckedState(
-      this._onPageLoadSwitchStatus(funName),
+      this.__runBehaviourSwitchStatus(funName),
       onLoad.toString(),
     );
     this.toolbar.toggleSettings();
   }
 
-  public EnableDisableAsyncFuncSettings(funName: string, onLoad = true) {
+  public EnableDisableAsyncFuncSettings(
+    funName: string,
+    runBehavior: "On page load" | "Manual",
+  ) {
     // Navigate to Settings tab
     this.toolbar.toggleSettings();
-    // Set onPageLoad
-    this.agHelper.CheckUncheck(this._onPageLoadSwitch(funName), onLoad);
+    // Set runBehavior to On page load
+    this.agHelper.GetNClick(this._runBehaviourSwitch(funName));
+    this.agHelper.GetNClickByContains(
+      this._dropdownOption,
+      runBehavior,
+      0,
+      true,
+    );
     // Return to code tab
     this.toolbar.toggleSettings();
   }

--- a/app/client/src/components/formControls/utils.ts
+++ b/app/client/src/components/formControls/utils.ts
@@ -422,7 +422,7 @@ export const getConfigInitialValues = (
   // TODO: Fix this the next time the file is edited
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const parseConfig = (section: any): any => {
-    if ("initialValue" in section) {
+    if ("initialValue" in section && section.configProperty !== "runBehavior") {
       if (section.controlType === "KEYVALUE_ARRAY") {
         section.initialValue.forEach(
           (initialValue: string | number, index: number) => {

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
@@ -81,7 +81,7 @@ const FunctionSettingRow = (props: FunctionSettingsRowProps) => {
         {props.action.name}
       </Text>
       <StyledSelect
-        data-testid={`execute-on-page-load-${props.action.id}`}
+        data-testid={`t--dropdown-runBehavior`}
         defaultValue={selectedValue}
         id={props.action.id}
         isDisabled={props.disabled}


### PR DESCRIPTION
## Description

Fixing cypress tests that are failing due to the change from executeOnLoad to runBehavior

Fixes [#39833](https://github.com/appsmithorg/appsmith/issues/39833)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD d9d2419226a0de412d650b04dcde0483d7fedcfb yet
> <hr>Wed, 30 Apr 2025 14:37:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Run behavior" dropdown for APIs, queries, and JS functions, allowing users to select between "On page load" and "Manual" execution modes.
  - Enhanced settings UI with descriptive labels and subtexts for run behavior options.

- **Improvements**
  - Replaced the simple "Run on page load" switch with a flexible dropdown across the platform for better control and clarity.
  - Updated terminology and UI across app settings, plugin configurations, and test suites to reflect the new run behavior model.

- **Bug Fixes**
  - Adjusted automated tests and UI interactions to align with the new run behavior selection, ensuring consistent behavior and reliability.

- **Documentation**
  - Updated labels, tooltips, and instructional text to guide users on the new run behavior options.

- **Refactor**
  - Unified internal logic and configuration to support the new run behavior property, replacing legacy boolean flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->