### PR TITLE
fix: handle undefined user object in LandingScreen for non-existent cloud billing domains

### DIFF
--- a/app/client/src/LandingScreen.tsx
+++ b/app/client/src/LandingScreen.tsx
@@ -15,8 +15,8 @@ interface Props {
 }
 
 function LandingScreen(props: Props) {
-  if (props.user && window.location.pathname === BASE_URL) {
-    if (props.user.email === ANONYMOUS_USERNAME) {
+  if (window.location.pathname === BASE_URL) {
+    if (!props.user || props.user.email === ANONYMOUS_USERNAME) {
       return <Redirect to={AUTH_LOGIN_URL} />;
     } else {
       return <Redirect to={APPLICATIONS_URL} />;


### PR DESCRIPTION
## Problem

With the introduction of cloud billing and multi-organization support, users can now access Appsmith through organization-specific subdomains (e.g., `testorg.appsmith.com`). However, when users attempt to access non-existent domains (e.g., `domaindoesnotexist.appsmith.com`), the system fails to return a user object, causing the application to get stuck in an infinite loading state.

## 🔍 Root Cause

The issue was in the `LandingScreen` component's conditional logic:

```tsx
// Previous implementation ❌
if (props.user && window.location.pathname === BASE_URL) {
  if (props.user.email === ANONYMOUS_USERNAME) {
    return <Redirect to={AUTH_LOGIN_URL} />;
  } else {
    return <Redirect to={APPLICATIONS_URL} />;
  }
}
```

**The problem:** When accessing a non-existent domain, `props.user` is `null`/`undefined`, causing the condition `props.user && window.location.pathname === BASE_URL` to evaluate to `false`. This prevented the redirect logic from executing, leaving users on a perpetual loading screen instead of being properly redirected to the login page.

## ✅ Solution

Updated the conditional logic to handle cases where the user object is undefined:

```tsx
// Fixed implementation ✅
if (window.location.pathname === BASE_URL) {
  if (!props.user || props.user.email === ANONYMOUS_USERNAME) {
    return <Redirect to={AUTH_LOGIN_URL} />;
  } else {
    return <Redirect to={APPLICATIONS_URL} />;
  }
}
```

### Key changes:
1. **Removed the `props.user &&` guard condition** - Now the redirect logic always executes when on the base URL
2. **Added explicit null/undefined check** - The condition `!props.user || props.user.email === ANONYMOUS_USERNAME` properly handles both scenarios:
   - When no user object exists (non-existent domains)
   - When the user is anonymous

## 📊 Impact

| Scenario | Before | After |
|----------|---------|-------|
| Valid org domain + authenticated user | ✅ Redirects to applications | ✅ Redirects to applications |
| Valid org domain + anonymous user | ✅ Redirects to login | ✅ Redirects to login |
| **Non-existent org domain** | ❌ **Infinite loading screen** | ✅ **Redirects to login** |
| Direct access to login URL | ✅ Works as expected | ✅ Works as expected |

## 🧪 Testing Scenarios

This fix addresses the following scenarios in the cloud billing multi-org environment:

- [x] Valid organization domain with authenticated user → Redirects to applications
- [x] Valid organization domain with anonymous user → Redirects to login  
- [x] **Non-existent organization domain → Redirects to login (instead of infinite loading)**
- [x] Direct access to login URL → Works as expected

## Automation

/ok-to-test tags="@tag.Authentication, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
