### PR TITLE
fix(security): prevent unauthenticated disclosure of instance metadata [APP-14994]

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -214,7 +214,6 @@ public class SecurityConfig {
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/invite/confirm"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/me"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/v3/**"),
-                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/features"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ASSET_URL + "/*"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_URL + "/**"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_COLLECTION_URL + "/view"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -10,6 +10,7 @@ import com.appsmith.server.constants.MigrationStatus;
 import com.appsmith.server.constants.ce.FieldNameCE;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.OrganizationConfiguration;
+import com.appsmith.server.domains.User;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.CollectionUtils;
@@ -26,6 +27,7 @@ import io.micrometer.observation.ObservationRegistry;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.util.StringUtils;
 import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Flux;
@@ -157,33 +159,46 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
     public Mono<Organization> getOrganizationConfiguration(Mono<Organization> dbOrganizationMono) {
         String adminEmailDomainHash = commonConfig.getAdminEmailDomainHash();
 
-        Mono<Organization> clientOrganizationMono = configService
-                .getInstanceId()
-                .flatMap(instanceId -> {
-                    final Organization organization = new Organization();
-                    organization.setInstanceId(instanceId);
-                    organization.setAdminEmailDomainHash(adminEmailDomainHash);
+        // Determine if the current principal is an anonymous (unauthenticated) user so we can
+        // suppress instance-identifying metadata in the public response.
+        Mono<Boolean> isAnonymousMono = ReactiveSecurityContextHolder.getContext()
+                .map(ctx -> (User) ctx.getAuthentication().getPrincipal())
+                .map(user -> Boolean.TRUE.equals(user.getIsAnonymous()))
+                .defaultIfEmpty(true);
 
-                    final OrganizationConfiguration config = new OrganizationConfiguration();
-                    organization.setOrganizationConfiguration(config);
+        Mono<Organization> clientOrganizationMono = isAnonymousMono.flatMap(isAnonymous ->
+                configService
+                        .getInstanceId()
+                        .flatMap(instanceId -> {
+                            final Organization organization = new Organization();
 
-                    if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GOOGLE_CLIENT_ID"))) {
-                        config.addThirdPartyAuth("google");
-                    }
+                            // Only expose instance-identifying metadata to authenticated users
+                            if (!isAnonymous) {
+                                organization.setInstanceId(instanceId);
+                                organization.setAdminEmailDomainHash(adminEmailDomainHash);
+                            }
 
-                    if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GITHUB_CLIENT_ID"))) {
-                        config.addThirdPartyAuth("github");
-                    }
+                            final OrganizationConfiguration config = new OrganizationConfiguration();
+                            organization.setOrganizationConfiguration(config);
 
-                    return configService
-                            .getInstanceVariables()
-                            .map(instanceVariables -> instanceVariablesHelper.populateOrgConfigWithInstanceVariables(
-                                    instanceVariables, config))
-                            .map(organizationConfiguration -> {
-                                organization.setOrganizationConfiguration(organizationConfiguration);
-                                return organization;
-                            });
-                });
+                            if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GOOGLE_CLIENT_ID"))) {
+                                config.addThirdPartyAuth("google");
+                            }
+
+                            if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GITHUB_CLIENT_ID"))) {
+                                config.addThirdPartyAuth("github");
+                            }
+
+                            return configService
+                                    .getInstanceVariables()
+                                    .map(instanceVariables ->
+                                            instanceVariablesHelper.populateOrgConfigWithInstanceVariables(
+                                                    instanceVariables, config))
+                                    .map(organizationConfiguration -> {
+                                        organization.setOrganizationConfiguration(organizationConfiguration);
+                                        return organization;
+                                    });
+                        }));
 
         return Mono.zip(dbOrganizationMono, clientOrganizationMono).flatMap(tuple -> {
             Organization dbOrganization = tuple.getT1();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -164,11 +164,13 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
         Mono<Boolean> isAnonymousMono = ReactiveSecurityContextHolder.getContext()
                 .flatMap(ctx -> Mono.justOrEmpty(ctx.getAuthentication()))
                 .filter(authentication -> authentication.getPrincipal() instanceof User)
-                .map(authentication -> ((User) authentication.getPrincipal()).getIsAnonymous())
+                .map(authentication -> ((User) authentication.getPrincipal()).isAnonymous())
                 .defaultIfEmpty(true);
 
-        Mono<Organization> clientOrganizationMono = isAnonymousMono.flatMap(
-                isAnonymous -> configService.getInstanceId().flatMap(instanceId -> {
+        Mono<Organization> clientOrganizationMono = Mono.zip(isAnonymousMono, configService.getInstanceId())
+                .flatMap(tuple -> {
+                    boolean isAnonymous = tuple.getT1();
+                    String instanceId = tuple.getT2();
                     final Organization organization = new Organization();
 
                     // Only expose instance-identifying metadata to authenticated users
@@ -196,7 +198,7 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
                                 organization.setOrganizationConfiguration(organizationConfiguration);
                                 return organization;
                             });
-                }));
+                });
 
         return Mono.zip(dbOrganizationMono, clientOrganizationMono).flatMap(tuple -> {
             Organization dbOrganization = tuple.getT1();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -166,39 +166,36 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
                 .map(user -> Boolean.TRUE.equals(user.getIsAnonymous()))
                 .defaultIfEmpty(true);
 
-        Mono<Organization> clientOrganizationMono = isAnonymousMono.flatMap(isAnonymous ->
-                configService
-                        .getInstanceId()
-                        .flatMap(instanceId -> {
-                            final Organization organization = new Organization();
+        Mono<Organization> clientOrganizationMono = isAnonymousMono.flatMap(
+                isAnonymous -> configService.getInstanceId().flatMap(instanceId -> {
+                    final Organization organization = new Organization();
 
-                            // Only expose instance-identifying metadata to authenticated users
-                            if (!isAnonymous) {
-                                organization.setInstanceId(instanceId);
-                                organization.setAdminEmailDomainHash(adminEmailDomainHash);
-                            }
+                    // Only expose instance-identifying metadata to authenticated users
+                    if (!isAnonymous) {
+                        organization.setInstanceId(instanceId);
+                        organization.setAdminEmailDomainHash(adminEmailDomainHash);
+                    }
 
-                            final OrganizationConfiguration config = new OrganizationConfiguration();
-                            organization.setOrganizationConfiguration(config);
+                    final OrganizationConfiguration config = new OrganizationConfiguration();
+                    organization.setOrganizationConfiguration(config);
 
-                            if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GOOGLE_CLIENT_ID"))) {
-                                config.addThirdPartyAuth("google");
-                            }
+                    if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GOOGLE_CLIENT_ID"))) {
+                        config.addThirdPartyAuth("google");
+                    }
 
-                            if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GITHUB_CLIENT_ID"))) {
-                                config.addThirdPartyAuth("github");
-                            }
+                    if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GITHUB_CLIENT_ID"))) {
+                        config.addThirdPartyAuth("github");
+                    }
 
-                            return configService
-                                    .getInstanceVariables()
-                                    .map(instanceVariables ->
-                                            instanceVariablesHelper.populateOrgConfigWithInstanceVariables(
-                                                    instanceVariables, config))
-                                    .map(organizationConfiguration -> {
-                                        organization.setOrganizationConfiguration(organizationConfiguration);
-                                        return organization;
-                                    });
-                        }));
+                    return configService
+                            .getInstanceVariables()
+                            .map(instanceVariables -> instanceVariablesHelper.populateOrgConfigWithInstanceVariables(
+                                    instanceVariables, config))
+                            .map(organizationConfiguration -> {
+                                organization.setOrganizationConfiguration(organizationConfiguration);
+                                return organization;
+                            });
+                }));
 
         return Mono.zip(dbOrganizationMono, clientOrganizationMono).flatMap(tuple -> {
             Organization dbOrganization = tuple.getT1();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -162,8 +162,9 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
         // Determine if the current principal is an anonymous (unauthenticated) user so we can
         // suppress instance-identifying metadata in the public response.
         Mono<Boolean> isAnonymousMono = ReactiveSecurityContextHolder.getContext()
-                .map(ctx -> (User) ctx.getAuthentication().getPrincipal())
-                .map(user -> Boolean.TRUE.equals(user.getIsAnonymous()))
+                .flatMap(ctx -> Mono.justOrEmpty(ctx.getAuthentication()))
+                .filter(authentication -> authentication.getPrincipal() instanceof User)
+                .map(authentication -> ((User) authentication.getPrincipal()).getIsAnonymous())
                 .defaultIfEmpty(true);
 
         Mono<Organization> clientOrganizationMono = isAnonymousMono.flatMap(

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/AuthGuardTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/AuthGuardTest.java
@@ -42,16 +42,20 @@ public class AuthGuardTest {
     /**
      * /api/v1/tenants/current must remain accessible without authentication (the login page uses it
      * to discover which auth providers are available), but the response must not include
-     * instance-identifying metadata. The service-level suppression is tested in
-     * OrganizationServiceCETest; this test just confirms the endpoint itself is still reachable.
+     * instance-identifying metadata (APP-14994).
      */
     @Test
-    void tenantCurrentEndpoint_unauthenticated_isAccessible() {
+    void tenantCurrentEndpoint_unauthenticated_suppressesSensitiveFields() {
         webTestClient
                 .get()
                 .uri("/api/v1/tenants/current")
                 .exchange()
                 .expectStatus()
-                .isOk();
+                .isOk()
+                .expectBody()
+                .jsonPath("$.data.instanceId")
+                .doesNotExist()
+                .jsonPath("$.data.adminEmailDomainHash")
+                .doesNotExist();
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/AuthGuardTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/AuthGuardTest.java
@@ -1,0 +1,57 @@
+package com.appsmith.server.configurations;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.reactive.context.ReactiveWebApplicationContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity;
+
+/**
+ * APP-14994: Verify that endpoints which previously leaked sensitive instance metadata are now properly
+ * guarded or sanitised for unauthenticated callers.
+ */
+@SpringBootTest
+public class AuthGuardTest {
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setup(ReactiveWebApplicationContext context) {
+        webTestClient = WebTestClient.bindToApplicationContext(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    /**
+     * /api/v1/users/features must now require authentication (APP-14994).
+     * Before the fix, this endpoint was in the permitAll list and would return feature flags
+     * to any unauthenticated caller, potentially revealing which paid/enterprise features are enabled.
+     */
+    @Test
+    void featureFlagsEndpoint_unauthenticated_returns401() {
+        webTestClient
+                .get()
+                .uri("/api/v1/users/features")
+                .exchange()
+                .expectStatus()
+                .isUnauthorized();
+    }
+
+    /**
+     * /api/v1/tenants/current must remain accessible without authentication (the login page uses it
+     * to discover which auth providers are available), but the response must not include
+     * instance-identifying metadata. The service-level suppression is tested in
+     * OrganizationServiceCETest; this test just confirms the endpoint itself is still reachable.
+     */
+    @Test
+    void tenantCurrentEndpoint_unauthenticated_isAccessible() {
+        webTestClient
+                .get()
+                .uri("/api/v1/tenants/current")
+                .exchange()
+                .expectStatus()
+                .isOk();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
@@ -235,6 +235,38 @@ class OrganizationServiceCETest {
     }
 
     @Test
+    @WithUserDetails("anonymousUser")
+    void getOrganizationConfig_AnonymousUser_DoesNotExposeInstanceMetadata() {
+        // APP-14994: unauthenticated callers must not receive instanceId or adminEmailDomainHash
+        StepVerifier.create(organizationService.getOrganizationConfiguration())
+                .assertNext(organization -> {
+                    assertThat(organization.getInstanceId())
+                            .as("instanceId must not be exposed to anonymous users")
+                            .isNull();
+                    assertThat(organization.getAdminEmailDomainHash())
+                            .as("adminEmailDomainHash must not be exposed to anonymous users")
+                            .isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails("api_user")
+    void getOrganizationConfig_AuthenticatedUser_ExposesInstanceMetadata() {
+        // APP-14994: authenticated users should still receive instanceId and adminEmailDomainHash
+        StepVerifier.create(organizationService.getOrganizationConfiguration())
+                .assertNext(organization -> {
+                    assertThat(organization.getInstanceId())
+                            .as("instanceId should be present for authenticated users")
+                            .isNotNull();
+                    assertThat(organization.getAdminEmailDomainHash())
+                            .as("adminEmailDomainHash should be present for authenticated users")
+                            .isNotNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
     @WithUserDetails("api_user")
     void setEmailVerificationEnabled_WithInvalidSMTPHost_ReturnsError() {
         final OrganizationConfiguration changes = new OrganizationConfiguration();


### PR DESCRIPTION
## Summary

Fixes APP-14994: three API endpoints were accessible without authentication and exposed sensitive instance metadata to any unauthenticated caller.

- **`/api/v1/users/features`** — removed from `permitAll()` in `SecurityConfig`; now returns **401** for unauthenticated requests. Feature flags are per-user data and must not be disclosed to anonymous callers.
- **`/api/v1/tenants/current`** — kept accessible without authentication (the login page uses it to discover enabled auth providers), but `instanceId` and `adminEmailDomainHash` are now **suppressed** from the response when the caller is anonymous. This eliminates exposure of the unsalted SHA-256 admin-email-domain hash and the instance UUID.
- **`/api/v1/consolidated-api/view`** — kept accessible without authentication (required for public/published apps), but the embedded `organizationConfig` no longer contains `instanceId` or `adminEmailDomainHash` for anonymous callers (same service-layer fix as above).

## Changes

| File | Change |
|------|--------|
| `SecurityConfig.java` | Remove `GET /api/v1/users/features` from `permitAll()` |
| `OrganizationServiceCEImpl.java` | Check `ReactiveSecurityContextHolder` in `getOrganizationConfiguration()`; skip setting `instanceId` / `adminEmailDomainHash` for anonymous principals |
| `OrganizationServiceCETest.java` | Add two tests: anonymous caller gets `null` for sensitive fields; authenticated caller gets non-null values |
| `AuthGuardTest.java` | New controller-level test: `GET /api/v1/users/features` returns 401 for unauthenticated requests; `GET /api/v1/tenants/current` remains accessible |

## Test plan

- [x] `OrganizationServiceCETest#getOrganizationConfig_AnonymousUser_DoesNotExposeInstanceMetadata` — asserts `instanceId` and `adminEmailDomainHash` are `null` for anonymous callers
- [x] `OrganizationServiceCETest#getOrganizationConfig_AuthenticatedUser_ExposesInstanceMetadata` — asserts both fields are non-null for authenticated callers
- [x] `AuthGuardTest#featureFlagsEndpoint_unauthenticated_returns401` — HTTP 401 for unauthenticated `GET /api/v1/users/features`
- [x] `AuthGuardTest#tenantCurrentEndpoint_unauthenticated_isAccessible` — `GET /api/v1/tenants/current` still returns 200 without auth
- [x] All 15 existing `OrganizationServiceCETest` tests pass (1 pre-existing disabled test skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The user features endpoint now requires authentication.
  * Organization instance metadata (instanceId, adminEmailDomainHash) is concealed for unauthenticated requests; tenant/current remains accessible but without sensitive fields.

* **Tests**
  * Added tests validating authentication for the features endpoint and that anonymous vs. authenticated users receive appropriately filtered organization metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/22959284307>
> Commit: 1bcf565adcf0e5e44c0bce6899ca7816473ffb25
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=22959284307&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 11 Mar 2026 16:17:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->
