### PR TITLE
chore: Updating the debounce time for executeBatchSaga to avoid multiple execute API calls

### DIFF
--- a/app/client/src/sagas/BatchSagas.tsx
+++ b/app/client/src/sagas/BatchSagas.tsx
@@ -89,7 +89,7 @@ function* executeBatchSaga() {
 
 export default function* root() {
   yield all([
-    debounce(500, ReduxActionTypes.EXECUTE_BATCH, executeBatchSaga),
+    debounce(20, ReduxActionTypes.EXECUTE_BATCH, executeBatchSaga),
     takeEvery(ReduxActionTypes.BATCHED_UPDATE, storeUpdatesSaga),
   ]);
 }

--- a/app/client/src/sagas/BatchSagas.tsx
+++ b/app/client/src/sagas/BatchSagas.tsx
@@ -89,7 +89,7 @@ function* executeBatchSaga() {
 
 export default function* root() {
   yield all([
-    debounce(20, ReduxActionTypes.EXECUTE_BATCH, executeBatchSaga),
+    debounce(500, ReduxActionTypes.EXECUTE_BATCH, executeBatchSaga),
     takeEvery(ReduxActionTypes.BATCHED_UPDATE, storeUpdatesSaga),
   ]);
 }

--- a/app/client/src/widgets/MetaHOC.tsx
+++ b/app/client/src/widgets/MetaHOC.tsx
@@ -134,11 +134,7 @@ function withMeta(WrappedWidget: typeof BaseWidget) {
 
     debouncedTriggerEvalOnMetaUpdate = debounce(
       this.handleTriggerEvalOnMetaUpdate,
-      200,
-      {
-        leading: true,
-        trailing: true,
-      },
+      300,
     );
 
     updateWidgetMetaProperty = (

--- a/app/client/src/widgets/MetaHOC.tsx
+++ b/app/client/src/widgets/MetaHOC.tsx
@@ -134,7 +134,7 @@ function withMeta(WrappedWidget: typeof BaseWidget) {
 
     debouncedTriggerEvalOnMetaUpdate = debounce(
       this.handleTriggerEvalOnMetaUpdate,
-      300,
+      200,
     );
 
     updateWidgetMetaProperty = (


### PR DESCRIPTION
## Description

Updating the debounce time for executeBatchSaga to avoid multiple execute API calls

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15615172747>
> Commit: b776ef2b865db9dd4ae4769824241c096bab3d32
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15615172747&attempt=2&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/Datepicker/DatePicker3_spec.ts
> <li>cypress/e2e/Regression/ClientSide/Widgets/Input/Inputv2_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/Inline_editing_2_spec.js
> <li>cypress/e2e/Regression/ClientSide/Widgets/TableV2/Table_InfiniteScroll_spec.ts</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Thu, 12 Jun 2025 18:18:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Adjusted the timing and behavior of certain update actions to improve responsiveness and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->