### PR TITLE
fix: use appsmith-built mongodb image by default in helm chart

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.6.7
+version: 3.6.8
 dependencies:
   - condition: redis.enabled
     name: redis
@@ -21,7 +21,7 @@ dependencies:
   - condition: mongodb.enabled
     name: mongodb
     version: 12.1.16
-    appVersion: 6.0.10
+    appVersion: 6.0.27
     repository: https://charts.bitnami.com/bitnami
   - condition: postgresql.enabled
     name: postgresql

--- a/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
@@ -25,7 +25,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.7
+        appsmith.sh/chart: appsmith-3.6.8
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
   3: |
@@ -36,7 +36,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.7
+        appsmith.sh/chart: appsmith-3.6.8
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -114,7 +114,7 @@
                 - sh
                 - -c
                 - until mongosh --host appsmith-mongodb.NAMESPACE.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done
-              image: docker.io/bitnamilegacy/mongodb:6.0.13
+              image: docker.io/appsmith/mongodb:6.0.27
               name: mongo-init-container
             - command:
                 - sh
@@ -142,7 +142,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.7
+        appsmith.sh/chart: appsmith-3.6.8
       name: RELEASE-NAME-appsmith-headless
       namespace: NAMESPACE
     spec:
@@ -181,7 +181,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.7
+        appsmith.sh/chart: appsmith-3.6.8
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -202,7 +202,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.7
+        appsmith.sh/chart: appsmith-3.6.8
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     secrets:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -34,8 +34,8 @@ mongodb:
   tolerations: []
   image:
     registry: docker.io
-    repository: bitnamilegacy/mongodb
-    tag: 6.0.13
+    repository: appsmith/mongodb
+    tag: 6.0.27
   arbiter:
     nodeSelector: {}
     affinity: {}


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

This PR updates the default image for a MongoDB cluster managed by the chart to use an image that has been patched for the recent MongoBleed vulnerability, since Bitnami stopped publishing updates to their images.

While not ideal, I made a few time-boxed attempts after the deprecation to use a non-Bitnami image while maintaining compatibility with the chart, but the coupling is too tight to patch over reliably. Ultimately, we need to remove the Bitnami chart from our stack, but that carries too much risk for a simple and critical security patch.

Since the Bitnami images are licensed under Apache 2.0, I’ve forked their builder and published a set of images for each major MongoDB version with the MongoBleed patch included: 6.0.27, 7.0.28, and 8.0.17. I’ve tested deployments using each of these versions, including an upgrade scenario. If anyone reading this decides to upgrade to 7.x or 8.x, please be sure to follow the upstream MongoDB documentation about feature compatibility [here](https://www.mongodb.com/docs/manual/reference/command/setFeatureCompatibilityVersion/), as we do not yet have an Appsmith-specific MongoDB upgrade guide and this is not automatically handled by MongoDB.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB to version 6.0.27
  * Bumped Helm chart version to 3.6.8

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->