### PR TITLE
fix: Updating the logo in the app editor to use favicon instead

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1698,13 +1698,13 @@ export const ADMIN_BRANDING_LOGO_FORMAT_ERROR = () =>
 export const ADMIN_BRANDING_LOGO_REQUIREMENT = () =>
   `.SVG, .PNG, or .JPG only • Max 2MB`;
 export const ADMIN_BRANDING_FAVICON_DIMENSION_ERROR = () =>
-  `Uploaded file must have a max size of 32X32 pixels`;
+  `Uploaded file must have a max size of 48X48 pixels`;
 export const ADMIN_BRANDING_FAVICON_SIZE_ERROR = () =>
   `Uploaded file must be less than 2MB`;
 export const ADMIN_BRANDING_FAVICON_FORMAT_ERROR = () =>
   `Uploaded file must be in .ICO, .PNG, and .JPG formats`;
 export const ADMIN_BRANDING_FAVICON_REQUIREMENT = () =>
-  `.ICO, .PNG, or .JPG only • Max 32X32`;
+  `.ICO, .PNG, or .JPG only • Max 48X48`;
 export const PROFILE_DISPLAY_PICTURE_REQUIREMENT = () =>
   `.ICO, .PNG, or .JPG only • Max 32X32`;
 export const ADMIN_BRANDING_COLOR_TOOLTIP_PRIMARY = () =>

--- a/app/client/src/pages/Editor/AppsmithLink.tsx
+++ b/app/client/src/pages/Editor/AppsmithLink.tsx
@@ -49,8 +49,8 @@ export const AppsmithLink = () => {
           alt="Appsmith logo"
           className="t--appsmith-logo"
           src={
-            organizationConfig.brandLogoUrl
-              ? organizationConfig.brandLogoUrl
+            organizationConfig.brandFaviconUrl
+              ? organizationConfig.brandFaviconUrl
               : AppsmithLogo
           }
         />

--- a/app/client/src/pages/Editor/AppsmithLink.tsx
+++ b/app/client/src/pages/Editor/AppsmithLink.tsx
@@ -22,7 +22,6 @@ export const StyledLink = styled((props) => {
     min-width: 24px;
     width: 24px;
     height: 24px;
-    object-fit: contain;
   }
 `;
 
@@ -49,7 +48,9 @@ export const AppsmithLink = () => {
           alt="Appsmith logo"
           className="t--appsmith-logo"
           src={
-            organizationConfig.brandFaviconUrl
+            organizationConfig.brandFaviconUrl &&
+            organizationConfig.brandFaviconUrl !==
+              "https://assets.appsmith.com/appsmith-favicon-orange.ico"
               ? organizationConfig.brandFaviconUrl
               : AppsmithLogo
           }

--- a/app/client/src/utils/BrandingUtils.ts
+++ b/app/client/src/utils/BrandingUtils.ts
@@ -13,8 +13,8 @@ import { ASSETS_CDN_URL } from "constants/ThirdPartyConstants";
 import { getAssetUrl } from "ee/utils/airgapHelpers";
 import { LightModeTheme } from "@appsmith/wds-theming";
 
-const FAVICON_MAX_WIDTH = 32;
-const FAVICON_MAX_HEIGHT = 32;
+const FAVICON_MAX_WIDTH = 48;
+const FAVICON_MAX_HEIGHT = 48;
 const DEFAULT_BRANDING_PRIMARY_COLOR = "#E15615";
 
 export const APPSMITH_BRAND_PRIMARY_COLOR =


### PR DESCRIPTION
## Description

Updating the logo in the app editor to use favicon instead

Fixes [#41134](https://github.com/appsmithorg/appsmith/issues/41134)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16591754385>
> Commit: 29ca67869963e9dbb9d684eeeb6713d865c6dd7f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16591754385&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 29 Jul 2025 09:56:28 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the logo in the Appsmith link to display the organization's favicon if available and different from the default, otherwise defaults to the standard logo.
* **Bug Fixes**
  * Increased the maximum allowed favicon size in branding settings from 32x32 to 48x48 pixels, with updated validation and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->