### PR TITLE
fix: preserve fixed decimals in currency input setValue

### DIFF
--- a/app/client/src/widgets/CurrencyInputWidget/widget/index.test.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/index.test.tsx
@@ -38,6 +38,32 @@ describe("defaultValueValidation", () => {
     });
   });
 
+  it("should preserve decimal precision for valid string defaults", () => {
+    result = defaultValueValidation(
+      "123.00",
+      { decimals: 2 } as CurrencyInputWidgetProps,
+      _,
+    );
+
+    expect(result).toEqual({
+      isValid: true,
+      parsed: "123.00",
+      messages: [{ name: "", message: "" }],
+    });
+
+    result = defaultValueValidation(
+      "4.10",
+      { decimals: 2 } as CurrencyInputWidgetProps,
+      _,
+    );
+
+    expect(result).toEqual({
+      isValid: true,
+      parsed: "4.10",
+      messages: [{ name: "", message: "" }],
+    });
+  });
+
   it("should validate defaulttext with object value", () => {
     const value = {};
 

--- a/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
@@ -77,6 +77,22 @@ export function defaultValueValidation(
   const decimalSeperator = getLocaleDecimalSeperator();
   const defaultDecimalSeperator = ".";
 
+  const getParsedString = (parsedValue: number) => {
+    if (!_.isString(value)) {
+      return String(parsedValue);
+    }
+
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue.includes(defaultDecimalSeperator)) {
+      return String(parsedValue);
+    }
+
+    const [, fractionalPart = ""] = trimmedValue.split(defaultDecimalSeperator);
+
+    return parsedValue.toFixed(fractionalPart.length);
+  };
+
   if (_.isObject(value)) {
     return {
       isValid: false,
@@ -144,7 +160,7 @@ export function defaultValueValidation(
       messages = [EMPTY_ERROR_MESSAGE];
     }
 
-    parsed = String(parsed);
+    parsed = getParsedString(parsed);
   }
 
   return {

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/config/propertyPaneConfig/validations/defaultValueValidation.ts
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/config/propertyPaneConfig/validations/defaultValueValidation.ts
@@ -33,6 +33,22 @@ export function defaultValueValidation(
   const decimalSeperator = getLocaleDecimalSeperator();
   const defaultDecimalSeperator = ".";
 
+  const getParsedString = (parsedValue: number) => {
+    if (!_.isString(value)) {
+      return String(parsedValue);
+    }
+
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue.includes(defaultDecimalSeperator)) {
+      return String(parsedValue);
+    }
+
+    const [, fractionalPart = ""] = trimmedValue.split(defaultDecimalSeperator);
+
+    return parsedValue.toFixed(fractionalPart.length);
+  };
+
   if (_.isObject(value)) {
     return {
       isValid: false,
@@ -100,7 +116,7 @@ export function defaultValueValidation(
       messages = [EMPTY_ERROR_MESSAGE];
     }
 
-    parsed = String(parsed);
+    parsed = getParsedString(parsed);
   }
 
   return {

--- a/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.test.tsx
+++ b/app/client/src/widgets/wds/WDSCurrencyInputWidget/widget/index.test.tsx
@@ -38,6 +38,32 @@ describe("defaultValueValidation", () => {
     });
   });
 
+  it("should preserve decimal precision for valid string defaults", () => {
+    result = defaultValueValidation(
+      "123.00",
+      { decimals: 2 } as CurrencyInputWidgetProps,
+      _,
+    );
+
+    expect(result).toEqual({
+      isValid: true,
+      parsed: "123.00",
+      messages: [{ name: "", message: "" }],
+    });
+
+    result = defaultValueValidation(
+      "4.10",
+      { decimals: 2 } as CurrencyInputWidgetProps,
+      _,
+    );
+
+    expect(result).toEqual({
+      isValid: true,
+      parsed: "4.10",
+      messages: [{ name: "", message: "" }],
+    });
+  });
+
   it("should validate defaulttext with object value", () => {
     const value = {};
 


### PR DESCRIPTION
## Summary
- preserve entered decimal precision for valid string defaults in both classic and WDS currency inputs
- keep setValue(CurrencyInput1.value.toFixed(2)) from collapsing values like 123.00 to 123
- add regression coverage for the currency input default-value validators

Closes #41118.

## Testing
- corepack yarn jest src/widgets/CurrencyInputWidget/widget/index.test.tsx src/widgets/wds/WDSCurrencyInputWidget/widget/index.test.tsx --runInBand
- corepack yarn exec eslint src/widgets/CurrencyInputWidget/widget/index.tsx src/widgets/CurrencyInputWidget/widget/index.test.tsx src/widgets/wds/WDSCurrencyInputWidget/config/propertyPaneConfig/validations/defaultValueValidation.ts src/widgets/wds/WDSCurrencyInputWidget/widget/index.test.tsx
- NODE_OPTIONS=--max-old-space-size=8192 corepack yarn check-types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Currency input widgets now preserve decimal formatting in default values (e.g., "123.00" maintains trailing zeros instead of being normalized to "123").

* **Tests**
  * Added test coverage for decimal validation scenarios with fixed decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->