### PR TITLE
chore: remove AWS_ROLE_ARN from deployment workflow and update deploy…

### DIFF
--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -261,7 +261,6 @@ jobs:
 
       - name: Deploy Helm chart
         env:
-          AWS_ROLE_ARN: ${{ secrets.APPSMITH_EKS_AWS_ROLE_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.APPSMITH_CI_AWS_SECRET_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.APPSMITH_CI_AWS_SECRET_ACCESS_KEY }}
           IMAGE_HASH: ${{ needs.push-image.outputs.imageHash }}

--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -16,22 +16,11 @@ export cluster_name=uatx-cluster
 echo "[default]
 region = $region
 output = json
-# [profile eksci]
-# role_arn = $AWS_ROLE_ARN
-# output = json
-# region = $region
-# source_profile = default" > ~/.aws/config
 
 echo "Region: $region"
 echo "Cluster name: $cluster_name"
 echo "Pull Request Number: $PULL_REQUEST_NUMBER"
 echo "DP_EFS_ID: $DP_EFS_ID"
-
-# sts_output="$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name ekscisession)"
-
-# export AWS_ACCESS_KEY_ID="$(echo "$sts_output" | jq -r .Credentials.AccessKeyId)"
-# export AWS_SECRET_ACCESS_KEY="$(echo "$sts_output" | jq -r .Credentials.SecretAccessKey)"
-# export AWS_SESSION_TOKEN="$(echo "$sts_output" | jq -r .Credentials.SessionToken)"
 
 export NAMESPACE="$edition$PULL_REQUEST_NUMBER"
 export CHARTNAME="$edition$PULL_REQUEST_NUMBER"
@@ -117,4 +106,5 @@ helm upgrade -i "$CHARTNAME" "appsmith-ee/$HELMCHART" -n "$NAMESPACE" --create-n
   --set applicationConfig.APPSMITH_CARBON_API_BASE_PATH="$APPSMITH_CARBON_API_BASE_PATH" \
   --set applicationConfig.APPSMITH_AI_SERVER_MANAGED_HOSTING="$APPSMITH_AI_SERVER_MANAGED_HOSTING" \
   --set applicationConfig.IN_DOCKER='$IN_DOCKER' \
-  --set applicationConfig.APPSMITH_CUSTOMER_PORTAL_URL="https://release-customer.appsmith.com"
+  --set applicationConfig.APPSMITH_CUSTOMER_PORTAL_URL="https://release-customer.appsmith.com" \
+  -f dp-node-affinity-values.yaml

--- a/scripts/dp-node-affinity-values.yaml
+++ b/scripts/dp-node-affinity-values.yaml
@@ -1,0 +1,15 @@
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: instance_name
+              operator: In
+              values:
+                - uatx-shared
+
+tolerations:
+  - key: instance_name
+    operator: Equal
+    value: uatx-shared
+    effect: NoSchedule


### PR DESCRIPTION
… script for node affinity

### Changes Made
- Removed `AWS_ROLE_ARN` from the environment variables in the GitHub Actions workflow for deploying the Helm chart.
- Cleaned up the `deploy_preview.sh` script by removing commented-out code related to role assumption.
- Added a new `dp-node-affinity-values.yaml` file to define node affinity and tolerations for deployment.

These changes streamline the deployment process and enhance the configuration for node scheduling.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow and scripts to simplify AWS credential handling.
  - Added a configuration to ensure preview deployments are scheduled only on specific Kubernetes nodes with matching labels and tolerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->