### PR TITLE
fix(server): prevent SQL injection in UQI filter service projection and sortBy columns

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -162,6 +162,9 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
         List<Map<String, String>> sortBy = uqiDataFilterParams.getSortBy();
         Map<String, String> paginateBy = uqiDataFilterParams.getPaginateBy();
 
+        validateProjectionColumns(projectionColumns, schema);
+        validateSortByColumns(sortBy, schema);
+
         Connection conn = checkAndGetConnection();
 
         StringBuilder sb = new StringBuilder();
@@ -277,6 +280,33 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
         values.add(new PreparedStatementValueDTO(offset, DataType.INTEGER));
     }
 
+    private void validateProjectionColumns(List<String> projectionColumns, Map<String, DataType> schema) {
+        if (CollectionUtils.isEmpty(projectionColumns)) {
+            return;
+        }
+        for (String columnName : projectionColumns) {
+            if (!schema.containsKey(columnName)) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                        columnName + " not found in the known column names: " + schema.keySet());
+            }
+        }
+    }
+
+    private void validateSortByColumns(List<Map<String, String>> sortBy, Map<String, DataType> schema) {
+        if (isSortConditionEmpty(sortBy)) {
+            return;
+        }
+        for (Map<String, String> sortCondition : sortBy) {
+            String columnName = sortCondition.get(SORT_BY_COLUMN_NAME_KEY);
+            if (!isBlank(columnName) && !schema.containsKey(columnName)) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                        columnName + " not found in the known column names: " + schema.keySet());
+            }
+        }
+    }
+
     /**
      * Display only those columns that the user has chosen to display.
      * E.g. if the projectionColumns is a list that contains ["ID, Name"], then this method will add the following
@@ -286,10 +316,15 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
      * @param projectionColumns - list of columns that need to be displayed
      * @param tableName         - table name in database
      */
+    private static String escapeBacktickIdentifier(String identifier) {
+        return identifier.replace("`", "``");
+    }
+
     private void addProjectionCondition(StringBuilder sb, List<String> projectionColumns, String tableName) {
         if (!CollectionUtils.isEmpty(projectionColumns)) {
             sb.append("SELECT");
-            projectionColumns.stream().forEach(columnName -> sb.append(" `" + columnName + "`,"));
+            projectionColumns.stream()
+                    .forEach(columnName -> sb.append(" `" + escapeBacktickIdentifier(columnName) + "`,"));
 
             sb.setLength(sb.length() - 1);
             sb.append(" FROM " + tableName);
@@ -337,7 +372,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                                         + "to parse the type of sort condition. Please reach out to Appsmith customer support "
                                         + "to resolve this.");
                     }
-                    sb.append(" `" + columnName + "` " + sortType + ",");
+                    sb.append(" `" + escapeBacktickIdentifier(columnName) + "` " + sortType + ",");
                 });
 
         sb.setLength(sb.length() - 1);
@@ -615,10 +650,10 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 .takeWhile(x -> fieldNamesIterator.hasNext())
                 .map(n -> fieldNamesIterator.next())
                 .map(name -> {
-                    if (name.contains("\"") || name.contains("\'")) {
+                    if (name.contains("\"") || name.contains("\'") || name.contains("`")) {
                         throw new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                                "\' or \" are unsupported symbols in column names for filtering. Caused by column name : "
+                                "', \" or ` are unsupported symbols in column names for filtering. Caused by column name : "
                                         + name);
                     }
                     return name;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -134,21 +134,21 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
         }
 
         Map<String, DataType> schema = generateSchema(items, dataTypeConversionMap);
+
+        validateProjectionColumns(uqiDataFilterParams.getProjectionColumns(), schema);
+        validateSortByColumns(uqiDataFilterParams.getSortBy(), schema);
+
         String tableName = generateTable(schema);
+        try {
+            insertAllData(tableName, items, schema, dataTypeConversionMap);
 
-        // insert the data
-        insertAllData(tableName, items, schema, dataTypeConversionMap);
+            List<Map<String, Object>> finalResults =
+                    executeFilterQueryNew(tableName, schema, uqiDataFilterParams, dataTypeConversionMap);
 
-        // Filter the data
-        List<Map<String, Object>> finalResults =
-                executeFilterQueryNew(tableName, schema, uqiDataFilterParams, dataTypeConversionMap);
-
-        // Now that the data has been filtered. Clean Up. Drop the table
-        dropTable(tableName);
-
-        ArrayNode finalResultsNode = objectMapper.valueToTree(finalResults);
-
-        return finalResultsNode;
+            return objectMapper.valueToTree(finalResults);
+        } finally {
+            dropTable(tableName);
+        }
     }
 
     private List<Map<String, Object>> executeFilterQueryNew(
@@ -161,9 +161,6 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
         List<String> projectionColumns = uqiDataFilterParams.getProjectionColumns();
         List<Map<String, String>> sortBy = uqiDataFilterParams.getSortBy();
         Map<String, String> paginateBy = uqiDataFilterParams.getPaginateBy();
-
-        validateProjectionColumns(projectionColumns, schema);
-        validateSortByColumns(sortBy, schema);
 
         Connection conn = checkAndGetConnection();
 
@@ -303,6 +300,21 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 throw new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
                         columnName + " not found in the known column names: " + schema.keySet());
