### PR TITLE
fix: CVE-2024-38821

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN <<END
     exit 1
   fi
 
-  if ! [ -f server/mongo/server.jar -a -f server/pg/server.jar ]; then
-    echo "Missing one or both server.jar files in the right place. Are you using the build script?" >&2
+  if ! [ -f server/mongo/server.jar ]; then
+    echo "Missing MongoDB server.jar file. Are you using the build script?" >&2
     exit 1
   fi
 END

--- a/scripts/prepare_server_artifacts.sh
+++ b/scripts/prepare_server_artifacts.sh
@@ -9,20 +9,18 @@ if [[ -z "${EDITION-}" ]]; then
   fi
 fi
 
-PG_TAG="${PG_TAG-pg}"
-echo "Will be copying pg server artifacts from appsmith-$EDITION:$PG_TAG"
+echo "Building server artifacts for $EDITION edition (PostgreSQL support removed)"
 
 target="deploy/docker/fs/opt/appsmith/server"
 mkdir -p "$target"
 rm -rf "$target"/{pg,mongo}
 
+# Build MongoDB server artifacts
 cp -r "app/server/dist" "$target/mongo"
 mv "$target/mongo"/server-*.jar "$target/mongo/server.jar"
 
-# Grab PostgreSQL server artifacts from Docker image.
-image="appsmith/appsmith-$EDITION:$PG_TAG"
-docker run --name xx --detach --entrypoint sleep "$image" infinity
-docker cp xx:/opt/appsmith/server/pg "$target/pg"
-docker cp xx:/opt/appsmith/info.json "$target/pg/source-info.json"
-docker rm --force xx
-docker image rm "$image"
+# PostgreSQL support has been removed - no more vulnerable artifacts
+# This eliminates CVE-2024-38821 from the Docker image
+echo "✅ MongoDB artifacts prepared successfully"
+echo "🗑️ PostgreSQL artifacts skipped (CVE-2024-38821 eliminated)"
+echo "📁 Only MongoDB artifacts: $target/mongo/"


### PR DESCRIPTION
## Description
**Before:**
The appsmith-ce release image contains CVE-2024-38821 critical vulnerability. 
<img width="1258" height="876" alt="Screenshot 2025-09-12 at 1 41 00 PM" src="https://github.com/user-attachments/assets/6e5292c7-d073-4241-970d-511ab0533547" />

[cves_report_ce.json](https://github.com/user-attachments/files/22292789/cves_report_ce.json)



**After:**
The current DP image doesn't contain CVE-2024-38821 after removing pg build from server.

<img width="1248" height="906" alt="Screenshot 2025-09-12 at 1 40 36 PM" src="https://github.com/user-attachments/assets/d7d2c812-d6e5-4994-9c08-923e0302b415" />

[cves_41221.txt](https://github.com/user-attachments/files/22292798/cves_41221.txt)


Fixes CVE-2024-38821

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/17725447283>
> Commit: 959d97e926357bfcd1e0aec32a9127be5b8df403
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=17725447283&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 15 Sep 2025 08:39:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed PostgreSQL support from build artifacts; only the MongoDB edition is produced going forward.
  * Updated Docker validation to require only the MongoDB server jar; error message reflects this change.
  * Simplified artifact preparation by removing PostgreSQL image extraction and related steps.
  * Maintains existing exit-on-failure behavior; successful MongoDB paths are unchanged.
  * No changes to runtime behavior for MongoDB users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->