### PR TITLE
fix: critical CVE 2025-70952 fix

### DIFF
--- a/app/server/appsmith-plugins/pom.xml
+++ b/app/server/appsmith-plugins/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.pf4j</groupId>
             <artifactId>pf4j-spring</artifactId>
-            <version>0.8.0</version>
+            <version>0.10.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -255,7 +255,7 @@
         <dependency>
             <groupId>org.pf4j</groupId>
             <artifactId>pf4j-spring</artifactId>
-            <version>0.8.0</version>
+            <version>0.10.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-lang</groupId>

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -38,7 +38,7 @@
         <mockito.version>4.4.0</mockito.version>
         <mockwebserver.version>5.0.0-alpha.2</mockwebserver.version>
         <okhttp3.version>4.12.0</okhttp3.version>
-        <org.pf4j.version>3.10.0</org.pf4j.version>
+        <org.pf4j.version>3.15.0</org.pf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.groupId>com.appsmith</project.groupId>
         <project.version>1.0-SNAPSHOT</project.version>


### PR DESCRIPTION
## Description

Upgrade PF4J plugin framework dependencies to address known vulnerabilities.

- **pf4j**: `3.10.0` → `3.15.0` (latest release)
- **pf4j-spring**: `0.8.0` → `0.10.0` (latest release)

### What changed

- `app/server/pom.xml` — Bump `org.pf4j.version` property from 3.10.0 to 3.15.0. This property is referenced via `${org.pf4j.version}` in:
  - `app/server/appsmith-server/pom.xml`
  - `app/server/appsmith-plugins/pom.xml`
  - `app/server/appsmith-interfaces/pom.xml`
- `app/server/appsmith-server/pom.xml` — Bump `pf4j-spring` from 0.8.0 to 0.10.0
- `app/server/appsmith-plugins/pom.xml` — Bump `pf4j-spring` from 0.8.0 to 0.10.0

### Compatibility

- pf4j 3.15.0 still carries one non-critical vulnerability — acceptable trade-off for the security fixes included in the upgrade.
- pf4j-spring 0.10.0 is built against Spring Framework 6.2.2 and uses the Jakarta namespace (`jakarta.annotation-api`), fully compatible with our Spring Boot 3.5.12 parent.

### Fixes: https://linear.app/appsmith/issue/APP-15065/address-cve-2025-70952-vulnerability-in-appsmith-images

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/23736830870>
> Commit: a5a2ef196930c27cc3954022ca1c6964ed31660e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=23736830870&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Mon, 30 Mar 2026 09:48:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No