### PR TITLE
chore: Updating the dropdown width for the run behavior settings of JS object

### DIFF
--- a/app/client/packages/design-system/ads/src/Select/Select.tsx
+++ b/app/client/packages/design-system/ads/src/Select/Select.tsx
@@ -26,6 +26,7 @@ function Select(props: SelectProps) {
     children,
     className,
     dropdownClassName,
+    dropdownMatchSelectWidth = true,
     isDisabled = false,
     isLoading = false,
     isMultiSelect,
@@ -88,6 +89,7 @@ function Select(props: SelectProps) {
         SelectDropdownClassName + `--${size}`,
         dropdownClassName,
       )}
+      dropdownMatchSelectWidth={dropdownMatchSelectWidth}
       dropdownRender={(menu: any) => {
         return (
           <div>

--- a/app/client/packages/design-system/ads/src/Select/Select.types.ts
+++ b/app/client/packages/design-system/ads/src/Select/Select.types.ts
@@ -11,6 +11,7 @@ export type SelectProps = RCSelectProps & {
   isDisabled?: boolean;
   isValid?: boolean;
   isLoading?: boolean;
+  dropdownMatchSelectWidth?: boolean | number;
 };
 
 export type SelectOptionProps = OptionProps & {

--- a/app/client/src/IDE/Components/ToolbarSettingsPopover.tsx
+++ b/app/client/src/IDE/Components/ToolbarSettingsPopover.tsx
@@ -24,8 +24,9 @@ const StyledPopoverHeader = styled(PopoverHeader)`
 `;
 
 const StyledPopoverContent = styled(PopoverContent)<{ popoverWidth?: string }>`
-  --popover-width: ${({ popoverWidth }) =>
-    popoverWidth ? popoverWidth : "280px"};
+  min-width: 280px;
+  max-width: ${({ popoverWidth }) => (popoverWidth ? popoverWidth : "280px")};
+  width: fit-content;
 `;
 
 export const ToolbarSettingsPopover = (props: Props) => {

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
@@ -18,7 +18,13 @@ import {
   RUN_BEHAVIOR_VALUES,
   type ActionRunBehaviourType,
 } from "PluginActionEditor/types/PluginActionTypes";
-import styled from "styled-components";
+import styled, { createGlobalStyle } from "styled-components";
+
+const PopoverStyles = createGlobalStyle`
+  .rc-select-dropdown {
+    width: 256px !important;
+  }
+`;
 
 const OptionLabel = styled(Text)`
   color: var(--ads-v2-color-fg);
@@ -35,7 +41,7 @@ const StyledSelect = styled(Select)`
   width: fit-content;
 
   .rc-select-selector {
-    min-width: 120px;
+    min-width: 110px;
   }
 `;
 
@@ -140,6 +146,7 @@ export const JSFunctionSettings = (props: Props) => {
       {props.actions.length === 0 && (
         <Text kind="body-s">{createMessage(NO_JS_FUNCTIONS)}</Text>
       )}
+      <PopoverStyles />
     </Flex>
   );
 };

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/JSFunctionSettings.tsx
@@ -18,13 +18,7 @@ import {
   RUN_BEHAVIOR_VALUES,
   type ActionRunBehaviourType,
 } from "PluginActionEditor/types/PluginActionTypes";
-import styled, { createGlobalStyle } from "styled-components";
-
-const PopoverStyles = createGlobalStyle`
-  .rc-select-dropdown {
-    width: 256px !important;
-  }
-`;
+import styled from "styled-components";
 
 const OptionLabel = styled(Text)`
   color: var(--ads-v2-color-fg);
@@ -95,8 +89,10 @@ const FunctionSettingRow = (props: FunctionSettingsRowProps) => {
         {props.action.name}
       </FunctionName>
       <StyledSelect
+        className="js-runBehaviour"
         data-testid={`t--dropdown-runBehaviour`}
         defaultValue={selectedValue}
+        dropdownMatchSelectWidth={256}
         id={props.action.id}
         isDisabled={props.disabled}
         listHeight={240}
@@ -146,7 +142,6 @@ export const JSFunctionSettings = (props: Props) => {
       {props.actions.length === 0 && (
         <Text kind="body-s">{createMessage(NO_JS_FUNCTIONS)}</Text>
       )}
-      <PopoverStyles />
     </Flex>
   );
 };


### PR DESCRIPTION
## Description

Updating the dropdown width for the run behavior settings of JS object

Fixes [#40657](https://github.com/appsmithorg/appsmith/issues/40657)

## Automation

/ok-to-test tags="@tag.JS, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
