### PR TITLE
chore: move apt install of git to base dockerfile

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -21,6 +21,7 @@ RUN set -o xtrace \
     supervisor curl nfs-common gnupg \
     gettext \
     ca-certificates \
+    git \
   # Install MongoDB v6, Redis, PostgreSQL v14
   && curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg \
   && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \


### PR DESCRIPTION
## Description
Part 1 of a 2 part move.

We added an install of `git` to the `Dockerfile` at the root of the repo, but it should go in the base Dockerfile to avoid unnecessary outside dependencies during the regular build process. We can't just remove it from the top level Dockerfile until it's in the base, so leaving the duplicate there for now to not disrupt builds.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
