### PR TITLE
fix: Swapped field order in OAuth2 form - Scope now comes before Authorization expires in (#31059)

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -683,6 +683,16 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+          {this.renderInputTextControlViaFormControl({
+            configProperty: "authentication.expiresIn",
+            label: "Authorization expires in (seconds)",
+            placeholderText: "3600",
+            dataType: "NUMBER",
+            encrypted: false,
+            isRequired: false,
+          })}
+        </FormInputContainer>
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +879,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&


### PR DESCRIPTION
## Description
Fixes #31059

Corrects the field order in the OAuth2 configuration form. Previously, "Authorization expires in" appeared before "Scope", which is backwards. This change swaps them so Scope appears first (as users typically define what access they need before setting expiration time).

**What changed:**
- Swapped two fields in the OAuth2 form
- Scope now appears before Authorization expires in
- No logic changes - purely UI/UX improvement

**Why this matters:**
The natural workflow for OAuth2 setup is:
1. Define what access you need (Scope)
2. Set expiration time (Authorization expires in)
This change aligns the form with that logical flow.

**File modified:** `src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 authentication configuration by ensuring the "Authorization expires in (seconds)" field is consistently available across all OAuth2 authentication methods, eliminating inconsistencies in the form UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->