### PR TITLE
fix(security): block SSRF via send-test-email SMTP host validation (GHSA-vvxf-f8q9-86gh)

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 @Slf4j
@@ -196,6 +197,47 @@ public class WebClientUtils {
         protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) {
             return new InetSocketAddressResolver(executor, new NameResolver(executor));
         }
+    }
+
+    /**
+     * Validates that a hostname or IP is safe for outbound connections from non-HTTP paths
+     * (e.g. SMTP via JavaMail). Checks against the cloud-metadata denylist and, after DNS
+     * resolution, rejects loopback, link-local, site-local, and other non-routable addresses.
+     *
+     * @return empty if the host is allowed; a reason string if it must be blocked
+     */
+    public static Optional<String> validateHostNotDisallowed(String host) {
+        if (!StringUtils.hasText(host)) {
+            return Optional.of("Host is null or empty.");
+        }
+
+        final String canonicalHost = normalizeHostForComparisonQuietly(host);
+
+        if (DISALLOWED_HOSTS.contains(canonicalHost)) {
+            return Optional.of(HOST_NOT_ALLOWED);
+        }
+
+        final InetAddress[] resolved;
+        try {
+            resolved = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            return Optional.of("Unable to resolve host.");
+        }
+
+        for (InetAddress addr : resolved) {
+            if (DISALLOWED_HOSTS.contains(normalizeHostForComparisonQuietly(addr.getHostAddress()))) {
+                return Optional.of(HOST_NOT_ALLOWED);
+            }
+            if (addr.isLoopbackAddress()
+                    || addr.isLinkLocalAddress()
+                    || addr.isSiteLocalAddress()
+                    || addr.isAnyLocalAddress()
+                    || addr.isMulticastAddress()) {
+                return Optional.of(HOST_NOT_ALLOWED);
+            }
+        }
+
+        return Optional.empty();
     }
 
     public static boolean isDisallowedAndFail(String host, Promise<?> promise) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
@@ -200,44 +200,54 @@ public class WebClientUtils {
     }
 
     /**
-     * Validates that a hostname or IP is safe for outbound connections from non-HTTP paths
-     * (e.g. SMTP via JavaMail). Checks against the cloud-metadata denylist and, after DNS
-     * resolution, rejects loopback, link-local, site-local, and other non-routable addresses.
+     * Resolves a hostname and validates that none of its addresses are disallowed for
+     * outbound connections from non-HTTP paths (e.g. SMTP via JavaMail). Checks against
+     * the cloud-metadata denylist, loopback, link-local, any-local, multicast, and IPv6
+     * Unique Local Addresses (fc00::/7). Returns the first validated resolved address so
+     * callers can connect to it directly, preventing DNS-rebinding TOCTOU bypasses.
      *
-     * @return empty if the host is allowed; a reason string if it must be blocked
+     * <p>RFC 1918 site-local ranges (10/8, 172.16/12, 192.168/16) are intentionally
+     * allowed because legitimate SMTP servers frequently reside on private networks.
+     *
+     * @return the resolved {@link InetAddress} if the host is allowed, or empty if blocked
      */
