### PR TITLE
chore: Return Mono.empty() when there is no match in AST replacement logic

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -169,7 +169,14 @@ public class AstServiceCEImpl implements AstServiceCE {
                         // - Old name: foo.bar
                         // - New name: foo.baz
                         // - Binding: "foo['bar']"
-                        return Mono.just(Tuples.of(bindingValue, bindingValue.getValue()));
+                        // Of course! Here’s a natural, concise rewrite:
+                        //
+                        // ---
+                        //
+                        // If the binding value doesn’t contain the old name, we should send an empty response. That
+                        // way, the caller doesn’t need to make any replacements, and it helps avoid unnecessary DB
+                        // calls.
+                        return Mono.empty();
                     }
                     EntityRefactorRequest entityRefactorRequest = new EntityRefactorRequest(
                             bindingValue.getValue(), oldName, newName, evalVersion, isJSObject);


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15491134315>
> Commit: fb4d75395e3ffe63b91cf251c645158e7b03ae6e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15491134315&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/15491134315" target="_blank">workflow here</a>.
> <hr>Mon, 09 Jun 2025 09:16:18 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency by skipping processing for bindings that do not require refactoring, reducing unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->