### PR TITLE
chore: UI module instance generation placeholder on page load and change

### DIFF
--- a/app/client/src/ce/sagas/PageSagas.tsx
+++ b/app/client/src/ce/sagas/PageSagas.tsx
@@ -149,12 +149,14 @@ import {
   selectGitApplicationCurrentBranch,
 } from "selectors/gitModSelectors";
 import { appsmithTelemetry } from "instrumentation";
-import { getLayoutSavePayload } from "ee/sagas/helpers";
+import {
+  getLayoutSavePayload,
+  generateUIModuleInstanceSaga,
+} from "ee/sagas/helpers";
 import { apiFailureResponseInterceptor } from "api/interceptors/response";
 import type { AxiosError } from "axios";
 import { handleFetchApplicationError } from "./ApplicationSagas";
 import { getCurrentUser } from "actions/authActions";
-import { generateUIModuleInstanceSaga } from "ee/sagas/moduleInterfaceSaga";
 
 export interface HandleWidgetNameUpdatePayload {
   newName: string;

--- a/app/client/src/ce/sagas/helpers.ts
+++ b/app/client/src/ce/sagas/helpers.ts
@@ -110,3 +110,6 @@ export function* getLayoutSavePayload(
     dsl: nestedDSL,
   };
 }
+
+// This is a placeholder saga and is extended in EE
+export function* generateUIModuleInstanceSaga() {}

--- a/app/client/src/ce/sagas/moduleInterfaceSagas.ts
+++ b/app/client/src/ce/sagas/moduleInterfaceSagas.ts
@@ -35,3 +35,6 @@ export function* handleUIModuleWidgetReplay(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   widgets: CanvasWidgetsReduxState,
 ) {}
+
+// This is a placeholder saga and is extended in EE
+export function* generateUIModuleInstanceSaga() {}

--- a/app/client/src/ce/sagas/moduleInterfaceSagas.ts
+++ b/app/client/src/ce/sagas/moduleInterfaceSagas.ts
@@ -35,6 +35,3 @@ export function* handleUIModuleWidgetReplay(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   widgets: CanvasWidgetsReduxState,
 ) {}
-
-// This is a placeholder saga and is extended in EE
-export function* generateUIModuleInstanceSaga() {}


### PR DESCRIPTION
## Description
This PR adds a placeholder saga to be called in page change or page load operation of app to generate UI module instance. This is extended in EE

PR for https://github.com/appsmithorg/appsmith-ee/pull/7928

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16070475917>
> Commit: 5fcbf3bf5d9be4ad503e5460a4743061acfd908c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16070475917&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 04 Jul 2025 11:03:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of UI module instances when switching pages in both edit and view modes, ensuring a smoother user experience during page transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->