### PR TITLE
fix: redirect users not part of organization to signup page

### DIFF
--- a/app/client/src/pages/UserAuth/Login.tsx
+++ b/app/client/src/pages/UserAuth/Login.tsx
@@ -167,7 +167,7 @@ export function Login(props: LoginFormProps) {
     {
       leftText: createMessage(MULTI_ORG_FOOTER_NOT_PART_OF_ORG_LEFT_TEXT),
       rightText: createMessage(MULTI_ORG_FOOTER_NOT_PART_OF_ORG_RIGHT_TEXT),
-      rightTextLink: getPrimaryLoginURL(),
+      rightTextLink: signupURL,
     },
     {
       leftText: createMessage(MULTI_ORG_FOOTER_CREATE_ORG_LEFT_TEXT),


### PR DESCRIPTION
## Description

### What changed
Updated the link destination for users who are not part of an organization in the multi-org login footer. The link now directs users to the signup URL instead of the primary login URL.

### Why
Previously, when users clicked "Sign up" in the "Not part of organization" section of the login page, they were incorrectly directed to the primary login URL. This created a confusing user experience as users wanting to sign up were being directed to another login page.

## Automation

/ok-to-test tags="@tag.Sanity, @tag.Authentication"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15186614671>
> Commit: 75acfc1efcec49ca048cbc213a05d842d5e7ec08
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15186614671&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Authentication`
> Spec:
> <hr>Thu, 22 May 2025 13:16:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the login page footer link to direct users to the correct sign-up page with a safe redirect, improving navigation for new users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->