### PR TITLE
docs: Fix incorrect path to .env.example in ClientSetup.md

### DIFF
--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -54,7 +54,7 @@ On your development machine, please ensure that:
         cat /etc/hosts | grep appsmith
         ```
 
-1. Run cmd: `cp .env.example .env`
+1. Run cmd: `cp ../../.env.example .env` (from the `app/client` directory)
 1. Run Backend server
 
    - The backend server can be run in two ways


### PR DESCRIPTION
## Summary

Fixed the documentation path for copying the .env.example file in the ClientSetup.md guide.

## Problem

The documentation at  instructed users to run  from what appears to be the  directory context, but the  file is located at the repository root, not in .

## Solution

Updated the instruction to use the correct relative path: 

## Changes

- : Fixed the path from  to 

Fixes #41586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to reflect the correct file path and working directory context for environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->