### PR TITLE
fix(Security): restrict draft action execution to editors

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -191,6 +191,14 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
         return aclPermission;
     }
 
+    protected AclPermission getActionExecutionPermission(
+            ExecuteActionDTO executeActionDTO, ExecuteActionMetaDTO executeActionMetaDTO) {
+        if (!TRUE.equals(executeActionDTO.getViewMode())) {
+            return getPermission(executeActionMetaDTO, actionPermission.getEditPermission());
+        }
+        return getPermission(executeActionMetaDTO, actionPermission.getExecutePermission());
+    }
+
     /**
      * Fetches the action from the DB, and populates the executeActionMetaDTO with the action
      * Also fetches the true environmentId for the action execution
@@ -201,7 +209,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
      */
     protected Mono<ActionExecutionResult> populateAndExecuteAction(
             ExecuteActionDTO executeActionDTO, ExecuteActionMetaDTO executeActionMetaDTO) {
-        AclPermission executePermission = getPermission(executeActionMetaDTO, actionPermission.getExecutePermission());
+        AclPermission executePermission = getActionExecutionPermission(executeActionDTO, executeActionMetaDTO);
         Mono<NewAction> newActionMono = newActionService
                 .findById(executeActionDTO.getActionId(), executePermission)
                 .cache();
@@ -980,25 +988,26 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
     @Override
     public Mono<ActionDTO> getValidActionForExecution(
             ExecuteActionDTO executeActionDTO, ExecuteActionMetaDTO executeActionMetaDTO) {
-        AclPermission executePermission = getPermission(executeActionMetaDTO, actionPermission.getExecutePermission());
-
-        // Security: Enforce that anonymous users can only execute published actions (viewMode=true)
-        // This is the primary security validation point for action execution
         return sessionUserService
                 .getCurrentUser()
                 .flatMap(user -> {
                     if (Boolean.TRUE.equals(user.getIsAnonymous())) {
-                        // Reject explicit attempts to access unpublished actions
                         if (FALSE.equals(executeActionDTO.getViewMode())) {
                             return Mono.error(new AppsmithException(
                                     AppsmithError.ACL_NO_RESOURCE_FOUND,
                                     "Anonymous users can only execute published actions"));
                         }
-                        // Default to published mode if viewMode is not specified
                         if (executeActionDTO.getViewMode() == null) {
                             executeActionDTO.setViewMode(TRUE);
                         }
                     }
+
+                    // Security: Compute permission after anonymous normalization so that
+                    // anonymous users with viewMode=null (normalized to TRUE above) get
+                    // EXECUTE_ACTIONS, while non-anonymous users with viewMode != TRUE
+                    // require MANAGE_ACTIONS (edit permission) for draft execution.
+                    AclPermission executePermission =
+                            getActionExecutionPermission(executeActionDTO, executeActionMetaDTO);
 
                     return newActionService
                             .findActionDTObyIdAndViewMode(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -244,7 +244,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
      */
     private Mono<String> getTrueEnvironmentId(
             NewAction newAction, ExecuteActionDTO executeActionDTO, ExecuteActionMetaDTO executeActionMetaDTO) {
-        boolean isEmbedded = executeActionDTO.getViewMode()
+        boolean isEmbedded = TRUE.equals(executeActionDTO.getViewMode())
                 ? newAction.getPublishedAction().getDatasource().getId() == null
                 : newAction.getUnpublishedAction().getDatasource().getId() == null;
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCETest.java
@@ -25,12 +25,14 @@ import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.GitArtifactMetadata;
 import com.appsmith.server.domains.Layout;
+import com.appsmith.server.domains.PermissionGroup;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationAccessDTO;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.ExecuteActionMetaDTO;
+import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.dtos.MockDataSource;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.exceptions.AppsmithError;
@@ -58,6 +60,7 @@ import com.appsmith.server.services.WorkspaceService;
 import com.appsmith.server.solutions.ActionExecutionSolution;
 import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.EnvironmentPermission;
+import com.appsmith.server.solutions.UserAndAccessManagementService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -73,6 +76,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.test.context.support.WithUserDetails;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -88,7 +96,9 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.appsmith.server.acl.AclPermission.READ_PAGES;
+import static com.appsmith.server.acl.AclPermission.READ_WORKSPACES;
 import static com.appsmith.server.constants.FieldName.ANONYMOUS_USER;
+import static com.appsmith.server.constants.FieldName.VIEWER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -176,6 +186,9 @@ public class ActionExecutionSolutionCETest {
 
     @Autowired
     CacheableRepositoryHelper cacheableRepositoryHelper;
+
+    @Autowired
+    UserAndAccessManagementService userAndAccessManagementService;
 
     Application testApp = null;
 
@@ -2055,5 +2068,186 @@ public class ActionExecutionSolutionCETest {
                     return false;
                 })
                 .verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testViewerCannotExecuteUnpublishedAction() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(any())).thenReturn(Mono.just(pluginExecutor));
+        Mockito.when(pluginExecutor.getHintMessages(any(), any()))
+                .thenReturn(Mono.zip(Mono.just(new HashSet<>()), Mono.just(new HashSet<>())));
+        Mockito.when(pluginExecutor.datasourceCreate(any())).thenReturn(Mono.empty());
+        Mockito.doReturn(Mono.just(false))
+                .when(spyDatasourceService)
+                .isEndpointBlockedForConnectionRequest(Mockito.any());
+
+        ActionDTO action = new ActionDTO();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        action.setPageId(testPage.getId());
+        action.setName("testViewerCannotExecuteUnpublishedAction");
+        action.setDatasource(datasource);
+        ActionDTO createdAction =
+                layoutActionService.createSingleAction(action, Boolean.FALSE).block();
+
+        List<PermissionGroup> permissionGroups = workspaceService
+                .findById(workspaceId, READ_WORKSPACES)
+                .flatMapMany(workspace -> {
+                    Set<String> defaultPermissionGroups = workspace.getDefaultPermissionGroups();
+                    return permissionGroupRepository.findAllById(defaultPermissionGroups);
+                })
+                .collectList()
+                .block();
+
+        PermissionGroup viewerPermissionGroup = permissionGroups.stream()
+                .filter(pg -> pg.getName().startsWith(VIEWER))
+                .findFirst()
+                .get();
+
+        InviteUsersDTO inviteUsersDTO = new InviteUsersDTO();
+        inviteUsersDTO.setPermissionGroupId(viewerPermissionGroup.getId());
+        inviteUsersDTO.setUsernames(List.of("usertest@usertest.com"));
+        userAndAccessManagementService.inviteUsers(inviteUsersDTO, "test").block();
+
+        User viewerUser = userService.findByEmail("usertest@usertest.com").block();
+        Mockito.doReturn(Mono.just(viewerUser)).when(sessionUserService).getCurrentUser();
+
+        Authentication viewerAuth =
+                new UsernamePasswordAuthenticationToken(viewerUser, null, viewerUser.getAuthorities());
+        SecurityContext viewerSecurityContext = new SecurityContextImpl(viewerAuth);
+
+        ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
+        executeActionDTO.setActionId(createdAction.getId());
+        executeActionDTO.setViewMode(false);
+
+        ExecuteActionMetaDTO executeActionMetaDTO = ExecuteActionMetaDTO.builder()
+                .environmentId(defaultEnvironmentId)
+                .build();
+
+        Mono<ActionDTO> actionDTOMono = actionExecutionSolution
+                .getValidActionForExecution(executeActionDTO, executeActionMetaDTO)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(viewerSecurityContext)));
+
+        StepVerifier.create(actionDTOMono)
+                .expectErrorMatches(error -> {
+                    if (error instanceof AppsmithException) {
+                        AppsmithException appsmithException = (AppsmithException) error;
+                        return appsmithException.getError() == AppsmithError.ACL_NO_RESOURCE_FOUND
+                                || appsmithException.getError() == AppsmithError.NO_RESOURCE_FOUND;
+                    }
+                    return false;
+                })
+                .verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testViewerCanExecutePublishedAction() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(any())).thenReturn(Mono.just(pluginExecutor));
+        Mockito.when(pluginExecutor.getHintMessages(any(), any()))
+                .thenReturn(Mono.zip(Mono.just(new HashSet<>()), Mono.just(new HashSet<>())));
+        Mockito.when(pluginExecutor.datasourceCreate(any())).thenReturn(Mono.empty());
+        Mockito.doReturn(Mono.just(false))
+                .when(spyDatasourceService)
+                .isEndpointBlockedForConnectionRequest(Mockito.any());
+
+        ActionDTO action = new ActionDTO();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        action.setPageId(testPage.getId());
+        action.setName("testViewerCanExecutePublishedAction");
+        action.setDatasource(datasource);
+        ActionDTO createdAction =
+                layoutActionService.createSingleAction(action, Boolean.FALSE).block();
+
+        applicationPageService.publish(testApp.getId(), true).block();
+
+        List<PermissionGroup> permissionGroups = workspaceService
+                .findById(workspaceId, READ_WORKSPACES)
+                .flatMapMany(workspace -> {
+                    Set<String> defaultPermissionGroups = workspace.getDefaultPermissionGroups();
+                    return permissionGroupRepository.findAllById(defaultPermissionGroups);
+                })
+                .collectList()
+                .block();
+
+        PermissionGroup viewerPermissionGroup = permissionGroups.stream()
+                .filter(pg -> pg.getName().startsWith(VIEWER))
+                .findFirst()
+                .get();
+
+        InviteUsersDTO inviteUsersDTO = new InviteUsersDTO();
+        inviteUsersDTO.setPermissionGroupId(viewerPermissionGroup.getId());
+        inviteUsersDTO.setUsernames(List.of("usertest@usertest.com"));
+        userAndAccessManagementService.inviteUsers(inviteUsersDTO, "test").block();
+
+        User viewerUser = userService.findByEmail("usertest@usertest.com").block();
+
+        Mockito.doReturn(Mono.just(viewerUser)).when(sessionUserService).getCurrentUser();
+
+        Authentication viewerAuth =
+                new UsernamePasswordAuthenticationToken(viewerUser, null, viewerUser.getAuthorities());
+        SecurityContext viewerSecurityContext = new SecurityContextImpl(viewerAuth);
+
+        ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
+        executeActionDTO.setActionId(createdAction.getId());
+        executeActionDTO.setViewMode(true);
+
+        ExecuteActionMetaDTO executeActionMetaDTO = ExecuteActionMetaDTO.builder()
+                .environmentId(defaultEnvironmentId)
+                .build();
+
+        Mono<ActionDTO> actionDTOMono = actionExecutionSolution
+                .getValidActionForExecution(executeActionDTO, executeActionMetaDTO)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(viewerSecurityContext)));
+
+        StepVerifier.create(actionDTOMono)
+                .assertNext(result -> {
+                    assertThat(result).isNotNull();
+                    assertThat(result.getName()).isEqualTo("testViewerCanExecutePublishedAction");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testEditorCanExecuteUnpublishedAction() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(any())).thenReturn(Mono.just(pluginExecutor));
+        Mockito.when(pluginExecutor.getHintMessages(any(), any()))
+                .thenReturn(Mono.zip(Mono.just(new HashSet<>()), Mono.just(new HashSet<>())));
+        Mockito.when(pluginExecutor.datasourceCreate(any())).thenReturn(Mono.empty());
+        Mockito.doReturn(Mono.just(false))
+                .when(spyDatasourceService)
+                .isEndpointBlockedForConnectionRequest(Mockito.any());
+
+        ActionDTO action = new ActionDTO();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        action.setPageId(testPage.getId());
+        action.setName("testEditorCanExecuteUnpublishedAction");
+        action.setDatasource(datasource);
+        ActionDTO createdAction =
+                layoutActionService.createSingleAction(action, Boolean.FALSE).block();
+
+        ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
+        executeActionDTO.setActionId(createdAction.getId());
+        executeActionDTO.setViewMode(false);
+
+        ExecuteActionMetaDTO executeActionMetaDTO = ExecuteActionMetaDTO.builder()
+                .environmentId(defaultEnvironmentId)
+                .build();
+
+        Mono<ActionDTO> actionDTOMono =
+                actionExecutionSolution.getValidActionForExecution(executeActionDTO, executeActionMetaDTO);
+
+        StepVerifier.create(actionDTOMono)
+                .assertNext(result -> {
+                    assertThat(result).isNotNull();
+                    assertThat(result.getName()).isEqualTo("testEditorCanExecuteUnpublishedAction");
+                })
+                .verifyComplete();
     }
 }


