### PR TITLE
feat: enable on-the-fly response compression in Caddy

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -84,6 +84,9 @@ parts.push(`
   }
   log_skip @source-map-files
 
+  # On-the-fly compression, honoring the client's Accept-Encoding header.
+  encode zstd gzip
+
   # The internal request ID header should never be accepted from an incoming request.
   request_header -X-Appsmith-Request-Id
 

--- a/deploy/docker/route-tests/common/encoding.hurl
+++ b/deploy/docker/route-tests/common/encoding.hurl
@@ -1,0 +1,21 @@
+# Verify on-the-fly compression when the client requests it.
+
+# gzip encoding
+GET http://localhost/static/test-encoding.txt
+Accept-Encoding: gzip
+HTTP 200
+[Asserts]
+header "Content-Encoding" == "gzip"
+
+# zstd encoding
+GET http://localhost/static/test-encoding.txt
+Accept-Encoding: zstd
+HTTP 200
+[Asserts]
+header "Content-Encoding" == "zstd"
+
+# No encoding requested, no encoding applied
+GET http://localhost/static/test-encoding.txt
+HTTP 200
+[Asserts]
+header "Content-Encoding" not exists

--- a/deploy/docker/route-tests/entrypoint.sh
+++ b/deploy/docker/route-tests/entrypoint.sh
@@ -49,6 +49,9 @@ mkdir -p "$WWW_PATH" /opt/appsmith/editor
 echo -n 'index.html body, this will be replaced' > "$WWW_PATH/index.html"
 echo '{}' > /opt/appsmith/info.json
 echo -n 'actual index.html body' > /opt/appsmith/editor/index.html
+# A file large enough (>256 bytes) for Caddy's encode directive to compress.
+mkdir -p /opt/appsmith/editor/static
+printf 'a%.0s' {1..512} > /opt/appsmith/editor/static/test-encoding.txt
 mkcert -install
 
 # Start echo server


### PR DESCRIPTION
Add `encode zstd gzip` to the Caddy configuration so that responses are compressed based on the client's Accept-Encoding header. This ensures customers get compressed API and static responses even when their ingress controller or load balancer doesn't handle compression (e.g., layer 4 proxies).

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled HTTP response compression to automatically reduce content sizes for improved performance and faster downloads.

* **Tests**
  * Added test coverage to verify on-the-fly compression behavior across different encoding types and client scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->