### PR TITLE
fix: replace PAT with GITHUB_TOKEN in cleanup-dp workflow

### DIFF
--- a/.github/workflows/cleanup-dp.yml
+++ b/.github/workflows/cleanup-dp.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   execute:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       # Checkout the code
       - uses: actions/checkout@v2
@@ -40,7 +43,7 @@ jobs:
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           DB_URL: ${{ secrets.DB_URL }}
-          GH_TOKEN: ${{ secrets.APPSMITH_DEPLOY_PREVIEW_PAT }}
+          GH_TOKEN: ${{ github.token }}
           DP_EFS_ID: ${{ secrets.APPSMITH_DP_EFS_ID }}
 
         run: /bin/bash ./scripts/cleanup_dp.sh


### PR DESCRIPTION
## Summary
This workflow does not need a long-lived GitHub PAT. Just use short-term token from GitHub.

## Test plan
- [x] Tested equivalent change on EE repo first — workflow runs successfully with `github.token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes to report. This release contains internal infrastructure updates to GitHub Actions workflow configuration and authentication mechanisms. End-users will not be impacted by these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->