### PR TITLE
feat: exclude app.appsmith.com from recent domains tracking

### DIFF
--- a/app/client/src/utils/multiOrgDomains.ts
+++ b/app/client/src/utils/multiOrgDomains.ts
@@ -16,6 +16,7 @@ function isValidAppsmithDomain(domain: string): boolean {
     domain.endsWith(".appsmith.com") &&
     !domain.startsWith("login.") &&
     !domain.startsWith("release.") &&
+    !domain.startsWith("app.") &&
     !domain.startsWith("dev.")
   );
 }


### PR DESCRIPTION
## Summary
Adds filtering to exclude domains starting with "app." from the recent domains tracking functionality.

## Changes
- Updated `isValidAppsmithDomain()` function to exclude domains that start with "app."
- This prevents domains like `app.appsmith.com` from being tracked and stored in recent domains

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/15966291652>
> Commit: b7f9bfa93b84592c5d2526410270799f5c44a9cd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=15966291652&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 30 Jun 2025 07:53:35 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain validation to exclude domains starting with "app." from being recognized as valid Appsmith domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->