### PR TITLE
docs: add Helm chart docs for extraVolumes and extraVolumeMounts

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -95,6 +95,8 @@ The command uninstalls the release and removes all Kubernetes resources associat
 | `nodeSelector`							| Node labels for pod assignment											| `{}`						|
 | `tolerations`								| Tolerations for pod assignment											| `[]`						|
 | `affinity`									| Affinity fod pod assignment													| `{}`						|
+| `extraVolumes`							| Additional volumes to add to the pod										| `[]`						|
+| `extraVolumeMounts`					| Additional volume mounts to add to the appsmith container				| `[]`						|
 
 #### Workload kind
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -167,10 +167,18 @@ securityContext: {}
   # runAsUser: 1000
 
 ## @param extraVolumes Additional volumes to add to the pod
+## e.g:
+## extraVolumes:
+##   - name: tmp-dir
+##     emptyDir: {}
 ##
 extraVolumes: []
 
 ## @param extraVolumeMounts Additional volume mounts to add to the appsmith container
+## e.g:
+## extraVolumeMounts:
+##   - name: tmp-dir
+##     mountPath: /tmp
 ##
 extraVolumeMounts: []
 


### PR DESCRIPTION
## Summary
- Adds `extraVolumes` and `extraVolumeMounts` to the deployment parameters table in the Helm chart README
- Adds commented usage examples (emptyDir mounted at `/tmp`) in `values.yaml` for both parameters

Follow-up to #41515, which introduced the parameters but didn't include documentation.

## Test plan
- [x] Verify `values.yaml` comments render correctly and the example is valid YAML when uncommented
- [x] Verify README table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new Helm chart parameters for configuring additional pod volumes and mounts.
  * Included example configurations to guide users in custom volume setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->