### PR TITLE
10/04 - Daily promotion

### DIFF
--- a/app/client/packages/ast/src/index.test.ts
+++ b/app/client/packages/ast/src/index.test.ts
@@ -1,8 +1,9 @@
-import { parseJSObject } from "../index";
+import { parseJSObject, entityRefactorFromCode } from "../index";
 import {
   extractIdentifierInfoFromCode,
   getMemberExpressionObjectFromProperty,
   isFunctionPresent,
+  wrapCode,
 } from "../src/index";
 
 describe("getAllIdentifiers", () => {
@@ -793,5 +794,82 @@ describe("getMemberExpressionObjectFromProperty", () => {
 
       expect(actualResponse).toStrictEqual(testDatum.expectedResponse);
     }
+  });
+});
+
+describe("entityRefactorFromCode", () => {
+  it("should refactor a simple identifier reference", () => {
+    const script = "inputs.title";
+    const result = entityRefactorFromCode(
+      script,
+      "inputs",
+      "Commons1.inputs",
+      false,
+      2,
+    );
+
+    expect(result.isSuccess).toBe(true);
+    const body = result.body as { script: string; refactorCount: number };
+
+    expect(body.script).toBe("Commons1.inputs.title");
+    expect(body.refactorCount).toBe(1);
+  });
+
+  it("should refactor inputs in a multi-line object literal (custom widget defaultModel)", () => {
+    // This is the exact pattern from a custom widget's defaultModel inside a UI module.
+    // The binding content starts with a newline followed by {, which triggers
+    // JavaScript's ASI after 'return' in wrapCode, causing a SyntaxError.
+    const script = `\n  {\n    title: inputs.title,\n    fields: inputs.fields,\n  }\n`;
+    const result = entityRefactorFromCode(
+      script,
+      "inputs",
+      "Commons1.inputs",
+      false,
+      2,
+    );
+
+    expect(result.isSuccess).toBe(true);
+    const body = result.body as { script: string; refactorCount: number };
+
+    expect(body.script).toContain("Commons1.inputs.title");
+    expect(body.script).toContain("Commons1.inputs.fields");
+    expect(body.refactorCount).toBe(2);
+  });
+
+  it("should refactor inputs in an inline object literal", () => {
+    const script = "{ title: inputs.title, fields: inputs.fields }";
+    const result = entityRefactorFromCode(
+      script,
+      "inputs",
+      "Commons1.inputs",
+      false,
+      2,
+    );
+
+    expect(result.isSuccess).toBe(true);
+    const body = result.body as { script: string; refactorCount: number };
+
+    expect(body.script).toContain("Commons1.inputs.title");
+    expect(body.script).toContain("Commons1.inputs.fields");
+    expect(body.refactorCount).toBe(2);
+  });
+
+  it("should refactor entity names in standard widget bindings", () => {
+    const script = "Api1.data";
+    const result = entityRefactorFromCode(script, "Api1", "NewApi1", false, 2);
+
+    expect(result.isSuccess).toBe(true);
+    const body = result.body as { script: string; refactorCount: number };
+
+    expect(body.script).toBe("NewApi1.data");
+    expect(body.refactorCount).toBe(1);
+  });
+
+  it("should handle wrapCode/unwrapCode roundtrip correctly", () => {
+    const code = "inputs.title";
+    const wrapped = wrapCode(code);
+
+    expect(wrapped).toContain("return");
+    expect(wrapped).toContain(code);
   });
 });

--- a/app/client/packages/ast/src/index.ts
+++ b/app/client/packages/ast/src/index.ts
@@ -350,20 +350,15 @@ const isArrayAccessorNode = (node: Node): node is MemberExpressionNode => {
   );
 };
 
+const WRAP_CODE_PREFIX = "\n    (function() {\n      return ";
+const WRAP_CODE_SUFFIX = "\n    })\n  ";
+
 export const wrapCode = (code: string) => {
-  return `
-    (function() {
-      return ${code}
-    })
-  `;
+  return `${WRAP_CODE_PREFIX}${code}${WRAP_CODE_SUFFIX}`;
 };
 
