### PR TITLE
feat: add onPageUnload option in UI behind feature flag.

### DIFF
--- a/app/client/src/PluginActionEditor/types/PluginActionTypes.ts
+++ b/app/client/src/PluginActionEditor/types/PluginActionTypes.ts
@@ -6,6 +6,7 @@ export enum ActionRunBehaviour {
   ON_PAGE_LOAD = "ON_PAGE_LOAD",
   MANUAL = "MANUAL",
   AUTOMATIC = "AUTOMATIC",
+  ON_PAGE_UNLOAD = "ON_PAGE_UNLOAD",
 }
 
 export type ActionRunBehaviourType = `${ActionRunBehaviour}`;

--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -60,6 +60,8 @@ export const FEATURE_FLAG = {
   release_ai_chat_integrations_enabled: "release_ai_chat_integrations_enabled",
   release_reactive_actions_enabled: "release_reactive_actions_enabled",
   license_ai_agent_instance_enabled: "license_ai_agent_instance_enabled",
+  release_jsobjects_onpageunloadctions_enabled:
+    "release_jsobjects_onpageunloadctions_enabled",
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG;
@@ -110,6 +112,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   release_ai_chat_integrations_enabled: false,
   release_reactive_actions_enabled: false,
   license_ai_agent_instance_enabled: false,
+  release_jsobjects_onpageunloadctions_enabled: false,
 };
 
 export const AB_TESTING_EVENT_KEYS = {

--- a/app/client/src/constants/AppsmithActionConstants/formConfig/PluginSettings.ts
+++ b/app/client/src/constants/AppsmithActionConstants/formConfig/PluginSettings.ts
@@ -21,4 +21,10 @@ export const RUN_BEHAVIOR_VALUES = [
     value: ActionRunBehaviour.MANUAL,
     children: "Manual",
   },
+  {
+    label: "On page unload",
+    subText: "Query runs when the page unloads or when manually triggered",
+    value: ActionRunBehaviour.ON_PAGE_UNLOAD,
+    children: "On page unload",
+  },
 ];

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/utils.test.ts
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/utils.test.ts
@@ -1,0 +1,139 @@
+import {
+  ActionRunBehaviour,
+  type ActionRunBehaviourType,
+} from "PluginActionEditor/types/PluginActionTypes";
+import {
+  getDefaultRunBehaviorOptionWhenFeatureFlagIsDisabled,
+  getRunBehaviorOptionsBasedOnFeatureFlags,
+} from "./utils";
+import { RUN_BEHAVIOR_VALUES } from "constants/AppsmithActionConstants/formConfig/PluginSettings";
+import type { SelectOptionProps } from "@appsmith/ads";
+
+describe("getRunBehaviorOptions", () => {
+  it("should return the correct options", () => {
+    const flagsOutputMatrix: [boolean, boolean, SelectOptionProps[]][] = [
+      [true, true, RUN_BEHAVIOR_VALUES],
+      [
+        false,
+        true,
+        RUN_BEHAVIOR_VALUES.filter(
+          (option) => option.value !== ActionRunBehaviour.AUTOMATIC,
+        ),
+      ],
+      [
+        true,
+        false,
+        RUN_BEHAVIOR_VALUES.filter(
+          (option) => option.value !== ActionRunBehaviour.ON_PAGE_UNLOAD,
+        ),
+      ],
+      [
+        false,
+        false,
+        RUN_BEHAVIOR_VALUES.filter(
+          (option) =>
+            option.value !== ActionRunBehaviour.AUTOMATIC &&
+            option.value !== ActionRunBehaviour.ON_PAGE_UNLOAD,
+        ),
+      ],
+    ];
+
+    flagsOutputMatrix.forEach(
+      ([isReactiveActionsEnabled, isOnPageUnloadEnabled, expectedOptions]) => {
+        const options = getRunBehaviorOptionsBasedOnFeatureFlags(
+          isReactiveActionsEnabled,
+          isOnPageUnloadEnabled,
+        );
+
+        expect(options).toEqual(expectedOptions);
+      },
+    );
+  });
+});
+
+describe("getDefaultRunBehaviorOptionWhenFeatureFlagIsDisabled", () => {
+  const onPageLoadOption =
+    RUN_BEHAVIOR_VALUES.find(
+      (option) => option.value === ActionRunBehaviour.ON_PAGE_LOAD,
+    ) ?? null;
+  const manualOption =
+    RUN_BEHAVIOR_VALUES.find(
+      (option) => option.value === ActionRunBehaviour.MANUAL,
+    ) ?? null;
+
+  const flagsOutputMatrix: {
+    runBehaviour: ActionRunBehaviourType;
+    isReactiveActionsEnabled: boolean;
+    isOnPageUnloadEnabled: boolean;
+    expectedOption: SelectOptionProps | null;
+  }[] = [
+    {
+      runBehaviour: ActionRunBehaviour.AUTOMATIC,
+      isReactiveActionsEnabled: true,
+      isOnPageUnloadEnabled: true,
+      expectedOption: null,
+    },
+    {
+      runBehaviour: ActionRunBehaviour.AUTOMATIC,
+      isReactiveActionsEnabled: false,
+      isOnPageUnloadEnabled: true,
+      expectedOption: onPageLoadOption,
+    },
+    {
+      runBehaviour: ActionRunBehaviour.AUTOMATIC,
+      isReactiveActionsEnabled: true,
+      isOnPageUnloadEnabled: false,
+      expectedOption: null,
+    },
+    {
+      runBehaviour: ActionRunBehaviour.AUTOMATIC,
+      isReactiveActionsEnabled: false,
+      isOnPageUnloadEnabled: false,
+      expectedOption: onPageLoadOption,
+    },
+    {
+      runBehaviour: ActionRunBehaviour.ON_PAGE_UNLOAD,
+      isReactiveActionsEnabled: true,
+      isOnPageUnloadEnabled: true,
+      expectedOption: null,
+    },
+    {
+      runBehaviour: ActionRunBehaviour.ON_PAGE_UNLOAD,
+      isReactiveActionsEnabled: false,
+      isOnPageUnloadEnabled: true,
+      expectedOption: null,
+    },
+    {
+      runBehaviour: ActionRunBehaviour.ON_PAGE_UNLOAD,
+      isReactiveActionsEnabled: true,
+      isOnPageUnloadEnabled: false,
+      expectedOption: manualOption,
+    },
+    {
+      runBehaviour: ActionRunBehaviour.ON_PAGE_UNLOAD,
+      isReactiveActionsEnabled: false,
+      isOnPageUnloadEnabled: false,
+      expectedOption: manualOption,
+    },
+  ];
+
+  it("should return the correct options", () => {
+    flagsOutputMatrix.forEach(
+      ({
+        expectedOption,
+        isOnPageUnloadEnabled,
+        isReactiveActionsEnabled,
+        runBehaviour,
+      }) => {
+        const option = getDefaultRunBehaviorOptionWhenFeatureFlagIsDisabled(
+          runBehaviour,
+          isReactiveActionsEnabled,
+          isOnPageUnloadEnabled,
+          RUN_BEHAVIOR_VALUES,
+        );
+
+        expect(option).toEqual(expectedOption);
+      },
+    );
+  });
+});

