### PR TITLE
fix: Updating the check for matching app libraries path

### DIFF
--- a/app/client/src/ce/constants/routes/appRoutes.ts
+++ b/app/client/src/ce/constants/routes/appRoutes.ts
@@ -128,7 +128,8 @@ export const matchAppLibrariesPath = (pathName: string) =>
   match(`${BUILDER_CUSTOM_PATH}${APP_LIBRARIES_EDITOR_PATH}`)(pathName);
 
 export const matchAppPackagesPath = (pathName: string) =>
-  match(`${BUILDER_PATH}${APP_PACKAGES_EDITOR_PATH}`)(pathName);
+  match(`${BUILDER_PATH}${APP_PACKAGES_EDITOR_PATH}`)(pathName) ||
+  match(`${BUILDER_CUSTOM_PATH}${APP_PACKAGES_EDITOR_PATH}`)(pathName);
 
 export const addBranchParam = (branch: string) => {
   const url = new URL(window.location.href);

--- a/app/client/src/ce/constants/routes/appRoutes.ts
+++ b/app/client/src/ce/constants/routes/appRoutes.ts
@@ -124,7 +124,8 @@ export const matchViewerForkPath = (pathName: string) =>
   match(`${VIEWER_PATH_DEPRECATED}${VIEWER_FORK_PATH}`)(pathName);
 
 export const matchAppLibrariesPath = (pathName: string) =>
-  match(`${BUILDER_PATH}${APP_LIBRARIES_EDITOR_PATH}`)(pathName);
+  match(`${BUILDER_PATH}${APP_LIBRARIES_EDITOR_PATH}`)(pathName) ||
+  match(`${BUILDER_CUSTOM_PATH}${APP_LIBRARIES_EDITOR_PATH}`)(pathName);
 
 export const matchAppPackagesPath = (pathName: string) =>
   match(`${BUILDER_PATH}${APP_PACKAGES_EDITOR_PATH}`)(pathName);


### PR DESCRIPTION
## Description

Updating the check for matching app libraries path to fix the redirection to JS Libraries section when page has a custom path.

Fixes [#41138](https://github.com/appsmithorg/appsmith/issues/41138)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16566848024>
> Commit: 55233a42b73de66a5def0e1287ca2513d632e60a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16566848024&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 28 Jul 2025 11:27:30 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path recognition for application libraries and packages, supporting both standard and custom builder paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->