### PR TITLE
fix: Custom widget in UI Module not receiving model data in app

### DIFF
--- a/app/client/src/ce/contexts/ModuleInputsContext.tsx
+++ b/app/client/src/ce/contexts/ModuleInputsContext.tsx
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+
+/**
+ * Context for module inputs. When a Custom widget is inside a ModuleContainer or
+ * ModuleWidget and its model (from defaultModel binding) is empty, it can fall
+ * back to these inputs. This fixes the issue where inputs/Commons1.inputs
+ * fails to resolve during evaluation.
+ */
+export const ModuleInputsContext = createContext<Record<string, unknown>>({});
+
+export const ModuleInputsProvider = ModuleInputsContext.Provider;
+
+/** Stable empty object to avoid unnecessary re-renders when inputs are undefined */
+export const EMPTY_MODULE_INPUTS: Record<string, unknown> = Object.freeze({});

--- a/app/client/src/ee/contexts/ModuleInputsContext.tsx
+++ b/app/client/src/ee/contexts/ModuleInputsContext.tsx
@@ -1,14 +1,1 @@
-import { createContext } from "react";
-
-/**
- * Context for module inputs. When a Custom widget is inside a ModuleContainer or
- * ModuleWidget and its model (from defaultModel binding) is empty, it can fall
- * back to these inputs. This fixes the issue where inputs/Commons1.inputs
- * fails to resolve during evaluation.
- */
-export const ModuleInputsContext = createContext<Record<string, unknown>>({});
-
-export const ModuleInputsProvider = ModuleInputsContext.Provider;
-
-/** Stable empty object to avoid unnecessary re-renders when inputs are undefined */
-export const EMPTY_MODULE_INPUTS: Record<string, unknown> = Object.freeze({});
+export * from "ce/contexts/ModuleInputsContext";

--- a/app/client/src/ee/contexts/ModuleInputsContext.tsx
+++ b/app/client/src/ee/contexts/ModuleInputsContext.tsx
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+
+/**
+ * Context for module inputs. When a Custom widget is inside a ModuleContainer or
+ * ModuleWidget and its model (from defaultModel binding) is empty, it can fall
+ * back to these inputs. This fixes the issue where inputs/Commons1.inputs
+ * fails to resolve during evaluation.
+ */
+export const ModuleInputsContext = createContext<Record<string, unknown>>({});
+
+export const ModuleInputsProvider = ModuleInputsContext.Provider;
+
+/** Stable empty object to avoid unnecessary re-renders when inputs are undefined */
+export const EMPTY_MODULE_INPUTS: Record<string, unknown> = Object.freeze({});

