### PR TITLE
fix: temporarily disable precompressed directive

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -55,7 +55,9 @@ parts.push(`
 
 (file_server) {
   file_server {
-    precompressed br gzip
+    # temporarily disabling precompressed files to deal with with https://github.com/appsmithorg/appsmith/issues/41313
+    # uncomment the next line and remove this one when Caddy 2.10.3+ is released.
+    # precompressed br gzip
     disable_canonical_uris
   }
 }


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

Disable precompressed directive in Caddy temporarily. This is to cause Caddy to serve static files with a 200 instead of a 206 due to a change in behavior in Caddy 2.10.2.

The 206 response is causing rate limit issues in some installs, and failed upgrades in others when folks use an HTTP request to `/` for health checks. It also causes browsers to not validate files correctly, so we make a lot of extra requests to the server.

There's 2 options to address it:

- Downgrade Caddy, which introduces a few 3 month old high CVEs via the Golang toolchain
- Disable precompressed directive and let Caddy compress the files on the fly during requests

There's a fix in the default branch of Caddy for this issue, we're just waiting for a release.

Fixes [#41313](https://github.com/appsmithorg/appsmith/issues/41313)

> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily disabled precompressed file delivery to resolve compatibility issues. This feature will be automatically re-enabled when Caddy updates to version 2.10.3 or later.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->