### PR TITLE
fix: allow running as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE
-FROM wyattappsmith/appsmith-base:latest
+FROM ${BASE}
 
 ENV IN_DOCKER=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ COPY deploy/docker/fs /
 
 # Install git
 RUN apt-get update && \
-    apt-get install -y git && \
-    apt-get clean && \
+    apt-get install -y git \
+    libnss-wrapper \
+    && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN <<END

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,12 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Setup nss_wrapper configuration in /etc/profile.d/
-RUN echo '# Setup nss_wrapper for arbitrary user support' > /etc/profile.d/nss_wrapper.sh && \
-    echo 'if [ -f $TMP/passwd ] && [ -f $TMP/group ]; then' >> /etc/profile.d/nss_wrapper.sh && \
-    echo '  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)' >> /etc/profile.d/nss_wrapper.sh && \
-    echo '  if [ -n "$NSS_WRAPPER_LIB" ]; then' >> /etc/profile.d/nss_wrapper.sh && \
-    echo '    export LD_PRELOAD="$NSS_WRAPPER_LIB"' >> /etc/profile.d/nss_wrapper.sh && \
-    echo '    export NSS_WRAPPER_PASSWD="$TMP/passwd"' >> /etc/profile.d/nss_wrapper.sh && \
-    echo '    export NSS_WRAPPER_GROUP="$TMP/group"' >> /etc/profile.d/nss_wrapper.sh && \
-    echo '  fi' >> /etc/profile.d/nss_wrapper.sh && \
-    echo 'fi' >> /etc/profile.d/nss_wrapper.sh && \
-    chmod +x /etc/profile.d/nss_wrapper.sh
+
+RUN NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1) && \
+    ln -sf "$NSS_WRAPPER_LIB" /usr/local/lib/libnss_wrapper.so
+ENV LD_PRELOAD="/usr/local/lib/libnss_wrapper.so"
+ENV NSS_WRAPPER_PASSWD="${TMP}/passwd"
+ENV NSS_WRAPPER_GROUP="${TMP}/group"
 
 RUN <<END
   if ! [ -f info.json ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,17 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Setup nss_wrapper configuration in /etc/profile
+RUN echo '# Setup nss_wrapper for arbitrary user support' >> /etc/profile && \
+    echo 'if [ -f ${TMP}/passwd ] && [ -f ${TMP}/group ]; then' >> /etc/profile && \
+    echo '  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)' >> /etc/profile && \
+    echo '  if [ -n "$NSS_WRAPPER_LIB" ]; then' >> /etc/profile && \
+    echo '    export LD_PRELOAD="$NSS_WRAPPER_LIB"' >> /etc/profile && \
+    echo '    export NSS_WRAPPER_PASSWD="${TMP}/appsmith/passwd"' >> /etc/profile && \
+    echo '    export NSS_WRAPPER_GROUP="${TMP}/appsmith/group"' >> /etc/profile && \
+    echo '  fi' >> /etc/profile && \
+    echo 'fi' >> /etc/profile
+
 RUN <<END
   if ! [ -f info.json ]; then
     echo "Missing info.json" >&2

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN echo '# Setup nss_wrapper for arbitrary user support' >> /etc/profile && \
     echo '  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)' >> /etc/profile && \
     echo '  if [ -n "$NSS_WRAPPER_LIB" ]; then' >> /etc/profile && \
     echo '    export LD_PRELOAD="$NSS_WRAPPER_LIB"' >> /etc/profile && \
-    echo '    export NSS_WRAPPER_PASSWD="${TMP}/appsmith/passwd"' >> /etc/profile && \
-    echo '    export NSS_WRAPPER_GROUP="${TMP}/appsmith/group"' >> /etc/profile && \
+    echo '    export NSS_WRAPPER_PASSWD="${TMP}/passwd"' >> /etc/profile && \
+    echo '    export NSS_WRAPPER_GROUP="${TMP}/group"' >> /etc/profile && \
     echo '  fi' >> /etc/profile && \
     echo 'fi' >> /etc/profile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,17 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Setup nss_wrapper configuration in /etc/bash.bashrc
-RUN echo '# Setup nss_wrapper for arbitrary user support' >> /etc/bash.bashrc && \
-    echo 'if [ -f $TMP/passwd ] && [ -f $TMP/group ]; then' >> /etc/bash.bashrc && \
-    echo '  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)' >> /etc/bash.bashrc && \
-    echo '  if [ -n "$NSS_WRAPPER_LIB" ]; then' >> /etc/bash.bashrc && \
-    echo '    export LD_PRELOAD="$NSS_WRAPPER_LIB"' >> /etc/bash.bashrc && \
-    echo '    export NSS_WRAPPER_PASSWD="$TMP/passwd"' >> /etc/bash.bashrc && \
-    echo '    export NSS_WRAPPER_GROUP="$TMP/group"' >> /etc/bash.bashrc && \
-    echo '  fi' >> /etc/bash.bashrc && \
-    echo 'fi' >> /etc/bash.bashrc
+# Setup nss_wrapper configuration in /etc/profile.d/
+RUN echo '# Setup nss_wrapper for arbitrary user support' > /etc/profile.d/nss_wrapper.sh && \
+    echo 'if [ -f $TMP/passwd ] && [ -f $TMP/group ]; then' >> /etc/profile.d/nss_wrapper.sh && \
+    echo '  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)' >> /etc/profile.d/nss_wrapper.sh && \
+    echo '  if [ -n "$NSS_WRAPPER_LIB" ]; then' >> /etc/profile.d/nss_wrapper.sh && \
+    echo '    export LD_PRELOAD="$NSS_WRAPPER_LIB"' >> /etc/profile.d/nss_wrapper.sh && \
+    echo '    export NSS_WRAPPER_PASSWD="$TMP/passwd"' >> /etc/profile.d/nss_wrapper.sh && \
+    echo '    export NSS_WRAPPER_GROUP="$TMP/group"' >> /etc/profile.d/nss_wrapper.sh && \
+    echo '  fi' >> /etc/profile.d/nss_wrapper.sh && \
+    echo 'fi' >> /etc/profile.d/nss_wrapper.sh && \
+    chmod +x /etc/profile.d/nss_wrapper.sh
 
 RUN <<END
   if ! [ -f info.json ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,16 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Setup nss_wrapper configuration in /etc/profile
-RUN echo '# Setup nss_wrapper for arbitrary user support' >> /etc/profile && \
-    echo 'if [ -f ${TMP}/passwd ] && [ -f ${TMP}/group ]; then' >> /etc/profile && \
-    echo '  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)' >> /etc/profile && \
-    echo '  if [ -n "$NSS_WRAPPER_LIB" ]; then' >> /etc/profile && \
-    echo '    export LD_PRELOAD="$NSS_WRAPPER_LIB"' >> /etc/profile && \
-    echo '    export NSS_WRAPPER_PASSWD="${TMP}/passwd"' >> /etc/profile && \
-    echo '    export NSS_WRAPPER_GROUP="${TMP}/group"' >> /etc/profile && \
-    echo '  fi' >> /etc/profile && \
-    echo 'fi' >> /etc/profile
+# Setup nss_wrapper configuration in /etc/bash.bashrc
+RUN echo '# Setup nss_wrapper for arbitrary user support' >> /etc/bash.bashrc && \
+    echo 'if [ -f $TMP/passwd ] && [ -f $TMP/group ]; then' >> /etc/bash.bashrc && \
+    echo '  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)' >> /etc/bash.bashrc && \
+    echo '  if [ -n "$NSS_WRAPPER_LIB" ]; then' >> /etc/bash.bashrc && \
+    echo '    export LD_PRELOAD="$NSS_WRAPPER_LIB"' >> /etc/bash.bashrc && \
+    echo '    export NSS_WRAPPER_PASSWD="$TMP/passwd"' >> /etc/bash.bashrc && \
+    echo '    export NSS_WRAPPER_GROUP="$TMP/group"' >> /etc/bash.bashrc && \
+    echo '  fi' >> /etc/bash.bashrc && \
+    echo 'fi' >> /etc/bash.bashrc
 
 RUN <<END
   if ! [ -f info.json ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE
-FROM wyattappsmith/appsmith-base:latest
+FROM ${BASE}
 
 ENV IN_DOCKER=1
 
@@ -13,8 +13,8 @@ COPY deploy/docker/fs /
 
 # Install git
 RUN apt-get update && \
-    apt-get install -y git \
-    && apt-get clean && \
+    apt-get install -y git && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN <<END

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,8 @@ COPY deploy/docker/fs /
 # Install git
 RUN apt-get update && \
     apt-get install -y git \
-    libnss-wrapper \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-
-ENV NSS_WRAPPER_SYMLINK=/usr/local/lib/libnss_wrapper.so
-RUN NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1) && \
-    ln -sf "$NSS_WRAPPER_LIB" $NSS_WRAPPER_SYMLINK
-ENV NSS_WRAPPER_PASSWD="${TMP}/passwd"
-ENV NSS_WRAPPER_GROUP="${TMP}/group"
 
 RUN <<END
   if ! [ -f info.json ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE
-FROM ${BASE}
+FROM wyattappsmith/appsmith-base:latest
 
 ENV IN_DOCKER=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 
+ENV NSS_WRAPPER_SYMLINK=/usr/local/lib/libnss_wrapper.so
 RUN NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1) && \
-    ln -sf "$NSS_WRAPPER_LIB" /usr/local/lib/libnss_wrapper.so
-ENV LD_PRELOAD="/usr/local/lib/libnss_wrapper.so"
+    ln -sf "$NSS_WRAPPER_LIB" $NSS_WRAPPER_SYMLINK
 ENV NSS_WRAPPER_PASSWD="${TMP}/passwd"
 ENV NSS_WRAPPER_GROUP="${TMP}/group"
 

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -40,14 +40,6 @@ RUN set -o xtrace \
     /var/lib/apt/lists/* \
     /tmp/*
 
-# libnss_wrapper.so is written to an architecture-specific directory, so we symlink to it in a common location to make it easier to activate
-ENV NSS_WRAPPER_SYMLINK=/usr/local/lib/libnss_wrapper.so
-RUN NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1) && \
-    ln -sf "$NSS_WRAPPER_LIB" $NSS_WRAPPER_SYMLINK
-# these env vars need to be set for NSS Wrapper to work but don't matter until LD_PRELOAD is set which is optionally done at runtime
-ENV NSS_WRAPPER_PASSWD="${TMP}/passwd"
-ENV NSS_WRAPPER_GROUP="${TMP}/group"
-
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 
 # Install Java
@@ -92,3 +84,11 @@ VOLUME [ "/appsmith-stacks" ]
 
 ENV TMP="/tmp/appsmith"
 ENV WWW_PATH="$TMP/www"
+
+# libnss_wrapper.so is written to an architecture-specific directory, so we symlink to it in a common location to make it easier to activate
+ENV NSS_WRAPPER_SYMLINK=/usr/local/lib/libnss_wrapper.so
+RUN NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1) && \
+    ln -sf "$NSS_WRAPPER_LIB" $NSS_WRAPPER_SYMLINK
+# these env vars need to be set for NSS Wrapper to work but don't matter until LD_PRELOAD is set which is optionally done at runtime
+ENV NSS_WRAPPER_PASSWD="${TMP}/passwd"
+ENV NSS_WRAPPER_GROUP="${TMP}/group"

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -21,6 +21,8 @@ RUN set -o xtrace \
     supervisor curl nfs-common gnupg \
     gettext \
     ca-certificates \
+    libnss-wrapper \
+    git \
   # Install MongoDB v6, Redis, PostgreSQL v14
   && curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg \
   && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
@@ -28,7 +30,23 @@ RUN set -o xtrace \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes mongodb-org redis postgresql-14 \
-  && apt-get clean
+  && apt-get clean \
+  && rm -rf \
+    /root/.cache \
+    /root/.npm \
+    /usr/local/share/doc \
+    /usr/share/doc \
+    /usr/share/man \
+    /var/lib/apt/lists/* \
+    /tmp/*
+
+# libnss_wrapper.so is written to an architecture-specific directory, so we symlink to it in a common location to make it easier to activate
+ENV NSS_WRAPPER_SYMLINK=/usr/local/lib/libnss_wrapper.so
+RUN NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1) && \
+    ln -sf "$NSS_WRAPPER_LIB" $NSS_WRAPPER_SYMLINK
+# these env vars need to be set for NSS Wrapper to work but don't matter until LD_PRELOAD is set which is optionally done at runtime
+ENV NSS_WRAPPER_PASSWD="${TMP}/passwd"
+ENV NSS_WRAPPER_GROUP="${TMP}/group"
 
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 
@@ -65,21 +83,10 @@ RUN set -o xtrace \
   && mkdir -p /opt/caddy \
   && version="$(curl --write-out '%{redirect_url}' 'https://github.com/caddyserver/caddy/releases/latest' | sed 's,.*/v,,')" \
   && curl --location "https://github.com/caddyserver/caddy/releases/download/v$version/caddy_${version}_linux_$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/').tar.gz" \
-  | tar -xz -C /opt/caddy
-
-RUN mv /opt/caddy/caddy /opt/caddy/caddy_vanilla
+    | tar -xz -C /opt/caddy && \
+  mv /opt/caddy/caddy /opt/caddy/caddy_vanilla
 
 COPY --from=caddybuilder /usr/bin/caddy /opt/caddy/caddy
-
-# Clean up
-RUN rm -rf \
-  /root/.cache \
-  /root/.npm \
-  /usr/local/share/doc \
-  /usr/share/doc \
-  /usr/share/man \
-  /var/lib/apt/lists/* \
-  /tmp/*
 
 VOLUME [ "/appsmith-stacks" ]
 

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -30,6 +30,7 @@ RUN set -o xtrace \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes mongodb-org redis postgresql-14 \
+  && find /etc/redis -type d -exec chmod o+rx {} + -o -type f -exec chmod o+r {} + \
   && apt-get clean \
   && rm -rf \
     /root/.cache \

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -19,7 +19,7 @@ if [ "$(id -u)" != "0" ]; then
     echo "appsmith:x:$(id -g):" > /tmp/appsmith/group
     chmod 444 /tmp/appsmith/passwd /tmp/appsmith/group
     # NSS_WRAPPER_PASSWD, NSS_WRAPPER_GROUP, and NSS_WRAPPER_SYMLINK are set in Dockerfile
-    export LD_PRELOAD="/usr/local/lib/libnss_wrapper.so"
+    export LD_PRELOAD="$NSS_WRAPPER_SYMLINK"
 fi
 
 tlog "Running as: $(id)"

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -15,9 +15,15 @@ mkdir -pv "$SUPERVISORD_CONF_TARGET" "$WWW_PATH"
 
 if [ "$(id -u)" != "0" ]; then
     # if user is non-root setup nss_wrapper
-    echo "appsmith:x:$(id -u):$(id -g):Appsmith:/opt/appsmith:/bin/bash" > /tmp/appsmith/passwd
-    echo "appsmith:x:$(id -g):" > /tmp/appsmith/group
-    chmod 444 /tmp/appsmith/passwd /tmp/appsmith/group
+    # If this is a container restart, the files may already exist and we want them to remain read-only
+    if [[ ! -f /tmp/appsmith/passwd ]]; then
+        echo "appsmith:x:$(id -u):$(id -g):Appsmith:/opt/appsmith:/bin/bash" > /tmp/appsmith/passwd
+        chmod 444 /tmp/appsmith/passwd
+    fi
+    if [[ ! -f /tmp/appsmith/group ]]; then
+        echo "appsmith:x:$(id -g):" > /tmp/appsmith/group
+        chmod 444 /tmp/appsmith/group
+    fi
     # NSS_WRAPPER_PASSWD, NSS_WRAPPER_GROUP, and NSS_WRAPPER_SYMLINK are set in Dockerfile
     export LD_PRELOAD="$NSS_WRAPPER_SYMLINK"
 fi

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -443,7 +443,7 @@ check_redis_compatible_page_size() {
 
 init_postgres() {
   # Initialize embedded postgres by default; set APPSMITH_ENABLE_EMBEDDED_DB to 0, to use existing cloud postgres mockdb instance
-  if [[ ${APPSMITH_ENABLE_EMBEDDED_DB: -1} != 0 || "$(id -u)" != "0" ]]; then
+  if [[ ${APPSMITH_ENABLE_EMBEDDED_DB: -1} != 0 ]]; then
     if [[ "$(id -u)" != "0" ]]; then
       tlog "== When running as a non-root user embedded PostgreSQL cannot be used. Please use an external PostgreSQL instance instead." >&2
       exit 1

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -5,6 +5,14 @@ source pg-utils.sh
 
 set -e
 
+stacks_path=/appsmith-stacks
+
+export APPSMITH_PG_DATABASE="appsmith"
+export SUPERVISORD_CONF_TARGET="$TMP/supervisor-conf.d/"  # export for use in supervisord.conf
+export MONGODB_TMP_KEY_PATH="$TMP/mongodb-key"  # export for use in supervisor process mongodb.conf
+
+mkdir -pv "$SUPERVISORD_CONF_TARGET" "$WWW_PATH"
+
 if ! getent passwd "$(id -u)" &> /dev/null; then
   NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)
   if [ -n "$NSS_WRAPPER_LIB" ]; then
@@ -22,14 +30,6 @@ if ! getent passwd "$(id -u)" &> /dev/null; then
 fi
 
 tlog "Running as: $(id)"
-
-stacks_path=/appsmith-stacks
-
-export APPSMITH_PG_DATABASE="appsmith"
-export SUPERVISORD_CONF_TARGET="$TMP/supervisor-conf.d/"  # export for use in supervisord.conf
-export MONGODB_TMP_KEY_PATH="$TMP/mongodb-key"  # export for use in supervisor process mongodb.conf
-
-mkdir -pv "$SUPERVISORD_CONF_TARGET" "$WWW_PATH"
 
 setup_proxy_variables() {
   export NO_PROXY="${NO_PROXY-localhost,127.0.0.1}"

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -268,7 +268,6 @@ init_replica_set() {
   fi
 
   if [[ $shouldPerformInitdb -gt 0 && $isUriLocal -eq 0 ]]; then
-  fail_if_non_root
     tlog "Initializing Replica Set for local database"
     # Start installed MongoDB service - Dependencies Layer
     mongod --fork --port 27017 --dbpath "$MONGO_DB_PATH" --logpath "$MONGO_LOG_PATH"
@@ -398,7 +397,6 @@ configure_supervisord() {
       cp "$supervisord_conf_source/mongodb.conf" "$SUPERVISORD_CONF_TARGET"
     fi
     if [[ $APPSMITH_REDIS_URL == *"localhost"* || $APPSMITH_REDIS_URL == *"127.0.0.1"* ]]; then
-      fail_if_non_root
       cp "$supervisord_conf_source/redis.conf" "$SUPERVISORD_CONF_TARGET"
       mkdir -p "$stacks_path/data/redis"
     fi

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -13,15 +13,14 @@ export MONGODB_TMP_KEY_PATH="$TMP/mongodb-key"  # export for use in supervisor p
 
 mkdir -pv "$SUPERVISORD_CONF_TARGET" "$WWW_PATH"
 
-# setup nss_wrapper
-touch /tmp/appsmith/passwd /tmp/appsmith/group
 if [ "$(id -u)" != "0" ]; then
+    # if user is non-root setup nss_wrapper
     echo "appsmith:x:$(id -u):$(id -g):Appsmith:/opt/appsmith:/bin/bash" > /tmp/appsmith/passwd
-fi
-if [ "$(id -g)" != "0" ]; then
     echo "appsmith:x:$(id -g):" > /tmp/appsmith/group
+    chmod 444 /tmp/appsmith/passwd /tmp/appsmith/group
+    # NSS_WRAPPER_PASSWD, NSS_WRAPPER_GROUP, and NSS_WRAPPER_SYMLINK are set in Dockerfile
+    export LD_PRELOAD="/usr/local/lib/libnss_wrapper.so"
 fi
-chmod 444 /tmp/appsmith/passwd /tmp/appsmith/group
 
 tlog "Running as: $(id)"
 

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -13,21 +13,15 @@ export MONGODB_TMP_KEY_PATH="$TMP/mongodb-key"  # export for use in supervisor p
 
 mkdir -pv "$SUPERVISORD_CONF_TARGET" "$WWW_PATH"
 
-if ! getent passwd "$(id -u)" &> /dev/null; then
-  NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)
-  if [ -n "$NSS_WRAPPER_LIB" ]; then
-    export LD_PRELOAD="$NSS_WRAPPER_LIB"
-    export NSS_WRAPPER_PASSWD="${TMP}/passwd"
-    export NSS_WRAPPER_GROUP="${TMP}/group"
-    echo "appsmith:x:$(id -u):$(id -g):Appsmith:/opt/appsmith:/bin/bash" > "$NSS_WRAPPER_PASSWD"
-    echo "appsmith:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-    # Remove write permissions after creation
-    chmod 444 "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-  else
-    echo "libnss_wrapper.so not found. Please install libnss-wrapper package." >&2
-    exit 1
-  fi
+# setup nss_wrapper
+touch /tmp/appsmith/passwd /tmp/appsmith/group
+if [ "$(id -u)" != "0" ]; then
+    echo "appsmith:x:$(id -u):$(id -g):Appsmith:/opt/appsmith:/bin/bash" > /tmp/appsmith/passwd
 fi
+if [ "$(id -g)" != "0" ]; then
+    echo "appsmith:x:$(id -g):" > /tmp/appsmith/group
+fi
+chmod 444 /tmp/appsmith/passwd /tmp/appsmith/group
 
 tlog "Running as: $(id)"
 
@@ -610,29 +604,3 @@ setup_monitoring || echo true
 
 # Handle CMD command
 exec "$@"
-
-# Function to setup nss_wrapper
-setup_nss_wrapper() {
-    # Check if user exists
-    if ! id -u "$(id -u)" >/dev/null 2>&1; then
-        # Find libnss_wrapper.so
-        NSS_WRAPPER_LIB=$(find /usr/lib -name libnss_wrapper.so -type f 2>/dev/null | head -n1)
-        if [ -n "$NSS_WRAPPER_LIB" ]; then
-            # Create nss_wrapper files
-            mkdir -p /tmp/appsmith
-            echo "appsmith:x:$(id -u):$(id -g):Appsmith User:/opt/appsmith:/bin/bash" > /tmp/appsmith/passwd
-            echo "appsmith:x:$(id -g):" > /tmp/appsmith/group
-            
-            # Set permissions to read-only
-            chmod 444 /tmp/appsmith/passwd /tmp/appsmith/group
-            
-            # Export environment variables
-            export LD_PRELOAD="$NSS_WRAPPER_LIB"
-            export NSS_WRAPPER_PASSWD="/tmp/appsmith/passwd"
-            export NSS_WRAPPER_GROUP="/tmp/appsmith/group"
-        else
-            echo "Error: libnss_wrapper.so not found"
-            exit 1
-        fi
-    fi
-}

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -5,6 +5,14 @@ source pg-utils.sh
 
 set -e
 
+if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+  export LD_PRELOAD=/usr/lib/libnss_wrapper.so
+  export NSS_WRAPPER_PASSWD=$(mktemp)
+  export NSS_WRAPPER_GROUP=$(mktemp)
+  echo "appsmith:x:$(id -u):$(id -g):Appsmith:/opt/appsmith:/bin/bash" > "$NSS_WRAPPER_PASSWD"
+  echo "appsmith:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+fi
+
 tlog "Running as: $(id)"
 
 stacks_path=/appsmith-stacks

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -437,8 +437,12 @@ check_redis_compatible_page_size() {
 
 init_postgres() {
   # Initialize embedded postgres by default; set APPSMITH_ENABLE_EMBEDDED_DB to 0, to use existing cloud postgres mockdb instance
-  if [[ ${APPSMITH_ENABLE_EMBEDDED_DB: -1} != 0 ]]; then
-    fail_if_non_root
+  if [[ ${APPSMITH_ENABLE_EMBEDDED_DB: -1} != 0 || "$(id -u)" != "0" ]]; then
+    if [[ "$(id -u)" != "0" ]]; then
+      tlog "== When running as a non-root user embedded PostgreSQL cannot be used. Please use an external PostgreSQL instance instead." >&2
+      exit 1
+    fi
+
     tlog "Checking initialized local postgres"
     POSTGRES_DB_PATH="$stacks_path/data/postgres/main"
 
@@ -556,14 +560,6 @@ print_appsmith_info(){
 
 function capture_infra_details(){
   bash /opt/appsmith/generate-infra-details.sh || true
-}
-
-function fail_if_non_root(){
-  if [[ "$(id -u)" != "0" ]]; then
-    tlog "== When running as a non-root user embedded databases cannot be used. Please use an external MongoDB, Redis, and Postgres instead." >&2
-    tlog "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
-    exit 1
-  fi
 }
 
 # Main Section


### PR DESCRIPTION
## Description

Allows the Appsmith container to run as a non-root user, specified at runtime through either docker-compose or Kubernetes pod security context. I didn't specify the user in the `Dockerfile` because environments like OpenShift choose a user at runtime, so it can't be known at build time.

This needs to be followed by an update to docs and changes in the Helm chart to finish it off, but that has a separate release cycle and this needs to go ahead of that.

Ideally we would run as non-root by default, but since there's data persisted on the filesystem automatically transitioning the default is impossible without a lot of pain. This moves us in that direction and enables it in the future if we go down that path.

Required to fix https://github.com/appsmithorg/appsmith/issues/38787

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 50ba745c5bb7709c60ce5194437f921f1a95c980 yet
> <hr>Thu, 15 May 2025 15:56:31 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for user identity emulation when running as a non-root user, improving compatibility in certain deployment environments.
  - Prevented embedded database initialization when running as a non-root user to ensure proper operation.

- **Chores**
  - Installed additional system packages to the base image for enhanced functionality.
  - Optimized image size by consolidating and improving cleanup steps during the build process.
  - Updated base image and refined installation commands for improved build consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->