### PR TITLE
fix: stop HTML entity decoding from corrupting binary file uploads in multipart form data

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
@@ -5,7 +5,6 @@ import com.appsmith.external.models.EntityDependencyNode;
 import com.appsmith.external.models.EntityReferenceType;
 import com.appsmith.external.models.MustacheBindingToken;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyAccessorFactory;
@@ -358,13 +357,12 @@ public class MustacheHelper {
                 rendered.append(token.getValue());
             }
         }
-        /**
-         * ReplaceAll is used to escape the double quotes symbol with \" so that
-         * JSON remains valid.
-         * &quot; and &#34; both are HTML reserved characters for double quotes (")
-         */
-        return StringEscapeUtils.unescapeHtml4(
-                rendered.toString().replaceAll("&quot;", "\\\\&quot;").replaceAll("&#34;", "\\\\&#34;"));
+        // Only handle &quot; and &#34; (HTML-encoded double quotes) by converting them
+        // to escaped double quotes (\") for JSON validity. Do NOT use unescapeHtml4()
+        // because it decodes ALL HTML entities (e.g., &#xA; → newline, &lt; → <), which
+        // corrupts binary file content that contains entity-like byte sequences.
+        // See: https://linear.app/appsmith/issue/V2-3662
+        return rendered.toString().replace("&quot;", "\\\"").replace("&#34;", "\\\"");
     }
 
     /**

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
@@ -347,22 +347,32 @@ public class MustacheHelper {
                 if (!keyValueMap.containsKey(tokenSubstring)) {
                     rendered.append(token.getValue());
                 } else if (bindingValue != null) {
-                    // If the binding value is not null, then append the binding value to the rendered string.
-                    // We are using the token.getValue() here to get the original value of the binding.
-                    // This is because we want to preserve the original formatting of the binding.
-                    // For example, if the binding is {{Input.text}}, we want to preserve the {{}} around it.
-                    rendered.append(bindingValue);
+                    // Handle &quot; and &#34; (HTML-encoded double quotes) inside the binding
+                    // VALUE only, converting them to escaped double quotes (\") so interpolating
+                    // the value into a JSON template keeps the JSON valid.
+                    //
+                    // Scoping to the binding value is deliberate: template literals and
+                    // pass-through content (e.g., binary uploads) must never be mutated by this
+                    // JSON-validity escape. Historically the replacement ran on the fully
+                    // assembled string and corrupted binary data that happened to contain these
+                    // byte sequences. See: https://linear.app/appsmith/issue/V2-3662
+                    rendered.append(escapeHtmlDoubleQuoteEntities(bindingValue));
                 }
             } else {
                 rendered.append(token.getValue());
             }
         }
-        // Only handle &quot; and &#34; (HTML-encoded double quotes) by converting them
-        // to escaped double quotes (\") for JSON validity. Do NOT use unescapeHtml4()
-        // because it decodes ALL HTML entities (e.g., &#xA; → newline, &lt; → <), which
-        // corrupts binary file content that contains entity-like byte sequences.
-        // See: https://linear.app/appsmith/issue/V2-3662
-        return rendered.toString().replace("&quot;", "\\\"").replace("&#34;", "\\\"");
+        return rendered.toString();
+    }
+
+    private static String escapeHtmlDoubleQuoteEntities(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        if (value.indexOf('&') < 0) {
+            return value;
+        }
+        return value.replace("&quot;", "\\\"").replace("&#34;", "\\\"");
     }
 
     /**

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -400,12 +400,15 @@ public class DataUtils {
         bodyBuilder.asyncPart(key, data, DataBuffer.class).filename(filename).contentType(MediaType.valueOf(mimeType));
     }
 
-    // Parse JSON multipart data
+    // Parse JSON multipart data. Trims input so leading whitespace does not cause
+    // a valid JSON payload to be rejected as invalid multipart data. Consistent with
+    // objectFromJson() in this class which trims before type detection.
     private List<MultipartFormDataDTO> parseMultipartData(String fileValue) throws IOException {
-        if (fileValue.startsWith("{")) {
-            return Collections.singletonList(objectMapper.readValue(fileValue, MultipartFormDataDTO.class));
-        } else if (fileValue.startsWith("[")) {
-            return Arrays.asList(objectMapper.readValue(fileValue, MultipartFormDataDTO[].class));
+        final String trimmed = fileValue == null ? "" : fileValue.trim();
+        if (trimmed.startsWith("{")) {
+            return Collections.singletonList(objectMapper.readValue(trimmed, MultipartFormDataDTO.class));
+        } else if (trimmed.startsWith("[")) {
+            return Arrays.asList(objectMapper.readValue(trimmed, MultipartFormDataDTO[].class));
         } else {
             throw new AppsmithPluginException(
                     AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, ERROR_INVALID_MULTIPART_DATA);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -306,7 +306,7 @@ public class DataUtils {
         final String fileValue = (String) property.getValue();
         final String key = property.getKey();
 
-        if (fileValue.contains(BASE64_DELIMITER)) {
+        if (fileValue.contains(BASE64_DELIMITER) && !fileValue.startsWith("{") && !fileValue.startsWith("[")) {
             processBase64Data(fileValue, key, bodyBuilder, outputMessage);
         } else {
             List<MultipartFormDataDTO> multipartFormDataDTOs = parseMultipartData(fileValue);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -305,11 +305,12 @@ public class DataUtils {
 
         final String fileValue = (String) property.getValue();
         final String key = property.getKey();
+        // Normalize once: routing decisions must be structural, not substring-based on raw input.
+        // Leading whitespace previously misrouted valid JSON payloads to the base64 path. See V2-3662.
+        final String normalized = fileValue == null ? "" : fileValue.trim();
 
-        if (fileValue.contains(BASE64_DELIMITER) && !fileValue.startsWith("{") && !fileValue.startsWith("[")) {
-            processBase64Data(fileValue, key, bodyBuilder, outputMessage);
-        } else {
-            List<MultipartFormDataDTO> multipartFormDataDTOs = parseMultipartData(fileValue);
+        if (normalized.startsWith("{") || normalized.startsWith("[")) {
+            List<MultipartFormDataDTO> multipartFormDataDTOs = parseMultipartData(normalized);
 
             for (MultipartFormDataDTO dto : multipartFormDataDTOs) {
                 String dataString = String.valueOf(dto.getData());
@@ -319,6 +320,11 @@ public class DataUtils {
                     processRegularData(dataString, key, bodyBuilder, outputMessage, dto.getName(), dto.getType());
                 }
             }
+        } else if (normalized.contains(BASE64_DELIMITER)) {
+            processBase64Data(normalized, key, bodyBuilder, outputMessage);
+        } else {
+            // Fall back to existing behavior for non-JSON, non-base64 strings (error thrown downstream).
+            parseMultipartData(normalized);
         }
     }
 

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/DataUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/DataUtilsTest.java
@@ -309,4 +309,65 @@ public class DataUtilsTest {
                 .expectComplete()
                 .verify();
     }
+
+    @Test
+    public void testParseMultipartFileData_withBase64FileArray_returnsExpectedBody() {
+        List<Property> properties = new ArrayList<>();
+        String base64DataUrl = "data:application/pdf;base64,JVBERi0xLjQKMSAwIG9iago=";
+        final Property p1 = new Property(
+                "fileField",
+                "[{\"name\": \"test.pdf\", \"type\": \"application/pdf\", \"data\": \"" + base64DataUrl + "\"}]");
+        p1.setType("file");
+        properties.add(p1);
+
+        final BodyInserter<Object, MockClientHttpRequest> bodyInserter =
+                (BodyInserter<Object, MockClientHttpRequest>) dataUtils.parseMultipartFileData(properties);
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.POST, URI.create("https://example.com"));
+
+        Mono<Void> result = bodyInserter.insert(request, this.context);
+        StepVerifier.create(result).expectComplete().verify();
+        StepVerifier.create(DataBufferUtils.join(request.getBody()))
+                .consumeNextWith(dataBuffer -> {
+                    byte[] resultBytes = new byte[dataBuffer.readableByteCount()];
+                    dataBuffer.read(resultBytes);
+                    DataBufferUtils.release(dataBuffer);
+                    String content = new String(resultBytes, StandardCharsets.UTF_8);
+                    assertTrue(content.contains(
+                            "Content-Disposition: form-data; name=\"fileField\"; filename=\"test.pdf\""));
+                    assertTrue(content.contains("Content-Type: application/pdf"));
+                })
+                .expectComplete()
+                .verify();
+    }
+
+    @Test
+    public void testParseMultipartFileData_withBinaryFileContainingHtmlEntityBytes_succeeds() {
+        List<Property> properties = new ArrayList<>();
+        final Property p1 = new Property(
+                "fileField",
+                "[{\"name\": \"test.pdf\", \"type\": \"application/pdf\", "
+                        + "\"data\": \"binary-prefix\u0026#xA;binary-suffix\"}]");
+        p1.setType("file");
+        properties.add(p1);
+
+        final BodyInserter<Object, MockClientHttpRequest> bodyInserter =
+                (BodyInserter<Object, MockClientHttpRequest>) dataUtils.parseMultipartFileData(properties);
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.POST, URI.create("https://example.com"));
+
+        Mono<Void> result = bodyInserter.insert(request, this.context);
+        StepVerifier.create(result).expectComplete().verify();
+        StepVerifier.create(DataBufferUtils.join(request.getBody()))
+                .consumeNextWith(dataBuffer -> {
+                    byte[] resultBytes = new byte[dataBuffer.readableByteCount()];
+                    dataBuffer.read(resultBytes);
+                    DataBufferUtils.release(dataBuffer);
+                    String content = new String(resultBytes, StandardCharsets.UTF_8);
+                    assertTrue(content.contains(
+                            "Content-Disposition: form-data; name=\"fileField\"; filename=\"test.pdf\""));
+                    assertTrue(content.contains("Content-Type: application/pdf"));
+                    assertTrue(content.contains("&#xA;"));
+                })
+                .expectComplete()
+                .verify();
+    }
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/DataUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/DataUtilsTest.java
@@ -370,4 +370,34 @@ public class DataUtilsTest {
                 .expectComplete()
                 .verify();
     }
+
+    @Test
+    public void testParseMultipartFileData_withLeadingWhitespaceJsonArray_routesAsMultipart() {
+        List<Property> properties = new ArrayList<>();
+        String base64DataUrl = "data:application/pdf;base64,JVBERi0xLjQKMSAwIG9iago=";
+        final Property p1 = new Property(
+                "fileField",
+                "   \n[{\"name\": \"test.pdf\", \"type\": \"application/pdf\", \"data\": \"" + base64DataUrl + "\"}]");
+        p1.setType("file");
+        properties.add(p1);
+
+        final BodyInserter<Object, MockClientHttpRequest> bodyInserter =
+                (BodyInserter<Object, MockClientHttpRequest>) dataUtils.parseMultipartFileData(properties);
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.POST, URI.create("https://example.com"));
+
+        Mono<Void> result = bodyInserter.insert(request, this.context);
+        StepVerifier.create(result).expectComplete().verify();
+        StepVerifier.create(DataBufferUtils.join(request.getBody()))
+                .consumeNextWith(dataBuffer -> {
+                    byte[] resultBytes = new byte[dataBuffer.readableByteCount()];
+                    dataBuffer.read(resultBytes);
+                    DataBufferUtils.release(dataBuffer);
+                    String content = new String(resultBytes, StandardCharsets.UTF_8);
+                    assertTrue(content.contains(
+                            "Content-Disposition: form-data; name=\"fileField\"; filename=\"test.pdf\""));
+                    assertTrue(content.contains("Content-Type: application/pdf"));
+                })
+                .expectComplete()
+                .verify();
+    }
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
@@ -619,4 +619,35 @@ public class MustacheHelperTest {
                         "gtSymbol", "&gt;"));
         assertThat(rendered).isEqualTo("Testing html lt < and gt > symbols");
     }
+
+    /**
+     * This test verifies that binary data containing HTML-entity-like byte sequences
+     * (e.g., &#xA; which is a newline entity) is NOT corrupted by the render method.
+     * PDF files and other binary content may contain such sequences as raw bytes.
+     * Regression test for: https://linear.app/appsmith/issue/V2-3662
+     */
+    @Test
+    public void render_WhenBinaryDataContainsHtmlEntityLikeSequences_DoesNotCorruptData() {
+        String binaryDataWithEntity = "[{\"name\":\"test.pdf\",\"type\":\"application/pdf\","
+                + "\"data\":\"some-binary-prefix\u0026#xA;some-binary-suffix\"}]";
+
+        final String rendered = render("{{filePicker.files}}", Map.of("filePicker.files", binaryDataWithEntity));
+
+        assertThat(rendered).isEqualTo(binaryDataWithEntity);
+        assertThat(rendered).contains("&#xA;");
+        assertThat(rendered).doesNotContain("\n");
+    }
+
+    /**
+     * Verifies that other HTML numeric character references in binary content
+     * are not decoded (e.g., &#xD; for carriage return, &#9; for tab).
+     */
+    @Test
+    public void render_WhenBinaryDataContainsVariousHtmlEntities_DoesNotCorruptData() {
+        String dataWithEntities = "prefix&#xD;middle&#9;suffix&amp;end&lt;final&gt;done";
+
+        final String rendered = render("{{data}}", Map.of("data", dataWithEntities));
+
+        assertThat(rendered).isEqualTo(dataWithEntities);
+    }
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
@@ -608,16 +608,20 @@ public class MustacheHelperTest {
     }
 
     /**
-     * This test case validates the unescaping of HTML characters to string
+     * Verifies that HTML entities other than &quot;/&#34; are NOT decoded.
+     * Previously, unescapeHtml4() decoded all entities, but this corrupted binary data
+     * containing entity-like byte sequences (e.g., &#xA; in PDFs). Now only &quot; and
+     * &#34; are handled for JSON validity.
+     * See: https://linear.app/appsmith/issue/V2-3662
      */
     @Test
