### PR TITLE
fix(server): prevent import from corrupting published layoutOnLoadActions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newpages/importable/NewPageImportableServiceCEImpl.java
@@ -597,24 +597,11 @@ public class NewPageImportableServiceCEImpl implements ImportableServiceCE<NewPa
             });
         }
 
-        if (page.getPublishedPage() != null && page.getPublishedPage().getLayouts() != null) {
-
-            page.getPublishedPage().getLayouts().forEach(layout -> {
-                if (layout.getLayoutOnLoadActions() != null) {
-                    layout.getLayoutOnLoadActions()
-                            .forEach(onLoadAction -> onLoadAction.forEach(actionDTO -> {
-                                String oldActionDTOId = actionDTO.getId();
-                                actionDTO.setId(actionIdMap.get(oldActionDTOId));
-                                if (!CollectionUtils.sizeIsEmpty(publishedActionIdToCollectionIdsMap)
-                                        && publishedActionIdToCollectionIdsMap.containsKey(actionDTO.getId())) {
-                                    actionDTO.setCollectionId(
-                                            publishedActionIdToCollectionIdsMap.get(actionDTO.getId()));
-                                }
-                                layoutOnLoadActions.add(actionDTO.getId());
-                            }));
-                }
-            });
-        }
+        // Published page layouts must NOT be modified during import.
+        // The published state is only updated by the explicit publishPages step during a successful deploy.
+        // Mutating published layouts here with the import's actionIdMap (which maps Git IDs, not production IDs)
+        // corrupts published layoutOnLoadActions — the production action IDs get replaced with null/wrong values.
+        // See: APP-15122
 
         layoutOnLoadActions.remove(null);
         return layoutOnLoadActions;


### PR DESCRIPTION
## Description

When a CD deployment is rejected by the orphan check (`GIT_CD_PUBLISH_ARTIFACT_FAILURE`), the previously deployed published app was being corrupted. The `layoutOnLoadActions` in the published page's layout — which determines which actions auto-execute on page load — was being mutated with wrong/null action IDs by the import step, before the orphan check had a chance to block the deployment.

**Root cause:** `getLayoutOnLoadActionsForPage` in `NewPageImportableServiceCEImpl` (lines 600-616) processed and mutated the published page's `layoutOnLoadActions` using the import's `actionIdMap`. This map is keyed by Git/import action IDs, but the published layout contains production action IDs from the last successful deployment. The lookup `actionIdMap.get(productionId)` returns null, corrupting the published layout. The page is then saved via full-document `saveAll`, persisting the corruption before the orphan check runs.

**Fix:** Remove the published page layout processing from `getLayoutOnLoadActionsForPage`. Published page state must only be updated by the explicit `publishPages` step during a successful deploy, never during import.

EE Companion PR: https://github.com/appsmithorg/appsmith-ee/pull/8918

Fixes https://linear.app/appsmith/issue/APP-15122/cd-deployment-corrupts-published-apps-layoutonloadactions-even-when

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24331202801>
> Commit: 94a4e1c2a800a62f26070312c74c296fed35a4ec
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24331202801&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 13 Apr 2026 08:31:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue during page import where published layouts were being unintentionally modified. The import process now correctly preserves published page layouts without alteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->