### PR TITLE
feat: add support for listing function versions and aliases in AWS Lambda Plugin

### DIFF
--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
@@ -220,6 +220,11 @@ public class AwsLambdaPlugin extends BasePlugin {
                 functionName =
                         getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionName", STRING_TYPE);
             }
+            if (!StringUtils.hasText(functionName)) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                        "function name is required for listing versions");
+            }
 
             ListVersionsByFunctionRequest request = new ListVersionsByFunctionRequest();
             request.setFunctionName(functionName);

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
@@ -123,7 +123,15 @@ public class AwsLambdaPlugin extends BasePlugin {
                             .collect(Collectors.toList());
                 }
                 case "FUNCTION_VERSIONS" -> {
-                    String functionName = (String) params.get("functionName");
+                    // Handle both old and new parameter structures
+                    String functionName;
+                    if (params.containsKey("parameters") && params.get("parameters") instanceof Map) {
+                        Map<?, ?> parameters = (Map<?, ?>) params.get("parameters");
+                        functionName = (String) parameters.get("functionName");
+                    } else {
+                        functionName = (String) params.get("functionName");
+                    }
+
                     if (!StringUtils.hasText(functionName)) {
                         throw new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
@@ -138,7 +146,15 @@ public class AwsLambdaPlugin extends BasePlugin {
                             .collect(Collectors.toList());
                 }
                 case "FUNCTION_ALIASES" -> {
-                    String functionName = (String) params.get("functionName");
+                    // Handle both old and new parameter structures
+                    String functionName;
+                    if (params.containsKey("parameters") && params.get("parameters") instanceof Map) {
+                        Map<?, ?> parameters = (Map<?, ?>) params.get("parameters");
+                        functionName = (String) parameters.get("functionName");
+                    } else {
+                        functionName = (String) params.get("functionName");
+                    }
+
                     if (!StringUtils.hasText(functionName)) {
                         throw new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
@@ -110,6 +110,7 @@ public class AwsLambdaPlugin extends BasePlugin {
             String requestType = request.getRequestType();
             ActionExecutionResult actionExecutionResult;
             List<Map<String, String>> options;
+            Map<String, String> params = request.getParams() == null ? Map.of() : request.getParams();
 
             switch (requestType) {
                 case "FUNCTION_NAMES" -> {
@@ -122,7 +123,7 @@ public class AwsLambdaPlugin extends BasePlugin {
                             .collect(Collectors.toList());
                 }
                 case "FUNCTION_VERSIONS" -> {
-                    String functionName = request.getParams().get("functionName");
+                    String functionName = params.get("functionName");
                     if (!StringUtils.hasText(functionName)) {
                         throw new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
@@ -137,7 +138,7 @@ public class AwsLambdaPlugin extends BasePlugin {
                             .collect(Collectors.toList());
                 }
                 case "FUNCTION_ALIASES" -> {
-                    String functionName = request.getParams().get("functionName");
+                    String functionName = params.get("functionName");
                     if (!StringUtils.hasText(functionName)) {
                         throw new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
@@ -9,7 +9,11 @@ import com.amazonaws.services.lambda.model.AWSLambdaException;
 import com.amazonaws.services.lambda.model.FunctionConfiguration;
 import com.amazonaws.services.lambda.model.InvokeRequest;
 import com.amazonaws.services.lambda.model.InvokeResult;
+import com.amazonaws.services.lambda.model.ListAliasesRequest;
+import com.amazonaws.services.lambda.model.ListAliasesResult;
 import com.amazonaws.services.lambda.model.ListFunctionsResult;
+import com.amazonaws.services.lambda.model.ListVersionsByFunctionRequest;
+import com.amazonaws.services.lambda.model.ListVersionsByFunctionResult;
 import com.amazonaws.services.lambda.model.ResourceNotFoundException;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
@@ -70,6 +74,10 @@ public class AwsLambdaPlugin extends BasePlugin {
                         ActionExecutionResult result;
                         switch (Objects.requireNonNull(command)) {
                             case "LIST_FUNCTIONS" -> result = listFunctions(actionConfiguration, connection);
+                            case "LIST_FUNCTION_VERSIONS" -> result =
+                                    listFunctionVersions(actionConfiguration, connection);
+                            case "LIST_FUNCTION_ALIASES" -> result =
+                                    listFunctionAliases(actionConfiguration, connection);
                             case "INVOKE_FUNCTION" -> result = invokeFunction(actionConfiguration, connection);
                             default -> throw new IllegalStateException("Unexpected value: " + command);
                         }
@@ -98,24 +106,84 @@ public class AwsLambdaPlugin extends BasePlugin {
                 throw new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "request type is missing");
             }
-            ActionExecutionResult actionExecutionResult = listFunctions(null, connection);
-            ArrayNode body = (ArrayNode) actionExecutionResult.getBody();
-            List<Map<String, String>> functionNames = StreamSupport.stream(body.spliterator(), false)
-                    .map(function -> function.get("functionName").asText())
-                    .sorted()
-                    .map(functionName -> Map.of("label", functionName, "value", functionName))
-                    .collect(Collectors.toList());
+
+            String requestType = request.getRequestType();
+            ActionExecutionResult actionExecutionResult;
+            List<Map<String, String>> options;
+
+            switch (requestType) {
+                case "FUNCTION_NAMES" -> {
+                    actionExecutionResult = listFunctions(null, connection);
+                    ArrayNode body = (ArrayNode) actionExecutionResult.getBody();
+                    options = StreamSupport.stream(body.spliterator(), false)
+                            .map(function -> function.get("functionName").asText())
+                            .sorted()
+                            .map(functionName -> Map.of("label", functionName, "value", functionName))
+                            .collect(Collectors.toList());
+                }
+                case "FUNCTION_VERSIONS" -> {
+                    String functionName = request.getParams().get("functionName");
+                    if (!StringUtils.hasText(functionName)) {
+                        throw new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                                "function name is required for listing versions");
+                    }
+                    actionExecutionResult = listFunctionVersions(null, connection, functionName);
+                    ArrayNode body = (ArrayNode) actionExecutionResult.getBody();
+                    options = StreamSupport.stream(body.spliterator(), false)
+                            .map(version -> version.get("version").asText())
+                            .sorted()
+                            .map(version -> Map.of("label", version, "value", version))
+                            .collect(Collectors.toList());
+                }
+                case "FUNCTION_ALIASES" -> {
+                    String functionName = request.getParams().get("functionName");
+                    if (!StringUtils.hasText(functionName)) {
+                        throw new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                                "function name is required for listing aliases");
+                    }
+                    actionExecutionResult = listFunctionAliases(null, connection, functionName);
+                    ArrayNode body = (ArrayNode) actionExecutionResult.getBody();
+                    options = StreamSupport.stream(body.spliterator(), false)
+                            .map(alias -> alias.get("name").asText())
+                            .sorted()
+                            .map(alias -> Map.of("label", alias, "value", alias))
+                            .collect(Collectors.toList());
+                }
+                default -> throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "Unsupported request type: " + requestType);
+            }
 
             TriggerResultDTO triggerResultDTO = new TriggerResultDTO();
-            triggerResultDTO.setTrigger(functionNames);
+            triggerResultDTO.setTrigger(options);
 
             return Mono.just(triggerResultDTO);
         }
 
         ActionExecutionResult invokeFunction(ActionConfiguration actionConfiguration, AWSLambda connection) {
             InvokeRequest invokeRequest = new InvokeRequest();
-            invokeRequest.setFunctionName(
-                    getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionName", STRING_TYPE));
+
+            // Build function name with version/alias if specified
+            String functionName =
+                    getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionName", STRING_TYPE);
+            String functionVersion =
+                    getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionVersion", STRING_TYPE);
+            String functionAlias =
+                    getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionAlias", STRING_TYPE);
+
+            // Construct the full function name
+            String fullFunctionName = functionName;
+            if (StringUtils.hasText(functionAlias)) {
+                // If alias is specified, use it (alias takes precedence over version)
+                fullFunctionName = functionName + ":" + functionAlias;
+            } else if (StringUtils.hasText(functionVersion)) {
+                // If version is specified and no alias, use version
+                fullFunctionName = functionName + ":" + functionVersion;
+            }
+            // If neither version nor alias is specified, use the function name as-is (defaults to $LATEST)
+
+            invokeRequest.setFunctionName(fullFunctionName);
             invokeRequest.setPayload(
                     getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "body", STRING_TYPE));
             invokeRequest.setInvocationType(
@@ -143,6 +211,56 @@ public class AwsLambdaPlugin extends BasePlugin {
             result.setBody(objectMapper.valueToTree(functions));
             result.setIsExecutionSuccess(true);
             return result;
+        }
+
+        ActionExecutionResult listFunctionVersions(
+                ActionConfiguration actionConfiguration, AWSLambda connection, String functionName) {
+            if (actionConfiguration != null) {
+                functionName =
+                        getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionName", STRING_TYPE);
+            }
+
+            ListVersionsByFunctionRequest request = new ListVersionsByFunctionRequest();
+            request.setFunctionName(functionName);
+
+            ListVersionsByFunctionResult listVersionsResult = connection.listVersionsByFunction(request);
+            List<FunctionConfiguration> versions = listVersionsResult.getVersions();
+
+            ActionExecutionResult result = new ActionExecutionResult();
+            result.setBody(objectMapper.valueToTree(versions));
+            result.setIsExecutionSuccess(true);
+            return result;
+        }
+
+        ActionExecutionResult listFunctionVersions(ActionConfiguration actionConfiguration, AWSLambda connection) {
+            String functionName =
+                    getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionName", STRING_TYPE);
+            return listFunctionVersions(null, connection, functionName);
+        }
+
+        ActionExecutionResult listFunctionAliases(
+                ActionConfiguration actionConfiguration, AWSLambda connection, String functionName) {
+            if (actionConfiguration != null) {
+                functionName =
+                        getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionName", STRING_TYPE);
+            }
+
+            ListAliasesRequest request = new ListAliasesRequest();
+            request.setFunctionName(functionName);
+
+            ListAliasesResult listAliasesResult = connection.listAliases(request);
+            List<com.amazonaws.services.lambda.model.AliasConfiguration> aliases = listAliasesResult.getAliases();
+
+            ActionExecutionResult result = new ActionExecutionResult();
+            result.setBody(objectMapper.valueToTree(aliases));
+            result.setIsExecutionSuccess(true);
+            return result;
+        }
+
+        ActionExecutionResult listFunctionAliases(ActionConfiguration actionConfiguration, AWSLambda connection) {
+            String functionName =
+                    getDataValueSafelyFromFormData(actionConfiguration.getFormData(), "functionName", STRING_TYPE);
+            return listFunctionAliases(null, connection, functionName);
         }
 
         @Override

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/invoke.json
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/invoke.json
@@ -58,7 +58,9 @@
                 "params": {
                   "requestType": "FUNCTION_VERSIONS",
                   "displayType": "DROP_DOWN",
-                  "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  "parameters": {
+                    "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  }
                 }
               }
             }
@@ -86,7 +88,9 @@
                 "params": {
                   "requestType": "FUNCTION_ALIASES",
                   "displayType": "DROP_DOWN",
-                  "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  "parameters": {
+                    "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  }
                 }
               }
             }

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/invoke.json
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/invoke.json
@@ -37,6 +37,62 @@
           }
         },
         {
+          "label": "Function version",
+          "tooltipText": "Optional: Specify a version number (e.g., 1, 2, $LATEST) or leave empty for $LATEST.",
+          "subtitle": "",
+          "isRequired": false,
+          "propertyName": "function_version",
+          "configProperty": "actionConfiguration.formData.functionVersion.data",
+          "controlType": "DROP_DOWN",
+          "initialValue": "",
+          "options": [],
+          "placeholderText": "Leave empty for $LATEST version",
+          "fetchOptionsConditionally": true,
+          "setFirstOptionAsDefault": false,
+          "alternateViewTypes": ["json"],
+          "conditionals": {
+            "enable": "{{actionConfiguration.formData.functionName.data}}",
+            "fetchDynamicValues": {
+              "condition": "{{actionConfiguration.formData.command.data === 'INVOKE_FUNCTION' && actionConfiguration.formData.functionName.data}}",
+              "config": {
+                "params": {
+                  "requestType": "FUNCTION_VERSIONS",
+                  "displayType": "DROP_DOWN",
+                  "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                }
+              }
+            }
+          }
+        },
+        {
+          "label": "Function alias",
+          "tooltipText": "Optional: Specify an alias name (e.g., PROD, STAGING) or leave empty for no alias.",
+          "subtitle": "",
+          "isRequired": false,
+          "propertyName": "function_alias",
+          "configProperty": "actionConfiguration.formData.functionAlias.data",
+          "controlType": "DROP_DOWN",
+          "initialValue": "",
+          "options": [],
+          "placeholderText": "Leave empty for no alias",
+          "fetchOptionsConditionally": true,
+          "setFirstOptionAsDefault": false,
+          "alternateViewTypes": ["json"],
+          "conditionals": {
+            "enable": "{{actionConfiguration.formData.functionName.data}}",
+            "fetchDynamicValues": {
+              "condition": "{{actionConfiguration.formData.command.data === 'INVOKE_FUNCTION' && actionConfiguration.formData.functionName.data}}",
+              "config": {
+                "params": {
+                  "requestType": "FUNCTION_ALIASES",
+                  "displayType": "DROP_DOWN",
+                  "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                }
+              }
+            }
+          }
+        },
+        {
           "label": "Type of invocation",
           "tooltipText": "Should the invocation be synchronous or asynchronous?",
           "subtitle": "",

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/listAliases.json
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/listAliases.json
@@ -1,0 +1,42 @@
+{
+  "identifier": "LIST_FUNCTION_ALIASES",
+  "controlType": "SECTION_V2",
+  "conditionals": {
+    "show": "{{actionConfiguration.formData.command.data === 'LIST_FUNCTION_ALIASES'}}"
+  },
+  "children": [
+    {
+      "controlType": "DOUBLE_COLUMN_ZONE",
+      "label": "Function details",
+      "children": [
+        {
+          "label": "Function name",
+          "tooltipText": "The name of the AWS Lambda function to list aliases for.",
+          "subtitle": "",
+          "isRequired": true,
+          "propertyName": "function_name",
+          "configProperty": "actionConfiguration.formData.functionName.data",
+          "controlType": "DROP_DOWN",
+          "initialValue": "",
+          "options": [],
+          "placeholderText": "All function names will be fetched.",
+          "fetchOptionsConditionally": true,
+          "setFirstOptionAsDefault": true,
+          "alternateViewTypes": ["json"],
+          "conditionals": {
+            "enable": "{{true}}",
+            "fetchDynamicValues": {
+              "condition": "{{actionConfiguration.formData.command.data === 'LIST_FUNCTION_ALIASES'}}",
+              "config": {
+                "params": {
+                  "requestType": "FUNCTION_NAMES",
+                  "displayType": "DROP_DOWN"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/listVersions.json
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/listVersions.json
@@ -1,0 +1,42 @@
+{
+  "identifier": "LIST_FUNCTION_VERSIONS",
+  "controlType": "SECTION_V2",
+  "conditionals": {
+    "show": "{{actionConfiguration.formData.command.data === 'LIST_FUNCTION_VERSIONS'}}"
+  },
+  "children": [
+    {
+      "controlType": "DOUBLE_COLUMN_ZONE",
+      "label": "Function details",
+      "children": [
+        {
+          "label": "Function name",
+          "tooltipText": "The name of the AWS Lambda function to list versions for.",
+          "subtitle": "",
+          "isRequired": true,
+          "propertyName": "function_name",
+          "configProperty": "actionConfiguration.formData.functionName.data",
+          "controlType": "DROP_DOWN",
+          "initialValue": "",
+          "options": [],
+          "placeholderText": "All function names will be fetched.",
+          "fetchOptionsConditionally": true,
+          "setFirstOptionAsDefault": true,
+          "alternateViewTypes": ["json"],
+          "conditionals": {
+            "enable": "{{true}}",
+            "fetchDynamicValues": {
+              "condition": "{{actionConfiguration.formData.command.data === 'LIST_FUNCTION_VERSIONS'}}",
+              "config": {
+                "params": {
+                  "requestType": "FUNCTION_NAMES",
+                  "displayType": "DROP_DOWN"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/root.json
@@ -13,11 +13,20 @@
               "description": "Choose the method you would like to use",
               "configProperty": "actionConfiguration.formData.command.data",
               "controlType": "DROP_DOWN",
+              "isRequired": true,
               "initialValue": "LIST_FUNCTIONS",
               "options": [
                 {
                   "label": "List all functions",
                   "value": "LIST_FUNCTIONS"
+                },
+                {
+                  "label": "List function versions",
+                  "value": "LIST_FUNCTION_VERSIONS"
+                },
+                {
+                  "label": "List function aliases",
+                  "value": "LIST_FUNCTION_ALIASES"
                 },
                 {
                   "label": "Invoke a function",
@@ -30,5 +39,5 @@
       ]
     }
   ],
-  "files": ["list.json", "invoke.json"]
+  "files": ["list.json", "listVersions.json", "listAliases.json", "invoke.json"]
 }

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/test/java/com/external/plugins/AwsLambdaPluginTest.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/test/java/com/external/plugins/AwsLambdaPluginTest.java
@@ -364,7 +364,7 @@ public class AwsLambdaPluginTest {
                 pluginExecutor.trigger(mockLambda, datasourceConfiguration, request);
         StepVerifier.create(resultMono)
                 .assertNext(result -> {
-                    assertEquals(2, result.getTrigger().size());
+                    assertEquals(2, ((List<?>) result.getTrigger()).size());
                 })
                 .verifyComplete();
     }
@@ -384,15 +384,15 @@ public class AwsLambdaPluginTest {
 
         TriggerRequestDTO request = new TriggerRequestDTO();
         request.setRequestType("FUNCTION_VERSIONS");
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("functionName", "test-function");
-        request.setParams(params);
+        request.setParameters(params);
 
         Mono<com.appsmith.external.models.TriggerResultDTO> resultMono =
                 pluginExecutor.trigger(mockLambda, datasourceConfiguration, request);
         StepVerifier.create(resultMono)
                 .assertNext(result -> {
-                    assertEquals(3, result.getTrigger().size());
+                    assertEquals(3, ((List<?>) result.getTrigger()).size());
                 })
                 .verifyComplete();
     }
@@ -409,15 +409,15 @@ public class AwsLambdaPluginTest {
 
         TriggerRequestDTO request = new TriggerRequestDTO();
         request.setRequestType("FUNCTION_ALIASES");
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("functionName", "test-function");
-        request.setParams(params);
+        request.setParameters(params);
 
         Mono<com.appsmith.external.models.TriggerResultDTO> resultMono =
                 pluginExecutor.trigger(mockLambda, datasourceConfiguration, request);
         StepVerifier.create(resultMono)
                 .assertNext(result -> {
-                    assertEquals(2, result.getTrigger().size());
+                    assertEquals(2, ((List<?>) result.getTrigger()).size());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
This PR adds support for listing AWS Lambda function versions and aliases in the plugin. It’s part of ongoing efforts to make Lambda management more robust and user-friendly for Appsmith users.

## Changes

- Introduced new commands, `LIST_FUNCTION_VERSIONS` and `LIST_FUNCTION_ALIASES`, to the AwsLambdaPlugin, enabling retrieval of function versions and aliases.
- Updated `invoke.json` to support optional fields for specifying function version and alias, improving invocation flexibility.
- Added dedicated JSON configuration files for listing function versions and aliases, streamlining command usage and future extensibility.
- Enhanced the plugin’s test suite to cover the new commands, ensuring correct behavior for version and alias retrieval.
- These changes align with our broader goal of making cloud integrations more manageable and transparent, especially as we scale Appsmith’s automation capabilities.

## Testing

Automated tests have been added to the plugin’s test suite, specifically targeting the new version and alias listing functionalities. These tests verify correct command execution and output structure.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/18035977310>
> Commit: 0148b540d74887bf64fd1eda1dff29cb73593c82
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=18035977310&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Fri, 26 Sep 2025 11:49:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List AWS Lambda function versions and aliases; invoke by selecting a version or alias (alias takes precedence).
  * New dynamic dropdowns for Function Version and Function Alias tied to the selected function; command menu adds "List Function Versions" and "List Function Aliases."
  * Trigger menus now return option lists for FUNCTION_NAMES/FUNCTION_VERSIONS/FUNCTION_ALIASES.
  * Added UI editor sections for listing versions and aliases.

* **Tests**
  * Added tests for listing versions/aliases, invoking with version/alias, trigger behavior, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->