### PR TITLE
chore: add SSH key support for CE git connect flow

### DIFF
--- a/app/client/src/git/components/ConnectModal/ConnectInitialize/index.tsx
+++ b/app/client/src/git/components/ConnectModal/ConnectInitialize/index.tsx
@@ -209,7 +209,14 @@ function ConnectInitialize({
         }
       }
     }
-  }, [activeStep, currentIndex, formData.remoteUrl, formData.sshKeySource, formData.sshKeyId, onSubmit]);
+  }, [
+    activeStep,
+    currentIndex,
+    formData.remoteUrl,
+    formData.sshKeySource,
+    formData.sshKeyId,
+    onSubmit,
+  ]);
 
   useEffect(
     function changeStepOnErrorEffect() {

--- a/app/client/src/git/components/ConnectModal/ConnectInitialize/index.tsx
+++ b/app/client/src/git/components/ConnectModal/ConnectInitialize/index.tsx
@@ -209,7 +209,7 @@ function ConnectInitialize({
         }
       }
     }
-  }, [activeStep, currentIndex, formData.remoteUrl, onSubmit]);
+  }, [activeStep, currentIndex, formData.remoteUrl, formData.sshKeySource, formData.sshKeyId, onSubmit]);
 
   useEffect(
     function changeStepOnErrorEffect() {

--- a/app/client/src/git/sagas/connectSaga.ts
+++ b/app/client/src/git/sagas/connectSaga.ts
@@ -24,6 +24,7 @@ export default function* connectSaga(
     const params: ConnectRequestParams = {
       remoteUrl: action.payload.remoteUrl,
       gitProfile: action.payload.gitProfile,
+      sshKeyId: action.payload.sshKeyId,
     };
 
     const isGitApiContractsEnabled: boolean = yield select(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -173,7 +173,7 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                                     error.getMessage(),
                                     false,
                                     false)
-                            .flatMap(user -> commonGitFileUtils.deleteLocalRepo(temporaryStorage))
+                            .then(user -> commonGitFileUtils.deleteLocalRepo(temporaryStorage))
                             .flatMap(isDeleted -> {
                                 if (error instanceof TransportException) {
                                     return Mono.error(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -173,7 +173,7 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                                     error.getMessage(),
                                     false,
                                     false)
-                            .then(user -> commonGitFileUtils.deleteLocalRepo(temporaryStorage))
+                            .then(commonGitFileUtils.deleteLocalRepo(temporaryStorage))
                             .flatMap(isDeleted -> {
                                 if (error instanceof TransportException) {
                                     return Mono.error(


### PR DESCRIPTION
## Description
Adds SSH key management support to the CE git connect flow.

### Changes
- **Client – ConnectInitialize**: Added `formData.sshKeySource` and `formData.sshKeyId` to the `useEffect` dependency array so the connect step reacts to SSH key selection changes.
- **Client – connectSaga**: Passed `sshKeyId` through in `ConnectRequestParams` so it reaches the backend on connect.
- **Server – GitFSServiceCEImpl**: Fixed reactive chain by replacing `.flatMap` with `.then` on the `deleteLocalRepo` call during error handling, ensuring correct signal propagation.

Fixes #`Issue Number`  

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23242272689>
> Commit: fc48d00fe44b23d54601aae901b24ae3f017f30b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23242272689&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Wed, 18 Mar 2026 12:38:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Test plan
- [ ] Verify git connect flow works with SSH key selection in CE
- [ ] Verify error handling during connect cleans up local repo correctly
- [ ] Verify existing git connect flow without SSH key still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSH key selection now reliably triggers UI updates during Git initialization when the key source or chosen key changes.
  * The selected SSH key identifier is correctly included in Git connection requests so the intended key is used.
  * Remote repository error handling improved so analytics complete reliably and cleanup proceeds without disrupting subsequent steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->