### PR TITLE
Fix corners of button group are cut off when there is just one button

### DIFF
--- a/app/client/src/widgets/ButtonGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/ButtonGroupWidget/component/index.tsx
@@ -106,7 +106,7 @@ const ButtonGroupWrapper = styled.div<ThemeProp & WrapperStyleProps>`
 
   & > *:only-child,
   & > *:only-child button {
-    border-radius: ${({ borderRadius }) => borderRadius} !important;
+    border-radius: ${({ borderRadius }) => borderRadius};
   }
 `;
 


### PR DESCRIPTION
## Description
Hello. I came across this open issue #41122, so I would like to attempt to solve it. This is my first PR for appsmith. Please let me know if any changes are needed. Thanks!
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL` https://github.com/appsmithorg/appsmith/issues/41122
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance of button groups with a single button by ensuring consistent border-radius on all corners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->