### PR TITLE
fix: update cluster name in deploy_preview script and adjust kubeconf…

### DIFF
--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -11,7 +11,7 @@ aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
 aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
 
 export region=ap-south-1
-export cluster_name=uat-cluster
+export cluster_name=uatx-cluster
 
 echo "[default]
 region = $region
@@ -48,7 +48,8 @@ export APPSMITH_AI_SERVER_MANAGED_HOSTING="$APPSMITH_AI_SERVER_MANAGED_HOSTING"
 export IN_DOCKER="$IN_DOCKER"
 
 
-aws eks update-kubeconfig --region "$region" --name "$cluster_name" --profile eksci
+# aws eks update-kubeconfig --region "$region" --name "$cluster_name" --profile eksci
+aws eks update-kubeconfig --region "$region" --name "$cluster_name"
 
 echo "Set the default namespace"
 kubectl config set-context --current --namespace=default


### PR DESCRIPTION
…ig command

### 📝 Summary
This commit updates the cluster name in the `deploy_preview.sh` script from `uat-cluster` to `uatx-cluster` and modifies the `aws eks update-kubeconfig` command to remove the profile option, ensuring compatibility with the current AWS configuration.

### 🎨 Changes Made
- **Cluster Name Update**: Changed `export cluster_name=uat-cluster` to `export cluster_name=uatx-cluster`.
- **Kubeconfig Command Adjustment**: Removed the `--profile eksci` option from the `aws eks update-kubeconfig` command for streamlined execution.

No user-facing changes were made, and the script remains functional for deployment tasks.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the AWS EKS cluster name used in deployment processes.
	- Modified deployment script to use default AWS credentials for cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->