### PR TITLE
fix: logout user if the session has expired between page switches

### DIFF
--- a/app/client/src/api/ApiResponses.tsx
+++ b/app/client/src/api/ApiResponses.tsx
@@ -1,5 +1,5 @@
 export interface APIResponseError {
-  code: string | number;
+  code: string;
   message: string;
   errorType?: string;
 }


### PR DESCRIPTION
## Description
If a user's session times out and the user navigates to a new page in an application the user was not navigated to the login page. This change makes sure that the user profile is updated in the redux store on page change and the page response is validated using the response interceptors.

This bug was introduced in [this PR](https://github.com/appsmithorg/appsmith/pull/36096).

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15155628540>
> Commit: a3349cda620d3af78d2604f9edea151f6f15408e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15155628540&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 21 May 2025 08:31:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when loading published page resources, ensuring better management of API errors and user profile updates.
- **Refactor**
	- Updated internal handling of API response error codes for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->