### PR TITLE
chore: upgrade redis to 7.4 in base dockerfile

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -23,13 +23,19 @@ RUN set -o xtrace \
     ca-certificates \
     libnss-wrapper \
     git \
-  # Install MongoDB v6, Redis, PostgreSQL v14
+  # Install MongoDB v6, Redis 7.4 (from packages.redis.io), PostgreSQL v14
   && curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg \
   && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
+  && curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
+  && chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg \
+  && echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(. /etc/os-release && echo "$VERSION_CODENAME") main" | tee /etc/apt/sources.list.d/redis.list \
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes mongodb-org redis postgresql-14 \
+  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
+    mongodb-org \
+    redis=6:7.4* redis-server=6:7.4* redis-tools=6:7.4* \
+    postgresql-14 \
   && find /etc/redis -type d -exec chmod o+rx {} + -o -type f -exec chmod o+r {} + \
   && apt-get clean \
   && rm -rf \


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

Upgrades the embedded Redis package to 7.4 and moves off the Ubuntu-managed packages.

Latest is 8.x, but we have some out-of-date client libraries still, so sticking with 7.x for now which is still supported.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker deployment environment to utilize Redis 7.4 with enhanced package management and repository configuration for improved build consistency.
  * Maintained PostgreSQL 14 and MongoDB 6.0 database versions to ensure compatibility across the deployment stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->