### PR TITLE
fix: Updating the logo in the app editor to use favicon instead (#41147)

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1698,13 +1698,13 @@ export const ADMIN_BRANDING_LOGO_FORMAT_ERROR = () =>
 export const ADMIN_BRANDING_LOGO_REQUIREMENT = () =>
   `.SVG, .PNG, or .JPG only • Max 2MB`;
 export const ADMIN_BRANDING_FAVICON_DIMENSION_ERROR = () =>
-  `Uploaded file must have a max size of 32X32 pixels`;
+  `Uploaded file must have a max size of 48X48 pixels`;
 export const ADMIN_BRANDING_FAVICON_SIZE_ERROR = () =>
   `Uploaded file must be less than 2MB`;
 export const ADMIN_BRANDING_FAVICON_FORMAT_ERROR = () =>
   `Uploaded file must be in .ICO, .PNG, and .JPG formats`;
 export const ADMIN_BRANDING_FAVICON_REQUIREMENT = () =>
-  `.ICO, .PNG, or .JPG only • Max 32X32`;
+  `.ICO, .PNG, or .JPG only • Max 48X48`;
 export const PROFILE_DISPLAY_PICTURE_REQUIREMENT = () =>
   `.ICO, .PNG, or .JPG only • Max 32X32`;
 export const ADMIN_BRANDING_COLOR_TOOLTIP_PRIMARY = () =>

--- a/app/client/src/pages/Editor/AppsmithLink.tsx
+++ b/app/client/src/pages/Editor/AppsmithLink.tsx
@@ -22,7 +22,6 @@ export const StyledLink = styled((props) => {
     min-width: 24px;
     width: 24px;
     height: 24px;
-    object-fit: contain;
   }
 `;
 
@@ -49,8 +48,10 @@ export const AppsmithLink = () => {
           alt="Appsmith logo"
           className="t--appsmith-logo"
           src={
-            organizationConfig.brandLogoUrl
-              ? organizationConfig.brandLogoUrl
+            organizationConfig.brandFaviconUrl &&
+            organizationConfig.brandFaviconUrl !==
+              "https://assets.appsmith.com/appsmith-favicon-orange.ico"
+              ? organizationConfig.brandFaviconUrl
               : AppsmithLogo
           }
         />

--- a/app/client/src/utils/BrandingUtils.ts
+++ b/app/client/src/utils/BrandingUtils.ts
@@ -13,8 +13,8 @@ import { ASSETS_CDN_URL } from "constants/ThirdPartyConstants";
 import { getAssetUrl } from "ee/utils/airgapHelpers";
 import { LightModeTheme } from "@appsmith/wds-theming";
 
-const FAVICON_MAX_WIDTH = 32;
-const FAVICON_MAX_HEIGHT = 32;
+const FAVICON_MAX_WIDTH = 48;
+const FAVICON_MAX_HEIGHT = 48;
 const DEFAULT_BRANDING_PRIMARY_COLOR = "#E15615";
 
 export const APPSMITH_BRAND_PRIMARY_COLOR =


### PR DESCRIPTION
## Description

Updating the logo in the app editor to use favicon instead

Fixes [#41134](https://github.com/appsmithorg/appsmith/issues/41134)

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16593078280>
> Commit: 9abe20e614db38219fd7e46b5ee55ade888080e3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16593078280&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 29 Jul 2025 10:52:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
* Updated the logo in the Appsmith link to display the organization's favicon if available and different from the default, otherwise defaults to the standard logo.
* **Bug Fixes**
* Increased the maximum allowed favicon size in branding settings from 32x32 to 48x48 pixels, with updated validation and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
