### PR TITLE
solve

### DIFF
--- a/app/client/src/widgets/BaseWidgetHOC/withBaseWidgetHOC.ts
+++ b/app/client/src/widgets/BaseWidgetHOC/withBaseWidgetHOC.ts
@@ -9,7 +9,8 @@ import { flow, identity } from "lodash";
 export interface BaseWidgetProps extends WidgetProps, WidgetState {}
 
 export const withBaseWidgetHOC = (
-  Widget: typeof BaseWidget,
+  // Another common way to type a class constructor
+  Widget: typeof BaseWidget extends new (...args: any[]) => infer R ? new (...args: any[]) => R : any,
   needsMeta: boolean,
   eagerRender: boolean,
 ) => {

--- a/app/client/src/widgets/ButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/widget/index.tsx
@@ -576,11 +576,11 @@ class ButtonWidget extends BaseWidget<ButtonWidgetProps, ButtonWidgetState> {
   }
 
   getWidgetView() {
-    const disabled =
+    const disableFromFormInvalidity =
       this.props.disabledWhenInvalid &&
       "isFormValid" in this.props &&
       !this.props.isFormValid;
-    const isDisabled = this.props.isDisabled || disabled;
+      const isDisabled = this.props.isDisabled || disableFromFormInvalidity;
 
     return (
       <ButtonComponent
@@ -630,6 +630,11 @@ export interface ButtonWidgetProps extends WidgetProps {
   placement?: ButtonPlacement;
   disabledWhenInvalid?: boolean;
   resetFormOnClick?: boolean;
+  
+  isFormValid?: boolean;
+  onReset?: () => void; 
+  maxWidth?: number;
+  minHeight?: number; 
 }
 
 interface ButtonWidgetState extends WidgetState {

--- a/app/client/tsconfig.json
+++ b/app/client/tsconfig.json
@@ -31,6 +31,9 @@
     "typeRoots": ["./typings", "./node_modules/@types"],
     "sourceMap": true,
     "baseUrl": "./src",
+    "paths": {
+      "components/*": ["components/*"]
+    },
     "noFallthroughCasesInSwitch": true,
     "verbatimModuleSyntax": true
   },


### PR DESCRIPTION
The error 'nvm' is not recognized happens because Windows cannot find nvm.exe in the system PATH, even after installing nvm-windows. To fix this, you need to first ensure NVM is installed correctly, usually in C:\nvm, and that both C:\nvm\nvm.exe and C:\nvm\nodejs\ exist. Then, add these two paths to the system PATH variable via Environment Variables, close and reopen PowerShell so the changes take effect, and verify the installation by running nvm version. Once NVM is recognized, install the required Node version for Appsmith using nvm install 20.11.1 and switch to it with nvm use 20.11.1, checking the version with node -v. Next, navigate to the Appsmith client directory and install dependencies using Yarn with yarn install, which correctly handles workspace packages. Ensure the package.json start script uses cross-env for Windows compatibility, then run yarn start to launch the Appsmith client in development mode. This process ensures that Node, NVM, and Yarn are properly configured for Appsmith on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Button widget now supports additional props: isFormValid, onReset, maxWidth, and minHeight for enhanced configurability.

- Refactor
  - Improved typing for widget composition to better support subclasses (no runtime changes).
  - Renamed an internal variable in the button widget for clarity (no behavior change).

- Chores
  - Added a TypeScript path alias to simplify component imports (build-time only, no user impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->