### PR TITLE
fix: Read admin emails for migration from the docker.env file directly

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration10000_UpdateSuperUser.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration10000_UpdateSuperUser.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.migrations.db.ce;
 
 import com.appsmith.server.acl.PolicyGenerator;
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Config;
 import com.appsmith.server.domains.Organization;
@@ -9,6 +10,7 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.TextUtils;
 import com.appsmith.server.migrations.solutions.UpdateSuperUserMigrationHelper;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
+import com.appsmith.server.solutions.EnvManager;
 import com.appsmith.server.solutions.PolicySolution;
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -18,6 +20,11 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -40,16 +47,22 @@ public class Migration10000_UpdateSuperUser {
     private final PolicySolution policySolution;
     private final PolicyGenerator policyGenerator;
     private final UpdateSuperUserMigrationHelper updateSuperUserMigrationHelper;
+    private final CommonConfig commonConfig;
+    private final EnvManager envManager;
 
     public Migration10000_UpdateSuperUser(
             MongoTemplate mongoTemplate,
             CacheableRepositoryHelper cacheableRepositoryHelper,
             PolicySolution policySolution,
-            PolicyGenerator policyGenerator) {
+            PolicyGenerator policyGenerator,
+            CommonConfig commonConfig,
+            EnvManager envManager) {
         this.mongoTemplate = mongoTemplate;
         this.cacheableRepositoryHelper = cacheableRepositoryHelper;
         this.policySolution = policySolution;
         this.policyGenerator = policyGenerator;
+        this.commonConfig = commonConfig;
+        this.envManager = envManager;
         this.updateSuperUserMigrationHelper = new UpdateSuperUserMigrationHelper();
     }
 
@@ -59,7 +72,22 @@ public class Migration10000_UpdateSuperUser {
     @Execution
     public void executeMigration() {
         // Read the admin emails from the environment and update the super users accordingly
-        String adminEmailsStr = System.getenv(String.valueOf(APPSMITH_ADMIN_EMAILS));
+        String originalContent = "";
+        try {
+            originalContent = Files.readString(Path.of(commonConfig.getEnvFilePath()));
+        } catch (NoSuchFileException e) {
+            log.error("Env file not found at " + commonConfig.getEnvFilePath(), e);
+            // No need to throw an exception here, as this is a non-critical migration
+            return;
+        } catch (IOException e) {
+            log.error("Unable to read env file " + commonConfig.getEnvFilePath(), e);
+            // No need to throw an exception here, as this is a non-critical migration
+            return;
+        }
+
+        Map<String, String> envVariableMap = envManager.parseToMap(originalContent);
+        // Get the admin emails from the environment variable
+        String adminEmailsStr = envVariableMap.get(APPSMITH_ADMIN_EMAILS.name());
 
         Set<String> adminEmails = TextUtils.csvToSet(adminEmailsStr);
 


### PR DESCRIPTION

## Description
In K8 deployments, sometimes, the environment variable seem to digress from the contents of docker.env. Since we are writing to the docker.env, also running the update super user migration using the file contents itself.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/test sanity

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14769222031>
> Commit: 72063ca47f41186cfc712c1950f1b6fc6aee5822
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14769222031&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 01 May 2025 04:16:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when updating super users by reading admin emails from a specified environment file instead of directly from system environment variables. If the file cannot be read, the process now logs an error and continues without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->