### PR TITLE
feat: handled error condition from cs

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/PluginScheduledTaskUtilsCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/PluginScheduledTaskUtilsCEImpl.java
@@ -47,15 +47,20 @@ public class PluginScheduledTaskUtilsCEImpl implements PluginScheduledTaskUtilsC
                         clientResponse.bodyToMono(new ParameterizedTypeReference<ResponseDTO<List<Plugin>>>() {}))
                 .map(listResponseDTO -> {
                     if (listResponseDTO.getData() == null) {
-                        log.error(
-                                "Error fetching plugins from cloud-services. Error: {}",
-                                listResponseDTO.getErrorDisplay());
+                        String errorMessage = listResponseDTO.getErrorDisplay();
+                        log.error("Error fetching plugins from cloud-services. Error: {}", errorMessage);
+
+                        // If there's an actual error message, propagate it as an error
+                        if (errorMessage != null && !errorMessage.isEmpty()) {
+                            throw new RuntimeException("Cloud Services error: " + errorMessage);
+                        }
+
+                        // Otherwise, return empty list (no plugins found)
                         return Collections.<Plugin>emptyList();
                     }
                     return listResponseDTO.getData();
                 })
                 .map(plugins -> {
-
                     // Parse plugins into map for easier manipulation
                     return plugins.stream()
                             .collect(Collectors.toMap(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/PluginScheduledTaskUtilsCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/PluginScheduledTaskUtilsCEImpl.java
@@ -48,8 +48,6 @@ public class PluginScheduledTaskUtilsCEImpl implements PluginScheduledTaskUtilsC
                 .map(listResponseDTO -> {
                     if (listResponseDTO.getData() == null) {
                         String errorMessage = listResponseDTO.getErrorDisplay();
-                        log.error("Error fetching plugins from cloud-services. Error: {}", errorMessage);
-
                         // If there's an actual error message, propagate it as an error
                         if (errorMessage != null && !errorMessage.isEmpty()) {
                             throw new RuntimeException("Cloud Services error: " + errorMessage);


### PR DESCRIPTION
## Description
This PR improves error handling when fetching plugins from CS. 
- Distinguish between legitimate "no plugins found" cases (not an error) and actual cloud service errors
- Return Mono.empty() with log info when no plugins are found (normal case)
- Propagate errors with Mono.error() when cloud services returns actual errors
- Preserve proper error details in exception messages

Fixes #40820 
Corresponding EE PR: https://github.com/appsmithorg/appsmith-ee/pull/7696


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15393377154>
> Commit: 8a2c61f27a7069d2f4babed0ccc47ac8e43459e7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15393377154&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 02 Jun 2025 14:01:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when fetching plugins from cloud services. Users will now receive clearer error notifications if there is an issue, rather than silently seeing an empty plugin list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->