### PR TITLE
chore: added reset before checkout ref

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -840,7 +840,9 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                 jsonTransformationDTO.getRepoName());
 
         // Tags and branch checkout with the same mechanism.
-        return fsGitHandler.checkoutToBranch(repoSuffix, jsonTransformationDTO.getRefName());
+        return fsGitHandler.resetToLastCommit(repoSuffix).flatMap(bool -> {
+            return fsGitHandler.checkoutToBranch(repoSuffix, jsonTransformationDTO.getRefName());
+        });
     }
 
     @Override


### PR DESCRIPTION
## Description


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15110572865>
> Commit: 4e470ffe6a65dfbbc1c0827664c2160e7ed6719f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15110572865&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Mon, 19 May 2025 11:20:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of branch or tag checkout operations by ensuring the repository is reset to the last commit before switching references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->