### PR TITLE
fix: reset table page number on infinite scroll reset

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -3066,6 +3066,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
 
   resetTableForInfiniteScroll = () => {
     resetWidget(this.props.widgetId, false);
+    this.updatePageNumber(0, EventType.ON_NEXT_PAGE);
   };
 }
 


### PR DESCRIPTION
## Description
<ins>Problem</ins>  
Table pagination would not reset properly when infinite scroll was reset, leading to incorrect data display or user being stuck on a non-existent page.

<ins>Root cause</ins>  
The `resetTableForInfiniteScroll` method did not reset the page number, causing the table to continue from an outdated page index.

<ins>Solution</ins>  
This PR handles resetting the page number to 0 in the `resetTableForInfiniteScroll` method, ensuring the table starts from the first page during infinite scroll resets for consistent pagination behavior.

Fixes #40594
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14884926062>
> Commit: ec11d1637f68bcdcdf42dbb8b8078bdf468f40f1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14884926062&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Wed, 07 May 2025 14:22:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where resetting the table with infinite scroll did not return to the first page. Now, the table correctly resets to the first page when infinite scroll is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->