### PR TITLE
fix: runBehaviour added in published mode as well

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -779,6 +779,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         actionViewDTO.setName(actionDTO.getValidName());
         actionViewDTO.setPageId(actionDTO.getPageId());
         actionViewDTO.setConfirmBeforeExecute(actionDTO.getConfirmBeforeExecute());
+        actionViewDTO.setRunBehaviour(actionDTO.getRunBehaviour());
 
         if (actionDTO.getJsonPathKeys() != null && !actionDTO.getJsonPathKeys().isEmpty()) {
             Set<String> jsonPathKeys;


### PR DESCRIPTION
## Description
This PR adds runBehaviour property in application view mode as well


Fixes #40721
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15159213029>
> Commit: c2f172bce46337a123c691693743d72279df11c8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15159213029&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 21 May 2025 10:38:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the run behavior setting is properly reflected when viewing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->