### PR TITLE
fix: Updating the styles for JS settings popover

### DIFF
--- a/app/client/src/IDE/Components/ToolbarSettingsPopover.tsx
+++ b/app/client/src/IDE/Components/ToolbarSettingsPopover.tsx
@@ -7,7 +7,7 @@ import {
   PopoverTrigger,
   ToggleButton,
 } from "@appsmith/ads";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 interface Props {
   isOpen: boolean;
@@ -16,21 +16,20 @@ interface Props {
   children: React.ReactNode;
   dataTestId?: string;
   disabled?: boolean;
+  popoverWidth?: string;
 }
 
-const Variables = css`
-  --popover-width: 280px;
-`;
 const StyledPopoverHeader = styled(PopoverHeader)`
   margin-bottom: var(--ads-v2-spaces-5);
 `;
 
-const StyledPopoverContent = styled(PopoverContent)`
-  ${Variables};
+const StyledPopoverContent = styled(PopoverContent)<{ popoverWidth?: string }>`
+  --popover-width: ${({ popoverWidth }) =>
+    popoverWidth ? popoverWidth : "280px"};
 `;
 
 export const ToolbarSettingsPopover = (props: Props) => {
-  const { handleOpenChange, isOpen, title } = props;
+  const { handleOpenChange, isOpen, popoverWidth, title } = props;
   const handleButtonClick = useCallback(() => {
     handleOpenChange(true);
   }, [handleOpenChange]);
@@ -54,6 +53,7 @@ export const ToolbarSettingsPopover = (props: Props) => {
       <StyledPopoverContent
         align="end"
         onEscapeKeyDown={handleEscapeKeyDown}
+        popoverWidth={popoverWidth}
         size="sm"
       >
         <StyledPopoverHeader isClosable>{title}</StyledPopoverHeader>

--- a/app/client/src/ce/pages/Editor/JSEditor/JSEditorToolbar/JSEditorToolbar.tsx
+++ b/app/client/src/ce/pages/Editor/JSEditor/JSEditorToolbar/JSEditorToolbar.tsx
@@ -75,6 +75,7 @@ export const JSEditorToolbar = (props: Props) => {
             dataTestId={"t--js-settings-trigger"}
             handleOpenChange={setIsOpen}
             isOpen={isOpen}
+            popoverWidth="345px"
             title={createMessage(JS_EDITOR_SETTINGS.TITLE)}
           >
             <JSFunctionSettings

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
@@ -33,6 +33,14 @@ const OptionSubText = styled(Text)`
 
 const StyledSelect = styled(Select)`
   width: fit-content;
+
+  .rc-select-selector {
+    min-width: 120px;
+  }
+`;
+
+const FunctionName = styled(Text)`
+  word-break: break-all;
 `;
 
 interface Props {
@@ -71,15 +79,15 @@ const FunctionSettingRow = (props: FunctionSettingsRowProps) => {
     <Flex
       alignItems="center"
       className={`t--async-js-function-settings ${props.action.name}-run-behavior-setting`}
-      gap="spaces-4"
+      gap="spaces-3"
       id={`${props.action.name}-settings`}
       justifyContent="space-between"
       key={props.action.id}
       w="100%"
     >
-      <Text htmlFor={props.action.id} renderAs="label">
+      <FunctionName htmlFor={props.action.id} renderAs="label">
         {props.action.name}
-      </Text>
+      </FunctionName>
       <StyledSelect
         data-testid={`t--dropdown-runBehaviour`}
         defaultValue={selectedValue}


### PR DESCRIPTION
## Description

Updating the styles for JS settings popover

Fixes #40657

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15045634120>
> Commit: 0346eec44945dee8b0a98ece911e23f36709c5b2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15045634120&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.JS`
> Spec:
> <hr>Thu, 15 May 2025 13:49:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to customize the width of the settings popover in toolbars.

- **Style**
  - Improved text wrapping for function names in the function settings panel.
  - Adjusted spacing and set a minimum width for dropdown selectors to enhance layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->