### PR TITLE
chore: Added logic to add branch and environment param to custom url editor #8576

### DIFF
--- a/app/client/src/pages/Editor/CustomWidgetBuilder/useCustomBuilder.tsx
+++ b/app/client/src/pages/Editor/CustomWidgetBuilder/useCustomBuilder.tsx
@@ -244,8 +244,11 @@ export function useCustomBuilder(): [CustomWidgetBuilderContextType, boolean] {
     });
 
     // if connection cannot be made, redirect to editor
+    // Preserve query params (branch, environment, etc.) when redirecting back
     connectionTimeout = setTimeout(() => {
-      history.replace(window.location.pathname.replace("/builder", ""));
+      const newPath = window.location.pathname.replace("/builder", "");
+
+      history.replace(`${newPath}${window.location.search}`);
     }, 4000);
   }, []);
 

--- a/app/client/src/utils/CustomWidgetBuilderService.test.ts
+++ b/app/client/src/utils/CustomWidgetBuilderService.test.ts
@@ -118,6 +118,78 @@ describe("Builder - ", () => {
     });
   });
 
+  describe("constructor URL construction", () => {
+    const originalLocation = window.location;
+
+    beforeEach(() => {
+      open.mockClear();
+      // Mock window.location
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: {
+          pathname: "/app/my-app/page-123/edit",
+          search: "",
+        },
+      });
+    });
+
+    afterAll(() => {
+      // Restore original location
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: originalLocation,
+      });
+    });
+
+    it("should preserve query params (branch, environment) when opening builder", () => {
+      window.location.pathname = "/app/my-app/page-123/edit";
+      window.location.search = "?branch=feature-x&environment=staging";
+
+      new Builder();
+
+      expect(open).toHaveBeenCalledWith(
+        "/app/my-app/page-123/edit/builder?branch=feature-x&environment=staging",
+        "_blank",
+      );
+    });
+
+    it("should handle /add suffix and preserve query params", () => {
+      window.location.pathname = "/app/my-app/page-123/edit/add";
+      window.location.search = "?branch=main";
+
+      new Builder();
+
+      expect(open).toHaveBeenCalledWith(
+        "/app/my-app/page-123/edit/builder?branch=main",
+        "_blank",
+      );
+    });
+
+    it("should work without query params", () => {
+      window.location.pathname = "/app/my-app/page-123/edit";
+      window.location.search = "";
+
+      new Builder();
+
+      expect(open).toHaveBeenCalledWith(
+        "/app/my-app/page-123/edit/builder",
+        "_blank",
+      );
+    });
+
+    it("should preserve only branch query param", () => {
+      window.location.pathname = "/app/my-app/page-123/edit";
+      window.location.search = "?branch=develop";
+
+      new Builder();
+
+      expect(open).toHaveBeenCalledWith(
+        "/app/my-app/page-123/edit/builder?branch=develop",
+        "_blank",
+      );
+    });
+  });
+
   describe("onMessage", () => {
     it("should test that its adding a message listener", () => {
       const type = "READY";

--- a/app/client/src/utils/CustomWidgetBuilderService.ts
+++ b/app/client/src/utils/CustomWidgetBuilderService.ts
@@ -8,8 +8,10 @@ export class Builder {
   constructor() {
     // when we add new widget, we add a /add to the url , so before opening the builder, we need to remove it
     const path = window.location.pathname.replace(/\/add$/, "");
+    // Preserve query params (branch, environment, etc.) when opening the builder
+    const search = window.location.search;
 
-    this.builderWindow = window.open(`${path}/builder`, "_blank");
+    this.builderWindow = window.open(`${path}/builder${search}`, "_blank");
 
     window?.addEventListener("message", this.handleMessageBound);
   }


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Widget"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/21622007581>
> Commit: 21c5f091c63bf33c217aa87d0fa705c3b2124a22
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=21622007581&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget`
> Spec:
> <hr>Tue, 03 Feb 2026 09:21:07 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL query parameters (such as branch and environment) are now preserved when redirecting or opening the custom widget builder, preventing loss of configuration during timeouts.

* **Tests**
  * Added comprehensive test coverage for URL parameter preservation in the custom widget builder across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->