### PR TITLE
fix(security): sanitize URL in ManualUpgrades to prevent reflected XSS

### DIFF
--- a/app/client/src/components/BottomBar/ManualUpgrades.tsx
+++ b/app/client/src/components/BottomBar/ManualUpgrades.tsx
@@ -28,6 +28,15 @@ import { useLocation } from "react-router";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
 import classNames from "classnames";
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 const StyledList = styled.ul`
   list-style: disc;
   margin-left: 16px;
@@ -156,17 +165,16 @@ function ManualUpgrades(props: {
       {
         name: createMessage(CLEAN_URL_UPDATE.name),
         shortDesc: createMessage(CLEAN_URL_UPDATE.shortDesc),
-        description: CLEAN_URL_UPDATE.description.map((formatter) =>
-          createMessage(
-            formatter.bind(
-              null,
-              window.location.href.replace(
-                `/applications/${applicationId}/pages/${pageId}`,
-                `/app/${applicationSlug}/${pageSlug}-${pageId}`,
-              ),
+        description: CLEAN_URL_UPDATE.description.map((formatter) => {
+          const sanitizedUrl = escapeHtml(
+            window.location.href.replace(
+              `/applications/${applicationId}/pages/${pageId}`,
+              `/app/${applicationSlug}/${pageSlug}-${pageId}`,
             ),
-          ),
-        ),
+          );
+
+          return createMessage(formatter.bind(null, sanitizedUrl));
+        }),
         disclaimer: {
           severity: "MODERATE",
           desc: createMessage(CLEAN_URL_UPDATE.disclaimer),

--- a/app/client/src/components/BottomBar/ManualUpgrades.tsx
+++ b/app/client/src/components/BottomBar/ManualUpgrades.tsx
@@ -160,32 +160,29 @@ function ManualUpgrades(props: {
   const { applicationSlug, pageSlug } = useSelector(selectURLSlugs);
   const location = useLocation();
 
-  const updates = React.useMemo(
-    () => {
-      const sanitizedUrl = escapeHtml(
-        window.location.href.replace(
-          `/applications/${applicationId}/pages/${pageId}`,
-          `/app/${applicationSlug}/${pageSlug}-${pageId}`,
-        ),
-      );
+  const updates = React.useMemo(() => {
+    const sanitizedUrl = escapeHtml(
+      window.location.href.replace(
+        `/applications/${applicationId}/pages/${pageId}`,
+        `/app/${applicationSlug}/${pageSlug}-${pageId}`,
+      ),
+    );
 
-      return [
-        {
-          name: createMessage(CLEAN_URL_UPDATE.name),
-          shortDesc: createMessage(CLEAN_URL_UPDATE.shortDesc),
-          description: CLEAN_URL_UPDATE.description.map((formatter) =>
-            createMessage(formatter.bind(null, sanitizedUrl)),
-          ),
-          disclaimer: {
-            severity: "MODERATE",
-            desc: createMessage(CLEAN_URL_UPDATE.disclaimer),
-          },
-          version: ApplicationVersion.SLUG_URL,
+    return [
+      {
+        name: createMessage(CLEAN_URL_UPDATE.name),
+        shortDesc: createMessage(CLEAN_URL_UPDATE.shortDesc),
+        description: CLEAN_URL_UPDATE.description.map((formatter) =>
+          createMessage(formatter.bind(null, sanitizedUrl)),
+        ),
+        disclaimer: {
+          severity: "MODERATE",
+          desc: createMessage(CLEAN_URL_UPDATE.disclaimer),
         },
-      ];
-    },
-    [location, applicationSlug, pageSlug, pageId, applicationId],
-  );
+        version: ApplicationVersion.SLUG_URL,
+      },
+    ];
+  }, [location, applicationSlug, pageSlug, pageId, applicationId]);
   const latestVersion = React.useMemo(
     () => updates.reduce((max, u) => (max > u.version ? max : u.version), 0),
     [],

--- a/app/client/src/components/BottomBar/ManualUpgrades.tsx
+++ b/app/client/src/components/BottomBar/ManualUpgrades.tsx
@@ -165,16 +165,15 @@ function ManualUpgrades(props: {
       {
         name: createMessage(CLEAN_URL_UPDATE.name),
         shortDesc: createMessage(CLEAN_URL_UPDATE.shortDesc),
-        description: CLEAN_URL_UPDATE.description.map((formatter) => {
-          const sanitizedUrl = escapeHtml(
-            window.location.href.replace(
-              `/applications/${applicationId}/pages/${pageId}`,
-              `/app/${applicationSlug}/${pageSlug}-${pageId}`,
-            ),
-          );
-
-          return createMessage(formatter.bind(null, sanitizedUrl));
-        }),
+        const sanitizedUrl = escapeHtml(
+          window.location.href.replace(
+            `/applications/${applicationId}/pages/${pageId}`,
+            `/app/${applicationSlug}/${pageSlug}-${pageId}`,
+          ),
+        );
+        description: CLEAN_URL_UPDATE.description.map((formatter) =>
+          createMessage(formatter.bind(null, sanitizedUrl)),
+        ),
         disclaimer: {
           severity: "MODERATE",
           desc: createMessage(CLEAN_URL_UPDATE.disclaimer),

--- a/app/client/src/components/BottomBar/ManualUpgrades.tsx
+++ b/app/client/src/components/BottomBar/ManualUpgrades.tsx
@@ -161,26 +161,29 @@ function ManualUpgrades(props: {
   const location = useLocation();
 
   const updates = React.useMemo(
-    () => [
-      {
-        name: createMessage(CLEAN_URL_UPDATE.name),
-        shortDesc: createMessage(CLEAN_URL_UPDATE.shortDesc),
-        const sanitizedUrl = escapeHtml(
-          window.location.href.replace(
-            `/applications/${applicationId}/pages/${pageId}`,
-            `/app/${applicationSlug}/${pageSlug}-${pageId}`,
-          ),
-        );
-        description: CLEAN_URL_UPDATE.description.map((formatter) =>
-          createMessage(formatter.bind(null, sanitizedUrl)),
+    () => {
+      const sanitizedUrl = escapeHtml(
+        window.location.href.replace(
+          `/applications/${applicationId}/pages/${pageId}`,
+          `/app/${applicationSlug}/${pageSlug}-${pageId}`,
         ),
-        disclaimer: {
-          severity: "MODERATE",
-          desc: createMessage(CLEAN_URL_UPDATE.disclaimer),
+      );
+
+      return [
+        {
+          name: createMessage(CLEAN_URL_UPDATE.name),
+          shortDesc: createMessage(CLEAN_URL_UPDATE.shortDesc),
+          description: CLEAN_URL_UPDATE.description.map((formatter) =>
+            createMessage(formatter.bind(null, sanitizedUrl)),
+          ),
+          disclaimer: {
+            severity: "MODERATE",
+            desc: createMessage(CLEAN_URL_UPDATE.disclaimer),
+          },
+          version: ApplicationVersion.SLUG_URL,
         },
-        version: ApplicationVersion.SLUG_URL,
-      },
-    ],
+      ];
+    },
     [location, applicationSlug, pageSlug, pageId, applicationId],
   );
   const latestVersion = React.useMemo(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Description

**TL;DR:** Fix a reflected Cross-Site Scripting (XSS) vulnerability in the Manual Upgrades modal where `window.location.href` was embedded unsanitized into HTML rendered via `dangerouslySetInnerHTML`.

### Vulnerability

The `ManualUpgrades` component reads `window.location.href`, embeds it into an HTML template string (via `CLEAN_URL_UPDATE.description`), and renders the result using `dangerouslySetInnerHTML`. Since the URL can contain attacker-controlled content (query parameters, fragments), a crafted URL such as:

```
http://target.com/applications/appId/pages/pageId?"><img src=x onerror=alert('XSS')>
```

would cause the injected HTML/JS to execute in the victim's browser when the Manual Upgrades modal is displayed.

### Fix

HTML-escape the URL string (encoding `&`, `<`, `>`, `"`, `'`) **before** it is interpolated into the HTML template. This neutralizes any embedded HTML tags or attribute injections while preserving the URL display for legitimate use.

The fix is intentionally minimal — a single `escapeHtml()` helper applied at the point where user-controlled data enters the HTML template. The sanitized URL is computed once inside the `useMemo` block body (before the returned array) to avoid redundant work per formatter.

Fixes https://linear.app/appsmith/issue/APP-15029/reflected-cross-site-scripting-xss-in-manual-upgrades-component

**Advisory:** [GHSA-xhfw-j46c-mcvf](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-xhfw-j46c-mcvf)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23310159018>
> Commit: b5e9a49ac91bcf96abadb1ca7d188f2dca08dcd8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23310159018&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 19 Mar 2026 19:57:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No


<div><a href="https://cursor.com/agents/bc-f607a96a-1446-423b-b971-29d458e5c5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f607a96a-1446-423b-b971-29d458e5c5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized rewritten URLs in the Manual Upgrades UI to prevent HTML injection and ensure displayed links are safe.
  * Stabilized update message rendering so link content remains consistent regardless of location changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->