### PR TITLE
fix: handle potential null basePageId in URL generation

### DIFF
--- a/app/client/src/pages/AppIDE/layouts/components/Header/index.tsx
+++ b/app/client/src/pages/AppIDE/layouts/components/Header/index.tsx
@@ -142,7 +142,7 @@ const Header = () => {
   );
 
   const deployLink = useHref(viewerURL, {
-    basePageId: currentPage?.basePageId,
+    basePageId: currentPage?.basePageId || null,
   });
 
   const updateApplicationDispatch = (

--- a/app/client/src/pages/Editor/utils.tsx
+++ b/app/client/src/pages/Editor/utils.tsx
@@ -300,7 +300,15 @@ export function useHref<T extends URLBuilderParams>(
   const pageId = useSelector(getCurrentPageId);
 
   useEffect(() => {
-    if (pageId) setHref(urlBuilderFn(params));
+    if (pageId) {
+      try {
+        setHref(urlBuilderFn(params));
+      } catch (error) {
+        // If basePageId is not available yet, keep href as empty string
+        // This can happen during initial page load or navigation
+        setHref("");
+      }
+    }
   }, [params, urlBuilderFn, pageId]);
 
   return href;


### PR DESCRIPTION
# PR Description

## Summary
Fixes an issue where `basePageId` could be undefined during initial page load or navigation, causing errors in the URL builder.

## Changes
- Added fallback to `null` for `basePageId` in Header component when undefined
- Wrapped `urlBuilderFn` call in try-catch block to gracefully handle missing `basePageId`
- Returns empty string for href when `basePageId` is not yet available

## Why
During initial page load or navigation transitions, `currentPage?.basePageId` may not be available yet, which could cause the URL builder to throw errors. This change ensures the application handles this edge case gracefully by providing a fallback value and catching any errors that may occur.

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/18742901184>
> Commit: 48dc01a73bbb816b63acd186d9d80eb36cdf5814
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=18742901184&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Thu, 23 Oct 2025 09:48:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