+            }
+            if (!isBlank(columnName)) {
+                String order = sortCondition.get(SORT_BY_TYPE_KEY);
+                if (isBlank(order)) {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Sort order is required for column: " + columnName);
+                }
+                try {
+                    SortType.valueOf(order.toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Unsupported sort order '" + order + "' for column: " + columnName);
+                }
             }
         }
     }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -1336,4 +1336,117 @@ public class FilterDataServiceTest {
             fail(e.getMessage());
         }
     }
+
+    private static final String SIMPLE_DATA = "[\n" + "  {\n"
+            + "    \"id\": 1,\n"
+            + "    \"email\": \"user@example.com\",\n"
+            + "    \"name\": \"Alice\"\n"
+            + "  },\n"
+            + "  {\n"
+            + "    \"id\": 2,\n"
+            + "    \"email\": \"admin@example.com\",\n"
+            + "    \"name\": \"Bob\"\n"
+            + "  }\n"
+            + "]";
+
+    @Test
+    public void testProjectionWithInvalidColumnName_throwsException() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<String> projectionColumns = List.of("id", "nonExistentColumn");
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, projectionColumns, null, null));
+        });
+        assertThat(exception.getMessage()).contains("nonExistentColumn");
+        assertThat(exception.getMessage()).contains("not found in the known column names");
+    }
+
+    @Test
+    public void testSortByWithInvalidColumnName_throwsException() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<Map<String, String>> sortBy =
+                List.of(Map.of(SORT_BY_COLUMN_NAME_KEY, "nonExistentColumn", SORT_BY_TYPE_KEY, VALUE_DESCENDING));
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, null, sortBy, null));
+        });
+        assertThat(exception.getMessage()).contains("nonExistentColumn");
+        assertThat(exception.getMessage()).contains("not found in the known column names");
+    }
+
+    @Test
+    public void testProjectionWithBacktickInjection_throwsException() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<String> maliciousProjection = List.of("id` , FILE_READ('/etc/passwd') AS leaked , `id");
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, maliciousProjection, null, null));
+        });
+        assertThat(exception.getMessage()).contains("not found in the known column names");
+    }
+
+    @Test
+    public void testSortByWithBacktickInjection_throwsException() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<Map<String, String>> maliciousSortBy = List.of(Map.of(
+                SORT_BY_COLUMN_NAME_KEY,
+                "id` , FILE_READ('/etc/passwd') AS leaked , `id",
+                SORT_BY_TYPE_KEY,
+                VALUE_DESCENDING));
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, null, maliciousSortBy, null));
+        });
+        assertThat(exception.getMessage()).contains("not found in the known column names");
+    }
+
+    @Test
+    public void testSchemaRejectsBackticksInColumnNames() {
+        String dataWithBacktickColumn =
+                "[\n" + "  {\n" + "    \"normal_col\": \"value1\",\n" + "    \"bad`col\": \"value2\"\n" + "  }\n" + "]";
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            ArrayNode items = (ArrayNode) objectMapper.readTree(dataWithBacktickColumn);
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, null, null, null));
+        });
+        assertThat(exception.getMessage()).contains("unsupported symbols in column names");
+    }
+
+    @Test
+    public void testProjectionWithSqlExpressionInjection_throwsException() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<String> maliciousProjection = List.of("(SELECT CURRENT_TIMESTAMP)");
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, maliciousProjection, null, null));
+        });
+        assertThat(exception.getMessage()).contains("not found in the known column names");
+    }
+
+    @Test
+    public void testValidProjectionStillWorks() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<String> projectionColumns = List.of("id", "email");
+
+        ArrayNode result =
+                filterDataService.filterDataNew(items, new UQIDataFilterParams(null, projectionColumns, null, null));
+
+        assertEquals(2, result.size());
+        List<String> returnedColumns = new ArrayList<>();
+        result.get(0).fieldNames().forEachRemaining(returnedColumns::add);
+        assertEquals(List.of("id", "email"), returnedColumns);
+    }
+
+    @Test
+    public void testValidSortByStillWorks() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<Map<String, String>> sortBy =
+                List.of(Map.of(SORT_BY_COLUMN_NAME_KEY, "id", SORT_BY_TYPE_KEY, VALUE_DESCENDING));
+
+        ArrayNode result = filterDataService.filterDataNew(items, new UQIDataFilterParams(null, null, sortBy, null));
+
+        assertEquals(2, result.size());
+        assertEquals(2, result.get(0).get("id").asInt());
+        assertEquals(1, result.get(1).get("id").asInt());
+    }
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -1449,4 +1449,44 @@ public class FilterDataServiceTest {
         assertEquals(2, result.get(0).get("id").asInt());
         assertEquals(1, result.get(1).get("id").asInt());
     }
