### PR TITLE
fix: Updating the function definition for checking reactive cyclic dependencies

### DIFF
--- a/app/client/src/ce/workers/Evaluation/evaluationUtils.ts
+++ b/app/client/src/ce/workers/Evaluation/evaluationUtils.ts
@@ -413,7 +413,9 @@ export function isAppsmithEntity(
   );
 }
 
-export function isJSAction(entity: DataTreeEntity): entity is JSActionEntity {
+export function isJSAction(
+  entity: Partial<DataTreeEntity>,
+): entity is JSActionEntity {
   return (
     typeof entity === "object" &&
     "ENTITY_TYPE" in entity &&

--- a/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
+++ b/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
@@ -10,6 +10,7 @@ import {
 import type { ConfigTree } from "entities/DataTree/dataTreeTypes";
 import { isPathDynamicTrigger } from "utils/DynamicBindingUtils";
 import { WorkerEnv } from "workers/Evaluation/handlers/workerEnv";
+import { ActionRunBehaviour } from "PluginActionEditor/types/PluginActionTypes";
 
 type SortDependencies =
   | {
@@ -179,13 +180,14 @@ export class DependencyMapUtils {
       if (isJSActionEntity) {
         // Only continue if at least one function is automatic
         const hasAutomaticFunc = Object.values(nodeConfig.meta).some(
-          (jsFunction) => jsFunction.runBehaviour === "AUTOMATIC",
+          (jsFunction) =>
+            jsFunction.runBehaviour === ActionRunBehaviour.AUTOMATIC,
         );
 
         if (!hasAutomaticFunc) continue;
       } else if (isActionEntity) {
         // Only continue if runBehaviour is AUTOMATIC
-        if (nodeConfig.runBehaviour !== "AUTOMATIC") continue;
+        if (nodeConfig.runBehaviour !== ActionRunBehaviour.AUTOMATIC) continue;
       } else {
         // If not a JSAction, or Action, skip
         continue;

--- a/app/client/src/entities/DependencyMap/__tests__/DependencyMapUtils.test.ts
+++ b/app/client/src/entities/DependencyMap/__tests__/DependencyMapUtils.test.ts
@@ -1,80 +1,133 @@
 import DependencyMap from "../index";
 import { DependencyMapUtils } from "../DependencyMapUtils";
-import type { ConfigTree } from "entities/DataTree/dataTreeTypes";
 import { PluginType } from "entities/Plugin";
+import {
+  ENTITY_TYPE,
+  type DataTreeEntityConfig,
+  type MetaArgs,
+} from "ee/entities/DataTree/types";
+import type { ActionRunBehaviourType } from "PluginActionEditor/types/PluginActionTypes";
 
 describe("detectReactiveDependencyMisuse", () => {
-  function makeConfigTreeWithAction(entityName: string): ConfigTree {
+  function makeConfigTreeWithAction(
+    entityName: string,
+    runBehaviour: ActionRunBehaviourType = "AUTOMATIC",
+  ): DataTreeEntityConfig {
     return {
-      [entityName]: {
-        ENTITY_TYPE: "ACTION",
-        dynamicTriggerPathList: [{ key: "run" }],
-        dynamicBindingPathList: [],
-        bindingPaths: {},
-        reactivePaths: {},
-        dependencyMap: {},
-        logBlackList: {},
-        pluginType: PluginType.API,
-        pluginId: "mockPluginId",
-        actionId: "mockActionId",
-        name: entityName,
-        runBehaviour: "MANUAL",
-      },
+      ENTITY_TYPE: ENTITY_TYPE.ACTION,
+      dynamicTriggerPathList: [{ key: "run" }],
+      dynamicBindingPathList: [],
+      bindingPaths: {},
+      reactivePaths: {},
+      dependencyMap: {},
+      logBlackList: {},
+      pluginType: PluginType.API,
+      pluginId: "mockPluginId",
+      actionId: "mockActionId",
+      name: entityName,
+      runBehaviour,
     };
   }
 
-  it("throws if a node depends on both .run and .data of the same ACTION entity - scenario 1", () => {
+  function makeConfigTreeWithJSAction(
+    entityName: string,
+    meta: Record<string, MetaArgs> = {},
+  ): DataTreeEntityConfig {
+    return {
+      ENTITY_TYPE: ENTITY_TYPE.JSACTION,
+      meta,
+      dynamicBindingPathList: [],
+      actionNames: new Set(["myFun1", "myFun2"]),
+      bindingPaths: {},
+      reactivePaths: {},
+      dependencyMap: {},
+      pluginType: PluginType.JS,
+      name: entityName,
+      actionId: "mockJSActionId",
+      dynamicTriggerPathList: [],
+      variables: [],
+    };
+  }
+
+  function makeConfigTreeWithWidget(entityName: string): DataTreeEntityConfig {
+    return {
+      ENTITY_TYPE: ENTITY_TYPE.WIDGET,
+      bindingPaths: {},
+      reactivePaths: {},
+      triggerPaths: {},
+      validationPaths: {},
+      logBlackList: {},
+      propertyOverrideDependency: {},
+      overridingPropertyPaths: {},
+      privateWidgets: {},
+      widgetId: "mockWidgetId",
+      defaultMetaProps: [],
+      type: "MOCK_WIDGET_TYPE",
+      dynamicBindingPathList: [],
+      name: entityName,
+    };
+  }
+
+  it("does not throw for Widget entity", () => {
     const dependencyMap = new DependencyMap();
 
-    // Add nodes
     dependencyMap.addNodes({
-      "JSObject1.myFun1": true,
-      "Query1.run": true,
-      "Query1.data": true,
+      Widget1: true,
+      "Widget1.run": true,
+      "Widget1.data": true,
     });
-    // JSObject1.myFun1 depends on both Query1.run and Query1.data
-    dependencyMap.addDependency("JSObject1.myFun1", [
-      "Query1.run",
-      "Query1.data",
-    ]);
+    dependencyMap.addDependency("Widget1", ["Widget1.run", "Widget1.data"]);
+    const configTree = {
+      Widget1: makeConfigTreeWithWidget("Widget1"),
+    };
 
-    const configTree = makeConfigTreeWithAction("Query1");
-
-    // Should throw
     expect(() => {
       DependencyMapUtils.detectReactiveDependencyMisuse(
         dependencyMap,
         configTree,
       );
-    }).toThrow(/Reactive dependency misuse/);
-  });
-
-  it("does not throw if a node depends only on .run or only on .data", () => {
-    const configTree = makeConfigTreeWithAction("Api1");
-
-    // Only .run
-    const depMapRun = new DependencyMap();
-
-    depMapRun.addNodes({ "JSObject1.myFun1": true, "Api1.run": true });
-    depMapRun.addDependency("JSObject1.myFun1", ["Api1.run"]);
-    expect(() => {
-      DependencyMapUtils.detectReactiveDependencyMisuse(depMapRun, configTree);
-    }).not.toThrow();
-
-    // Only .data
-    const depMapData = new DependencyMap();
-
-    depMapData.addNodes({ "JSObject2.myFun1": true, "Api1.data": true });
-    depMapData.addDependency("JSObject2.myFun1", ["Api1.data"]);
-    expect(() => {
-      DependencyMapUtils.detectReactiveDependencyMisuse(depMapData, configTree);
     }).not.toThrow();
   });
 
-  it("throws if a node depends on both .run and .data of the same ACTION entity via transitive dependency - scenario 2", () => {
+  it("does not throw for MANUAL ACTION entity", () => {
     const dependencyMap = new DependencyMap();
 
-    // Add nodes
+    dependencyMap.addNodes({
+      "JSObject1.myFun1": true,
+      "Query3.run": true,
+      "Query3.data": true,
+    });
+    dependencyMap.addDependency("JSObject1.myFun1", [
+      "Query3.run",
+      "Query3.data",
+    ]);
+    const configTree = {
+      Query3: makeConfigTreeWithAction("Query3", "MANUAL"),
+      JSObject1: makeConfigTreeWithJSAction("JSObject1", {
+        myFun1: {
+          runBehaviour: "MANUAL",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          runBehaviour: "MANUAL",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+      }),
+    };
+
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(
+        dependencyMap,
+        configTree,
+      );
+    }).not.toThrow();
+  });
+
+  it("does not throw for JSAction entity with no AUTOMATIC function", () => {
+    const dependencyMap = new DependencyMap();
+
     dependencyMap.addNodes({
       "JSObject1.myFun1": true,
       "JSObject1.myFun2": true,
@@ -89,9 +142,191 @@ describe("detectReactiveDependencyMisuse", () => {
       "Query2.data",
     ]);
 
-    const configTree = makeConfigTreeWithAction("Query2");
+    // meta has no AUTOMATIC runBehaviour
+    const configTree = {
+      JSObject1: makeConfigTreeWithJSAction("JSObject1", {
+        myFun1: {
+          runBehaviour: "MANUAL",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          runBehaviour: "MANUAL",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+      }),
+      Query2: makeConfigTreeWithAction("Query2", "AUTOMATIC"),
+    };
 
-    // Should throw
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(
+        dependencyMap,
+        configTree,
+      );
+    }).not.toThrow();
+  });
+
+  it("does not throw if a node depends only on .run or only on .data for AUTOMATIC ACTION", () => {
+    const configTree = {
+      Api1: makeConfigTreeWithAction("Api1", "AUTOMATIC"),
+      JSObject1: makeConfigTreeWithJSAction("JSObject1", {
+        myFun1: {
+          runBehaviour: "AUTOMATIC",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          runBehaviour: "AUTOMATIC",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+      }),
+      JSObject2: makeConfigTreeWithJSAction("JSObject2", {
+        myFun1: {
+          runBehaviour: "AUTOMATIC",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          runBehaviour: "AUTOMATIC",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+      }),
+    };
+
+    // Only .run
+    const depMapRun = new DependencyMap();
+
+    depMapRun.addNodes({ "JSObject1.myFun1": true, "Api1.run": true });
+    depMapRun.addDependency("JSObject1.myFun1", ["Api1.run"]);
+
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(depMapRun, configTree);
+    }).not.toThrow();
+
+    // Only .data
+    const depMapData = new DependencyMap();
+
+    depMapData.addNodes({ "JSObject2.myFun1": true, "Api1.data": true });
+    depMapData.addDependency("JSObject2.myFun1", ["Api1.data"]);
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(depMapData, configTree);
+    }).not.toThrow();
+  });
+
+  it("throws if a node depends on both .run and .data of the same AUTOMATIC ACTION entity", () => {
+    const dependencyMap = new DependencyMap();
+
+    // Add nodes
+    dependencyMap.addNodes({
+      "JSObject1.myFun1": true,
+      "Query1.run": true,
+      "Query1.data": true,
+    });
+    // JSObject1.myFun1 depends on both Query1.run and Query1.data
+    dependencyMap.addDependency("JSObject1.myFun1", [
+      "Query1.run",
+      "Query1.data",
+    ]);
+    const configTree = {
+      JSObject1: makeConfigTreeWithJSAction("JSObject1", {
+        myFun1: {
+          runBehaviour: "AUTOMATIC",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          runBehaviour: "MANUAL",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+      }),
+      Query1: makeConfigTreeWithAction("Query1", "AUTOMATIC"),
+    };
+
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(
+        dependencyMap,
+        configTree,
+      );
+    }).toThrow(/Reactive dependency misuse/);
+  });
+
+  it("throws if a node depends on both .run and .data of the same AUTOMATIC ACTION entity via transitive dependency", () => {
+    const dependencyMap = new DependencyMap();
+
+    dependencyMap.addNodes({
+      "JSObject1.myFun1": true,
+      "JSObject1.myFun2": true,
+      "Query2.run": true,
+      "Query2.data": true,
+    });
+    // JSObject1.myFun2 depends on Query2.run
+    dependencyMap.addDependency("JSObject1.myFun2", ["Query2.run"]);
+    // JSObject1.myFun1 depends on both JSObject1.myFun2 and and Query2.data (transitive)
+    dependencyMap.addDependency("JSObject1.myFun1", [
+      "JSObject1.myFun2",
+      "Query2.data",
+    ]);
+    const configTree = {
+      Query2: makeConfigTreeWithAction("Query2", "AUTOMATIC"),
+      JSObject1: makeConfigTreeWithJSAction("JSObject1", {
+        myFun1: {
+          runBehaviour: "AUTOMATIC",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          runBehaviour: "MANUAL",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+      }),
+    };
+
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(
+        dependencyMap,
+        configTree,
+      );
+    }).toThrow(/Reactive dependency misuse/);
+  });
+
+  it("throws for JSAction entity with at least one AUTOMATIC function", () => {
+    // meta has one AUTOMATIC runBehaviour
+    const dependencyMap = new DependencyMap();
+
+    dependencyMap.addNodes({
+      "JSObject1.myFun1": true,
+      "JSObject1.myFun2": true,
+      "Query2.run": true,
+      "Query2.data": true,
+    });
+    // JSObject1.myFun2 depends on Query2.run
+    dependencyMap.addDependency("JSObject1.myFun2", ["Query2.run"]);
+    // JSObject1.myFun1 depends on both JSObject1.myFun2 and and Query2.data (transitive)
+    dependencyMap.addDependency("JSObject1.myFun1", [
+      "JSObject1.myFun2",
+      "Query2.data",
+    ]);
+    const configTree = {
+      JSObject1: makeConfigTreeWithJSAction("JSObject1", {
+        myFun1: {
+          runBehaviour: "AUTOMATIC",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          runBehaviour: "MANUAL",
+          arguments: [],
+          confirmBeforeExecute: false,
+        },
+      }),
+      Query2: makeConfigTreeWithAction("Query2", "MANUAL"),
+    };
+
     expect(() => {
       DependencyMapUtils.detectReactiveDependencyMisuse(
         dependencyMap,

--- a/app/client/src/entities/DependencyMap/__tests__/DependencyMapUtils.test.ts
+++ b/app/client/src/entities/DependencyMap/__tests__/DependencyMapUtils.test.ts
@@ -1,0 +1,102 @@
+import DependencyMap from "../index";
+import { DependencyMapUtils } from "../DependencyMapUtils";
+import type { ConfigTree } from "entities/DataTree/dataTreeTypes";
+import { PluginType } from "entities/Plugin";
+
+describe("detectReactiveDependencyMisuse", () => {
+  function makeConfigTreeWithAction(entityName: string): ConfigTree {
+    return {
+      [entityName]: {
+        ENTITY_TYPE: "ACTION",
+        dynamicTriggerPathList: [{ key: "run" }],
+        dynamicBindingPathList: [],
+        bindingPaths: {},
+        reactivePaths: {},
+        dependencyMap: {},
+        logBlackList: {},
+        pluginType: PluginType.API,
+        pluginId: "mockPluginId",
+        actionId: "mockActionId",
+        name: entityName,
+        runBehaviour: "MANUAL",
+      },
+    };
+  }
+
+  it("throws if a node depends on both .run and .data of the same ACTION entity - scenario 1", () => {
+    const dependencyMap = new DependencyMap();
+
+    // Add nodes
+    dependencyMap.addNodes({
+      "JSObject1.myFun1": true,
+      "Query1.run": true,
+      "Query1.data": true,
+    });
+    // JSObject1.myFun1 depends on both Query1.run and Query1.data
+    dependencyMap.addDependency("JSObject1.myFun1", [
+      "Query1.run",
+      "Query1.data",
+    ]);
+
+    const configTree = makeConfigTreeWithAction("Query1");
+
+    // Should throw
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(
+        dependencyMap,
+        configTree,
+      );
+    }).toThrow(/Reactive dependency misuse/);
+  });
+
+  it("does not throw if a node depends only on .run or only on .data", () => {
+    const configTree = makeConfigTreeWithAction("Api1");
+
+    // Only .run
+    const depMapRun = new DependencyMap();
+
+    depMapRun.addNodes({ "JSObject1.myFun1": true, "Api1.run": true });
+    depMapRun.addDependency("JSObject1.myFun1", ["Api1.run"]);
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(depMapRun, configTree);
+    }).not.toThrow();
+
+    // Only .data
+    const depMapData = new DependencyMap();
+
+    depMapData.addNodes({ "JSObject2.myFun1": true, "Api1.data": true });
+    depMapData.addDependency("JSObject2.myFun1", ["Api1.data"]);
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(depMapData, configTree);
+    }).not.toThrow();
+  });
+
+  it("throws if a node depends on both .run and .data of the same ACTION entity via transitive dependency - scenario 2", () => {
+    const dependencyMap = new DependencyMap();
+
+    // Add nodes
+    dependencyMap.addNodes({
+      "JSObject1.myFun1": true,
+      "JSObject1.myFun2": true,
+      "Query2.run": true,
+      "Query2.data": true,
+    });
+    // JSObject1.myFun2 depends on Query2.run
+    dependencyMap.addDependency("JSObject1.myFun2", ["Query2.run"]);
+    // JSObject1.myFun1 depends on both JSObject1.myFun2 and and Query2.data (transitive)
+    dependencyMap.addDependency("JSObject1.myFun1", [
+      "JSObject1.myFun2",
+      "Query2.data",
+    ]);
+
+    const configTree = makeConfigTreeWithAction("Query2");
+
+    // Should throw
+    expect(() => {
+      DependencyMapUtils.detectReactiveDependencyMisuse(
+        dependencyMap,
+        configTree,
+      );
+    }).toThrow(/Reactive dependency misuse/);
+  });
+});


### PR DESCRIPTION
## Description

Updating the function definition for checking reactive cyclic dependencies to throw an error in all such scenarios and block multiple execute API calls.

Fixes [#41048](https://github.com/appsmithorg/appsmith/issues/41048)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15919295485>
> Commit: 05c9f6481e464dc802b2b556a0eba48c66cc3030
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15919295485&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 27 Jun 2025 07:06:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for detecting reactive dependency misuse, resulting in clearer and more efficient checks.
  * Updated type handling to support partial entities in action detection.

* **New Features**
  * Enhanced detection of conflicting trigger and data paths within dependencies, providing immediate feedback when misuse is found.
  * Introduced a feature flag to control reactive dependency misuse detection.

* **Tests**
  * Added comprehensive tests to validate detection of reactive dependency misuse in various direct and transitive dependency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->