### PR TITLE
fix: pin caddy to 2.10.0 due to precompressed file issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE
-FROM ${BASE}
+FROM wyattappsmith/appsmith-base
 
 ENV IN_DOCKER=1
 

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:builder-alpine AS caddybuilder
+FROM caddy:2.10.0-builder-alpine AS caddybuilder
 
 RUN xcaddy build \
   --with github.com/mholt/caddy-ratelimit
@@ -74,7 +74,8 @@ END
 # Install Caddy
 RUN set -o xtrace \
   && mkdir -p /opt/caddy \
-  && version="$(curl --write-out '%{redirect_url}' 'https://github.com/caddyserver/caddy/releases/latest' | sed 's,.*/v,,')" \
+  # && version="$(curl --write-out '%{redirect_url}' 'https://github.com/caddyserver/caddy/releases/latest' | sed 's,.*/v,,')" \
+  && version="2.10.0" \
   && curl --location "https://github.com/caddyserver/caddy/releases/download/v$version/caddy_${version}_linux_$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/').tar.gz" \
     | tar -xz -C /opt/caddy && \
   mv /opt/caddy/caddy /opt/caddy/caddy_vanilla


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
