### PR TITLE
fix(server): enforce edit permission on application snapshot deletion (GHSA-g2hc-wmw2-32jr)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
@@ -131,8 +131,11 @@ public class ApplicationSnapshotServiceCEImpl implements ApplicationSnapshotServ
 
     @Override
     public Mono<Boolean> deleteSnapshot(String branchedApplicationId) {
-        return applicationSnapshotRepository
-                .deleteAllByApplicationId(branchedApplicationId)
+        return applicationService
+                .findById(branchedApplicationId, applicationPermission.getEditPermission())
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, branchedApplicationId)))
+                .flatMap(application -> applicationSnapshotRepository.deleteAllByApplicationId(application.getId()))
                 .thenReturn(Boolean.TRUE);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
@@ -60,9 +60,12 @@ public class ApplicationSnapshotServiceCEImpl implements ApplicationSnapshotServ
 
     @Override
     public Mono<ApplicationSnapshotResponseDTO> getWithoutDataByBranchedApplicationId(String branchedApplicationId) {
-        // get application first to check the permission and get child aka branched application ID
-        return applicationSnapshotRepository
-                .findByApplicationIdAndChunkOrder(branchedApplicationId, 1)
+        return applicationService
+                .findById(branchedApplicationId, applicationPermission.getReadPermission())
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, branchedApplicationId)))
+                .flatMap(application ->
+                        applicationSnapshotRepository.findByApplicationIdAndChunkOrder(application.getId(), 1))
                 .defaultIfEmpty(new ApplicationSnapshotResponseDTO(null));
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.services;
 
 import com.appsmith.server.applications.base.ApplicationService;
+import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.ApplicationMode;
 import com.appsmith.server.domains.ApplicationSnapshot;
@@ -9,6 +10,8 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.PageDTO;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import com.appsmith.server.repositories.ApplicationSnapshotRepository;
@@ -277,22 +280,43 @@ public class ApplicationSnapshotServiceTest {
     }
 
     @Test
