### PR TITLE
chore: revert in-memory git status (CE)

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
@@ -1,6 +1,5 @@
 package com.appsmith.git.files;
 
-import com.appsmith.external.dtos.GitStatusDTO;
 import com.appsmith.external.dtos.ModifiedResources;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
@@ -20,7 +19,6 @@ import com.appsmith.git.configurations.GitServiceConfig;
 import com.appsmith.git.constants.CommonConstants;
 import com.appsmith.git.helpers.DSLTransformerHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Span;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +31,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.util.StringUtils;
-import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -93,7 +90,7 @@ public class FileUtilsCEImpl implements FileInterface {
     protected final FileOperations fileOperations;
     private final ObservationHelper observationHelper;
     protected final ObjectMapper objectMapper;
-    private final ObservationRegistry observationRegistry;
+
     private static final String EDIT_MODE_URL_TEMPLATE = "{{editModeUrl}}";
 
     private static final String VIEW_MODE_URL_TEMPLATE = "{{viewModeUrl}}";
@@ -111,15 +108,13 @@ public class FileUtilsCEImpl implements FileInterface {
             GitExecutor gitExecutor,
             FileOperations fileOperations,
             ObservationHelper observationHelper,
-            ObjectMapper objectMapper,
-            ObservationRegistry observationRegistry) {
+            ObjectMapper objectMapper) {
         this.gitServiceConfig = gitServiceConfig;
         this.fsGitHandler = fsGitHandler;
         this.gitExecutor = gitExecutor;
         this.fileOperations = fileOperations;
         this.observationHelper = observationHelper;
         this.objectMapper = objectMapper;
-        this.observationRegistry = observationRegistry;
     }
 
     protected Map<GitResourceType, GitResourceType> getModifiedResourcesTypes() {
@@ -293,66 +288,6 @@ public class FileUtilsCEImpl implements FileInterface {
                             });
                 })
                 .subscribeOn(scheduler);
