### PR TITLE
fix: mixpanel start stop recording check

### DIFF
--- a/app/client/src/utils/Analytics/mixpanel.ts
+++ b/app/client/src/utils/Analytics/mixpanel.ts
@@ -61,13 +61,19 @@ class MixpanelSingleton {
   }
 
   public startRecording() {
-    if (this.mixpanel) {
+    if (
+      this.mixpanel &&
+      typeof this.mixpanel.start_session_recording === "function"
+    ) {
       this.mixpanel.start_session_recording();
     }
   }
 
   public stopRecording() {
-    if (this.mixpanel) {
+    if (
+      this.mixpanel &&
+      typeof this.mixpanel.stop_session_recording === "function"
+    ) {
       this.mixpanel.stop_session_recording();
     }
   }


### PR DESCRIPTION
## Description
Cherry Picking this into Master - https://github.com/appsmithorg/appsmith/pull/40717

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15162814431>
> Commit: b6c3243b013f42aa4888b5b94a3c5310714fd119
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15162814431&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 21 May 2025 13:41:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
