### PR TITLE
fix: Betterbugs cyclic dependency by refactoring metadata into HelpButton and HomepageHeade…

### DIFF
--- a/app/client/src/pages/Editor/HelpButton.tsx
+++ b/app/client/src/pages/Editor/HelpButton.tsx
@@ -41,6 +41,7 @@ import { getIsAiAgentApp } from "ee/selectors/aiAgentSelectors";
 import { DOCS_AI_BASE_URL } from "constants/ThirdPartyConstants";
 import BetterbugsUtil from "utils/Analytics/betterbugs";
 import { isAirgapped } from "ee/utils/airgapHelpers";
+import { useBetterbugsMetadata } from "utils/hooks/useBetterbugsMetadata";
 
 const { appVersion, betterbugs, cloudHosting, intercomAppID } =
   getAppsmithConfigs();
@@ -185,6 +186,8 @@ function HelpButton() {
   const onboardingModalOpen = useSelector(getFirstTimeUserOnboardingModal);
   const unreadSteps = useSelector(getSignpostingUnreadSteps);
   const setOverlay = useSelector(getSignpostingSetOverlay);
+  const betterbugsMetadata = useBetterbugsMetadata();
+
   const showUnreadSteps =
     !!unreadSteps.length &&
     isFirstTimeUserOnboardingEnabled &&
@@ -306,7 +309,7 @@ function HelpButton() {
 
                     if (item.id === "betterbugs-trigger") {
                       e?.preventDefault();
-                      BetterbugsUtil.show(user);
+                      BetterbugsUtil.show(user, betterbugsMetadata);
                     }
                   }}
                   startIcon={item.icon}

--- a/app/client/src/pages/common/SearchBar/HomepageHeaderAction.tsx
+++ b/app/client/src/pages/common/SearchBar/HomepageHeaderAction.tsx
@@ -43,6 +43,7 @@ import { ReduxActionTypes } from "ee/constants/ReduxActionConstants";
 import styled from "styled-components";
 import { getIsAiAgentInstanceEnabled } from "ee/selectors/aiAgentSelectors";
 import BetterbugsUtil from "utils/Analytics/betterbugs";
+import { useBetterbugsMetadata } from "utils/hooks/useBetterbugsMetadata";
 
 const { betterbugs, cloudHosting, intercomAppID } = getAppsmithConfigs();
 
@@ -75,6 +76,7 @@ const HomepageHeaderAction = ({
   const howMuchTimeBefore = howMuchTimeBeforeText(appVersion.releaseDate);
   const [showIntercomConsent, setShowIntercomConsent] = useState(false);
   const isAiAgentInstanceEnabled = useSelector(getIsAiAgentInstanceEnabled);
+  const betterbugsMetadata = useBetterbugsMetadata();
 
   if (!isHomePage || !!isCreateNewAppFlow) return null;
 
@@ -147,7 +149,7 @@ const HomepageHeaderAction = ({
                 {betterbugs.enabled && !isAirgapped() && (
                   <MenuItem
                     onClick={() => {
-                      BetterbugsUtil.show(user);
+                      BetterbugsUtil.show(user, betterbugsMetadata);
                     }}
                     startIcon="support"
                   >

--- a/app/client/src/utils/hooks/useBetterbugsMetadata.ts
+++ b/app/client/src/utils/hooks/useBetterbugsMetadata.ts
@@ -1,0 +1,24 @@
+import { useSelector } from "react-redux";
+import type { DefaultRootState } from "react-redux";
+import { getInstanceId } from "ee/selectors/organizationSelectors";
+import {
+  getCurrentApplicationId,
+  getCurrentPageId,
+} from "selectors/editorSelectors";
+import type { BetterbugsMetadata } from "utils/Analytics/betterbugs";
+
+export const useBetterbugsMetadata = (): BetterbugsMetadata => {
+  const instanceId = useSelector(getInstanceId);
+  const tenantId = useSelector(
+    (state: DefaultRootState) => state.organization?.tenantId,
+  );
+  const applicationId = useSelector(getCurrentApplicationId);
+  const pageId = useSelector(getCurrentPageId);
+
+  return {
+    instanceId,
+    tenantId,
+    applicationId,
+    pageId,
+  };
+};


### PR DESCRIPTION
…rAction

- Added `useBetterbugsMetadata` hook to retrieve Betterbugs-related metadata.
- Updated `HelpButton` and `HomepageHeaderAction` components to utilize the new metadata when invoking the Betterbugs SDK, enhancing the context provided during bug reporting.
- Refactored `BetterbugsUtil` to accept metadata parameters for improved functionality and data accuracy.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/22006715339>
> Commit: 3c98b61e939e0239829badbf4fbfacbc3278744a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=22006715339&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Sat, 14 Feb 2026 01:06:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved bug reporting metadata handling to ensure more accurate context is captured when submitting bug reports. The system now explicitly passes session and application metadata to the bug reporting utility, replacing reliance on implicit global state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->