### PR TITLE
feat: execute on load backwards compatibility backend changes

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -73,6 +73,10 @@ public class NewActionCE extends RefAwareDomain {
                 dotted(unpublishedAction, ActionDTO.Fields.userSetOnLoad);
         public static final String unpublishedAction_runBehaviour =
                 dotted(unpublishedAction, ActionDTO.Fields.runBehaviour);
+        public static final String unpublishedAction_executeOnLoad = dotted(
+                unpublishedAction,
+                ActionDTO.Fields
+                        .executeOnLoad); // This is kept in code to provide backwards compatibility for older actions
         public static final String unpublishedAction_fullyQualifiedName =
                 dotted(unpublishedAction, ActionDTO.Fields.fullyQualifiedName);
         public static final String unpublishedAction_actionConfiguration_httpMethod =

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/NewActionCE.java
@@ -73,10 +73,8 @@ public class NewActionCE extends RefAwareDomain {
                 dotted(unpublishedAction, ActionDTO.Fields.userSetOnLoad);
         public static final String unpublishedAction_runBehaviour =
                 dotted(unpublishedAction, ActionDTO.Fields.runBehaviour);
-        public static final String unpublishedAction_executeOnLoad = dotted(
-                unpublishedAction,
-                ActionDTO.Fields
-                        .executeOnLoad); // This is kept in code to provide backwards compatibility for older actions
+        public static final String unpublishedAction_executeOnLoad =
+                dotted(unpublishedAction, ActionDTO.Fields.executeOnLoad);
         public static final String unpublishedAction_fullyQualifiedName =
                 dotted(unpublishedAction, ActionDTO.Fields.fullyQualifiedName);
         public static final String unpublishedAction_actionConfiguration_httpMethod =

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCEImpl.java
@@ -181,12 +181,14 @@ public class CustomNewActionRepositoryCEImpl extends BaseAppsmithRepositoryImpl<
     @Override
     public Flux<NewAction> findUnpublishedActionsByPageIdAndRunbehaviourSetByUserOnPageLoad(
             String pageId, AclPermission permission) {
-        BridgeQuery<NewAction> q = Bridge.<NewAction>equal(
-                        NewAction.Fields.unpublishedAction_runBehaviour, RunBehaviourEnum.ON_PAGE_LOAD)
+        BridgeQuery<NewAction> q = Bridge.<NewAction>or(
+                        // First condition: new runBehaviour = ON_PAGE_LOAD
+                        Bridge.<NewAction>equal(
+                                NewAction.Fields.unpublishedAction_runBehaviour, RunBehaviourEnum.ON_PAGE_LOAD),
+                        // Second condition: legacy executeOnLoad = true
+                        Bridge.<NewAction>isTrue(NewAction.Fields.unpublishedAction_executeOnLoad))
                 .isTrue(NewAction.Fields.unpublishedAction_userSetOnLoad)
                 .equal(NewAction.Fields.unpublishedAction_pageId, pageId)
-                // In case an action has been deleted in edit mode, but still exists in deployed mode, NewAction object
-                // would exist. To handle this, only fetch non-deleted actions
                 .isNull(NewAction.Fields.unpublishedAction_deletedAt);
 
         return queryBuilder().criteria(q).permission(permission).all();


### PR DESCRIPTION
## Description
This PR provides backward compatibility for older actions which do not have runBehaviour property in the DB. When such actions have been configured to be run on page load explicitly, they will get executed as other actions which get set to be run on page load when binding happens.


### Steps to reproduce:
- Create app on production ([app.appsmith.com](http://app.appsmith.com/))
- Create mock db users datasource
- Create 3 queries, Q1, Q2 and Q3
- Attach Q1 to table so it runs on page load
- Change executeOnLoad setting of Q3 to page load
- Export this app
- Import this on our DP
- Observe that Q3 does not run on page load


Fixes #40633   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/14979473254>
> Commit: 5009eb44ac2c1a713f3a604dddf3545c898208e1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=14979473254&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource, @tag.Sanity`
> Spec:
> <hr>Tue, 13 May 2025 03:57:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