-    public static Optional<String> validateHostNotDisallowed(String host) {
+    public static Optional<InetAddress> resolveIfAllowed(String host) {
         if (!StringUtils.hasText(host)) {
-            return Optional.of("Host is null or empty.");
+            return Optional.empty();
         }
 
         final String canonicalHost = normalizeHostForComparisonQuietly(host);
 
         if (DISALLOWED_HOSTS.contains(canonicalHost)) {
-            return Optional.of(HOST_NOT_ALLOWED);
+            return Optional.empty();
         }
 
         final InetAddress[] resolved;
         try {
             resolved = InetAddress.getAllByName(host);
         } catch (UnknownHostException e) {
-            return Optional.of("Unable to resolve host.");
+            return Optional.empty();
         }
 
         for (InetAddress addr : resolved) {
             if (DISALLOWED_HOSTS.contains(normalizeHostForComparisonQuietly(addr.getHostAddress()))) {
-                return Optional.of(HOST_NOT_ALLOWED);
+                return Optional.empty();
+            }
+            if (addr instanceof Inet6Address) {
+                byte firstByte = addr.getAddress()[0];
+                if ((firstByte & (byte) 0xFE) == (byte) 0xFC) {
+                    return Optional.empty();
+                }
             }
             if (addr.isLoopbackAddress()
                     || addr.isLinkLocalAddress()
-                    || addr.isSiteLocalAddress()
                     || addr.isAnyLocalAddress()
                     || addr.isMulticastAddress()) {
-                return Optional.of(HOST_NOT_ALLOWED);
+                return Optional.empty();
             }
         }
 
-        return Optional.empty();
+        return Optional.of(resolved[0]);
     }
 
     public static boolean isDisallowedAndFail(String host, Promise<?> promise) {

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
@@ -9,6 +9,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.Optional;
@@ -49,44 +50,48 @@ public class WebClientUtilsTest {
     @ValueSource(
             strings = {
                 "127.0.0.1",
-                "10.0.0.1",
-                "192.168.1.1",
-                "172.16.0.1",
                 "169.254.169.254",
                 "169.254.10.10",
                 "100.100.100.200",
                 "168.63.129.16",
                 "0.0.0.0",
             })
-    public void validateHostNotDisallowed_blocksPrivateAndMetadataHosts(String host) {
-        Optional<String> result = WebClientUtils.validateHostNotDisallowed(host);
-        assertTrue(result.isPresent(), "Expected host " + host + " to be blocked");
+    public void resolveIfAllowed_blocksLoopbackMetadataAndSpecialHosts(String host) {
+        Optional<InetAddress> result = WebClientUtils.resolveIfAllowed(host);
+        assertTrue(result.isEmpty(), "Expected host " + host + " to be blocked");
     }
 
     @Test
-    public void validateHostNotDisallowed_blocksNullAndEmpty() {
-        assertTrue(WebClientUtils.validateHostNotDisallowed(null).isPresent());
-        assertTrue(WebClientUtils.validateHostNotDisallowed("").isPresent());
-        assertTrue(WebClientUtils.validateHostNotDisallowed("  ").isPresent());
+    public void resolveIfAllowed_blocksNullAndEmpty() {
+        assertTrue(WebClientUtils.resolveIfAllowed(null).isEmpty());
+        assertTrue(WebClientUtils.resolveIfAllowed("").isEmpty());
+        assertTrue(WebClientUtils.resolveIfAllowed("  ").isEmpty());
     }
 
     @Test
-    public void validateHostNotDisallowed_blocksLocalhostHostname() {
-        Optional<String> result = WebClientUtils.validateHostNotDisallowed("localhost");
-        assertTrue(result.isPresent(), "Expected 'localhost' to be blocked");
+    public void resolveIfAllowed_blocksLocalhostHostname() {
+        Optional<InetAddress> result = WebClientUtils.resolveIfAllowed("localhost");
+        assertTrue(result.isEmpty(), "Expected 'localhost' to be blocked");
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"smtp.gmail.com", "email-smtp.us-east-1.amazonaws.com", "smtp.sendgrid.net"})
-    public void validateHostNotDisallowed_allowsLegitimateSmtpHosts(String host) {
-        Optional<String> result = WebClientUtils.validateHostNotDisallowed(host);
-        assertTrue(result.isEmpty(), "Expected host " + host + " to be allowed, but got: " + result.orElse(""));
+    public void resolveIfAllowed_allowsLegitimateSmtpHosts(String host) {
+        Optional<InetAddress> result = WebClientUtils.resolveIfAllowed(host);
+        assertTrue(result.isPresent(), "Expected host " + host + " to be allowed");
     }
 
     @Test
-    public void validateHostNotDisallowed_blocksUnresolvableHost() {
-        Optional<String> result = WebClientUtils.validateHostNotDisallowed("definitely-not-a-real-host-xyz123.invalid");
-        assertTrue(result.isPresent(), "Expected unresolvable host to be blocked");
+    public void resolveIfAllowed_blocksUnresolvableHost() {
+        Optional<InetAddress> result = WebClientUtils.resolveIfAllowed("definitely-not-a-real-host-xyz123.invalid");
+        assertTrue(result.isEmpty(), "Expected unresolvable host to be blocked");
+    }
+
+    @Test
+    public void resolveIfAllowed_returnsResolvedAddress() {
+        Optional<InetAddress> result = WebClientUtils.resolveIfAllowed("smtp.gmail.com");
+        assertTrue(result.isPresent());
+        assertTrue(result.get().getHostAddress().matches("\\d+\\.\\d+\\.\\d+\\.\\d+"));
     }
 
     @SuppressWarnings("unchecked")

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
@@ -1,5 +1,6 @@
 package com.appsmith.util;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpMethod;
@@ -10,6 +11,7 @@ import reactor.test.StepVerifier;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,6 +43,50 @@ public class WebClientUtilsTest {
     @ValueSource(strings = {"metadata.tencentyun.com", "Metadata.TencentYun.Com.", "METAdata.google.internal."})
     public void testIsDisallowedAndFailNormalizesMetadataHostnames(String host) {
         assertTrue(WebClientUtils.isDisallowedAndFail(host, null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "127.0.0.1",
+                "10.0.0.1",
+                "192.168.1.1",
+                "172.16.0.1",
+                "169.254.169.254",
+                "169.254.10.10",
+                "100.100.100.200",
+                "168.63.129.16",
+                "0.0.0.0",
+            })
+    public void validateHostNotDisallowed_blocksPrivateAndMetadataHosts(String host) {
+        Optional<String> result = WebClientUtils.validateHostNotDisallowed(host);
+        assertTrue(result.isPresent(), "Expected host " + host + " to be blocked");
+    }
+
+    @Test
+    public void validateHostNotDisallowed_blocksNullAndEmpty() {
+        assertTrue(WebClientUtils.validateHostNotDisallowed(null).isPresent());
+        assertTrue(WebClientUtils.validateHostNotDisallowed("").isPresent());
+        assertTrue(WebClientUtils.validateHostNotDisallowed("  ").isPresent());
+    }
+
+    @Test
+    public void validateHostNotDisallowed_blocksLocalhostHostname() {
+        Optional<String> result = WebClientUtils.validateHostNotDisallowed("localhost");
+        assertTrue(result.isPresent(), "Expected 'localhost' to be blocked");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"smtp.gmail.com", "email-smtp.us-east-1.amazonaws.com", "smtp.sendgrid.net"})
+    public void validateHostNotDisallowed_allowsLegitimateSmtpHosts(String host) {
+        Optional<String> result = WebClientUtils.validateHostNotDisallowed(host);
+        assertTrue(result.isEmpty(), "Expected host " + host + " to be allowed, but got: " + result.orElse(""));
+    }
+
+    @Test
+    public void validateHostNotDisallowed_blocksUnresolvableHost() {
+        Optional<String> result = WebClientUtils.validateHostNotDisallowed("definitely-not-a-real-host-xyz123.invalid");
+        assertTrue(result.isPresent(), "Expected unresolvable host to be blocked");
     }
 
     @SuppressWarnings("unchecked")

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -790,14 +790,13 @@ public class EnvManagerCEImpl implements EnvManagerCE {
     @Override
     public Mono<Boolean> sendTestEmail(TestEmailConfigRequestDTO requestDTO) {
         return verifyCurrentUserIsSuper().flatMap(user -> {
-            var hostCheckResult = WebClientUtils.validateHostNotDisallowed(requestDTO.getSmtpHost());
-            if (hostCheckResult.isPresent()) {
-                return Mono.error(new AppsmithException(
-                        AppsmithError.GENERIC_BAD_REQUEST, "Invalid SMTP host: " + hostCheckResult.get()));
+            var resolvedAddress = WebClientUtils.resolveIfAllowed(requestDTO.getSmtpHost());
+            if (resolvedAddress.isEmpty()) {
+                return Mono.error(new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Invalid SMTP host."));
             }
 
             JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-            mailSender.setHost(requestDTO.getSmtpHost());
+            mailSender.setHost(resolvedAddress.get().getHostAddress());
             mailSender.setPort(requestDTO.getSmtpPort());
 
             Properties props = mailSender.getJavaMailProperties();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -784,15 +784,42 @@ public class EnvManagerCEImpl implements EnvManagerCE {
         return Mono.empty();
     }
 
+    private static final Set<Integer> DEFAULT_SMTP_PORTS = Set.of(25, 465, 587, 2525);
+
+    private static final Set<Integer> ALLOWED_SMTP_PORTS = computeAllowedSmtpPorts();
+
+    private static Set<Integer> computeAllowedSmtpPorts() {
+        Set<Integer> ports = new HashSet<>(DEFAULT_SMTP_PORTS);
+        String extra = System.getenv("APPSMITH_MAIL_ALLOWED_PORTS");
+        if (extra != null && !extra.isBlank()) {
+            for (String token : extra.split(",")) {
+                try {
+                    int port = Integer.parseInt(token.trim());
+                    if (port > 0 && port <= 65535) {
+                        ports.add(port);
+                    }
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        return Set.copyOf(ports);
+    }
+
     private static final String SMTP_GENERIC_ERROR =
             "Failed to connect to the SMTP server. Please verify the host, " + "port, and credentials are correct.";
 
     @Override
     public Mono<Boolean> sendTestEmail(TestEmailConfigRequestDTO requestDTO) {
         return verifyCurrentUserIsSuper().flatMap(user -> {
+            if (!ALLOWED_SMTP_PORTS.contains(requestDTO.getSmtpPort())) {
+                return Mono.error(
+                        new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Invalid SMTP configuration."));
+            }
+
             var resolvedAddress = WebClientUtils.resolveIfAllowed(requestDTO.getSmtpHost());
             if (resolvedAddress.isEmpty()) {
-                return Mono.error(new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Invalid SMTP host."));
+                return Mono.error(
+                        new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Invalid SMTP configuration."));
             }
 
             JavaMailSenderImpl mailSender = new JavaMailSenderImpl();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -829,8 +829,14 @@ public class EnvManagerCEImpl implements EnvManagerCE {
             Properties props = mailSender.getJavaMailProperties();
             props.put("mail.transport.protocol", "smtp");
 
-            props.put(
-                    "mail.smtp.starttls.enable", requestDTO.getStarttlsEnabled().toString());
+            if (requestDTO.getSmtpPort() == 465) {
+                props.put("mail.smtp.ssl.enable", "true");
+                props.put("mail.smtp.starttls.enable", "false");
+            } else {
+                props.put(
+                        "mail.smtp.starttls.enable",
+                        requestDTO.getStarttlsEnabled().toString());
+            }
 
             props.put("mail.smtp.timeout", 7000); // 7 seconds
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -28,6 +28,7 @@ import com.appsmith.server.services.OrganizationService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserService;
+import com.appsmith.util.WebClientUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.mail.MessagingException;
@@ -783,9 +784,18 @@ public class EnvManagerCEImpl implements EnvManagerCE {
         return Mono.empty();
     }
 
+    private static final String SMTP_GENERIC_ERROR =
+            "Failed to connect to the SMTP server. Please verify the host, " + "port, and credentials are correct.";
+
     @Override
     public Mono<Boolean> sendTestEmail(TestEmailConfigRequestDTO requestDTO) {
         return verifyCurrentUserIsSuper().flatMap(user -> {
+            var hostCheckResult = WebClientUtils.validateHostNotDisallowed(requestDTO.getSmtpHost());
+            if (hostCheckResult.isPresent()) {
+                return Mono.error(new AppsmithException(
+                        AppsmithError.GENERIC_BAD_REQUEST, "Invalid SMTP host: " + hostCheckResult.get()));
+            }
+
             JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
             mailSender.setHost(requestDTO.getSmtpHost());
             mailSender.setPort(requestDTO.getSmtpPort());
@@ -817,15 +827,15 @@ public class EnvManagerCEImpl implements EnvManagerCE {
             try {
                 mailSender.testConnection();
             } catch (MessagingException e) {
-                return Mono.error(new AppsmithException(
-                        AppsmithError.GENERIC_BAD_REQUEST, e.getMessage().trim()));
+                log.error("SMTP test-connection failed for host {}", requestDTO.getSmtpHost(), e);
+                return Mono.error(new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, SMTP_GENERIC_ERROR));
             }
 
             try {
                 mailSender.send(message);
             } catch (MailException mailException) {
                 log.error("failed to send test email", mailException);
-                return Mono.error(new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, mailException.getMessage()));
+                return Mono.error(new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, SMTP_GENERIC_ERROR));
             }
             return Mono.just(TRUE);
         });

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -4,6 +4,7 @@ import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.configurations.GoogleRecaptchaConfig;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.TestEmailConfigRequestDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.BlacklistedEnvVariableHelper;
@@ -381,6 +382,70 @@ public class EnvManagerTest {
 
         StepVerifier.create(envManager.sendTestEmail(null))
                 .expectErrorMessage(AppsmithError.UNAUTHORIZED_ACCESS.getMessage())
+                .verify();
+    }
+
+    private void mockSuperUser() {
+        User user = new User();
+        user.setEmail("admin@appsmith.com");
+        Mockito.when(userUtils.isCurrentUserSuperUser()).thenReturn(Mono.just(true));
+        Mockito.when(sessionUserService.getCurrentUser()).thenReturn(Mono.just(user));
+    }
+
+    private TestEmailConfigRequestDTO buildDto(String smtpHost) {
+        TestEmailConfigRequestDTO dto = new TestEmailConfigRequestDTO();
+        dto.setSmtpHost(smtpHost);
+        dto.setSmtpPort(25);
+        dto.setFromEmail("test@appsmith.com");
+        dto.setStarttlsEnabled(false);
+        return dto;
+    }
+
+    @Test
+    public void sendTestEmail_WhenLocalhostHost_ThrowsException() {
+        mockSuperUser();
+
+        StepVerifier.create(envManager.sendTestEmail(buildDto("127.0.0.1")))
+                .expectErrorSatisfies(e -> {
+                    assertThat(e).isInstanceOf(AppsmithException.class);
+                    assertThat(e.getMessage()).contains("Invalid SMTP host");
+                })
+                .verify();
+    }
+
+    @Test
+    public void sendTestEmail_WhenCloudMetadataHost_ThrowsException() {
+        mockSuperUser();
+
+        StepVerifier.create(envManager.sendTestEmail(buildDto("169.254.169.254")))
+                .expectErrorSatisfies(e -> {
+                    assertThat(e).isInstanceOf(AppsmithException.class);
+                    assertThat(e.getMessage()).contains("Invalid SMTP host");
+                })
+                .verify();
+    }
+
+    @Test
+    public void sendTestEmail_WhenPrivateNetworkHost_ThrowsException() {
+        mockSuperUser();
+
+        StepVerifier.create(envManager.sendTestEmail(buildDto("10.0.0.1")))
+                .expectErrorSatisfies(e -> {
+                    assertThat(e).isInstanceOf(AppsmithException.class);
+                    assertThat(e.getMessage()).contains("Invalid SMTP host");
+                })
+                .verify();
+    }
+
+    @Test
+    public void sendTestEmail_WhenLocalhost_ThrowsException() {
+        mockSuperUser();
+
+        StepVerifier.create(envManager.sendTestEmail(buildDto("localhost")))
+                .expectErrorSatisfies(e -> {
+                    assertThat(e).isInstanceOf(AppsmithException.class);
+                    assertThat(e.getMessage()).contains("Invalid SMTP host");
+                })
                 .verify();
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -395,9 +395,13 @@ public class EnvManagerTest {
     }
 
     private TestEmailConfigRequestDTO buildDto(String smtpHost) {
+        return buildDto(smtpHost, 25);
+    }
+
+    private TestEmailConfigRequestDTO buildDto(String smtpHost, int port) {
         TestEmailConfigRequestDTO dto = new TestEmailConfigRequestDTO();
         dto.setSmtpHost(smtpHost);
-        dto.setSmtpPort(25);
+        dto.setSmtpPort(port);
         dto.setFromEmail("test@appsmith.com");
         dto.setStarttlsEnabled(false);
         return dto;
@@ -411,7 +415,20 @@ public class EnvManagerTest {
         StepVerifier.create(envManager.sendTestEmail(buildDto(host)))
                 .expectErrorSatisfies(e -> {
                     assertThat(e).isInstanceOf(AppsmithException.class);
-                    assertThat(e.getMessage()).contains("Invalid SMTP host");
+                    assertThat(e.getMessage()).contains("Invalid SMTP configuration");
+                })
+                .verify();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {80, 443, 6379, 8080, 27017, 0, -1})
+    public void sendTestEmail_WhenDisallowedPort_ThrowsException(int port) {
+        mockSuperUser();
+
+        StepVerifier.create(envManager.sendTestEmail(buildDto("smtp.gmail.com", port)))
+                .expectErrorSatisfies(e -> {
+                    assertThat(e).isInstanceOf(AppsmithException.class);
+                    assertThat(e.getMessage()).contains("Invalid SMTP configuration");
                 })
                 .verify();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -25,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -401,47 +403,12 @@ public class EnvManagerTest {
         return dto;
     }
 
-    @Test
-    public void sendTestEmail_WhenLocalhostHost_ThrowsException() {
+    @ParameterizedTest
+    @ValueSource(strings = {"127.0.0.1", "169.254.169.254", "localhost"})
+    public void sendTestEmail_WhenBlockedHost_ThrowsException(String host) {
         mockSuperUser();
 
-        StepVerifier.create(envManager.sendTestEmail(buildDto("127.0.0.1")))
-                .expectErrorSatisfies(e -> {
-                    assertThat(e).isInstanceOf(AppsmithException.class);
-                    assertThat(e.getMessage()).contains("Invalid SMTP host");
-                })
-                .verify();
-    }
-
-    @Test
-    public void sendTestEmail_WhenCloudMetadataHost_ThrowsException() {
-        mockSuperUser();
-
-        StepVerifier.create(envManager.sendTestEmail(buildDto("169.254.169.254")))
-                .expectErrorSatisfies(e -> {
-                    assertThat(e).isInstanceOf(AppsmithException.class);
-                    assertThat(e.getMessage()).contains("Invalid SMTP host");
-                })
-                .verify();
-    }
-
-    @Test
-    public void sendTestEmail_WhenPrivateNetworkHost_ThrowsException() {
-        mockSuperUser();
-
-        StepVerifier.create(envManager.sendTestEmail(buildDto("10.0.0.1")))
-                .expectErrorSatisfies(e -> {
-                    assertThat(e).isInstanceOf(AppsmithException.class);
-                    assertThat(e.getMessage()).contains("Invalid SMTP host");
-                })
-                .verify();
-    }
-
-    @Test
-    public void sendTestEmail_WhenLocalhost_ThrowsException() {
-        mockSuperUser();
-
-        StepVerifier.create(envManager.sendTestEmail(buildDto("localhost")))
+        StepVerifier.create(envManager.sendTestEmail(buildDto(host)))
                 .expectErrorSatisfies(e -> {
                     assertThat(e).isInstanceOf(AppsmithException.class);
                     assertThat(e.getMessage()).contains("Invalid SMTP host");


### PR DESCRIPTION
## Description

**TL;DR:** The `POST /api/v1/admin/send-test-email` endpoint was vulnerable to SSRF (CWE-918) and error-based information disclosure (CWE-209). Attacker-controlled `smtpHost`/`smtpPort` were passed directly to JavaMail, bypassing the `WebClientUtils.IP_CHECK_FILTER` that only protects HTTP requests. This fix adds host validation and sanitizes error messages.

### Root Cause
`EnvManagerCEImpl.sendTestEmail()` accepted user-controlled SMTP host/port and established raw TCP connections via `JavaMailSenderImpl` without any IP validation. The existing `WebClientUtils.IP_CHECK_FILTER` only applies to Spring WebClient HTTP requests — a completely separate code path from JavaMail SMTP.

### Changes
1. **`WebClientUtils.validateHostNotDisallowed()`** — new reusable method that checks a hostname against the existing cloud-metadata denylist, resolves it via DNS, and rejects loopback, link-local, site-local, any-local, and multicast addresses.
2. **`EnvManagerCEImpl.sendTestEmail()`** — calls the new validation before connecting. Error messages from `MessagingException`/`MailException` are no longer returned verbatim to the caller, preventing error-based port scanning.
3. **Tests** — added parameterized tests in `WebClientUtilsTest` for blocked hosts (private ranges, metadata IPs, localhost, unresolvable) and allowed hosts (legitimate SMTP servers). Added SSRF regression tests in `EnvManagerTest`.

Fixes https://linear.app/appsmith/issue/APP-15034/ssrf-via-post-apiv1adminsend-test-email-javamail-bypasses-webclient-ip
Advisory: [GHSA-vvxf-f8q9-86gh](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-vvxf-f8q9-86gh)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23764710161>
> Commit: ead902522adcef370125b3c433f2cc24f1363cc6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23764710161&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 30 Mar 2026 21:09:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound SMTP host validation and resolution to block disallowed, private, loopback, link-local, multicast, and unresolvable hosts; connections use resolved addresses.
  * Enforced an allowed SMTP-port list and adjusted TLS/SSL behavior for secure port handling.

* **Bug Fixes**
  * Fail-fast for invalid SMTP configuration and unified, non-sensitive error messaging on connection/send failures.

* **Tests**
  * Expanded tests covering blocked/allowed hosts, null/empty input, unresolvable hosts, and disallowed ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->