### PR TITLE
feat: add multi-org support to signup redirect helpers

### DIFF
--- a/app/client/src/ce/utils/signupHelpers.ts
+++ b/app/client/src/ce/utils/signupHelpers.ts
@@ -24,6 +24,7 @@ export interface RedirectUserAfterSignupProps {
   validLicense?: boolean;
   dispatch: Dispatch;
   isAiAgentInstanceEnabled: boolean;
+  isMultiOrgEnabled?: boolean;
   isOnLoginPage: boolean;
 }
 


### PR DESCRIPTION
## Description
Added `isMultiOrgEnabled` property to the `RedirectUserAfterSignupProps` interface to support multi-organization functionality in the signup redirect flow.

## Changes
- Added optional `isMultiOrgEnabled?: boolean` property to `RedirectUserAfterSignupProps` interface in `app/client/src/ce/utils/signupHelpers.ts`

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16159330322>
> Commit: f3e264df4248cfdd3d4b8e766ecbdef0f11b4c78
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16159330322&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 09 Jul 2025 03:53:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
