### PR TITLE
fix: Corrected message for REDEPLOY_APP_WARNING. Also not showing Redeploy when Pull button is shown in GIT Modal. (#41474)

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1055,7 +1055,7 @@ export const CURRENT_PAGE_DISCARD_WARNING = (page: string) =>
 export const DISCARD_MESSAGE = () =>
   `Some changes may reappear after discarding them, these changes support new features in Appsmith. You can safely commit them to your repository.`;
 export const REDEPLOY_APP_WARNING = () =>
-  "The deployed version of this app is not using the latest versions of some packages. Redeploy to apply the latest package versions to the app.";
+  "The deployed version of this app may be out of sync with what you see in edit mode. Redeploy to apply the latest state.";
 
 // GIT DEPLOY end
 

--- a/app/client/src/git/components/OpsModal/TabDeploy/TabDeployView.tsx
+++ b/app/client/src/git/components/OpsModal/TabDeploy/TabDeployView.tsx
@@ -147,9 +147,6 @@ function TabDeployView({
     !isCommitLoading &&
     !isDiscarding;
 
-  const shouldShowRedeploy =
-    !isFetchStatusLoading && !hasChangesToCommit && !!redeployTrigger;
-
   const isCommitting =
     !!commitButtonLoading &&
     (commitRequired || showCommitButton) &&
@@ -170,6 +167,12 @@ function TabDeployView({
     !isFetchStatusLoading &&
     ((pullRequired && !isConflicting) ||
       (statusBehindCount > 0 && statusIsClean));
+
+  const shouldShowRedeploy =
+    !isFetchStatusLoading &&
+    !hasChangesToCommit &&
+    !showPullButton &&
+    !!redeployTrigger;
 
   const isCommitSuccess = useMemo(() => {
     return hasSubmitted && !isCommitLoading;


### PR DESCRIPTION
## Description
Corrected message for REDEPLOY_APP_WARNING. Also not showing Redeploy when Pull button is shown in GIT Modal. (#41474)

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the
maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/20329707386>
> Commit: 326bff3bc31958a0cd3b272e951926f2f1f3f89c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=20329707386&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Thu, 18 Dec 2025 08:37:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Updated redeploy warning message to better reflect state synchronization issues between deployed app and editor.
* Refined conditions for displaying redeploy options to improve accuracy and user guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
