### PR TITLE
fix(test): handle virtual scroll in multiselect Cypress helper

### DIFF
--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -357,6 +357,7 @@ export class CommonLocators {
   _listItemTitle = ".ads-v2-listitem__title";
   _dropdownOption = ".rc-select-item-option-content";
   _dropdownActiveOption = ".rc-select-dropdown .rc-select-item-option-active";
+  _rcVirtualListHolder = ".rc-virtual-list-holder";
   _homeIcon = "[data-testid='t--default-home-icon']";
   _widget = (widgetName: string) => `.t--widget-${widgetName}`;
 }

--- a/app/client/cypress/support/Pages/DeployModeHelper.ts
+++ b/app/client/cypress/support/Pages/DeployModeHelper.ts
@@ -237,30 +237,28 @@ export class DeployMode {
   private scrollVirtualListToOption(option: string): Cypress.Chainable<void> {
     const selector = this.locator._multiSelectOptions(option);
 
-    return cy
-      .get(this.locator._rcVirtualListHolder)
-      .then(($holder) => {
-        if (Cypress.$(selector).length > 0) return;
+    return cy.get(this.locator._rcVirtualListHolder).then(($holder) => {
+      if (Cypress.$(selector).length > 0) return;
 
-        const holder = $holder[0];
-        const step = 100;
-        const maxScroll = holder.scrollHeight - holder.clientHeight;
+      const holder = $holder[0];
+      const step = 100;
+      const maxScroll = holder.scrollHeight - holder.clientHeight;
 
-        const scroll = (pos: number): Cypress.Chainable<void> => {
-          holder.scrollTop = pos;
+      const scroll = (pos: number): Cypress.Chainable<void> => {
+        holder.scrollTop = pos;
 
-          // rc-virtual-list renders items asynchronously after scrollTop changes;
-          // a short wait is needed because there is no DOM event or Cypress-retryable
-          // assertion to detect when the virtual list has finished re-rendering.
-          return cy.wait(50).then(() => {
-            if (Cypress.$(selector).length > 0) return;
-            if (pos >= maxScroll) return;
+        // rc-virtual-list renders items asynchronously after scrollTop changes;
+        // a short wait is needed because there is no DOM event or Cypress-retryable
+        // assertion to detect when the virtual list has finished re-rendering.
+        return cy.wait(50).then(() => {
+          if (Cypress.$(selector).length > 0) return;
+          if (pos >= maxScroll) return;
 
-            return scroll(pos + step);
-          });
-        };
+          return scroll(pos + step);
+        });
+      };
 
-        return scroll(0);
-      });
+      return scroll(0);
+    });
   }
 }

--- a/app/client/cypress/support/Pages/DeployModeHelper.ts
+++ b/app/client/cypress/support/Pages/DeployModeHelper.ts
@@ -234,28 +234,33 @@ export class DeployMode {
     cy.get("body").type("{esc}");
   }
 
-  private scrollVirtualListToOption(option: string) {
+  private scrollVirtualListToOption(option: string): Cypress.Chainable<void> {
     const selector = this.locator._multiSelectOptions(option);
 
-    cy.get(".rc-virtual-list-holder").then(($holder) => {
-      if (Cypress.$(selector).length > 0) return;
+    return cy
+      .get(this.locator._rcVirtualListHolder)
+      .then(($holder) => {
+        if (Cypress.$(selector).length > 0) return;
 
-      const holder = $holder[0];
-      const step = 100;
-      const maxScroll = holder.scrollHeight - holder.clientHeight;
+        const holder = $holder[0];
+        const step = 100;
+        const maxScroll = holder.scrollHeight - holder.clientHeight;
 
-      const scroll = (pos: number) => {
-        holder.scrollTop = pos;
+        const scroll = (pos: number): Cypress.Chainable<void> => {
+          holder.scrollTop = pos;
 
-        return cy.wait(50).then(() => {
-          if (Cypress.$(selector).length > 0) return;
-          if (pos >= maxScroll) return;
+          // rc-virtual-list renders items asynchronously after scrollTop changes;
+          // a short wait is needed because there is no DOM event or Cypress-retryable
+          // assertion to detect when the virtual list has finished re-rendering.
+          return cy.wait(50).then(() => {
+            if (Cypress.$(selector).length > 0) return;
+            if (pos >= maxScroll) return;
 
-          return scroll(pos + step);
-        });
-      };
+            return scroll(pos + step);
+          });
+        };
 
-      scroll(0);
-    });
+        return scroll(0);
+      });
   }
 }

