### PR TITLE
chore: specify Google Chrome version in CI workflow

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -254,12 +254,12 @@ jobs:
           chmod a+x ./cypress/setup-test-ci.sh
           ./cypress/setup-test-ci.sh
 
-      - name: Install Google Chrome
+      - name: Install Google Chrome 129.0.6668.100
         run: |
           sudo apt-get remove google-chrome-stable
-          wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          wget -q https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb --show-progress
           sudo apt-get update
-          sudo apt-get install -y ./google-chrome-stable_current_amd64.deb
+          sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version
 


### PR DESCRIPTION
Updated the CI workflow to install a specific version of Google Chrome (129.0.6668.100) instead of the latest version. This change ensures consistency in the testing environment by using a known version for all CI runs.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to pin Google Chrome to a specific version for improved test consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->