### PR TITLE
fix: update java version in the base Docker image

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -46,12 +46,8 @@ ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 # Install Java
 RUN set -o xtrace \
   && mkdir -p /opt/java \
-  # Assets from https://github.com/adoptium/temurin17-binaries/releases
-  # TODO: The release jdk-17.0.9+9.1 doesn't include Linux binaries, so this fails.
-  #       Temporarily using hardcoded version in URL until we figure out a more elaborate/smarter solution.
-  #&& version="$(curl --write-out '%{redirect_url}' 'https://github.com/adoptium/temurin17-binaries/releases/latest' | sed 's,.*jdk-,,')" \
-  && version="17.0.9+9" \
-  && curl --location "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$version/OpenJDK17U-jdk_$(uname -m | sed s/x86_64/x64/)_linux_hotspot_$(echo $version | tr + _).tar.gz" \
+  # Assets from https://github.com/adoptium/temurin17-binaries/releases using the Adoptium API
+  && curl --location "http://api.adoptium.net/v3/binary/latest/17/ga/linux/$(uname -m | sed s/x86_64/x64/)/jdk/hotspot/normal/eclipse" \
   | tar -xz -C /opt/java --strip-components 1
 
 # Install NodeJS

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -47,7 +47,7 @@ ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 RUN set -o xtrace \
   && mkdir -p /opt/java \
   # Assets from https://github.com/adoptium/temurin17-binaries/releases using the Adoptium API
-  && curl --location "http://api.adoptium.net/v3/binary/latest/17/ga/linux/$(uname -m | sed s/x86_64/x64/)/jdk/hotspot/normal/eclipse" \
+  && curl --location "https://api.adoptium.net/v3/binary/latest/17/ga/linux/$(uname -m | sed s/x86_64/x64/)/jdk/hotspot/normal/eclipse" \
   | tar -xz -C /opt/java --strip-components 1
 
 # Install NodeJS


### PR DESCRIPTION
Use the latest 17 jdk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build to obtain the latest JDK 17 from the Adoptium API instead of a hardcoded download.
  * Streamlined installation by piping the downloaded archive directly into extraction, simplifying the build steps.
  * Uses secure HTTPS API access and reduces maintenance for JVM updates.
  * No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->