-//Tech-debt: should upgrade this to better logic
-//Used slice for a quick resolve of critical bug
 const unwrapCode = (code: string) => {
-  const unwrapedCode = code.slice(32);
-
-  return unwrapedCode.slice(0, -10);
+  return code.slice(WRAP_CODE_PREFIX.length, -WRAP_CODE_SUFFIX.length);
 };
 
 const getFunctionalParamNamesFromNode = (
@@ -486,8 +481,17 @@ export const entityRefactorFromCode = (
   //Sanitizing leads to removal of special charater.
   //Hence we are not sanatizing the script. Fix(#18492)
   //If script is a JSObject then replace export default to decalartion.
+  // Trim leading whitespace before wrapping to prevent ASI after 'return'.
+  // When code starts with a newline before '{' (e.g., multi-line object literals
+  // in custom widget defaultModel), JS inserts a semicolon after 'return',
+  // making '{' parse as a block statement instead of an object literal.
+  let leadingWhitespace = "";
+
   if (isJSObject) script = jsObjectToCode(script);
-  else script = wrapCode(script);
+  else {
+    leadingWhitespace = script.match(/^(\s*)/)?.[0] ?? "";
+    script = wrapCode(script.trimStart());
+  }
 
   let ast: Node = { end: 0, start: 0, type: "" };
   //Copy of script to refactor
@@ -572,7 +576,7 @@ export const entityRefactorFromCode = (
 
     //If script is a JSObject then revert decalartion to export default.
     if (isJSObject) refactorScript = jsCodeToObject(refactorScript);
-    else refactorScript = unwrapCode(refactorScript);
+    else refactorScript = leadingWhitespace + unwrapCode(refactorScript);
 
     return {
       isSuccess: true,


### PR DESCRIPTION
## Description

When a UI module containing a custom widget is instantiated in an app, the `inputs` references inside the custom widget's `defaultModel` property are not refactored. For example, `inputs.title` should become `Commons1.inputs.title` but remains unchanged.

**Root cause:** The `entityRefactorFromCode` function in the AST package passes raw binding content (which may have leading whitespace/newlines) directly to `wrapCode` without sanitization. `wrapCode` wraps code as `(function() { return ${code} })`. When the binding content starts with a newline followed by `{` (common in custom widget `defaultModel` which contains multi-line object literals), JavaScript's Automatic Semicolon Insertion (ASI) rule inserts a semicolon after `return`. This causes `{` to be parsed as a block statement instead of an object literal, resulting in a `SyntaxError`. The error is silently swallowed in `AstServiceCEImpl.refactorNameInDynamicBindings`, leaving the binding unrefactored.

**Fix:** Trim leading whitespace from the script in `entityRefactorFromCode` before passing it to `wrapCode`, so `{` lands on the same line as `return` (preventing ASI). The leading whitespace is restored after unwrapping to preserve the original content. This fix is localized to `entityRefactorFromCode` — `wrapCode` itself is unchanged because other consumers (linting, ActionCreator, etc.) pass multi-statement evaluation scripts through it, and those would break if the return expression were parenthesized. Also replaces the magic-number slicing in `unwrapCode` (flagged as tech-debt) with named constants.

Fixes https://github.com/appsmithorg/appsmith/issues/32841 Fixes
https://linear.app/appsmith/issue/APP-15087/bug-ast-fails-to-refactor-if-moustache-binding-starts-with-a-new-line

**TDD verification:**
| Phase | Result |
|-------|--------|
| Red: multi-line object literal test | Failed as expected (`isSuccess: false`) |
| Green: applied localized fix in `entityRefactorFromCode` | All 73 tests across 4 AST suites pass |
| No regression to `wrapCode` consumers | `wrapCode` output is identical to original |

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run:
<https://github.com/appsmithorg/appsmith/actions/runs/24177924705>
> Commit: 76a1a67750eba5ce483a7ae25ca713b0cdbe1d42
> <a
href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24177924705&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 09 Apr 2026 09:10:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
* Added comprehensive test coverage for code entity refactoring functionality.

* **Refactor**
* Improved code wrapping logic with named constants for better maintainability.
* Enhanced preservation of whitespace formatting in code transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No
