### PR TITLE
chore: Allow UI module private entities in action selector query/js selection

### DIFF
--- a/app/client/src/ce/selectors/modulesSelector.ts
+++ b/app/client/src/ce/selectors/modulesSelector.ts
@@ -13,3 +13,6 @@ export const getCurrentModuleId = (state: DefaultRootState) => "";
 export const getCurrentBaseModuleId = (state: DefaultRootState) => "";
 
 export const showUIModulesList = (state: DefaultRootState) => false;
+
+export const getActionsInCurrentModule = (state: DefaultRootState) => [];
+export const getJSCollectionsInCurrentModule = (state: DefaultRootState) => [];

--- a/app/client/src/components/editorComponents/ActionCreator/helpers.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/helpers.tsx
@@ -66,7 +66,11 @@ import { isJSAction } from "ee/workers/Evaluation/evaluationUtils";
 import type { DataTreeEntity } from "entities/DataTree/dataTreeTypes";
 import type { ModuleInstanceDataState } from "ee/constants/ModuleInstanceConstants";
 import { getModuleIcon } from "pages/Editor/utils";
-import { getAllModules } from "ee/selectors/modulesSelector";
+import {
+  getAllModules,
+  getActionsInCurrentModule,
+  getJSCollectionsInCurrentModule,
+} from "ee/selectors/modulesSelector";
 import type { Module } from "ee/constants/ModuleConstants";
 import {
   createNewJSCollectionFromActionCreator,
@@ -682,14 +686,18 @@ export function useApisQueriesAndJsActionOptions(handleClose: () => void) {
   const plugins = useSelector((state: DefaultRootState) => {
     return state.entities.plugins.list;
   });
-  const actions = useSelector(getCurrentActions);
-  const jsActions = useSelector(getCurrentJSCollections);
+  const pageActions = useSelector(getCurrentActions);
+  const pageJsActions = useSelector(getCurrentJSCollections);
+  const moduleActions = useSelector(getActionsInCurrentModule);
+  const moduleJSCollections = useSelector(getJSCollectionsInCurrentModule);
   const queryModuleInstances = useSelector(
     getQueryModuleInstances,
   ) as unknown as ModuleInstanceDataState;
   const jsModuleInstancesData = useSelector(getJSModuleInstancesData);
   const modules = useSelector(getAllModules);
   const pluginImages = useSelector(getPluginImages);
+  const actions = [...pageActions, ...moduleActions];
+  const jsActions = [...pageJsActions, ...moduleJSCollections];
 
   // this function gets all the Queries/API's/JS Objects and attaches it to actionList
   return getApiQueriesAndJSActionOptionsWithChildren(

--- a/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
+++ b/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/useSource/useConnectToOptions.tsx
@@ -24,7 +24,10 @@ import type {
   ModuleInstanceDataState,
 } from "ee/constants/ModuleInstanceConstants";
 import type { Module } from "ee/constants/ModuleConstants";
-import { getAllModules } from "ee/selectors/modulesSelector";
+import {
+  getActionsInCurrentModule,
+  getAllModules,
+} from "ee/selectors/modulesSelector";
 import { getModuleIcon } from "pages/Editor/utils";
 import { isDynamicValue } from "@shared/dsl";
 
@@ -173,9 +176,11 @@ function useConnectToOptions(props: ConnectToOptionsProps) {
     updateConfig,
   } = useContext(WidgetQueryGeneratorFormContext);
 
-  const queries = useSelector(getCurrentActions);
+  const pageQueries = useSelector(getCurrentActions);
+  const moduleQueries = useSelector(getActionsInCurrentModule);
   const pluginsPackageNamesMap = useSelector(getPluginIdPackageNamesMap);
   const plugins = useSelector(getPlugins);
+  const queries = [...pageQueries, ...moduleQueries];
 
   const { pluginImages, widget } = props;
 


### PR DESCRIPTION
## Description
This PR allows module private entities i.e queries and JS objects to be listed in the action selectors of a UI module.
The selectors return`[]` in CE and is extended in EE

PR for https://github.com/appsmithorg/appsmith-ee/pull/7455

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15061113685>
> Commit: 176563bb507a71b9d8164c2d518150b7d644f698
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15061113685&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 16 May 2025 06:26:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded action and JS collection selection to include both page-level and module-level options in relevant dropdowns and hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->