### PR TITLE
chore: move apt packages from main Dockerfile into base image layer

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -29,6 +29,8 @@ on:
       - "app/server/**"
       - "app/client/packages/rts/**"
       - "!app/client/cypress/manual_TestSuite/**"
+      - "Dockerfile"
+      - "deploy/docker/base.dockerfile"
 
 jobs:
   setup:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,6 @@ ENV APPSMITH_BETTERBUGS_API_KEY=${APPSMITH_BETTERBUGS_API_KEY}
 
 COPY deploy/docker/fs /
 
-RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository -y ppa:git-core/ppa && \
-    apt-get update && \
-    apt-get install -y git tar zstd openssh-client && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 RUN <<END
   if ! [ -f info.json ]; then
     echo "Missing info.json" >&2

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -24,7 +24,9 @@ RUN set -o xtrace \
     gettext \
     ca-certificates \
     libnss-wrapper \
+    software-properties-common \
     git \
+  && add-apt-repository -y ppa:git-core/ppa \
   # Install MongoDB v6, PostgreSQL v14
   && curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg \
   && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
@@ -34,6 +36,7 @@ RUN set -o xtrace \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
     mongodb-org \
     postgresql-14 \
+    git tar zstd openssh-client \
   && apt-get clean \
   && rm -rf \
     /root/.cache \


### PR DESCRIPTION
## Summary
- Moves `software-properties-common`, `tar`, `zstd`, `openssh-client`, and the `git-core` PPA upgrade from the main `Dockerfile` into `deploy/docker/base.Dockerfile`
- Consolidated into the existing single apt `RUN` block (alongside MongoDB/PostgreSQL installs) to keep everything in one layer rather than adding a new layer

## Test plan
- [ ] Trigger a base image build and verify the packages are present in the resulting image
- [ ] Verify the main image build succeeds with the apt block removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized Docker build setup and consolidated system dependency installation (including version control, archive, compression, and SSH tools) into the container build process.
  * Added an extra software repository used during builds.
  * CI build triggers expanded to run when container configuration changes.
  * No user-facing feature or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 02c54bd639e4ddedfe2bdcd4caec7c7414c85b98 yet
> <hr>Tue, 17 Mar 2026 21:04:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->
