### PR TITLE
fix: use atomic setIfAbsent for Redis lock acquisition in RedisUtils

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedisUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedisUtils.java
@@ -37,16 +37,19 @@ public class RedisUtils {
 
     public Mono<Boolean> addFileLock(String key, String gitCommand) {
         String command = hasText(gitCommand) ? gitCommand : REDIS_FILE_LOCK_VALUE;
-        return redisOperations.hasKey(key).flatMap(isKeyPresent -> {
-            if (!Boolean.TRUE.equals(isKeyPresent)) {
-                return redisOperations.opsForValue().set(key, gitCommand, FILE_LOCK_TIME_LIMIT);
-            }
-            return redisOperations
-                    .opsForValue()
-                    .get(key)
-                    .flatMap(commandName ->
-                            Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE, command, commandName)));
-        });
+        return redisOperations
+                .opsForValue()
+                .setIfAbsent(key, command, FILE_LOCK_TIME_LIMIT)
+                .flatMap(locked -> {
+                    if (Boolean.TRUE.equals(locked)) {
+                        return Mono.just(Boolean.TRUE);
+                    }
+                    return redisOperations
+                            .opsForValue()
+                            .get(key)
+                            .flatMap(commandName -> Mono.error(
+                                    new AppsmithException(AppsmithError.GIT_FILE_IN_USE, command, commandName)));
+                });
     }
 
     @Deprecated
@@ -54,12 +57,15 @@ public class RedisUtils {
         if (gitServiceConfig.isGitInMemory()) {
             return Mono.just(true);
         }
-        return redisOperations.hasKey(key).flatMap(isKeyPresent -> {
-            if (Boolean.TRUE.equals(isKeyPresent)) {
-                return Mono.error(exception);
-            }
-            return redisOperations.opsForValue().set(key, REDIS_FILE_LOCK_VALUE, expirationPeriod);
-        });
+        return redisOperations
+                .opsForValue()
+                .setIfAbsent(key, REDIS_FILE_LOCK_VALUE, expirationPeriod)
+                .flatMap(locked -> {
+                    if (Boolean.TRUE.equals(locked)) {
+                        return Mono.just(Boolean.TRUE);
+                    }
+                    return Mono.error(exception);
+                });
     }
 
     @Deprecated
@@ -76,12 +82,15 @@ public class RedisUtils {
 
     public Mono<Boolean> startAutoCommit(String defaultApplicationId, String branchName) {
         String key = String.format(AUTO_COMMIT_KEY_FORMAT, defaultApplicationId);
-        return redisOperations.hasKey(key).flatMap(isKeyPresent -> {
-            if (Boolean.TRUE.equals(isKeyPresent)) {
-                return Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE, AUTO_COMMIT, AUTO_COMMIT));
-            }
-            return redisOperations.opsForValue().set(key, branchName, AUTO_COMMIT_TIME_LIMIT);
-        });
+        return redisOperations
+                .opsForValue()
+                .setIfAbsent(key, branchName, AUTO_COMMIT_TIME_LIMIT)
+                .flatMap(locked -> {
+                    if (Boolean.TRUE.equals(locked)) {
+                        return Mono.just(Boolean.TRUE);
+                    }
+                    return Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE, AUTO_COMMIT, AUTO_COMMIT));
+                });
     }
 
     public Mono<Boolean> setAutoCommitProgress(String defaultApplicationId, Integer progress) {


### PR DESCRIPTION
## Description

The `addFileLock` and `startAutoCommit` methods in `RedisUtils` used a non-atomic `hasKey` + `set` pattern that is susceptible to race conditions. Between the `hasKey` check and the `set` call, another concurrent caller could observe the key as absent and also proceed to acquire the lock, resulting in two callers believing they hold the lock simultaneously.

This replaces the two-step pattern with Redis's atomic `setIfAbsent` (SET NX) which checks and sets in a single atomic operation, consistent with how `GitRouteAspectCE` and `DistributedLockAspect` already handle lock acquisition in this codebase.

**Methods fixed:**
- `addFileLock(String key, String gitCommand)` — also fixes a pre-existing bug where the raw `gitCommand` parameter was stored instead of the normalized `command` value
- `addFileLock(String key, Duration, AppsmithException)` (deprecated)
- `startAutoCommit(String defaultApplicationId, String branchName)`

The method signatures and return types are unchanged, so all callers and mocked tests remain compatible.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file lock handling for more reliable concurrent file operations and clearer error messages when files are in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->