### PR TITLE
fix: normalize user emails on save to strip invisible Unicode characters

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/EmailNormalizer.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/EmailNormalizer.java
@@ -1,0 +1,38 @@
+package com.appsmith.server.helpers;
+
+import java.text.Normalizer;
+import java.util.regex.Pattern;
+
+public class EmailNormalizer {
+
+    private static final Pattern INVISIBLE_CHAR_PATTERN =
+            Pattern.compile("[\u200B-\u200D\uFEFF\u2060\u00AD\u200C\u200E\u200F\u202A-\u202E\u2061-\u2063]");
+
+    /**
+     * Normalizes an email address by applying NFKC Unicode normalization, stripping invisible
+     * characters, trimming whitespace, and lowercasing. Returns null if the result is empty.
+     */
+    public static String normalizeEmail(String email) {
+        if (email == null) {
+            return null;
+        }
+
+        String normalized = Normalizer.normalize(email, Normalizer.Form.NFKC);
+        normalized = INVISIBLE_CHAR_PATTERN.matcher(normalized).replaceAll("");
+        normalized = normalized.trim();
+        normalized = normalized.toLowerCase();
+
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    /**
+     * Returns true if the email contains invisible Unicode characters that would be stripped
+     * by normalization.
+     */
+    public static boolean containsInvisibleCharacters(String email) {
+        if (email == null) {
+            return false;
+        }
+        return INVISIBLE_CHAR_PATTERN.matcher(email).find();
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -22,6 +22,7 @@ import com.appsmith.server.dtos.UserSignupDTO;
 import com.appsmith.server.dtos.UserUpdateDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.EmailNormalizer;
 import com.appsmith.server.helpers.RedirectHelper;
 import com.appsmith.server.helpers.UserServiceHelper;
 import com.appsmith.server.helpers.UserUtils;
@@ -462,8 +463,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
     public Mono<User> userCreate(User user, boolean isAdminUser) {
         // It is assumed here that the user's password has already been encoded.
 
-        // convert the user email to lowercase
-        user.setEmail(user.getEmail().toLowerCase());
+        user.setEmail(EmailNormalizer.normalizeEmail(user.getEmail()));
 
         Mono<User> userWithOrgMono =
                 Mono.just(user).flatMap(this::setOrganizationIdForUser).cache();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/EmailNormalizerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/EmailNormalizerTest.java
@@ -1,0 +1,68 @@
+package com.appsmith.server.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmailNormalizerTest {
+
+    @Test
+    void normalizeEmail_stripsWordJoiner() {
+        assertThat(EmailNormalizer.normalizeEmail("\u2060user@example.com")).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void normalizeEmail_stripsZeroWidthSpace() {
+        assertThat(EmailNormalizer.normalizeEmail("\u200Buser@example.com")).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void normalizeEmail_stripsMultipleInvisibleChars() {
+        assertThat(EmailNormalizer.normalizeEmail("\u200B\u200C\u2060user@example\uFEFF.com"))
+                .isEqualTo("user@example.com");
+    }
+
+    @Test
+    void normalizeEmail_lowercasesAndTrims() {
+        assertThat(EmailNormalizer.normalizeEmail("  User@Example.COM  ")).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void normalizeEmail_returnsNullForNull() {
+        assertThat(EmailNormalizer.normalizeEmail(null)).isNull();
+    }
+
+    @Test
+    void normalizeEmail_returnsNullForOnlyInvisibleChars() {
+        assertThat(EmailNormalizer.normalizeEmail("\u200B\u2060")).isNull();
+    }
+
+    @Test
+    void normalizeEmail_cleanEmailUnchanged() {
+        assertThat(EmailNormalizer.normalizeEmail("user@example.com")).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void normalizeEmail_isIdempotent() {
+        String once = EmailNormalizer.normalizeEmail("\u2060user@example.com");
+        String twice = EmailNormalizer.normalizeEmail(once);
+        assertThat(once).isEqualTo(twice);
+    }
+
+    @Test
+    void containsInvisibleCharacters_detectsWordJoiner() {
+        assertThat(EmailNormalizer.containsInvisibleCharacters("\u2060user@example.com"))
+                .isTrue();
+    }
+
+    @Test
+    void containsInvisibleCharacters_falseForCleanEmail() {
+        assertThat(EmailNormalizer.containsInvisibleCharacters("user@example.com"))
+                .isFalse();
+    }
+
+    @Test
+    void containsInvisibleCharacters_falseForNull() {
+        assertThat(EmailNormalizer.containsInvisibleCharacters(null)).isFalse();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -218,8 +218,6 @@ public class UserServiceTest {
         newUser.setEmail(sampleEmail);
         newUser.setPassword("new-user-test-password");
 
-        Mono<User> usercreateMono = userService.create(newUser).cache();
-
         Mono<User> userCreateMono = userService.create(newUser).cache();
 
         Mono<PermissionGroup> permissionGroupMono = userCreateMono.flatMap(user -> {
@@ -261,6 +259,107 @@ public class UserServiceTest {
                     assertThat(optionalViewUserPolicy.get().getPermissionGroups())
                             .contains(permissionGroup.getId());
                     assertThat(permissionGroup.getAssignedToUserIds()).containsAll(Set.of(user.getId()));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void createNewUser_WhenEmailHasInvisibleUnicode_SavedNormalized() {
+        String dirtyEmail = "\u2060new-invisible-char-user@example.com";
+        String expectedCleanEmail = "new-invisible-char-user@example.com";
+
+        User newUser = new User();
+        newUser.setEmail(dirtyEmail);
+        newUser.setPassword("test-password-123");
+
+        Mono<User> userCreateMono = userService.create(newUser);
+
+        StepVerifier.create(userCreateMono)
+                .assertNext(user -> {
+                    assertThat(user).isNotNull();
+                    assertThat(user.getEmail()).isEqualTo(expectedCleanEmail);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void createNewUser_WhenEmailHasMultipleDirtyChars_SavedFullyNormalized() {
+        String dirtyEmail = "  \u200B\u200CNew-Multi-Dirty@Example\uFEFF.COM  ";
+        String expectedCleanEmail = "new-multi-dirty@example.com";
+
+        User newUser = new User();
+        newUser.setEmail(dirtyEmail);
+        newUser.setPassword("test-password-123");
+
+        Mono<User> userCreateMono = userService.create(newUser);
+
+        StepVerifier.create(userCreateMono)
+                .assertNext(user -> {
+                    assertThat(user).isNotNull();
+                    assertThat(user.getEmail()).isEqualTo(expectedCleanEmail);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void createNewUser_WhenCleanEmail_SavedUnchanged() {
+        String cleanEmail = "clean-email-unchanged@example.com";
+
+        User newUser = new User();
+        newUser.setEmail(cleanEmail);
+        newUser.setPassword("test-password-123");
+
+        Mono<User> userCreateMono = userService.create(newUser);
+
+        StepVerifier.create(userCreateMono)
+                .assertNext(user -> {
+                    assertThat(user).isNotNull();
+                    assertThat(user.getEmail()).isEqualTo(cleanEmail);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void signUpViaFormLogin_WhenEmailHasInvisibleUnicode_SavedNormalized() {
+        String dirtyEmail = "\u200Bform-signup-dirty@example.com";
+        String expectedCleanEmail = "form-signup-dirty@example.com";
+
+        User signupUser = new User();
+        signupUser.setEmail(dirtyEmail);
+        signupUser.setPassword("test-password-123");
+        signupUser.setSource(LoginSource.FORM);
+
+        Mono<User> userMono = userService.create(signupUser);
+
+        StepVerifier.create(userMono)
+                .assertNext(user -> {
+                    assertThat(user.getEmail()).isEqualTo(expectedCleanEmail);
+                    assertThat(user.getSource()).isEqualTo(LoginSource.FORM);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void signUpViaGoogle_WhenEmailHasInvisibleUnicode_SavedNormalized() {
+        String dirtyEmail = "\u2060google-signup-dirty@example.com";
+        String expectedCleanEmail = "google-signup-dirty@example.com";
+
+        User signupUser = new User();
+        signupUser.setEmail(dirtyEmail);
+        signupUser.setPassword("test-password-123");
+        signupUser.setSource(LoginSource.GOOGLE);
+
+        Mono<User> userMono = userService.create(signupUser);
+
+        StepVerifier.create(userMono)
+                .assertNext(user -> {
+                    assertThat(user.getEmail()).isEqualTo(expectedCleanEmail);
+                    assertThat(user.getSource()).isEqualTo(LoginSource.GOOGLE);
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
EE PR: https://github.com/appsmithorg/appsmith-ee/pull/8830

## Summary

- Add `EmailNormalizer` utility to strip invisible Unicode characters (U+2060, U+200B, etc.), apply NFKC normalization, trim, and lowercase emails
- Add collision-aware `ReactiveBeforeSaveCallback<User>` that normalizes emails on every User save, regardless of entry point
- When normalization would collide with an existing user (dirty + clean duplicate pair), normalization is skipped to avoid data loss

This is a defense-in-depth measure complementing the cloud-services fixes in [APP-15054](https://linear.app/appsmith/issue/APP-15054) and [APP-15055](https://linear.app/appsmith/issue/APP-15055).

## Slack Thread

https://theappsmith.slack.com/archives/C0341RERY4R/p1774364105450899?thread_ts=1767798360.977899&cid=C0341RERY4R

## Test Plan

- [x] Unit tests for `EmailNormalizer` (invisible char stripping, idempotency, null handling)
- [x] Unit tests for `UserBeforeSaveCallback` (normalization, collision skip, clean email no-op, non-user collection no-op)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced email address normalization during user registration and authentication to remove hidden formatting characters and ensure consistent email matching and comparison across the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23641217711>
> Commit: 9bc4b3782c73f7ef9181974a2bfa639a91d2e822
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23641217711&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 27 Mar 2026 11:24:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->
