### PR TITLE
chore: Added reset before checkout

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -2781,8 +2781,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                     final String baseArtifactId = baseGitMetadata.getDefaultArtifactId();
                     final String repoName = baseGitMetadata.getRepoName();
 
-                    // 1. Hydrate from db to git system for both ref Artifacts
-                    // Update function call
+                    // 1. Hydrate from db to a git system for both branch artifacts
                     return Mono.usingWhen(
                             gitRedisUtils.acquireGitLock(
                                     artifactType, baseArtifactId, GitConstants.GitCommandConstants.MERGE_BRANCH, TRUE),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -770,11 +770,18 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                 jsonTransformationDTO.getBaseArtifactId(),
                 jsonTransformationDTO.getRepoName());
 
-        // TODO: add the checkout to the current branch as well.
-        return fsGitHandler.checkoutToBranch(repoSuffix, baseRefName).flatMap(isCheckedOut -> fsGitHandler
-                .createAndCheckoutReference(repoSuffix, gitRefDTO)
-                .flatMap(newRef -> fsGitHandler.pushArtifact(
-                        repoSuffix, remoteUrl, publicKey, privateKey, gitRefDTO.getRefName(), incomingRefType)));
+        return fsGitHandler
+                .resetToLastCommit(repoSuffix)
+                .then(fsGitHandler.checkoutToBranch(repoSuffix, baseRefName))
+                .flatMap(isCheckedOut -> fsGitHandler
+                        .createAndCheckoutReference(repoSuffix, gitRefDTO)
+                        .flatMap(newRef -> fsGitHandler.pushArtifact(
+                                repoSuffix,
+                                remoteUrl,
+                                publicKey,
+                                privateKey,
+                                gitRefDTO.getRefName(),
+                                incomingRefType)));
     }
 
     @Override
@@ -787,7 +794,9 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                 jsonTransformationDTO.getBaseArtifactId(),
                 jsonTransformationDTO.getRepoName());
 
-        return fsGitHandler.checkoutRemoteBranch(repoSuffix, jsonTransformationDTO.getRefName());
+        return fsGitHandler
+                .resetToLastCommit(repoSuffix)
+                .then(fsGitHandler.checkoutRemoteBranch(repoSuffix, jsonTransformationDTO.getRefName()));
     }
 
     @Override


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14883064527>
> Commit: ebb628c4a7fcc4faf6b2802611163bff437f1907
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14883064527&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Wed, 07 May 2025 13:11:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of branch checkout operations by resetting the repository to the last commit before performing checkout actions.

- **Documentation**
  - Updated comments for better clarity in the merge branch process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->