### PR TITLE
feat: implement multi-organization login page

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -2698,3 +2698,18 @@ export const PASSWORD_INSUFFICIENT_STRENGTH = () =>
 
 export const PLUGIN_NOT_INSTALLED = () =>
   "Upgrade your plan to unlock access to these integrations.";
+
+// Multi-org login footer constants
+export const MULTI_ORG_FOOTER_NOT_RIGHT_ORG_LEFT_TEXT = () =>
+  "Not the right organization?";
+export const MULTI_ORG_FOOTER_NOT_RIGHT_ORG_RIGHT_TEXT = () =>
+  "Enter other URL";
+
+export const MULTI_ORG_FOOTER_NOT_PART_OF_ORG_LEFT_TEXT = () =>
+  "Not part of the organization?";
+export const MULTI_ORG_FOOTER_NOT_PART_OF_ORG_RIGHT_TEXT = () => "Sign up";
+
+export const MULTI_ORG_FOOTER_CREATE_ORG_LEFT_TEXT = () =>
+  "Looking to create one?";
+export const MULTI_ORG_FOOTER_CREATE_ORG_RIGHT_TEXT = () =>
+  "Create an organization";

--- a/app/client/src/ce/reducers/organizationReducer.ts
+++ b/app/client/src/ce/reducers/organizationReducer.ts
@@ -12,6 +12,8 @@ import {
 import { createReducer } from "utils/ReducerUtils";
 
 export interface OrganizationReduxState<T> {
+  displayName?: string;
+  slug?: string;
   userPermissions: string[];
   organizationConfiguration: Record<string, T>;
   new: boolean;

--- a/app/client/src/pages/UserAuth/Container.tsx
+++ b/app/client/src/pages/UserAuth/Container.tsx
@@ -13,7 +13,7 @@ import { selectFeatureFlags } from "ee/selectors/featureFlagsSelectors";
 import { isBrandingEnabled, isMultiOrgFFEnabled } from "ee/utils/planHelpers";
 
 interface ContainerProps {
-  title: string;
+  title: string | React.ReactNode;
   subtitle?: React.ReactNode;
   children: React.ReactNode;
   footer?: React.ReactNode;


### PR DESCRIPTION
## Description
This PR implements the multi-organization login page UI to improve the authentication experience for users within organizations.

## Changes
- Add new message constants for multi-org login footer in messages.ts
- Update OrganizationReduxState interface to include displayName and slug properties
- Modify Container component to accept React.ReactNode for title prop
- Implement organization-specific title and subtitle on login page
- Add footer with contextual options for users:
  - "Not the right organization?" - Allows users to enter a different organization URL
  - "Not part of the organization?" - Redirects to the sign-up page
  - "Looking to create one?" - Redirects to organization creation

## How to Test
1. Enable the `license_multi_org_enabled` feature flag
2. Access the login page through an organization subdomain
3. Verify that the organization name appears in the title
4. Verify that the organization slug appears in the subtitle
5. Test the footer links to ensure they redirect to the correct pages
## Automation

/ok-to-test tags="@tag.Sanity, @tag.Authentication"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15110788513>
> Commit: a16c118b747331c152aff2f85fd021f63b041ecc
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15110788513&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Authentication`
> Spec:
> <hr>Mon, 19 May 2025 11:28:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced login page to support multi-organization environments, including dynamic titles, subtitles, and a new footer with contextual messages and links for different organization scenarios.
- **Improvements**
  - Login page title now supports rich content, allowing for more flexible display.
  - Organization information now includes display name and slug for improved context in multi-org scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->