+    @WithUserDetails("api_user")
     public void deleteSnapshot_WhenSnapshotExists_Deleted() {
-        String testAppId = "app-" + UUID.randomUUID();
-        ApplicationSnapshot snapshot1 = new ApplicationSnapshot();
-        snapshot1.setChunkOrder(1);
-        snapshot1.setApplicationId(testAppId);
+        Application testApplication = new Application();
+        testApplication.setName("Test app for snapshot delete");
+        testApplication.setWorkspaceId(workspace.getId());
 
-        ApplicationSnapshot snapshot2 = new ApplicationSnapshot();
-        snapshot2.setApplicationId(testAppId);
-        snapshot2.setChunkOrder(2);
-
-        Flux<ApplicationSnapshot> snapshotFlux = applicationSnapshotRepository
-                .saveAll(List.of(snapshot1, snapshot2))
-                .then(applicationSnapshotService.deleteSnapshot(testAppId))
-                .thenMany(applicationSnapshotRepository.findByApplicationId(testAppId));
+        Flux<ApplicationSnapshot> snapshotFlux = applicationPageService
+                .createApplication(testApplication)
+                .flatMapMany(application -> applicationSnapshotService
+                        .createApplicationSnapshot(application.getId())
+                        .then(applicationSnapshotService.deleteSnapshot(application.getId()))
+                        .thenMany(applicationSnapshotRepository.findByApplicationId(application.getId())));
 
         StepVerifier.create(snapshotFlux).verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails("usertest@usertest.com")
+    public void deleteSnapshot_WhenUserHasNoAccess_ThrowsError() {
+        // Create app and snapshot as api_user by running blocking setup outside the reactive chain
+        Application testApplication = new Application();
+        testApplication.setName("Test app for snapshot delete no-access");
+        testApplication.setWorkspaceId(workspace.getId());
+
+        // The application is owned by api_user (set up in @BeforeEach under api_user context).
+        // We switch the security context to usertest@usertest.com for this test, so the app
+        // created in setup (owned by api_user) is not visible under usertest's permissions.
+        String randomAppId = "app-" + UUID.randomUUID();
+
+        Mono<Boolean> deleteMono = applicationSnapshotService.deleteSnapshot(randomAppId);
+
+        StepVerifier.create(deleteMono)
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && throwable
+                                .getMessage()
+                                .equals(AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.APPLICATION, randomAppId)))
+                .verify();
     }
 
     @WithUserDetails("api_user")

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
@@ -299,23 +299,36 @@ public class ApplicationSnapshotServiceTest {
     @Test
     @WithUserDetails("usertest@usertest.com")
     public void deleteSnapshot_WhenUserHasNoAccess_ThrowsError() {
-        // Create app and snapshot as api_user by running blocking setup outside the reactive chain
-        Application testApplication = new Application();
-        testApplication.setName("Test app for snapshot delete no-access");
-        testApplication.setWorkspaceId(workspace.getId());
+        // usertest@usertest.com has no access to applications owned by api_user.
+        // applicationService.findById applies ACL filtering, so an inaccessible app
+        // and a non-existent app both produce an empty Mono → NO_RESOURCE_FOUND.
+        String inaccessibleAppId = "app-" + UUID.randomUUID();
 
-        // The application is owned by api_user (set up in @BeforeEach under api_user context).
-        // We switch the security context to usertest@usertest.com for this test, so the app
-        // created in setup (owned by api_user) is not visible under usertest's permissions.
-        String randomAppId = "app-" + UUID.randomUUID();
-
-        Mono<Boolean> deleteMono = applicationSnapshotService.deleteSnapshot(randomAppId);
+        Mono<Boolean> deleteMono = applicationSnapshotService.deleteSnapshot(inaccessibleAppId);
 
         StepVerifier.create(deleteMono)
                 .expectErrorMatches(throwable -> throwable instanceof AppsmithException
                         && throwable
                                 .getMessage()
-                                .equals(AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.APPLICATION, randomAppId)))
+                                .equals(AppsmithError.NO_RESOURCE_FOUND.getMessage(
+                                        FieldName.APPLICATION, inaccessibleAppId)))
+                .verify();
+    }
+
+    @Test
+    @WithUserDetails("usertest@usertest.com")
+    public void getWithoutDataByBranchedApplicationId_WhenUserHasNoAccess_ThrowsError() {
+        String inaccessibleAppId = "app-" + UUID.randomUUID();
+
+        Mono<ApplicationSnapshotResponseDTO> snapshotMono =
+                applicationSnapshotService.getWithoutDataByBranchedApplicationId(inaccessibleAppId);
+
+        StepVerifier.create(snapshotMono)
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && throwable
+                                .getMessage()
+                                .equals(AppsmithError.NO_RESOURCE_FOUND.getMessage(
+                                        FieldName.APPLICATION, inaccessibleAppId)))
                 .verify();
     }
 


### PR DESCRIPTION
## Description

Fixes a Broken Object-Level Authorization (BOLA/IDOR) vulnerability in the application snapshot deletion endpoint (GHSA-g2hc-wmw2-32jr).

**Root cause:** `ApplicationSnapshotServiceCEImpl.deleteSnapshot` was calling `applicationSnapshotRepository.deleteAllByApplicationId` directly without performing any authorization check. Any authenticated user who knew a target application ID could send `DELETE /api/v1/applications/snapshot/{appId}` and successfully destroy that application's snapshots — including snapshots belonging to other users and tenants.

**Fix:** Mirror the existing `restoreSnapshot` pattern in the same class. Resolve the application via `applicationService.findById(id, applicationPermission.getEditPermission())` before executing the delete. When the caller does not have edit permission on the application, `findById` returns empty, which triggers `switchIfEmpty` and returns `NO_RESOURCE_FOUND` to the caller — identical behavior to all other protected operations in this service.

**Changes:**
- `ApplicationSnapshotServiceCEImpl.java`: 5-line change to `deleteSnapshot` — permission check added, no interface or API signature changes
- `ApplicationSnapshotServiceTest.java`: Updated existing `deleteSnapshot` happy-path test to run under a real user + owned application; added new regression test `deleteSnapshot_WhenUserHasNoAccess_ThrowsError` asserting that an inaccessible app ID returns `AppsmithError.NO_RESOURCE_FOUND`

Fixes https://linear.app/appsmith/issue/APP-15032/high-broken-object-level-authorization-allows-non-owner-to-delete

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23285869385>
> Commit: e4911c0e7800c0942470ed535ebb3b2f235c925b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23285869385&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 19 Mar 2026 09:54:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot read and delete actions now validate application existence and user permissions before proceeding; unauthorized access returns a clear error.

* **Tests**
  * Added tests covering access control for snapshot deletion and snapshot read-without-data to assert proper error handling for users without access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->