### PR TITLE
fix: disallows page load to automatic transition in run behaviour for older actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
@@ -316,13 +316,11 @@ public class OnLoadExecutablesUtilCEImpl implements OnLoadExecutablesUtilCE {
         return featureFlagService
                 .check(FeatureFlagEnum.release_reactive_actions_enabled)
                 .flatMap(isReactiveActionsEnabled -> {
-                    RunBehaviourEnum runBehaviourToCheck =
-                            isReactiveActionsEnabled ? RunBehaviourEnum.AUTOMATIC : RunBehaviourEnum.ON_PAGE_LOAD;
-
                     // Before we update the actions, fetch all the actions which are currently set to execute on load.
                     Mono<List<Executable>> existingOnLoadExecutablesMono = creatorContextExecutablesFlux
                             .flatMap(executable -> {
-                                if (runBehaviourToCheck.equals(executable.getRunBehaviour())) {
+                                if (RunBehaviourEnum.AUTOMATIC.equals(executable.getRunBehaviour())
+                                        || RunBehaviourEnum.ON_PAGE_LOAD.equals(executable.getRunBehaviour())) {
                                     return Mono.just(executable);
                                 }
                                 return Mono.empty();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
@@ -319,10 +319,8 @@ public class OnLoadExecutablesUtilCEImpl implements OnLoadExecutablesUtilCE {
                     // Before we update the actions, fetch all the actions which are currently set to execute on load.
                     Mono<List<Executable>> existingOnLoadExecutablesMono = creatorContextExecutablesFlux
                             .flatMap(executable -> {
-                                if (executable.getRunBehaviour() != null
-                                        && (RunBehaviourEnum.AUTOMATIC.equals(executable.getRunBehaviour())
-                                                || RunBehaviourEnum.ON_PAGE_LOAD.equals(
-                                                        executable.getRunBehaviour()))) {
+                                if (RunBehaviourEnum.AUTOMATIC.equals(executable.getRunBehaviour())
+                                        || RunBehaviourEnum.ON_PAGE_LOAD.equals(executable.getRunBehaviour())) {
                                     return Mono.just(executable);
                                 }
                                 return Mono.empty();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/onload/internal/OnLoadExecutablesUtilCEImpl.java
@@ -319,8 +319,10 @@ public class OnLoadExecutablesUtilCEImpl implements OnLoadExecutablesUtilCE {
                     // Before we update the actions, fetch all the actions which are currently set to execute on load.
                     Mono<List<Executable>> existingOnLoadExecutablesMono = creatorContextExecutablesFlux
                             .flatMap(executable -> {
-                                if (RunBehaviourEnum.AUTOMATIC.equals(executable.getRunBehaviour())
-                                        || RunBehaviourEnum.ON_PAGE_LOAD.equals(executable.getRunBehaviour())) {
+                                if (executable.getRunBehaviour() != null
+                                        && (RunBehaviourEnum.AUTOMATIC.equals(executable.getRunBehaviour())
+                                                || RunBehaviourEnum.ON_PAGE_LOAD.equals(
+                                                        executable.getRunBehaviour()))) {
                                     return Mono.just(executable);
                                 }
                                 return Mono.empty();


### PR DESCRIPTION
## Description
This PR updates run behaviour logic so that it does not transition from page load to automatic for older actions. This allows users to be intentional about their choice to be automatic with older actions.

Fixes #40752   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15271052226>
> Commit: 1aaa57506bd227d3e78eebce2919911a8ec54c43
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15271052226&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 27 May 2025 09:39:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify that executables with "ON_PAGE_LOAD" run behavior are not incorrectly updated when a specific feature flag is enabled.

- **Refactor**
  - Simplified internal logic for checking run behavior, making the code more concise without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->