### PR TITLE
ci: run config for jdk 25

### DIFF
--- a/app/server/.run/ServerApplication.run.xml
+++ b/app/server/.run/ServerApplication.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ServerApplication" type="Application" factoryName="Application" nameIsGenerated="true">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-17" />
+    <option name="ALTERNATIVE_JRE_PATH" value="homebrew-25" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.appsmith.server.ServerApplication" />


### PR DESCRIPTION
## Description
Updated ALTERNATIVE_JRE_PATH option from temurin-17 to homebrew-25.

Fixes #`Issue Number` 

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Java runtime environment configuration for the server application to use an alternative runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->