### PR TITLE
fix: add missing displayName and slug to organization reducer

### DIFF
--- a/app/client/src/ce/reducers/organizationReducer.ts
+++ b/app/client/src/ce/reducers/organizationReducer.ts
@@ -74,6 +74,8 @@ export const handlers = {
         ...action.payload.organizationConfiguration.brandColors,
       },
     },
+    displayName: action.payload.displayName,
+    slug: action.payload.slug,
     isLoading: false,
     instanceId: action.payload.instanceId,
     tenantId: action.payload.tenantId,


### PR DESCRIPTION
## Description
Fixes a bug where the organization's `displayName` and `slug` fields were not being properly stored in the Redux state when fetching the current organization configuration.

## Changes
- Added `displayName` and `slug` fields to the `FETCH_CURRENT_ORGANIZATION_CONFIG_SUCCESS` reducer handler
- These fields were already defined in the `OrganizationReduxState` interface but were missing from the actual state update

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
