### PR TITLE
chore: Added tag to exclude Airtable_Basic_Spec.ts from airgapped runs

### DIFF
--- a/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts
@@ -18,7 +18,12 @@ let dsName: any, jsonSpecies: any, offset: any, insertedRecordId: any;
 describe(
   "Validate Airtable Ds",
   {
-    tags: ["@tag.Airtable", "@tag.Datasource", "@tag.Sanity"],
+    tags: [
+      "@tag.Airtable",
+      "@tag.Datasource",
+      "@tag.Sanity",
+      "@tag.excludeForAirgap",
+    ],
   },
   () => {
     before("Create a new Airtable DS", () => {


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Airtable"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15773945412>
> Commit: 12cefda7fc78991cd287017ed3d88ebb39851455
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15773945412&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Airtable`
> Spec:
> <hr>Fri, 20 Jun 2025 08:12:59 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test metadata by adding a new tag to the Airtable datasource test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->