### PR TITLE
fix: revert applications display correctly when AI agent flags are partially enabled

### DIFF
--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -929,7 +929,7 @@ export function ApplicationsSection(props: any) {
             <ResourceListLoader isMobile={isMobile} resources={applications} />
           ) : (
             <>
-              {(!isAiAgentInstanceEnabled || !isAiAgentFlowEnabled) && (
+              {!isAiAgentInstanceEnabled && (
                 <ApplicationCardList
                   applications={nonAnvilApplications}
                   canInviteToWorkspace={canInviteToWorkspace}
@@ -946,7 +946,7 @@ export function ApplicationsSection(props: any) {
                   workspaceId={activeWorkspace.id}
                 />
               )}
-              {isAiAgentFlowEnabled && isAiAgentInstanceEnabled && (
+              {isAiAgentFlowEnabled && (
                 <ApplicationCardList
                   applications={anvilApplications}
                   canInviteToWorkspace={canInviteToWorkspace}


### PR DESCRIPTION
Reverts appsmithorg/appsmith#41317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated application display conditions for different application types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/18837702804>
> Commit: 5a0df5d6500ea84fd54647fafdf10329bdf41747
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=18837702804&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 27 Oct 2025 11:08:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->
