### PR TITLE
feat: add RepositoryInfo component to BranchListView and TabGeneral

### DIFF
--- a/app/client/src/git/components/BranchList/BranchListView.tsx
+++ b/app/client/src/git/components/BranchList/BranchListView.tsx
@@ -35,6 +35,7 @@ import useActiveHoverIndex from "./hooks/useActiveHoverIndex";
 import { Space } from "pages/Editor/gitSync/components/StyledComponents";
 import type { FetchProtectedBranchesResponseData } from "git/requests/fetchProtectedBranchesRequest.types";
 import type { GitBranch } from "git/types";
+import RepositoryInfo from "../SettingsModal/TabGeneral/RepositoryInfo";
 
 const ListContainer = styled.div`
   flex: 1;
@@ -364,6 +365,7 @@ export default function BranchListView({
           onClickClose={handleClickOnClose}
           onClickRefresh={handleClickOnRefresh}
         />
+        <RepositoryInfo />
         <Space size={3} />
         <div data-testid="t--git-branch-search-input" style={{ width: 300 }}>
           {isLoading && (

--- a/app/client/src/git/components/SettingsModal/TabGeneral/RepositoryInfo.tsx
+++ b/app/client/src/git/components/SettingsModal/TabGeneral/RepositoryInfo.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback } from "react";
+import styled from "styled-components";
+import { Text, Icon } from "@appsmith/ads";
+import useMetadata from "git/hooks/useMetadata";
+
+const Header = styled.div`
+  margin-bottom: ${(props) => props.theme.spaces[3]}px;
+`;
+
+const RepositoryLinkContainer = styled.a`
+  display: flex;
+  align-items: center;
+  gap: ${(props) => props.theme.spaces[2]}px;
+  padding: ${(props) => props.theme.spaces[4]}px;
+  background: var(--ads-v2-color-bg-subtle);
+  border: 1px solid var(--ads-v2-color-border);
+  border-radius: var(--ads-v2-border-radius);
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: var(--ads-v2-color-bg-muted);
+    border-color: var(--ads-v2-color-border-emphasis);
+  }
+`;
+
+const RepositoryDetails = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${(props) => props.theme.spaces[1]}px;
+`;
+
+const RepositoryName = styled(Text)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+function RepositoryInfo() {
+  const { metadata } = useMetadata();
+
+  const browserSupportedUrl =
+    metadata?.browserSupportedRemoteUrl ||
+    metadata?.browserSupportedUrl ||
+    null;
+  const repoName = metadata?.repoName || null;
+  const remoteUrl = metadata?.remoteUrl || null;
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+
+      if (browserSupportedUrl) {
+        window.open(browserSupportedUrl, "_blank", "noopener,noreferrer");
+      }
+    },
+    [browserSupportedUrl],
+  );
+
+  if (!browserSupportedUrl && !repoName && !remoteUrl) {
+    return null;
+  }
+
+  return (
+    <div className="px-0 mb-4">
+      <Header>
+        <Text kind="heading-xs">Repository</Text>
+      </Header>
+      {browserSupportedUrl && (
+        <RepositoryLinkContainer
+          data-testid="t--git-settings-repo-link"
+          href={browserSupportedUrl}
+          onClick={handleClick}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <Icon name="git-repository" size="md" />
+          <RepositoryDetails>
+            {repoName && (
+              <RepositoryName kind="body-m">{repoName}</RepositoryName>
+            )}
+          </RepositoryDetails>
+          <Icon name="share-box-line" size="sm" />
+        </RepositoryLinkContainer>
+      )}
+    </div>
+  );
+}
+
+export default RepositoryInfo;

--- a/app/client/src/git/components/SettingsModal/TabGeneral/index.tsx
+++ b/app/client/src/git/components/SettingsModal/TabGeneral/index.tsx
@@ -3,6 +3,7 @@ import LocalProfile from "../../LocalProfile";
 import DangerZone from "../../DangerZone";
 import styled from "styled-components";
 import InvalidKeyWarning from "./InvalidKeyWarning";
+import RepositoryInfo from "./RepositoryInfo";
 
 const Container = styled.div`
   overflow: auto;
@@ -23,6 +24,7 @@ function TabGeneral({
   return (
     <Container>
       <InvalidKeyWarning />
+      <RepositoryInfo />
       <LocalProfile />
       {showDangerZone && <DangerZone />}
     </Container>


### PR DESCRIPTION
## Description
We use the output of the consolidated API to show this

<img width="348" height="574" alt="Screenshot 2025-11-13 at 4 23 14 PM" src="https://github.com/user-attachments/assets/0ac8c7e0-dec5-42c3-b0ee-a7f50d0a9df9" />
<img width="647" height="703" alt="Screenshot 2025-11-13 at 4 23 03 PM" src="https://github.com/user-attachments/assets/c0144038-8832-49bd-be3b-7d918afba5f0" />


Fixes `[Issue URL](https://github.com/appsmithorg/appsmith/issues/41374)`

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/19417955467>
> Commit: 7ece0778cdbe1e188d2ff4b98b68786b75352a98
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=19417955467&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Mon, 17 Nov 2025 04:58:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository information display showing repository name and URL. Users can click the repository link to open it in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->