### PR TITLE
fix(server): harden admin env value escaping

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -124,6 +124,8 @@ public class EnvManagerCEImpl implements EnvManagerCE {
      */
     private static final Pattern ENV_VARIABLE_PATTERN = Pattern.compile("^(?<name>[A-Z\\d_]+)\\s*=\\s*(?<value>.*)$");
 
+    private static final Pattern SAFE_SHELL_VALUE_PATTERN = Pattern.compile("^[A-Za-z\\d_@%+=:,./-]*$");
+
     private static final Set<String> VARIABLE_WHITELIST =
             Stream.of(EnvVariables.values()).map(Enum::name).collect(Collectors.toUnmodifiableSet());
 
@@ -238,7 +240,11 @@ public class EnvManagerCEImpl implements EnvManagerCE {
     }
 
     private String escapeForShell(String input) {
-        if (org.apache.commons.lang3.StringUtils.containsAny(input, " ?*#'")) {
+        if (input.chars().anyMatch(Character::isISOControl)) {
+            throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "environment variable value");
+        }
+
+        if (!input.isEmpty() && !SAFE_SHELL_VALUE_PATTERN.matcher(input).matches()) {
             return ("'" + input.replace("'", "'\"'\"'") + "'")
                     .replaceAll("^''", "")
                     .replaceAll("''$", "");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -349,6 +349,29 @@ public class EnvManagerTest {
     }
 
     @Test
+    public void unsafeShellValuesAreQuoted() {
+        final String content = "APPSMITH_DISABLE_TELEMETRY=false";
+
+        StepVerifier.create(envManager.transformEnvContent(
+                        content, Map.of("APPSMITH_DISABLE_TELEMETRY", "$(touch${IFS}/tmp/pwned)")))
+                .assertNext(value ->
+                        assertThat(value).containsExactly("APPSMITH_DISABLE_TELEMETRY='$(touch${IFS}/tmp/pwned)'"))
+                .verifyComplete();
+    }
+
+    @Test
+    public void controlCharactersInValuesAreRejected() {
+        final String content = "APPSMITH_DISABLE_TELEMETRY=false";
+
+        StepVerifier.create(envManager.transformEnvContent(
+                        content,
+                        Map.of("APPSMITH_DISABLE_TELEMETRY", "false\nAPPSMITH_JAVA_ARGS=$(touch${IFS}/tmp/pwned)")))
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && ((AppsmithException) throwable).getError().equals(AppsmithError.INVALID_PARAMETER))
+                .verify();
+    }
+
+    @Test
     public void sendTestEmail_WhenUserNotSuperUser_ThrowsException() {
         User user = new User();
         user.setEmail("sample-super-user");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
> [!TIP]
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

TL;DR: APP-15033 is valid for the admin-controlled RCE chain through `PUT /api/v1/admin/env`. This patch blocks that path by rejecting control characters in admin env values and shell-quoting any value that contains bash-sensitive characters before writing to `docker.env`.

Fixes https://linear.app/appsmith/issue/APP-15033/rce-via-newline-injection-in-put-apiv1adminenv-shell-sourcing-of

Context:
- Confirmed the report is exploitable through the default admin env update path.
- The key issue is that admin-supplied values were written to `docker.env` with insufficient shell escaping.
- This change hardens the server-side writer so a single value cannot inject new lines or leave `$(...)` style payloads executable when the env file is loaded.

Changes:
- reject ISO control characters in admin env values before they are serialized to `docker.env`
- quote values unless they consist solely of a conservative shell-safe character set
- add regression tests for shell-substitution payloads and multiline injection attempts

Validation:
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -pl appsmith-server -am -Dtest=EnvManagerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -pl appsmith-server -am -DskipTests spotless:check`

Slack thread: N/A (no Slack thread link was provided in the ticket or comments)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23294831363>
> Commit: d3646c71a94306cf0a025c97651d2c4543e8dba6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23294831363&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 19 Mar 2026 13:41:47 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8721b317-a020-45c1-84d2-a9e6d4bde4e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8721b317-a020-45c1-84d2-a9e6d4bde4e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced environment variable validation to prevent shell injection risks by rejecting control characters in variable values.
  * Improved shell escaping behavior for environment variables to safely handle special characters and shell-substitution syntax.

* **Tests**
  * Added validation tests to verify proper handling of shell-unsafe values and control characters in environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->