### PR TITLE
chore: updated the run behaviour toast messages

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
@@ -29,6 +29,7 @@ public enum FeatureFlagEnum {
     release_git_autocommit_feature_enabled,
     release_git_autocommit_eligibility_enabled,
     release_dynamodb_connection_time_to_live_enabled,
+    release_reactive_actions_enabled,
 
     // Add EE flags below this line, to avoid conflicts.
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/RunBehaviourEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/RunBehaviourEnum.java
@@ -5,5 +5,6 @@ package com.appsmith.external.models;
  */
 public enum RunBehaviourEnum {
     MANUAL, // Action will only run when manually triggered
-    ON_PAGE_LOAD // Action will run when the page loads
+    ON_PAGE_LOAD, // Action will run when the page loads
+    AUTOMATIC // Action will run automatically when a variable it depends on changes
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.helpers.ObservationHelperImpl;
 import com.appsmith.server.onload.executables.ExecutableOnLoadService;
 import com.appsmith.server.services.AstService;
+import com.appsmith.server.services.FeatureFlagService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.observation.ObservationRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +19,14 @@ public class OnLoadExecutablesUtilImpl extends OnLoadExecutablesUtilCEImpl imple
             ObjectMapper objectMapper,
             ExecutableOnLoadService<NewPage> pageExecutableOnLoadService,
             ObservationRegistry observationRegistry,
-            ObservationHelperImpl observationHelper) {
-        super(astService, objectMapper, pageExecutableOnLoadService, observationRegistry, observationHelper);
+            ObservationHelperImpl observationHelper,
+            FeatureFlagService featureFlagService) {
+        super(
+                astService,
+                objectMapper,
+                pageExecutableOnLoadService,
+                observationRegistry,
+                observationHelper,
+                featureFlagService);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
@@ -1,10 +1,12 @@
 package com.appsmith.server.onload.internal;
 
 import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
+import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.Executable;
 import com.appsmith.external.models.RunBehaviourEnum;
 import com.appsmith.server.onload.executables.ExecutableOnLoadService;
 import com.appsmith.server.services.AstService;
+import com.appsmith.server.services.FeatureFlagService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
@@ -1,0 +1,254 @@
+package com.appsmith.server.onload.internal;
+
+import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
+import com.appsmith.external.models.Executable;
+import com.appsmith.external.models.RunBehaviourEnum;
+import com.appsmith.server.onload.executables.ExecutableOnLoadService;
+import com.appsmith.server.services.AstService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class OnLoadExecutablesUtilCEImplTest {
+
+    @Mock
+    private AstService astService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ExecutableOnLoadService executableOnLoadService;
+
+    @Mock
+    private FeatureFlagService featureFlagService;
+
+    @InjectMocks
+    private OnLoadExecutablesUtilCEImpl onLoadExecutablesUtilCEImpl;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        onLoadExecutablesUtilCEImpl = new OnLoadExecutablesUtilCEImpl(
+                astService,
+                objectMapper,
+                executableOnLoadService,
+                null, // ObservationRegistry
+                null, // ObservationHelperImpl
+                featureFlagService);
+    }
+
+    @Test
+    void updateExecutablesRunBehaviour_shouldReturnFalseWhenNoExecutables() {
+        List<Executable> onLoadExecutables = new ArrayList<>();
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any())).thenReturn(Flux.empty());
+
+        StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                .expectNext(false)
+                .verifyComplete();
+    }
+
+    @Test
+    void updateExecutablesRunBehaviour_shouldAddMessageWhenExecutableTurnedOn_FeatureFlagOff() {
+        ActionDTO existing = new ActionDTO();
+        existing.setName("Api1");
+        existing.setUserSetOnLoad(false);
+        existing.setRunBehaviour(RunBehaviourEnum.MANUAL);
+        existing.setId("1");
+
+        ActionDTO toTurnOn = new ActionDTO();
+        toTurnOn.setName("Api1");
+        toTurnOn.setUserSetOnLoad(false);
+        toTurnOn.setRunBehaviour(RunBehaviourEnum.ON_PAGE_LOAD);
+        toTurnOn.setId("1");
+
+        List<Executable> onLoadExecutables = List.of(toTurnOn);
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any())).thenReturn(Flux.just(existing));
+        when(featureFlagService.check(any())).thenReturn(Mono.just(false));
+
+        StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                .expectNext(true)
+                .verifyComplete();
+
+        // Should contain the old message
+        assert messagesRef.stream()
+                .anyMatch(msg -> msg.contains("Api1") && msg.contains("executed automatically on page load"));
+    }
+
+    @Test
+    void updateExecutablesRunBehaviour_shouldAddMessageWhenExecutableTurnedOn_FeatureFlagOn() {
+        ActionDTO existing = new ActionDTO();
+        existing.setName("Api1");
+        existing.setUserSetOnLoad(false);
+        existing.setRunBehaviour(RunBehaviourEnum.MANUAL);
+        existing.setId("1");
+
+        ActionDTO toTurnOn = new ActionDTO();
+        toTurnOn.setName("Api1");
+        toTurnOn.setUserSetOnLoad(false);
+        toTurnOn.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
+        toTurnOn.setId("1");
+
+        List<Executable> onLoadExecutables = List.of(toTurnOn);
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any())).thenReturn(Flux.just(existing));
+        when(featureFlagService.check(any())).thenReturn(Mono.just(true));
+
+        StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                .expectNext(true)
+                .verifyComplete();
+
+        // Should contain the new message
+        assert messagesRef.stream()
+                .anyMatch(msg -> msg.contains("Api1")
+                        && msg.contains(
+                                "will run automatically on page load or when a variable it depends on changes"));
+    }
+
+    @Test
+    void updateExecutablesRunBehaviour_shouldAddMessageWhenExecutableTurnedOff_FeatureFlagOff() {
+        ActionDTO existing = new ActionDTO();
+        existing.setName("Api2");
+        existing.setUserSetOnLoad(false);
+        existing.setRunBehaviour(RunBehaviourEnum.ON_PAGE_LOAD);
+        existing.setId("2");
+
+        List<Executable> onLoadExecutables = List.of(); // Now none should be on page load
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any())).thenReturn(Flux.just(existing));
+        when(featureFlagService.check(any())).thenReturn(Mono.just(false));
+
+        StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                .expectNext(true)
+                .verifyComplete();
+
+        // Should contain the old message
+        assert messagesRef.stream()
+                .anyMatch(msg -> msg.contains("Api2") && msg.contains("no longer be executed on page load"));
+    }
+
+    @Test
+    void updateExecutablesRunBehaviour_shouldAddMessageWhenExecutableTurnedOff_FeatureFlagOn() {
+        ActionDTO existing = new ActionDTO();
+        existing.setName("Api2");
+        existing.setUserSetOnLoad(false);
+        existing.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
+        existing.setId("2");
+
+        List<Executable> onLoadExecutables = List.of(); // Now none should be on page load
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any())).thenReturn(Flux.just(existing));
+        when(featureFlagService.check(any())).thenReturn(Mono.just(true));
+
+        StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                .expectNext(true)
+                .verifyComplete();
+
+        // Should contain the new message
+        assert messagesRef.stream()
+                .anyMatch(msg -> msg.contains("Api2")
+                        && msg.contains("will no longer run automatically. You can run it manually when needed."));
+    }
+
+    @Test
+    void updateExecutablesRunBehaviour_shouldAddMessagesForBothOnAndOff_FeatureFlagOn() {
+        ActionDTO existing1 = new ActionDTO();
+        existing1.setName("Api1");
+        existing1.setUserSetOnLoad(false);
+        existing1.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
+        existing1.setId("1");
+
+        ActionDTO existing2 = new ActionDTO();
+        existing2.setName("Api2");
+        existing2.setUserSetOnLoad(false);
+        existing2.setRunBehaviour(RunBehaviourEnum.MANUAL);
+        existing2.setId("2");
+
+        ActionDTO toTurnOn = new ActionDTO();
+        toTurnOn.setName("Api2");
+        toTurnOn.setUserSetOnLoad(false);
+        toTurnOn.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
+        toTurnOn.setId("2");
+
+        List<Executable> onLoadExecutables = List.of(toTurnOn); // Api2 turned on, Api1 turned off
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any()))
+                .thenReturn(Flux.just(existing1, existing2));
+        when(featureFlagService.check(any())).thenReturn(Mono.just(true));
+
+        StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                .expectNext(true)
+                .verifyComplete();
+
+        assert messagesRef.stream()
+                .anyMatch(msg -> msg.contains("Api1")
+                        && msg.contains("will no longer run automatically. You can run it manually when needed."));
+        assert messagesRef.stream()
+                .anyMatch(msg -> msg.contains("Api2")
+                        && msg.contains(
+                                "will run automatically on page load or when a variable it depends on changes"));
+    }
+
+    @Test
+    void updateExecutablesRunBehaviour_shouldNotAddMessageWhenNoChange_FeatureFlagOn() {
+        ActionDTO existing = new ActionDTO();
+        existing.setName("Api3");
+        existing.setUserSetOnLoad(false);
+        existing.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
+        existing.setId("3");
+
+        ActionDTO toStayOn = new ActionDTO();
+        toStayOn.setName("Api3");
+        toStayOn.setUserSetOnLoad(false);
+        toStayOn.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
+        toStayOn.setId("3");
+
+        List<Executable> onLoadExecutables = List.of(toStayOn);
+        List<LayoutExecutableUpdateDTO> executableUpdatesRef = new ArrayList<>();
+        List<String> messagesRef = new ArrayList<>();
+
+        when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any())).thenReturn(Flux.just(existing));
+        when(featureFlagService.check(any())).thenReturn(Mono.just(true));
+
+        StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                .expectNext(false)
+                .verifyComplete();
+
+        assert messagesRef.isEmpty();
+    }
+
+    // Add more tests for other scenarios as needed
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
@@ -16,6 +16,9 @@ import org.mockito.MockitoAnnotations;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import io.micrometer.observation.ObservationRegistry;
+import com.appsmith.server.helpers.ObservationHelperImpl;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,18 +40,26 @@ class OnLoadExecutablesUtilCEImplTest {
     @Mock
     private FeatureFlagService featureFlagService;
 
+    @Mock
+    private ObservationRegistry observationRegistry;
+
+    @Mock
+    private ObservationHelperImpl observationHelper;
+
     @InjectMocks
     private OnLoadExecutablesUtilCEImpl onLoadExecutablesUtilCEImpl;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        observationRegistry = ObservationRegistry.create(); // No-op registry
+        observationHelper = Mockito.mock(ObservationHelperImpl.class);
         onLoadExecutablesUtilCEImpl = new OnLoadExecutablesUtilCEImpl(
                 astService,
                 objectMapper,
                 executableOnLoadService,
-                null, // ObservationRegistry
-                null, // ObservationHelperImpl
+                observationRegistry,
+                observationHelper,
                 featureFlagService);
     }
 
