### PR TITLE
fix: correct placeholder text for graphql action editor

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionForm/components/GraphQLEditor/PostBodyData.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/components/GraphQLEditor/PostBodyData.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 const EXPECTED_VARIABLE = {
   type: "object",
-  example: '{\n  "name": "{{ inputName.property }}"\n}',
+  example: '{\n  "name": "{{ inputName.text }}"\n}',
   autocompleteDataType: AutocompleteDataType.OBJECT,
 };
 

--- a/app/client/src/components/formControls/CustomActionControls/CustomGraphQLActionsConfigControl.tsx
+++ b/app/client/src/components/formControls/CustomActionControls/CustomGraphQLActionsConfigControl.tsx
@@ -46,7 +46,7 @@ const StyledFormLabel = styled(FormLabel)`
 
 const EXPECTED_VARIABLE = {
   type: "object",
-  example: '{\n  "name": "{{ inputName.property }}"\n}',
+  example: '{\n  "name": "{{ inputName.text }}"\n}',
   autocompleteDataType: AutocompleteDataType.OBJECT,
 };
 


### PR DESCRIPTION
## Description
This PR replaces the placeholder text for custom graphql actions with a valid example.


Fixes #41422 

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/19724407878>
> Commit: ac5f41c3cb884c8c44708f730abe2495be0f0762
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=19724407878&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Thu, 27 Nov 2025 04:22:34 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified the example payload shown in the GraphQL variables editor and updated the GraphQL query template placeholder to a clearer, concrete example for improved clarity in the configuration UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->