### PR TITLE
fix: anonymous user can execute unpublished action

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -53,6 +53,7 @@ import org.springframework.http.codec.multipart.Part;
 import org.springframework.http.codec.xml.Jaxb2XmlDecoder;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.web.reactive.function.BodyExtractor;
 import org.springframework.web.reactive.function.BodyExtractors;
 import reactor.core.publisher.Flux;
@@ -270,6 +271,7 @@ class ActionExecutionSolutionCEImplTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void testExecuteAPIWithUsualOrderingOfTheParts() {
         String usualOrderOfParts =
                 """
@@ -328,6 +330,7 @@ class ActionExecutionSolutionCEImplTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void testExecuteAPIWithParameterMapAsLastPart() {
         String parameterMapAtLast =
                 """


### PR DESCRIPTION
## Description
Publicly accessible apps allow unauthenticated users to execute unpublished (edit-mode) actions by sending viewMode=false (or omitting it) to POST /api/v1/actions/execute. This bypasses the expected publish boundary: public viewers should only execute published actions, not edit-mode versions.

Affected Endpoint
POST /api/v1/actions/execute

Impact
Unauthorized execution of edit‑mode queries and APIs Potential access/modification of development data sources Ability to trigger side effects (write operations, external API calls) Leakage of sensitive data from unpublished actions.


I have created this[ shadow PR in EE](https://github.com/appsmithorg/appsmith-ee/pull/8557) where I verified the fix on the DP.

Fixes https://linear.app/appsmith/issue/V2-2524/vulnerability-platform-vulnerable-to-unauthorized-actions-by-public
Fixes CVE-2026-24042


## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/21136951155>
> Commit: e1051d7c97f35c0d1ab02a71a90af29becd34ae2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=21136951155&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 19 Jan 2026 16:43:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security by restricting anonymous users from accessing unpublished actions. Unauthenticated users can now only execute actions in published apps.

* **Tests**
  * Added test coverage for anonymous user action execution restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->