-    public void render_WhenValueContainsHtmlReservedCharacters_ReturnsEscapedCharacters() {
+    public void render_WhenValueContainsHtmlReservedCharacters_DoesNotDecodeNonQuoteEntities() {
         final String rendered = render(
                 "Testing html lt {{ltSymbol}} and gt {{gtSymbol}} symbols",
                 Map.of(
                         "ltSymbol", "&lt;",
                         "gtSymbol", "&gt;"));
-        assertThat(rendered).isEqualTo("Testing html lt < and gt > symbols");
+        assertThat(rendered).isEqualTo("Testing html lt &lt; and gt &gt; symbols");
     }
 
     /**

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
@@ -654,4 +654,34 @@ public class MustacheHelperTest {
 
         assertThat(rendered).isEqualTo(dataWithEntities);
     }
+
+    /**
+     * Proves the JSON-quote escape is scoped to binding values only. When the template
+     * contains a literal &quot; AND the binding value also contains a &quot;, only the
+     * value is mutated; the literal is preserved byte-for-byte.
+     * Regression test for: V2-3662 (follow-up)
+     */
+    @Test
+    public void render_WhenTemplateLiteralAndValueBothContainQuoteEntity_OnlyValueIsEscaped() {
+        final String rendered = render("literal &quot; then {{data}} end", Map.of("data", "A&quot;B"));
+
+        // Template literal preserved
+        assertThat(rendered).startsWith("literal &quot; then ");
+        assertThat(rendered).endsWith(" end");
+        // Binding value escaped for JSON validity
+        assertThat(rendered).contains("A\\\"B");
+        assertThat(rendered).isEqualTo("literal &quot; then A\\\"B end");
+    }
+
+    /**
+     * A literal &quot; sitting in the template text (not inside a mustache binding)
+     * must pass through unchanged. Only binding values participate in JSON-validity
+     * escaping.
+     */
+    @Test
+    public void render_WhenTemplateLiteralContainsQuoteEntity_IsPreserved() {
+        final String rendered = render("static &quot;literal&quot; {{k}}", Map.of("k", "v"));
+
+        assertThat(rendered).isEqualTo("static &quot;literal&quot; v");
+    }
 }


