### PR TITLE
fix: correct reassignment in CurrencyInputWidget value parsing

### DIFF
--- a/app/client/src/widgets/CurrencyInputWidget/widget/derived.js
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/derived.js
@@ -75,7 +75,7 @@ export default {
     }
 
     if (text) {
-      const parsed = parseFloat(
+      let parsed = parseFloat(
         text
           .replace(new RegExp(`[${getLocaleThousandSeparator()}]`, "g"), "")
           .replace(new RegExp(`[${getLocaleDecimalSeperator()}]`), "."),


### PR DESCRIPTION
## Description
This PR addresses a `TypeError` in the `CurrencyInputWidget`'s `value` derived property. The `parsed` variable, intended to hold the numeric value of the input, was declared with `const` but was then reassigned to `undefined` if the `parseFloat` operation resulted in `NaN`. The fix changes the declaration of `parsed` from `const` to `let`, allowing it to be correctly updated. This ensures that non-numeric or empty inputs that result in `NaN` are properly handled by returning `undefined` without runtime errors.

Fixes #41073.

## Automation

/ok-to-test tags="@tag.Widget, @tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of numeric input in the currency input widget to ensure correct value parsing and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->