### PR TITLE
fix: update assertion method in DebuggerHelper to use GetNAssertElementText

### DIFF
--- a/app/client/cypress/support/Pages/DebuggerHelper.ts
+++ b/app/client/cypress/support/Pages/DebuggerHelper.ts
@@ -141,8 +141,8 @@ export class DebuggerHelper {
   }
 
   AssertErrorCount(count: number) {
-    const assertion = count > 0 ? `Debug (${count})` : "Debug";
-    this.agHelper.GetNAssertContains(this.locators._errorCount, assertion);
+    const assertion = count > 0 ? `Debug (${count})` : "Debug ";
+    this.agHelper.GetNAssertElementText(this.locators._errorCount, assertion);
   }
 
   changeLogsGroup(option: string) {


### PR DESCRIPTION

## Description
<ins>Problem</ins>

The existing assertion in `DebuggerHelper` falsely passed even when there were visible errors in the debug console, leading to unreliable test validations.

<ins>Root cause</ins>

The assertion used `assert contains`, which only checked for the presence of the word "debug". Since this word is present regardless of the actual error count, the assertion would always pass, even if there were errors.

<ins>Solution</ins>

This PR handles the update of the assertion method in `DebuggerHelper` to use `getNAssertElementText` instead of `assert contains`. This enforces strict validation by checking for an exact match in the debug message text, ensuring accurate test outcomes when error count is expected to be zero.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource, @tag.Widget, @Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
