### PR TITLE
fix: flaky Tree_Select_2_spec.ts

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
@@ -229,8 +229,9 @@ describe(
       agHelper.GetNClick(propPane._actionSelectorPopupClose);
       deployMode.DeployApp();
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")}`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
+      agHelper.AssertElementVisibility(locators._treeSelectTitle);
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
       agHelper.ValidateToastMessage("Success");
     });
@@ -252,7 +253,7 @@ describe(
       );
       deployMode.DeployApp();
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")}`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
 
       cy.window().then((win) => {
@@ -291,7 +292,7 @@ describe(
       );
       deployMode.DeployApp();
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")}`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
       agHelper.ValidateToastMessage("Option Changed");
@@ -342,7 +343,7 @@ describe(
         "false",
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")}`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
       agHelper.AssertExistingCheckedState(locators._checkboxInDeployedMode);
@@ -366,7 +367,7 @@ describe(
       agHelper.GetNClick(locators._closeModal, 0, true);
       deployMode.DeployApp();
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")}`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Red"));
       agHelper.AssertElementVisibility(locators._modal);
@@ -404,7 +405,7 @@ describe(
       );
       deployMode.DeployApp();
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")}`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
@@ -229,10 +229,10 @@ describe(
       agHelper.GetNClick(propPane._actionSelectorPopupClose);
       deployMode.DeployApp();
       agHelper.WaitUntilEleAppear(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.AssertElementVisibility(locators._treeSelectTitle);
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
@@ -256,10 +256,10 @@ describe(
       );
       deployMode.DeployApp();
       agHelper.WaitUntilEleAppear(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
 
       cy.window().then((win) => {
@@ -298,10 +298,10 @@ describe(
       );
       deployMode.DeployApp();
       agHelper.WaitUntilEleAppear(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
       agHelper.ValidateToastMessage("Option Changed");
@@ -325,7 +325,7 @@ describe(
           });}}`,
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Red"));
       agHelper.ValidateToastMessage("Download Success");
@@ -347,7 +347,7 @@ describe(
       );
       deployMode.DeployApp();
       agHelper.WaitUntilEleAppear(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(`${locators._widgetInDeployed("checkbox1")}`);
       agHelper.AssertExistingCheckedState(
@@ -355,7 +355,7 @@ describe(
         "false",
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
       agHelper.AssertExistingCheckedState(locators._checkboxInDeployedMode);
@@ -379,10 +379,10 @@ describe(
       agHelper.GetNClick(locators._closeModal, 0, true);
       deployMode.DeployApp();
       agHelper.WaitUntilEleAppear(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Red"));
       agHelper.AssertElementVisibility(locators._modal);
@@ -419,10 +419,10 @@ describe(
       );
       deployMode.DeployApp();
       agHelper.WaitUntilEleAppear(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} ${locators._treeSelectSelector}`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Green"));
 

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TreeSelect/Tree_Select_2_spec.ts
@@ -228,6 +228,9 @@ describe(
       );
       agHelper.GetNClick(propPane._actionSelectorPopupClose);
       deployMode.DeployApp();
+      agHelper.WaitUntilEleAppear(
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+      );
       agHelper.GetNClick(
         `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
@@ -252,6 +255,9 @@ describe(
         "{{navigateTo('www.google.com', {}, 'NEW_WINDOW');}}",
       );
       deployMode.DeployApp();
+      agHelper.WaitUntilEleAppear(
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+      );
       agHelper.GetNClick(
         `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
@@ -291,6 +297,9 @@ describe(
         "{{showAlert('Option Changed', '');}}",
       );
       deployMode.DeployApp();
+      agHelper.WaitUntilEleAppear(
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+      );
       agHelper.GetNClick(
         `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
@@ -316,7 +325,7 @@ describe(
           });}}`,
       );
       agHelper.GetNClick(
-        `${locators._widgetInDeployed("singleselecttreewidget")}`,
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Red"));
       agHelper.ValidateToastMessage("Download Success");
@@ -337,6 +346,9 @@ describe(
         '{{resetWidget("Checkbox1", true);}}',
       );
       deployMode.DeployApp();
+      agHelper.WaitUntilEleAppear(
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+      );
       agHelper.GetNClick(`${locators._widgetInDeployed("checkbox1")}`);
       agHelper.AssertExistingCheckedState(
         locators._checkboxInDeployedMode,
@@ -366,14 +378,16 @@ describe(
       agHelper.AssertElementVisibility(locators._modal);
       agHelper.GetNClick(locators._closeModal, 0, true);
       deployMode.DeployApp();
+      agHelper.WaitUntilEleAppear(
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+      );
       agHelper.GetNClick(
         `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );
       agHelper.GetNClick(locators._dropDownMultiTreeValue("Red"));
       agHelper.AssertElementVisibility(locators._modal);
       agHelper.GetNClick(locators._closeModal, 0, true);
-      agHelper.Sleep(3000);
-      agHelper.AssertElementAbsence(locators._modal);
+      agHelper.WaitUntilEleDisappear(locators._modal);
     });
 
     it("12. Verify onOptionChange with iframe", () => {
@@ -404,6 +418,9 @@ describe(
         `{{postWindowMessage('Test', 'Iframe1', "*");}}`,
       );
       deployMode.DeployApp();
+      agHelper.WaitUntilEleAppear(
+        `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
+      );
       agHelper.GetNClick(
         `${locators._widgetInDeployed("singleselecttreewidget")} .rc-tree-select-selector`,
       );

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -302,6 +302,7 @@ export class CommonLocators {
   _buttonInDeployedMode = ".bp3-button";
   _treeSelectPlaceholder = ".rc-tree-select-selection-placeholder";
   _treeSelectTitle = ".rc-tree-select-tree-title";
+  _treeSelectSelector = ".rc-tree-select-selector";
   _callbackAddBtn = ".action-callback-add .ads-v2-button";
   _checkboxInDeployedMode = "//label[contains(@class, 'bp3-checkbox')]//input";
   _listText = "//span[text()='Blue']/../..";


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes https://linear.app/appsmith/issue/APP-14995/fix-flaky-tree-select2-spects-cypress-test

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!IMPORTANT]
> 🟣 🟣 🟣 Your tests are running.
> Tests running at: <https://github.com/appsmithorg/appsmith/actions/runs/22919877135>
> Commit: 70b4e4a112b22fe43db8c6c36c90291afcbc6f72
> Workflow: `PR Automation test suite`
> Tags: `@tag.All`
> Spec: ``
> <hr>Tue, 10 Mar 2026 19:12:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved TreeSelect widget test reliability by targeting the visible tree-select element, standardizing selection paths, adding explicit waits for widget appearance/disappearance (replacing fixed sleeps), and adding assertions to confirm the tree title is visible after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->