### PR TITLE
docs: fix Helm README Kubernetes link

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -22,7 +22,7 @@ This chart bootstrap an [Appsmith](https://github.com/appsmithorg/appsmith) depl
 ---
 * Install Helm package manager: [https://helm.sh/docs/intro/install/](https://helm.sh/docs/intro/install/)
 * Ensure `kubectl` is installed and configured to connect to your cluster
-    * Install kubectl: [kubernetes.io/vi/docs/tasks/tools/install-kubectl/](https://kubernetes.io/vi/docs/tasks/tools/install-kubectl/)
+    * Install kubectl: [https://kubernetes.io/vi/docs/tasks/tools/install-kubectl/](https://kubernetes.io/vi/docs/tasks/tools/install-kubectl/)
     * Minikube: [Setup Kubectl](https://minikube.sigs.k8s.io/docs/handbook/kubectl/)
     * Google Cloud Kubernetes: [Configuring cluster access for kubectl](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl)
     * Aws EKS: [Create a kubeconfig for Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html)

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -16,7 +16,7 @@ helm install stable-appsmith/appsmith --generate-name
 
 ## Introduction
 ---
-This chart bootstrap an [Appsmith](https://github.com/appsmithorg/appsmith) deployment on a [Kubernetes](kubernetes.io) cluster using [Helm](https://helm.sh) package manager.
+This chart bootstrap an [Appsmith](https://github.com/appsmithorg/appsmith) deployment on a [Kubernetes](https://kubernetes.io) cluster using [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 ---


### PR DESCRIPTION
## Summary
- add the missing `https://` scheme to the Kubernetes link in `deploy/helm/README.md`

## Problem
The Helm README currently links Kubernetes as `[Kubernetes](kubernetes.io)`, which renders as a relative link instead of opening the Kubernetes website.

## Solution
- update the Markdown link target to `https://kubernetes.io`

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment docs to use explicit HTTPS for the main Kubernetes reference link.
  * Replaced the kubectl installation link with an explicit HTTPS target to ensure secure, direct referencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->