### PR TITLE
fix: upgrade simple-git to 3.32.3 to resolve critical CVE-2026-28292

### DIFF
--- a/app/client/packages/rts/package.json
+++ b/app/client/packages/rts/package.json
@@ -33,7 +33,7 @@
     "mongodb": "^5.8.0",
     "nodemailer": "6.9.9",
     "readline-sync": "1.4.10",
-    "simple-git": "^3.27.0"
+    "simple-git": "^3.32.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.14",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -13631,7 +13631,7 @@ __metadata:
     mongodb: ^5.8.0
     nodemailer: 6.9.9
     readline-sync: 1.4.10
-    simple-git: ^3.27.0
+    simple-git: ^3.32.3
     supertest: ^6.3.3
     ts-jest: 29.1.0
     typescript: ^5.5.4
@@ -32113,14 +32113,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.27.0":
-  version: 3.27.0
-  resolution: "simple-git@npm:3.27.0"
+"simple-git@npm:^3.32.3":
+  version: 3.33.0
+  resolution: "simple-git@npm:3.33.0"
   dependencies:
     "@kwsites/file-exists": ^1.1.1
     "@kwsites/promise-deferred": ^1.1.1
-    debug: ^4.3.5
-  checksum: bc602d67317a5421363f4cbe446bc71336387a7ea9864b23993dcbbd7e4847e346a234aa5b46bf9d80130d2448cbaeb21cf8f7b62572dce093fb4643ff7ffafd
+    debug: ^4.4.0
+  checksum: 9c0105f21781d9761d6a82444b7f6c85c21c72b63b38c0e7b53420d248f08541d5b008866d043155cddcc89ea71bb0028d7ed3ec7e0b885a59ee4fd9cce1a99e
   languageName: node
   linkType: hard
 

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -17355,7 +17355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:


### PR DESCRIPTION
## Summary
- Bump `simple-git` from `^3.27.0` to `^3.32.3` (resolves to `3.33.0`) in `app/client/packages/rts/package.json`
- Resolves [Dependabot alert #523](https://github.com/appsmithorg/appsmith/security/dependabot/523) — **CVE-2026-28292** (CVSS 9.8, critical RCE)

## Details
The `blockUnsafeOperationsPlugin` in `simple-git` uses a case-sensitive regex to block `-c protocol.allow=always` arguments. Git treats config keys case-insensitively, so uppercase variants like `PROTOCOL.ALLOW=always` bypass the check entirely, enabling arbitrary command execution via the `ext::` protocol.

Version `3.32.3` adds the `/i` flag to the regex, closing the bypass.

No breaking API changes exist between 3.27.0 and 3.33.0 — the APIs used by Appsmith (`simpleGit()`, `ResetMode`, `git.reset()`, `git.clean()`) are unchanged.


Fixes https://linear.app/appsmith/issue/APP-15006/critical-vulnerability-simple-git-has-blockunsafeoperationsplugin

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/22991205090>
> Commit: ed8489938daf710740fa3701ae49353c78d7c842
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=22991205090&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 12 Mar 2026 08:56:46 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency bump intended to patch a security issue; main risk is subtle behavior changes in `simple-git` affecting `gitService` reset/clean operations.
> 
> **Overview**
> Upgrades the `appsmith-rts` dependency on `simple-git` from `^3.27.0` to `^3.32.3` (resolving to `3.33.0`) to address the critical RCE vulnerability **CVE-2026-28292**.
> 
> Updates `yarn.lock` accordingly, including `simple-git`’s transitive dependency bump to `debug@^4.4.0`; no application code changes beyond the dependency version update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed8489938daf710740fa3701ae49353c78d7c842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to incorporate latest improvements and stability enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->