### PR TITLE
fix: Show Red Asterisk on Required Fields

### DIFF
--- a/app/client/src/widgets/BaseInputWidget/component/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/component/index.tsx
@@ -729,6 +729,7 @@ class BaseInputComponent extends React.Component<
             fontStyle={labelStyle}
             helpText={tooltip}
             isDynamicHeightEnabled={isDynamicHeightEnabled}
+            isRequired={this.props.isRequired}
             loading={isLoading}
             position={labelPosition}
             rtl={this.props.rtl}
@@ -817,6 +818,7 @@ export interface BaseInputComponentProps extends ComponentProps {
   widgetId: string;
   onStep?: (direction: number) => void;
   spellCheck?: boolean;
+  isRequired?: boolean;
   maxNum?: number;
   minNum?: number;
   inputRef?: MutableRefObject<

--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -619,6 +619,7 @@ class BaseInputWidget<
         intent={this.props.intent}
         isInvalid={this.props.isInvalid}
         isLoading={this.props.isLoading}
+        isRequired={this.props.isRequired}
         label={this.props.label}
         labelAlignment={this.props.labelAlignment}
         labelPosition={this.props.labelPosition}

--- a/app/client/src/widgets/InputWidget/component/index.tsx
+++ b/app/client/src/widgets/InputWidget/component/index.tsx
@@ -653,6 +653,7 @@ class InputComponent extends React.Component<
             fontSize={labelTextSize}
             fontStyle={labelStyle}
             helpText={tooltip}
+            isRequired={this.props.isRequired}
             loading={isLoading}
             position={labelPosition}
             text={label}
@@ -733,6 +734,7 @@ export interface InputComponentProps extends ComponentProps {
   borderRadius: string;
   boxShadow?: string;
   accentColor: string;
+  isRequired?: boolean;
 }
 
 export default InputComponent;

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -1050,6 +1050,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
         inputType={this.props.inputType}
         isInvalid={isInvalid}
         isLoading={this.props.isLoading}
+        isRequired={this.props.isRequired}
         label={this.props.label}
         labelAlignment={this.props.labelAlignment}
         labelPosition={this.props.labelPosition}

--- a/app/client/src/widgets/InputWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/component/index.tsx
@@ -51,6 +51,7 @@ const InputComponent = (props: InputComponentProps) => {
       isDynamicHeightEnabled={props.isDynamicHeightEnabled}
       isInvalid={isInvalid}
       isLoading={props.isLoading}
+      isRequired={props.isRequired}
       label={props.label}
       labelAlignment={props.labelAlignment}
       labelPosition={props.labelPosition}

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -896,6 +896,7 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
         isDynamicHeightEnabled={isAutoHeightEnabledForWidget(this.props)}
         isInvalid={isInvalid}
         isLoading={this.props.isLoading}
+        isRequired={this.props.isRequired}
         label={this.props.label}
         labelAlignment={this.props.labelAlignment}
         labelPosition={this.props.labelPosition}

--- a/app/client/src/widgets/components/LabelWithTooltip.tsx
+++ b/app/client/src/widgets/components/LabelWithTooltip.tsx
@@ -299,10 +299,35 @@ const LabelWithTooltip = React.forwardRef<
         isOpen={tooltipOpen}
         position="top"
       >
-        <span
-          className="label-text-wrapper"
-          style={{ display: "flex", alignItems: "center" }}
-        >
+        {isRequired ? (
+          <span
+            className="label-text-wrapper"
+            style={{ display: "flex", alignItems: "center" }}
+          >
+            <StyledLabel
+              $compact={compact}
+              $hasHelpText={!!helpText}
+              $isDynamicHeightEnabled={isDynamicHeightEnabled}
+              className={`${
+                loading ? Classes.SKELETON : Classes.TEXT_OVERFLOW_ELLIPSIS
+              } ${className}`}
+              color={color}
+              disabled={disabled}
+              elementRef={labelRef}
+              fontSize={fontSize}
+              fontStyle={fontStyle}
+              onMouseEnter={handleMouseEnter}
+              onMouseLeave={handleMouseLeave}
+              position={position}
+              rtl={rtl}
+            >
+              {text}
+            </StyledLabel>
+            <StyledRequiredMarker aria-label="(required)">
+              *
+            </StyledRequiredMarker>
+          </span>
+        ) : (
           <StyledLabel
             $compact={compact}
             $hasHelpText={!!helpText}
@@ -322,12 +347,7 @@ const LabelWithTooltip = React.forwardRef<
           >
             {text}
           </StyledLabel>
-          {isRequired && (
-            <StyledRequiredMarker aria-label="(required)">
-              *
-            </StyledRequiredMarker>
-          )}
-        </span>
+        )}
       </StyledTooltip>
       {helpText && (
         <Tooltip

--- a/app/client/src/widgets/components/LabelWithTooltip.tsx
+++ b/app/client/src/widgets/components/LabelWithTooltip.tsx
@@ -23,6 +23,7 @@ export interface LabelWithTooltipProps {
   helpText?: string;
   cyHelpTextClassName?: string;
   inline?: boolean;
+  isRequired?: boolean;
   loading?: boolean;
   optionCount?: number;
   position?: LabelPosition;
@@ -233,6 +234,12 @@ const ToolTipIcon = styled(IconWrapper)<TooltipIconProps>`
   }};
 `;
 
+const StyledRequiredMarker = styled.span`
+  color: ${Colors.CRIMSON};
+  margin-left: 2px;
+  flex-shrink: 0;
+`;
+
 const LabelWithTooltip = React.forwardRef<
   HTMLDivElement,
   LabelWithTooltipProps
@@ -249,6 +256,7 @@ const LabelWithTooltip = React.forwardRef<
     helpText,
     inline,
     isDynamicHeightEnabled,
+    isRequired,
     loading,
     optionCount,
     position,
@@ -291,25 +299,35 @@ const LabelWithTooltip = React.forwardRef<
         isOpen={tooltipOpen}
         position="top"
       >
-        <StyledLabel
-          $compact={compact}
-          $hasHelpText={!!helpText}
-          $isDynamicHeightEnabled={isDynamicHeightEnabled}
-          className={`${
-            loading ? Classes.SKELETON : Classes.TEXT_OVERFLOW_ELLIPSIS
-          } ${className}`}
-          color={color}
-          disabled={disabled}
-          elementRef={labelRef}
-          fontSize={fontSize}
-          fontStyle={fontStyle}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          position={position}
-          rtl={rtl}
+        <span
+          className="label-text-wrapper"
+          style={{ display: "flex", alignItems: "center" }}
         >
-          {text}
-        </StyledLabel>
+          <StyledLabel
+            $compact={compact}
+            $hasHelpText={!!helpText}
+            $isDynamicHeightEnabled={isDynamicHeightEnabled}
+            className={`${
+              loading ? Classes.SKELETON : Classes.TEXT_OVERFLOW_ELLIPSIS
+            } ${className}`}
+            color={color}
+            disabled={disabled}
+            elementRef={labelRef}
+            fontSize={fontSize}
+            fontStyle={fontStyle}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            position={position}
+            rtl={rtl}
+          >
+            {text}
+          </StyledLabel>
+          {isRequired && (
+            <StyledRequiredMarker aria-label="(required)">
+              *
+            </StyledRequiredMarker>
+          )}
+        </span>
       </StyledTooltip>
       {helpText && (
         <Tooltip


### PR DESCRIPTION
Fix Mark Required

- Add isRequired prop to LabelWithTooltip component
- Display red asterisk (*) next to label when isRequired is true
- Pass isRequired from BaseInputWidget, InputWidget, and InputWidgetV2 to components
- Fixes enterprise customer request for required field indicator in Form widget

Made-with: Cursor

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #41608  
_or_  
Fixes APP-15005
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23160366665>
> Commit: 125732e016ac2b4eae85beabece61822af37f1aa
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23160366665&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 17 Mar 2026 04:27:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form labels now show a red asterisk for required fields for clearer required-field indication.
  * Required-state support added across input widgets so the required marker appears consistently in forms and custom inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->