### PR TITLE
fix: JSModule instance non-async function invocation not evaluating on page refresh.

### DIFF
--- a/app/client/src/ce/selectors/moduleInstanceSelectors.ts
+++ b/app/client/src/ce/selectors/moduleInstanceSelectors.ts
@@ -2,6 +2,7 @@
 import type { DefaultRootState } from "react-redux";
 import type { ModuleInstance } from "ee/constants/ModuleInstanceConstants";
 import type { JSCollection } from "entities/JSCollection";
+import { getJSCollectionFromAllEntities } from "ce/selectors/entitiesSelector";
 
 export const getModuleInstanceById = (
   state: DefaultRootState,
@@ -12,8 +13,9 @@ export const getModuleInstanceJSCollectionById = (
   state: DefaultRootState,
   jsCollectionId: string,
 ): JSCollection | undefined => {
-  return undefined;
+  return getJSCollectionFromAllEntities(state, jsCollectionId);
 };
+
 export const getAllUniqueWidgetTypesInUiModules = (state: DefaultRootState) => {
   return [];
 };


### PR DESCRIPTION
### Description

Fixes JSModule instance non-async function invocation not evaluating on page refresh.

#41146

### What was the issue?
JSModule instance functions (like `JSModule11.myFun1()`) were throwing "is not a function" errors on page refresh because the `getModuleInstanceJSCollectionById` selector was returning `undefined` for all JSModule instances.

### What was fixed?
Updated the `getModuleInstanceJSCollectionById` selector in `app/client/src/ce/selectors/moduleInstanceSelectors.ts` to use the existing `getJSCollectionFromAllEntities` function, ensuring JSModule instance functions are properly resolved and available for evaluation.

### Impact
- ✅ JSModule instance functions now work correctly on page refresh
- ✅ No breaking changes to existing functionality
- ✅ Minimal, targeted fix using existing infrastructure

**Files changed:** 1  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logic for retrieving JS Collections by ID, ensuring more accurate data is returned when accessing module instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->