### PR TITLE
fix: enhance CA certificate handling in entrypoint script

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -365,6 +365,10 @@ setup-custom-ca-certificates() (
   rm -rf "$temp_cert_dir"
   mkdir -p "$temp_cert_dir"
 
+  if [[ -n "$(ls "$stacks_ca_certs_path"/*.pem 2>/dev/null)" ]]; then
+    tlog "Looks like you have some '.pem' files in your 'ca-certs' folder. Please rename them to '.crt' to be picked up automatically.".
+  fi
+
   if ! [[ -d "$stacks_ca_certs_path" && "$(find "$stacks_ca_certs_path" -maxdepth 1 -type f -o -type l -name '*.crt' | wc -l)" -gt 0 ]]; then
     tlog "No custom CA certificates found."
     return

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -369,7 +369,7 @@ setup-custom-ca-certificates() (
     tlog "Looks like you have some '.pem' files in your 'ca-certs' folder. Please rename them to '.crt' to be picked up automatically.".
   fi
 
-  if ! [[ -d "$stacks_ca_certs_path" && "$(find "$stacks_ca_certs_path" -maxdepth 1 -type f -o -type l -name '*.crt' | wc -l)" -gt 0 ]]; then
+  if ! [[ -d "$stacks_ca_certs_path" && "$(find "$stacks_ca_certs_path" -maxdepth 1 \( -type f -name '*.crt' -o -type l -name '*.crt' \) | wc -l)" -gt 0 ]]; then
     tlog "No custom CA certificates found."
     return
   fi

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -366,7 +366,7 @@ setup-custom-ca-certificates() (
     tlog "Looks like you have some '.pem' files in your 'ca-certs' folder. Please rename them to '.crt' to be picked up automatically.".
   fi
 
-  if ! [[ -d "$stacks_ca_certs_path" && "$(find "$stacks_ca_certs_path" -maxdepth 1 -type f -name '*.crt' | wc -l)" -gt 0 ]]; then
+  if ! [[ -d "$stacks_ca_certs_path" && "$(find "$stacks_ca_certs_path" -maxdepth 1 -type f -o -type l -name '*.crt' | wc -l)" -gt 0 ]]; then
     tlog "No custom CA certificates found."
     return
   fi
@@ -378,8 +378,8 @@ setup-custom-ca-certificates() (
     -srcstorepass changeit \
     -deststorepass changeit
 
-  # Add the custom CA certificates to the store.
-  find -L "$stacks_ca_certs_path" -maxdepth 1 -type f -name '*.crt' \
+  # Add the custom CA certificates to the store, following symlinks
+  find -L "$stacks_ca_certs_path" -maxdepth 1 -type f -o -type l -name '*.crt' \
     -print \
     -exec keytool -import -alias '{}' -noprompt -keystore "$store" -file '{}' -storepass changeit ';'
 


### PR DESCRIPTION
Updated the entrypoint script to improve the detection and processing of custom CA certificates. The script now correctly identifies both regular files and symbolic links with a '.crt' extension, ensuring that all relevant certificates are included in the keystore. This change enhances the robustness of the CA certificate setup process.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 534af3a44c572e8ec63cb6de9dc3d60e88f17f53 yet
> <hr>Wed, 02 Jul 2025 09:06:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and import of custom CA certificates by including support for symbolic links, ensuring all relevant `.crt` files are recognized and imported.
  - Enhanced handling of certificate bundles by splitting and importing individual certificates for better compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->