### PR TITLE
fix: add security hardening to MongoDB plugin RAW and form commands

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -139,6 +139,7 @@ import static com.external.plugins.utils.MongoPluginUtils.generateTemplatesAndSt
 import static com.external.plugins.utils.MongoPluginUtils.getDatabaseName;
 import static com.external.plugins.utils.MongoPluginUtils.getRawQuery;
 import static com.external.plugins.utils.MongoPluginUtils.isRawCommand;
+import static com.external.plugins.utils.MongoPluginUtils.validateQueryDocument;
 import static java.lang.Boolean.TRUE;
 import static java.util.Arrays.asList;
 import static org.apache.logging.log4j.util.Strings.isBlank;
@@ -352,6 +353,7 @@ public class MongoPlugin extends BasePlugin {
                             AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
                             String.format(MongoPluginErrorMessages.DISALLOWED_COMMAND_ERROR_MSG, commandName));
                 }
+                validateQueryDocument("Command", commandDoc);
                 Bson command = commandDoc;
 
                 mongoOutputMono = Mono.from(database.runCommand(command));

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -356,6 +356,8 @@ public class MongoPlugin extends BasePlugin {
 
                 mongoOutputMono = Mono.from(database.runCommand(command));
                 requestParams = List.of(new RequestParamDTO(ACTION_CONFIGURATION_BODY, query, null, null, null));
+            } catch (AppsmithPluginException e) {
+                return Mono.error(e);
             } catch (Exception error) {
                 return Mono.error(new AppsmithPluginException(
                         MongoPluginError.QUERY_EXECUTION_FAILED,

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Aggregate.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Aggregate.java
@@ -44,7 +44,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 @NoArgsConstructor
 public class Aggregate extends MongoCommand {
     private static final Set<String> BLOCKED_PIPELINE_STAGES =
-            Set.of("$out", "$merge", "$function", "$accumulator");
+            Set.of("$out", "$merge", "$function", "$accumulator", "$where");
 
     private static void validateBsonValue(BsonValue value) {
         if (value.isDocument()) {

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Count.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Count.java
@@ -24,6 +24,7 @@ import static com.external.plugins.constants.FieldName.COUNT;
 import static com.external.plugins.constants.FieldName.COUNT_QUERY;
 import static com.external.plugins.constants.FieldName.SMART_SUBSTITUTION;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafely;
+import static com.external.plugins.utils.MongoPluginUtils.validateQueryDocument;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Getter
@@ -52,7 +53,9 @@ public class Count extends MongoCommand {
             this.query = "{}";
         }
 
-        document.put("query", parseSafely("Query", this.query));
+        Document queryDocument = parseSafely("Query", this.query);
+        validateQueryDocument("Query", queryDocument);
+        document.put("query", queryDocument);
 
         return document;
     }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Delete.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Delete.java
@@ -26,6 +26,7 @@ import static com.external.plugins.constants.FieldName.DELETE_LIMIT;
 import static com.external.plugins.constants.FieldName.DELETE_QUERY;
 import static com.external.plugins.constants.FieldName.SMART_SUBSTITUTION;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafely;
+import static com.external.plugins.utils.MongoPluginUtils.validateQueryDocument;
 
 @Getter
 @Setter
@@ -71,6 +72,7 @@ public class Delete extends MongoCommand {
         document.put(DELETE, this.collection);
 
         Document queryDocument = parseSafely("Query", this.query);
+        validateQueryDocument("Query", queryDocument);
 
         Document delete = new Document();
         delete.put("q", queryDocument);

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Distinct.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Distinct.java
@@ -25,6 +25,7 @@ import static com.external.plugins.constants.FieldName.DISTINCT_KEY;
 import static com.external.plugins.constants.FieldName.DISTINCT_QUERY;
 import static com.external.plugins.constants.FieldName.SMART_SUBSTITUTION;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafely;
+import static com.external.plugins.utils.MongoPluginUtils.validateQueryDocument;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Getter
@@ -71,7 +72,9 @@ public class Distinct extends MongoCommand {
             this.query = "{}";
         }
 
-        document.put("query", parseSafely("Query", this.query));
+        Document queryDocument = parseSafely("Query", this.query);
+        validateQueryDocument("Query", queryDocument);
+        document.put("query", queryDocument);
 
         document.put("key", this.key);
 

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Find.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Find.java
@@ -86,7 +86,9 @@ public class Find extends MongoCommand {
         }
 
         if (!StringUtils.isNullOrEmpty(this.projection)) {
-            document.put("projection", parseSafely("Projection", this.projection));
+            Document projectionDocument = parseSafely("Projection", this.projection);
+            validateQueryDocument("Projection", projectionDocument);
+            document.put("projection", projectionDocument);
         }
 
         // Default to returning 10 documents if not mentioned

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Find.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Find.java
@@ -28,6 +28,7 @@ import static com.external.plugins.constants.FieldName.FIND_SKIP;
 import static com.external.plugins.constants.FieldName.FIND_SORT;
 import static com.external.plugins.constants.FieldName.SMART_SUBSTITUTION;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafely;
+import static com.external.plugins.utils.MongoPluginUtils.validateQueryDocument;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Getter
@@ -76,7 +77,9 @@ public class Find extends MongoCommand {
 
         document.put(FIND, this.collection);
 
-        document.put("filter", parseSafely("Query", this.query));
+        Document queryDocument = parseSafely("Query", this.query);
+        validateQueryDocument("Query", queryDocument);
+        document.put("filter", queryDocument);
 
         if (!StringUtils.isNullOrEmpty(this.sort)) {
             document.put("sort", parseSafely("Sort", this.sort));

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Find.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Find.java
@@ -82,7 +82,9 @@ public class Find extends MongoCommand {
         document.put("filter", queryDocument);
 
         if (!StringUtils.isNullOrEmpty(this.sort)) {
-            document.put("sort", parseSafely("Sort", this.sort));
+            Document sortDocument = parseSafely("Sort", this.sort);
+            validateQueryDocument("Sort", sortDocument);
+            document.put("sort", sortDocument);
         }
 
         if (!StringUtils.isNullOrEmpty(this.projection)) {

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
@@ -27,6 +27,7 @@ import static com.external.plugins.constants.FieldName.UPDATE_OPERATION;
 import static com.external.plugins.constants.FieldName.UPDATE_QUERY;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafely;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafelyDocumentAndArrayOfDocuments;
+import static com.external.plugins.utils.MongoPluginUtils.validateQueryDocument;
 
 @Getter
 @Setter
@@ -84,6 +85,7 @@ public class UpdateMany extends MongoCommand {
         document.put("update", this.collection);
 
         Document queryDocument = parseSafely("Query", this.query);
+        validateQueryDocument("Query", queryDocument);
 
         Object updateDocument = parseSafelyDocumentAndArrayOfDocuments("Update", this.update);
 

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
@@ -88,6 +88,15 @@ public class UpdateMany extends MongoCommand {
         validateQueryDocument("Query", queryDocument);
 
         Object updateDocument = parseSafelyDocumentAndArrayOfDocuments("Update", this.update);
+        if (updateDocument instanceof Document) {
+            validateQueryDocument("Update", (Document) updateDocument);
+        } else if (updateDocument instanceof List) {
+            for (Object stage : (List<?>) updateDocument) {
+                if (stage instanceof Document) {
+                    validateQueryDocument("Update", (Document) stage);
+                }
+            }
+        }
 
         Document update = new Document();
         update.put("q", queryDocument);

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
@@ -92,6 +92,12 @@ public class MongoPluginErrorMessages {
             "Appsmith server has failed to fetch SSL configuration from datasource configuration "
                     + "form. Please reach out to Appsmith customer support to resolve this.";
 
+    /*
+    ************************************************************************************************************************************************
+                                       Error messages related to security validation of commands and operators.
+    ************************************************************************************************************************************************
+    */
+
     public static final String DISALLOWED_COMMAND_ERROR_MSG =
             "MongoDB command '%s' is not permitted. Only data operations (find, insert, update, delete, aggregate,"
                     + " count, distinct, findandmodify, getmore, bulkwrite) are allowed.";
@@ -100,5 +106,5 @@ public class MongoPluginErrorMessages {
             "Aggregation pipeline stage '%s' is not permitted for security reasons.";
 
     public static final String DISALLOWED_QUERY_OPERATOR_ERROR_MSG =
-            "Query operator '%s' is not permitted for security reasons.";
+            "Operator '%s' in field '%s' is not permitted for security reasons.";
 }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
@@ -94,7 +94,7 @@ public class MongoPluginErrorMessages {
 
     public static final String DISALLOWED_COMMAND_ERROR_MSG =
             "MongoDB command '%s' is not permitted. Only data operations (find, insert, update, delete, aggregate,"
-                    + " count, distinct, findAndModify, getMore, bulkWrite) are allowed.";
+                    + " count, distinct, findandmodify, getmore, bulkwrite) are allowed.";
 
     public static final String DISALLOWED_PIPELINE_STAGE_ERROR_MSG =
             "Aggregation pipeline stage '%s' is not permitted for security reasons.";

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
@@ -91,4 +91,14 @@ public class MongoPluginErrorMessages {
     public static final String DS_SSL_CONFIGURATION_FETCHING_ERROR_MSG =
             "Appsmith server has failed to fetch SSL configuration from datasource configuration "
                     + "form. Please reach out to Appsmith customer support to resolve this.";
+
+    public static final String DISALLOWED_COMMAND_ERROR_MSG =
+            "MongoDB command '%s' is not permitted. Only data operations (find, insert, update, delete, aggregate,"
+                    + " count, distinct, findAndModify, getMore, bulkWrite) are allowed.";
+
+    public static final String DISALLOWED_PIPELINE_STAGE_ERROR_MSG =
+            "Aggregation pipeline stage '%s' is not permitted for security reasons.";
+
+    public static final String DISALLOWED_QUERY_OPERATOR_ERROR_MSG =
+            "Query operator '%s' is not permitted for security reasons.";
 }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
@@ -59,11 +59,17 @@ public class MongoPluginUtils {
             if (value instanceof Document) {
                 validateQueryDocument(fieldName, (Document) value);
             } else if (value instanceof List) {
-                for (Object item : (List<?>) value) {
-                    if (item instanceof Document) {
-                        validateQueryDocument(fieldName, (Document) item);
-                    }
-                }
+                validateQueryList(fieldName, (List<?>) value);
+            }
+        }
+    }
+
+    private static void validateQueryList(String fieldName, List<?> list) {
+        for (Object item : list) {
+            if (item instanceof Document) {
+                validateQueryDocument(fieldName, (Document) item);
+            } else if (item instanceof List) {
+                validateQueryList(fieldName, (List<?>) item);
             }
         }
     }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
@@ -45,15 +45,16 @@ import static com.external.plugins.constants.FieldName.RAW;
 
 public class MongoPluginUtils {
 
-    private static final Set<String> BLOCKED_QUERY_OPERATORS = Set.of("$where", "$function", "$accumulator");
+    private static final Set<String> BLOCKED_OPERATORS =
+            Set.of("$where", "$function", "$accumulator", "$out", "$merge");
 
     public static void validateQueryDocument(String fieldName, Document queryDoc) {
         if (queryDoc == null) return;
         for (String key : queryDoc.keySet()) {
-            if (BLOCKED_QUERY_OPERATORS.contains(key.toLowerCase())) {
+            if (BLOCKED_OPERATORS.contains(key.toLowerCase())) {
                 throw new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                        String.format(MongoPluginErrorMessages.DISALLOWED_QUERY_OPERATOR_ERROR_MSG, key));
+                        String.format(MongoPluginErrorMessages.DISALLOWED_QUERY_OPERATOR_ERROR_MSG, key, fieldName));
             }
             Object value = queryDoc.get(key);
             if (value instanceof Document) {


### PR DESCRIPTION
## Summary
- Add command allowlist to MongoDB RAW query mode — only data operations (`find`, `insert`, `update`, `delete`, `aggregate`, `count`, `distinct`, `findandmodify`, `getmore`, `bulkwrite`) are permitted via `database.runCommand()`
- Block dangerous aggregation pipeline stages (`$out`, `$merge`, `$function`, `$accumulator`) in `Aggregate.java`
- Block dangerous query operators (`$where`, `$function`, `$accumulator`) with recursive validation in Find, Count, Delete, Distinct, and UpdateMany form commands

## Description
The MongoDB plugin's RAW query mode passes user-supplied BSON directly to `database.runCommand()` with no command validation. Any authenticated Appsmith user can execute arbitrary MongoDB administrative commands including `dropDatabase`, `createUser`, `shutdown`, `eval`, and `getLog`. The form-based mode also accepts dangerous operators (`$where` for server-side JS execution) and pipeline stages (`$out` for data exfiltration).

This PR adds a 3-layer defense:

1. **Command allowlist** in `MongoPlugin.executeCommon()` — validates the first key of the parsed BSON document against a set of permitted data operations before passing to `runCommand()`
2. **Pipeline stage blocklist** in `Aggregate.java` — rejects `$out`, `$merge`, `$function`, `$accumulator` stages in both form-parsed and raw pipeline arrays
3. **Query operator blocklist** in `MongoPluginUtils.validateQueryDocument()` — recursively scans parsed query documents for `$where`, `$function`, `$accumulator` across all form commands (Find, Count, Delete, Distinct, UpdateMany)

## Test plan
- [ ] Verify RAW mode allows normal CRUD commands: `find`, `insert`, `update`, `delete`, `aggregate`, `count`, `distinct`
- [ ] Verify RAW mode blocks administrative commands: `dropDatabase`, `createUser`, `shutdown`, `eval`, `getLog`
- [ ] Verify form-mode FIND rejects `{"$where": "sleep(5000)"}` in query filter
- [ ] Verify form-mode AGGREGATE rejects `[{"$match": {}}, {"$out": "exfil"}]` pipeline
- [ ] Verify form-mode Count, Delete, Distinct, UpdateMany reject `$where` / `$function` in query
- [ ] Verify existing MongoDB queries in applications continue to work without disruption
- [ ] Run existing MongoPlugin unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MongoDB plugin now restricts allowed commands to a safe whitelist to improve security.
  * Added validation to block unsafe aggregation pipeline stages and disallowed query operators.
  * Invalid, empty, or unauthorized commands and pipeline stages are now rejected with clear error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->