### PR TITLE
fix: JSobject test fixed after generate crud issue fixes

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/JSObject/JSObject_Tests_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/JSObject/JSObject_Tests_spec.ts
@@ -236,7 +236,7 @@ describe("Validate JSObj", { tags: ["@tag.JS", "@tag.Datasource"] }, () => {
     debuggerHelper.DoesConsoleLogExist("Operation was successful!");
   });
 
-  it.skip("8. Verify Queries", () => {
+  it("8. Verify Queries", () => {
     dataSources.CreateDataSource("Postgres");
     dataSources.CreateQueryAfterDSSaved(" ");
     agHelper.TypeIntoTextArea(locators._codeEditorTarget, "/");
@@ -247,21 +247,28 @@ describe("Validate JSObj", { tags: ["@tag.JS", "@tag.Datasource"] }, () => {
     agHelper.GetNAssertContains(locators._hints, "MainContainer");
 
     cy.get("@guid").then((uid) => {
-      dataSources.GeneratePageForDS(`Postgres ${uid}`);
+      EditorNavigation.SelectEntityByName(
+        `Postgres ${uid}`,
+        EntityType.Datasource,
+      );
+      dataSources.SelectTableFromPreviewSchemaList("public.users");
+      agHelper.GetNClick(dataSources._datasourceCardGeneratePageBtn);
     });
     assertHelper.AssertNetworkStatus("@postExecute", 200);
     agHelper.ClickButton("Got it");
     assertHelper.AssertNetworkStatus("@updateLayout", 200);
     agHelper.Sleep(2000);
     table.WaitUntilTableLoad(0, 0, "v2");
-    EditorNavigation.SelectEntityByName("SelectQuery", EntityType.Query);
+    EditorNavigation.SelectEntityByName("DeleteQuery", EntityType.Query);
     agHelper.GetNClick(locators._codeEditorTarget);
     agHelper.AssertElementVisibility(locators._evaluatedValue);
 
     cy.get(`${locators._codeMirrorCode} pre`).then(($elements) => {
       const text = [...$elements].map((el) => el.innerText).join("");
       agHelper.GetText(locators._evaluatedValue).then((evalText: any) => {
-        expect(evalText.replace(/\n/g, "")).to.eq(text);
+        expect(evalText.replace(/\n/g, "")).to.eq(
+          'DELETE FROM public."users"  WHERE "id" = $1;',
+        );
       });
     });
   });


### PR DESCRIPTION
## Description
This PR fixes client/cypress/e2e/Regression/ClientSide/JSObject/JSObject_Tests_spec.ts. This test started failing after fixing [generate crud issue with dynamicBindingPathList](https://github.com/appsmithorg/appsmith/pull/40792). With this fix, dynamicBindingPathList started appearing for generated queries as well and so it started breaking one of the test cases which was asserting the evaluated popup's value. 

The test was asserting that value in evaluated value popup should be equal to the query itself earlier, but after the right fix for generate crud, it won't be equal, rather bindings will be replaced by placeholders. This PR fixes the test by adding correct assertion for evaluated value.


Fixes #40857
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15699603166>
> Commit: a7041c31f14d619ba235bc31446377facf4f1124
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15699603166&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 17 Jun 2025 06:32:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Reactivated and updated a test case for verifying query generation and editing, including improved selection and validation steps for datasource entities and queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->