### PR TITLE
chore: cache theme value properties, since it is a frequent property

### DIFF
--- a/app/client/src/ce/entities/DataTree/utils.ts
+++ b/app/client/src/ce/entities/DataTree/utils.ts
@@ -84,3 +84,14 @@ export function isWidgetActionOrJsObject(
 ): entity is ActionEntity | WidgetEntity | JSActionEntity {
   return isWidget(entity) || isAction(entity) || isJSAction(entity);
 }
+
+const THEME_PROPERTIES = new Set([
+  "{{appsmith.theme.fontFamily.appFont}}",
+  "{{appsmith.theme.boxShadow.appBoxShadow}}",
+  "{{appsmith.theme.colors.primaryColor}}",
+  "{{appsmith.theme.borderRadius.appBorderRadius}}",
+]);
+
+export function isThemeUnevaluatedValue(value: string): boolean {
+  return THEME_PROPERTIES.has(value);
+}


### PR DESCRIPTION
## Description
Added caching of theme property value since it is a frequent expression, it constitutes 20% of all binding expressions for a large customer app. Expecting a 400ms reduction in LCP for a large customer app.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15880337835>
> Commit: 11fab20fe285aa1b3b59c164179902628d35d97d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15880337835&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 25 Jun 2025 17:45:37 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved performance when evaluating theme-related properties by introducing caching for repeated values.

- **Chores**
  - Added a utility to identify specific theme-related unevaluated values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->