### PR TITLE
ci(playwright): add orchestrator workflow and wire up CI pipeline

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -5,6 +5,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      branch:
+        description: "Branch to checkout when pr is 0 (must match client/server/rts builds)"
+        required: false
+        type: string
+        default: ""
       pr:
         description: "This is the PR number in case the workflow is being called in a pull request"
         required: false
@@ -33,8 +38,14 @@ jobs:
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
-        if: inputs.pr == 0
+        if: inputs.pr == 0 && inputs.branch == ''
         uses: actions/checkout@v4
+
+      - name: Checkout the specified branch
+        if: inputs.pr == 0 && inputs.branch != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Download the client build artifact
         if: steps.run_result.outputs.run_result != 'success'

--- a/.github/workflows/ci-test-playwright.yml
+++ b/.github/workflows/ci-test-playwright.yml
@@ -1,37 +1,16 @@
 name: Appsmith Playwright E2E
 
+# Invoked only via playwright-e2e.yml (or another orchestrator) so Docker image + run_id align.
 on:
-  workflow_dispatch:
-    inputs:
-      project:
-        description: "Playwright project (smoke, sanity, regression, regression-git, chromium, chromium-ee). Empty = all projects."
-        required: false
-        type: string
-        default: ""
-      feature:
-        description: "Feature subdirectory within tier (e.g. git, datasource). Only used with tier projects."
-        required: false
-        type: string
-        default: ""
-      flag_overrides:
-        description: 'JSON feature flag overrides merged on top of real server response (e.g. {"flag":true})'
-        required: false
-        type: string
-        default: ""
-      docker_image_name:
-        description: Docker image name
-        required: false
-        type: string
-        default: ""
   workflow_call:
     inputs:
       project:
-        description: "Playwright project (smoke, sanity, regression, regression-git, chromium, chromium-ee). Empty = all projects."
+        description: "Playwright project (smoke, sanity, regression, chromium). Empty = all."
         required: false
         type: string
         default: ""
       feature:
-        description: "Feature subdirectory within tier (e.g. git, datasource)"
+        description: "Feature subdirectory (e.g. git)."
         required: false
         type: string
         default: ""
@@ -41,18 +20,29 @@ on:
         type: string
         default: ""
       docker_image_name:
-        description: Docker image name
+        description: "Non-empty = docker pull this image; empty = load cicontainer from same-run cache"
         required: false
         type: string
         default: ""
+      pr:
+        description: "PR number for merge ref checkout"
+        required: false
+        type: number
+        default: 0
+      branch:
+        description: "Branch when pr is 0"
+        required: false
+        type: string
+        default: ""
+      ted_tag:
+        description: "test-event-driver image tag"
+        required: false
+        type: string
+        default: "latest"
 
 jobs:
   playwright-test:
     runs-on: warp-ubuntu-latest-x64-4x
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
     defaults:
       run:
         shell: bash
@@ -68,10 +58,141 @@ jobs:
           - 27017:27017
 
     steps:
