### PR TITLE
fix: Updating the logic for page load action checks to fix reactivity for new bindings

### DIFF
--- a/app/client/src/ce/reducers/uiReducers/editorReducer.tsx
+++ b/app/client/src/ce/reducers/uiReducers/editorReducer.tsx
@@ -38,7 +38,7 @@ export const initialState: EditorReduxState = {
   isPreviewMode: false,
   isProtectedMode: true,
   zoomLevel: 1,
-  onLoadActionExecution: {},
+  onLoadActionExecution: false,
 };
 
 export const handlers = {
@@ -52,7 +52,6 @@ export const handlers = {
       pageWidgetId: undefined,
       pageActions: undefined,
       layoutOnLoadActionErrors: undefined,
-      onLoadActionExecution: undefined,
       loadingStates: {
         ...state.loadingStates,
         saving: false,
@@ -129,20 +128,9 @@ export const handlers = {
     action: ReduxAction<SavePageResponse>,
   ) => {
     const layoutOnLoadActions = action.payload.data.layoutOnLoadActions;
-    const newlyBindedActions: Record<string, boolean> = {};
-
-    layoutOnLoadActions.forEach((actionsPerPage) => {
-      actionsPerPage.forEach((action) => {
-        newlyBindedActions[action.id] = true;
-      });
-    });
 
     state.loadingStates.saving = false;
     state.pageActions = layoutOnLoadActions;
-    state.onLoadActionExecution = {
-      ...state.onLoadActionExecution,
-      ...newlyBindedActions,
-    };
 
     return { ...state };
   },
@@ -175,14 +163,6 @@ export const handlers = {
     state.loadingStates.publishing = false;
     state.loadingStates.publishingError = false;
 
-    const newMap: Record<string, boolean> = {};
-
-    pageActions?.forEach((action) => {
-      if (action.length > 0) {
-        newMap[action[0].id] = false;
-      }
-    });
-
     return {
       ...state,
       currentPageName,
@@ -192,7 +172,6 @@ export const handlers = {
       currentPageId,
       pageActions,
       layoutOnLoadActionErrors,
-      onLoadActionExecution: newMap,
     };
   },
   [ReduxActionTypes.CLONE_PAGE_INIT]: (state: EditorReduxState) => {
@@ -325,14 +304,11 @@ export const handlers = {
   },
   [ReduxActionTypes.SET_ONLOAD_ACTION_EXECUTED]: (
     state: EditorReduxState,
-    action: ReduxAction<{ id: string; isExecuted: boolean }>,
+    action: ReduxAction<boolean>,
   ) => {
     return {
       ...state,
-      onLoadActionExecution: {
-        ...state.onLoadActionExecution,
-        [action.payload.id]: action.payload.isExecuted,
-      },
+      onLoadActionExecution: action.payload,
     };
   },
 };
@@ -354,7 +330,7 @@ export interface EditorReduxState {
   isProtectedMode: boolean;
   zoomLevel: number;
   layoutOnLoadActionErrors?: LayoutOnLoadActionErrors[];
-  onLoadActionExecution?: Record<string, boolean>;
+  onLoadActionExecution?: boolean;
   loadingStates: {
     saving: boolean;
     savingError: boolean;

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -1164,11 +1164,6 @@ function* executePageLoadAction(
       }
     }
 
-    yield put({
-      type: ReduxActionTypes.SET_ONLOAD_ACTION_EXECUTED,
-      payload: { id: pageAction.id, isExecuted: true },
-    });
-
     // open response tab in debugger on exection of action on page load.
     // Only if current page is the page on which the action is executed.
     if (
@@ -1298,6 +1293,11 @@ function* executePageLoadActionsSaga(
         ),
       );
     }
+
+    yield put({
+      type: ReduxActionTypes.SET_ONLOAD_ACTION_EXECUTED,
+      payload: true,
+    });
 
     // We show errors in the debugger once onPageLoad actions
     // are executed

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -358,8 +358,9 @@ export function* executeReactiveQueries(
   const executedActions = new Set<string>();
   const pendingActions = new Set(executeReactiveActions);
 
-  const onLoadActionExecutions: Record<string, string | boolean>[] =
-    yield select(getOnLoadActionsWithExecutionStatus);
+  const onLoadActionExecutions: boolean = yield select(
+    getOnLoadActionsWithExecutionStatus,
+  );
 
   while (pendingActions.size > 0) {
     // Get next action to execute
@@ -432,13 +433,10 @@ export function* executeReactiveQueries(
 
     if (isAction(entity)) {
       const entityConfig = configTree[entityName] as ActionEntityConfig;
-      const onLoadAction = onLoadActionExecutions.find(
-        (action) => action.id == entity.actionId,
-      );
 
       if (
         entityConfig.runBehaviour === ActionRunBehaviour.AUTOMATIC &&
-        onLoadAction?.isExecuted
+        onLoadActionExecutions
       ) {
         yield runSingleAction(entityConfig.actionId);
       }

--- a/app/client/src/selectors/editorSelectors.tsx
+++ b/app/client/src/selectors/editorSelectors.tsx
@@ -130,18 +130,8 @@ export const getLayoutOnLoadIssues = (state: DefaultRootState) => {
   return state.ui.editor.layoutOnLoadActionErrors || [];
 };
 
-export const getOnLoadActionsWithExecutionStatus = createSelector(
-  getLayoutOnLoadActions,
-  (state: DefaultRootState) => state.ui.editor.onLoadActionExecution,
-  (onLoadActions, onLoadActionExecution) => {
-    // onLoadActions is PageAction[][]
-    // Flatten and map to { id, isExecuted }
-    return (onLoadActions.flat() || []).map((action) => ({
-      id: action.id,
-      isExecuted: !!onLoadActionExecution?.[action.id],
-    }));
-  },
-);
+export const getOnLoadActionsWithExecutionStatus = (state: DefaultRootState) =>
+  state.ui.editor.onLoadActionExecution;
 
 export const getIsPublishingApplication = (state: DefaultRootState) =>
   state.ui.editor.loadingStates.publishing;


### PR DESCRIPTION
## Description

Updating the logic for page load action checks to fix reactivity for new bindings

Fixes [#41027](https://github.com/appsmithorg/appsmith/issues/41027)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15846753581>
> Commit: 04caf3892aad8a731267e93c21224f7f9c7c147d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15846753581&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 24 Jun 2025 10:39:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the management of on-load action execution status from tracking multiple actions to a single boolean flag, streamlining related logic and state handling.
- **Bug Fixes**
	- Improved reliability by updating the execution status only after all on-load actions have completed, reducing potential inconsistencies.
- **Performance**
	- Enhanced performance by removing unnecessary mapping and array operations in selectors and sagas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->