### PR TITLE
fix: removed usage of gs shared drive flag

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
@@ -14,7 +14,6 @@ public enum FeatureFlagEnum {
     APP_NAVIGATION_LOGO_UPLOAD,
     release_embed_hide_share_settings_enabled,
     rollout_datasource_test_rate_limit_enabled,
-    release_google_sheets_shared_drive_support_enabled,
     release_gs_all_sheets_options_enabled,
     /**
      * Feature flag to detect if the git reset optimization is enabled

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/ExecutionMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/ExecutionMethod.java
@@ -104,9 +104,4 @@ public interface ExecutionMethod {
         conversionMap.put(DataType.FLOAT, DataType.DOUBLE);
         return conversionMap;
     }
-
-    default WebClient.RequestHeadersSpec<?> getExecutionClientWithFlags(
-            WebClient webClient, MethodConfig methodConfig, Map<String, Boolean> featureFlagMap) {
-        return getExecutionClient(webClient, methodConfig);
-    }
 }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/FileListMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/FileListMethod.java
@@ -1,6 +1,5 @@
 package com.external.config;
 
-import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.external.constants.ErrorMessages;
 import com.external.enums.GoogleSheetMethodEnum;
@@ -39,16 +38,11 @@ public class FileListMethod implements ExecutionMethod, TriggerMethod {
     }
 
     @Override
-    public WebClient.RequestHeadersSpec<?> getExecutionClientWithFlags(
-            WebClient webClient, MethodConfig methodConfig, Map<String, Boolean> featureFlagMap) {
-        // TODO: Flags are needed here for google sheets integration to support shared drive behind a flag
-        // Once thoroughly tested, this flag can be removed
-        Boolean isSharedDriveSupportEnabled = featureFlagMap.getOrDefault(
-                FeatureFlagEnum.release_google_sheets_shared_drive_support_enabled.name(), Boolean.FALSE);
+    public WebClient.RequestHeadersSpec<?> getExecutionClient(WebClient webClient, MethodConfig methodConfig) {
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(
                 this.BASE_DRIVE_API_URL,
                 "?orderBy=name&q=mimeType%3D'application%2Fvnd.google-apps.spreadsheet'%20and%20trashed%3Dfalse"
-                        + (isSharedDriveSupportEnabled.equals(Boolean.TRUE) ? SHARED_DRIVE_PARAMS : ""),
+                        + SHARED_DRIVE_PARAMS,
                 true);
 
         return webClient
@@ -82,9 +76,8 @@ public class FileListMethod implements ExecutionMethod, TriggerMethod {
     }
 
     @Override
-    public WebClient.RequestHeadersSpec<?> getTriggerClientWithFlags(
-            WebClient webClient, MethodConfig methodConfig, Map<String, Boolean> featureFlagMap) {
-        return this.getExecutionClientWithFlags(webClient, methodConfig, featureFlagMap);
+    public WebClient.RequestHeadersSpec<?> getTriggerClient(WebClient webClient, MethodConfig methodConfig) {
+        return this.getExecutionClient(webClient, methodConfig);
     }
 
     @Override

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
@@ -86,28 +86,17 @@ public class GoogleSheetsPlugin extends BasePlugin {
         }
 
         @Override
-        public Mono<ActionExecutionResult> executeParameterized(
-                Void connection,
-                ExecuteActionDTO executeActionDTO,
-                DatasourceConfiguration datasourceConfiguration,
-                ActionConfiguration actionConfiguration) {
-            return executeParameterizedWithFlags(
-                    connection, executeActionDTO, datasourceConfiguration, actionConfiguration, null);
-        }
-
-        @Override
         public Mono<TriggerResultDTO> trigger(
                 Void connection, DatasourceConfiguration datasourceConfiguration, TriggerRequestDTO request) {
             return triggerWithFlags(connection, datasourceConfiguration, request, null);
         }
 
         @Override
-        public Mono<ActionExecutionResult> executeParameterizedWithFlags(
+        public Mono<ActionExecutionResult> executeParameterized(
                 Void connection,
                 ExecuteActionDTO executeActionDTO,
                 DatasourceConfiguration datasourceConfiguration,
-                ActionConfiguration actionConfiguration,
-                Map<String, Boolean> featureFlagMap) {
+                ActionConfiguration actionConfiguration) {
 
             log.debug(Thread.currentThread().getName() + ": executeParameterized() called for GoogleSheets plugin.");
             boolean smartJsonSubstitution;
@@ -160,7 +149,7 @@ public class GoogleSheetsPlugin extends BasePlugin {
 
             prepareConfigurationsForExecution(executeActionDTO, actionConfiguration, datasourceConfiguration);
 
-            return this.executeCommon(connection, datasourceConfiguration, actionConfiguration, featureFlagMap)
+            return this.executeCommon(connection, datasourceConfiguration, actionConfiguration)
                     .tag("plugin", this.getClass().getName())
                     .name(PLUGIN_EXECUTE_COMMON)
                     .tap(Micrometer.observation(observationRegistry));
@@ -169,8 +158,7 @@ public class GoogleSheetsPlugin extends BasePlugin {
         public Mono<ActionExecutionResult> executeCommon(
                 Void connection,
                 DatasourceConfiguration datasourceConfiguration,
-                ActionConfiguration actionConfiguration,
-                Map<String, Boolean> featureFlagMap) {
+                ActionConfiguration actionConfiguration) {
 
             log.debug(Thread.currentThread().getName() + ": executeCommon() called for GoogleSheets plugin.");
             // Initializing object for error condition
@@ -216,7 +204,7 @@ public class GoogleSheetsPlugin extends BasePlugin {
                     // method
                     .flatMap(res -> {
                         return executionMethod
-                                .getExecutionClientWithFlags(client, methodConfig, featureFlagMap)
+                                .getExecutionClient(client, methodConfig)
                                 .headers(headers -> headers.set(
                                         "Authorization",
                                         "Bearer "
@@ -380,7 +368,7 @@ public class GoogleSheetsPlugin extends BasePlugin {
                     validateAndGetUserAuthorizedSheetIds(datasourceConfiguration, methodConfig);
 
             return triggerMethod
-                    .getTriggerClientWithFlags(client, methodConfig, featureFlagMap)
+                    .getTriggerClient(client, methodConfig)
                     .headers(headers -> headers.set(
                             "Authorization",
                             "Bearer " + oauth2.getAuthenticationResponse().getToken()))


### PR DESCRIPTION
## Description
Removed usage of flag release_google_sheets_shared_drive_support_enabled as this feature is enabled for all.


Fixes #40618  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14911706942>
> Commit: b2fdf94d752d1b5ed12daee862cf1475a19559d2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14911706942&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.Sanity`
> Spec:
> <hr>Thu, 08 May 2025 19:03:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
