### PR TITLE
feat: updated toast messages for on page load actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
@@ -312,129 +312,158 @@ public class OnLoadExecutablesUtilCEImpl implements OnLoadExecutablesUtilCE {
         Flux<Executable> creatorContextExecutablesFlux =
                 this.getAllExecutablesByCreatorIdFlux(creatorId, creatorType).cache();
 
-        // Before we update the actions, fetch all the actions which are currently set to execute on load.
-        Mono<List<Executable>> existingOnLoadExecutablesMono = creatorContextExecutablesFlux
-                .flatMap(executable -> {
-                    if (RunBehaviourEnum.ON_PAGE_LOAD.equals(executable.getRunBehaviour())) {
-                        return Mono.just(executable);
-                    }
-                    return Mono.empty();
-                })
-                .collectList();
+        // Check the feature flag first to determine which RunBehaviourEnum to use for comparison
+        return featureFlagService
+                .check(FeatureFlagEnum.release_reactive_actions_enabled)
+                .flatMap(isReactiveActionsEnabled -> {
+                    RunBehaviourEnum runBehaviourToCheck =
+                            isReactiveActionsEnabled ? RunBehaviourEnum.AUTOMATIC : RunBehaviourEnum.ON_PAGE_LOAD;
 
-        return existingOnLoadExecutablesMono
-                .zipWith(creatorContextExecutablesFlux.collectList())
-                .flatMap(tuple -> featureFlagService
-                        .check(FeatureFlagEnum.release_reactive_actions_enabled)
-                        .flatMap(isReactiveActionsEnabled -> {
-                            List<Executable> existingOnLoadExecutables = tuple.getT1();
-                            List<Executable> creatorContextExecutables = tuple.getT2();
+                    // Before we update the actions, fetch all the actions which are currently set to execute on load.
+                    Mono<List<Executable>> existingOnLoadExecutablesMono = creatorContextExecutablesFlux
+                            .flatMap(executable -> {
+                                if (runBehaviourToCheck.equals(executable.getRunBehaviour())) {
+                                    return Mono.just(executable);
+                                }
+                                return Mono.empty();
+                            })
+                            .collectList();
 
-                            // There are no actions in this page. No need to proceed further since no actions would get
-                            // updated
-                            if (CollectionUtils.isNullOrEmpty(creatorContextExecutables)) {
-                                return Mono.just(FALSE);
-                            }
+                    return existingOnLoadExecutablesMono
+                            .zipWith(creatorContextExecutablesFlux.collectList())
+                            .flatMap(tuple -> {
+                                List<Executable> existingOnLoadExecutables = tuple.getT1();
+                                List<Executable> creatorContextExecutables = tuple.getT2();
 
-                            // No actions require an update if no actions have been found as page load actions as well
-                            // as
-                            // existing on load page actions are empty
-                            if (CollectionUtils.isNullOrEmpty(existingOnLoadExecutables)
-                                    && (onLoadExecutables == null
-                                            || CollectionUtils.isNullOrEmpty(onLoadExecutables))) {
-                                return Mono.just(FALSE);
-                            }
+                                // There are no actions in this page. No need to proceed further since no actions would
+                                // get
+                                // updated
+                                if (CollectionUtils.isNullOrEmpty(creatorContextExecutables)) {
+                                    return Mono.just(FALSE);
+                                }
 
-                            // Extract names of existing page load actions and new page load actions for quick lookup.
-                            Set<String> existingOnLoadExecutableNames = existingOnLoadExecutables.stream()
-                                    .map(Executable::getUserExecutableName)
-                                    .collect(Collectors.toSet());
+                                // No actions require an update if no actions have been found as page load actions as
+                                // well
+                                // as
+                                // existing on load page actions are empty
+                                if (CollectionUtils.isNullOrEmpty(existingOnLoadExecutables)
+                                        && (onLoadExecutables == null
+                                                || CollectionUtils.isNullOrEmpty(onLoadExecutables))) {
+                                    return Mono.just(FALSE);
+                                }
 
-                            Set<String> newOnLoadExecutableNames = onLoadExecutables.stream()
-                                    .map(Executable::getUserExecutableName)
-                                    .collect(Collectors.toSet());
+                                // Extract names of existing page load actions and new page load actions for quick
+                                // lookup.
+                                Set<String> existingOnLoadExecutableNames = existingOnLoadExecutables.stream()
+                                        .map(Executable::getUserExecutableName)
+                                        .collect(Collectors.toSet());
 
-                            // Calculate the actions which would need to be updated from execute on load TRUE to FALSE.
-                            Set<String> turnedOffExecutableNames = new HashSet<>();
-                            turnedOffExecutableNames.addAll(existingOnLoadExecutableNames);
-                            turnedOffExecutableNames.removeAll(newOnLoadExecutableNames);
+                                Set<String> newOnLoadExecutableNames = onLoadExecutables.stream()
+                                        .map(Executable::getUserExecutableName)
+                                        .collect(Collectors.toSet());
 
-                            // Calculate the actions which would need to be updated from execute on load FALSE to TRUE
-                            Set<String> turnedOnExecutableNames = new HashSet<>();
-                            turnedOnExecutableNames.addAll(newOnLoadExecutableNames);
-                            turnedOnExecutableNames.removeAll(existingOnLoadExecutableNames);
+                                // Calculate the actions which would need to be updated from execute on load TRUE to
+                                // FALSE.
+                                Set<String> turnedOffExecutableNames = new HashSet<>();
+                                turnedOffExecutableNames.addAll(existingOnLoadExecutableNames);
+                                turnedOffExecutableNames.removeAll(newOnLoadExecutableNames);
 
-                            for (Executable executable : creatorContextExecutables) {
+                                // Calculate the actions which would need to be updated from execute on load FALSE to
+                                // TRUE
+                                Set<String> turnedOnExecutableNames = new HashSet<>();
+                                turnedOnExecutableNames.addAll(newOnLoadExecutableNames);
+                                turnedOnExecutableNames.removeAll(existingOnLoadExecutableNames);
 
-                                String executableName = executable.getUserExecutableName();
-                                // If a user has ever set execute on load, this field can not be changed automatically.
-                                // It has
-                                // to be explicitly changed by the user again. Add the executable to update only if this
-                                // condition is false.
-                                if (FALSE.equals(executable.getUserSetOnLoad())) {
+                                for (Executable executable : creatorContextExecutables) {
 
-                                    // If this executable is no longer an onload executable, turn the execute on load to
-                                    // false
-                                    if (turnedOffExecutableNames.contains(executableName)) {
-                                        executable.setRunBehaviour(RunBehaviourEnum.MANUAL);
-                                        toUpdateExecutables.add(executable);
-                                    }
+                                    String executableName = executable.getUserExecutableName();
+                                    // If a user has ever set execute on load, this field can not be changed
+                                    // automatically.
+                                    // It has
+                                    // to be explicitly changed by the user again. Add the executable to update only if
+                                    // this
+                                    // condition is false.
+                                    if (FALSE.equals(executable.getUserSetOnLoad())) {
 
-                                    // If this executable is newly found to be on load, turn execute on load to true
-                                    if (turnedOnExecutableNames.contains(executableName)) {
-                                        // Use the prefetched feature flag value
-                                        if (isReactiveActionsEnabled) {
-                                            executable.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
-                                        } else {
-                                            executable.setRunBehaviour(RunBehaviourEnum.ON_PAGE_LOAD);
+                                        // If this executable is no longer an onload executable, turn the execute on
+                                        // load to
+                                        // false
+                                        if (turnedOffExecutableNames.contains(executableName)) {
+                                            executable.setRunBehaviour(RunBehaviourEnum.MANUAL);
+                                            toUpdateExecutables.add(executable);
                                         }
-                                        toUpdateExecutables.add(executable);
+
+                                        // If this executable is newly found to be on load, turn execute on load to true
+                                        if (turnedOnExecutableNames.contains(executableName)) {
+                                            // Use the prefetched feature flag value
+                                            if (isReactiveActionsEnabled) {
+                                                executable.setRunBehaviour(RunBehaviourEnum.AUTOMATIC);
+                                            } else {
+                                                executable.setRunBehaviour(RunBehaviourEnum.ON_PAGE_LOAD);
+                                            }
+                                            toUpdateExecutables.add(executable);
+                                        }
+
+                                    } else {
+                                        // Remove the executable name from either of the lists (if present) because this
+                                        // executable
+                                        // should not be updated
+                                        turnedOnExecutableNames.remove(executableName);
+                                        turnedOffExecutableNames.remove(executableName);
+                                    }
+                                }
+
+                                // Add newly turned on page actions to report back to the caller
+                                executableUpdatesRef.addAll(addExecutableUpdatesForExecutableNames(
+                                        creatorContextExecutables, turnedOnExecutableNames));
+
+                                // Add newly turned off page actions to report back to the caller
+                                executableUpdatesRef.addAll(addExecutableUpdatesForExecutableNames(
+                                        creatorContextExecutables, turnedOffExecutableNames));
+
+                                for (Executable executable : creatorContextExecutables) {
+                                    String executableName = executable.getUserExecutableName();
+                                    if (Boolean.FALSE.equals(executable.isOnLoadMessageAllowed())) {
+                                        turnedOffExecutableNames.remove(executableName);
+                                        turnedOnExecutableNames.remove(executableName);
+                                    }
+                                }
+
+                                // Now add messagesRef that would eventually be displayed to the developer user
+                                // informing
+                                // them
+                                // about the action setting change.
+                                if (isReactiveActionsEnabled) {
+                                    if (!turnedOffExecutableNames.isEmpty()) {
+                                        messagesRef.add(
+                                                turnedOffExecutableNames.toString()
+                                                        + " will no longer run automatically. You can run it manually when needed.");
                                     }
 
+                                    if (!turnedOnExecutableNames.isEmpty()) {
+                                        messagesRef.add(
+                                                turnedOnExecutableNames.toString()
+                                                        + " will run automatically on page load or when a variable it depends on changes");
+                                    }
                                 } else {
-                                    // Remove the executable name from either of the lists (if present) because this
-                                    // executable
-                                    // should not be updated
-                                    turnedOnExecutableNames.remove(executableName);
-                                    turnedOffExecutableNames.remove(executableName);
+                                    if (!turnedOffExecutableNames.isEmpty()) {
+                                        messagesRef.add(turnedOffExecutableNames.toString()
+                                                + " will no longer be executed on page load");
+                                    }
+
+                                    if (!turnedOnExecutableNames.isEmpty()) {
+                                        messagesRef.add(turnedOnExecutableNames.toString()
+                                                + " will be executed automatically on page load");
+                                    }
                                 }
-                            }
 
-                            // Add newly turned on page actions to report back to the caller
-                            executableUpdatesRef.addAll(addExecutableUpdatesForExecutableNames(
-                                    creatorContextExecutables, turnedOnExecutableNames));
-
-                            // Add newly turned off page actions to report back to the caller
-                            executableUpdatesRef.addAll(addExecutableUpdatesForExecutableNames(
-                                    creatorContextExecutables, turnedOffExecutableNames));
-
-                            for (Executable executable : creatorContextExecutables) {
-                                String executableName = executable.getUserExecutableName();
-                                if (Boolean.FALSE.equals(executable.isOnLoadMessageAllowed())) {
-                                    turnedOffExecutableNames.remove(executableName);
-                                    turnedOnExecutableNames.remove(executableName);
-                                }
-                            }
-
-                            // Now add messagesRef that would eventually be displayed to the developer user informing
-                            // them
-                            // about the action setting change.
-                            if (!turnedOffExecutableNames.isEmpty()) {
-                                messagesRef.add(turnedOffExecutableNames.toString()
-                                        + " will no longer be executed on page load");
-                            }
-
-                            if (!turnedOnExecutableNames.isEmpty()) {
-                                messagesRef.add(turnedOnExecutableNames.toString()
-                                        + " will be executed automatically on page load");
-                            }
-
-                            // Finally update the actions which require an update
-                            return Flux.fromIterable(toUpdateExecutables)
-                                    .flatMap(executable -> this.updateUnpublishedExecutable(
-                                            executable.getId(), executable, creatorType))
-                                    .then(Mono.just(TRUE));
-                        }));
+                                // Finally update the actions which require an update
+                                return Flux.fromIterable(toUpdateExecutables)
+                                        .flatMap(executable -> this.updateUnpublishedExecutable(
+                                                executable.getId(), executable, creatorType))
+                                        .then(Mono.just(TRUE));
+                            });
+                });
     }
 
     @Override


### PR DESCRIPTION
## Description
This PR:
- updates the toast message that we see on add/remove of query binding with widget after the introduction of automatic run behaviour. We have updated the toast messages as per https://miro.com/app/board/uXjVIQ1GcX4=/?moveToWidget=3458764621410290209&cot=14
- Also resolves #40720 

**Steps To Reproduce**
1. Create Query1
2. Create Table1
3. Edit Query1 body to be -> SELECT * FROM public."users" LIMIT {{Query2.data.length}};
4. Attach this query1 to table1 -> We should a toast message saying Query1 will execute automatically on page load
Now add Query2 and see the toast message -> It says "Query1, Query2 will execute automatically on page load instead it should just be Query2 in the message

Ref: https://github.com/appsmithorg/appsmith/issues/40656#issuecomment-2896912279


Fixes #40720 #40471  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15179938858>
> Commit: 141e2754cf202ee54d7373a0ef3ed0ee1217c876
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15179938858&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Table`
> Spec:
> <hr>Thu, 22 May 2025 08:31:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved how on-load executables are managed based on a feature flag, dynamically adjusting their run behavior and user messages.
- **Tests**
	- Added new tests to verify correct messaging and behavior updates for executables under different feature flag conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->