### PR TITLE
fix: improve full name input styling to match radio buttons

### DIFF
--- a/app/client/src/pages/setup/NonSuperUserProfilingQuestions.tsx
+++ b/app/client/src/pages/setup/NonSuperUserProfilingQuestions.tsx
@@ -33,6 +33,35 @@ const StyledButton = styled(Button)`
   width: 160px;
 `;
 
+// Styled Input to match the radio button group styling
+const StyledFormTextField = styled(FormTextField)`
+  .ads-v2-input {
+    width: 100%;
+    max-width: none;
+  }
+
+  .ads-v2-input__input {
+    height: 36px;
+    border-radius: var(--ads-v2-border-radius);
+    padding: var(--ads-v2-spaces-3);
+    font-size: var(--ads-font-size-4);
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .ads-v2-input__label {
+    font-size: var(--ads-font-size-4);
+    font-weight: var(--ads-font-weight-bold-xl);
+    color: var(--ads-v2-color-gray-700);
+    margin-bottom: 0.5rem;
+  }
+`;
+
+// Input section container for consistent spacing
+const InputSection = styled.div`
+  margin-bottom: ${(props) => props.theme.spaces[10]}px;
+`;
+
 interface UserFormProps {
   onGetStarted?: (proficiency?: string, useCase?: string) => void;
 }
@@ -76,16 +105,14 @@ function NonSuperUserProfilingQuestions(
   return (
     <form onSubmit={props.handleSubmit(onSubmit)}>
       {isCloudBillingEnabled && (
-        <>
-          <Space />
-          <FormTextField
+        <InputSection>
+          <StyledFormTextField
             data-testid="t--user-full-name"
             label={createMessage(WELCOME_FORM_FULL_NAME)}
             name="fullName"
             placeholder="Enter your full name"
           />
-          <Space />
-        </>
+        </InputSection>
       )}
       <Field
         component={RadioButtonGroup}
@@ -95,7 +122,6 @@ function NonSuperUserProfilingQuestions(
         showSubtitle
         testid="t--user-proficiency"
       />
-      <Space />
       <Field
         component={RadioButtonGroup}
         label={createMessage(WELCOME_FORM_NON_SUPER_USER_USE_CASE)}


### PR DESCRIPTION
### Summary
This PR updates the styling of the user full name input field on the onboarding screen to match the styling of the radio button groups, creating a more consistent and polished UI.

### Problem
The full name input field in the onboarding form had inconsistent styling compared to the radio button groups, which created a visually disjointed user experience.

### Solution
- Created a styled version of `FormTextField` that matches the styling of radio buttons
- Added proper spacing with a dedicated `InputSection` component
- Removed unnecessary vertical spacing elements
- Ensured consistent typography, sizing, and spacing across form elements

### Changes
- Added `StyledFormTextField` with custom CSS to match radio button styling:
  - Same font size and weight for labels
  - Consistent height, padding, and border-radius
  - Full width input field
- Created `InputSection` for consistent vertical spacing
- Replaced original `FormTextField` with the styled version
- Removed redundant `Space` components

### Screenshots
![Before](
<img width="1449" alt="Screenshot 2025-05-22 at 6 50 04 AM" src="https://github.com/user-attachments/assets/54384e0d-4874-4550-8415-54b15a8e9b13" />
) | ![After](
<img width="1452" alt="Screenshot 2025-05-22 at 6 39 38 AM" src="https://github.com/user-attachments/assets/01b8fd1e-0c47-4d8f-abe7-4f47a31366b6" />
)

## Automation

/ok-to-test tags="@tag.Sanity, @tag.Authentication"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
