### PR TITLE
fix(security): upgrade handlebars to 4.7.9 to fix CVE-2026-33937

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -435,6 +435,7 @@
     "formidable": "2.1.3",
     "brace-expansion": "1.1.12",
     "form-data": "4.0.4",
-    "fast-xml-parser": "4.5.4"
+    "fast-xml-parser": "4.5.4",
+    "handlebars": "4.7.9"
   }
 }

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -21007,12 +21007,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.4.3":
-  version: 4.7.7
-  resolution: "handlebars@npm:4.7.7"
+"handlebars@npm:4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: ^1.2.5
-    neo-async: ^2.6.0
+    neo-async: ^2.6.2
     source-map: ^0.6.1
     uglify-js: ^3.1.4
     wordwrap: ^1.0.0
@@ -21021,7 +21021,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 1e79a43f5e18d15742977cb987923eab3e2a8f44f2d9d340982bcb69e1735ed049226e534d7c1074eaddaf37e4fb4f471a8adb71cddd5bc8cf3f894241df5cee
+  checksum: ac39070fc1c3c76a654e4b526383eaf1601976eaa474547b263915b4806977f083600e586ca923709baeed7c82a42640bcc9cc04c37a7efd3fb444f49b8347d6
   languageName: node
   linkType: hard
 
@@ -26285,7 +26285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.5.0, neo-async@npm:^2.6.0, neo-async@npm:^2.6.2":
+"neo-async@npm:^2.5.0, neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

**TL;DR:** Upgrades the transitive `handlebars` dependency from 4.7.7 to 4.7.9 via a Yarn resolution to fix a critical (CVSS 9.8) JavaScript injection vulnerability (CVE-2026-33937 / GHSA-2w6w-674q-4c4q).

### Vulnerability Details

`Handlebars.compile()` accepts a pre-parsed AST object in addition to a template string. The `value` field of a `NumberLiteral` AST node is emitted directly into the generated JavaScript without quoting or sanitization. An attacker who can supply a crafted AST to `compile()` can inject and execute arbitrary JavaScript, leading to Remote Code Execution.

### Impact Assessment

- **Risk: Very Low** — Handlebars is a **transitive dev dependency** only (`plop` -> `node-plop` -> `handlebars`)
- **No direct application code** imports or requires handlebars
- Handlebars is used only by **Plop code generators** (widget generator + design system component generator) via `.hbs` template files
- Version 4.7.9 is a **security-only release** with identical dependency structure to 4.7.7

### Changes

- Added `"handlebars": "4.7.9"` to the `resolutions` field in `app/client/package.json`
- Updated `app/client/yarn.lock` accordingly (4.7.7 -> 4.7.9)

### Verification

- Confirmed handlebars 4.7.9 loads and reports correct version
- Verified normal template compilation works correctly
- Verified the AST type confusion attack is now blocked (`"Invalid AST: NumberLiteral.value must be a number"`)
- Verified all 12 `.hbs` template files compile successfully
- Verified Plop widget generator initializes and lists generators correctly

Fixes https://linear.app/appsmith/issue/APP-15063/security-critical-handlebarsjs-has-javascript-injection-via-ast-type

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23732745262>
> Commit: e0a8e594edeedca8d125f876eab7aac523aaf37f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23732745262&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 30 Mar 2026 08:56:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-406b4df7-4bac-4771-aa9d-32007842832c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-406b4df7-4bac-4771-aa9d-32007842832c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `handlebars` library to project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->