### PR TITLE
fix: scroll list widget to top on page change (#41287)

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -848,6 +848,17 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
     };
   }
 
+  scrollToTop = () => {
+    // Find the scrollable container using the widget's generated class name
+    const scrollableElement = document.querySelector(
+      `.${this.props.widgetId}`,
+    );
+
+    if (scrollableElement) {
+      scrollableElement.scrollTop = 0;
+    }
+  };
+
   onPageChange = (page: number) => {
     const currentPage = this.props.pageNo;
     const eventType =
@@ -860,6 +871,9 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
         type: eventType,
       },
     });
+
+    // Scroll to top after page change
+    setTimeout(() => this.scrollToTop(), 0);
   };
 
   /**
@@ -1527,7 +1541,10 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
               boxShadow={this.props.boxShadow}
               current={this.state.page}
               disabled={false && this.props.renderMode === RenderModes.CANVAS}
-              onChange={(page: number) => this.setState({ page })}
+              onChange={(page: number) => {
+                this.setState({ page });
+                setTimeout(() => this.scrollToTop(), 0);
+              }}
               perPage={perPage}
               total={(this.props.listData || []).length}
             />


### PR DESCRIPTION
## Description
Fixes List widget UX issue where content stayed scrolled down when changing pages. Now scrolls to top on page change for better user experience.

**Fixes**: [#41287](https://github.com/appsmithorg/appsmith/issues/41287)

**Tested locally**:
1. `yarn dev`
2. Add List widget (20+ items)
3. Click "Next" page → **scrolls to top** ✅

**Files changed**: `app/client/src/widgets/ListWidget/index.tsx` (3 lines)

First-time contributor! 🚀

## Automation
/ok-to-test

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lists now automatically scroll to the top when navigating between pages for improved browsing experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->