### PR TITLE
chore: docker file cleanup for base JDK removal and install of JDK25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 ARG BASE
 FROM ${BASE}
 
-RUN rm -rf /opt/java \
-  && mkdir -p /opt/java \
-  && arch="$(uname -m | sed 's/x86_64/x64/; s/aarch64/aarch64/')" \
-  && curl --location "https://api.adoptium.net/v3/binary/latest/25/ga/linux/${arch}/jdk/hotspot/normal/eclipse" \
-  | tar -xz -C /opt/java --strip-components 1
-
 ENV IN_DOCKER=1
 
 ARG APPSMITH_CLOUD_SERVICES_BASE_URL


### PR DESCRIPTION
## Description 
This is a housekeeping PR that removes an unnecessary step where we previously deleted the JDK from the base image and reinstalled JDK 25. Since the base image now already includes JDK 25, this manual replacement is no longer required.


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Docker image no longer includes Java runtime by default. Users requiring Java will need to provision it separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->