### PR TITLE
chore: address pinned old jdk version

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -46,12 +46,8 @@ ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 # Install Java
 RUN set -o xtrace \
   && mkdir -p /opt/java \
-  # Assets from https://github.com/adoptium/temurin17-binaries/releases
-  # TODO: The release jdk-17.0.9+9.1 doesn't include Linux binaries, so this fails.
-  #       Temporarily using hardcoded version in URL until we figure out a more elaborate/smarter solution.
-  #&& version="$(curl --write-out '%{redirect_url}' 'https://github.com/adoptium/temurin17-binaries/releases/latest' | sed 's,.*jdk-,,')" \
-  && version="17.0.9+9" \
-  && curl --location "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$version/OpenJDK17U-jdk_$(uname -m | sed s/x86_64/x64/)_linux_hotspot_$(echo $version | tr + _).tar.gz" \
+  && arch="$(uname -m | sed 's/x86_64/x64/; s/aarch64/aarch64/')" \
+  && curl --location "https://api.adoptium.net/v3/binary/latest/17/ga/linux/${arch}/jdk/hotspot/normal/eclipse" \
   | tar -xz -C /opt/java --strip-components 1
 
 # Install NodeJS


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

It appears that we pinned the version of the JDK a long time ago because the Temurin binaries changed distribution source and no one brought this forward.

This is the version of Java that our CI runners are using, so bringing the image up-to-date to address the mismatch.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image builds to support multiple processor architectures, enabling deployments across diverse system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->