### PR TITLE
ci: remove discontinued XATA_TOKEN usage

### DIFF
--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Get Latest flaky Tests
         shell: bash
         run: |
-          curl --request POST --url https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/query --header 'Authorization: Bearer ${{ secrets.XATA_TOKEN }}' --header 'Content-Type: application/json'|jq -r |grep Spec|cut -d ':' -f 2 2> /dev/null|sed 's/"//g'|sed 's/,//g' >  ~/knownfailures
+          touch ~/knownfailures
 
       # Verify CI test failures against known failures
       - name: Verify CI test failures against known failures
@@ -424,7 +424,7 @@ jobs:
       - name: Get Latest flaky Tests
         shell: bash
         run: |
-          curl --request POST --url https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/query --header 'Authorization: Bearer ${{ secrets.XATA_TOKEN }}' --header 'Content-Type: application/json'|jq -r |grep Spec|cut -d ':' -f 2 2> /dev/null|sed 's/"//g'|sed 's/,//g' >  ~/knownfailures
+          touch ~/knownfailures
 
       # Verify CI test failures against known failures
       - name: Verify CI test failures against known failures

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Get Latest flaky Tests
         shell: bash
         run: |
-          curl --request POST --url https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/query --header 'Authorization: Bearer ${{ secrets.XATA_TOKEN }}' --header 'Content-Type: application/json'|jq -r |grep Spec|cut -d ':' -f 2 2> /dev/null|sed 's/"//g'|sed 's/,//g' >  ~/knownfailures
+          touch ~/knownfailures
 
       # Verify CI test failures against known failures
       - name: Verify CI test failures against known failures
@@ -344,7 +344,7 @@ jobs:
       - name: Get Latest flaky Tests
         shell: bash
         run: |
-          curl --request POST --url https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/query --header 'Authorization: Bearer ${{ secrets.XATA_TOKEN }}' --header 'Content-Type: application/json'|jq -r |grep Spec|cut -d ':' -f 2 2> /dev/null|sed 's/"//g'|sed 's/,//g' >  ~/knownfailures
+          touch ~/knownfailures
 
       # Verify CI test failures against known failures
       - name: Verify CI test failures against known failures

--- a/app/client/cypress/xataadd.sh
+++ b/app/client/cypress/xataadd.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -x
-
-curl --request POST --url 'https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/data?columns=id' --header "Authorization: Bearer $XATATOKEN" --header 'Content-Type: application/json' --data "{\"Spec\":\"$1\"}"

--- a/app/client/cypress/xatadel.sh
+++ b/app/client/cypress/xatadel.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -x
-
-idlist=$(curl --request POST --url https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/query --header "Authorization: Bearer $XATATOKEN" --header 'Content-Type: application/json'|jq -r  ".[] | .[] |  select(.Spec==\"$1\") | .id")
-
-while IFS= read -r line; do
-    echo "... $line ..."
-	curl --request DELETE --url "https://yatin-s-workspace-jk8ru5.us-east-1.xata.sh/db/CypressKnownFailures:main/tables/CypressKnownFailuires/data/$line?columns=id" --header "Authorization: Bearer $XATATOKEN"
-	
-done <<< "$idlist"


### PR DESCRIPTION
## Summary
- Replace discontinued Xata database curl calls with `touch ~/knownfailures` in `build-client-server.yml` and `build-client-server-count.yml` (matching the fix already applied to `pr-cypress.yml` in e61375d297)
- Delete orphaned `app/client/cypress/xataadd.sh` and `app/client/cypress/xatadel.sh` scripts that are not referenced by any workflow

## Context
XATA Lite has been discontinued. The existing curl calls were silently failing (stderr redirected to `/dev/null`), producing an empty `~/knownfailures` file — identical behavior to the `touch` replacement. This completes the partial cleanup started in pr-cypress.yml.

**After merging, the `XATA_TOKEN` GitHub secret can be safely removed from the repository settings.**

## Test plan
- [ ] Verify `build-client-server` workflow runs successfully on a test PR
- [ ] Verify `build-client-server-count` workflow runs successfully on a test PR
- [ ] Confirm PR comment behavior for CI failures remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD pipeline by simplifying test failure tracking and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24066890157>
> Commit: 9982ddf168d0cfc5eb5032fa749c3649398498d1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24066890157&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Tue, 07 Apr 2026 06:35:51 UTC
<!-- end of auto-generated comment: Cypress test results  -->
