### PR TITLE
fix(arangoDBPlugin): prevent AQL injection via unsafe string concatenation

### DIFF
--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/StructureUtils.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/StructureUtils.java
@@ -79,8 +79,9 @@ public class StructureUtils {
         String filterKey = "_key";
         String filterValue = sampleValues.get("_key");
 
-        String rawQuery = "FOR document IN " + collectionName + "\n" + "FILTER " + "document." + filterKey + " == \""
-                + filterValue + "\"\n" + "RETURN document";
+        String rawQuery = "FOR document IN " + sanitizeCollectionName(collectionName) + "\n" + "FILTER "
+                + "document." + filterKey + " == \"" + escapeAqlStringLiteral(filterValue) + "\"\n"
+                + "RETURN document";
 
         return new DatasourceStructure.Template("Select", rawQuery, true);
     }
@@ -88,7 +89,8 @@ public class StructureUtils {
     private static DatasourceStructure.Template generateCreateTemplate(Map<String, Object> templateConfiguration) {
         String collectionName = (String) templateConfiguration.get("collectionName");
 
-        String rawQuery = "INSERT \n" + "{\n" + "    insertKey: \"insertValue\"\n" + "}\n" + "INTO " + collectionName;
+        String rawQuery = "INSERT \n" + "{\n" + "    insertKey: \"insertValue\"\n" + "}\n" + "INTO "
+                + sanitizeCollectionName(collectionName);
 
         return new DatasourceStructure.Template("Create", rawQuery, false);
     }
@@ -101,13 +103,13 @@ public class StructureUtils {
 
         String rawQuery = "UPDATE\n" + "{\n"
                 + "    "
-                + filterKey + ": \"" + filterValue + "\"\n" + "}\n"
+                + filterKey + ": \"" + escapeAqlStringLiteral(filterValue) + "\"\n" + "}\n"
                 + "WITH\n"
                 + "{\n"
                 + "    updateKey: \"updateVal\"\n"
                 + "}\n"
                 + "IN "
-                + collectionName;
+                + sanitizeCollectionName(collectionName);
 
         return new DatasourceStructure.Template("Update", rawQuery, false);
     }
@@ -117,12 +119,40 @@ public class StructureUtils {
         Map<String, String> sampleValues = (Map<String, String>) templateConfiguration.get("sampleValues");
         String filterValue = sampleValues.get("_key");
 
-        String rawQuery = "REMOVE \"" + filterValue + "\" IN " + collectionName;
+        String rawQuery =
+                "REMOVE \"" + escapeAqlStringLiteral(filterValue) + "\" IN " + sanitizeCollectionName(collectionName);
 
         return new DatasourceStructure.Template("Delete", rawQuery, false);
     }
 
+    /**
+     * Backtick-quotes a collection name for safe inclusion in AQL queries,
+     * preventing AQL injection via crafted collection names. Internal backticks
+     * are escaped by doubling them per AQL identifier quoting rules.
+     */
+    static String sanitizeCollectionName(String collectionName) {
+        if (collectionName == null) {
+            return "``";
+        }
+        return "`" + collectionName.replace("`", "``") + "`";
+    }
+
+    /**
+     * Escapes special characters in a value for safe inclusion within a
+     * double-quoted AQL string literal, preventing AQL injection via
+     * crafted string values.
+     */
+    static String escapeAqlStringLiteral(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
+    }
+
     public static String getOneDocumentQuery(String collectionName) {
-        return "for doc in " + collectionName + " limit 1 return doc";
+        return "for doc in " + sanitizeCollectionName(collectionName) + " limit 1 return doc";
     }
 }

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/utils/StructureUtilsTest.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/utils/StructureUtilsTest.java
@@ -1,0 +1,191 @@
+package com.external.utils;
+
+import com.appsmith.external.models.DatasourceStructure;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StructureUtilsTest {
+
+    @Test
+    public void testSanitizeCollectionName_normalName() {
+        assertEquals("`users`", StructureUtils.sanitizeCollectionName("users"));
+    }
+
+    @Test
+    public void testSanitizeCollectionName_nameWithBacktick() {
+        assertEquals("`col``lection`", StructureUtils.sanitizeCollectionName("col`lection"));
+    }
+
+    @Test
+    public void testSanitizeCollectionName_nullName() {
+        assertEquals("``", StructureUtils.sanitizeCollectionName(null));
+    }
+
+    @Test
+    public void testSanitizeCollectionName_nameWithInjectionAttempt() {
+        String malicious = "users` REMOVE \"1\" IN users //";
+        String sanitized = StructureUtils.sanitizeCollectionName(malicious);
+        assertEquals("`users`` REMOVE \"1\" IN users //`", sanitized);
+    }
+
+    @Test
+    public void testEscapeAqlStringLiteral_normalValue() {
+        assertEquals("hello", StructureUtils.escapeAqlStringLiteral("hello"));
+    }
+
+    @Test
+    public void testEscapeAqlStringLiteral_nullValue() {
+        assertEquals("", StructureUtils.escapeAqlStringLiteral(null));
+    }
+
+    @Test
+    public void testEscapeAqlStringLiteral_valueWithDoubleQuotes() {
+        assertEquals("say \\\"hello\\\"", StructureUtils.escapeAqlStringLiteral("say \"hello\""));
+    }
+
+    @Test
+    public void testEscapeAqlStringLiteral_valueWithBackslash() {
+        assertEquals("path\\\\to\\\\file", StructureUtils.escapeAqlStringLiteral("path\\to\\file"));
+    }
+
+    @Test
+    public void testEscapeAqlStringLiteral_valueWithNewlines() {
+        assertEquals("line1\\nline2\\rline3", StructureUtils.escapeAqlStringLiteral("line1\nline2\rline3"));
+    }
+
+    @Test
+    public void testEscapeAqlStringLiteral_injectionAttempt() {
+        String malicious = "\" OR 1==1 RETURN document //";
+        String escaped = StructureUtils.escapeAqlStringLiteral(malicious);
+        assertEquals("\\\" OR 1==1 RETURN document //", escaped);
+        assertFalse(escaped.startsWith("\""));
+    }
+
+    @Test
+    public void testGetOneDocumentQuery_normalCollection() {
+        String query = StructureUtils.getOneDocumentQuery("users");
+        assertEquals("for doc in `users` limit 1 return doc", query);
+    }
+
+    @Test
+    public void testGetOneDocumentQuery_injectionInCollectionName() {
+        String malicious = "users` REMOVE \"1\" IN users //";
+        String query = StructureUtils.getOneDocumentQuery(malicious);
+        assertTrue(query.contains("`users`` REMOVE \"1\" IN users //`"));
+        assertFalse(query.contains("REMOVE \"1\" IN users") && !query.contains("`"));
+    }
+
+    @Test
+    public void testGenerateTemplates_withInjectionInFilterValue() {
+        String collectionName = "testCollection";
+        Map<String, Object> document = new HashMap<>();
+        document.put("_id", "testCollection/123");
+        document.put("_key", "\" OR 1==1 RETURN document //");
+        document.put("_rev", "abc");
+        document.put("name", "test");
+
+        ArrayList<DatasourceStructure.Column> columns = new ArrayList<>();
+        ArrayList<DatasourceStructure.Template> templates = new ArrayList<>();
+
+        StructureUtils.generateTemplatesAndStructureForACollection(collectionName, document, columns, templates);
+
+        assertEquals(4, templates.size());
+
+        DatasourceStructure.Template selectTemplate = templates.stream()
+                .filter(t -> "Select".equals(t.getTitle()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(selectTemplate != null);
+        String selectQuery = selectTemplate.getBody();
+        assertTrue(selectQuery.contains("\\\" OR 1==1 RETURN document //"));
+        assertFalse(selectQuery.contains("== \"\" OR 1==1"));
+
+        DatasourceStructure.Template deleteTemplate = templates.stream()
+                .filter(t -> "Delete".equals(t.getTitle()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(deleteTemplate != null);
+        String deleteQuery = deleteTemplate.getBody();
+        assertTrue(deleteQuery.contains("\\\" OR 1==1 RETURN document //"));
+        assertFalse(deleteQuery.contains("\"\" OR 1==1"));
+
+        DatasourceStructure.Template updateTemplate = templates.stream()
+                .filter(t -> "Update".equals(t.getTitle()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(updateTemplate != null);
+        String updateQuery = updateTemplate.getBody();
+        assertTrue(updateQuery.contains("\\\" OR 1==1 RETURN document //"));
+    }
+
+    @Test
+    public void testGenerateTemplates_withInjectionInCollectionName() {
+        String maliciousCollectionName = "users` REMOVE \"1\" IN users //";
+        Map<String, Object> document = new HashMap<>();
+        document.put("_id", "test/123");
+        document.put("_key", "123");
+        document.put("_rev", "abc");
+
+        ArrayList<DatasourceStructure.Column> columns = new ArrayList<>();
+        ArrayList<DatasourceStructure.Template> templates = new ArrayList<>();
+
+        StructureUtils.generateTemplatesAndStructureForACollection(
+                maliciousCollectionName, document, columns, templates);
+
+        assertEquals(4, templates.size());
+
+        for (DatasourceStructure.Template template : templates) {
+            String query = template.getBody();
+            assertTrue(
+                    query.contains("`users`` REMOVE \"1\" IN users //`"),
+                    "Template '" + template.getTitle() + "' should contain escaped collection name");
+        }
+    }
+
+    @Test
+    public void testGenerateTemplates_normalValues() {
+        String collectionName = "users";
+        Map<String, Object> document = new HashMap<>();
+        document.put("_id", "users/12345");
+        document.put("_key", "12345");
+        document.put("_rev", "abc");
+        document.put("name", "John");
+
+        ArrayList<DatasourceStructure.Column> columns = new ArrayList<>();
+        ArrayList<DatasourceStructure.Template> templates = new ArrayList<>();
+
+        StructureUtils.generateTemplatesAndStructureForACollection(collectionName, document, columns, templates);
+
+        assertEquals(4, templates.size());
+
+        DatasourceStructure.Template selectTemplate = templates.stream()
+                .filter(t -> "Select".equals(t.getTitle()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(selectTemplate != null);
+        assertTrue(selectTemplate.getBody().contains("`users`"));
+        assertTrue(selectTemplate.getBody().contains("\"12345\""));
+
+        DatasourceStructure.Template createTemplate = templates.stream()
+                .filter(t -> "Create".equals(t.getTitle()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(createTemplate != null);
+        assertTrue(createTemplate.getBody().contains("`users`"));
+
+        DatasourceStructure.Template deleteTemplate = templates.stream()
+                .filter(t -> "Delete".equals(t.getTitle()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(deleteTemplate != null);
+        assertTrue(deleteTemplate.getBody().contains("`users`"));
+        assertTrue(deleteTemplate.getBody().contains("\"12345\""));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes an AQL (ArangoDB Query Language) injection vulnerability in the ArangoDB plugin where user-provided inputs (collection names, filter keys, and values) were concatenated directly into query strings without sanitization or parameter binding.

**TL;DR:** The `StructureUtils` class constructed AQL queries via unsafe string concatenation, allowing attackers to manipulate query structure and execute arbitrary AQL commands. This fix introduces proper escaping for string literals and backtick-quoting for collection names.

### Vulnerability Details

The methods `generateSelectTemplate`, `generateCreateTemplate`, `generateUpdateTemplate`, `generateRemoveTemplate`, and `getOneDocumentQuery` in `StructureUtils.java` were vulnerable to AQL injection. For example:

```java
// Before (vulnerable):
String rawQuery = "FOR document IN " + collectionName + "\n"
    + "FILTER document._key == \"" + filterValue + "\"\n"
    + "RETURN document";
```

An attacker controlling `filterValue` (e.g., `" OR 1==1 RETURN document //`) could force the query to return all documents.

### Fix

1. **`sanitizeCollectionName()`** - Backtick-quotes collection names for safe AQL identifier inclusion, escaping internal backticks by doubling them per AQL quoting rules.
2. **`escapeAqlStringLiteral()`** - Escapes `\`, `"`, `\n`, `\r` in string values for safe inclusion within double-quoted AQL string literals.
3. Both methods are applied to all five vulnerable query construction points.

### Advisory

- **GHSA:** [GHSA-7mv3-55hh-pp69](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-7mv3-55hh-pp69)
- **CVSS:** 8.8 (High)
- **Impact:** AQL Injection leading to potential data exfiltration, data manipulation, and denial of service.

Fixes https://linear.app/appsmith/issue/APP-15027/aql-injection-in-arangodb-plugin-via-unsafe-string-concatenation

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23336206945>
> Commit: 9d4322808c60d3dca8963c19b2ce318159e622fc
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23336206945&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 20 Mar 2026 10:21:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdf438c7-aeaf-497b-9623-484a7970aa3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdf438c7-aeaf-497b-9623-484a7970aa3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ArangoDBPlugin security by implementing input sanitization to prevent injection vulnerabilities in database queries.

* **Tests**
  * Added comprehensive test coverage verifying proper handling of malicious inputs and edge cases in the ArangoDBPlugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->