### PR TITLE
chore: git: write only changed files to the FS

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/operations/FileOperationsCEv2Impl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/operations/FileOperationsCEv2Impl.java
@@ -113,6 +113,28 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
         }
     }
 
+    public boolean hasFileChanged(Object sourceEntity, Object fsSourceEntity) throws IOException {
+        if (fsSourceEntity == null) {
+            return true;
+        }
+
+        boolean hasChanged = true;
+        if (sourceEntity instanceof String s) {
+            hasChanged = !s.equals(fsSourceEntity.toString());
+        } else if (sourceEntity instanceof JSONObject json) {
+            JsonNode sourceNode = objectMapper.readTree(json.toString());
+            String contentToWrite = objectWriter.writeValueAsString(sourceNode);
+            String fsContent = objectWriter.writeValueAsString(fsSourceEntity);
+            hasChanged = !contentToWrite.equals(fsContent);
+        } else {
+            String contentToWrite = objectWriter.writeValueAsString(sourceEntity);
+            String fsContent = objectWriter.writeValueAsString(fsSourceEntity);
+            hasChanged = !contentToWrite.equals(fsContent);
+        }
+
+        return hasChanged;
+    }
+
     /**
      * This method will be used to read and dehydrate the json file present from the local git repo
      *

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/operations/FileOperationsCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/operations/FileOperationsCE.java
@@ -18,6 +18,8 @@ public interface FileOperationsCE {
 
     boolean writeToFile(Object sourceEntity, Path path) throws IOException;
 
+    boolean hasFileChanged(Object sourceEntity, Object fsSourceEntity) throws IOException;
+
     void scanAndDeleteFileForDeletedResources(Set<String> validResources, Path resourceDirectory);
 
     void scanAndDeleteDirectoryForDeletedResources(Set<String> validResources, Path resourceDirectory);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
@@ -178,7 +178,7 @@ public class CommonGitFileUtilsCE {
             Path baseRepoSuffix, ArtifactExchangeJson artifactExchangeJson, String branchName) {
 
         // this should come from the specific files
-        GitResourceMap gitResourceMap = createGitResourceMap(artifactExchangeJson);
+        GitResourceMap gitResourceMapFromDB = createGitResourceMap(artifactExchangeJson);
         Mono<Boolean> keepWorkingDirChangesMono =
                 featureFlagService.check(FeatureFlagEnum.release_git_reset_optimization_enabled);
 
@@ -186,7 +186,7 @@ public class CommonGitFileUtilsCE {
         return keepWorkingDirChangesMono.flatMap(keepWorkingDirChanges -> {
             try {
                 return fileUtils
-                        .saveArtifactToGitRepo(baseRepoSuffix, gitResourceMap, branchName, keepWorkingDirChanges)
+                        .saveArtifactToGitRepo(baseRepoSuffix, gitResourceMapFromDB, branchName, keepWorkingDirChanges)
                         .subscribeOn(Schedulers.boundedElastic());
             } catch (IOException | GitAPIException exception) {
                 return Mono.error(exception);


### PR DESCRIPTION
## Description
This PR ensures that the file contents have changed before we start writing un-commited changed to the FS. We are seeing around 30% improvement in the latency of both git status api and git auto commit api with this change


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14924855165>
> Commit: dc53aa6b15c0137d16c1e41d8ee5d2adf392bfad
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14924855165&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 09 May 2025 09:37:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection of file changes between the database and filesystem for more accurate updates in Git repositories.

- **Bug Fixes**
  - Enhanced logic to ensure obsolete files are deleted and only changed resources are updated in the repository.

- **Chores**
  - Updated variable names for improved clarity in internal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->