### PR TITLE
fix: Updating the logo in App editor to use branding logo instead

### DIFF
--- a/app/client/src/pages/Editor/AppsmithLink.tsx
+++ b/app/client/src/pages/Editor/AppsmithLink.tsx
@@ -22,6 +22,7 @@ export const StyledLink = styled((props) => {
     min-width: 24px;
     width: 24px;
     height: 24px;
+    object-fit: contain;
   }
 `;
 

--- a/app/client/src/pages/Editor/AppsmithLink.tsx
+++ b/app/client/src/pages/Editor/AppsmithLink.tsx
@@ -5,6 +5,8 @@ import { LOGO_TOOLTIP, createMessage } from "ee/constants/messages";
 import { APPLICATIONS_URL } from "constants/routes";
 import AppsmithLogo from "assets/images/appsmith_logo_square.png";
 import history from "utils/history";
+import { useSelector } from "react-redux";
+import { getOrganizationConfig } from "ee/selectors/organizationSelectors";
 
 export const StyledLink = styled((props) => {
   // we are removing non input related props before passing them in the components
@@ -24,6 +26,8 @@ export const StyledLink = styled((props) => {
 `;
 
 export const AppsmithLink = () => {
+  const organizationConfig = useSelector(getOrganizationConfig);
+
   const handleOnClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       e.stopPropagation();
@@ -43,7 +47,11 @@ export const AppsmithLink = () => {
         <img
           alt="Appsmith logo"
           className="t--appsmith-logo"
-          src={AppsmithLogo}
+          src={
+            organizationConfig.brandLogoUrl
+              ? organizationConfig.brandLogoUrl
+              : AppsmithLogo
+          }
         />
       </StyledLink>
     </Tooltip>


### PR DESCRIPTION
## Description

Updating the logo in App editor to use branding logo instead.

Fixes [#41134](https://github.com/appsmithorg/appsmith/issues/41134)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
