### PR TITLE
chore: update appsmith chart version in Helm test snapshots to 3.6.3

### DIFF
--- a/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
@@ -25,7 +25,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.2
+        appsmith.sh/chart: appsmith-3.6.3
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
   3: |
@@ -36,7 +36,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.2
+        appsmith.sh/chart: appsmith-3.6.3
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -143,7 +143,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.2
+        appsmith.sh/chart: appsmith-3.6.3
       name: RELEASE-NAME-appsmith-headless
       namespace: NAMESPACE
     spec:
@@ -182,7 +182,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.2
+        appsmith.sh/chart: appsmith-3.6.3
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -203,7 +203,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.2
+        appsmith.sh/chart: appsmith-3.6.3
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     secrets:


### PR DESCRIPTION
Updated the chart version from 3.6.2 to 3.6.3 in the Helm test snapshots to reflect the latest changes and ensure consistency across deployments.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
