### PR TITLE
chore: updated docs url for Redeploy App

### DIFF
--- a/app/client/src/ce/constants/DeploymentConstants.ts
+++ b/app/client/src/ce/constants/DeploymentConstants.ts
@@ -13,3 +13,8 @@ export const REDEPLOY_WARNING_MESSAGE: Record<
 > = {
   [REDEPLOY_TRIGGERS.PendingDeployment]: REDEPLOY_APP_WARNING,
 };
+
+export const REDEPLOY_DOC_URL: Record<RedeployTriggerValue, string> = {
+  [REDEPLOY_TRIGGERS.PendingDeployment]:
+    "https://docs.appsmith.com/help-and-support/troubleshooting-guide/git-errors#edit-and-view-mode-out-of-sync",
+};

--- a/app/client/src/git/components/OpsModal/TabDeploy/RedeployWarning.tsx
+++ b/app/client/src/git/components/OpsModal/TabDeploy/RedeployWarning.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createMessage } from "ee/constants/messages";
 import {
   REDEPLOY_WARNING_MESSAGE,
+  REDEPLOY_DOC_URL,
   type RedeployTriggerValue,
 } from "ee/constants/DeploymentConstants";
 import { Callout, Text } from "@appsmith/ads";
@@ -18,8 +19,9 @@ interface RedeployWarningProps {
 const RedeployWarning: React.FC<RedeployWarningProps> = ({
   redeployTrigger,
 }) => {
-  const redeployDocUrl =
-    "https://docs.appsmith.com/advanced-concepts/version-control-with-git/commit-and-push";
+  if (!redeployTrigger) {
+    return null;
+  }
 
   return (
     <Container>
@@ -30,14 +32,13 @@ const RedeployWarning: React.FC<RedeployWarningProps> = ({
           {
             children: "Learn more",
             endIcon: "right-arrow",
-            to: redeployDocUrl,
+            to: REDEPLOY_DOC_URL[redeployTrigger],
             target: "_blank",
           },
         ]}
       >
         <Text kind="heading-xs">
-          {redeployTrigger &&
-            createMessage(REDEPLOY_WARNING_MESSAGE[redeployTrigger])}
+          {createMessage(REDEPLOY_WARNING_MESSAGE[redeployTrigger])}
         </Text>
       </Callout>
     </Container>


### PR DESCRIPTION
## Description
Updated appsmith docs to explain about Redeploy button, and updated the docs url for Learn more in the callout.

Fixes [41482 ](https://github.com/appsmithorg/appsmith/issues/41482)

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/20430054336>
> Commit: e4db9194c83998c8171846f5257321599db22668
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=20430054336&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Mon, 22 Dec 2025 11:59:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential rendering issue in deployment warnings by adding null check for redeploy triggers.

* **Refactor**
  * Centralized documentation URL configuration for deployment warnings to improve maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->