### PR TITLE
chore: Adjust WDS border neutral subtle (light mode)

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -1063,7 +1063,7 @@ export class LightModeTheme implements ColorModeTheme {
     // Slightly subtler version of neutral border, used in outlined buttons
     const color = this.bdNeutral.clone();
 
-    color.oklch.l += 0.47;
+    color.oklch.l += 0.35;
 
     return color;
   }


### PR DESCRIPTION
## Description

Slightly more subtle and nicer-looking border.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14837454433>
> Commit: ba34566ae70e97803acd3ecf3a8fe726633a4fac
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14837454433&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 05 May 2025 14:09:11 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the subtle neutral border color in light mode to appear less bright, affecting the appearance of outlined buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->