@@ -251,6 +262,4 @@ class OnLoadExecutablesUtilCEImplTest {
 
         assert messagesRef.isEmpty();
     }
-
-    // Add more tests for other scenarios as needed
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImplTest.java
@@ -2,23 +2,24 @@ package com.appsmith.server.onload.internal;
 
 import com.appsmith.external.dtos.LayoutExecutableUpdateDTO;
 import com.appsmith.external.models.ActionDTO;
+import com.appsmith.external.models.CreatorContextType;
 import com.appsmith.external.models.Executable;
 import com.appsmith.external.models.RunBehaviourEnum;
+import com.appsmith.server.helpers.ObservationHelperImpl;
 import com.appsmith.server.onload.executables.ExecutableOnLoadService;
 import com.appsmith.server.services.AstService;
 import com.appsmith.server.services.FeatureFlagService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-import io.micrometer.observation.ObservationRegistry;
-import com.appsmith.server.helpers.ObservationHelperImpl;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,7 +73,7 @@ class OnLoadExecutablesUtilCEImplTest {
         when(executableOnLoadService.getAllExecutablesByCreatorIdFlux(any())).thenReturn(Flux.empty());
 
         StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
-                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, CreatorContextType.PAGE))
                 .expectNext(false)
                 .verifyComplete();
     }
