### PR TITLE
chore: ui module - ce/ee split for state inspector

### DIFF
--- a/app/client/src/ce/PluginActionEditor/components/PluginActionResponse/hooks/usePluginActionResponseTabs.tsx
+++ b/app/client/src/ce/PluginActionEditor/components/PluginActionResponse/hooks/usePluginActionResponseTabs.tsx
@@ -170,7 +170,7 @@ function usePluginActionResponseTabs() {
       },
     );
 
-    if (ideType === IDE_TYPE.App) {
+    if (ideType === IDE_TYPE.App || ideType === IDE_TYPE.UIPackage) {
       tabs.push({
         key: DEBUGGER_TAB_KEYS.STATE_TAB,
         title: createMessage(DEBUGGER_STATE),

--- a/app/client/src/ce/hooks/stateInspector/useGetInputItemsForStateInspector.tsx
+++ b/app/client/src/ce/hooks/stateInspector/useGetInputItemsForStateInspector.tsx
@@ -1,0 +1,5 @@
+import type { GetGroupHookType } from "components/editorComponents/Debugger/StateInspector/types";
+
+export const useGetInputItemsForStateInspector: GetGroupHookType = () => {
+  return { group: "Inputs", items: [] };
+};

--- a/app/client/src/ce/hooks/stateInspector/useGetJSItemsForStateInspector.ts
+++ b/app/client/src/ce/hooks/stateInspector/useGetJSItemsForStateInspector.ts
@@ -1,6 +1,6 @@
 import { useSelector } from "react-redux";
 import { getJSSegmentItems } from "ee/selectors/entitiesSelector";
-import type { GetGroupHookType } from "../types";
+import type { GetGroupHookType } from "components/editorComponents/Debugger/StateInspector/types";
 
 export const useGetJSItemsForStateInspector: GetGroupHookType = () => {
   const jsObjects = useSelector(getJSSegmentItems);

--- a/app/client/src/ce/hooks/stateInspector/useGetQueryItemsForStateInspector.ts
+++ b/app/client/src/ce/hooks/stateInspector/useGetQueryItemsForStateInspector.ts
@@ -1,6 +1,6 @@
 import { useSelector } from "react-redux";
 import { getQuerySegmentItems } from "ee/selectors/entitiesSelector";
-import type { GetGroupHookType } from "../types";
+import type { GetGroupHookType } from "components/editorComponents/Debugger/StateInspector/types";
 
 export const useGetQueryItemsForStateInspector: GetGroupHookType = () => {
   const queries = useSelector(getQuerySegmentItems);

--- a/app/client/src/ce/hooks/stateInspector/useGetUIItemsForStateInspector.ts
+++ b/app/client/src/ce/hooks/stateInspector/useGetUIItemsForStateInspector.ts
@@ -1,6 +1,6 @@
 import { useSelector } from "react-redux";
 import { getUISegmentItems } from "ee/selectors/entitiesSelector";
-import type { GetGroupHookType } from "../types";
+import type { GetGroupHookType } from "components/editorComponents/Debugger/StateInspector/types";
 
 export const useGetUIItemsForStateInspector: GetGroupHookType = () => {
   const widgets = useSelector(getUISegmentItems);

--- a/app/client/src/components/editorComponents/Debugger/DebuggerTabs.tsx
+++ b/app/client/src/components/editorComponents/Debugger/DebuggerTabs.tsx
@@ -79,7 +79,7 @@ function DebuggerTabs() {
       },
     ];
 
-    if (ideType === IDE_TYPE.App) {
+    if (ideType === IDE_TYPE.App || ideType === IDE_TYPE.UIPackage) {
       tabs.push({
         key: DEBUGGER_TAB_KEYS.STATE_TAB,
         title: createMessage(DEBUGGER_STATE),

--- a/app/client/src/components/editorComponents/Debugger/StateInspector/hooks/useStateInspectorItems.ts
+++ b/app/client/src/components/editorComponents/Debugger/StateInspector/hooks/useStateInspectorItems.ts
@@ -1,9 +1,10 @@
 import { useEffect, useMemo } from "react";
 import { useStateInspectorState } from "./useStateInspectorState";
 import { useGetGlobalItemsForStateInspector } from "./useGetGlobalItemsForStateInspector";
-import { useGetQueryItemsForStateInspector } from "./useGetQueryItemsForStateInspector";
-import { useGetJSItemsForStateInspector } from "./useGetJSItemsForStateInspector";
-import { useGetUIItemsForStateInspector } from "./useGetUIItemsForStateInspector";
+import { useGetQueryItemsForStateInspector } from "ee/hooks/stateInspector/useGetQueryItemsForStateInspector";
+import { useGetJSItemsForStateInspector } from "ee/hooks/stateInspector/useGetJSItemsForStateInspector";
+import { useGetUIItemsForStateInspector } from "ee/hooks/stateInspector/useGetUIItemsForStateInspector";
+import { useGetInputItemsForStateInspector } from "ee/hooks/stateInspector/useGetInputItemsForStateInspector";
 import type { GroupedItems } from "../types";
 import { enhanceItemForListItem } from "../utils";
 import type { GenericEntityItem } from "ee/IDE/Interfaces/EntityItem";
@@ -17,10 +18,11 @@ export const useStateInspectorItems: () => [
   const queries = useGetQueryItemsForStateInspector();
   const jsItems = useGetJSItemsForStateInspector();
   const uiItems = useGetUIItemsForStateInspector();
+  const inputItems = useGetInputItemsForStateInspector();
   const globalItems = useGetGlobalItemsForStateInspector();
 
   const [groups, selectedItem] = useMemo(() => {
-    const allGroups = [queries, jsItems, uiItems, globalItems];
+    const allGroups = [queries, jsItems, uiItems, inputItems, globalItems];
 
     const processedGroups = allGroups
       .filter((groupedItems) => groupedItems.items.length > 0)
@@ -35,18 +37,32 @@ export const useStateInspectorItems: () => [
       .flatMap((group) => group.items)
       .find((item) => item.id === selectedItemId);
 
-    const selectedItem: GenericEntityItem | undefined = {
-      key: selectedItemFromGroups?.id || "",
-      title: selectedItemFromGroups?.title || "",
-      icon: selectedItemFromGroups?.startIcon,
-    };
+    const selectedItem: GenericEntityItem | undefined = selectedItemFromGroups
+      ? {
+          key: selectedItemFromGroups.id || "",
+          title: selectedItemFromGroups.title || "",
+          icon: selectedItemFromGroups.startIcon,
+        }
+      : undefined;
 
     return [processedGroups, selectedItem];
-  }, [globalItems, jsItems, queries, selectedItemId, setSelectedItem, uiItems]);
+  }, [
+    globalItems,
+    inputItems,
+    jsItems,
+    queries,
+    selectedItemId,
+    setSelectedItem,
+    uiItems,
+  ]);
 
   useEffect(
     function handleNoItemSelected() {
-      if (!selectedItemId) {
+      if (
+        !selectedItemId &&
+        groups.length > 0 &&
+        groups[0]?.items?.length > 0
+      ) {
         const firstItem = groups[0].items[0];
 
         setSelectedItem(firstItem.id as string);

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -241,7 +241,7 @@ function JSResponseView(props: Props) {
         panelComponent: <ErrorLogs />,
       });
 
-      if (ideType === IDE_TYPE.App) {
+      if (ideType === IDE_TYPE.App || ideType === IDE_TYPE.UIPackage) {
         jsTabs.push({
           key: DEBUGGER_TAB_KEYS.STATE_TAB,
           title: createMessage(DEBUGGER_STATE),

--- a/app/client/src/ee/hooks/stateInspector/useGetInputItemsForStateInspector.tsx
+++ b/app/client/src/ee/hooks/stateInspector/useGetInputItemsForStateInspector.tsx
@@ -1,0 +1,1 @@
+export { useGetInputItemsForStateInspector } from "ce/hooks/stateInspector/useGetInputItemsForStateInspector";

--- a/app/client/src/ee/hooks/stateInspector/useGetJSItemsForStateInspector.ts
+++ b/app/client/src/ee/hooks/stateInspector/useGetJSItemsForStateInspector.ts
@@ -1,0 +1,1 @@
+export { useGetJSItemsForStateInspector } from "ce/hooks/stateInspector/useGetJSItemsForStateInspector";

--- a/app/client/src/ee/hooks/stateInspector/useGetQueryItemsForStateInspector.ts
+++ b/app/client/src/ee/hooks/stateInspector/useGetQueryItemsForStateInspector.ts
@@ -1,0 +1,1 @@
+export { useGetQueryItemsForStateInspector } from "ce/hooks/stateInspector/useGetQueryItemsForStateInspector";

--- a/app/client/src/ee/hooks/stateInspector/useGetUIItemsForStateInspector.ts
+++ b/app/client/src/ee/hooks/stateInspector/useGetUIItemsForStateInspector.ts
@@ -1,0 +1,1 @@
+export { useGetUIItemsForStateInspector } from "ce/hooks/stateInspector/useGetUIItemsForStateInspector";


### PR DESCRIPTION
## Description
- Breaks hooks required by state inspector into ce and ee files

Fixes https://github.com/appsmithorg/appsmith/issues/40798

## Automation

/ok-to-test tags="@tag.Module"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15573188466>
> Commit: e2503d0161f2a2cc038273055d36ec86e5074dfd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15573188466&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Module`
> Spec:
> <hr>Wed, 11 Jun 2025 00:55:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "Inputs" group to the state inspector feature, providing an input group structure for enhanced state inspection.
  - The "State" tab is now available in the debugger and related views for both App and UIPackage IDE types, expanding access beyond just App IDEs.

- **Improvements**
  - Enhanced handling of selected items in the state inspector for a more robust user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->