### PR TITLE
fix: add security hardening to Redis plugin command execution

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -122,7 +122,7 @@ public class RedisPlugin extends BasePlugin {
                                     String.format(RedisErrorMessages.BODY_IS_NULL_OR_EMPTY_ERROR_MSG, query)));
                         }
 
-                        Map cmdAndArgs = getCommandAndArgs(query.trim());
+                        Map<String, Object> cmdAndArgs = getCommandAndArgs(query.trim());
                         if (!cmdAndArgs.containsKey(CMD_KEY)) {
                             return Mono.error(new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
@@ -224,7 +224,7 @@ public class RedisPlugin extends BasePlugin {
             return result;
         }
 
-        private Map getCommandAndArgs(String query) {
+        private Map<String, Object> getCommandAndArgs(String query) {
             /**
              * - This regex matches either a whole word, or anything inside double quotes. If something is inside
              * single quotes then it gets matched like a whole word

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -80,6 +80,12 @@ public class RedisPlugin extends BasePlugin {
                 "FLUSHALL", "FLUSHDB",
                 // Scripting / RCE
                 "EVAL", "EVALSHA", "SCRIPT",
+                // Redis 7+: persistent server-side code loading (same RCE surface as EVAL,
+                // with added persistence/replication risk — CVE-2025-49844 sandbox escape)
+                "FUNCTION",
+                // Note: EVAL_RO / EVALSHA_RO (Redis 7+ read-only eval variants) are not
+                // blocked here — they should be controlled via Redis ACL roles when support
+                // for Redis 7+ and a newer Jedis client is added.
                 // ACL manipulation
                 "ACL",
                 // Cluster / migration

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/exceptions/RedisErrorMessages.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/exceptions/RedisErrorMessages.java
@@ -20,6 +20,17 @@ public class RedisErrorMessages extends BasePluginErrorMessages {
 
     /*
     ************************************************************************************************************************************************
+                                       Error messages related to security validation of commands.
+    ************************************************************************************************************************************************
+    */
+
+    public static final String BLOCKED_COMMAND_ERROR_MSG =
+            "Redis command '%s' is not permitted for security reasons."
+                    + " Only data-manipulation commands (GET, SET, HGET, LPUSH, etc.) are allowed."
+                    + " Server administration commands are blocked to protect the Redis instance.";
+
+    /*
+    ************************************************************************************************************************************************
                                        Error messages related to validation of datasource.
     ************************************************************************************************************************************************
     */

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -390,6 +390,10 @@ public class RedisPluginTest {
                     assertNotNull(result);
                     assertFalse(result.getIsExecutionSuccess());
                     assertEquals(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR.getTitle(), result.getTitle());
+                    assertNotNull(result.getBody());
+                    assertTrue(
+                            result.getBody().toString().contains("FLUSHALL"),
+                            "Error message should contain the blocked command name");
                 })
                 .verifyComplete();
     }
@@ -410,6 +414,10 @@ public class RedisPluginTest {
                     assertNotNull(result);
                     assertFalse(result.getIsExecutionSuccess());
                     assertEquals(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR.getTitle(), result.getTitle());
+                    assertNotNull(result.getBody());
+                    assertTrue(
+                            result.getBody().toString().contains("CONFIG"),
+                            "Error message should contain the blocked command name");
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Summary
- Adds a blocklist of 24 dangerous Redis commands to the Redis plugin, preventing authenticated users from executing server administration, data destruction, scripting/RCE, replication, and other high-risk commands through Appsmith
- Blocked categories: server admin (`SHUTDOWN`, `DEBUG`, `MONITOR`, `SAVE`, `BGSAVE`, `BGREWRITEAOF`), config manipulation (`CONFIG`), replication/data exfiltration (`SLAVEOF`, `REPLICAOF`), module loading/RCE (`MODULE`), data destruction (`FLUSHALL`, `FLUSHDB`), scripting/RCE (`EVAL`, `EVALSHA`, `SCRIPT`), ACL manipulation (`ACL`), cluster/migration (`CLUSTER`, `MIGRATE`), client manipulation (`CLIENT`), DoS/deserialization risks (`KEYS`, `RESTORE`, `SWAPDB`, `SYNC`, `PSYNC`, `SENTINEL`)
- All standard data-manipulation commands (`GET`, `SET`, `HGET`, `LPUSH`, `SCAN`, `TTL`, `INFO`, `SUBSCRIBE`, `PUBLISH`, etc.) remain fully functional

## Changes
- **`RedisPlugin.java`**: Added `BLOCKED_COMMANDS` set and validation check before `jedis.sendCommand()` — blocked commands return a clear error message without reaching the Redis server
- **`RedisErrorMessages.java`**: Added `BLOCKED_COMMAND_ERROR_MSG` constant with security-section banner (matching MongoDB plugin pattern)
- **`RedisPluginTest.java`**: Fixed `testSelectedDatabase` and `testDefaultDatabase` tests (previously used blocked `CLIENT INFO` command, replaced with `SET`/`GET` and `PING` respectively); added `itShouldRejectBlockedCommand` and `itShouldRejectBlockedCommandWithArgs` tests

## Test plan
- [ ] Verify `PING`, `GET`, `SET`, `MGET`, `MSET`, `DEL`, `HGET`, `LPUSH`, `SCAN`, `TTL`, `INFO`, `DBSIZE`, `SELECT`, `SUBSCRIBE`, `PUBLISH` all work normally
- [ ] Verify `FLUSHALL`, `SHUTDOWN`, `CONFIG GET requirepass`, `EVAL "return 1" 0`, `SLAVEOF`, `MODULE LOAD` all return the blocked command error
- [ ] Verify existing Redis queries in production apps continue to function
- [ ] Run full Redis plugin test suite: `mvn test -pl appsmith-plugins/redisPlugin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Block specific unsafe Redis commands (case-insensitive) and return clear, descriptive error messages that reference the command attempted.
  * Improve validation to reject disallowed commands earlier in execution.

* **Tests**
  * Added/updated end-to-end tests to verify blocked-command behavior (with and without arguments), case-insensitivity, and cross-database command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->