--- a/app/client/cypress/support/Pages/DeployModeHelper.ts
+++ b/app/client/cypress/support/Pages/DeployModeHelper.ts
@@ -210,6 +210,7 @@ export class DeployMode {
 
     if (check) {
       options.forEach(($each) => {
+        this.scrollVirtualListToOption($each);
         cy.get(this.locator._multiSelectOptions($each))
           .check({ force: true })
           .wait(800);
@@ -220,6 +221,7 @@ export class DeployMode {
       });
     } else {
       options.forEach(($each) => {
+        this.scrollVirtualListToOption($each);
         cy.get(this.locator._multiSelectOptions($each))
           .uncheck({ force: true })
           .wait(800);
@@ -230,5 +232,30 @@ export class DeployMode {
       });
     }
     cy.get("body").type("{esc}");
+  }
+
+  private scrollVirtualListToOption(option: string) {
+    const selector = this.locator._multiSelectOptions(option);
+
+    cy.get(".rc-virtual-list-holder").then(($holder) => {
+      if (Cypress.$(selector).length > 0) return;
+
+      const holder = $holder[0];
+      const step = 100;
+      const maxScroll = holder.scrollHeight - holder.clientHeight;
+
+      const scroll = (pos: number) => {
+        holder.scrollTop = pos;
+
+        return cy.wait(50).then(() => {
+          if (Cypress.$(selector).length > 0) return;
+          if (pos >= maxScroll) return;
+
+          return scroll(pos + step);
+        });
+      };
+
+      scroll(0);
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Fix Cypress test failures in `Json_Spec.ts` (and any other spec using `SelectJsonFormMultiSelect`) caused by multiselect dropdown options beyond the virtual scroll viewport not being rendered in the DOM
- Add `scrollVirtualListToOption` helper to `DeployModeHelper.ts` that scrolls the `rc-virtual-list-holder` container until the target option appears before checking/unchecking it

## Context
[Slack thread](https://theappsmith.slack.com/archives/C09NG5BJ18S/p1775544003897439)

PR #41656 (`fix: scrollbar select widgets style`) changed `listItemHeight` from the default 24px to 38px in the MultiSelect widget. This reduced the number of items rendered in the `rc-virtual-list` DOM from ~12 to ~8 (calculated as `listHeight(300) / listItemHeight(38) = 7.89`).

The `genres` Postgres enum used by `Json_Spec.ts` has 11 values. Items 10 (`Reference`) and 11 (`Spirituality`) are now outside the virtual viewport and not in the DOM. The existing `SelectJsonFormMultiSelect` method does `cy.get(div[title='Reference'] input[type='checkbox'])` which times out after 30s because the element doesn't exist until scrolled into view.

**Before**: `listItemHeight=24` → `300/24 = 12.5` items visible → all 11 genres in DOM
**After**: `listItemHeight=38` → `300/38 = 7.89` items visible → only first ~8 genres in DOM

## Changes
**File**: `app/client/cypress/support/Pages/DeployModeHelper.ts`

- Added `scrollVirtualListToOption()` private method that programmatically scrolls the `rc-virtual-list-holder` in 100px increments until the target option element appears in the DOM
- Short-circuits immediately if the option is already visible (no unnecessary scrolling for items within the viewport)
- Applied to both the check and uncheck branches of `SelectJsonFormMultiSelect`


Fixes https://linear.app/appsmith/issue/APP-15088/fix-multiselect-virtual-scroll-breaking-cypress-tests-after-scrollbar

## Test plan
- [ ] Run `Json_Spec.ts` and verify tests 19 (`Reference`), 20 (`Spirituality`), and 21-23 pass
- [ ] Verify tests 1-18 still pass (no regression for items already in viewport)
- [ ] Verify other specs using `SelectJsonFormMultiSelect` are unaffected

## Automation

/ok-to-test tags="@tag.Datasource"

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24084898391>
> Commit: f183546638e15586a1cbeb4adc416b3f80c70dfa
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24084898391&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Tue, 07 Apr 2026 14:47:17 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved multiselect dropdown interaction tests by adding automatic scrolling for virtualized lists so options are reliably brought into view before selection actions.
  * Added a dedicated locator for virtual list containers to make tests more robust and reduce flakiness when interacting with offscreen items.
  * Enhanced wait/scroll logic to ensure selections succeed consistently across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->