### PR TITLE
fix: fixed the upcoming integrations display logic

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx
@@ -43,14 +43,27 @@ export default function EmptySearchedPlugins({
       FEATURE_FLAG.release_external_saas_plugins_enabled,
     ),
   );
-  const isIntegrationsEnabledForPaid = useSelector((state) =>
+  const isLicenseExternalSaasEnabled = useSelector((state) =>
     selectFeatureFlagCheck(
       state,
       FEATURE_FLAG.license_external_saas_plugins_enabled,
     ),
   );
 
+  // We are using this feature flag to identify whether its the enterprise/business user
+  const isGACEnabled = useSelector((state) =>
+    selectFeatureFlagCheck(state, FEATURE_FLAG.license_gac_enabled),
+  );
+
   const pluginNames = plugins.map((plugin) => plugin.name.toLocaleLowerCase());
+
+  // Logic for EXTERNAL_SAAS integrations:
+  // These integrations are only available for business and enterprise instances.
+  // For non business/enterprise instances (GAC disabled): show Premium tag (regardless of flag values)
+  // For business/enterprise instances (GAC enabled): show in upcoming section when either release OR license flag is true
+  const shouldShowIntegrations = isGACEnabled
+    ? isExternalSaasEnabled || isLicenseExternalSaasEnabled
+    : true;
 
   const searchedItems =
     filterSearch(
@@ -59,7 +72,7 @@ export default function EmptySearchedPlugins({
         { name: createMessage(CREATE_NEW_DATASOURCE_AUTHENTICATED_REST_API) },
         ...mockDatasources,
         ...getFilteredUpcomingIntegrations(
-          isExternalSaasEnabled || isIntegrationsEnabledForPaid,
+          shouldShowIntegrations,
           pluginNames,
           upcomingPlugins,
         ),

--- a/app/client/src/pages/Editor/IntegrationEditor/PremiumDatasources/index.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/PremiumDatasources/index.tsx
@@ -41,6 +41,9 @@ export default function PremiumDatasources(props: {
     }
   };
 
+  // Show Premium tag only when NOT in the upcoming section (i.e., for non-GAC instances)
+  const showPremiumTag = !props.isIntegrationsEnabledForPaid;
+
   return (
     <>
       {props.plugins.map((integration) => (
@@ -53,7 +56,7 @@ export default function PremiumDatasources(props: {
           key={integration.name}
           name={integration.name}
           rightSibling={
-            !props.isIntegrationsEnabledForPaid && (
+            showPremiumTag && (
               <PremiumTag isClosable={false} kind={"premium"}>
                 {createMessage(PREMIUM_DATASOURCES.PREMIUM_TAG)}
               </PremiumTag>


### PR DESCRIPTION
## Description
Fixes an edge case in the EXTERNAL_SAAS integration display logic where business/enterprise instances were not correctly showing integrations in the "Upcoming Integrations" section.

## Issue
When `license_external_saas_plugins_enabled` was `true` but `release_external_saas_plugins_enabled` was `false`, business/enterprise instances were displaying the integrations as `PREMIUM` instead of showing them in the upcoming section.

## Solution
Updated the logic for business/enterprise instances, so that integrations are shown in the "Upcoming Integrations" section when **either** flag is true:
- `release_external_saas_plugins_enabled` OR 
- `license_external_saas_plugins_enabled`

## Behavior Summary
- **CE instances**: Always show integrations with Premium tags
- **EE instances**: Show in "Upcoming" section when either flag is true
- **EE instances**: Hide only when both flags are false

## Files Changed
- `src/pages/Editor/IntegrationEditor/APIOrSaasPlugins.tsx`
- `src/pages/Editor/IntegrationEditor/EmptySearchedPlugins.tsx`

Fixes #41056 

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16199268111>
> Commit: 088d80b1fb659839397488510c859ab4e859acc7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16199268111&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 10 Jul 2025 16:10:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced control over the visibility and categorization of upcoming SaaS integrations based on user licensing, enterprise/business status, and hosting environment.
  * Simplified and unified feature flag logic to determine which users see upcoming integrations and how they are presented.

* **Refactor**
  * Improved clarity in the display logic for Premium tags and integration sections by renaming variables and extracting conditions into named constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->