### PR TITLE
fix: generate crud queries to have dynamicBindingPathList

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -637,6 +637,11 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
             actionDTO.setRefType(templateAction.getRefType());
             actionDTO.setRefName(templateAction.getRefName());
 
+            if (templateAction.getUnpublishedAction() != null) {
+                actionDTO.setDynamicBindingPathList(
+                        templateAction.getUnpublishedAction().getDynamicBindingPathList());
+            }
+
             // Indicates that source of action creation is generate-crud-page
             actionDTO.setSource(ActionCreationSourceTypeEnum.GENERATE_PAGE);
 


### PR DESCRIPTION
## Description
Generate CRUD issue fixed where dynamicBindingPathList was not getting added for newly generated actions. 

### Steps To Reproduce (#40812) Needs to be tested on https://ee-7616.dp.appsmith.com/ as this has reactivity changes

- Create a CRUD page using the mock postgres db
- Click on table widget generated, go to the property pane and remove onPageChange event
- Now in the table, change the page, data should be refreshed automatically.

### Steps To Reproduce (#39660)

- Create a CRUD page using the mock postgres db
- Change any widget name using the entity explorer rename option or the property pane rename option
- Note that this changed name is not reflected in any of the queries that uses this widget property


Fixes #40812 
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15414265041>
> Commit: f638e96ae94f282e68ef58d4ddd83a221091842b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15414265041&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 03 Jun 2025 11:01:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that dynamic binding paths are preserved when cloning actions from template applications, improving consistency in cloned actions.
- **Tests**
  - Added a test to verify dynamic binding paths are correctly handled when creating pages with PostgreSQL datasources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->