### PR TITLE
feat: add support for READ_ONLY connection mode in MSSQL plugin

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -626,6 +626,14 @@ public class MssqlPlugin extends BasePlugin {
 
         addSslOptionsToUrlBuilder(datasourceConfiguration, urlBuilder);
 
+        // Add connection mode configuration for READ_ONLY
+        if (datasourceConfiguration.getConnection() != null
+                && datasourceConfiguration.getConnection().getMode()
+                        == com.appsmith.external.models.Connection.Mode.READ_ONLY) {
+            urlBuilder.append("ApplicationIntent=ReadOnly;");
+            hikariConfig.setReadOnly(true);
+        }
+
         hikariConfig.setJdbcUrl(urlBuilder.toString());
 
         try {

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
@@ -9,6 +9,7 @@
           "configProperty": "datasourceConfiguration.connection.mode",
           "controlType": "SEGMENTED_CONTROL",
           "initialValue": "READ_WRITE",
+          "tooltipText": "Read-only mode uses ApplicationIntent=ReadOnly. Note: This only enforces read-only connections when using Always On Availability Groups.",
           "options": [
             {
               "label": "Read / Write",

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -773,4 +773,52 @@ public class MssqlPluginTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    public void testReadOnlyConnectionMode() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+
+        // Set connection mode to READ_ONLY
+        com.appsmith.external.models.Connection connection = new com.appsmith.external.models.Connection();
+        connection.setMode(com.appsmith.external.models.Connection.Mode.READ_ONLY);
+        dsConfig.setConnection(connection);
+
+        // Create connection pool
+        HikariDataSource connectionPool =
+                mssqlPluginExecutor.datasourceCreate(dsConfig).block();
+
+        // Verify the JDBC URL contains ApplicationIntent=ReadOnly
+        assertNotNull(connectionPool);
+        String jdbcUrl = connectionPool.getJdbcUrl();
+        assertTrue(
+                jdbcUrl.contains("ApplicationIntent=ReadOnly"),
+                "JDBC URL should contain ApplicationIntent=ReadOnly parameter");
+
+        // Cleanup
+        connectionPool.close();
+    }
+
+    @Test
+    public void testReadWriteConnectionMode() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+
+        // Set connection mode to READ_WRITE
+        com.appsmith.external.models.Connection connection = new com.appsmith.external.models.Connection();
+        connection.setMode(com.appsmith.external.models.Connection.Mode.READ_WRITE);
+        dsConfig.setConnection(connection);
+
+        // Create connection pool
+        HikariDataSource connectionPool =
+                mssqlPluginExecutor.datasourceCreate(dsConfig).block();
+
+        // Verify the JDBC URL does NOT contain ApplicationIntent parameter
+        assertNotNull(connectionPool);
+        String jdbcUrl = connectionPool.getJdbcUrl();
+        assertTrue(
+                !jdbcUrl.contains("ApplicationIntent"),
+                "JDBC URL should not contain ApplicationIntent parameter for READ_WRITE mode");
+
+        // Cleanup
+        connectionPool.close();
+    }
 }


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

- Implemented connection mode configuration for READ_ONLY, appending "ApplicationIntent=ReadOnly" to the JDBC URL and setting the HikariCP configuration to read-only.
- Updated form.json to include a tooltip explaining the implications of using read-only mode.
- Added unit tests to verify the correct behavior of both READ_ONLY and READ_WRITE connection modes, ensuring the JDBC URL is constructed appropriately based on the selected mode.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
