### PR TITLE
chore: re-instate status call for protected branches in git connected apps

### DIFF
--- a/app/client/src/git/sagas/fetchStatusSaga.ts
+++ b/app/client/src/git/sagas/fetchStatusSaga.ts
@@ -7,7 +7,6 @@ import type { GitArtifactPayloadAction } from "git/store/types";
 import { call, put, select } from "redux-saga/effects";
 import { validateResponse } from "sagas/ErrorSagas";
 import handleApiErrors from "./helpers/handleApiErrors";
-import { selectProtectedMode } from "git/store/selectors/gitArtifactSelectors";
 
 export default function* fetchStatusSaga(
   action: GitArtifactPayloadAction<FetchStatusInitPayload>,
@@ -20,22 +19,6 @@ export default function* fetchStatusSaga(
     const isGitApiContractsEnabled: boolean = yield select(
       selectGitApiContractsEnabled,
     );
-
-    const isCurrentBranchProtected: boolean = yield select(
-      selectProtectedMode,
-      artifactDef,
-    );
-
-    if (isCurrentBranchProtected) {
-      // Skip status check for protected branches and set empty status
-      yield put(
-        gitArtifactActions.resetGitStatus({
-          artifactDef,
-        }),
-      );
-
-      return;
-    }
 
     response = yield call(
       fetchStatusRequest,


### PR DESCRIPTION
## Description


Fixes https://github.com/appsmithorg/appsmith/issues/40879

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15484395801>
> Commit: 41372a7f50609198d71755e5429708adeb048ed4
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15484395801&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Fri, 06 Jun 2025 07:36:41 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git status is now consistently fetched for all branches, including previously protected ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->