### PR TITLE
chore: switch deploy preview scripts to OIDC auth

### DIFF
--- a/.github/workflows/cleanup-dp.yml
+++ b/.github/workflows/cleanup-dp.yml
@@ -11,9 +11,16 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      id-token: write
     steps:
       # Checkout the code
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.APPSMITH_EKS_AWS_ROLE_ARN }}
+          aws-region: ap-south-1
 
       - name: Install mongosh
         run: |
@@ -37,13 +44,9 @@ jobs:
 
       - name: Delete Helm chart
         env:
-          AWS_ROLE_ARN: ${{ secrets.APPSMITH_EKS_AWS_ROLE_ARN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.APPSMITH_CI_AWS_SECRET_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.APPSMITH_CI_AWS_SECRET_ACCESS_KEY }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           DB_URL: ${{ secrets.DB_URL }}
           GH_TOKEN: ${{ github.token }}
           DP_EFS_ID: ${{ secrets.APPSMITH_DP_EFS_ID }}
-
         run: /bin/bash ./scripts/cleanup_dp.sh

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -258,6 +258,9 @@ jobs:
   build-deploy-preview:
     needs: [resolve-params, push-image]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: "."
@@ -268,6 +271,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ needs.resolve-params.outputs.pr_number }}/merge"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.APPSMITH_EKS_AWS_ROLE_ARN }}
+          aws-region: ap-south-1
 
       - name: Print versions of tools
         run: |
@@ -297,8 +306,6 @@ jobs:
 
       - name: Deploy Helm chart
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.APPSMITH_CI_AWS_SECRET_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.APPSMITH_CI_AWS_SECRET_ACCESS_KEY }}
           IMAGE_HASH: ${{ needs.push-image.outputs.imageHash }}
           AWS_RELEASE_CERT: ${{ secrets.APPSMITH_AWS_RELEASE_CERT_RELEASE }}
           DOCKER_HUB_ORGANIZATION: ${{ vars.DOCKER_HUB_ORGANIZATION }}

--- a/scripts/cleanup_dp.sh
+++ b/scripts/cleanup_dp.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
-# Configure the AWS & kubectl environment
-
-mkdir -p ~/.aws
-cat > ~/.aws/config <<EOF
-[default]
-region = ap-south-1
-output = json
-EOF
-
-aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
-aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+# Configure the kubectl environment
+# AWS credentials are provided via OIDC (configure-aws-credentials action)
 
 export region="ap-south-1"
 export cluster_name="uatx-cluster"

--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -5,17 +5,7 @@ set -euo pipefail
 
 edition="ce"
 
-# Configure AWS CLI and kubectl environment
-mkdir -p ~/.aws
-cat > ~/.aws/config <<EOF
-[default]
-region = ap-south-1
-output = json
-EOF
-
-aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
-aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
-
+# AWS credentials are provided via OIDC (configure-aws-credentials action)
 export region="ap-south-1"
 export cluster_name="uatx-cluster"
 


### PR DESCRIPTION
## Summary
- Replace static AWS access key/secret pairs with OIDC role assumption (`aws-actions/configure-aws-credentials@v4`) in both the deploy preview and cleanup workflows
- Remove manual `~/.aws/config` creation and `aws configure set` calls from `deploy_preview.sh` and `cleanup_dp.sh`
- Bump checkout action from v2 to v4 in cleanup workflow

## Test plan
- [x] Tested OIDC auth pattern on `ww-test-dp` branch with a standalone workflow that successfully authenticated and ran kubectl commands against uatx-cluster
- [ ] Trigger a deploy preview via `/build-deploy-preview` on a test PR to validate end-to-end
- [ ] Verify nightly cleanup job runs successfully on next schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated CI/CD AWS authentication to OIDC-based credentials and tightened job permissions.
  * Removed reliance on static AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY in workflows and scripts.
  * Removed local AWS CLI credential setup from deployment/cleanup scripts.
  * Updated CI tooling to newer action versions for improved security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 4d7ff2abbf3a56578e105bbb342389ac7c4bee01 yet
> <hr>Mon, 06 Apr 2026 22:09:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->
