### PR TITLE
feat: add registry override support for init containers

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -65,7 +65,8 @@ spec:
       {{- if ((.Values.initContainer.redis).image) }}
         image: {{ .Values.initContainer.redis.image }}
       {{- else }}
-        image: "docker.io/redis:7.0.15"
+        {{- $redisImage := .Values.initContainer.redis | default dict }}
+        image: {{ dig "registry" "docker.io" $redisImage }}/{{ dig "repository" "redis" $redisImage }}:{{ dig "tag" "7.0.15" $redisImage }}
       {{- end }}
         command: ['sh', '-c', "until redis-cli -h {{.Release.Name}}-redis-master.{{.Release.Namespace}}.svc.cluster.local ping ; do echo waiting for redis; sleep 2; done"]
       {{- end }}
@@ -74,7 +75,8 @@ spec:
       {{- if ((.Values.initContainer.mongodb).image) }}
         image: {{ .Values.initContainer.mongodb.image }}
       {{- else }}
-        image:  "docker.io/bitnami/mongodb:6.0.13"
+        {{- $mongoImage := .Values.initContainer.mongodb | default dict }}
+        image: {{ dig "registry" "docker.io" $mongoImage }}/{{ dig "repository" "bitnami/mongodb" $mongoImage }}:{{ dig "tag" "6.0.13" $mongoImage }}
       {{- end }}
         command: ['sh', '-c', "until mongosh --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
       {{- end }}
@@ -83,7 +85,8 @@ spec:
       {{- if ((.Values.initContainer.postgresql).image) }}
         image: {{ .Values.initContainer.postgresql.image }}
       {{- else}}
-        image: docker.io/bitnami/postgresql:14.5.0-debian-11-r21
+        {{- $postgresImage := .Values.initContainer.postgresql | default dict }}
+        image: {{ dig "registry" "docker.io" $postgresImage }}/{{ dig "repository" "bitnami/postgresql" $postgresImage }}:{{ dig "tag" "14.5.0-debian-11-r21" $postgresImage }}
       {{- end}}
         command: ['sh', '-c', "until pg_isready -U $postgresuser -d $postgresdb -h {{.Release.Name}}-postgresql.{{.Release.Namespace}}.svc.cluster.local; do echo waiting for postgresql; sleep 2; done"]
       {{- end }}
@@ -171,7 +174,7 @@ spec:
       volumes:
       {{- if .Values.customCAcert }}
       - name: ca-cert
-        configMap: 
+        configMap:
           name: {{ $releaseName }}-trustedca
           items:
           {{- range $key, $value := .Values.customCAcert }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -121,11 +121,20 @@ strategyType: RollingUpdate
 ##
 initContainer: {}
   # redis:
-  #   image: docker.io/redis:7.0.15
+  #   image: docker.io/redis:7.0.15  # Full image override (legacy)
+  #   registry: docker.io            # Registry override
+  #   repository: redis              # Repository override
+  #   tag: 7.0.15                   # Tag override
   # mongodb:
-  #   image:  docker.io/bitnami/mongodb:5.0.21-debian-11-r5
+  #   image: docker.io/bitnami/mongodb:6.0.13  # Full image override (legacy)
+  #   registry: docker.io                      # Registry override
+  #   repository: bitnami/mongodb              # Repository override
+  #   tag: 6.0.13                             # Tag override
   # postgresql:
-  #   image: docker.io/bitnami/postgresql:14.5.0-debian-11-r21
+  #   image: docker.io/bitnami/postgresql:14.5.0-debian-11-r21  # Full image override (legacy)
+  #   registry: docker.io                                        # Registry override
+  #   repository: bitnami/postgresql                             # Repository override
+  #   tag: 14.5.0-debian-11-r21                                 # Tag override
 ## Image
 ##
 image:


### PR DESCRIPTION
Adds registry override support for init containers in the Helm chart. Previously, init containers (redis, mongodb, postgresql) only supported full image path overrides. This change allows granular control over registry, repository, and tag components separately.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved flexibility for specifying default images of init containers (Redis, MongoDB, PostgreSQL) in Helm deployments.

* **Documentation**
  * Enhanced example configurations in the values file to show more granular image override options for init containers, including separate registry, repository, and tag fields.
  * Updated example image tags for MongoDB to a newer version in comments.

* **Style**
  * Minor formatting fix in the deployment template for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->