### PR TITLE
chore: update Google Chrome download link in CI workflow

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Install Google Chrome 129.0.6668.100
         run: |
           sudo apt-get remove google-chrome-stable
-          wget -q https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb --show-progress
+          wget -q https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb --show-progress
           sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV


### PR DESCRIPTION
Changed the download link for Google Chrome version 129.0.6668.100 in the CI workflow to a new S3 location, ensuring continued access to the specified version for consistent testing environments.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 9c0cfc8d0f0738a7355dded8eb20acb58afbc8ba yet
> <hr>Mon, 03 Nov 2025 07:10:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration for test environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->