### PR TITLE
refactor: Update PluginSchemaSolution return type from JsonNode to List<Object>

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/solutions/PluginSchemaSolutionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/solutions/PluginSchemaSolutionCE.java
@@ -1,8 +1,9 @@
 package com.appsmith.server.plugins.solutions;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
 public interface PluginSchemaSolutionCE {
-    Mono<JsonNode> getPluginSchema(String pluginId);
+    Mono<List<Object>> getPluginSchema(String pluginId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/solutions/PluginSchemaSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/plugins/solutions/PluginSchemaSolutionCEImpl.java
@@ -1,13 +1,14 @@
 package com.appsmith.server.plugins.solutions;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @Component
 public class PluginSchemaSolutionCEImpl implements PluginSchemaSolutionCE {
     @Override
-    public Mono<JsonNode> getPluginSchema(String pluginId) {
+    public Mono<List<Object>> getPluginSchema(String pluginId) {
         return Mono.empty();
     }
 }


### PR DESCRIPTION
## Description
### Type of Change
- API Change
- Interface Modification

### Changes
This PR updates the return type of getPluginSchema method in the plugin schema solution:

- Changed return type from Mono<JsonNode> to Mono<List<Object>> in both the interface and implementation
- Updated import statements to reflect the type change
- Removed unused Jackson dependency import



Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15203195158>
> Commit: bedbd384ebcfef51e1af2d1882ddc46380fa8294
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15203195158&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 23 May 2025 06:19:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the internal structure for retrieving plugin schemas, changing the expected format from a JSON node to a list of objects. This may affect how plugin schema data is processed or displayed in future updates. No visible changes to current user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->