### PR TITLE
fix(security): mitigate CVE-2026-22732 — Spring Security HTTP headers not written

### DIFF
--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.11</version>
+        <version>3.5.12</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -30,6 +30,8 @@
         <jackson-bom.version>2.17.0</jackson-bom.version>
         <jackson.version>2.17.0</jackson.version>
         <java.version>25</java.version>
+        <!-- Pin Lombok to 1.18.42 to avoid breaking @FieldNameConstants inner class constructor change in 1.18.44 -->
+        <lombok.version>1.18.42</lombok.version>
         <javadoc.disabled>true</javadoc.disabled>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -30,9 +30,9 @@
         <jackson-bom.version>2.17.0</jackson-bom.version>
         <jackson.version>2.17.0</jackson.version>
         <java.version>25</java.version>
+        <javadoc.disabled>true</javadoc.disabled>
         <!-- Pin Lombok to 1.18.42 to avoid breaking @FieldNameConstants inner class constructor change in 1.18.44 -->
         <lombok.version>1.18.42</lombok.version>
-        <javadoc.disabled>true</javadoc.disabled>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <mockito.version>4.4.0</mockito.version>


### PR DESCRIPTION
## Description

**TL;DR:** Upgrades Spring Boot from 3.5.11 to 3.5.12 to mitigate [CVE-2026-22732](https://spring.io/security/cve-2026-22732) (CVSS 9.1 — Critical), a vulnerability where Spring Security HTTP response headers may not be written under certain conditions.

### What is CVE-2026-22732?

Under some conditions, Spring Security fails to write HTTP response headers (such as `Cache-Control`, `Pragma`, `X-Content-Type-Options`) for servlet applications. This can expose applications to:

- **Data leakage** through browser and proxy caching mechanisms
- **Clickjacking** due to missing frame-options headers
- **XSS via MIME-sniffing** due to missing content-type-options headers

**Affected versions:** Spring Security 6.5.0 – 6.5.8  
**Fix version:** Spring Security **6.5.9**  
**Advisory:** https://spring.io/security/cve-2026-22732

### Why upgrade Spring Boot instead of just overriding `spring-security.version`?

Two approaches were evaluated:

| Approach | Pros | Cons |
|---|---|---|
| Override `spring-security.version` to 6.5.9 | Narrowest change | Creates version skew — Security 6.5.9 was tested with Framework 6.2.17, not 6.2.16. Breaks the BOM compatibility contract. |
| **Upgrade Spring Boot 3.5.11 → 3.5.12** | All dependencies tested together by the Spring Boot team. Gets both Security 6.5.9 + Framework 6.2.17. | More transitive dependency changes (all patch-level). |

**We chose Option B** because:

1. **Spring Boot 3.5.12** was released on March 19, 2026 — the same day as the CVE disclosure — specifically to address this vulnerability
2. All dependency changes are **patch-level bumps** within the same minor versions (Reactor 2024.0.15→16, Micrometer 1.15.9→10, etc.)
3. The libraries that changed beyond Spring itself (Kafka, Hibernate, Jetty, Pulsar) are **not direct dependencies** of the Appsmith server module — zero runtime impact
4. Keeps the BOM's **tested-together guarantee** intact rather than introducing manual version overrides

### Lombok pin

Spring Boot 3.5.12 bumps Lombok from 1.18.42 to 1.18.44. Lombok 1.18.44 introduced a breaking change where `@FieldNameConstants` generates inner `Fields` classes with **private constructors**, which broke the project's pattern of subclassing `BaseDomain.Fields` across 13 domain classes. The fix pins Lombok back to 1.18.42 via `<lombok.version>1.18.42</lombok.version>` — the same pattern already used in the project for Jackson and SnakeYAML overrides.

### Applicability note

While the CVE advisory specifically states "servlet applications" and Appsmith uses **WebFlux (reactive)**, the vulnerable `spring-security-web` jar is on the classpath. Upgrading is prudent for compliance, defense-in-depth, and because the reactive header-writing code shares internals with the servlet path.

### Changes

- `app/server/pom.xml`: Bump `spring-boot-starter-parent` from `3.5.11` → `3.5.12`
- `app/server/pom.xml`: Pin `<lombok.version>1.18.42</lombok.version>` to avoid `@FieldNameConstants` breakage

### Verification

| Check | Result |
|---|---|
| Spring Security version | 6.5.9 (patched) |
| Spring Framework version | 6.2.17 (patched) |
| Lombok version | 1.18.42 (pinned) |
| Full project build (`./build.sh -DskipTests -T 8`, 31 modules) | BUILD SUCCESS |
| Unit tests (reactive-caching, appsmith-interfaces, appsmith-git) | All 68 passed |
| appsmith-server unit tests (non-Spring-context) | All passed |

Fixes https://spring.io/security/cve-2026-22732
Fixes https://linear.app/appsmith/issue/APP-15061/critical-cve-2026-22732-spring-security-http-headers-not-written

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23677516478>
> Commit: e2bec36597795a5b783a2bec0e685d56a22c68a3
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23677516478&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Sat, 28 Mar 2026 09:31:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Spring Boot parent version to 3.5.12.
  * Added and set Lombok version to 1.18.42 and configured the build to use this Lombok version for compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->