--- a/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/utils.ts
+++ b/app/client/src/pages/Editor/JSEditor/JSEditorToolbar/components/utils.ts
@@ -1,0 +1,47 @@
+import {
+  ActionRunBehaviour,
+  type ActionRunBehaviourType,
+} from "PluginActionEditor/types/PluginActionTypes";
+import { RUN_BEHAVIOR_VALUES } from "constants/AppsmithActionConstants/formConfig/PluginSettings";
+
+import { type SelectOptionProps } from "@appsmith/ads";
+
+export const getRunBehaviorOptionsBasedOnFeatureFlags = (
+  isReactiveActionsEnabled: boolean,
+  isOnPageUnloadEnabled: boolean,
+) =>
+  RUN_BEHAVIOR_VALUES.filter(
+    (option) =>
+      (isReactiveActionsEnabled ||
+        option.value !== ActionRunBehaviour.AUTOMATIC) &&
+      (isOnPageUnloadEnabled ||
+        option.value !== ActionRunBehaviour.ON_PAGE_UNLOAD),
+  ) as SelectOptionProps[];
+
+export const getDefaultRunBehaviorOptionWhenFeatureFlagIsDisabled = (
+  runBehaviour: ActionRunBehaviourType,
+  isReactiveActionsEnabled: boolean,
+  isOnPageUnloadEnabled: boolean,
+  options: SelectOptionProps[],
+): SelectOptionProps | null => {
+  if (
+    runBehaviour === ActionRunBehaviour.AUTOMATIC &&
+    !isReactiveActionsEnabled
+  ) {
+    return (
+      options.find((opt) => opt.value === ActionRunBehaviour.ON_PAGE_LOAD) ??
+      null
+    );
+  }
+
+  if (
+    runBehaviour === ActionRunBehaviour.ON_PAGE_UNLOAD &&
+    !isOnPageUnloadEnabled
+  ) {
+    return (
+      options.find((opt) => opt.value === ActionRunBehaviour.MANUAL) ?? null
+    );
+  }
+
+  return null;
+};


### PR DESCRIPTION

## Description
<ins>Problem</ins>

The action configuration UI lacked support for running actions specifically on page unload, limiting automation and flexibility for users.

<ins>Root cause</ins>

There was no ON_PAGE_UNLOAD option in the ActionRunBehaviour enum or related UI, and feature flag handling for this behavior was missing.

<ins>Solution</ins>

This PR handles the addition of the ON_PAGE_UNLOAD run behavior to the ActionRunBehaviour enum, updates UI and settings to support it, leverages feature flags for dynamic option availability, and adds tests to ensure robust behavior.

Fixes #40995
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.JS"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
