### PR TITLE
fix: add authorization checks to application snapshot endpoints (GHSA-w596-rgcw-82qf)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
@@ -60,10 +60,13 @@ public class ApplicationSnapshotServiceCEImpl implements ApplicationSnapshotServ
 
     @Override
     public Mono<ApplicationSnapshotResponseDTO> getWithoutDataByBranchedApplicationId(String branchedApplicationId) {
-        // get application first to check the permission and get child aka branched application ID
-        return applicationSnapshotRepository
-                .findByApplicationIdAndChunkOrder(branchedApplicationId, 1)
-                .defaultIfEmpty(new ApplicationSnapshotResponseDTO(null));
+        return applicationService
+                .findById(branchedApplicationId, applicationPermission.getReadPermission())
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, branchedApplicationId)))
+                .flatMap(application -> applicationSnapshotRepository
+                        .findByApplicationIdAndChunkOrder(application.getId(), 1)
+                        .defaultIfEmpty(new ApplicationSnapshotResponseDTO(null)));
     }
 
     @Override
@@ -131,8 +134,12 @@ public class ApplicationSnapshotServiceCEImpl implements ApplicationSnapshotServ
 
     @Override
     public Mono<Boolean> deleteSnapshot(String branchedApplicationId) {
-        return applicationSnapshotRepository
-                .deleteAllByApplicationId(branchedApplicationId)
-                .thenReturn(Boolean.TRUE);
+        return applicationService
+                .findById(branchedApplicationId, applicationPermission.getEditPermission())
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, branchedApplicationId)))
+                .flatMap(application -> applicationSnapshotRepository
+                        .deleteAllByApplicationId(application.getId())
+                        .thenReturn(Boolean.TRUE));
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
@@ -277,20 +277,28 @@ public class ApplicationSnapshotServiceTest {
     }
 
     @Test
