### PR TITLE
chore: promoted release_static_url_enabled to license

### DIFF
--- a/app/client/cypress/support/Objects/FeatureFlags.ts
+++ b/app/client/cypress/support/Objects/FeatureFlags.ts
@@ -5,7 +5,7 @@ const defaultFlags = {
   rollout_remove_feature_walkthrough_enabled: false, // remove this flag from here when it's removed from code
   release_git_modularisation_enabled: true,
   release_git_api_contracts_enabled: true,
-  release_static_url_enabled: true,
+  license_static_url_enabled: true,
 };
 
 export const featureFlagIntercept = (

--- a/app/client/src/ce/entities/FeatureFlag.ts
+++ b/app/client/src/ce/entities/FeatureFlag.ts
@@ -64,7 +64,7 @@ export const FEATURE_FLAG = {
     "release_jsobjects_onpageunloadactions_enabled",
   configure_block_event_tracking_for_anonymous_users:
     "configure_block_event_tracking_for_anonymous_users",
-  release_static_url_enabled: "release_static_url_enabled",
+  license_static_url_enabled: "license_static_url_enabled",
   release_window_dimensions_enabled: "release_window_dimensions_enabled",
   release_branding_logo_resize_enabled: "release_branding_logo_resize_enabled",
   release_ssh_key_manager_enabled: "release_ssh_key_manager_enabled",
@@ -120,7 +120,7 @@ export const DEFAULT_FEATURE_FLAG_VALUE: FeatureFlags = {
   license_ai_agent_instance_enabled: false,
   release_jsobjects_onpageunloadactions_enabled: false,
   configure_block_event_tracking_for_anonymous_users: false,
-  release_static_url_enabled: false,
+  license_static_url_enabled: false,
   release_window_dimensions_enabled: false,
   release_branding_logo_resize_enabled: false,
   release_ssh_key_manager_enabled: false,

--- a/app/client/src/pages/AppIDE/components/AppSettings/components/GeneralSettings.tsx
+++ b/app/client/src/pages/AppIDE/components/AppSettings/components/GeneralSettings.tsx
@@ -128,7 +128,7 @@ function GeneralSettings() {
   ] = useState(false);
   const [modalType, setModalType] = useState<"change" | "disable">("change");
   const isStaticUrlFeatureEnabled = useFeatureFlag(
-    FEATURE_FLAG.release_static_url_enabled,
+    FEATURE_FLAG.license_static_url_enabled,
   );
 
   useEffect(

--- a/app/client/src/pages/AppIDE/components/AppSettings/components/PageSettings.tsx
+++ b/app/client/src/pages/AppIDE/components/AppSettings/components/PageSettings.tsx
@@ -76,7 +76,7 @@ function PageSettings(props: { page: Page }) {
   const isFeatureEnabled = useFeatureFlag(FEATURE_FLAG.license_gac_enabled);
 
   const isStaticUrlFeatureFlagEnabled = useFeatureFlag(
-    FEATURE_FLAG.release_static_url_enabled,
+    FEATURE_FLAG.license_static_url_enabled,
   );
   const isStaticUrlEnabled =
     useSelector(getIsStaticUrlEnabled) && isStaticUrlFeatureFlagEnabled;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
@@ -38,6 +38,11 @@ public enum FeatureFlagEnum {
      */
     license_static_url_enabled,
     /**
+     * Though this flag is not used, however this has been retained in order to protect 
+     * organization migration failures during start-up due to missing flag.
+     */
+    release_static_url_enabled,
+    /**
      * Feature flag to enable alphabetical ordering for workspaces and applications
      */
     release_alphabetical_ordering_enabled,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
@@ -38,7 +38,7 @@ public enum FeatureFlagEnum {
      */
     license_static_url_enabled,
     /**
-     * Though this flag is not used, however this has been retained in order to protect 
+     * Though this flag is not used, however this has been retained in order to protect
      * organization migration failures during start-up due to missing flag.
      */
     release_static_url_enabled,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/enums/FeatureFlagEnum.java
@@ -36,7 +36,7 @@ public enum FeatureFlagEnum {
      * predictable, unique slugs for app and page routes instead of dynamic URLs,
      * improving usability, cross-instance navigation, and compatibility with Git.
      */
-    release_static_url_enabled,
+    license_static_url_enabled,
     /**
      * Feature flag to enable alphabetical ordering for workspaces and applications
      */

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/staticurl/StaticUrlServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/staticurl/StaticUrlServiceImpl.java
@@ -97,7 +97,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @see TextUtils#isSlugFormatValid(String)
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<Application> updateApplicationSlug(String branchedApplicationId, UniqueSlugDTO staticUrlDTO) {
         log.info("Starting application slug update for applicationId: {}", branchedApplicationId);
 
@@ -129,7 +129,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      *   <li>Appending a random suffix if the slug is already taken</li>
      * </ol>
      *
-     * <p>This method is feature-flagged and requires the {@code release_static_url_enabled}
+     * <p>This method is feature-flagged and requires the {@code license_static_url_enabled}
      * feature flag to be enabled.</p>
      *
      * @param branchedApplicationId the ID of the application
@@ -139,10 +139,10 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @throws AppsmithException if the current slug format is invalid
      *
      * @see #generateUniqueApplicationSlug(Application, String, int)
-     * @see FeatureFlagEnum#release_static_url_enabled
+     * @see FeatureFlagEnum#license_static_url_enabled
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<String> suggestUniqueApplicationSlug(String branchedApplicationId) {
         log.info("Suggesting unique application slug for applicationId: {}", branchedApplicationId);
 
@@ -184,7 +184,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      *   <li>Generating unique slugs for all pages in the application</li>
      * </ol>
      *
-     * <p>This method is feature-flagged and requires the {@code release_static_url_enabled}
+     * <p>This method is feature-flagged and requires the {@code license_static_url_enabled}
      * feature flag to be enabled.</p>
      *
      * @param branchedApplicationId the ID of the application
@@ -194,11 +194,11 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @throws AppsmithException if the slug format is invalid
      * @throws AppsmithException if the slug is already taken by another application
      *
-     * @see FeatureFlagEnum#release_static_url_enabled
+     * @see FeatureFlagEnum#license_static_url_enabled
      * @see #generateUniquePageSlugsForApplication(Application)
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<Application> autoGenerateStaticUrl(String branchedApplicationId, UniqueSlugDTO uniqueSlugDTO) {
         log.info("Auto-generating static URL for applicationId: {}", branchedApplicationId);
 
@@ -504,7 +504,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @throws AppsmithException if the application is not found
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<Application> deleteStaticUrlSettings(String branchedApplicationId) {
         log.info("Deleting static URL settings for applicationId: {}", branchedApplicationId);
 
@@ -600,7 +600,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @throws AppsmithException if the application is not found
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<UniqueSlugDTO> isApplicationSlugUnique(String branchedApplicationId, String uniqueSlug) {
         log.info(
                 "Checking application slug uniqueness for applicationId: {}, slug: {}",
@@ -695,7 +695,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @throws AppsmithException if the slug is already taken by another page
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<NewPage> updatePageSlug(UniqueSlugDTO uniqueSlugDTO) {
         String pageId = uniqueSlugDTO.getBranchedPageId();
         final String normalizedPageSlug = TextUtils.makeSlug(uniqueSlugDTO.getUniquePageSlug());
@@ -895,7 +895,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @throws AppsmithException if the page or application is not found
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<UniqueSlugDTO> isPageSlugUnique(String branchedPageId, String uniquePageSlug) {
         log.info("Checking page slug uniqueness for pageId: {}, slug: {}", branchedPageId, uniquePageSlug);
 
@@ -1077,7 +1077,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @see GitUtils#isArtifactConnectedToGit(GitArtifactMetadata)
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<Tuple2<Application, NewPage>> getApplicationAndPageTupleFromStaticNames(
             String uniqueAppSlug, String uniquePageSlug, String refName, ApplicationMode mode) {
 
@@ -1161,17 +1161,17 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * the application has a unique slug. If the static URL is not enabled or
      * the slug format is invalid, it clears the slug.</p>
      *
-     * <p>This method is feature-flagged and requires the {@code release_static_url_enabled}
+     * <p>This method is feature-flagged and requires the {@code license_static_url_enabled}
      * feature flag to be enabled.</p>
      *
      * @param application the application being imported
      * @return Mono&lt;Application&gt; the application with updated slug
      *
-     * @see FeatureFlagEnum#release_static_url_enabled
+     * @see FeatureFlagEnum#license_static_url_enabled
      * @see #generateUniqueApplicationSlug(Application, String, int)
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<Application> generateAndUpdateApplicationSlugForNewImports(Application application) {
         log.info("Generating application slug for new import - applicationId: {}", application.getId());
         StaticUrlSettings staticUrlSettingsFromJson = application.getStaticUrlSettings();
@@ -1202,18 +1202,18 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * application to ensure slug uniqueness. It uses the existing application
      * as the base for uniqueness checking.</p>
      *
-     * <p>This method is feature-flagged and requires the {@code release_static_url_enabled}
+     * <p>This method is feature-flagged and requires the {@code license_static_url_enabled}
      * feature flag to be enabled.</p>
      *
      * @param applicationFromJson the application being imported from JSON
      * @param applicationFromDB the existing application in the database
      * @return Mono&lt;Application&gt; the application with updated slug
      *
-     * @see FeatureFlagEnum#release_static_url_enabled
+     * @see FeatureFlagEnum#license_static_url_enabled
      * @see #generateUniqueApplicationSlug(Application, String, int)
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<Application> generateAndUpdateApplicationSlugForImportsOnExistingApps(
             Application applicationFromJson, Application applicationFromDB) {
         log.info(
@@ -1251,7 +1251,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * slugs don't conflict with existing pages. It handles both Git-connected
      * and non-Git applications differently.</p>
      *
-     * <p>This method is feature-flagged and requires the {@code release_static_url_enabled}
+     * <p>This method is feature-flagged and requires the {@code license_static_url_enabled}
      * feature flag to be enabled.</p>
      *
      * @param pagesToImport the pages being imported
@@ -1259,11 +1259,11 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
      * @param importedApplication the application being imported into
      * @return Mono&lt;List&lt;NewPage&gt;&gt; the pages with updated unique slugs
      *
-     * @see FeatureFlagEnum#release_static_url_enabled
+     * @see FeatureFlagEnum#license_static_url_enabled
      * @see GitUtils#isArtifactConnectedToGit(GitArtifactMetadata)
      */
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<List<NewPage>> updateUniquePageSlugsBeforeImport(
             List<NewPage> pagesToImport, List<NewPage> pagesFromDb, Application importedApplication) {
 
@@ -1329,7 +1329,7 @@ public class StaticUrlServiceImpl extends StaticUrlServiceCECompatibleImpl imple
     }
 
     @Override
-    @FeatureFlagged(featureFlagName = FeatureFlagEnum.release_static_url_enabled)
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.license_static_url_enabled)
     public Mono<PageDTO> updateUniqueSlugBeforeClone(PageDTO incomingPageDTO, List<NewPage> existingPagesFromApp) {
         if (!StringUtils.hasText(incomingPageDTO.getUniqueSlug())) {
             return Mono.just(incomingPageDTO);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ConsolidatedAPIServiceImplTest.java
@@ -174,7 +174,7 @@ public class ConsolidatedAPIServiceImplTest {
         when(mockProductAlertService.getSingleApplicableMessage())
                 .thenReturn(Mono.just(List.of(sampleProductAlertResponseDTO)));
 
-        doReturn(Mono.just(Boolean.TRUE)).when(featureFlagService).check(FeatureFlagEnum.release_static_url_enabled);
+        doReturn(Mono.just(Boolean.TRUE)).when(featureFlagService).check(FeatureFlagEnum.license_static_url_enabled);
 
         Mono<ConsolidatedAPIResponseDTO> consolidatedInfoForPageLoad =
                 consolidatedAPIService.getConsolidatedInfoForPageLoad(
@@ -744,7 +744,7 @@ public class ConsolidatedAPIServiceImplTest {
         when(mockProductAlertService.getSingleApplicableMessage())
                 .thenReturn(Mono.just(List.of(sampleProductAlertResponseDTO)));
 
-        doReturn(Mono.just(Boolean.TRUE)).when(featureFlagService).check(FeatureFlagEnum.release_static_url_enabled);
+        doReturn(Mono.just(Boolean.TRUE)).when(featureFlagService).check(FeatureFlagEnum.license_static_url_enabled);
 
         Mockito.doReturn(Mono.empty())
                 .when(mockNewPageRepository)


### PR DESCRIPTION
## Description

### Feature flag rename: release_static_url_enabled → license_static_url_enabled

- FeatureFlag.ts (enum key, string value, default)
- FeatureFlagEnum.java (enum constant)
- StaticUrlServiceImpl.java (annotations and javadoc references)
- ConsolidatedAPIServiceImplTest.java (test mocks)
- PageSettings.tsx and GeneralSettings.tsx (feature flag checks)
- FeatureFlags.ts (cypress feature flag override)

 Note: this breaks EE compilation

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Settings"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23185762854>
> Commit: 893224c90e19bc4c5ee42a4488975b0e1dcd067f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23185762854&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Settings`
> Spec:
> <hr>Tue, 17 Mar 2026 09:12:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The Static URL feature flag has been renamed and the app now uses a license-based flag to control Static URL availability.
  * Settings pages, server checks, and tests updated so the Static URL UI and behavior are gated by the new license-based flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->