### PR TITLE
fix: Adding `responseMeta` in query object even when the query fails

### DIFF
--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -641,7 +641,15 @@ export default function* executePluginActionTriggerSaga(
     } else {
       throw new PluginTriggerFailureError(
         createMessage(ERROR_PLUGIN_ACTION_EXECUTE, pluginActionNameToDisplay),
-        [],
+        [
+          payload.body,
+          params,
+          {
+            isExecutionSuccess: payload.isExecutionSuccess,
+            statusCode: payload.statusCode,
+            headers: payload.headers,
+          },
+        ],
       );
     }
   } else {

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -533,6 +533,8 @@ export function* executeTriggerRequestSaga(
     responsePayload.error = {
       // @ts-expect-error: reason is of type string
       message: error.responseData?.[0] || error.message,
+      // @ts-expect-error: responseData is of type array
+      responseData: error.responseData || [],
     };
   }
 

--- a/app/client/src/workers/Evaluation/fns/actionFns.ts
+++ b/app/client/src/workers/Evaluation/fns/actionFns.ts
@@ -68,6 +68,27 @@ export default async function run(
      * */
     return response[0];
   } catch (e) {
+    const error = {
+      // TODO: Fix this the next time the file is edited
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      message: (e as any).message,
+    };
+
+    // If error contains responseData, update action data and responseMeta before throwing
+    // @ts-expect-error: responseData is a custom property
+    if (e.responseData && e.responseData.length > 0) {
+      // @ts-expect-error: self type is not defined
+      const action = self[this.name] as ActionEntity;
+      // @ts-expect-error: responseData is array format
+      const responseData = e.responseData;
+
+      if (action && responseData.length >= 3) {
+        action.data = responseData[0]; // error response body
+        action.responseMeta = responseData[2]; // { isExecutionSuccess, statusCode, headers }
+        action.isLoading = false;
+      }
+    }
+
     if (typeof onError === "function") {
       // TODO: Fix this the next time the file is edited
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -76,7 +97,7 @@ export default async function run(
       return;
     }
 
-    throw e;
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
