### PR TITLE
feat: implement upgrade button within editor header

### DIFF
--- a/app/client/src/pages/AppIDE/layouts/components/Header/index.tsx
+++ b/app/client/src/pages/AppIDE/layouts/components/Header/index.tsx
@@ -65,6 +65,7 @@ import { AppsmithLink } from "pages/Editor/AppsmithLink";
 import DeployButton from "./DeployButton";
 import { GitApplicationContextProvider } from "git-artifact-helpers/application/components";
 import ChevronMenu from "./ChevronMenu";
+import { ShowUpgradeMenuItem } from "ee/utils/licenseHelpers";
 
 const StyledDivider = styled(Divider)`
   height: 50%;
@@ -194,6 +195,7 @@ const Header = () => {
           )}
         </IDEHeader.Center>
         <IDEHeader.Right>
+          <ShowUpgradeMenuItem />
           <HelpBar />
           <StyledDivider orientation={"vertical"} />
           <ToggleModeButton />


### PR DESCRIPTION
## Summary
This PR adds an upgrade button to the IDE header, allowing users to access upgrade options directly from the editor interface.

## Changes Made
- Added `ShowUpgradeMenuItem` import from `ee/utils/licenseHelpers`
- Integrated `<ShowUpgradeMenuItem />` component into the IDE header right section
- Positioned the upgrade menu item before the help bar for better visibility

## Automation

/ok-to-test tags="@tag.Sanity, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16440833655>
> Commit: e5fcc5f11bfb9770481e72855b46f085ee0271e3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16440833655&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity, @tag.IDE`
> Spec:
> <hr>Tue, 22 Jul 2025 10:38:16 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an upgrade menu item to the IDE header for easier access to upgrade options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->