### PR TITLE
fix: BorderRadius and BoxShadow button styles in JSONForm property pane

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
@@ -515,6 +515,29 @@ const generateButtonStyleControlsV2For = (prefix: string) => [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: { type: ValidationTypes.TEXT },
+        updateHook: (
+          props: JSONFormWidgetProps,
+          propertyPath: string,
+          propertyValue: string,
+        ) => {
+          const parentProperty = prefix;
+          const parentStyles = props[parentProperty as keyof JSONFormWidgetProps];
+
+          // Replace the parent styles object with a shallow copy containing the updated value for proper reactivity
+          if (parentStyles && typeof parentStyles === "object") {
+            return [
+              {
+                propertyPath: parentProperty,
+                propertyValue: {
+                  ...parentStyles,
+                  borderRadius: propertyValue,
+                },
+              },
+            ];
+          }
+
+          return [];
+        },
       },
       {
         propertyName: `${prefix}.boxShadow`,
@@ -527,6 +550,29 @@ const generateButtonStyleControlsV2For = (prefix: string) => [
         isTriggerProperty: false,
         validation: {
           type: ValidationTypes.TEXT,
+        },
+        updateHook: (
+          props: JSONFormWidgetProps,
+          propertyPath: string,
+          propertyValue: string,
+        ) => {
+          const parentProperty = prefix;
+          const parentStyles = props[parentProperty as keyof JSONFormWidgetProps];
+
+          // Replace the parent styles object with a shallow copy containing the updated value proper reactivity
+          if (parentStyles && typeof parentStyles === "object") {
+            return [
+              {
+                propertyPath: parentProperty,
+                propertyValue: {
+                  ...parentStyles,
+                  boxShadow: propertyValue,
+                },
+              },
+            ];
+          }
+
+          return [];
         },
       },
     ],


### PR DESCRIPTION
## Description

Enhances the property update mechanism for button style controls in the JSON Form widget by introducing custom updateHook functions. These hooks ensure that updates to borderRadius and boxShadow correctly trigger reactivity by replacing the parent style object with a shallow copy containing the updated value.

#### Changes:

* Added an **updateHook** to the **borderRadius property** control so that changes update the parent style object with a shallow copy, ensuring proper reactivity. **(app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts)**
* Added an **updateHook** to the **boxShadow property** control to update the parent style object with a shallow copy for correct reactivity when the property changes. **(app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts)**

Fixes #24376   


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed real-time reactivity for button styling properties. Border radius and box shadow changes now instantly reflect in the editor without requiring manual refresh. This ensures immediate visual feedback during style property edits, providing a more responsive and seamless experience when configuring button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->