### PR TITLE
chore: remove old flags that have been rolled out to 100%

### DIFF
--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -37,13 +37,11 @@ export const FEATURE_FLAG = {
   release_ide_datasource_selector_enabled:
     "release_ide_datasource_selector_enabled",
   release_custom_widget_ai_builder: "release_custom_widget_ai_builder",
-  ab_request_new_integration_enabled: "ab_request_new_integration_enabled",
   release_evaluation_scope_cache: "release_evaluation_scope_cache",
   release_gs_all_sheets_options_enabled:
     "release_gs_all_sheets_options_enabled",
   release_git_modularisation_enabled: "release_git_modularisation_enabled",
   release_git_api_contracts_enabled: "release_git_api_contracts_enabled",
-  ab_premium_datasources_view_enabled: "ab_premium_datasources_view_enabled",
   kill_session_recordings_enabled: "kill_session_recordings_enabled",
   config_mask_session_recordings_enabled:
     "config_mask_session_recordings_enabled",
@@ -93,12 +91,10 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_ide_animations_enabled: false,
   release_ide_datasource_selector_enabled: false,
   release_custom_widget_ai_builder: false,
-  ab_request_new_integration_enabled: false,
   release_evaluation_scope_cache: false,
   release_gs_all_sheets_options_enabled: false,
   release_git_modularisation_enabled: false,
   release_git_api_contracts_enabled: false,
-  ab_premium_datasources_view_enabled: false,
   kill_session_recordings_enabled: false,
   config_user_session_recordings_enabled: true,
   config_mask_session_recordings_enabled: true,

--- a/app/client/src/pages/Editor/IntegrationEditor/APIOrSaasPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/APIOrSaasPlugins.tsx
@@ -73,7 +73,6 @@ interface CreateAPIOrSaasPluginsProps {
     parentEntityType: ActionParentEntityTypeInterface,
     apiType: string,
   ) => void;
-  isPremiumDatasourcesViewEnabled?: boolean;
   upcomingIntegrations: UpcomingIntegration[];
   authApiPlugin?: Plugin;
   restAPIVisible?: boolean;
@@ -302,7 +301,6 @@ const mapStateToProps = (
   state: DefaultRootState,
   props: {
     showSaasAPIs?: boolean;
-    isPremiumDatasourcesViewEnabled: boolean;
     isCreating?: boolean;
   },
 ) => {
@@ -356,17 +354,16 @@ const mapStateToProps = (
     plugin.name.toLocaleLowerCase(),
   );
 
-  const upcomingIntegrations =
-    props.showSaasAPIs && props.isPremiumDatasourcesViewEnabled
-      ? (filterSearch(
-          getFilteredUpcomingIntegrations(
-            isExternalSaasEnabled || isIntegrationsEnabledForPaid,
-            pluginNames,
-            upcomingPlugins,
-          ),
-          searchedPlugin,
-        ) as UpcomingIntegration[])
-      : [];
+  const upcomingIntegrations = props.showSaasAPIs
+    ? (filterSearch(
+        getFilteredUpcomingIntegrations(
+          isExternalSaasEnabled || isIntegrationsEnabledForPaid,
+          pluginNames,
+          upcomingPlugins,
+        ),
+        searchedPlugin,
+      ) as UpcomingIntegration[])
+    : [];
 
   const restAPIVisible =
     !props.showSaasAPIs &&

--- a/app/client/src/pages/Editor/IntegrationEditor/CreateNewDatasourceTab.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/CreateNewDatasourceTab.tsx
@@ -4,10 +4,7 @@ import styled from "styled-components";
 import { thinScrollbar } from "constants/DefaultTheme";
 import type { DefaultRootState } from "react-redux";
 import { getCurrentAppWorkspace } from "ee/selectors/selectedWorkspaceSelectors";
-import {
-  selectFeatureFlagCheck,
-  selectFeatureFlags,
-} from "ee/selectors/featureFlagsSelectors";
+import { selectFeatureFlags } from "ee/selectors/featureFlagsSelectors";
 import { isGACEnabled } from "ee/utils/planHelpers";
 import { getHasCreateDatasourcePermission } from "ee/utils/BusinessFeatures/permissionPageHelpers";
 import {
@@ -35,7 +32,6 @@ import RequestNewIntegration from "./RequestNewIntegration";
 import { StyledDivider } from "./IntegrationStyledComponents";
 import CreateNewDatasourceHeader from "./CreateNewDatasourceHeader";
 import EmptySearchedPlugins from "./EmptySearchedPlugins";
-import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 // This css file contains for the EXTERNAL_SAAS plugin modal
 import "./index.css";
 
@@ -61,8 +57,6 @@ interface CreateNewDatasourceScreenProps {
   showDebugger: boolean;
   pageId: string;
   isOnboardingScreen?: boolean;
-  isRequestNewIntegrationEnabled: boolean;
-  isPremiumDatasourcesViewEnabled: boolean;
 }
 
 interface CreateNewDatasourceScreenState {
@@ -94,8 +88,6 @@ class CreateNewDatasourceTab extends React.Component<
       dataSources,
       isCreating,
       isOnboardingScreen,
-      isPremiumDatasourcesViewEnabled,
-      isRequestNewIntegrationEnabled,
       pageId,
       showDebugger,
     } = this.props;
@@ -132,7 +124,6 @@ class CreateNewDatasourceTab extends React.Component<
             active={false}
             isCreating={isCreating}
             isOnboardingScreen={!!isOnboardingScreen}
-            isPremiumDatasourcesViewEnabled={isPremiumDatasourcesViewEnabled}
             location={location}
             pageId={pageId}
             showUnsupportedPluginDialog={this.showUnsupportedPluginDialog}
@@ -148,7 +139,6 @@ class CreateNewDatasourceTab extends React.Component<
           <APIOrSaasPlugins
             active={false}
             isCreating={isCreating}
-            isPremiumDatasourcesViewEnabled={isPremiumDatasourcesViewEnabled}
             location={location}
             pageId={pageId}
             showSaasAPIs
@@ -165,14 +155,9 @@ class CreateNewDatasourceTab extends React.Component<
               preDivider
             />
           )}
-          <EmptySearchedPlugins
-            isPremiumDatasourcesViewEnabled={
-              this.props.isPremiumDatasourcesViewEnabled
-            }
-            mockDatasources={this.props.mockDatasources}
-          />
+          <EmptySearchedPlugins mockDatasources={this.props.mockDatasources} />
         </NewIntegrationsContainer>
-        {isRequestNewIntegrationEnabled && <RequestNewIntegration />}
+        <RequestNewIntegration />
         {showDebugger && <Debugger />}
       </>
     );
