### PR TITLE
fix: Enable Roles and Groups Display on Cloud Instances

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCE.java
@@ -5,6 +5,5 @@ import com.appsmith.server.dtos.UserProfileDTO;
 import reactor.core.publisher.Mono;
 
 public interface PACConfigurationServiceCE {
-    Mono<UserProfileDTO> setRolesAndGroups(
-            UserProfileDTO profile, User user, boolean showUsersAndGroups, boolean isCloudHosting);
+    Mono<UserProfileDTO> setRolesAndGroups(UserProfileDTO profile, User user, boolean showUsersAndGroups);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PACConfigurationServiceCEImpl.java
@@ -12,8 +12,7 @@ import static com.appsmith.server.constants.ce.AccessControlConstantsCE.UPGRADE_
 @Service
 public class PACConfigurationServiceCEImpl implements PACConfigurationServiceCE {
     @Override
-    public Mono<UserProfileDTO> setRolesAndGroups(
-            UserProfileDTO profile, User user, boolean showUsersAndGroups, boolean isCloudHosting) {
+    public Mono<UserProfileDTO> setRolesAndGroups(UserProfileDTO profile, User user, boolean showUsersAndGroups) {
         profile.setRoles(
                 List.of(UPGRADE_TO_BUSINESS_EDITION_TO_ACCESS_ROLES_AND_GROUPS_FOR_CONDITIONAL_BUSINESS_LOGIC));
         profile.setGroups(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -775,8 +775,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                             commonConfig.isCloudHosting() ? true : userData.isIntercomConsentGiven());
                     profile.setSuperUser(isSuperUser);
                     profile.setConfigurable(!StringUtils.isEmpty(commonConfig.getEnvFilePath()));
-                    return pacConfigurationService.setRolesAndGroups(
-                            profile, userFromDb, true, commonConfig.isCloudHosting());
+                    return pacConfigurationService.setRolesAndGroups(profile, userFromDb, true);
                 });
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/PACConfigurationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/PACConfigurationServiceCETest.java
@@ -22,7 +22,7 @@ class PACConfigurationServiceCETest {
     public void test_setRolesAndGroups_featureFlagDisabled() {
         UserProfileDTO userProfileDTO = new UserProfileDTO();
         Mono<UserProfileDTO> userProfileDTOMono =
-                pacConfigurationService.setRolesAndGroups(userProfileDTO, null, false, false);
+                pacConfigurationService.setRolesAndGroups(userProfileDTO, null, false);
         StepVerifier.create(userProfileDTOMono)
                 .assertNext(userProfileDTO1 -> {
                     assertThat(userProfileDTO1.getRoles())


### PR DESCRIPTION
## Description
This PR removes the cloud hosting restriction for displaying user roles and groups in the PAC (Programatic Access Control) Configuration Service. With the introduction of paid features on Appsmith Cloud, users should now be able to view their roles and groups regardless of hosting type.

/test Settings

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16002744334>
> Commit: c62921a3f19a29e3afd2a0562b7a9a87b4a92b0e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16002744334&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Tue, 01 Jul 2025 15:09:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified user role and group assignment logic to streamline internal processes. No changes to visible features or behavior for end-users.
* **Tests**
  * Updated related tests to align with the streamlined logic. No impact on test outcomes or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->