### PR TITLE
feat: Redis datasource: add TLS (SSL mode) support in backend + datasource UI

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -10,6 +10,7 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.RequestParamDTO;
+import com.appsmith.external.models.SSLDetails;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.external.plugins.exceptions.RedisErrorMessages;
@@ -258,14 +259,36 @@ public class RedisPlugin extends BasePlugin {
             log.debug(Thread.currentThread().getName() + ": datasourceCreate() called for Redis plugin.");
             return Mono.fromCallable(() -> {
                         final JedisPoolConfig poolConfig = buildPoolConfig();
+                        boolean isTlsEnabled = isTlsEnabled(datasourceConfiguration);
                         int timeout =
                                 (int) Duration.ofSeconds(CONNECTION_TIMEOUT).toMillis();
-                        URI uri = RedisURIUtils.getURI(datasourceConfiguration);
+                        URI uri = RedisURIUtils.getURI(datasourceConfiguration, isTlsEnabled);
                         JedisPool jedisPool = new JedisPool(poolConfig, uri, timeout);
                         log.debug(Thread.currentThread().getName() + ": Created Jedis pool.");
                         return jedisPool;
                     })
                     .subscribeOn(scheduler);
+        }
+
+        private boolean isTlsEnabled(DatasourceConfiguration datasourceConfiguration) throws AppsmithPluginException {
+            if (datasourceConfiguration.getConnection() == null
+                    || datasourceConfiguration.getConnection().getSsl() == null
+                    || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
+                return false;
+            }
+
+            SSLDetails.AuthType sslAuthType =
+                    datasourceConfiguration.getConnection().getSsl().getAuthType();
+            switch (sslAuthType) {
+                case ENABLED:
+                    return true;
+                case DISABLED:
+                    return false;
+                default:
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
+                            String.format(RedisErrorMessages.DS_UNEXPECTED_SSL_OPTION_ERROR_MSG, sslAuthType));
+            }
         }
 
         @Override

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/exceptions/RedisErrorMessages.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/exceptions/RedisErrorMessages.java
@@ -18,6 +18,10 @@ public class RedisErrorMessages extends BasePluginErrorMessages {
     public static final String QUERY_EXECUTION_FAILED_ERROR_MSG =
             "Error occurred while executing Redis query. To know more about the error please check the error details.";
 
+    public static final String DS_UNEXPECTED_SSL_OPTION_ERROR_MSG =
+            "Appsmith server has found an unexpected SSL option: %s. Please reach out to Appsmith customer support"
+                    + " to resolve this.";
+
     /*
     ************************************************************************************************************************************************
                                        Error messages related to validation of datasource.

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
@@ -12,10 +12,12 @@ import java.net.URISyntaxException;
 public class RedisURIUtils {
     public static final Long DEFAULT_PORT = 6379L;
     private static final String REDIS_SCHEME = "redis://";
+    private static final String REDISS_SCHEME = "rediss://";
 
-    public static URI getURI(DatasourceConfiguration datasourceConfiguration) throws URISyntaxException {
+    public static URI getURI(DatasourceConfiguration datasourceConfiguration, boolean isTlsEnabled)
+            throws URISyntaxException {
         StringBuilder builder = new StringBuilder();
-        builder.append(REDIS_SCHEME);
+        builder.append(isTlsEnabled ? REDISS_SCHEME : REDIS_SCHEME);
 
         String uriAuth = getUriAuth(datasourceConfiguration);
         builder.append(uriAuth);

--- a/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
@@ -58,6 +58,28 @@
           ]
         }
       ]
+    },
+    {
+      "id": 3,
+      "sectionName": "SSL (optional)",
+      "children": [
+        {
+          "label": "SSL mode",
+          "configProperty": "datasourceConfiguration.connection.ssl.authType",
+          "controlType": "DROP_DOWN",
+          "initialValue": "DISABLED",
+          "options": [
+            {
+              "label": "Disabled",
+              "value": "DISABLED"
+            },
+            {
+              "label": "Enabled",
+              "value": "ENABLED"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -1,13 +1,16 @@
 package com.external.plugins;
 
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionResult;
+import com.appsmith.external.models.Connection;
 import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.RequestParamDTO;
+import com.appsmith.external.models.SSLDetails;
 import com.external.plugins.exceptions.RedisErrorMessages;
 import com.external.plugins.exceptions.RedisPluginError;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -66,6 +69,16 @@ public class RedisPluginTest {
         return datasourceConfiguration;
     }
 
+    private DatasourceConfiguration createDatasourceConfigurationWithTlsAuthType(SSLDetails.AuthType authType) {
+        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
+        Connection connection = new Connection();
+        SSLDetails sslDetails = new SSLDetails();
+        sslDetails.setAuthType(authType);
+        connection.setSsl(sslDetails);
+        datasourceConfiguration.setConnection(connection);
+        return datasourceConfiguration;
+    }
+
     @Test
     public void itShouldCreateDatasource() {
         DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
@@ -74,6 +87,42 @@ public class RedisPluginTest {
         StepVerifier.create(jedisPoolMono).assertNext(Assertions::assertNotNull).verifyComplete();
 
         pluginExecutor.datasourceDestroy(jedisPoolMono.block());
+    }
+
+    @Test
+    public void itShouldCreateDatasourceWithTlsEnabled() {
+        DatasourceConfiguration datasourceConfiguration =
+                createDatasourceConfigurationWithTlsAuthType(SSLDetails.AuthType.ENABLED);
+        Mono<JedisPool> jedisPoolMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
+
+        StepVerifier.create(jedisPoolMono).assertNext(Assertions::assertNotNull).verifyComplete();
+
+        pluginExecutor.datasourceDestroy(jedisPoolMono.block());
+    }
+
+    @Test
+    public void itShouldCreateDatasourceWithTlsDisabled() {
+        DatasourceConfiguration datasourceConfiguration =
+                createDatasourceConfigurationWithTlsAuthType(SSLDetails.AuthType.DISABLED);
+        Mono<JedisPool> jedisPoolMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
+
+        StepVerifier.create(jedisPoolMono).assertNext(Assertions::assertNotNull).verifyComplete();
+
+        pluginExecutor.datasourceDestroy(jedisPoolMono.block());
+    }
+
+    @Test
+    public void itShouldThrowErrorForUnsupportedTlsAuthType() {
+        DatasourceConfiguration datasourceConfiguration =
+                createDatasourceConfigurationWithTlsAuthType(SSLDetails.AuthType.REQUIRE);
+        Mono<JedisPool> jedisPoolMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
+
+        StepVerifier.create(jedisPoolMono)
+                .expectErrorSatisfies(error -> {
+                    assertTrue(error instanceof AppsmithPluginException);
+                    assertTrue(error.getMessage().contains("unexpected SSL option"));
+                })
+                .verify();
     }
 
     @Test

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/utils/RedisURIUtilsTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/utils/RedisURIUtilsTest.java
@@ -1,0 +1,46 @@
+package com.external.utils;
+
+import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.Endpoint;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RedisURIUtilsTest {
+
+    private DatasourceConfiguration createDatasourceConfiguration() {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setHost("localhost");
+        endpoint.setPort(6379L);
+
+        DBAuth auth = new DBAuth();
+        auth.setUsername("user");
+        auth.setPassword("password");
+        auth.setDatabaseName("2");
+
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
+        datasourceConfiguration.setAuthentication(auth);
+
+        return datasourceConfiguration;
+    }
+
+    @Test
+    public void itShouldBuildRedisUriWhenTlsDisabled() throws URISyntaxException {
+        URI uri = RedisURIUtils.getURI(createDatasourceConfiguration(), false);
+
+        assertEquals("redis://user:password@localhost:6379/2", uri.toString());
+    }
+
+    @Test
+    public void itShouldBuildRedissUriWhenTlsEnabled() throws URISyntaxException {
+        URI uri = RedisURIUtils.getURI(createDatasourceConfiguration(), true);
+
+        assertEquals("rediss://user:password@localhost:6379/2", uri.toString());
+    }
+}


### PR DESCRIPTION
## Summary
This PR enables TLS connections for the Redis datasource and exposes the setting in the datasource configuration UI.

## What changed
- Added Redis TLS mode handling in datasource creation:
  - `ENABLED` => use TLS
  - `DISABLED` or missing SSL config => no TLS (backward compatible default)
  - any other SSL auth type => fail fast with datasource argument error
- Updated Redis URI construction to support `rediss://` when TLS is enabled.
- Added Redis datasource form control:
  - Section: `SSL (optional)`
  - Field: `SSL mode`
  - Options: `Disabled (DISABLED)` and `Enabled (ENABLED)`
  - Default: `DISABLED`
- Added/updated tests for TLS behavior and URI generation.

## Behavior / compatibility
- Existing Redis datasources without SSL config continue to work as non-TLS.
- TLS is opt-in via datasource `SSL mode = Enabled`.

## Test plan
- Added unit tests for:
  - Redis datasource creation with TLS `ENABLED`
  - Redis datasource creation with TLS `DISABLED`
  - Unsupported SSL auth type returns error
  - Redis URI uses `redis://` for non-TLS and `rediss://` for TLS

## Verification
- Pre-commit Spotless checks were applied successfully during commit.
- Full plugin tests were not run in this step.

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/22610750972>
> Commit: 4a9a492d99ebeca70320ec86cf4c4cfbb2bf513a
> Workflow: `PR Automation test suite`
> Tags: `@tag.All`
> Spec: ``
> <hr>Tue, 03 Mar 2026 06:10:33 UTC
<!-- end of auto-generated comment: Cypress test results  -->
