### PR TITLE
fix: widgets getting disappeared when page name contains parentheses

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/ApplicationGitFileUtilsCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/ApplicationGitFileUtilsCEImpl.java
@@ -61,6 +61,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.git.constants.GitConstants.NAME_SEPARATOR;
@@ -724,6 +725,15 @@ public class ApplicationGitFileUtilsCEImpl implements ArtifactGitFileUtilsCE<App
 
         // widgets
         pageList.parallelStream().forEach(newPage -> {
+            String pathToReplace = Pattern.quote(PAGE_DIRECTORY
+                    + DELIMITER_PATH
+                    + newPage.getUnpublishedPage().getName()
+                    + DELIMITER_PATH
+                    + WIDGETS
+                    + DELIMITER_PATH);
+            String replacementString = MAIN_CONTAINER + DELIMITER_PATH;
+            Pattern replacementPattern = Pattern.compile(pathToReplace);
+
             Map<String, org.json.JSONObject> widgetsData = resourceMap.entrySet().stream()
                     .filter(entry -> {
                         GitResourceIdentity key = entry.getKey();
@@ -731,17 +741,9 @@ public class ApplicationGitFileUtilsCEImpl implements ArtifactGitFileUtilsCE<App
                                 && key.getResourceIdentifier().startsWith(newPage.getGitSyncId() + "-");
                     })
                     .collect(Collectors.toMap(
-                            entry -> entry.getKey()
-                                    .getFilePath()
-                                    .replaceFirst(
-                                            PAGE_DIRECTORY
-                                                    + DELIMITER_PATH
-                                                    + newPage.getUnpublishedPage()
-                                                            .getName()
-                                                    + DELIMITER_PATH
-                                                    + WIDGETS
-                                                    + DELIMITER_PATH,
-                                            MAIN_CONTAINER + DELIMITER_PATH),
+                            entry -> replacementPattern
+                                    .matcher(entry.getKey().getFilePath())
+                                    .replaceFirst(replacementString),
                             entry -> {
                                 try {
                                     return new org.json.JSONObject(objectMapper.writeValueAsString(entry.getValue()));


### PR DESCRIPTION
## Description
EE Counterpart: https://github.com/appsmithorg/appsmith-ee/pull/7681

Steps to reproduce this issue demonstread here: https://jam.dev/c/eced3a5a-d958-4f85-bdb9-19064e08d781

Fixes #40817  
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15379020387>
> Commit: c96be344be501c7d0beab4a119ecae302520d6d1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15379020387&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Sun, 01 Jun 2025 21:06:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of widget file path replacements for enhanced reliability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->