### PR TITLE
chore: flaky tests fixed

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/ApiBugs_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/ApiBugs_Spec.ts
@@ -66,24 +66,7 @@ describe(
       AppSidebar.navigate(AppSidebarButton.Editor);
     });
 
-    it("3. Bug 18876 Ensures application does not crash when saving datasource", () => {
-      apiPage.CreateAndFillApi(
-        dataManager.dsValues[dataManager.defaultEnviorment].mockApiUrl,
-        "FirstAPI",
-        10000,
-        "POST",
-      );
-      apiPage.SelectPaneTab("Authentication");
-      cy.get(apiPage._saveAsDS).last().click({ force: true });
-      cy.go("back");
-      cy.get(dataSources._datasourceModalSave).click();
-      // ensures app does not crash and datasource is saved.
-      cy.contains("Edit datasource to access authentication settings").should(
-        "exist",
-      );
-    });
-
-    it("4. Bug 16683, When Api url has dynamic binding expressions, ensures the query params is not truncated", function () {
+    it("3. Bug 16683, When Api url has dynamic binding expressions, ensures the query params is not truncated", function () {
       const apiUrl = `http://host.docker.internal:5001/v1/mock-api?records=4{{Math.random() > 0.5 ? '&param1=5' : '&param2=6'}}`;
 
       apiPage.CreateAndFillApi(apiUrl, "BindingExpressions");
@@ -91,9 +74,15 @@ describe(
         key: "records",
         value: "4{{Math.random() > 0.5 ? '&param1=5' : '&param2=6'}}",
       });
+
+      // Delete the action
+      agHelper.ActionContextMenuWithInPane({
+        action: "Delete",
+        entityType: entityItems.Api,
+      });
     });
 
-    it("5. Bug 26897, Invalid binding of table data when used existing suggested widgets for an action returning object & array", function () {
+    it("4. Bug 26897, Invalid binding of table data when used existing suggested widgets for an action returning object & array", function () {
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE);
 
       // Case where api returns array response
@@ -127,6 +116,23 @@ describe(
       propPane.ValidatePropertyFieldValue(
         "Table data",
         "{{OBJECT_RESPONSE.data.users}}",
+      );
+    });
+
+    it("5. Bug 18876 Ensures application does not crash when saving datasource", () => {
+      apiPage.CreateAndFillApi(
+        dataManager.dsValues[dataManager.defaultEnviorment].mockApiUrl,
+        "FirstAPI",
+        10000,
+        "POST",
+      );
+      apiPage.SelectPaneTab("Authentication");
+      cy.get(apiPage._saveAsDS).last().click({ force: true });
+      cy.go("back");
+      cy.get(dataSources._datasourceModalSave).click();
+      // ensures app does not crash and datasource is saved.
+      cy.contains("Edit datasource to access authentication settings").should(
+        "exist",
       );
     });
   },


### PR DESCRIPTION
## Description
This PR fixes flakiness of client/cypress/e2e/Regression/ClientSide/BugTests/ApiBugs_Spec.ts


Fixes #40584   
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15602807166>
> Commit: cfbf48094bd3632eda682fc853b83e3c152fb0ed
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15602807166&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Thu, 12 Jun 2025 07:49:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the order of certain test cases in the suite.
  - Enhanced a test case to include cleanup of created API actions after validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->