### PR TITLE
feat: move expires_in field after scope in OAuth2 datasource config

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -683,6 +683,16 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+          {this.renderInputTextControlViaFormControl({
+            configProperty: "authentication.expiresIn",
+            label: "Authorization expires in (seconds)",
+            placeholderText: "3600",
+            dataType: "NUMBER",
+            encrypted: false,
+            isRequired: false,
+          })}
+        </FormInputContainer>
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +879,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -683,16 +683,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
-        </FormInputContainer>
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -844,6 +834,16 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
     return (
       <>
         {this.renderOauth2Common()}
+        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+          {this.renderInputTextControlViaFormControl({
+            configProperty: "authentication.expiresIn",
+            label: "Authorization expires in (seconds)",
+            placeholderText: "3600",
+            dataType: "NUMBER",
+            encrypted: false,
+            isRequired: false,
+          })}
+        </FormInputContainer>
         <FormInputContainer
           data-location-id={btoa("authentication.authorizationUrl")}
         >


### PR DESCRIPTION
## Description

This PR moves the `expires_in` field to appear after the `scope` field in the OAuth2 datasource configuration, keeping all authentication-related fields together for better UX.

## Fixes #31059

## Changes

- Moved `expiresIn` input field from `renderOauth2AuthorizationCode` to `renderOauth2Common` (after `scopeString`)
- This ensures the field appears right after the Scope(s) input in all OAuth2 authorization flows

## Testing

- Verified the field order change in the code
- The field now appears: Access token URL → Client ID → Client secret → Scope(s) → Authorization expires in

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved the OAuth2 "Authorization expires in (seconds)" field into the Authorization Code flow of the REST API datasource form, changing its placement in the UI without affecting validation or data shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->