@@ -201,16 +186,6 @@ const mapStateToProps = (state: DefaultRootState) => {
     userWorkspacePermissions,
   );
 
-  const isRequestNewIntegrationEnabled = selectFeatureFlagCheck(
-    state,
-    FEATURE_FLAG.ab_request_new_integration_enabled,
-  );
-
-  const isPremiumDatasourcesViewEnabled = selectFeatureFlagCheck(
-    state,
-    FEATURE_FLAG.ab_premium_datasources_view_enabled,
-  );
-
   return {
     dataSources: getDatasources(state),
     mockDatasources: getMockDatasources(state),
@@ -219,8 +194,6 @@ const mapStateToProps = (state: DefaultRootState) => {
     canCreateDatasource,
     showDebugger,
     pageId,
-    isRequestNewIntegrationEnabled,
-    isPremiumDatasourcesViewEnabled,
   };
 };
 

--- a/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
@@ -24,10 +24,8 @@ const EmptyImage = styled.img`
 `;
 
 export default function EmptySearchedPlugins({
-  isPremiumDatasourcesViewEnabled,
   mockDatasources,
 }: {
-  isPremiumDatasourcesViewEnabled: boolean;
   mockDatasources: MockDatasource[];
 }) {
   let searchedPlugin = useSelector((state) =>
@@ -60,13 +58,11 @@ export default function EmptySearchedPlugins({
         ...plugins,
         { name: createMessage(CREATE_NEW_DATASOURCE_AUTHENTICATED_REST_API) },
         ...mockDatasources,
-        ...(isPremiumDatasourcesViewEnabled
-          ? getFilteredUpcomingIntegrations(
-              isExternalSaasEnabled || isIntegrationsEnabledForPaid,
-              pluginNames,
-              upcomingPlugins,
-            )
-          : []),
+        ...getFilteredUpcomingIntegrations(
+          isExternalSaasEnabled || isIntegrationsEnabledForPaid,
+          pluginNames,
+          upcomingPlugins,
+        ),
       ],
       searchedPlugin,
     ).length > 0;


### PR DESCRIPTION
## Description
- `ab_premium_datasources_view_enabled`
- `ab_request_new_integration_enabled`

flags have been removed



Fixes #40625  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14929090658>
> Commit: 8e10c28c4ffce5f4d602a2445fbe557fe5a90de0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14929090658&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Fri, 09 May 2025 13:26:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed feature flag controls for "Request New Integration" and "Premium Datasources View" across relevant screens.
  - Simplified integration and datasource creation flows by eliminating related feature flag checks and props.
  - Updated components to always display relevant options previously gated by these feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->