### PR TITLE
fix(security): enforce ACL permission check in OAuth2 callback datasource lookup (GHSA-rg2x-4v4h-g78w)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
@@ -241,7 +241,7 @@ public class AuthenticationServiceCEImpl implements AuthenticationServiceCE {
                         return Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS));
                     } else
                         return datasourceService
-                                .findById(splitStates[1])
+                                .findById(splitStates[1], datasourcePermission.getEditPermission())
                                 .flatMap(datasource1 -> datasourceStorageService.findByDatasourceAndEnvironmentId(
                                         datasource1, splitStates[2]));
                 })

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
@@ -15,6 +15,7 @@ import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.Workspace;
+import com.appsmith.server.dtos.AuthorizationCodeCallbackDTO;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.PluginWorkspaceDTO;
 import com.appsmith.server.dtos.WorkspacePluginStatus;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
@@ -364,4 +364,110 @@ public class AuthenticationServiceTest {
                 })
                 .verifyComplete();
     }
+
+    /**
+     * Verifies that getAccessTokenForGenericOAuth2 enforces ACL permission checks
+     * on the datasource ID embedded in the OAuth2 callback state parameter.
+     *
+     * Before the fix (APP-15028 / GHSA-rg2x-4v4h-g78w), the method used the
+     * 1-argument findById(id) which skipped ACL checks, allowing any authenticated
+     * user to manipulate OAuth2 credentials for datasources they had no access to.
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testGetAccessTokenForGenericOAuth2_nonExistentDatasource_returnsEmpty() {
+        String fakeDatasourceId = "nonExistentDatasourceId";
+        String fakeEnvironmentId = "fakeEnvId";
+        String fakePageId = "fakePageId";
+        String fakeRedirectUrl = "https://mock.origin.com";
+        String fakeWorkspaceId = "fakeWorkspaceId";
+
+        String state =
+                String.join(",", fakePageId, fakeDatasourceId, fakeEnvironmentId, fakeRedirectUrl, fakeWorkspaceId);
+
+        AuthorizationCodeCallbackDTO callbackDTO = new AuthorizationCodeCallbackDTO();
+        callbackDTO.setCode("auth_code");
+        callbackDTO.setState(state);
+
+        Mono<String> resultMono = authenticationService.getAccessTokenForGenericOAuth2(callbackDTO);
+
+        StepVerifier.create(resultMono).verifyComplete();
+    }
+
+    /**
+     * Verifies that getAccessTokenForGenericOAuth2 enforces edit permission on the
+     * datasource referenced in the OAuth2 callback state parameter. When a valid
+     * datasource exists and the current user holds the edit permission, the method
+     * should progress past the ACL check and attempt the OAuth2 token exchange
+     * (which will fail because the AccessTokenUrl is not a real server).
+     * The error is caught and converted into a redirect containing "appsmith_error",
+     * confirming the ACL gate was passed.
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testGetAccessTokenForGenericOAuth2_authorizedDatasource_progressesPastAcl() {
+        String defaultEnvironmentId = workspaceService
+                .getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission())
+                .block();
+
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        PageDTO testPage = new PageDTO();
+        testPage.setName("OAuthAclTestPage");
+
+        Application newApp = new Application();
+        newApp.setName(UUID.randomUUID().toString());
+        Application application = applicationPageService
+                .createApplication(newApp, workspace.getId())
+                .block();
+
+        testPage.setApplicationId(application.getId());
+        PageDTO pageDto = applicationPageService.createPage(testPage).block();
+
+        Mono<Plugin> pluginMono = pluginService.findByName("Installed Plugin Name");
+        Datasource datasource = new Datasource();
+        datasource.setName("OAuth2 ACL Test Datasource");
+        datasource.setWorkspaceId(workspace.getId());
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        OAuth2 authenticationDTO = new OAuth2();
+        authenticationDTO.setClientId("ClientId");
+        authenticationDTO.setClientSecret("ClientSecret");
+        authenticationDTO.setAuthorizationUrl("AuthorizationURL");
+        authenticationDTO.setAccessTokenUrl("http://localhost:0/non-existent-token-endpoint");
+        authenticationDTO.setScope(Set.of("Scope1"));
+        authenticationDTO.setIsAuthorizationHeader(false);
+        datasourceConfiguration.setAuthentication(authenticationDTO);
+
+        HashMap<String, DatasourceStorageDTO> storages = new HashMap<>();
+        datasource.setDatasourceStorages(storages);
+        storages.put(
+                defaultEnvironmentId, new DatasourceStorageDTO(null, defaultEnvironmentId, datasourceConfiguration));
+        Datasource createdDatasource = pluginMono
+                .map(plugin -> {
+                    datasource.setPluginId(plugin.getId());
+                    return datasource;
+                })
+                .flatMap(datasourceService::create)
+                .block();
+
+        String datasourceId = createdDatasource.getId();
+        String redirectUrl = "https://mock.origin.com";
+
+        String state =
+                String.join(",", pageDto.getId(), datasourceId, defaultEnvironmentId, redirectUrl, workspace.getId());
+
+        AuthorizationCodeCallbackDTO callbackDTO = new AuthorizationCodeCallbackDTO();
+        callbackDTO.setCode("fake_auth_code");
+        callbackDTO.setState(state);
+
+        Mono<String> resultMono = authenticationService.getAccessTokenForGenericOAuth2(callbackDTO);
+
+        StepVerifier.create(resultMono)
+                .assertNext(url -> {
+                    assertThat(url).contains("appsmith_error");
+                })
+                .verifyComplete();
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
@@ -25,6 +25,7 @@ import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.newpages.base.NewPageService;
 import com.appsmith.server.plugins.base.PluginService;
+import com.appsmith.server.repositories.DatasourceRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
 import com.appsmith.server.services.ApplicationPageService;
 import com.appsmith.server.services.UserService;
@@ -90,6 +91,9 @@ public class AuthenticationServiceTest {
 
     @SpyBean
     NewPageService newPageService;
+
+    @Autowired
+    DatasourceRepository datasourceRepository;
 
     Workspace workspace;
 
@@ -373,18 +377,57 @@ public class AuthenticationServiceTest {
      * Before the fix (APP-15028 / GHSA-rg2x-4v4h-g78w), the method used the
      * 1-argument findById(id) which skipped ACL checks, allowing any authenticated
      * user to manipulate OAuth2 credentials for datasources they had no access to.
+     *
+     * This test creates a real datasource, then strips all its ACL policies so the
+     * caller no longer has permission to access it. The callback must then return
+     * an empty Mono (no redirect URL), proving that the ACL-checked findById
+     * correctly denies access.
      */
     @Test
     @WithUserDetails(value = "api_user")
