### PR TITLE
fix: update column position check in TableV2 freeze column test

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column_query_change_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/freeze_column_query_change_spec.js
@@ -47,7 +47,7 @@ describe(
       cy.updateCodeInput(PROPERTY_SELECTOR.tableData, TABLE_DATA_STATIC);
 
       //Check the id column is still frozen to the right:
-      cy.checkColumnPosition("customColumn1", 5);
+      cy.checkColumnPosition("customColumn1", 4);
     });
 
     it("1.3 Check if the custom + common columns retain their positon", () => {


### PR DESCRIPTION
## Description
<ins>Problem</ins>

The freeze column test in TableV2 is failing due to incorrect column position checks.

<ins>Root cause</ins>

The test logic for verifying column positions does not accurately reflect the expected behavior after columns are frozen.

<ins>Solution</ins>

This PR handles updating the column position check logic in the TableV2 freeze column test to ensure it correctly validates the positions of columns after freezing.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Table"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
