### PR TITLE
fix: Suppress webpack-dev-server ResizeObserver loop development runtime error

### DIFF
--- a/app/client/config/webpackDevServer.config.js
+++ b/app/client/config/webpackDevServer.config.js
@@ -79,11 +79,14 @@ module.exports = function (proxy, allowedHost) {
       overlay: {
         warnings: false,
         errors: false,
+        // Suppress known noisy runtime error(s) without hiding legitimate ones
         runtimeErrors: (error) => {
-          const ignoreErrors = [
-            "ResizeObserver loop completed with undelivered notifications.",
+          const message =
+            typeof error?.message === "string" ? error.message : "";
+          const IGNORE_ERRORS = [
+            "ResizeObserver loop completed with undelivered notifications",
           ];
-          if (ignoreErrors.includes(error.message)) {
+          if (IGNORE_ERRORS.some((m) => message.includes(m))) {
             return false;
           }
           return true;

--- a/app/client/config/webpackDevServer.config.js
+++ b/app/client/config/webpackDevServer.config.js
@@ -79,6 +79,15 @@ module.exports = function (proxy, allowedHost) {
       overlay: {
         warnings: false,
         errors: false,
+        runtimeErrors: (error) => {
+          const ignoreErrors = [
+            "ResizeObserver loop completed with undelivered notifications.",
+          ];
+          if (ignoreErrors.includes(error.message)) {
+            return false;
+          }
+          return true;
+        },
       },
     },
     devMiddleware: {


### PR DESCRIPTION
## Description
Suppresses ResizeObserver runtime error until the usage of the ResizeObserver API is investigated.


We can prioritize this lower for now because of the following reasons:
1. The error has existed for quite some time without issues to our users.
2. The notifications are not lost, just delayed by the browser.
3. The error only surfaced when `webpack-dev-server` was upgraded.
4. This error is shown only during development.


## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15723923513>
> Commit: 590db966896005b8969052148fbf387253a9febe
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15723923513&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 18 Jun 2025 05:43:31 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - Suppressed display of specific runtime errors related to "ResizeObserver loop completed with undelivered notifications" in the development error overlay, reducing unnecessary error popups during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->