-    public void testGetAccessTokenForGenericOAuth2_nonExistentDatasource_returnsEmpty() {
-        String fakeDatasourceId = "nonExistentDatasourceId";
-        String fakeEnvironmentId = "fakeEnvId";
-        String fakePageId = "fakePageId";
-        String fakeRedirectUrl = "https://mock.origin.com";
-        String fakeWorkspaceId = "fakeWorkspaceId";
+    public void testGetAccessTokenForGenericOAuth2_datasourceWithoutPermission_returnsEmpty() {
+        String defaultEnvironmentId = workspaceService
+                .getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission())
+                .block();
 
-        String state =
-                String.join(",", fakePageId, fakeDatasourceId, fakeEnvironmentId, fakeRedirectUrl, fakeWorkspaceId);
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Mono<Plugin> pluginMono = pluginService.findByName("Installed Plugin Name");
+        Datasource datasource = new Datasource();
+        datasource.setName("OAuth2 ACL Denied Datasource");
+        datasource.setWorkspaceId(workspace.getId());
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        OAuth2 authenticationDTO = new OAuth2();
+        authenticationDTO.setClientId("ClientId");
+        authenticationDTO.setClientSecret("ClientSecret");
+        authenticationDTO.setAuthorizationUrl("AuthorizationURL");
+        authenticationDTO.setAccessTokenUrl("AccessTokenURL");
+        authenticationDTO.setScope(Set.of("Scope1"));
+        authenticationDTO.setIsAuthorizationHeader(false);
+        datasourceConfiguration.setAuthentication(authenticationDTO);
+
+        HashMap<String, DatasourceStorageDTO> storages = new HashMap<>();
+        datasource.setDatasourceStorages(storages);
+        storages.put(
+                defaultEnvironmentId, new DatasourceStorageDTO(null, defaultEnvironmentId, datasourceConfiguration));
+        Datasource createdDatasource = pluginMono
+                .map(plugin -> {
+                    datasource.setPluginId(plugin.getId());
+                    return datasource;
+                })
+                .flatMap(datasourceService::create)
+                .block();
+
+        String datasourceId = createdDatasource.getId();
+
+        // Strip all ACL policies so the caller no longer has permission
+        createdDatasource.setPolicies(Set.of());
+        datasourceRepository.save(createdDatasource).block();
+
+        String state = String.join(
+                ",", "fakePageId", datasourceId, defaultEnvironmentId, "https://mock.origin.com", workspace.getId());
 
         AuthorizationCodeCallbackDTO callbackDTO = new AuthorizationCodeCallbackDTO();
         callbackDTO.setCode("auth_code");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The OAuth2 callback handler in `AuthenticationServiceCEImpl.getAccessTokenForGenericOAuth2()` used the 1-argument `findById(id)` — which performs **no ACL check** — to fetch the datasource whose ID is embedded in the client-controlled `state` parameter. An authenticated user could craft the OAuth2 callback `state` to reference a datasource in another workspace, bypassing authorization and gaining access to that datasource's OAuth2 credentials.

This fix replaces the unprotected call with the 2-argument `findById(id, aclPermission)` overload using `datasourcePermission.getEditPermission()`, consistent with all three other `findById` calls in the same class (lines ~120, ~402, ~586).

**Advisory:** [GHSA-rg2x-4v4h-g78w](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-rg2x-4v4h-g78w)  
**CVSS:** 8.1 (High) — `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N`  
**CWE:** CWE-862 (Missing Authorization)

**EE issue:** https://github.com/appsmithorg/appsmith-ee/issues/8793

### Changes
- **`AuthenticationServiceCEImpl.java`** — single-line fix: `findById(splitStates[1])` → `findById(splitStates[1], datasourcePermission.getEditPermission())`
- **`AuthenticationServiceTest.java`** — two new tests:
  - `testGetAccessTokenForGenericOAuth2_datasourceWithoutPermission_returnsEmpty` — creates a real datasource, strips its ACL policies, then verifies the OAuth2 callback returns an empty Mono (ACL denial). This test would fail if the 1-arg findById (no ACL) were used.
  - `testGetAccessTokenForGenericOAuth2_authorizedDatasource_progressesPastAcl` — verifies that an authorized datasource passes the ACL gate and progresses to the token exchange step

Fixes APP-15028

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23438291755>
> Commit: 82f8ca9202094b74cc5926c4a64516f9ab4f5c6b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23438291755&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 23 Mar 2026 14:07:24 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76a9b8b1-ba08-44e5-b451-8756c73660d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76a9b8b1-ba08-44e5-b451-8756c73660d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced access-control checks during OAuth2 authorization-code callbacks to prevent unauthorized access to datasource credentials and improve security of OAuth flows.

* **Tests**
  * Added tests covering OAuth2 callback scenarios, including missing-datasource handling and ACL-validated token-exchange error paths to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->