### PR TITLE
fix: Skip JSObject eval where the path is the function

### DIFF
--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -39,6 +39,7 @@ import {
   getAllPathsBasedOnDiffPaths,
   isDataPath,
   isJSModuleInstance,
+  isPropertyAnEntityAction,
 } from "ee/workers/Evaluation/evaluationUtils";
 
 import {
@@ -1192,7 +1193,11 @@ export default class DataTreeEvaluator {
           valuechanged[fullPropertyPath] = true;
           continue;
         }
+
         // Skip evaluations for actions in JSObjects
+        if (isPropertyAnEntityAction(entity, propertyPath, entityConfig)) {
+          continue;
+        }
 
         // TODO: Fix this the next time the file is edited
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description
JSObjects and JSModuleInstance function paths were earlier skipped eval when present in the eval order. In the [reactive actions](https://github.com/appsmithorg/appsmith/pull/40963) PR this check was removed and due to that JSModuleInstances function were overriden in `evalContextCache` with it's uneval value. Due to which during any eval where the JSModuleInstance function is present as a binding, fails to evaluate

This PR reverts the check

Fixes https://github.com/appsmithorg/appsmith/issues/41146

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/16665740260>
> Commit: 9a10adbc79bf5c2f2258b6dc4e013e4d66ac441d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=16665740260&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 01 Aug 2025 05:00:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation process to prevent unintended evaluation of action properties within JSObjects, resulting in more stable and predictable behavior for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->