### PR TITLE
fix: Failure in downloading hurl due to upstream changes

### DIFF
--- a/deploy/docker/route-tests/Dockerfile
+++ b/deploy/docker/route-tests/Dockerfile
@@ -4,9 +4,9 @@ SHELL ["bash", "-eux", "-c"]
 
 RUN <<END
   version="$(basename "$(curl -sS --write-out '%{redirect_url}' 'https://github.com/Orange-OpenSource/hurl/releases/latest')")"
-  curl -sS --location "https://github.com/Orange-OpenSource/hurl/releases/download/$version/hurl-$version-$(uname -m)-unknown-linux-gnu.tar.gz" \
-    | tar xvz -C /tmp --strip-components 1
-  mv /tmp/hurl /bin
+  arch="$(uname -m)"
+  curl -sS --location "https://github.com/Orange-OpenSource/hurl/releases/download/$version/hurl-$version-$arch-unknown-linux-gnu.tar.gz" \
+    | tar -xvz -C /bin --strip-components 2 "hurl-$version-$arch-unknown-linux-gnu/bin/hurl"
   chmod +x /bin/hurl
 
   version="$(basename "$(curl -sS --write-out '%{redirect_url}' 'https://github.com/FiloSottile/mkcert/releases/latest')")"


### PR DESCRIPTION
Fix the [Caddy route tests workflow](https://github.com/appsmithorg/appsmith/actions/workflows/caddy-routes-test.yml).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for route test container by selecting the correct binary for the running architecture (e.g., ARM, x86), reducing setup failures.

* **Chores**
  * Streamlined binary installation in the test container by extracting directly to the system path, removing unnecessary intermediate steps.
  * Maintained existing certificate setup with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->