### PR TITLE
chore: build base image when the file changes in commit or release

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * MON"
-  push:
-    branches:
-      - release
-      - master
-    paths:
-      - "deploy/docker/base.dockerfile"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Docker tag override (e.g. release, nightly). Defaults to branch-based detection."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-docker:
@@ -25,6 +26,18 @@ jobs:
     steps:
       - name: Checkout the head commit of the branch
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if base.dockerfile changed
+        id: check
+        if: github.event_name == 'workflow_call'
+        run: |
+          if git diff HEAD~1 HEAD --name-only | grep -q "deploy/docker/base.dockerfile"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -35,9 +48,13 @@ jobs:
       - name: Get tag
         id: tag
         run: |
-          tag="${GITHUB_REF_NAME//\//-}"
-          if [[ "$tag" == master ]]; then
-            tag=nightly
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME//\//-}"
+            if [[ "$tag" == master ]]; then
+              tag=nightly
+            fi
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -45,6 +62,7 @@ jobs:
         uses: depot/setup-action@v1
 
       - name: Build and push base image
+        if: steps.check.outputs.changed != 'false'
         uses: depot/build-push-action@v1
         with:
           project: ${{ secrets.DEPOT_PROJECT_ID }}

--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -27,13 +27,19 @@ jobs:
       - name: Checkout the head commit of the branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check if base.dockerfile changed
         id: check
         if: github.event_name == 'workflow_call'
         run: |
-          if git diff HEAD~1 HEAD --name-only | grep -q "deploy/docker/base.dockerfile"; then
+          if [[ -n "${{ github.event.before }}" ]]; then
+            range="${{ github.event.before }}..${{ github.sha }}"
+          else
+            range="HEAD~1..HEAD"
+          fi
+
+          if git diff --name-only "$range" | grep -qx "deploy/docker/base.dockerfile"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -205,8 +205,14 @@ jobs:
           path: app/client/packages/rts/rts-dist.tar
           overwrite: true
 
+  build-base-image:
+    uses: ./.github/workflows/docker-base-image.yml
+    secrets: inherit
+    with:
+      tag: nightly
+
   package:
-    needs: [prelude, client-build, server-build, rts-build]
+    needs: [prelude, client-build, server-build, rts-build, build-base-image]
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -29,6 +29,7 @@ on:
       - "app/server/**"
       - "app/client/packages/rts/**"
       - "!app/client/cypress/manual_TestSuite/**"
+      - "deploy/docker/base.dockerfile"
 
 jobs:
   setup:
@@ -87,8 +88,12 @@ jobs:
     with:
       pr: 0
 
+  build-base-image:
+    uses: ./.github/workflows/docker-base-image.yml
+    secrets: inherit
+
   build-docker-image:
-    needs: [client-build, server-build, rts-build]
+    needs: [client-build, server-build, rts-build, build-base-image]
     # Only run if the build step is successful
     if: success()
     name: build-docker-image


### PR DESCRIPTION
## Description

The existing base Docker image build job was completely independent of the final image build, and they run in parallel. That means that in practice, often we were seeing the image on the `release` branch be built with the older base image which makes rollout of changes with dependencies between the two tricky.

This removes the direct push trigger on the base Docker image build, and shifts it to the places where we build the image. It calls the base image job which checks whether it needs to be re-built for this commit. If not, it skips the build step. But if it does, it halts the build of the downstream image until the base is updated.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 9a823930d96307b1eff3497ece7a10150db6e7e0 yet
> <hr>Fri, 27 Feb 2026 23:07:59 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows to support invoking the base-image build with an optional tag and conditional execution only when the base definition changes.
  * Added a reusable base-image build job and integrated it into release and test pipelines so the base image is built before packaging and Docker image builds.
  * Enabled nightly tagging for automated base-image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->