### PR TITLE
fix(ssrf): expand metadata denylist (GHSA-9m89-5jw7-q5cr)

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -29,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 @Slf4j
@@ -64,15 +66,33 @@ public class WebClientUtils {
     private WebClientUtils() {}
 
     private static Set<String> computeDisallowedHosts() {
-        final Set<String> hosts = new HashSet<>(Set.of(
-                "169.254.169.254", "0:0:0:0:0:0:a9fe:a9fe", "fd00:ec2:0:0:0:0:0:254", "metadata.google.internal"));
+        final Set<String> hosts = new HashSet<>();
+        addDisallowedHosts(
+                hosts,
+                "169.254.169.254",
+                "fd00:ec2::254",
+                "fd20:ce::254",
+                "100.100.100.200",
+                "169.254.10.10",
+                "169.254.170.2",
+                "metadata.google.internal",
+                "metadata.tencentyun.com");
 
         if ("1".equals(System.getenv("IN_DOCKER"))) {
-            hosts.add("127.0.0.1");
-            hosts.add("0:0:0:0:0:0:0:1");
+            addDisallowedHosts(hosts, "127.0.0.1", "::1");
         }
 
         return Collections.unmodifiableSet(hosts);
+    }
+
+    private static void addDisallowedHosts(Set<String> hosts, String... hostCandidates) {
+        for (String hostCandidate : hostCandidates) {
+            try {
+                hosts.add(normalizeHostForComparison(hostCandidate));
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException("Invalid disallowed host configured: " + hostCandidate, e);
+            }
+        }
     }
 
     public static WebClient create() {
@@ -178,7 +198,7 @@ public class WebClientUtils {
     }
 
     public static boolean isDisallowedAndFail(String host, Promise<?> promise) {
-        if (DISALLOWED_HOSTS.contains(host)) {
+        if (DISALLOWED_HOSTS.contains(normalizeHostForComparisonQuietly(host))) {
             log.warn("Host {} is disallowed. Failing the request.", host);
             if (promise != null) {
                 promise.setFailure(new UnknownHostException(HOST_NOT_ALLOWED));
@@ -196,22 +216,14 @@ public class WebClientUtils {
                     AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, "Requested url host is null or empty"));
         }
 
-        String canonicalHost = host;
-        if (isValidIpAddress(host)) {
-            try {
-                // This is to ensure we have the canonical representation of the IP Address. For example,
-                //   - `10.4` and `10.0.0.4` represent the same IPv4 address.
-                //   - `::1` and `0:0:0:0:0:0:0:1` represent the same IPv6 address.
-                //   - `::a9fe:a9fe`, `0:0:0:0:0:0:a9fe:a9fe` and `[::169.254.169.254]` all represent the same IPv4
-                // address in IPv6 notation.
-                // Getting the canonical form makes the check for disallowed hosts more resilient.
-                canonicalHost = InetAddress.getByName(host).getHostAddress();
-            } catch (UnknownHostException e) {
-                // This exception is thrown, if the given host couldn't be resolved to an IP address. But, since we only
-                // call this method after ensuring that `host` is a valid IP address, this exception should never occur.
-                return Mono.error(new AppsmithPluginException(
-                        AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, "IP Address resolution is invalid"));
-            }
+        final String canonicalHost;
+        try {
+            canonicalHost = normalizeHostForComparison(host);
+        } catch (UnknownHostException e) {
+            // This exception is thrown, if the given host couldn't be resolved to an IP address. But, since we only
+            // canonicalize after ensuring that `host` is a valid IP address, this exception should never occur.
+            return Mono.error(new AppsmithPluginException(
+                    AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, "IP Address resolution is invalid"));
         }
 
         return DISALLOWED_HOSTS.contains(canonicalHost)
@@ -223,10 +235,68 @@ public class WebClientUtils {
         if (!StringUtils.hasText(host)) {
             return false;
         }
-        if (host.startsWith("[") && host.endsWith("]")) {
-            host = host.substring(1, host.length() - 1);
-        }
+        host = stripHostDecorators(host);
         return inetAddressValidator.isValid(host);
+    }
+
+    private static String normalizeHostForComparison(String host) throws UnknownHostException {
+        if (!StringUtils.hasText(host)) {
+            return host;
+        }
+
+        final String normalizedHost = stripHostDecorators(host.trim().toLowerCase(Locale.ROOT));
+        return isValidIpAddress(normalizedHost) ? normalizeIpAddress(normalizedHost) : normalizedHost;
+    }
+
+    private static String normalizeHostForComparisonQuietly(String host) {
+        try {
+            return normalizeHostForComparison(host);
+        } catch (UnknownHostException e) {
+            return StringUtils.hasText(host) ? stripHostDecorators(host.trim().toLowerCase(Locale.ROOT)) : host;
+        }
+    }
+
+    private static String stripHostDecorators(String host) {
+        String sanitizedHost = host;
+        while (sanitizedHost.endsWith(".")) {
+            sanitizedHost = sanitizedHost.substring(0, sanitizedHost.length() - 1);
+        }
+        if (sanitizedHost.startsWith("[") && sanitizedHost.endsWith("]")) {
+            sanitizedHost = sanitizedHost.substring(1, sanitizedHost.length() - 1);
+        }
+        return sanitizedHost;
+    }
+
+    private static String normalizeIpAddress(String host) throws UnknownHostException {
+        final InetAddress address = InetAddress.getByName(host);
+
+        if (address instanceof Inet6Address) {
+            final byte[] addressBytes = address.getAddress();
+            // Normalize IPv4-compatible and IPv4-mapped IPv6 literals back to the embedded IPv4 address so a single
+            // denylist entry blocks equivalent literal representations such as `100.100.100.200` and
+            // `[::100.100.100.200]`.
+            if (isIpv4CompatibleOrMapped(addressBytes)) {
+                return InetAddress.getByAddress(Arrays.copyOfRange(addressBytes, 12, 16))
+                        .getHostAddress();
+            }
+        }
+
+        return address.getHostAddress();
+    }
+
+    private static boolean isIpv4CompatibleOrMapped(byte[] addressBytes) {
+        if (addressBytes.length != 16) {
+            return false;
+        }
+
+        for (int i = 0; i < 10; i++) {
+            if (addressBytes[i] != 0) {
+                return false;
+            }
+        }
+
+        return (addressBytes[10] == 0 && addressBytes[11] == 0)
+                || (addressBytes[10] == (byte) 0xff && addressBytes[11] == (byte) 0xff);
     }
 
     private static class NameResolver extends InetNameResolver {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
@@ -36,13 +36,13 @@ import java.util.Set;
 @Slf4j
 public class WebClientUtils {
 
+    private static final InetAddressValidator inetAddressValidator = InetAddressValidator.getInstance();
+
     private static final Set<String> DISALLOWED_HOSTS = computeDisallowedHosts();
 
     public static final String HOST_NOT_ALLOWED = "Host not allowed.";
 
     private static final int MAX_IN_MEMORY_SIZE_IN_BYTES = 16 * 1024 * 1024;
-
-    private static final InetAddressValidator inetAddressValidator = InetAddressValidator.getInstance();
 
     public static final ExchangeFilterFunction IP_CHECK_FILTER =
             ExchangeFilterFunction.ofRequestProcessor(WebClientUtils::requestFilterFn);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
@@ -70,6 +70,7 @@ public class WebClientUtils {
         addDisallowedHosts(
                 hosts,
                 "169.254.169.254",
+                "168.63.129.16",
                 "fd00:ec2::254",
                 "fd20:ce::254",
                 "100.100.100.200",

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
@@ -1,0 +1,53 @@
+package com.appsmith.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WebClientUtilsTest {
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "http://100.100.100.200/latest/meta-data",
+                "http://[::100.100.100.200]/latest/meta-data",
+                "http://169.254.10.10/latest/meta-data",
+                "http://169.254.170.2/v2/metadata",
+                "http://[fd20:ce::254]/computeMetadata/v1",
+                "http://Metadata.TencentYun.Com./latest/meta-data"
+            })
+    public void testRequestFilterFnRejectsExpandedMetadataEndpoints(String url) throws Exception {
+        StepVerifier.create(invokeRequestFilterFn(url))
+                .expectErrorSatisfies(throwable -> {
+                    assertTrue(throwable instanceof UnknownHostException);
+                    assertEquals(WebClientUtils.HOST_NOT_ALLOWED, throwable.getMessage());
+                })
+                .verify();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"metadata.tencentyun.com", "Metadata.TencentYun.Com.", "METAdata.google.internal."})
+    public void testIsDisallowedAndFailNormalizesMetadataHostnames(String host) {
+        assertTrue(WebClientUtils.isDisallowedAndFail(host, null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<ClientRequest> invokeRequestFilterFn(String url) throws Exception {
+        final Method method = WebClientUtils.class.getDeclaredMethod("requestFilterFn", ClientRequest.class);
+        method.setAccessible(true);
+
+        final ClientRequest request =
+                ClientRequest.create(HttpMethod.GET, URI.create(url)).build();
+        return (Mono<ClientRequest>) method.invoke(null, request);
+    }
+}

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
@@ -21,6 +21,8 @@ public class WebClientUtilsTest {
             strings = {
                 "http://100.100.100.200/latest/meta-data",
                 "http://[::100.100.100.200]/latest/meta-data",
+                "http://168.63.129.16/metadata/instance",
+                "http://[::168.63.129.16]/metadata/instance",
                 "http://169.254.10.10/latest/meta-data",
                 "http://169.254.170.2/v2/metadata",
                 "http://[fd20:ce::254]/computeMetadata/v1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Fixes APP-15026

- expand the shared metadata denylist with additional well-known metadata endpoints used by Alibaba, Azure, Tencent, ECS task metadata, and GCP IPv6 metadata
- normalize host comparisons so case, trailing dots, and IPv4-compatible IPv6 literals are checked consistently against the denylist
- add focused `WebClientUtils` regression tests for the new denylist coverage

### Validation
- `mvn spotless:apply`
- `mvn -pl appsmith-interfaces -Dtest=WebClientUtilsTest test`
- `mvn -pl appsmith-plugins/restApiPlugin -am -Dtest=RestApiPluginTest#testDenyInstanceMetadataAwsViaCompatibleIpv6Address -Dsurefire.failIfNoSpecifiedTests=false test`

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23350965531>
> Commit: 4737f73e00812957fb6748c74d2070e49ac83577
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23350965531&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 20 Mar 2026 17:06:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a994f158-93b2-4d60-b7d0-c457ff006566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a994f158-93b2-4d60-b7d0-c457ff006566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host normalization and canonicalization to more reliably block additional cloud metadata endpoints (including Tencent variants), IP literal forms, and Docker loopback addresses.

* **Tests**
  * Added parameterized tests verifying request filtering and denylist behavior across IPv4, IPv6, and metadata-hostname variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->