### PR TITLE
fix(ci): disable XATA flaky test check in pr-cypress workflow

### DIFF
--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -174,7 +174,8 @@ jobs:
       - name: Get latest flaky tests
         shell: bash
         run: |
-          curl --request POST --url https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/query --header 'Authorization: Bearer ${{ secrets.XATA_TOKEN }}' --header 'Content-Type: application/json'|jq -r |grep Spec|cut -d ':' -f 2 2> /dev/null|sed 's/"//g'|sed 's/,//g' >  ~/knownfailures
+          # XATA lite has been discontinued; using empty list until migrated to Cypress DB
+          touch ~/knownfailures
 
       # Verify CI test failures against known failures
       - name: Verify CI test failures against known failures


### PR DESCRIPTION
## Description

XATA lite has been discontinued, causing the **"Get latest flaky tests"** step in the `ci-test-result` job of the PR Cypress workflow to fail unconditionally on every PR run, blocking all PR merges.

This is a minimal, temporary fix: the `curl` call to the XATA endpoint is replaced with `touch ~/knownfailures`, which creates an empty file so all downstream steps (flaky test comparison, PR status comments) continue to work correctly — they will just treat the known-failures list as empty for now.

The check will be re-enabled once @yatin-chaubal migrates the flaky list to Cypress DB and shares the credentials.

Fixes https://linear.app/appsmith/issue/APP-15007/task-disable-ci-test-result-step-as-xata-lite-is-discontinued

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/22955958490>
> Commit: aeb608813236571b3aee4d49ae9f2c1ccce9a100
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=22955958490&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 11 Mar 2026 14:27:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test workflow configuration to modify how known test failures are processed during pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->