### PR TITLE
chore: use redis from upstream image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,17 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+  - package-ecosystem: "docker"
+    directory: "/deploy/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "maven"
     directory: "/app/server"
     schedule:

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -1,6 +1,4 @@
-ARG REDIS_VERSION=7.4.8
-
-FROM redis:${REDIS_VERSION} AS redis-source
+FROM redis:7.4.8 AS redis-source
 
 FROM caddy:builder-alpine AS caddybuilder
 
@@ -47,7 +45,6 @@ RUN set -o xtrace \
     /tmp/*
 
 # Install Redis from official image to avoid false positive CVE reports from dpkg-based scanners.
-# To upgrade, change the REDIS_VERSION ARG at the top of this file.
 COPY --from=redis-source /usr/local/bin/redis-server /usr/local/bin/redis-server
 COPY --from=redis-source /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -1,3 +1,7 @@
+ARG REDIS_VERSION=7.4.8
+
+FROM redis:${REDIS_VERSION} AS redis-source
+
 FROM caddy:builder-alpine AS caddybuilder
 
 RUN xcaddy build \
@@ -23,20 +27,15 @@ RUN set -o xtrace \
     ca-certificates \
     libnss-wrapper \
     git \
-  # Install MongoDB v6, Redis 7.4 (from packages.redis.io), PostgreSQL v14
+  # Install MongoDB v6, PostgreSQL v14
   && curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg \
   && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
-  && curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
-  && chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg \
-  && echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(. /etc/os-release && echo "$VERSION_CODENAME") main" | tee /etc/apt/sources.list.d/redis.list \
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
     mongodb-org \
-    redis=6:7.4* redis-server=6:7.4* redis-tools=6:7.4* \
     postgresql-14 \
-  && find /etc/redis -type d -exec chmod o+rx {} + -o -type f -exec chmod o+r {} + \
   && apt-get clean \
   && rm -rf \
     /root/.cache \
@@ -47,6 +46,11 @@ RUN set -o xtrace \
     /var/lib/apt/lists/* \
     /tmp/*
 
+# Install Redis from official image to avoid false positive CVE reports from dpkg-based scanners.
+# To upgrade, change the REDIS_VERSION ARG at the top of this file.
+COPY --from=redis-source /usr/local/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-source /usr/local/bin/redis-cli /usr/local/bin/redis-cli
+RUN mkdir -p /etc/redis
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 
 # Install Java

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -50,7 +50,6 @@ RUN set -o xtrace \
 # To upgrade, change the REDIS_VERSION ARG at the top of this file.
 COPY --from=redis-source /usr/local/bin/redis-server /usr/local/bin/redis-server
 COPY --from=redis-source /usr/local/bin/redis-cli /usr/local/bin/redis-cli
-RUN mkdir -p /etc/redis
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 
 # Install Java

--- a/deploy/docker/fs/opt/appsmith/templates/supervisord/redis.conf
+++ b/deploy/docker/fs/opt/appsmith/templates/supervisord/redis.conf
@@ -1,5 +1,4 @@
 [program:redis]
-directory=/etc/redis
 ; The `--save` is for saving session data to disk more often, so recent sessions aren't cleared on restart.
 ; The empty string to `--logfile` is for logging to stdout so that supervisor can capture it.
 command=redis-server --save 15 1 --dir /appsmith-stacks/data/redis --daemonize no --logfile ""


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

Even with newer packages from the Redis project, container scanners are showing false positives for vulnerabilities. Switching to use the upstream Redis built docker images instead.

This bypasses scanners that look for dpkg metadata about packages, but I'm enabling docker dependency updates here via Dependabot to keep this up-to-date.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD edb91ff00ee59af04f559081cb0f539aaa686f56 yet
> <hr>Fri, 13 Mar 2026 16:04:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency updates for Docker images.
  * Updated Docker build to source Redis binaries from an upstream image instead of installing them during build.
  * Adjusted Redis runtime configuration to remove an explicit working-directory setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->