-      - name: Checkout
+      - name: Checkout PR merge
+        if: inputs.pr != 0
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.pr != 0 && format('refs/pull/{0}/merge', inputs.pr) || '' }}
+          ref: refs/pull/${{ inputs.pr }}/merge
+
+      - name: Checkout branch
+        if: inputs.pr == 0 && inputs.branch != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Checkout default ref
+        if: inputs.pr == 0 && inputs.branch == ''
+        uses: actions/checkout@v4
+
+      - name: Clean up disk
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Get Docker image id
+        run: |
+          if [[ '${{ inputs.docker_image_name }}' != '' ]]; then
+            echo 'docker_container_name=${{ inputs.docker_image_name }}' >> "$GITHUB_ENV"
+          else
+            echo 'docker_container_name=cicontainer' >> "$GITHUB_ENV"
+          fi
+
+      - name: Restore Docker image cache
+        if: inputs.docker_image_name == ''
+        uses: actions/cache@v4
+        with:
+          path: cicontainer.tar.gz
+          key: docker-image-${{ github.run_id }}
+
+      - name: Load Docker image
+        run: |
+          if [[ '${{ inputs.docker_image_name }}' == '' ]]; then
+            gunzip cicontainer.tar.gz
+            docker load -i cicontainer.tar
+          else
+            docker pull ${{ env.docker_container_name }}
+          fi
+
+      - name: Create Appsmith stacks folder
+        working-directory: "."
+        run: mkdir -p cicontainerlocal/stacks/configuration/
+
+      - name: Set license for Appsmith container
+        run: echo "APPSMITH_LICENSE_KEY=VALID-LICENSE-KEY" >> "$GITHUB_ENV"
+
+      - name: Run Appsmith, CS & TED docker images
+        env:
+          LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY: ${{ secrets.LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY }}
+          APPSMITH_CARBON_API_KEY: ${{ secrets.CYPRESS_APPSMITH_CARBON_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.CYPRESS_OPENAI_API_KEY }}
+          OPENAI_ASSISTANT_ID: ${{ secrets.CYPRESS_OPENAI_ASSISTANT_ID }}
+        working-directory: "."
+        run: |
+          sudo /etc/init.d/ssh stop || true
+          sudo systemctl disable --now ssh.socket || true
+          mkdir -p ~/git-server/keys
+          ted_tag="${{ inputs.ted_tag }}"
+          docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
+            -p 5433:5432 -p 28017:27017 -p 25:25 -p 4200:4200 -p 5000:5000 -p 3001:3000 -p 6001:6001 -p 8001:8000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
+            "appsmith/test-event-driver:${ted_tag:-latest}"
+          docker run --name cloud-services -d -p 8000:80 -p 8090:8090 \
+            --privileged --pid=host --ipc=host --add-host=host.docker.internal:host-gateway\
+            -e KEYGEN_API_URL=http://host.docker.internal:5001 \
+            -e KEYGEN_BYPASS_SIGNATURE_VERIFICATION=true \
+            -e CREATE_DUMMY_LICENSES=true \
+            -e APPSMITH_CLOUD_SERVICES_MONGODB_URI=mongodb://host.docker.internal:27017 \
+            -e APPSMITH_CLOUD_SERVICES_MONGODB_DATABASE=cs \
+            -e APPSMITH_CLOUD_SERVICES_MONGODB_AUTH_DATABASE=admin \
+            -e APPSMITH_REDIS_URL=redis://host.docker.internal:6379/ \
+            -e APPSMITH_APPS_API_KEY=dummy-api-key \
+            -e APPSMITH_REMOTE_API_KEY=dummy-api-key \
+            -e APPSMITH_GITHUB_API_KEY=dummy-appsmith-gh-api-key \
+            -e APPSMITH_JWT_SECRET=appsmith-cloud-services-jwt-secret-dummy-key \
+            -e APPSMITH_ENCRYPTION_SALT=encryption-salt \
+            -e APPSMITH_ENCRYPTION_PASSWORD=encryption-password \
+            -e APPSMITH_CUSTOMER_PORTAL_URL=https://dev.appsmith.com \
+            -e APPSMITH_CLOUD_SERVICES_BASE_URL=https://cs-dev.appsmith.com \
+            -e AUTH0_ISSUER_URL=https://login.release-customer.appsmith.com/ \
+            -e AUTH0_CLIENT_ID=dummy-client-id \
+            -e AUTH0_CLIENT_SECRET=dummy-secret-id \
+            -e AUTH0_AUDIENCE_URL=https://login.local-customer.appsmith.com/ \
+            -e CLOUDSERVICES_URL=cs-dev.appsmith.com \
+            -e CUSTOMER_URL=dev.appsmith.com  \
+            -e ENTERPRISE_USER_NAME=ent-user@appsmith.com \
+            -e ENTERPRISE_USER_PASSWORD=ent_user_password \
+            -e ENTERPRISE_ADMIN_NAME=ent-admin@appsmith.com \
+            -e ENTERPRISE_ADMIN_PASSWORD=ent_admin_password \
+            -e LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY=$LAUNCHDARKLY_BUSINESS_FLAGS_SERVER_KEY \
+            appsmith/cloud-services:release
+          cd cicontainerlocal
+          docker run -d --name appsmith -p 80:80 \
+            -v "$PWD/stacks:/appsmith-stacks" \
+            -e APPSMITH_LICENSE_KEY="$APPSMITH_LICENSE_KEY" \
+            -e APPSMITH_DISABLE_TELEMETRY=true \
+            -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \
+            -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
+            -e APPSMITH_CLOUD_SERVICES_SIGNATURE_BASE_URL=http://host.docker.internal:8090 \
+            -e APPSMITH_RATE_LIMIT=1000 \
+            -e APPSMITH_CARBON_API_BASE_PATH=https://carbon.appsmith.com \
+            -e APPSMITH_CARBON_API_KEY="$APPSMITH_CARBON_API_KEY" \
+            -e APPSMITH_AI_SERVER_MANAGED_HOSTING=true \
+            -e OPENAI_ASSISTANT_ID="$OPENAI_ASSISTANT_ID" \
+            -e OPENAI_API_KEY="$OPENAI_API_KEY" \
+            --add-host=host.docker.internal:host-gateway --add-host=api.segment.io:host-gateway --add-host=t.appsmith.com:host-gateway \
+            ${{ env.docker_container_name }}
+
+      - name: Wait for Appsmith to be ready
+        run: |
+          for i in $(seq 1 30); do
+            status=$(curl -o /dev/null -s -w "%{http_code}" http://localhost/api/v1/users || echo "000")
+            if [ "$status" -ne "502" ] && [ "$status" -ne "000" ]; then
+              echo "Appsmith is ready (status: $status)"
+              break
+            fi
+            echo "Waiting for Appsmith... attempt $i (status: $status)"
+            sleep 10
+          done
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -98,52 +219,6 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ hashFiles('app/client/yarn.lock') }}
-
-      - name: Get Docker image
-        run: |
-          if [[ '${{ inputs.docker_image_name }}' != '' ]]; then
-            echo 'docker_container_name=${{ inputs.docker_image_name }}' >> "$GITHUB_ENV"
-          else
-            echo 'docker_container_name=cicontainer' >> "$GITHUB_ENV"
-          fi
-
-      - name: Restore Docker image cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.docker_container_name }}.tar.gz
-          key: docker-image-${{ github.run_id }}
-
-      - name: Load Docker image
-        run: |
-          if [[ '${{ inputs.docker_image_name }}' == '' ]]; then
-            gunzip ${{ env.docker_container_name }}.tar.gz
-            docker load -i ${{ env.docker_container_name }}.tar
-          else
-            docker pull ${{ env.docker_container_name }}
-          fi
-
-      - name: Start Appsmith container
-        run: |
-          mkdir -p cicontainerlocal/stacks/configuration/
-          cd cicontainerlocal
-          docker run -d --name appsmith -p 80:80 \
-            -v "$PWD/stacks:/appsmith-stacks" \
-            -e APPSMITH_DISABLE_TELEMETRY=true \
-            -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
-            --add-host=host.docker.internal:host-gateway \
-            ${{ env.docker_container_name }}
-
-      - name: Wait for Appsmith to be ready
-        run: |
-          for i in $(seq 1 30); do
-            status=$(curl -o /dev/null -s -w "%{http_code}" http://localhost/api/v1/users || echo "000")
-            if [ "$status" -ne "502" ] && [ "$status" -ne "000" ]; then
-              echo "Appsmith is ready (status: $status)"
-              break
-            fi
-            echo "Waiting for Appsmith... attempt $i (status: $status)"
-            sleep 10
-          done
 
       - name: Run Playwright tests (attempt 1)
         id: attempt1

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -3,6 +3,11 @@ name: Playwright E2E
 # Orchestrates client/server/rts build, Docker image, TED + cloud-services + Appsmith, then Playwright.
 # Manual: workflow_dispatch. PR comment /test-pw: pw-test-command.yml → workflow_call.
 
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr != 0 && format('refs/pull/{0}/merge', inputs.pr) || (inputs.branch != '' && inputs.branch || github.sha) }}
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -97,7 +97,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{ inputs.pr }}
-      skip-tests: true
+      skip-tests: "true"
       branch: ${{ inputs.branch }}
 
   rts-build:

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,139 @@
+name: Playwright E2E
+
+# Orchestrates client/server/rts build, Docker image, TED + cloud-services + Appsmith, then Playwright.
+# Manual: workflow_dispatch. PR comment /test-pw: pw-test-command.yml → workflow_call.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number — checkout refs/pull/<n>/merge. Use 0 with branch for branch-only runs."
+        required: false
+        type: number
+        default: 0
+      branch:
+        description: "Branch when pr is 0 (e.g. release)."
+        required: false
+        type: string
+        default: ""
+      docker_image_name:
+        description: "If set, skip all builds and docker pull this image instead."
+        required: false
+        type: string
+        default: ""
+      project:
+        description: "Playwright --project (e.g. smoke, sanity, regression, chromium). Empty = all."
+        required: false
+        type: string
+        default: ""
+      feature:
+        description: "Feature folder under tests (e.g. git)."
+        required: false
+        type: string
+        default: ""
+      flag_overrides:
+        description: 'JSON feature-flag overrides (e.g. {"flag":true})'
+        required: false
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      pr:
+        required: false
+        type: number
+        default: 0
+      branch:
+        required: false
+        type: string
+        default: ""
+      docker_image_name:
+        required: false
+        type: string
+        default: ""
+      project:
+        required: false
+        type: string
+        default: ""
+      feature:
+        required: false
+        type: string
+        default: ""
+      flag_overrides:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  path-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      not-ci: ${{ steps.filter.outputs.not-ci }}
+    steps:
+      - name: Checkout for path filter
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr != 0 && format('refs/pull/{0}/merge', inputs.pr) || (inputs.branch != '' && inputs.branch || github.sha) }}
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            not-ci:
+              - '!.github/**'
+              - '!app/v2-platform/**'
+
+  client-build:
+    needs: path-filter
+    if: success() && needs.path-filter.outputs.not-ci == 'true' && inputs.docker_image_name == ''
+    uses: ./.github/workflows/client-build.yml
+    secrets: inherit
+    with:
+      pr: ${{ inputs.pr }}
+      branch: ${{ inputs.branch }}
+
+  server-build:
+    needs: path-filter
+    if: success() && needs.path-filter.outputs.not-ci == 'true' && inputs.docker_image_name == ''
+    uses: ./.github/workflows/server-build.yml
+    secrets: inherit
+    with:
+      pr: ${{ inputs.pr }}
+      skip-tests: true
+      branch: ${{ inputs.branch }}
+
+  rts-build:
+    needs: path-filter
+    if: success() && needs.path-filter.outputs.not-ci == 'true' && inputs.docker_image_name == ''
+    uses: ./.github/workflows/rts-build.yml
+    secrets: inherit
+    with:
+      pr: ${{ inputs.pr }}
+      branch: ${{ inputs.branch }}
+
+  build-docker-image:
+    needs: [client-build, server-build, rts-build, path-filter]
+    if: success() && needs.path-filter.outputs.not-ci == 'true' && inputs.docker_image_name == ''
+    uses: ./.github/workflows/build-docker-image.yml
+    secrets: inherit
+    with:
+      pr: ${{ inputs.pr }}
+      branch: ${{ inputs.branch }}
+
+  playwright-e2e:
+    needs: [path-filter, client-build, server-build, rts-build, build-docker-image]
+    if: |
+      always() &&
+      needs.path-filter.result == 'success' &&
+      needs.path-filter.outputs.not-ci == 'true' &&
+      (
+        (inputs.docker_image_name != '' && needs.build-docker-image.result == 'skipped') ||
+        (inputs.docker_image_name == '' && needs.build-docker-image.result == 'success')
+      )
+    uses: ./.github/workflows/ci-test-playwright.yml
+    secrets: inherit
+    with:
+      pr: ${{ inputs.pr }}
+      branch: ${{ inputs.branch }}
+      docker_image_name: ${{ inputs.docker_image_name }}
+      project: ${{ inputs.project }}
+      feature: ${{ inputs.feature }}
+      flag_overrides: ${{ inputs.flag_overrides }}

