### PR TITLE
fix: updated the Google AI datasource's gemini models with options compatatible with generate command

### DIFF
--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/constants/GoogleAIConstants.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/constants/GoogleAIConstants.java
@@ -23,7 +23,12 @@ public class GoogleAIConstants {
     public static final String MESSAGES = "messages";
     public static final String LABEL = "label";
     public static final String VALUE = "value";
-    public static final List<String> GOOGLE_AI_MODELS = List.of("gemini-pro");
+    public static final List<String> GOOGLE_AI_MODELS = List.of(
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini-2.0-flash",
+            "gemini-flash-latest",
+            "gemini-flash-lite-latest");
     public static final ExchangeStrategies EXCHANGE_STRATEGIES = ExchangeStrategies.builder()
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(/* 10MB */ 10 * 1024 * 1024))
             .build();

--- a/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GenerateContentCommandTest.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GenerateContentCommandTest.java
@@ -32,10 +32,11 @@ public class GenerateContentCommandTest {
     @Test
     public void testCreateExecutionUri() {
         ActionConfiguration actionConfiguration = new ActionConfiguration();
-        actionConfiguration.setFormData(Map.of(GENERATE_CONTENT_MODEL, Map.of(DATA, "gemini-pro")));
+        actionConfiguration.setFormData(Map.of(GENERATE_CONTENT_MODEL, Map.of(DATA, "gemini-2.5-pro")));
         URI uri = generateContentCommand.createExecutionUri(actionConfiguration);
         Assertions.assertEquals(
-                "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent", uri.toString());
+                "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+                uri.toString());
     }
 
     @Test

--- a/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GoogleAiPluginTest.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GoogleAiPluginTest.java
@@ -109,7 +109,7 @@ public class GoogleAiPluginTest {
         apiKeyAuth.setValue("apiKey");
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
         datasourceConfiguration.setAuthentication(apiKeyAuth);
-        String responseBody = "[\"gemini-pro\"]";
+        String responseBody = "[\"gemini-2.5-pro\"]";
         MockResponse mockResponse = new MockResponse().setBody(responseBody);
         mockResponse.setResponseCode(200);
         mockEndpoint.enqueue(mockResponse);
@@ -122,8 +122,15 @@ public class GoogleAiPluginTest {
         StepVerifier.create(datasourceTriggerResultMono)
                 .assertNext(result -> {
                     assertTrue(result.getTrigger() instanceof List<?>);
-                    assertEquals(((List) result.getTrigger()).size(), 1);
-                    assertEquals(result.getTrigger(), getDataToMap(List.of("gemini-pro")));
+                    assertEquals(((List) result.getTrigger()).size(), 5);
+                    assertEquals(
+                            result.getTrigger(),
+                            getDataToMap(List.of(
+                                    "gemini-2.5-pro",
+                                    "gemini-2.5-flash",
+                                    "gemini-2.0-flash",
+                                    "gemini-flash-latest",
+                                    "gemini-flash-lite-latest")));
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
Replace gemini-pro that has been deprecated with 5 models as below
1. gemini-2.5-flash
2. gemini-2.5-pro
3. gemini-2.0-flash
4. gemini-flash-latest
5. gemini-flash-lite-latest

All these models support the generate content command as verified from this List Models API here: https://generativelanguage.googleapis.com/v1beta/models?key=<GOOGLE_API_KEY>

Fixes https://github.com/appsmithorg/appsmith/issues/41105

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/19674900186>
> Commit: 13074e86724681f19796d704309e0c7d2581e493
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=19674900186&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 25 Nov 2025 16:44:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google AI plugin now supports additional AI models: Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.0 Flash, Gemini Flash Latest, and Gemini Flash Lite Latest, expanding your model selection options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->