### PR TITLE
Improve query preparation error messages for SQL plugins

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/exceptions/MssqlErrorMessages.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/exceptions/MssqlErrorMessages.java
@@ -11,8 +11,11 @@ public class MssqlErrorMessages extends BasePluginErrorMessages {
     public static final String QUERY_EXECUTION_FAILED_ERROR_MSG =
             "Your query failed to execute. Please check more information in the error details.";
 
-    public static final String QUERY_PREPARATION_FAILED_ERROR_MSG = "Query preparation failed while inserting value: %s"
-            + " for binding: {{%s}}. Please check the query again.";
+    public static final String QUERY_PREPARATION_FAILED_ERROR_MSG =
+        "Query preparation failed while inserting value: %s"
+                + " for binding: {{%s}}. "
+                + "This may happen when a value that looks numeric (for example, starts with a leading zero) "
+                + "is treated as a number instead of a string. Please double-check the query and the widget configuration.";
 
     public static final String CONNECTION_POOL_CREATION_FAILED_ERROR_MSG =
             "Exception occurred while creating connection pool. One or more arguments in the datasource configuration may be invalid. Please check your datasource configuration.";

--- a/app/server/appsmith-plugins/oraclePlugin/src/main/java/com/external/plugins/exceptions/OracleErrorMessages.java
+++ b/app/server/appsmith-plugins/oraclePlugin/src/main/java/com/external/plugins/exceptions/OracleErrorMessages.java
@@ -16,7 +16,11 @@ public class OracleErrorMessages extends BasePluginErrorMessages {
             "The Appsmith server has failed to fetch the structure of your schema.";
 
     public static final String QUERY_PREPARATION_FAILED_ERROR_MSG =
-            "Query preparation failed while inserting value: %s" + " for binding: {{%s}}.";
+            "Query preparation failed while inserting value: %s"
+                    + " for binding: {{%s}}. "
+                    + "This may happen when a value that looks numeric (for example, starts with a leading zero) "
+                    + "is treated as a number instead of a string. Please double-check the query and the widget configuration.";
+
 
     public static final String SSL_CONFIGURATION_ERROR_MSG =
             "The Appsmith server has failed to fetch SSL configuration from datasource configuration form. ";

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/exceptions/PostgresErrorMessages.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/exceptions/PostgresErrorMessages.java
@@ -16,7 +16,10 @@ public class PostgresErrorMessages extends BasePluginErrorMessages {
             "The Appsmith server has failed to fetch the structure of your schema.";
 
     public static final String QUERY_PREPARATION_FAILED_ERROR_MSG =
-            "Query preparation failed while inserting value: %s" + " for binding: {{%s}}.";
+            "Query preparation failed while inserting value: %s"
+                    + " for binding: {{%s}}. "
+                    + "This may happen when a value that looks numeric (for example, starts with a leading zero) "
+                    + "is treated as a number instead of a string. Please double-check the query and the widget configuration.";
 
     public static final String SSL_CONFIGURATION_ERROR_MSG =
             "The Appsmith server has failed to fetch SSL configuration from datasource configuration form. ";


### PR DESCRIPTION
## Description
**TL;DR:** Improve SQL query preparation error messages for the PostgreSQL, MSSQL, and Oracle plugins so that users get more actionable guidance when bindings fail.

This PR updates the `QUERY_PREPARATION_FAILED_ERROR_MSG` constant in:

- `PostgresErrorMessages`
- `MssqlErrorMessages`
- `OracleErrorMessages`

The new messages:
- Explicitly call out that *numeric-looking* values (for example, values starting with a leading zero) may be treated as numbers instead of strings by the database/driver.
- Encourage users to double-check both the query and the widget configuration when query preparation fails.

The goal is to make it easier for users and maintainers to debug issues like #41189, where values such as `"09:30"` or `"01234"` can cause query preparation errors, by surfacing more context directly in the error message.

No new dependencies are introduced by this change.

Related to #41189

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error messages for database query preparation failures across MSSQL, Oracle, and Postgres plugins. Error messages now provide clearer guidance on handling numeric-looking values (such as leading zeros) and include recommendations to verify query and widget configuration for better troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->