### PR TITLE
fix(ci): make Chrome removal safe and guard missing Cypress results

### DIFF
--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -140,7 +140,11 @@ jobs:
       - name: Install Google Chrome 129.0.6668.100
         run: |
           set -euxo pipefail
-          sudo apt-get remove -y google-chrome-stable || true 
+          if dpkg -s google-chrome-stable >/dev/null 2>&1; then
+            sudo apt-get remove -y google-chrome-stable 
+          else 
+              echo "Google Chrome Stable is not installed; skipping removal."
+            fi
           wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -139,7 +139,8 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          sudo apt-get remove google-chrome-stable
+          set -euxo pipefail
+          sudo apt-get remove -y google-chrome-stable || true 
           wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
@@ -261,7 +262,11 @@ jobs:
         if: failure()
         run: |
           mkdir -p ~/results
+          if [ -d "${{ github.workspace }}/app/client/results" ]; then
           mv ${{ github.workspace }}/app/client/results ~/results/${{ matrix.job }}
+          else 
+            echo "No cypress results directory found; skipping mv."
+            fi
 
       - name: Upload cypress report
         if: failure()

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -144,7 +144,7 @@ jobs:
             sudo apt-get remove -y google-chrome-stable 
           else 
               echo "Google Chrome Stable is not installed; skipping removal."
-            fi
+          fi
           wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
@@ -270,7 +270,7 @@ jobs:
           mv ${{ github.workspace }}/app/client/results ~/results/${{ matrix.job }}
           else 
             echo "No cypress results directory found; skipping mv."
-            fi
+          fi
 
       - name: Upload cypress report
         if: failure()


### PR DESCRIPTION
## Description
This PR makes the hosted Cypress CI workflow more robust on `ubuntu-latest`.

### What changed
- **Chrome install step:** only attempts to remove `google-chrome-stable` if it is actually installed (checked via `dpkg -s`), while keeping `set -euxo pipefail` so real failures still surface.
- **Artifacts step:** guards the Cypress results move step so it doesn’t fail when `app/client/results` is not created (e.g., when Cypress fails before generating reports).

## Testing
- GitHub Actions CI on this PR.

## Fixes
- N/A (CI workflow improvement; no existing issue linked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability through enhanced error handling for system dependency installation and test result processing. Workflow now includes safety checks to prevent failures from missing artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->