### PR TITLE
fix: move cookie sameSite initializer to constructor to prevent OverflowError

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ce/CustomCookieWebSessionIdResolverCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ce/CustomCookieWebSessionIdResolverCE.java
@@ -23,6 +23,7 @@ public class CustomCookieWebSessionIdResolverCE extends CookieWebSessionIdResolv
         // If the max age is not set, some browsers will default to deleting the cookies on session close.
         this.setCookieMaxAge(Duration.of(30, DAYS));
         this.addCookieInitializer((builder) -> builder.path("/"));
+        this.addCookieInitializer((builder) -> builder.sameSite(LAX));
     }
 
     @Override
@@ -31,8 +32,16 @@ public class CustomCookieWebSessionIdResolverCE extends CookieWebSessionIdResolv
         super.setSessionId(exchange, id);
     }
 
+    /**
+     * Hook for subclasses to apply per-request cookie attributes.
+     * <p>
+     * WARNING: Implementations must NOT call {@link #addCookieInitializer} here.
+     * That method permanently appends to the singleton's Consumer chain via
+     * {@code Consumer.andThen()}, causing unbounded growth and eventually a
+     * {@link StackOverflowError}. Instead, modify cookies on the response after
+     * {@code super.setSessionId()} builds them.
+     */
     protected void addCookieInitializers(ServerWebExchange exchange) {
-        // Add the appropriate SameSite attribute based on the exchange attribute
-        addCookieInitializer((builder) -> builder.sameSite(LAX));
+        // No-op in CE. SameSite=Lax is set once in the constructor.
     }
 }


### PR DESCRIPTION
addCookieInitializer() was called on every setSessionId() invocation, permanently chaining Consumer.andThen() on the singleton bean's initializer field. After enough session-setting requests, the chain depth exceeded the JVM stack size, crashing SSO login with a StackOverflowError.

Move the sameSite(Lax) initializer to the constructor so it's set once. Leave addCookieInitializers(exchange) as a no-op hook for EE subclasses.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cookie configuration stability by consolidating SameSite attribute setup and preventing potential initialization accumulation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->