### PR TITLE
chore: added JVM args for traces with JDK25

### DIFF
--- a/deploy/docker/fs/opt/appsmith/run-java.sh
+++ b/deploy/docker/fs/opt/appsmith/run-java.sh
@@ -88,7 +88,7 @@ sh /opt/appsmith/run-starting-page-init.sh &
 exec java ${APPSMITH_JAVA_ARGS:-} ${APPSMITH_JAVA_HEAP_ARG:-} \
   --add-opens java.base/java.lang=ALL-UNNAMED \
   --add-opens java.base/java.time=ALL-UNNAMED \
-  --add-opens java.base/java.nio=ALL-UNNAMED \  
+  --add-opens java.base/java.nio=ALL-UNNAMED \
   --add-opens java.base/java.util=ALL-UNNAMED \
   -Dserver.port=8080 \
   -XX:+ShowCodeDetailsInExceptionMessages \

--- a/deploy/docker/fs/opt/appsmith/run-java.sh
+++ b/deploy/docker/fs/opt/appsmith/run-java.sh
@@ -86,8 +86,10 @@ sh /opt/appsmith/run-starting-page-init.sh &
 
 # Ref -Dlog4j2.formatMsgNoLookups=true https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot
 exec java ${APPSMITH_JAVA_ARGS:-} ${APPSMITH_JAVA_HEAP_ARG:-} \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
   --add-opens java.base/java.time=ALL-UNNAMED \
-  --add-opens java.base/java.nio=ALL-UNNAMED \
+  --add-opens java.base/java.nio=ALL-UNNAMED \  
+  --add-opens java.base/java.util=ALL-UNNAMED \
   -Dserver.port=8080 \
   -XX:+ShowCodeDetailsInExceptionMessages \
   -Djava.security.egd=file:/dev/./urandom \


### PR DESCRIPTION
## Description
 JVM args for JDK25 with traces and other entries. solves NO class def found issues.

Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 209c369c20cc771e09b30811f17c3311c418ba1f yet
> <hr>Tue, 31 Mar 2026 14:02:43 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java application startup parameters in Docker deployments with enhanced runtime module access configuration to improve stability and ensure better compatibility across containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->