-    }
-
-    public Mono<GitStatusDTO> computeGitStatus(
-            Path baseRepoSuffix, GitResourceMap gitResourceMapFromDB, String branchName, boolean keepWorkingDirChanges)
-            throws GitAPIException, IOException {
-        return fsGitHandler
-                .resetToLastCommit(baseRepoSuffix, branchName, keepWorkingDirChanges)
-                .flatMap(__ -> constructGitResourceMapFromGitRepo(baseRepoSuffix, branchName))
-                .flatMap(gitResourceMapFromFS -> {
-                    Map<GitResourceIdentity, Object> resourceMapFromDB = gitResourceMapFromDB.getGitResourceMap();
-                    Map<GitResourceIdentity, Object> resourceMapFromFS = gitResourceMapFromFS.getGitResourceMap();
-
-                    Map<String, Object> filePathObjectsMapFromFS = resourceMapFromFS.entrySet().parallelStream()
-                            .collect(
-                                    Collectors.toMap(entry -> entry.getKey().getFilePath(), entry -> entry.getValue()));
-
-                    Map<String, Object> filePathToObjectsFromDB = resourceMapFromDB.entrySet().parallelStream()
-                            .collect(
-                                    Collectors.toMap(entry -> entry.getKey().getFilePath(), entry -> entry.getValue()));
-
-                    Set<String> filePathsInDb = new HashSet<>(filePathToObjectsFromDB.keySet());
-                    Set<String> filePathsInFS = new HashSet<>(filePathObjectsMapFromFS.keySet());
-
-                    // added files
-                    Set<String> addedFiles = new HashSet<>(filePathsInDb);
-                    addedFiles.removeAll(filePathsInFS);
-
-                    // removed files
-                    Set<String> removedFiles = new HashSet<>(filePathsInFS);
-                    removedFiles.removeAll(filePathsInDb);
-                    removedFiles.remove(README_FILE_NAME);
-
-                    // common files
-                    Set<String> commonFiles = new HashSet<>(filePathsInDb);
-                    commonFiles.retainAll(filePathsInFS);
-
-                    // modified files
-                    Set<String> modifiedFiles = commonFiles.stream()
-                            .filter(filePath -> {
-                                Object fileInDB = filePathToObjectsFromDB.get(filePath);
-                                Object fileInFS = filePathObjectsMapFromFS.get(filePath);
-                                try {
-                                    return fileOperations.hasFileChanged(fileInDB, fileInFS);
-                                } catch (IOException e) {
-                                    log.error("Error while checking if file has changed", e);
-                                    return false;
-                                }
-                            })
-                            .collect(Collectors.toSet());
-
-                    GitStatusDTO localRepoStatus = new GitStatusDTO();
-                    localRepoStatus.setAdded(addedFiles);
-                    localRepoStatus.setModified(modifiedFiles);
-                    localRepoStatus.setRemoved(removedFiles);
-                    boolean isClean = addedFiles.isEmpty() && modifiedFiles.isEmpty() && removedFiles.isEmpty();
-                    localRepoStatus.setIsClean(isClean);
-
-                    fsGitHandler.populateModifiedEntities(localRepoStatus);
-                    return Mono.just(localRepoStatus);
-                });
     }
 
     protected Set<String> getWhitelistedPaths() {
@@ -867,10 +802,7 @@ public class FileUtilsCEImpl implements FileInterface {
     @Override
     public Mono<GitResourceMap> constructGitResourceMapFromGitRepo(Path repositorySuffix, String refName) {
         Path repositoryPath = Paths.get(gitServiceConfig.getGitRootPath()).resolve(repositorySuffix);
-        return Mono.fromCallable(() -> fetchGitResourceMap(repositoryPath))
-                .subscribeOn(scheduler)
-                .name("construct-git-resource-map")
-                .tap(Micrometer.observation(observationRegistry));
+        return Mono.fromCallable(() -> fetchGitResourceMap(repositoryPath)).subscribeOn(scheduler);
     }
 
     /**

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsImpl.java
@@ -7,7 +7,6 @@ import com.appsmith.external.git.operations.FileOperations;
 import com.appsmith.external.helpers.ObservationHelper;
 import com.appsmith.git.configurations.GitServiceConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.observation.ObservationRegistry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Import;
@@ -27,15 +26,7 @@ public class FileUtilsImpl extends FileUtilsCEImpl implements FileInterface {
             GitExecutor gitExecutor,
             FileOperations fileOperations,
             ObservationHelper observationHelper,
-            ObjectMapper objectMapper,
-            ObservationRegistry observationRegistry) {
-        super(
-                gitServiceConfig,
-                fsGitHandler,
-                gitExecutor,
-                fileOperations,
-                observationHelper,
-                objectMapper,
-                observationRegistry);
+            ObjectMapper objectMapper) {
+        super(gitServiceConfig, fsGitHandler, gitExecutor, fileOperations, observationHelper, objectMapper);
     }
 }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -935,8 +935,7 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                 .subscribeOn(scheduler);
     }
 
-    @Override
-    public void populateModifiedEntities(GitStatusDTO response) {
+    protected void populateModifiedEntities(GitStatusDTO response) {
         populatePageChanges(response);
         populateQueryChanges(response);
         populateJsObjectChanges(response);

--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
@@ -9,7 +9,6 @@ import com.appsmith.git.files.FileUtilsImpl;
 import com.appsmith.git.files.operations.FileOperationsImpl;
 import com.appsmith.git.service.GitExecutorImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.AfterEach;
@@ -52,8 +51,7 @@ public class FileUtilsImplTest {
                 gitExecutor,
                 fileOperations,
                 ObservationHelper.NOOP,
-                new ObjectMapper(),
-                ObservationRegistry.NOOP);
+                new ObjectMapper());
     }
 
     @AfterEach

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/FileInterface.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/FileInterface.java
@@ -1,6 +1,5 @@
 package com.appsmith.external.git;
 
-import com.appsmith.external.dtos.GitStatusDTO;
 import com.appsmith.external.git.models.GitResourceMap;
 import com.appsmith.external.models.ApplicationGitReference;
 import com.appsmith.external.models.ArtifactGitReference;
@@ -40,10 +39,6 @@ public interface FileInterface {
             throws IOException, GitAPIException;
 
     Mono<Path> saveArtifactToGitRepo(
-            Path baseRepoSuffix, GitResourceMap gitResourceMap, String branchName, boolean keepWorkingDirChanges)
-            throws GitAPIException, IOException;
-
-    Mono<GitStatusDTO> computeGitStatus(
             Path baseRepoSuffix, GitResourceMap gitResourceMap, String branchName, boolean keepWorkingDirChanges)
             throws GitAPIException, IOException;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/handler/FSGitHandler.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/handler/FSGitHandler.java
@@ -160,8 +160,6 @@ public interface FSGitHandler {
      */
     Mono<GitStatusDTO> getStatus(Path repoPath, String branchName, boolean keepWorkingDirChanges);
 
-    void populateModifiedEntities(GitStatusDTO response);
-
     /**
      * This method merges source branch into destination branch for a git repository which is present on the partial
      * path provided. <B> This assumes that the branch on which the merge will happen is already checked out </B>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/GitHandlingServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/GitHandlingServiceCE.java
@@ -86,9 +86,6 @@ public interface GitHandlingServiceCE {
     Mono<Boolean> prepareChangesToBeCommitted(
             ArtifactJsonTransformationDTO jsonTransformationDTO, ArtifactExchangeJson artifactExchangeJson);
 
-    Mono<GitStatusDTO> computeGitStatus(
-            ArtifactJsonTransformationDTO jsonTransformationDTO, ArtifactExchangeJson artifactExchangeJson);
-
     Mono<Tuple2<? extends Artifact, String>> commitArtifact(
             Artifact branchedArtifact, CommitDTO commitDTO, ArtifactJsonTransformationDTO jsonTransformationDTO);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -764,19 +764,6 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                 keepWorkingDirChanges -> fsGitHandler.getStatus(repoPath, refName, keepWorkingDirChanges));
     }
 
-    public Mono<GitStatusDTO> computeGitStatus(
-            ArtifactJsonTransformationDTO jsonTransformationDTO, ArtifactExchangeJson artifactExchangeJson) {
-        String workspaceId = jsonTransformationDTO.getWorkspaceId();
-        String baseArtifactId = jsonTransformationDTO.getBaseArtifactId();
-        String repoName = jsonTransformationDTO.getRepoName();
-        String branchName = jsonTransformationDTO.getRefName();
-
-        ArtifactType artifactType = jsonTransformationDTO.getArtifactType();
-        GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
-        Path repoSuffix = gitArtifactHelper.getRepoSuffixPath(workspaceId, baseArtifactId, repoName);
-        return commonGitFileUtils.computeGitStatus(repoSuffix, artifactExchangeJson, branchName);
-    }
-
     @Override
     public Mono<String> createGitReference(
             ArtifactJsonTransformationDTO baseRefJsonTransformationDTO,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.helpers.ce;
 
 import com.appsmith.external.constants.AnalyticsEvents;
-import com.appsmith.external.dtos.GitStatusDTO;
 import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.external.git.FileInterface;
 import com.appsmith.external.git.models.GitResourceIdentity;
@@ -194,18 +193,6 @@ public class CommonGitFileUtilsCE {
                 return Mono.error(exception);
             }
         });
-    }
-
-    public Mono<GitStatusDTO> computeGitStatus(
-            Path baseRepoSuffix, ArtifactExchangeJson artifactExchangeJson, String branchName) {
-        GitResourceMap gitResourceMapFromDB = createGitResourceMap(artifactExchangeJson);
-        try {
-            return fileUtils
-                    .computeGitStatus(baseRepoSuffix, gitResourceMapFromDB, branchName, true)
-                    .subscribeOn(Schedulers.boundedElastic());
-        } catch (IOException | GitAPIException exception) {
-            return Mono.error(exception);
-        }
     }
 
     public Mono<Path> saveArtifactToLocalRepoWithAnalytics(


### PR DESCRIPTION
## Description
This reverts commit dea1c030da221cc4dd614e03615287fb4538184a.

There are duplicate entries for the same js object in the DB for git connected application. In these cases the map generated from the DB git resource map fails as the map doesn't allow duplicate entries.

@manish will fix the root cause of the duplicate entries of JS object and then restore this PR. [Relevant thread
](https://theappsmith.slack.com/archives/C04HERDNZPA/p1750063381844219)

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15732621899>
> Commit: e2585053fc35703705fac2e276f0e025a811a1fa
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15732621899&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 18 Jun 2025 13:53:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed certain Git status computation features and related methods from the application.
  - Internal instrumentation and observation logic have been eliminated.
  - Adjusted method visibility for improved encapsulation.

- **Chores**
  - Updated internal interfaces and constructors to reflect the removal of deprecated methods and parameters.
  - Cleaned up unused imports and code references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->