### PR TITLE
fix: Adding an additional check to show correct cyclic dependency errors in the Reactive flow

### DIFF
--- a/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
+++ b/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
@@ -215,7 +215,11 @@ export class DependencyMapUtils {
           dataPath = dep;
         }
 
-        if (hasRun && hasData) {
+        if (
+          hasRun &&
+          hasData &&
+          runPath.split(".")[0] === dataPath.split(".")[0]
+        ) {
           throw Object.assign(
             new Error(
               `Reactive dependency misuse: '${node}' depends on both trigger path '${runPath}' and data path '${dataPath}' from the same entity. This can cause unexpected reactivity.`,

--- a/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
+++ b/app/client/src/entities/DependencyMap/DependencyMapUtils.ts
@@ -202,6 +202,7 @@ export class DependencyMapUtils {
       const transitiveDeps = this.getAllTransitiveDependencies(
         dependencyMap,
         node,
+        configTree,
       );
 
       for (const dep of transitiveDeps) {
@@ -237,11 +238,21 @@ export class DependencyMapUtils {
   static getAllTransitiveDependencies(
     dependencyMap: DependencyMap,
     node: string,
+    configTree: ConfigTree,
   ): string[] {
     const dependencies = dependencyMap.rawDependencies;
     const visited = new Set<string>();
 
     function traverse(current: string) {
+      const { entityName } = getEntityNameAndPropertyPath(current);
+      const entityConfig = configTree[entityName];
+
+      if (!entityConfig) return;
+
+      if (!isActionConfig(entityConfig) && !isJSActionConfig(entityConfig)) {
+        return;
+      }
+
       const directDeps = dependencies.get(current) || new Set<string>();
 
       for (const dep of directDeps) {


### PR DESCRIPTION
## Description

Adding an additional check to show correct cyclic dependency errors in the Reactive flow

Fixes [#41070](https://github.com/appsmithorg/appsmith/issues/41070)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16123657082>
> Commit: 278e7c45f85de419ac53cfb07ec8fbffa4741316
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16123657082&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 07 Jul 2025 18:39:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection for reactive dependency misuse, ensuring errors are only raised when trigger and data paths originate from the same entity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->