### PR TITLE
refactor: streamline BetterBugs script loading in index.html

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -81,16 +81,7 @@
           successMessageHeaderText: "Information received",
           successMessageSubHeaderText: "Our support team will use it to review the issue",
         };
-        (function () {
-          var s1 = document.createElement("script");
-          s1.src = "https://cdn.betterbugs.io/scripts/latest/logs-capture.js";
-          s1.async = true;
-          document.head.appendChild(s1);
-          var s2 = document.createElement("script");
-          s2.src = "https://cdn.betterbugs.io/scripts/latest/recorder.js";
-          s2.async = true;
-          document.head.appendChild(s2);
-        })();
+        !function(){function n(){var r=new URLSearchParams(window.location.search);if(r.has("betterbugs-recording"))return!0;try{var e=localStorage.getItem("recordingStatuses");if(e){var t=JSON.parse(e);if(Array.isArray(t)&&t.some(function(n){return n&&!0===n.currentlyRecording}))return!0}}catch(n){}return!1}function o(n){var r=document.createElement("script");r.src=n,r.async=!0,document.head.prepend(r)}n()&&(o("https://cdn.betterbugs.io/scripts/latest/logs-capture.js"),o("https://cdn.betterbugs.io/scripts/latest/recorder.js"))}();
       }
     </script>
     <!-- End of BetterBugs Recording Links -->


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._

Replaced the previous script loading method for BetterBugs with a more efficient inline function that checks for recording status before appending the necessary scripts. This change enhances performance by conditionally loading scripts only when required, improving the overall user experience.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23329064176>
> Commit: 5d8b25bfb79c25fdc27c9a7a38090349bb0a1cc1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23329064176&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 20 Mar 2026 05:08:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved BetterBugs recording functionality to intelligently manage support script loading. Recording scripts now load only when no active session is detected, preventing conflicts and reducing unnecessary resource consumption during active recording operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->