### PR TITLE
fix: support non-default Firestore database ID in datasource configuration

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -945,11 +945,12 @@ public class FirestorePlugin extends BasePlugin {
                     .subscribeOn(scheduler);
         }
 
-        private String getDatabaseId(DatasourceConfiguration datasourceConfiguration) {
+        String getDatabaseId(DatasourceConfiguration datasourceConfiguration) {
             if (!CollectionUtils.isEmpty(datasourceConfiguration.getProperties())) {
                 for (Property property : datasourceConfiguration.getProperties()) {
                     if (property != null
                             && "databaseId".equals(property.getKey())
+                            && property.getValue() instanceof String
                             && !StringUtils.isEmpty((String) property.getValue())) {
                         return (String) property.getValue();
                     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/form.json
@@ -25,6 +25,21 @@
           "dataType": "PASSWORD",
           "isRequired": true,
           "initialValue": ""
+        },
+        {
+          "label": "Database ID",
+          "configProperty": "datasourceConfiguration.properties[0].value",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "initialValue": "(default)",
+          "placeholderText": "(default)"
+        },
+        {
+          "label": "Database ID key",
+          "configProperty": "datasourceConfiguration.properties[0].key",
+          "controlType": "INPUT_TEXT",
+          "initialValue": "databaseId",
+          "hidden": true
         }
       ]
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -53,7 +53,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -1799,31 +1798,21 @@ public class FirestorePluginTest {
     }
 
     @Test
-    public void testDatasourceCreate_withDefaultDatabaseId() {
-        // When no properties are set, datasourceCreate should use "(default)" database ID
+    public void testGetDatabaseId_withNoProperties_returnsDefault() {
         DatasourceConfiguration config = new DatasourceConfiguration();
-        config.setUrl(emulator.getEmulatorEndpoint());
-        DBAuth auth = new DBAuth();
-        auth.setUsername("test-project");
-        auth.setPassword("");
-        config.setAuthentication(auth);
-        // No properties set - should default to "(default)"
-
-        // Validate that datasource config is valid (no errors related to database ID)
-        Set<String> invalids = pluginExecutor.validateDatasource(config);
-        assertTrue(invalids.isEmpty());
+        assertEquals("(default)", pluginExecutor.getDatabaseId(config));
     }
 
     @Test
-    public void testDatasourceCreate_withCustomDatabaseId() {
-        // When a custom database ID is set via properties, it should be used
+    public void testGetDatabaseId_withNullProperties_returnsDefault() {
         DatasourceConfiguration config = new DatasourceConfiguration();
-        config.setUrl(emulator.getEmulatorEndpoint());
-        DBAuth auth = new DBAuth();
-        auth.setUsername("test-project");
-        auth.setPassword("");
-        config.setAuthentication(auth);
+        config.setProperties(null);
+        assertEquals("(default)", pluginExecutor.getDatabaseId(config));
+    }
 
+    @Test
+    public void testGetDatabaseId_withCustomDatabaseId_returnsCustomValue() {
+        DatasourceConfiguration config = new DatasourceConfiguration();
         List<Property> properties = new ArrayList<>();
         Property databaseIdProperty = new Property();
         databaseIdProperty.setKey("databaseId");
@@ -1831,21 +1820,12 @@ public class FirestorePluginTest {
         properties.add(databaseIdProperty);
         config.setProperties(properties);
 
-        // Validate that datasource config with custom database ID is valid
-        Set<String> invalids = pluginExecutor.validateDatasource(config);
-        assertTrue(invalids.isEmpty());
+        assertEquals("my-custom-database", pluginExecutor.getDatabaseId(config));
     }
 
     @Test
-    public void testDatasourceCreate_withEmptyDatabaseId() {
-        // When the database ID property exists but is empty, should fall back to "(default)"
+    public void testGetDatabaseId_withEmptyValue_returnsDefault() {
         DatasourceConfiguration config = new DatasourceConfiguration();
-        config.setUrl(emulator.getEmulatorEndpoint());
-        DBAuth auth = new DBAuth();
-        auth.setUsername("test-project");
-        auth.setPassword("");
-        config.setAuthentication(auth);
-
         List<Property> properties = new ArrayList<>();
         Property databaseIdProperty = new Property();
         databaseIdProperty.setKey("databaseId");
@@ -1853,9 +1833,20 @@ public class FirestorePluginTest {
         properties.add(databaseIdProperty);
         config.setProperties(properties);
 
-        // Validate that datasource config with empty database ID is valid
-        Set<String> invalids = pluginExecutor.validateDatasource(config);
-        assertTrue(invalids.isEmpty());
+        assertEquals("(default)", pluginExecutor.getDatabaseId(config));
+    }
+
+    @Test
+    public void testGetDatabaseId_withNonStringValue_returnsDefault() {
+        DatasourceConfiguration config = new DatasourceConfiguration();
+        List<Property> properties = new ArrayList<>();
+        Property databaseIdProperty = new Property();
+        databaseIdProperty.setKey("databaseId");
+        databaseIdProperty.setValue(12345);
+        properties.add(databaseIdProperty);
+        config.setProperties(properties);
+
+        assertEquals("(default)", pluginExecutor.getDatabaseId(config));
     }
 
     @Test

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -1795,6 +1796,66 @@ public class FirestorePluginTest {
                     }
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    public void testDatasourceCreate_withDefaultDatabaseId() {
+        // When no properties are set, datasourceCreate should use "(default)" database ID
+        DatasourceConfiguration config = new DatasourceConfiguration();
+        config.setUrl(emulator.getEmulatorEndpoint());
+        DBAuth auth = new DBAuth();
+        auth.setUsername("test-project");
+        auth.setPassword("");
+        config.setAuthentication(auth);
+        // No properties set - should default to "(default)"
+
+        // Validate that datasource config is valid (no errors related to database ID)
+        Set<String> invalids = pluginExecutor.validateDatasource(config);
+        assertTrue(invalids.isEmpty());
+    }
+
+    @Test
+    public void testDatasourceCreate_withCustomDatabaseId() {
+        // When a custom database ID is set via properties, it should be used
+        DatasourceConfiguration config = new DatasourceConfiguration();
+        config.setUrl(emulator.getEmulatorEndpoint());
+        DBAuth auth = new DBAuth();
+        auth.setUsername("test-project");
+        auth.setPassword("");
+        config.setAuthentication(auth);
+
+        List<Property> properties = new ArrayList<>();
+        Property databaseIdProperty = new Property();
+        databaseIdProperty.setKey("databaseId");
+        databaseIdProperty.setValue("my-custom-database");
+        properties.add(databaseIdProperty);
+        config.setProperties(properties);
+
+        // Validate that datasource config with custom database ID is valid
+        Set<String> invalids = pluginExecutor.validateDatasource(config);
+        assertTrue(invalids.isEmpty());
+    }
+
+    @Test
+    public void testDatasourceCreate_withEmptyDatabaseId() {
+        // When the database ID property exists but is empty, should fall back to "(default)"
+        DatasourceConfiguration config = new DatasourceConfiguration();
+        config.setUrl(emulator.getEmulatorEndpoint());
+        DBAuth auth = new DBAuth();
+        auth.setUsername("test-project");
+        auth.setPassword("");
+        config.setAuthentication(auth);
+
+        List<Property> properties = new ArrayList<>();
+        Property databaseIdProperty = new Property();
+        databaseIdProperty.setKey("databaseId");
+        databaseIdProperty.setValue("");
+        properties.add(databaseIdProperty);
+        config.setProperties(properties);
+
+        // Validate that datasource config with empty database ID is valid
+        Set<String> invalids = pluginExecutor.validateDatasource(config);
+        assertTrue(invalids.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes #38121 — Firestore connection always connects to the default database, ignoring non-default database configuration.

## Changes
- **form.json**: Added optional "Database ID" field (defaults to `(default)`)
- **FirestorePlugin.java**: 
  - Added [getDatabaseId()](cci:1://file:///Users/surendraraika/opensource/appsmith/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java:947:8-958:9) helper to extract database ID from datasource properties
  - Changed `FirestoreClient::getFirestore` → `FirestoreClient.getFirestore(app, databaseId)`
- **FirestorePluginTest.java**: Added 3 tests for default, custom, and empty database ID scenarios

## Root Cause
`FirestoreClient::getFirestore` (no-arg) always returns the default database. 
The fix uses `FirestoreClient.getFirestore(app, databaseId)` from Firebase Admin SDK 9.2.0.

## Testing
- Compilation verified locally (mvn compile + test-compile pass)
- Unit tests added (require Docker/Testcontainers for Firestore emulator — CI will run them)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Database ID setting to Firestore datasource configuration; you can specify a custom Firestore database or leave it blank to use "(default)".

* **Tests**
  * Added tests covering Database ID handling for various configuration scenarios (missing, null, empty, non-string, and custom values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->