### PR TITLE
fix: ensure applications display correctly when AI agent flags are partially enabled

### DIFF
--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -929,7 +929,7 @@ export function ApplicationsSection(props: any) {
             <ResourceListLoader isMobile={isMobile} resources={applications} />
           ) : (
             <>
-              {!isAiAgentInstanceEnabled && (
+              {(!isAiAgentInstanceEnabled || !isAiAgentFlowEnabled) && (
                 <ApplicationCardList
                   applications={nonAnvilApplications}
                   canInviteToWorkspace={canInviteToWorkspace}
@@ -946,7 +946,7 @@ export function ApplicationsSection(props: any) {
                   workspaceId={activeWorkspace.id}
                 />
               )}
-              {isAiAgentFlowEnabled && (
+              {isAiAgentFlowEnabled && isAiAgentInstanceEnabled && (
                 <ApplicationCardList
                   applications={anvilApplications}
                   canInviteToWorkspace={canInviteToWorkspace}


### PR DESCRIPTION
## Description
Fixed a logic gap in the Applications page where no applications would be displayed when `isAiAgentInstanceEnabled` is true but `isAiAgentFlowEnabled` is false.

## Changes
- Updated conditional rendering logic for application lists to handle all combinations of AI agent feature flags
- Non-anvil applications now display when either flag is disabled: `(!isAiAgentInstanceEnabled || !isAiAgentFlowEnabled)`
- Anvil applications (AI agents) now only display when both flags are enabled: `isAiAgentFlowEnabled && isAiAgentInstanceEnabled`

## Problem
Previously, when `isAiAgentInstanceEnabled` was `true` and `isAiAgentFlowEnabled` was `false`, neither ApplicationCardList component would render, resulting in no applications being shown to the user.

### Logic Gap:
- First list: `!isAiAgentInstanceEnabled` → evaluates to `false`, doesn't render
- Second list: `isAiAgentFlowEnabled` → evaluates to `false`, doesn't render  
- Result: No applications displayed

## Solution
Updated the conditions to ensure at least one list always renders based on the flag states:
- Regular applications display unless both AI flags are enabled
- AI agent applications only display when both flags are enabled

## Testing
- [ ] Verified applications display when both flags are false
- [ ] Verified applications display when `isAiAgentInstanceEnabled` is true but `isAiAgentFlowEnabled` is false
- [ ] Verified both application types display correctly when both flags are true
- [ ] Verified AI agent applications only when both flags are enabled

## Files Changed
- `app/client/src/ce/pages/Applications/index.tsx`


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application availability by refining the logic that determines which application card lists are displayed based on different system configuration combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->