### PR TITLE
fix: Removing a part of code as its not updating the API params dependency correctly in Evaluations

### DIFF
--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -124,15 +124,6 @@ function* syncApiParamsSaga(
         `${currentPath}${paramsString}`,
       ),
     );
-
-    // Also update the action property to ensure the path is updated in the action
-    yield put(
-      setActionProperty({
-        actionId: actionId,
-        propertyName: "actionConfiguration.path",
-        value: `${currentPath}${paramsString}`,
-      }),
-    );
   }
 }
 


### PR DESCRIPTION
## Description

Removing a part of code as its not updating the API params dependency correctly in Evaluations

Fixes [#41021](https://github.com/appsmithorg/appsmith/issues/41021)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15827212934>
> Commit: 0c78c53a95dbdf37c0e157e0cb15fdce9aa6674c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15827212934&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 23 Jun 2025 16:31:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the behavior of the API configuration form to streamline how path and query parameters are handled during autofill. The form now updates the visible path field without triggering additional background updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->