### PR TITLE
fix: update mongodb fcv to 6

### DIFF
--- a/deploy/docker/fs/opt/appsmith/mongodb-fixer.sh
+++ b/deploy/docker/fs/opt/appsmith/mongodb-fixer.sh
@@ -17,10 +17,10 @@ tlog "MongoDB is RUNNING"
 
 for _ in {1..60}; do
   if mongosh --quiet "$APPSMITH_DB_URL" --eval '
-    parseFloat(db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version) < 5 &&
-      db.adminCommand({setFeatureCompatibilityVersion: "5.0"})
+    parseFloat(db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1}).featureCompatibilityVersion.version) < 6 &&
+      db.adminCommand({setFeatureCompatibilityVersion: "6.0"})
   '; then
-    tlog "MongoDB version set to 5.0"
+    tlog "MongoDB version set to 6.0"
     break
   fi
   sleep 1


### PR DESCRIPTION
## Description

Looks like when the embedded MongoDB version was last updated, the feature compatibility version parameter was not updated. This means that any instances that started on 1.66 or less using the embedded MongoDB didn't have their compatibility version updated. This'll make the jump to 7.x harder as we need to ensure this is at least 6 in those scenarios. Getting this in place now.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB feature compatibility from version 5.x to 6.x in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->