### PR TITLE
fix: ignore firestore option.

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -933,6 +933,10 @@ public class FirestorePlugin extends BasePlugin {
                     .onErrorMap(Exceptions::unwrap)
                     .map(options -> {
                         try {
+                            if(options != null) {
+                                return FirebaseApp.initializeApp(options, projectId);
+
+                            }
                             return FirebaseApp.getInstance(projectId);
                         } catch (IllegalStateException e) {
                             return FirebaseApp.initializeApp(options, projectId);


### PR DESCRIPTION
## Description

Fixes [#38121](https://github.com/appsmithorg/appsmith/issues/38121)

I don't know It needs more test case because testcases already use DatabaseUrl.

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when connecting to Firestore by ensuring the app does not attempt to initialize with invalid configuration options. This reduces the likelihood of errors during datasource creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->