### PR TITLE
fix: show left side auth content when multi-org feature is enabled

### DIFF
--- a/app/client/src/pages/UserAuth/Container.tsx
+++ b/app/client/src/pages/UserAuth/Container.tsx
@@ -52,7 +52,7 @@ function Container(props: ContainerProps) {
   const brandingEnabled = isBrandingEnabled(featureFlags);
 
   const shouldShowLeftSideContent =
-    cloudHosting && !isMobileDevice && !multiOrgEnabled && brandingEnabled;
+    cloudHosting && !isMobileDevice && multiOrgEnabled && !brandingEnabled;
   const isAiAgentInstanceEnabled = useSelector(getIsAiAgentInstanceEnabled);
 
   return (


### PR DESCRIPTION
## Description
This PR fixes an issue where the left side content in the authentication screen wasn't displaying properly when the multi-organization feature was enabled.

## Fix
Updated the condition in the `UserAuth` container to correctly display the left side content when the multi-org feature flag is enabled.

## Testing
* Verified the left side content appears correctly with multi-org enabled.
* Ensured the component still behaves correctly on mobile devices.
* Confirmed the UI renders properly with and without branding enabled.

## Automation

/ok-to-test tags="@tag.Sanity, @tag.Authentication"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15109876659>
> Commit: 4f88a93734ff4a6f71b5fed22dd8364a14486093
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15109876659&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Authentication`
> Spec:
> <hr>Mon, 19 May 2025 10:38:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the conditions for displaying the left side content on the user authentication page, which may change when this content is visible to users based on organization and branding settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->