### PR TITLE
feat: add setValue method for radio group

### DIFF
--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -718,6 +718,11 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
           path: "options",
           type: "array",
         },
+        setValue: {
+          path: "defaultOptionValue",
+          type: "string",
+          accessor: "selectedOptionValue",
+        },
       },
     };
   }


### PR DESCRIPTION
## Description

TL;DR: Add widget setter configuration for the legacy `Radio Group` widget so it can be controlled via Appsmith’s setter APIs (visibility, disabled state, data, and value), consistent with other input widgets.

This change introduces a `static getSetterConfig()` implementation for the `RadioGroupWidget` so that it exposes the standard widget setters used by JS actions and future automation:

- **`setVisibility`** → maps to `isVisible` (boolean)  
- **`setDisabled`** → maps to `isDisabled` (boolean)  
- **`setData`** → maps to `options` (array) so callers can update the radio options programmatically  
- **`setValue`** → maps to `defaultOptionValue` (string) with `selectedOptionValue` as the accessor, so the selected value stays in sync with the widget’s meta state and derived properties

This aligns the legacy `RadioGroupWidget` with other widgets (for example `CurrencyInputWidget`) that already expose setter methods, enabling a more consistent programmatic API across widgets and unblocking flows that rely on setters to drive form state. There are no server-side changes and no new external dependencies; all changes are confined to the client widget implementation.

Fixes [#8433](https://github.com/appsmithorg/appsmith-ee/issues/8433) 



## Automation

/ok-to-test tags="@tag.Radio"



### :mag: Cypress test results

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/19581110175>
> Commit: 2681f986ac12b723ab9e129123cccfe0141a2e63
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=19581110175&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Radio`
> Spec:
> <hr>Fri, 21 Nov 2025 19:46:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->



## Communication

Should the DevRel and Marketing teams inform users about this change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public setter to the RadioGroupWidget that enables developers to programmatically set and update the default selected option value at runtime. This enhancement expands the available configuration options for radio button group widgets, providing greater flexibility for dynamic form scenarios and allowing better programmatic control over default option selection behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->