### PR TITLE
chore: Module editor Remove page tab from navigate to action selector

### DIFF
--- a/app/client/src/ce/selectors/modulesSelector.ts
+++ b/app/client/src/ce/selectors/modulesSelector.ts
@@ -16,3 +16,6 @@ export const showUIModulesList = (state: DefaultRootState) => false;
 
 export const getActionsInCurrentModule = (state: DefaultRootState) => [];
 export const getJSCollectionsInCurrentModule = (state: DefaultRootState) => [];
+
+export const getModuleInstanceActions = (state: DefaultRootState) => [];
+export const getModuleInstanceJSCollections = (state: DefaultRootState) => [];

--- a/app/client/src/components/editorComponents/ActionCreator/FieldGroup/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/FieldGroup/index.tsx
@@ -5,10 +5,15 @@ import { getCodeFromMoustache, isValueValidURL } from "../utils";
 import { getFieldFromValue } from "../helpers";
 import { useSelector } from "react-redux";
 import { getDataTreeForActionCreator } from "sagas/selectors";
+import { useLocation } from "react-router";
+import { getIDETypeByUrl } from "ee/entities/IDE/utils";
+import { IDE_TYPE } from "ee/IDE/Interfaces/IDETypes";
 
 function FieldGroup(props: FieldGroupProps) {
   const { isChainedAction = false, ...otherProps } = props;
   const dataTree = useSelector(getDataTreeForActionCreator);
+  const location = useLocation();
+  const ideType = getIDETypeByUrl(location.pathname);
 
   const NAVIGATE_TO_TAB_SWITCHER: Array<SwitchType> = [
     {
@@ -42,9 +47,18 @@ function FieldGroup(props: FieldGroupProps) {
     },
   ];
 
-  const [activeTabNavigateTo, setActiveTabNavigateTo] = useState(
-    NAVIGATE_TO_TAB_SWITCHER[isValueValidURL(props.value) ? 1 : 0],
-  );
+  const defaultNavigateToTab =
+    ideType === IDE_TYPE.UIPackage
+      ? NAVIGATE_TO_TAB_SWITCHER[1]
+      : NAVIGATE_TO_TAB_SWITCHER[isValueValidURL(props.value) ? 1 : 0];
+
+  const navigateToSwitches =
+    ideType === IDE_TYPE.UIPackage
+      ? [NAVIGATE_TO_TAB_SWITCHER[1]]
+      : NAVIGATE_TO_TAB_SWITCHER;
+
+  const [activeTabNavigateTo, setActiveTabNavigateTo] =
+    useState(defaultNavigateToTab);
   const [activeTabApiAndQueryCallback, setActiveTabApiAndQueryCallback] =
     useState<SwitchType>(apiAndQueryCallbackTabSwitches[0]);
 
@@ -69,7 +83,7 @@ function FieldGroup(props: FieldGroupProps) {
         activeNavigateToTab: activeTabNavigateTo,
         activeTabApiAndQueryCallback: activeTabApiAndQueryCallback,
         apiAndQueryCallbackTabSwitches: apiAndQueryCallbackTabSwitches,
-        navigateToSwitches: NAVIGATE_TO_TAB_SWITCHER,
+        navigateToSwitches,
       })}
 
       <ul className="flex flex-col mt-2 gap-2">
@@ -119,7 +133,7 @@ function FieldGroup(props: FieldGroupProps) {
                   activeTabApiAndQueryCallback: activeTabApiAndQueryCallback,
                   apiAndQueryCallbackTabSwitches:
                     apiAndQueryCallbackTabSwitches,
-                  navigateToSwitches: NAVIGATE_TO_TAB_SWITCHER,
+                  navigateToSwitches,
                 })}
               </li>
             );

--- a/app/client/src/sagas/WidgetLoadingSaga.ts
+++ b/app/client/src/sagas/WidgetLoadingSaga.ts
@@ -18,6 +18,7 @@ import {
 import log from "loglevel";
 import { appsmithTelemetry } from "instrumentation";
 import { findLoadingEntities } from "utils/WidgetLoadingStateUtils";
+import { getModuleInstanceActions } from "ee/selectors/modulesSelector";
 
 const actionExecutionRequestActions = [
   ReduxActionTypes.EXECUTE_PLUGIN_ACTION_REQUEST,
@@ -48,7 +49,11 @@ function* setWidgetsLoadingSaga(action: ReduxAction<unknown>) {
     yield take(ReduxActionTypes.SET_EVALUATED_TREE);
   }
 
-  const actions: ActionDataState = yield select(getActions);
+  const entityActions: ActionDataState = yield select(getActions);
+  const moduleInstanceActions: ActionDataState = yield select(
+    getModuleInstanceActions,
+  );
+  const actions = [...entityActions, ...moduleInstanceActions];
   const isLoadingActions: string[] = actions
     .filter((action: ActionData) => action.isLoading)
     .map((action: ActionData) => action.config.name);


### PR DESCRIPTION
## Description
<img width="658" alt="Screenshot 2025-05-23 at 11 32 51 AM" src="https://github.com/user-attachments/assets/bdbd051d-7135-41b1-8789-921547a91802" />

Fixes https://github.com/appsmithorg/appsmith/issues/40741

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15203473904>
> Commit: 76b7112333792f4612b5ef6e4524552c99fe88a8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15203473904&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 23 May 2025 07:28:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the "Navigate To" section to adjust available tabs and default selection based on the IDE type, offering a tailored experience for UIPackage IDE users.

- **Improvements**
  - Improved loading state handling by considering additional action sources, resulting in more accurate widget loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->