### PR TITLE
Fix problem with scrolling the table when pagination is disabled

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -185,6 +185,12 @@ export default {
     const componentHeight = props.componentHeight - 10;
     const tableSizes = TABLE_SIZES[compactMode];
 
+    // If pagination is completely disabled (no page navigation)
+    // and server-side pagination is also off, display all data with scroll
+    if (!props.showPagination && !props.serverSidePaginationEnabled) {
+      return props.tableData ? props.tableData.length : 100;
+    }
+
     let pageSize =
       (componentHeight -
         tableSizes.TABLE_HEADER_HEIGHT -
@@ -380,9 +386,9 @@ export default {
     const sortByColumnId = props.sortOrder.column;
 
     let sortedTableData;
-    /* 
-    Check if there are select columns, 
-    and if the columns are sorting by label instead of default value 
+    /*
+    Check if there are select columns,
+    and if the columns are sorting by label instead of default value
     */
     const selectColumnKeysWithSortByLabel = [];
 
@@ -397,9 +403,9 @@ export default {
       }
     });
 
-    /* 
-    If there are select columns, 
-    transform the specific columns data to show the label instead of the value for sorting 
+    /*
+    If there are select columns,
+    transform the specific columns data to show the label instead of the value for sorting
     */
     let processedTableDataWithLabelInsteadOfValue;
 


### PR DESCRIPTION
# Description
This pull request fixes a issue with TableWidgetV2 where not all table rows were accessible via scrolling when pagination is disabled.

# Problem
When pagination is completely disabled (showPagination: false and serverSidePaginationEnabled: false), the number of rows displayed was incorrectly limited to the visible height of the container. This meant that in a table with, for example, 20 rows, only 5-6 rows could be displayed and scrolled, even though all data had been loaded.

# Cause
The `getPageSize` function in `derived.js` calculated the pageSize based on the container height, even if paging was not used. This limited the number of rendered rows to the calculated pageSize.

# Solution
The logic was adjusted to return the full number of table rows (`props.tableData.length`) when pagination was disabled. This allows all data to be rendered and scrolled through the table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table behavior to display all data in a single scrollable view when pagination is fully disabled.
* **Style**
  * Cleaned up formatting in multi-line comments for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->