### PR DESCRIPTION
## Summary

- **Bug 1:** `MustacheHelper.render()` called `StringEscapeUtils.unescapeHtml4()` on all template-rendered values, which decoded HTML-entity-like byte sequences in binary file content (e.g., `&#xA;` in PDFs → literal newline). This broke Jackson JSON parsing downstream, surfacing as `PE-RST-5000: Unable to parse content. Expected an array or object of multipart data`.
- **Bug 2:** `DataUtils.populateFileTypeBodyBuilder()` used a naive `fileValue.contains(";base64,")` check that matched JSON arrays containing embedded base64 data URLs, misrouting them to `processBase64Data()` instead of the correct `parseMultipartData()` path.
- Both fixes are in `appsmith-interfaces` (CE code, identical in EE). TDD approach: wrote failing tests first, then applied minimal targeted fixes.

## Changes

| File | Change |
|------|--------|
| `MustacheHelper.java` | Replace blanket `unescapeHtml4()` with targeted `&quot;`/`&#34;` → `\"` replacement; remove unused import |
| `MustacheHelperTest.java` | Add 2 new regression tests for binary data with HTML entities; update 1 existing test to reflect corrected behavior |
| `DataUtils.java` | Add `!fileValue.startsWith("{") && !fileValue.startsWith("[")` guard to base64 detection |
| `DataUtilsTest.java` | Add tests for base64 file arrays, binary data with `&#xA;` bytes, and leading-whitespace JSON routing |

