### PR TITLE
docs(helm): document annotations parameter in README

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -86,6 +86,7 @@ The command uninstalls the release and removes all Kubernetes resources associat
 | --------------------------- | --------------------------------------------------- | --------------- |
 | `strategyType`							| Appsmith deployment strategy type										| `RollingUpdate` |
 | `schedulerName`							| Alternate scheduler																	| `""`						|
+| `annotations`								| Annotations to add to the Deployment/StatefulSet resource		| `{}`						|
 | `podAnnotations`						| Annotations for Appsmith pods												| `{}`						|
 | `podLabels`						| Labels for Appsmith pods												| `{}`						|
 | `podSecurityContext`				| Appsmith pods security context											| `{}`						|


### PR DESCRIPTION
The `annotations` value (for adding annotations to the Deployment/StatefulSet
resource) was added to values.yaml but was missing from the README parameters
table. Added it to the deployment parameters section alongside `podAnnotations`.

https://claude.ai/code/session_013oSUp3viPsj7rPsgXjLht5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new deployment configuration parameter for custom annotations on Deployment and StatefulSet resources, enabling users to add custom metadata during deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->