### PR TITLE
chore: Remove Airtable tests from being excluded from CI runs

### DIFF
--- a/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
@@ -18,7 +18,7 @@ let dsName: any, jsonSpecies: any, offset: any, insertedRecordId: any;
 describe(
   "Validate Airtable Ds",
   {
-    tags: ["@tag.Airtable"],
+    tags: ["@tag.Airtable", "@tag.Datasource", "@tag.Sanity"],
   },
   () => {
     before("Create a new Airtable DS", () => {

--- a/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
@@ -403,7 +403,6 @@ describe(
       table.WaitForTableEmpty("v2");
       deployMode.NavigateBacktoEditor();
       dataSources.DeleteDatasourceFromWithinDS(dsName);
-
     });
   },
 );

--- a/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
@@ -403,6 +403,7 @@ describe(
       table.WaitForTableEmpty("v2");
       deployMode.NavigateBacktoEditor();
       dataSources.DeleteDatasourceFromWithinDS(dsName);
+
     });
   },
 );

--- a/app/client/cypress_ci.config.ts
+++ b/app/client/cypress_ci.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
     excludeSpecPattern: [
       "cypress/e2e/**/spec_utility.ts",
       "cypress/e2e/GSheet/**/**/*",
-      "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
       "cypress/e2e/Regression/ClientSide/CommunityTemplate/*",
       "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
     ],

--- a/app/client/cypress_ci_custom.config.ts
+++ b/app/client/cypress_ci_custom.config.ts
@@ -61,7 +61,6 @@ export default defineConfig({
       "cypress/e2e/**/spec_utility.ts",
       "cypress/e2e/Regression/ClientSide/CommunityTemplate/*",
       "cypress/e2e/GSheet/**/**/*",
-      "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
       "cypress/e2e/EE/Enterprise/MultipleEnv/ME_airtable_spec.ts",
       "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
       "cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts",

--- a/app/client/cypress_ci_hosted.config.ts
+++ b/app/client/cypress_ci_hosted.config.ts
@@ -53,7 +53,6 @@ export default defineConfig({
       return require("./cypress/plugins/index.js")(on, config);
     },
     specPattern: [
-      "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
       "cypress/e2e/GSheet/**/**/*",
       "cypress/e2e/Regression/ServerSide/Datasources/Oracle_Spec.ts",
       "cypress/e2e/Regression/ClientSide/Widgets/Others/MapWidget_Spec.ts",


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Airtable"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15680047685>
> Commit: 514391a403034c9afefca0a69e82951d268c859d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15680047685&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Airtable`
> Spec:
> <hr>Mon, 16 Jun 2025 12:13:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated test configurations to include the Airtable basic datasource sanity test in standard test runs, while excluding it from hosted environment test runs.
	- Added new tags to the Airtable basic datasource sanity test for improved test categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->