### PR TITLE
fix: remove extra nfs field in persistentVolume object

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.6.9
+version: 3.6.10
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/templates/persistentVolume.yaml
+++ b/deploy/helm/templates/persistentVolume.yaml
@@ -36,7 +36,6 @@ spec:
   {{- if .Values.persistence.efs.enabled }}
   csi:
     driver: {{ .Values.persistence.efs.driver }}
-    nfs:
     volumeHandle: {{ .Values.persistence.efs.volumeHandle }}
   {{ end }}
 {{- end }}

--- a/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
@@ -25,7 +25,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.9
+        appsmith.sh/chart: appsmith-3.6.10
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
   3: |
@@ -36,7 +36,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.9
+        appsmith.sh/chart: appsmith-3.6.10
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -142,7 +142,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.9
+        appsmith.sh/chart: appsmith-3.6.10
       name: RELEASE-NAME-appsmith-headless
       namespace: NAMESPACE
     spec:
@@ -181,7 +181,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.9
+        appsmith.sh/chart: appsmith-3.6.10
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -202,7 +202,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.6.9
+        appsmith.sh/chart: appsmith-3.6.10
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     secrets:


### PR DESCRIPTION
## Description

Removes extra `nfs:` field in the persistentVolume object when EFS enabled.

Older Helm versions seem to have just ignored this, but latest Helm does not.

Fixes [Issue URL](https://github.com/appsmithorg/appsmith/issues/41686)
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 3.6.10
  * Modified persistent volume configuration for EFS-backed storage deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->