### PR TITLE
fix: improve infinite scroll reset logic in TableWidgetV2

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -1045,14 +1045,14 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
 
     // Reset widget state when infinite scroll is initially enabled
     // This should come after all updateInfiniteScrollProperties are done
-    if (!prevProps.infiniteScrollEnabled && infiniteScrollEnabled) {
-      this.resetTableForInfiniteScroll();
-    }
+    const didInfiniteScrollEnabledChange =
+      prevProps.infiniteScrollEnabled !== infiniteScrollEnabled;
+    const didComponentHeightChange =
+      prevProps.componentHeight !== componentHeight;
 
-    // Reset widget state when height changes while infinite scroll is enabled
     if (
-      infiniteScrollEnabled &&
-      prevProps.componentHeight !== componentHeight
+      didInfiniteScrollEnabledChange ||
+      (infiniteScrollEnabled && didComponentHeightChange)
     ) {
       this.resetTableForInfiniteScroll();
     }


### PR DESCRIPTION
## Description
<ins>Problem</ins>  
Table would show inconsistent views or appear empty when infinite scroll setting changed or component height was modified.

<ins>Root cause</ins>  
Page number was not reset properly during changes to infinite scroll or component height, causing the table to render an incorrect or empty state.

<ins>Solution</ins>  
This PR handles improving the reset logic for the table when infinite scroll is enabled or component height changes. It refactors the reset conditions, introduces variables to track relevant state changes, and ensures the table resets correctly to maintain consistent behavior.

Fixes #40411
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14903775919>
> Commit: efe1c54169d21708cb519e749047ff207fffeb0e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14903775919&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Thu, 08 May 2025 10:36:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for resetting the table when infinite scroll is enabled or when the component height changes, resulting in clearer and more consistent behavior. No visible changes to features or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->