### PR DESCRIPTION
## Description

**TL;DR:** Authenticated viewers can bypass the editor/publish boundary by sending `viewMode=false` in the action execute request, causing the server to run unpublished draft actions. This fix requires `MANAGE_ACTIONS` (edit) permission for draft execution instead of `EXECUTE_ACTIONS`.

### Root Cause
The action execution path (`getValidActionForExecution`, `populateAndExecuteAction`) only checks `EXECUTE_ACTIONS` permission regardless of `viewMode`. Since viewers inherit `EXECUTE_ACTIONS` via `READ_APPLICATIONS → READ_PAGES → EXECUTE_ACTIONS`, any authenticated viewer can set `viewMode=false` and execute unpublished draft actions. Only anonymous users were blocked.

### Fix
Introduced `getActionExecutionPermission()` helper that returns:
- `MANAGE_ACTIONS` (edit permission) when `viewMode=false` (draft execution)
- `EXECUTE_ACTIONS` (execute permission) when `viewMode=true` (published execution)

Editors retain `MANAGE_ACTIONS` via the `MANAGE_PAGES → MANAGE_ACTIONS` hierarchy and continue working normally. Viewers only have `EXECUTE_ACTIONS` and are now blocked from draft execution.

### Regression Tests
- `testViewerCannotExecuteUnpublishedAction` — viewer with `viewMode=false` is rejected
- `testViewerCanExecutePublishedAction` — viewer with `viewMode=true` succeeds
- `testEditorCanExecuteUnpublishedAction` — editor with `viewMode=false` succeeds

Fixes https://linear.app/appsmith/issue/APP-15010/vulnerability-authenticated-viewers-can-execute-unpublished-draft

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23017716243>
> Commit: ed2b421448972c6b88a78f93b511f3539e64e8a2
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23017716243&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 12 Mar 2026 19:57:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized permission decision for action execution so viewers can run published actions but cannot run unpublished ones; aligns draft (editor) vs published (viewer) behavior.

* **Tests**
  * Added role- and publication-state tests covering viewer/editor execution paths, invitation/role setup, and ACL enforcement for published and unpublished actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->