### PR TITLE
fix: use bitnamilegacy images temporarily

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.6.3
+version: 3.6.4
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
@@ -25,7 +25,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.3
+        appsmith.sh/chart: appsmith-3.6.4
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
   3: |
@@ -36,7 +36,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.3
+        appsmith.sh/chart: appsmith-3.6.4
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -143,7 +143,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.3
+        appsmith.sh/chart: appsmith-3.6.4
       name: RELEASE-NAME-appsmith-headless
       namespace: NAMESPACE
     spec:
@@ -182,7 +182,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.3
+        appsmith.sh/chart: appsmith-3.6.4
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -203,7 +203,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.3
+        appsmith.sh/chart: appsmith-3.6.4
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     secrets:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -34,7 +34,7 @@ mongodb:
   tolerations: []
   image:
     registry: docker.io
-    repository: bitnami/mongodb
+    repository: bitnamilegacy/mongodb
     tag: 6.0.13
   arbiter:
     nodeSelector: {}
@@ -44,10 +44,6 @@ mongodb:
     nodeSelector: {}
     affinity: {}
     tolerations: []
-  image:
-    registry: docker.io
-    repository: bitnami/mongodb
-    tag: 6.0.13
 
 ## postgresql parameters
 postgresql:
@@ -59,7 +55,7 @@ postgresql:
     database: keycloak
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 14.12.0
   primary:
     affinity: {}


### PR DESCRIPTION
## Description
Bitnami has deprecated the images we rely on by default in the chart. We need to figure out how we adjust to this situation (and upgrade MongoDB as well to get off the EOL version here). For now, use the bitnamilegacy images.

see: https://github.com/bitnami/charts/issues/35256


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated Helm chart to version 3.6.4.
  * Switched default container image repositories for MongoDB and PostgreSQL to bitnamilegacy while keeping the existing tags, improving continuity with upstream changes.
  * Cleaned up a deprecated MongoDB image configuration block to avoid confusion in values configuration.
  * These changes affect deployment configuration only and do not modify application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->