### PR TITLE
fix: add missing check for organization data in form login command

### DIFF
--- a/app/client/packages/rts/src/ctl/enable_form_login.ts
+++ b/app/client/packages/rts/src/ctl/enable_form_login.ts
@@ -32,6 +32,7 @@ export async function run() {
     ]);
 
     const orgData = JSON.parse(orgCheckResult);
+
     if (!orgData || !orgData._id) {
       throw new Error("Organization with slug 'default' not found in database");
     }

--- a/app/client/packages/rts/src/ctl/utils.ts
+++ b/app/client/packages/rts/src/ctl/utils.ts
@@ -3,7 +3,6 @@ import * as Constants from "./constants";
 import childProcess from "child_process";
 import fs from "node:fs";
 import { ConnectionString } from "mongodb-connection-string-url";
-import { parse } from "acorn";
 
 export function showHelp() {
   console.log(
@@ -44,17 +43,19 @@ export function parseRedisUrl(redisUrlObject) {
   if (redisUrlObject && redisUrlObject !== "undefined") {
     try {
       const redisUrl = new URL(redisUrlObject);
+
       return redisUrl.hostname;
     } catch (err) {
       console.error("Error parsing redis URL:", err);
     }
   }
+
   return null;
 }
 
 export function getRedisUrl() {
-  let redisUrl = null;
-  let redisUrlObject = process.env.APPSMITH_REDIS_URL;
+  const redisUrlObject = process.env.APPSMITH_REDIS_URL;
+
   // Make sure redisUrl takes precedence over process.env.APPSMITH_REDIS_URL
   if (redisUrlObject && redisUrlObject !== "undefined") {
     try {
@@ -63,6 +64,7 @@ export function getRedisUrl() {
       console.error("Error parsing redis URL from environment variable:", err);
     }
   }
+
   // If environment variable APPSMITH_REDIS_URL is not set, read from the environment file
   try {
     const env_array = fs
@@ -75,13 +77,15 @@ export function getRedisUrl() {
         const redisUrl = parseRedisUrl(
           env_array[i].toString().split("=")[1].trim(),
         );
-        break;
+
+        return redisUrl;
       }
     }
   } catch (err) {
     console.error("Error reading the environment file:", err);
   }
-  return redisUrl;
+
+  return null;
 }
 
 export function getDburl() {


### PR DESCRIPTION
Added a check to ensure that the organization data retrieved during the form login enablement process is valid. This prevents potential errors when the organization with the specified slug is not found in the database.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
