### PR TITLE
chore: optional base image to build appsmith image from

### DIFF
--- a/.github/workflows/ad-hoc-docker-image.yml
+++ b/.github/workflows/ad-hoc-docker-image.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ad-hoc
+      base-image-tag:
+        description: Base image tag to use for creating appsmith docker image. Defaults to nightly.
+        required: false
+        type: string
+        default: nightly
       pg_tag:
         description: Postgres tag to use for image
         required: false
@@ -122,7 +127,7 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
             APPSMITH_BETTERBUGS_API_KEY=${{ secrets.APPSMITH_BETTERBUGS_API_KEY }}
-            BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:nightly
+            BASE=${{ vars.DOCKER_HUB_ORGANIZATION }}/base-${{ vars.EDITION }}:${{ inputs.base-image-tag }}
           tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:${{ inputs.tag }}
           labels: |

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -12,6 +12,10 @@ on:
         description: Deploy an image from this pr number
         required: true
         type: string
+      base_image_tag:
+        description: Base image tag to use (overrides branch-based default)
+        required: false
+        type: string
 
 jobs:
   resolve-params:
@@ -44,6 +48,7 @@ jobs:
             env: `${{ github.event.client_payload.slash_command.args.named.env }}`.
             PR: ${{ needs.resolve-params.outputs.pr_number }}.
             recreate: ${{ github.event.client_payload.slash_command.args.named.recreate }}.
+            base-image-tag: ${{ github.event.client_payload.slash_command.args.named.base-image-tag || inputs.base_image_tag }}.
 
   server-build:
     needs: [resolve-params]
@@ -218,7 +223,10 @@ jobs:
       - name: Set base image tag
         id: set_base_tag
         run: |
-          if [[ "${{ github.event.client_payload.pull_request.base.ref }}" == 'pg' ]]; then
+          base_tag_arg="${{ github.event.client_payload.slash_command.args.named.base-image-tag || inputs.base_image_tag }}"
+          if [[ -n "$base_tag_arg" ]]; then
+            base_tag="$base_tag_arg"
+          elif [[ "${{ github.event.client_payload.pull_request.base.ref }}" == 'pg' ]]; then
             base_tag=pg
           else
             base_tag=release


### PR DESCRIPTION
## Description

### 1. `ad-hoc-docker-image.yml` — Configurable base image tag

Added a new optional `base-image-tag` workflow dispatch input (default: `nightly`) so the base image tag used in the Docker build is no longer hardcoded. The `BASE` build-arg now references `inputs.base-image-tag` instead of the previously hardcoded `:nightly` tag. Backward-compatible since the default preserves existing behavior.

### 2. `on-demand-build-docker-image-deploy-preview.yml` — Configurable base image tag for deploy previews

Added a new optional `base_image_tag` workflow dispatch input and support for a `--base-image-tag` slash command arg. The `set_base_tag` step now checks for this explicit override first; if not provided, it falls back to the existing branch-based logic (`pg` for the pg branch, `release` otherwise). The chosen tag is also logged in the PR notification comment for visibility.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build workflows to accept base image tag inputs for ad-hoc and on-demand deployment builds.
  * Workflow configurations now support flexible base image selection during deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->