### PR TITLE
chore: remove git install from main dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,6 @@ ENV APPSMITH_SEGMENT_CE_KEY=${APPSMITH_SEGMENT_CE_KEY}
 
 COPY deploy/docker/fs /
 
-# Install git
-RUN apt-get update && \
-    apt-get install -y git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 RUN <<END
   if ! [ -f info.json ]; then
     echo "Missing info.json" >&2


### PR DESCRIPTION
## Description

As part of https://github.com/appsmithorg/appsmith/pull/40642, I moved the git install to the base dockerfile to reduce the network activity in the main action. This finishes off that move and removes the now-redundant installation.



## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile to remove explicit installation of git, streamlining the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->