@@ -99,7 +100,7 @@ class OnLoadExecutablesUtilCEImplTest {
         when(featureFlagService.check(any())).thenReturn(Mono.just(false));
 
         StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
-                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, CreatorContextType.PAGE))
                 .expectNext(true)
                 .verifyComplete();
 
@@ -130,7 +131,7 @@ class OnLoadExecutablesUtilCEImplTest {
         when(featureFlagService.check(any())).thenReturn(Mono.just(true));
 
         StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
-                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, CreatorContextType.PAGE))
                 .expectNext(true)
                 .verifyComplete();
 
@@ -157,7 +158,7 @@ class OnLoadExecutablesUtilCEImplTest {
         when(featureFlagService.check(any())).thenReturn(Mono.just(false));
 
         StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
-                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, CreatorContextType.PAGE))
                 .expectNext(true)
                 .verifyComplete();
 
@@ -182,7 +183,7 @@ class OnLoadExecutablesUtilCEImplTest {
         when(featureFlagService.check(any())).thenReturn(Mono.just(true));
 
         StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
-                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, CreatorContextType.PAGE))
                 .expectNext(true)
                 .verifyComplete();
 
@@ -221,7 +222,7 @@ class OnLoadExecutablesUtilCEImplTest {
         when(featureFlagService.check(any())).thenReturn(Mono.just(true));
 
         StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
-                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, CreatorContextType.PAGE))
                 .expectNext(true)
                 .verifyComplete();
 
@@ -256,7 +257,7 @@ class OnLoadExecutablesUtilCEImplTest {
         when(featureFlagService.check(any())).thenReturn(Mono.just(true));
 
         StepVerifier.create(onLoadExecutablesUtilCEImpl.updateExecutablesRunBehaviour(
-                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, null))
+                        onLoadExecutables, "creatorId", executableUpdatesRef, messagesRef, CreatorContextType.PAGE))
                 .expectNext(false)
                 .verifyComplete();
 


### PR DESCRIPTION
## Description

Changed the logic to update the message of the actions getting executed on page load or automatic based on the flag `release_reactive_actions_enabled`. Added the test case for onLoadExecutables file.

- If flag is true, toast message would say automatic on binding and manual on removal of binding
- If flag is false, toast message would say page load on binding and manual on removal of binding

Fixes #40471 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table, @tag.JS, @tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD f042d9861b9e3a5b1916c62c49e3d878452a326d yet
> <hr>Mon, 19 May 2025 08:09:11 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new feature flag to control reactive actions.
  - Added support for an "automatic" run behavior, allowing actions to run automatically when dependent variables change.

- **Bug Fixes**
  - Improved logic for updating which actions run automatically on page load, with behavior now controlled by the new feature flag.

- **Tests**
  - Added comprehensive tests to verify correct behavior and messaging when updating action run behaviors under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->