### PR TITLE
fix(server): stabilize app deletion flow to avoid resource spikes and restarts

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCE.java
@@ -68,7 +68,7 @@ public interface ActionCollectionServiceCE extends CrudService<ActionCollection,
 
     Mono<ActionCollection> archiveById(String id);
 
-    Mono<List<ActionCollection>> archiveActionCollectionByApplicationId(String applicationId, AclPermission permission);
+    Mono<Void> archiveActionCollectionByApplicationId(String applicationId, AclPermission permission);
 
     Flux<ActionCollection> findAllActionCollectionsByContextIdAndContextTypeAndViewMode(
             String contextId, CreatorContextType contextType, AclPermission permission, boolean viewMode);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -386,12 +386,16 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
     }
 
     @Override
-    public Mono<List<ActionCollection>> archiveActionCollectionByApplicationId(
-            String applicationId, AclPermission permission) {
+    public Mono<Void> archiveActionCollectionByApplicationId(String applicationId, AclPermission permission) {
+        // During bulk application deletion, archive action collections directly without per-entity
+        // analytics/audit-log events and without cascading to child actions. Child actions are separately
+        // archived by NewActionService.archiveActionsByApplicationId in the delete-application flow.
+        // This avoids the OOM caused by hundreds of concurrent audit-log DB operations that previously
+        // exhausted heap memory and crashed the container.
         return repository
                 .findByApplicationId(applicationId, permission, null)
-                .flatMap(this::archiveGivenActionCollection)
-                .collectList();
+                .flatMap(repository::archive, 4)
+                .then();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCE.java
@@ -118,7 +118,7 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
 
     Mono<NewAction> archiveById(String id);
 
-    Mono<List<NewAction>> archiveActionsByApplicationId(String applicationId, AclPermission permission);
+    Mono<Void> archiveActionsByApplicationId(String applicationId, AclPermission permission);
 
     Flux<ActionDTO> getUnpublishedActionsExceptJs(MultiValueMap<String, String> params);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -1315,15 +1315,18 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
     }
 
     @Override
-    public Mono<List<NewAction>> archiveActionsByApplicationId(String applicationId, AclPermission permission) {
+    public Mono<Void> archiveActionsByApplicationId(String applicationId, AclPermission permission) {
+        // Limit concurrency to avoid saturating the MongoDB NIO event loop thread pool
+        // during bulk application deletion. Per-entity analytics are intentionally skipped here;
+        // only the top-level application.deleted event is logged.
         return repository
                 .findByApplicationId(applicationId, permission)
-                .flatMap(repository::archive)
+                .flatMap(repository::archive, 8)
                 .onErrorResume(throwable -> {
                     log.error(throwable.getMessage());
                     return Mono.empty();
                 })
-                .collectList();
+                .then();
     }
 
     private Mono<Datasource> updateDatasourcePolicyForPublicAction(NewAction action, Datasource datasource) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCE.java
@@ -54,7 +54,7 @@ public interface NewPageServiceCE extends CrudService<NewPage, String> {
     Mono<PageDTO> findByNameAndApplicationIdAndViewMode(
             String name, String applicationId, AclPermission permission, Boolean view);
 
-    Mono<List<NewPage>> archivePagesByApplicationId(String applicationId, AclPermission permission);
+    Mono<Void> archivePagesByApplicationId(String applicationId, AclPermission permission);
 
     Mono<PageDTO> updatePage(String pageId, PageDTO page);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/base/NewPageServiceCEImpl.java
@@ -455,10 +455,12 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     }
 
     @Override
-    public Mono<List<NewPage>> archivePagesByApplicationId(String applicationId, AclPermission permission) {
+    public Mono<Void> archivePagesByApplicationId(String applicationId, AclPermission permission) {
+        // Limit concurrency to avoid saturating the MongoDB NIO event loop thread pool
+        // during bulk application deletion.
         return findNewPagesByApplicationId(applicationId, permission)
-                .flatMap(repository::archive)
-                .collectList();
+                .flatMap(repository::archive, 4)
+                .then();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -543,10 +543,14 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                     }
                     return Flux.fromIterable(List.of(application));
                 })
-                .flatMap(application -> {
-                    log.debug("Archiving application with id: {}", application.getId());
-                    return deleteApplicationByResource(application);
-                })
+                // Limit concurrency to avoid saturating the event loop during deletion of
+                // git-connected apps with many branches
+                .flatMap(
+                        application -> {
+                            log.debug("Archiving application with id: {}", application.getId());
+                            return deleteApplicationByResource(application);
+                        },
+                        2)
                 .then(applicationMono)
                 .flatMap(application -> {
                     GitArtifactMetadata gitData = application.getGitApplicationMetadata();
@@ -592,7 +596,16 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                 Map.of(FieldName.APP_MODE, ApplicationMode.EDIT.toString(), FieldName.APPLICATION, deletedApplication);
         final Map<String, Object> data = Map.of(FieldName.EVENT_DATA, eventData);
 
-        return analyticsService.sendDeleteEvent(deletedApplication, data);
+        // Run analytics/audit-log on the elastic scheduler so it does not block the
+        // MongoDB NIO event-loop threads, and swallow errors to avoid failing the delete.
+        return analyticsService
+                .sendDeleteEvent(deletedApplication, data)
+                .subscribeOn(LoadShifter.elasticScheduler)
+                .onErrorResume(throwable -> {
+                    log.error(
+                            "Error sending delete analytics for application {}", deletedApplication.getId(), throwable);
+                    return Mono.just(deletedApplication);
+                });
     }
 
     @Override


### PR DESCRIPTION
## Description

[Shadow EE PR](https://github.com/appsmithorg/appsmith-ee/pull/8617)
# Delete Flow Diagnostics Insights

## What was added
- Point-in-time diagnostics around app delete flow (`start` and `end-success/end-error`).
- Captured:
  - JVM memory (`heap`, `non-heap`, memory pools like `G1 Eden`, `G1 Old Gen`)
  - Thread stats (`eventLoop`, `elastic`, `parallel`, `other`, total threads)
  - Reactive Mongo connection stats (`current`, `available`, `totalCreated`, `active`)
  - Elapsed delete duration and start/end deltas

## High-level observations from runs shared

### Earlier heavy runs (4-run batch)
- Duration mostly high: ~7s to ~9.5s.
- Memory behavior volatile:
  - 3 runs had positive heap growth (`+1.69 GiB`, `+0.89 GiB`, `+0.33 GiB`)
  - 1 run had heap drop (`-0.73 GiB`)
- Largest spike showed strong `G1 Old Gen` growth (promotion/retention pressure).
- Mongo connections were stable in most runs, but one run expanded pool (`current +16`, `available -16`).
- Thread counts were broadly stable (no sustained thread leak pattern).

### Later stable runs (3-run batch)
- Faster: ~1.3s to ~3.3s.
- Heap mostly stable or improved:
  - `+17 MB`, `-28 MB`, `-13 MB`
- Mongo mostly stable:
  - first run warmed up (`current +6`), then flat.
- Threads mostly stable:
  - one run `+6` (eventLoop), then flat.

## What this indicates
- Delete flow now shows better runtime behavior in the later runs:
  - lower latency
  - smaller/negative heap deltas
  - stable thread and DB connection behavior after warm-up
- No consistent leak signature seen in the stable batch.

## Suggested way to report improvement
- “We now have start/end diagnostics for delete flow covering memory, thread pools, and Mongo connections.”
- “Compared to earlier runs, recent runs are faster and show controlled memory behavior.”
- “Connection/thread growth appears warm-up related and stabilizes in subsequent runs.”

## Guardrails to monitor going forward
- `elapsedMs` consistently > 5000
- `heapUsedDeltaBytes` repeatedly > `+512 MB`
- repeated `G1 Old Gen` growth across consecutive deletes
- `mongoCurrentConnectionsDelta` repeatedly > `+8`
- monotonic rise in `totalThreadCount` across runs


Fixes https://linear.app/appsmith/issue/APP-14877/appsmith-crashes-and-restarts-on-app-deletion-with-high-cpu-usage

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/22549602904>
> Commit: 6ae882148196ed14ad6772d57cb88b941b982699
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=22549602904&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 02 Mar 2026 04:51:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized bulk archival operations for applications, action collections, actions, and pages
  * Enhanced concurrency controls in application deletion workflows
  * Improved analytics event handling to prevent deletion failures from analytics errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->