+    @WithUserDetails("api_user")
     public void deleteSnapshot_WhenSnapshotExists_Deleted() {
-        String testAppId = "app-" + UUID.randomUUID();
-        ApplicationSnapshot snapshot1 = new ApplicationSnapshot();
-        snapshot1.setChunkOrder(1);
-        snapshot1.setApplicationId(testAppId);
+        Application testApplication = new Application();
+        testApplication.setName("Test app for snapshot delete");
+        testApplication.setWorkspaceId(workspace.getId());
 
-        ApplicationSnapshot snapshot2 = new ApplicationSnapshot();
-        snapshot2.setApplicationId(testAppId);
-        snapshot2.setChunkOrder(2);
+        Flux<ApplicationSnapshot> snapshotFlux = applicationPageService
+                .createApplication(testApplication)
+                .flatMap(application -> {
+                    ApplicationSnapshot snapshot1 = new ApplicationSnapshot();
+                    snapshot1.setChunkOrder(1);
+                    snapshot1.setApplicationId(application.getId());
 
-        Flux<ApplicationSnapshot> snapshotFlux = applicationSnapshotRepository
-                .saveAll(List.of(snapshot1, snapshot2))
-                .then(applicationSnapshotService.deleteSnapshot(testAppId))
-                .thenMany(applicationSnapshotRepository.findByApplicationId(testAppId));
+                    ApplicationSnapshot snapshot2 = new ApplicationSnapshot();
+                    snapshot2.setApplicationId(application.getId());
+                    snapshot2.setChunkOrder(2);
+
+                    return applicationSnapshotRepository
+                            .saveAll(List.of(snapshot1, snapshot2))
+                            .then(applicationSnapshotService.deleteSnapshot(application.getId()))
+                            .thenMany(applicationSnapshotRepository.findByApplicationId(application.getId()));
+                });
 
         StepVerifier.create(snapshotFlux).verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
@@ -9,15 +9,23 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.PageDTO;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.projections.ApplicationSnapshotResponseDTO;
 import com.appsmith.server.repositories.ApplicationSnapshotRepository;
+import com.appsmith.server.services.UserService;
 import com.appsmith.server.solutions.ApplicationPermission;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.test.context.support.WithUserDetails;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -55,6 +63,9 @@ public class ApplicationSnapshotServiceTest {
 
     @Autowired
     SessionUserService sessionUserService;
+
+    @Autowired
+    UserService userService;
 
     Workspace workspace;
 
@@ -301,6 +312,43 @@ public class ApplicationSnapshotServiceTest {
                 });
 
         StepVerifier.create(snapshotFlux).verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails("api_user")
+    public void deleteSnapshot_WhenUserLacksEditPermission_Denied() {
+        // Load the non-owner eagerly so it can be referenced inside the reactive chain.
+        // usertest@usertest.com is seeded by the test framework but never invited to this
+        // workspace, so it has no policies granting EDIT on any app created here.
+        User nonOwner = userService.findByEmail("usertest@usertest.com").block();
+        Authentication nonOwnerAuth =
+                new UsernamePasswordAuthenticationToken(nonOwner, null, nonOwner.getAuthorities());
+        SecurityContext nonOwnerContext = new SecurityContextImpl(nonOwnerAuth);
+
+        Application testApplication = new Application();
+        testApplication.setName("Test app for snapshot delete permission denied");
+        testApplication.setWorkspaceId(workspace.getId());
+
+        Mono<Boolean> deniedMono = applicationPageService
+                .createApplication(testApplication)
+                .flatMap(application -> {
+                    ApplicationSnapshot snapshot1 = new ApplicationSnapshot();
+                    snapshot1.setChunkOrder(1);
+                    snapshot1.setApplicationId(application.getId());
+
+                    return applicationSnapshotRepository
+                            .save(snapshot1)
+                            .thenReturn(application.getId());
+                })
+                .flatMap(applicationId -> applicationSnapshotService
+                        .deleteSnapshot(applicationId)
+                        .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                                Mono.just(nonOwnerContext))));
+
+        StepVerifier.create(deniedMono)
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && ((AppsmithException) throwable).getError() == AppsmithError.NO_RESOURCE_FOUND)
+                .verify();
     }
 
     @WithUserDetails("api_user")

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationSnapshotServiceTest.java
@@ -321,6 +321,9 @@ public class ApplicationSnapshotServiceTest {
         // usertest@usertest.com is seeded by the test framework but never invited to this
         // workspace, so it has no policies granting EDIT on any app created here.
         User nonOwner = userService.findByEmail("usertest@usertest.com").block();
+        assertThat(nonOwner)
+                .as("Expected seeded non-owner user 'usertest@usertest.com' to exist")
+                .isNotNull();
         Authentication nonOwnerAuth =
                 new UsernamePasswordAuthenticationToken(nonOwner, null, nonOwner.getAuthorities());
         SecurityContext nonOwnerContext = new SecurityContextImpl(nonOwnerAuth);
@@ -342,6 +345,43 @@ public class ApplicationSnapshotServiceTest {
                 })
                 .flatMap(applicationId -> applicationSnapshotService
                         .deleteSnapshot(applicationId)
+                        .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                                Mono.just(nonOwnerContext))));
+
+        StepVerifier.create(deniedMono)
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && ((AppsmithException) throwable).getError() == AppsmithError.NO_RESOURCE_FOUND)
+                .verify();
+    }
+
+    @Test
+    @WithUserDetails("api_user")
+    public void getWithoutDataByBranchedApplicationId_WhenUserLacksReadPermission_Denied() {
+        User nonOwner = userService.findByEmail("usertest@usertest.com").block();
+        assertThat(nonOwner)
+                .as("Expected seeded non-owner user 'usertest@usertest.com' to exist")
+                .isNotNull();
+        Authentication nonOwnerAuth =
+                new UsernamePasswordAuthenticationToken(nonOwner, null, nonOwner.getAuthorities());
+        SecurityContext nonOwnerContext = new SecurityContextImpl(nonOwnerAuth);
+
+        Application testApplication = new Application();
+        testApplication.setName("Test app for snapshot read permission denied");
+        testApplication.setWorkspaceId(workspace.getId());
+
+        Mono<ApplicationSnapshotResponseDTO> deniedMono = applicationPageService
+                .createApplication(testApplication)
+                .flatMap(application -> {
+                    ApplicationSnapshot snapshot1 = new ApplicationSnapshot();
+                    snapshot1.setChunkOrder(1);
+                    snapshot1.setApplicationId(application.getId());
+
+                    return applicationSnapshotRepository
+                            .save(snapshot1)
+                            .thenReturn(application.getId());
+                })
+                .flatMap(applicationId -> applicationSnapshotService
+                        .getWithoutDataByBranchedApplicationId(applicationId)
                         .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
                                 Mono.just(nonOwnerContext))));
 


### PR DESCRIPTION
## Summary

Fixes GHSA-w596-rgcw-82qf — Missing Authorization (IDOR) on application snapshot endpoints.

- `DELETE /api/v1/applications/snapshot/{id}` — any authenticated user could delete another user's snapshot for an application they have no access to. Now requires EDIT permission on the application.
- `GET /api/v1/applications/snapshot/{id}` — snapshot metadata was readable without any permission check. Now requires READ permission on the application.

Both methods follow the pattern already used by `restoreSnapshot` in the same class: call `applicationService.findById` with the appropriate permission level before touching the repository.

## Test plan

- [ ] Verify that a user with EDIT access on an application can still delete its snapshot
- [ ] Verify that a user with no access to an application receives 404 on `DELETE /api/v1/applications/snapshot/{id}`
- [ ] Verify that a user with READ access on an application can still fetch snapshot metadata
- [ ] Verify that a user with no access receives 404 on `GET /api/v1/applications/snapshot/{id}`
- [ ] Confirm existing snapshot integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization and error handling for snapshot retrieval and deletion, enforcing read/edit permissions and returning clearer errors when resources are missing.

* **Tests**
  * Updated snapshot deletion tests to run under a specific user context, use real application setup, and add a case verifying deletion is denied for users without edit permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD b1cb454ec8ef97999aeb7b2c25abaf986f13660b yet
> <hr>Wed, 18 Mar 2026 19:07:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->
