### PR TITLE
feat: enable fetching organizations based on cloud billing status

### DIFF
--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -1022,6 +1022,7 @@ export const ApplictionsMainPage = (props: any) => {
   const organizations = useSelector(getMyOrganizations);
   const isFetchingOrganizations = useSelector(getIsFetchingMyOrganizations);
   const currentOrganizationId = useSelector(activeOrganizationId);
+  const isCloudBillingEnabled = useIsCloudBillingEnabled();
 
   // TODO: Fix this the next time the file is edited
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1044,8 +1045,10 @@ export const ApplictionsMainPage = (props: any) => {
   );
 
   useEffect(() => {
-    dispatch(fetchMyOrganizations());
-  }, []);
+    if (isCloudBillingEnabled) {
+      dispatch(fetchMyOrganizations());
+    }
+  }, [isCloudBillingEnabled]);
 
   useEffect(() => {
     setActiveWorkspaceId(


### PR DESCRIPTION
## Description
Fix failing fetch organizations endpoint when cloud billing is not enabled. 

## Automation

/ok-to-test tags="@tag.Sanity, @tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15819205361>
> Commit: 690015bcb5bc09131c68dfa3e7a360b683824e7e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15819205361&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.Settings`
> Spec:
> <hr>Mon, 23 Jun 2025 09:03:07 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved application behavior by only fetching organizations when cloud billing is enabled, preventing unnecessary data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->