### PR TITLE
feat: Enhance column order management in TableWidgetV2

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -202,24 +202,7 @@ export default {
 
     if (props.infiniteScrollEnabled) {
       /* This logic is needed as the cachedTableData will have data based on each pageNo. Since the object would be { 1: array of page 1 data, 2: array of page 2 data }, hence the values will have array of array data, hence it is flattened to store back in tableData for processing. */
-      const cachedData = props.cachedTableData;
-      const firstPageData = cachedData[1] || [];
-      const allData = _.flatten(_.values(cachedData));
-
-      // Get all unique keys from the first page of data
-      const firstPageKeys = new Set(Object.keys(firstPageData[0] || {}));
-
-      // Ensure all rows have the same structure as the first page
-      tableData = allData.map((row) => {
-        const newRow = {};
-
-        // Copy all keys from first page, using empty string as default value
-        firstPageKeys.forEach((key) => {
-          newRow[key] = row[key] !== undefined ? row[key] : "";
-        });
-
-        return newRow;
-      });
+      tableData = _.flatten(_.values(props.cachedTableData));
     } else {
       tableData = props.tableData;
     }

--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -202,7 +202,24 @@ export default {
 
     if (props.infiniteScrollEnabled) {
       /* This logic is needed as the cachedTableData will have data based on each pageNo. Since the object would be { 1: array of page 1 data, 2: array of page 2 data }, hence the values will have array of array data, hence it is flattened to store back in tableData for processing. */
-      tableData = _.flatten(_.values(props.cachedTableData));
+      const cachedData = props.cachedTableData;
+      const firstPageData = cachedData[1] || [];
+      const allData = _.flatten(_.values(cachedData));
+
+      // Get all unique keys from the first page of data
+      const firstPageKeys = new Set(Object.keys(firstPageData[0] || {}));
+
+      // Ensure all rows have the same structure as the first page
+      tableData = allData.map((row) => {
+        const newRow = {};
+
+        // Copy all keys from first page, using empty string as default value
+        firstPageKeys.forEach((key) => {
+          newRow[key] = row[key] !== undefined ? row[key] : "";
+        });
+
+        return newRow;
+      });
     } else {
       tableData = props.tableData;
     }

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -949,10 +949,10 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
     if (
       this.props.primaryColumns &&
       (!equal(prevProps.columnOrder, this.props.columnOrder) ||
-        getAllStickyColumnsCount(prevProps.orderedTableColumns) !==
-          getAllStickyColumnsCount(this.props.orderedTableColumns) ||
         filter(prevProps.orderedTableColumns, { isVisible: false }).length !==
-          filter(this.props.orderedTableColumns, { isVisible: false }).length)
+          filter(this.props.orderedTableColumns, { isVisible: false }).length ||
+        getAllStickyColumnsCount(prevProps.orderedTableColumns) !==
+          getAllStickyColumnsCount(this.props.orderedTableColumns))
     ) {
       if (this.props.renderMode === RenderModes.CANVAS) {
         super.batchUpdateWidgetProperty(

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -943,25 +943,16 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
       return;
     }
 
-    const didColumnOrderChange = !equal(
-      prevProps.columnOrder,
-      this.props.columnOrder,
-    );
-
-    const didStickyColumnsChange =
-      getAllStickyColumnsCount(prevProps.orderedTableColumns) !==
-      getAllStickyColumnsCount(this.props.orderedTableColumns);
-
-    const didHiddenColumnsChange =
-      filter(prevProps.orderedTableColumns, { isVisible: false }).length !==
-      filter(this.props.orderedTableColumns, { isVisible: false }).length;
-
     const shouldIgnoreColumnOrderUpdate =
       this.props.infiniteScrollEnabled && this.props.pageNo !== 0;
 
     if (
       this.props.primaryColumns &&
-      (didColumnOrderChange || didHiddenColumnsChange || didStickyColumnsChange)
+      (!equal(prevProps.columnOrder, this.props.columnOrder) ||
+        getAllStickyColumnsCount(prevProps.orderedTableColumns) !==
+          getAllStickyColumnsCount(this.props.orderedTableColumns) ||
+        filter(prevProps.orderedTableColumns, { isVisible: false }).length !==
+          filter(this.props.orderedTableColumns, { isVisible: false }).length)
     ) {
       if (this.props.renderMode === RenderModes.CANVAS) {
         super.batchUpdateWidgetProperty(


### PR DESCRIPTION
## Description

<ins>Problem</ins>
Column order would break and cause inconsistent table behavior when paginated data returned fewer columns due to corrupted subsets during infinite scroll.

<ins>Root cause</ins>
When infinite scroll was enabled, subsequent pages with incomplete or corrupted data (fewer columns) would override the initially correct column order.

<ins>Solution</ins>
This PR handles preserving the initial column order when infinite scroll is enabled by ignoring updates to the column structure unless the user is on the first page. It assumes the first page has the correct column state and prevents subsequent corrupted data from modifying it.

Fixes #40457
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14877195646>
> Commit: 489a9fe9906c32fc374239e920fff847204572e8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14877195646&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Wed, 07 May 2025 07:42:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved table widget to preserve user-defined column order during infinite scroll, ensuring column arrangement remains consistent when navigating through pages.
- **Bug Fixes**
  - Prevented unintended column order changes when table data updates while using infinite scroll.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->