--- a/.github/workflows/pw-test-command.yml
+++ b/.github/workflows/pw-test-command.yml
@@ -80,12 +80,15 @@ jobs:
 
   run-tests:
     needs: parse-and-run
-    uses: ./.github/workflows/ci-test-playwright.yml
+    uses: ./.github/workflows/playwright-e2e.yml
     secrets: inherit
     with:
       project: ${{ needs.parse-and-run.outputs.project }}
       feature: ${{ needs.parse-and-run.outputs.feature }}
       flag_overrides: ${{ needs.parse-and-run.outputs.flag_overrides }}
+      pr: ${{ github.event.client_payload.pull_request.number }}
+      branch: ""
+      docker_image_name: ""
 
   post-results:
     needs: [parse-and-run, run-tests]


### PR DESCRIPTION
## Description

Wire up the full Playwright CI pipeline with a new orchestrator workflow and updates to existing workflows:

- **`playwright-e2e.yml`** (new): Top-level orchestrator that runs path-filter → client/server/rts builds → Docker image → Playwright tests. Supports `workflow_dispatch` for manual runs and `workflow_call` for PR comment triggers. Skips builds when `docker_image_name` is provided (pull existing image instead).
- **`ci-test-playwright.yml`**: Refactored from standalone `workflow_dispatch` to `workflow_call` only (invoked by orchestrator). Adds TED + cloud-services containers, Depot CLI, DockerHub login, disk cleanup. Moves Node.js/Yarn/Playwright install after Appsmith is ready (parallel with container startup).
- **`build-docker-image.yml`**: Adds `branch` input so the orchestrator can pass a specific branch for checkout when `pr` is 0.
- **`pw-test-command.yml`**: Routes `/test-pw` PR comments through `playwright-e2e.yml` instead of directly to `ci-test-playwright.yml`, passing `pr`, `branch`, and `docker_image_name`.

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Playwright end-to-end workflow to orchestrate conditional builds and E2E tests.

* **Chores**
  * Reworked CI test workflow to support reusable invocation, new inputs (PR/branch/tag), and improved checkout handling.
  * Added/updated build orchestration and Docker image handling, container setup, caching, and test-run wiring to improve reliability.
* **Chores**
  * Updated test-run command to invoke the new Playwright E2E workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 870c9b6348650ca2c8405efdc541fc58810cc7ea yet
> <hr>Tue, 07 Apr 2026 15:49:52 UTC
<!-- end of auto-generated comment: Cypress test results  -->