--- a/app/client/src/widgets/CustomWidget/component/index.tsx
+++ b/app/client/src/widgets/CustomWidget/component/index.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
+import { ModuleInputsContext } from "ee/contexts/ModuleInputsContext";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore
@@ -56,6 +57,42 @@ const { disableIframeWidgetSandbox } = getAppsmithConfigs();
 
 function CustomComponent(props: CustomComponentProps) {
   const iframe = useRef<HTMLIFrameElement>(null);
+  const moduleInputs = useContext(ModuleInputsContext);
+  const effectiveModelRef = useRef<Record<string, unknown>>({});
+  const effectiveModelKeyRef = useRef<string>("{}");
+
+  // TODO: This is a workaround. The root cause is that `inputs.*` bindings in defaultModel
+  // fail to resolve for Custom widgets inside module instances. Other widget types resolve
+  // fine. The proper fix is in the evaluation pipeline (meta-widget scoping for defaultModel).
+  // Once that is fixed, this fallback and the ModuleInputsContext can be removed.
+  // Fall back to moduleInputs only when model is undefined/null (binding failed to resolve).
+  // An intentionally empty model ({}) from defaultModel is preserved as-is.
+  const effectiveModel = useMemo(() => {
+    const result =
+      (props.model === undefined || props.model === null) &&
+      moduleInputs != null &&
+      Object.keys(moduleInputs).length > 0
+        ? (moduleInputs as Record<string, unknown>)
+        : props.model ?? {};
+
+    // Stabilize reference: return previous object when content is unchanged
+    // to prevent unnecessary postMessage calls and effect re-runs
+    try {
+      const key = JSON.stringify(result);
+
+      if (key === effectiveModelKeyRef.current) {
+        return effectiveModelRef.current;
+      }
+
+      effectiveModelKeyRef.current = key;
+    } catch {
+      // Non-serializable content; treat as changed
+    }
+
+    effectiveModelRef.current = result;
+
+    return result;
+  }, [props.model, moduleInputs]);
 
   const [loading, setLoading] = React.useState(true);
 
@@ -97,7 +134,7 @@ function CustomComponent(props: CustomComponentProps) {
             iframe.current?.contentWindow?.postMessage(
               {
                 type: EVENTS.CUSTOM_WIDGET_READY_ACK,
-                model: props.model,
+                model: effectiveModel,
                 ui: {
                   width: props.width,
                   height: props.height,
@@ -151,24 +188,26 @@ function CustomComponent(props: CustomComponentProps) {
 
     return () => window.removeEventListener("message", handler, false);
   }, [
-    props.model,
+    effectiveModel,
+    theme,
     props.width,
     props.height,
+    props.renderMode,
     props.layoutSystemType,
     props.dynamicHeight,
   ]);
 
   useEffect(() => {
-    if (iframe.current && iframe.current.contentWindow && isIframeReady) {
+    if (iframe.current?.contentWindow && isIframeReady) {
       iframe.current.contentWindow.postMessage(
         {
           type: EVENTS.CUSTOM_WIDGET_MODEL_CHANGE,
-          model: props.model,
+          model: effectiveModel,
         },
         "*",
       );
     }
-  }, [props.model]);
+  }, [effectiveModel]);
 
   useEffect(() => {
     if (iframe.current && iframe.current.contentWindow && isIframeReady) {
@@ -205,12 +244,8 @@ function CustomComponent(props: CustomComponentProps) {
       iframe.current?.style.setProperty("height", `${props.height}px`);
       setHeight(props.height);
     }
-  }, [
-    props.dynamicHeight,
-    props.height,
-    iframe.current,
-    props.layoutSystemType,
-  ]);
+    // Note: iframe.current intentionally omitted - refs don't trigger re-runs
+  }, [props.dynamicHeight, props.height, props.layoutSystemType]);
 
   const srcDoc = `
     <html>
@@ -281,7 +316,7 @@ function CustomComponent(props: CustomComponentProps) {
 export interface CustomComponentProps {
   execute: (eventName: string, contextObj: Record<string, unknown>) => void;
   update: (data: Record<string, unknown>) => void;
-  model: Record<string, unknown>;
+  model?: Record<string, unknown>;
   srcDoc: {
     html: string;
     js: string;

--- a/app/client/src/widgets/CustomWidget/widget/index.tsx
+++ b/app/client/src/widgets/CustomWidget/widget/index.tsx
@@ -448,7 +448,7 @@ class CustomWidget extends BaseWidget<CustomWidgetProps, WidgetState> {
         height={this.props.componentHeight - WIDGET_PADDING * 2}
         layoutSystemType={this.props.layoutSystemType}
         minDynamicHeight={this.props.minDynamicHeight}
-        model={this.props.model || {}}
+        model={this.props.model}
         renderMode={this.getRenderMode()}
         srcDoc={this.props.srcDoc}
         theme={this.props.theme}


### PR DESCRIPTION
## Description
### Problem
A Custom widget inside a UI Module renders correctly in the module editor but not in the app that uses the module. The widget does not the React content (e.g. title, key-value table). Other widgets in the same module (Text, Table) receive module inputs as expected.

### Root cause
The Custom widget’s defaultModel binding (e.g. `{{ { title: inputs.title, fields: inputs.fields } }}`) is not resolved when the widget is inside a module instance in the app. The evaluation pipeline does not provide inputs in scope for the Custom widget’s defaultModel evaluation, so the widget receives an empty model and the iframe never gets data.

### Solution (workaround)
A React context–based fallback was added so Custom widgets inside modules can use module inputs when the evaluated model is missing:

1. ModuleInputsContext – New context that holds the current module inputs.
2. Custom widget component – Reads context and, when model is undefined/null (binding failed), uses module inputs as the effective model. When model is present (including intentional {}), it is used as-is.
3. Reference stabilization – effectiveModel is memoized and its reference is stabilized via JSON.stringify comparison so that unchanged content does not trigger extra effect runs or postMessage calls when the provider passes new object references.

Fixes https://github.com/appsmithorg/appsmith-ee/issues/8713

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD daba8b1e695b935c160eac495590da95e7fe69c5 yet
> <hr>Thu, 02 Apr 2026 13:12:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom widgets can now access module-level inputs as backup when their directly bound model inputs are empty.

* **Refactor**
  * Custom widget model inputs parameter is now optional, improving flexibility and removing automatic empty object default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->