### PR TITLE
fix: update info generation step in ad-hoc image

### DIFF
--- a/.github/workflows/ad-hoc-docker-image.yml
+++ b/.github/workflows/ad-hoc-docker-image.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Generate info.json
         id: info_json
         run: |
-          scripts/generate_info_json.sh "${{ inputs.tag }}"
+          scripts/generate_info_json.sh
 
       - name: Place server artifacts-es
         run: |


### PR DESCRIPTION
Remove unused argument from generate_info_json.sh script call

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