+
+    @Test
+    public void testSortByWithNullOrder_throwsException() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        Map<String, String> sortCondition = new HashMap<>();
+        sortCondition.put(SORT_BY_COLUMN_NAME_KEY, "id");
+        sortCondition.put(SORT_BY_TYPE_KEY, null);
+        List<Map<String, String>> sortBy = List.of(sortCondition);
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, null, sortBy, null));
+        });
+        assertThat(exception.getMessage()).contains("Sort order is required for column");
+    }
+
+    @Test
+    public void testSortByWithInvalidOrder_throwsException() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<Map<String, String>> sortBy =
+                List.of(Map.of(SORT_BY_COLUMN_NAME_KEY, "id", SORT_BY_TYPE_KEY, "INVALID_ORDER"));
+
+        AppsmithPluginException exception = assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, null, sortBy, null));
+        });
+        assertThat(exception.getMessage()).contains("Unsupported sort order");
+    }
+
+    @Test
+    public void testInvalidProjectionDoesNotLeakTable() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        List<String> badProjection = List.of("nonExistentColumn");
+
+        assertThrows(AppsmithPluginException.class, () -> {
+            filterDataService.filterDataNew(items, new UQIDataFilterParams(null, badProjection, null, null));
+        });
+
+        ArrayNode result =
+                filterDataService.filterDataNew(items, new UQIDataFilterParams(null, List.of("id"), null, null));
+        assertEquals(2, result.size());
+    }
 }


### PR DESCRIPTION
## Description

**TL;DR:** Fix a High-severity SQL injection vulnerability (GHSA-7634-7vm9-xg5q, CVSS 7.7) in `FilterDataServiceCE` where unsanitized projection and sortBy column names allow arbitrary SQL injection into the H2 in-memory database, enabling server-side file reads via `FILE_READ()` and cross-user data exposure.

### Root Cause

`addProjectionCondition()` and `addSortCondition()` in `FilterDataServiceCE` construct SQL queries by wrapping user-supplied column names in backticks without escaping backtick characters within the input. An authenticated attacker with developer-level workspace access can break out of the backtick quoting and inject arbitrary SQL expressions into the H2 in-memory database.

The WHERE clause was already protected via schema validation (`validConditionList()`), but this same validation was never applied to projection or sortBy column names — an inconsistency that this fix addresses.

### Fix (Defense in Depth — 3 Layers)

1. **Schema validation (primary fix):** Added `validateProjectionColumns()` and `validateSortByColumns()` methods that whitelist column names against the data schema before any SQL is constructed. This eliminates the entire class of identifier injection — any column name not present in the actual data is rejected with an `AppsmithPluginException`.

2. **Backtick escaping (defense in depth):** Added `escapeBacktickIdentifier()` that escapes backtick characters (`` ` `` → ```` `` ````) in `addProjectionCondition` and `addSortCondition`, preventing breakout even if Layer 1 were bypassed.

3. **Schema generation hardening:** Extended the existing quote rejection in `generateSchema()` to also reject backtick characters in data column names, preventing the attack character from entering the system via the data source itself.

### Affected Plugins

- **Google Sheets** (`RowsGetMethod`) — uses both projection and sortBy from formData
- **Amazon S3** (`AmazonS3Plugin`) — uses sortBy from formData (projection is null)

### Test Coverage

Added 8 new unit tests covering:
- Invalid column names in projection and sortBy (rejected)
- SQL injection payloads via backtick breakout in projection and sortBy (rejected)
- SQL expression injection via projection (rejected)
- Backtick characters in data column names via schema generation (rejected)
- Valid projection and sortBy still work correctly (regression tests)

All 29 tests pass (21 existing + 8 new).

Fixes https://github.com/appsmithorg/appsmith/security/advisories/GHSA-7634-7vm9-xg5q
Fixes https://linear.app/appsmith/issue/APP-14992/bug-prevent-sql-injection-in-uqi-filter-service-projection-and-sortby

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23039906046>
> Commit: 38e04515e8ebf3b34e1c5bd2938bce6c795e4cb6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23039906046&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 13 Mar 2026 08:10:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-validate projection and sort inputs against generated schema to catch invalid columns early.
  * Reject column names containing backticks and consistently quote identifiers to prevent injection.
  * Ensure temporary resources are always cleaned up after queries and improve error messages for invalid query configs.

* **Tests**
  * Expanded coverage for projection/sort validation, backtick and SQL-injection protection, sort-order errors, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->