### PR TITLE
docs: fix Helm chart link in setup guide

### DIFF
--- a/deploy/helm/Setup-https.md
+++ b/deploy/helm/Setup-https.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-- Deploying Appsmith application on a Kubernetes cluster is easier with [Appsmith's Helm chart](). However, it is best practice to secure your web application with TLS certificates.
+- Deploying Appsmith application on a Kubernetes cluster is easier with [Appsmith's Helm chart](./README.md). However, it is best practice to secure your web application with TLS certificates.
 
 - This guide will show you how to secure HTTP traffic with TLS and SSL certificates using [Cert Manager](https://cert-manager.io/).
 


### PR DESCRIPTION
## Summary
- fix the empty Appsmith Helm chart link in `deploy/helm/Setup-https.md` so it points to the local Helm README

## Validation
- not run (docs-only link fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a broken hyperlink in the HTTPS setup guide to properly reference the relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->