### Follow-up systemic tightening (pushed on this PR)

- `DataUtils.populateFileTypeBodyBuilder` — trim once, dispatch JSON-first then base64. Fixes leading-whitespace misrouting CodeRabbit flagged.
- `DataUtils.parseMultipartData` — trim before `startsWith` check, consistent with `objectFromJson` in the same class.
- `MustacheHelper.render` — `&quot;` / `&#34;` → `\"` escape scoped to binding values only (via new private `escapeHtmlDoubleQuoteEntities` helper). Template literals in the mustache template are no longer mutated by the JSON-validity escape.

## Compatibility notes

Non-quote HTML entities in binding values (`&lt;`, `&gt;`, `&amp;`, `&#xA;`, etc.) are no longer decoded by the server. Prior to this fix, `MustacheHelper.render()` called `StringEscapeUtils.unescapeHtml4()` on all rendered values. Any workflow that relied on the server decoding those entities must now decode them client-side or in the action body.

`&quot;` and `&#34;` inside binding values are still converted to `\"` for JSON validity. After the follow-up, this escape is scoped to the binding value itself — template literals (mustache template text outside `{{ }}`) are not touched.

## Test plan

- [x] New tests reproduce both bugs (verified failing before fix)
- [x] All 41 MustacheHelperTest tests pass
- [x] All 12 DataUtilsTest tests pass
- [x] All 55 RestApiPluginTest tests pass (downstream regression check)
- [x] Full appsmith-interfaces suite: 181 tests pass, 0 failures

## Slack thread

https://theappsmith.slack.com/archives/C0341RERY4R/p1775456137121339

Fixes https://linear.app/appsmith/issue/V2-3662/fix-json-serialization-failure-for-pdf-uploads-in-appsmith

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template rendering now preserves HTML entities in non-binding text and scopes quote-escaping to interpolated values to avoid unintended decoding.
  * File upload handling more robustly distinguishes trimmed JSON payloads from base64 multipart data, improving multipart generation for varied inputs.

* **Tests**
  * Added tests covering multipart file handling, leading-whitespace JSON, and entity-preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24529595291>
> Commit: 3fe8b8ef955600cdb8cc45308118a7d03e2f2ced
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24529595291&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 16 Apr 2026 20:28:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->

