### PR TITLE
chore: fix resetting of Dropdown control of UQI 

### DIFF
--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -334,7 +334,11 @@ function renderDropdown(
   });
 
   // Re-sync multi-select if stale
-  if (isMultiSelect && Array.isArray(selectedValue)) {
+  if (
+    isMultiSelect &&
+    Array.isArray(selectedValue) &&
+    selectedOptions.length > 0
+  ) {
     const validValues = selectedOptions.map((so) => so.value);
 
     if (


### PR DESCRIPTION
Before the options of dropdown control could load up, the dropdown control was hitting `onChange` which was resetting the options for that control. 
This PR adds a check to look for selectionOptions before resetting the options.

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the behavior of multi-select dropdowns to ensure selected values are only re-synced when valid options are present, preventing unnecessary updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15319483195>
> Commit: caa978dc326fe017c06c7ceafe64f6f1890814fe
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15319483195&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 29 May 2025 09:01:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->
