### PR TITLE
fix: the invoke a function functionality for listing versions and aliases

### DIFF
--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
@@ -123,7 +123,15 @@ public class AwsLambdaPlugin extends BasePlugin {
                             .collect(Collectors.toList());
                 }
                 case "FUNCTION_VERSIONS" -> {
-                    String functionName = (String) params.get("functionName");
+                    // Handle both old and new parameter structures
+                    String functionName;
+                    if (params.containsKey("parameters") && params.get("parameters") instanceof Map) {
+                        Map<?, ?> parameters = (Map<?, ?>) params.get("parameters");
+                        functionName = (String) parameters.get("functionName");
+                    } else {
+                        functionName = (String) params.get("functionName");
+                    }
+
                     if (!StringUtils.hasText(functionName)) {
                         throw new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
@@ -138,7 +146,15 @@ public class AwsLambdaPlugin extends BasePlugin {
                             .collect(Collectors.toList());
                 }
                 case "FUNCTION_ALIASES" -> {
-                    String functionName = (String) params.get("functionName");
+                    // Handle both old and new parameter structures
+                    String functionName;
+                    if (params.containsKey("parameters") && params.get("parameters") instanceof Map) {
+                        Map<?, ?> parameters = (Map<?, ?>) params.get("parameters");
+                        functionName = (String) parameters.get("functionName");
+                    } else {
+                        functionName = (String) params.get("functionName");
+                    }
+
                     if (!StringUtils.hasText(functionName)) {
                         throw new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/invoke.json
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/resources/editor/invoke.json
@@ -58,7 +58,9 @@
                 "params": {
                   "requestType": "FUNCTION_VERSIONS",
                   "displayType": "DROP_DOWN",
-                  "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  "parameters": {
+                    "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  }
                 }
               }
             }
@@ -86,7 +88,9 @@
                 "params": {
                   "requestType": "FUNCTION_ALIASES",
                   "displayType": "DROP_DOWN",
-                  "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  "parameters": {
+                    "functionName": "{{actionConfiguration.formData.functionName.data}}"
+                  }
                 }
               }
             }


### PR DESCRIPTION


## Description
- Enhanced the AwsLambdaPlugin to support both old and new parameter structures for retrieving function names in FUNCTION_VERSIONS and FUNCTION_ALIASES requests.
- Updated the invoke.json to reflect the new parameter structure, ensuring compatibility with the updated logic.

This change improves the robustness of the plugin by accommodating different parameter formats, preventing potential errors during function name retrieval.
Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
