### PR TITLE
fix: Reverting the change to add debounce to `onValueChange` for input widgets

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
@@ -1,4 +1,3 @@
-import { DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE } from "../../../../../../src/constants/WidgetConstants";
 import { agHelper } from "../../../../../support/Objects/ObjectsCore";
 
 const widgetName = "inputwidgetv2";
@@ -386,9 +385,7 @@ describe(
       cy.get(widgetInput).clear();
       cy.wait(300);
       // Input text and hit enter key
-      cy.get(widgetInput).type("test{enter}", {
-        delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
-      });
+      cy.get(widgetInput).type("test{enter}");
       // Assert if the Text widget contains the whole value, test
       cy.get(".t--widget-textwidget").should("have.text", "test");
     });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicClientSideData_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicClientSideData_spec.js
@@ -1,7 +1,6 @@
 const publishLocators = require("../../../../../locators/publishWidgetspage.json");
 const commonlocators = require("../../../../../locators/commonlocators.json");
 
-import { DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE } from "../../../../../../src/constants/WidgetConstants";
 import * as _ from "../../../../../support/Objects/ObjectsCore";
 
 const widgetSelector = (name) => `[data-widgetname-cy="${name}"]`;
@@ -77,7 +76,7 @@ describe(
       cy.get(".t--draggable-inputwidgetv2").each(($inputWidget, index) => {
         cy.wrap($inputWidget)
           .find("input")
-          .type(index + 1, { delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE });
+          .type(index + 1);
       });
 
       // Verify the typed value
@@ -102,7 +101,7 @@ describe(
       cy.get(".t--draggable-inputwidgetv2").each(($inputWidget, index) => {
         cy.wrap($inputWidget)
           .find("input")
-          .type(index + 4, { delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE });
+          .type(index + 4);
       });
 
       // Verify the typed value

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Nested_EventBindings_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_Nested_EventBindings_spec.js
@@ -1,4 +1,3 @@
-import { DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE } from "../../../../../../src/constants/WidgetConstants";
 const nestedListDSL = require("../../../../../fixtures/Listv2/nestedList.json");
 const commonlocators = require("../../../../../locators/commonlocators.json");
 
@@ -23,14 +22,10 @@ describe(
         "{{showAlert(`${level_1.currentView.Text1.text} _ ${level_1.currentItem.id} _ ${level_1.currentIndex} _ ${level_1.currentView.Input1.text} _ ${currentView.Input2.text}`)}}",
       );
       // Enter text in the parent list widget's text input
-      cy.get(widgetSelector("Input1"))
-        .find("input")
-        .type("outer input", { delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE });
+      cy.get(widgetSelector("Input1")).find("input").type("outer input");
 
       // Enter text in the child list widget's text input in first row
-      cy.get(widgetSelector("Input2"))
-        .find("input")
-        .type("inner input", { delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE });
+      cy.get(widgetSelector("Input2")).find("input").type("inner input");
 
       // click the button on inner list 1st row.
       cy.get(widgetSelector("Button3")).find("button").click({ force: true });
@@ -45,17 +40,13 @@ describe(
       cy.get(widgetSelector("Input1"))
         .find("input")
         .clear()
-        .type("outer input updated", {
-          delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
-        });
+        .type("outer input updated");
 
       // Enter text in the child list widget's text input in first row
       cy.get(widgetSelector("Input2"))
         .find("input")
         .clear()
-        .type("inner input updated", {
-          delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
-        });
+        .type("inner input updated");
 
       // click the button on inner list 1st row.
       cy.get(widgetSelector("Button3")).find("button").click({ force: true });

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -7,7 +7,6 @@ import { EntityItems } from "./AssertHelper";
 import EditorNavigator from "./EditorNavigation";
 import { EntityType } from "./EditorNavigation";
 import ClickOptions = Cypress.ClickOptions;
-import { DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE } from "../../../src/constants/WidgetConstants";
 const {
   SAVE_TRIGGER_DELAY_MS,
 } = require("../../../src/components/editorComponents/CodeEditor/debounceConstants");
@@ -954,13 +953,10 @@ export class AggregateHelper {
         .focus()
         .type("{backspace}".repeat(charCount), { timeout: 2, force: true })
         .wait(50)
-        .type(totype, { delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE });
+        .type(totype);
     else {
       if (charCount == -1) this.GetElement(selector).eq(index).clear();
-      this.TypeText(selector, totype, {
-        index,
-        delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
-      });
+      this.TypeText(selector, totype, index);
     }
   }
 
@@ -985,10 +981,7 @@ export class AggregateHelper {
     force = false,
   ) {
     this.ClearTextField(selector, force, index);
-    return this.TypeText(selector, totype, {
-      index,
-      delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
-    });
+    return this.TypeText(selector, totype, index);
   }
 
   public TypeText(
@@ -1340,7 +1333,6 @@ export class AggregateHelper {
       .trigger("click")
       .type(input, {
         parseSpecialCharSequences: false,
-        delay: DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
       });
   }
 

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -279,6 +279,3 @@ export type PasteWidgetReduxAction = {
   groupWidgets: boolean;
   existingWidgets?: unknown;
 } & EitherMouseLocationORGridPosition;
-
-// Constant for debouncing the input change to avoid multiple Execute calls in reactive flow
-export const DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE = 300;

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -18,7 +18,6 @@ import type { ExecutionResult } from "constants/AppsmithActionConstants/ActionCo
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import type { TextSize } from "constants/WidgetConstants";
 import {
-  DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
   GridDefaults,
   RenderModes,
   WIDGET_TAGS,
@@ -48,7 +47,6 @@ import {
 import type { InputType } from "../constants";
 import { InputTypes } from "../constants";
 import IconSVG from "../icon.svg";
-import { debounce } from "lodash";
 
 export function defaultValueValidation(
   // TODO: Fix this the next time the file is edited
@@ -143,29 +141,12 @@ export function defaultValueValidation(
   };
 }
 
-interface InputWidgetState extends WidgetState {
-  inputValue: string;
-}
-
-class InputWidget extends BaseWidget<InputWidgetProps, InputWidgetState> {
+class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
   constructor(props: InputWidgetProps) {
     super(props);
     this.state = {
       text: props.text,
-      inputValue: props.text ?? "",
     };
-  }
-
-  componentDidUpdate(prevProps: InputWidgetProps) {
-    if (prevProps.text !== this.props.text) {
-      this.setState({ inputValue: this.props.text ?? "" });
-      // Cancel any pending debounced calls when value is updated externally
-      this.debouncedOnValueChange.cancel();
-    }
-  }
-
-  componentWillUnmount() {
-    this.debouncedOnValueChange.cancel();
   }
 
   static type = "INPUT_WIDGET";
@@ -896,8 +877,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, InputWidgetState> {
     };
   }
 
-  // debouncing the input change to avoid multiple Execute calls in reactive flow
-  debouncedOnValueChange = debounce((value: string) => {
+  onValueChange = (value: string) => {
     this.props.updateWidgetMetaProperty("text", value, {
       triggerPropertyName: "onTextChanged",
       dynamicString: this.props.onTextChanged,
@@ -909,11 +889,6 @@ class InputWidget extends BaseWidget<InputWidgetProps, InputWidgetState> {
     if (!this.props.isDirty) {
       this.props.updateWidgetMetaProperty("isDirty", true);
     }
-  }, DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE);
-
-  onValueChange = (value: string) => {
-    this.setState({ inputValue: value });
-    this.debouncedOnValueChange(value);
   };
 
   onCurrencyTypeChange = (code?: string) => {
@@ -992,13 +967,12 @@ class InputWidget extends BaseWidget<InputWidgetProps, InputWidgetState> {
 
   getFormattedText = () => {
     if (this.props.isFocused || this.props.inputType !== InputTypes.CURRENCY) {
-      return this.state.inputValue !== undefined ? this.state.inputValue : "";
+      return this.props.text !== undefined ? this.props.text : "";
     }
 
-    if (this.state.inputValue === "" || this.state.inputValue === undefined)
-      return "";
+    if (this.props.text === "" || this.props.text === undefined) return "";
 
-    const valueToFormat = String(this.state.inputValue);
+    const valueToFormat = String(this.props.text);
 
     const locale = getLocale();
     const decimalSeparator = getDecimalSeparator(locale);

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -18,7 +18,7 @@ import {
   INPUT_TEXT_MAX_CHAR_ERROR,
 } from "ee/constants/messages";
 import type { SetterConfig, Stylesheet } from "entities/AppTheming";
-import { debounce, isNil, isNumber, merge, toString } from "lodash";
+import { isNil, isNumber, merge, toString } from "lodash";
 import React from "react";
 import { DynamicHeight } from "utils/WidgetFeatures";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
@@ -48,10 +48,7 @@ import type {
   PropertyUpdates,
   SnipingModeProperty,
 } from "WidgetProvider/constants";
-import {
-  DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
-  WIDGET_TAGS,
-} from "constants/WidgetConstants";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
 import { FEATURE_FLAG } from "ee/entities/FeatureFlag";
 import { ResponsiveBehavior } from "layoutSystems/common/utils/constants";
 
@@ -302,16 +299,11 @@ function InputTypeUpdateHook(
   return updates;
 }
 
-interface InputWidgetState extends WidgetState {
-  inputValue: string;
-}
-
-class InputWidget extends BaseInputWidget<InputWidgetProps, InputWidgetState> {
+class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
   constructor(props: InputWidgetProps) {
     super(props);
     this.state = {
       isFocused: false,
-      inputValue: props.inputText ?? "",
     };
   }
 
@@ -714,12 +706,6 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, InputWidgetState> {
   };
 
   componentDidUpdate = (prevProps: InputWidgetProps) => {
-    if (prevProps.inputText !== this.props.inputText) {
-      this.setState({ inputValue: this.props.inputText ?? "" });
-      // Cancel any pending debounced calls when value is updated externally
-      this.debouncedOnValueChange.cancel();
-    }
-
     if (
       prevProps.inputText !== this.props.inputText &&
       this.props.inputText !== toString(this.props.text)
@@ -746,12 +732,7 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, InputWidgetState> {
     }
   };
 
-  componentWillUnmount() {
-    this.debouncedOnValueChange.cancel();
-  }
-
-  // debouncing the input change to avoid multiple Execute calls in reactive flow
-  debouncedOnValueChange = debounce((value: string) => {
+  onValueChange = (value: string) => {
     /*
      * Ideally text property should be derived property. But widgets
      * with derived properties won't work as expected inside a List
@@ -774,11 +755,6 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, InputWidgetState> {
     if (!this.props.isDirty) {
       this.props.updateWidgetMetaProperty("isDirty", true);
     }
-  }, DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE);
-
-  onValueChange = (value: string) => {
-    this.setState({ inputValue: value });
-    this.debouncedOnValueChange(value);
   };
 
   static getSetterConfig(): SetterConfig {
@@ -814,7 +790,7 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, InputWidgetState> {
   };
 
   getWidgetView() {
-    const value = this.state.inputValue ?? "";
+    const value = this.props.inputText ?? "";
     let isInvalid = false;
 
     if (this.props.isDirty) {

--- a/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
@@ -34,11 +34,7 @@ import type {
   SnipingModeProperty,
   PropertyUpdates,
 } from "WidgetProvider/constants";
-import {
-  DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE,
-  WIDGET_TAGS,
-} from "constants/WidgetConstants";
-import { debounce } from "lodash";
+import { WIDGET_TAGS } from "constants/WidgetConstants";
 
 export enum RTEFormats {
   MARKDOWN = "markdown",
@@ -52,21 +48,10 @@ const RichTextEditorComponent = lazy(async () =>
 
 const converter = new showdown.Converter();
 
-interface RichTextEditorWidgetState extends WidgetState {
-  inputValue: string;
-}
-
 class RichTextEditorWidget extends BaseWidget<
   RichTextEditorWidgetProps,
-  RichTextEditorWidgetState
+  WidgetState
 > {
-  constructor(props: RichTextEditorWidgetProps) {
-    super(props);
-    this.state = {
-      inputValue: props.text ?? "",
-    };
-  }
-
   static type = "RICH_TEXT_EDITOR_WIDGET";
 
   static getConfig() {
@@ -506,12 +491,6 @@ class RichTextEditorWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: RichTextEditorWidgetProps): void {
-    if (prevProps.text !== this.props.text) {
-      this.setState({ inputValue: this.props.text ?? "" });
-      // Cancel any pending debounced calls when value is updated externally
-      this.debouncedOnValueChange.cancel();
-    }
-
     if (this.props.defaultText !== prevProps.defaultText) {
       if (this.props.isDirty) {
         this.props.updateWidgetMetaProperty("isDirty", false);
@@ -519,12 +498,7 @@ class RichTextEditorWidget extends BaseWidget<
     }
   }
 
-  componentWillUnmount() {
-    this.debouncedOnValueChange.cancel();
-  }
-
-  // debouncing the input change to avoid multiple Execute calls in reactive flow
-  debouncedOnValueChange = debounce((text: string) => {
+  onValueChange = (text: string) => {
     if (!this.props.isDirty) {
       this.props.updateWidgetMetaProperty("isDirty", true);
     }
@@ -536,11 +510,6 @@ class RichTextEditorWidget extends BaseWidget<
         type: EventType.ON_TEXT_CHANGE,
       },
     });
-  }, DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE);
-
-  onValueChange = (text: string) => {
-    this.setState({ inputValue: text });
-    this.debouncedOnValueChange(text);
   };
 
   static getSetterConfig(): SetterConfig {
@@ -563,7 +532,7 @@ class RichTextEditorWidget extends BaseWidget<
   }
 
   getWidgetView() {
-    let value = this.state.inputValue;
+    let value = this.props.text ?? "";
 
     if (this.props.inputType === RTEFormats.MARKDOWN) {
       value = converter.makeHtml(value);

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.tsx
@@ -1,4 +1,4 @@
-import _, { debounce } from "lodash";
+import _ from "lodash";
 import React from "react";
 import log from "loglevel";
 import type { WidgetState } from "widgets/BaseWidget";
@@ -30,20 +30,11 @@ import { WDSBaseInputWidget } from "widgets/wds/WDSBaseInputWidget";
 import { getCountryCodeFromCurrencyCode, validateInput } from "./helpers";
 import type { KeyDownEvent } from "widgets/wds/WDSBaseInputWidget/component/types";
 import { appsmithTelemetry } from "instrumentation";
-import { DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE } from "constants/WidgetConstants";
 
-interface WDSCurrencyInputWidgetState extends WidgetState {
-  inputValue: string;
-}
 class WDSCurrencyInputWidget extends WDSBaseInputWidget<
   CurrencyInputWidgetProps,
-  WDSCurrencyInputWidgetState
+  WidgetState
 > {
-  constructor(props: CurrencyInputWidgetProps) {
-    super(props);
-    this.state = { inputValue: props.rawText ?? "" };
-  }
-
   static type = "WDS_CURRENCY_INPUT_WIDGET";
 
   static getConfig() {
@@ -161,12 +152,6 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
   }
 
   componentDidUpdate(prevProps: CurrencyInputWidgetProps) {
-    if (prevProps.rawText !== this.props.rawText) {
-      this.setState({ inputValue: this.props.rawText ?? "" });
-      // Cancel any pending debounced calls when value is updated externally
-      this.debouncedOnValueChange.cancel();
-    }
-
     if (
       prevProps.text !== this.props.text &&
       !this.props.isFocused &&
@@ -191,27 +176,6 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
     }
   }
 
-  componentWillUnmount(): void {
-    this.debouncedOnValueChange.cancel();
-  }
-
-  // debouncing the input change to avoid multiple Execute calls in reactive flow
-  debouncedOnValueChange = debounce((value: string, formattedValue: string) => {
-    this.props.updateWidgetMetaProperty("text", String(formattedValue));
-
-    this.props.updateWidgetMetaProperty("rawText", value, {
-      triggerPropertyName: "onTextChanged",
-      dynamicString: this.props.onTextChanged,
-      event: {
-        type: EventType.ON_TEXT_CHANGE,
-      },
-    });
-
-    if (!this.props.isDirty) {
-      this.props.updateWidgetMetaProperty("isDirty", true);
-    }
-  }, DEBOUNCE_WAIT_TIME_ON_INPUT_CHANGE);
-
   onValueChange = (value: string) => {
     let formattedValue = "";
     const decimalSeperator = getLocaleDecimalSeperator();
@@ -230,8 +194,19 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
       });
     }
 
-    this.setState({ inputValue: formattedValue });
-    this.debouncedOnValueChange(value, formattedValue);
+    this.props.updateWidgetMetaProperty("text", String(formattedValue));
+
+    this.props.updateWidgetMetaProperty("rawText", value, {
+      triggerPropertyName: "onTextChanged",
+      dynamicString: this.props.onTextChanged,
+      event: {
+        type: EventType.ON_TEXT_CHANGE,
+      },
+    });
+
+    if (!this.props.isDirty) {
+      this.props.updateWidgetMetaProperty("isDirty", true);
+    }
   };
 
   onFocusChange = (isFocused?: boolean) => {
@@ -348,7 +323,7 @@ class WDSCurrencyInputWidget extends WDSBaseInputWidget<
   }
 
   getWidgetView() {
-    const value = this.state.inputValue;
+    const value = this.props.rawText ?? "";
     const validation = validateInput(this.props);
 
     return (


### PR DESCRIPTION
## Description

Reverting the change to add debounce to `onValueChange` for input widgets. (Reverting PR: [#40849](https://github.com/appsmithorg/appsmith/pull/40849))

Fixes [#40912](https://github.com/appsmithorg/appsmith/issues/40912)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15583889634>
> Commit: 49e570bcdd2d90fab8844bc8d42190d3fd6d396d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15583889634&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 11 Jun 2025 12:48:50 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved input widgets and related components to update values instantly without delay, removing internal state management and debounced input handling. All text and value changes are now immediately reflected in the UI and underlying data.
- **Chores**
  - Updated automated tests to use immediate typing actions, removing artificial delays previously used for input events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->