### PR TITLE
fix(deps): pin protobufjs to ^7.5.5 (GHSA-xq3m-2v4x-88gg)

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -448,6 +448,7 @@
     "brace-expansion": "1.1.12",
     "form-data": "4.0.4",
     "fast-xml-parser": "4.5.4",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "protobufjs": "^7.5.5"
   }
 }

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -29029,9 +29029,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.3.0":
-  version: 7.3.2
-  resolution: "protobufjs@npm:7.3.2"
+"protobufjs@npm:^7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -29045,7 +29045,7 @@ __metadata:
     "@protobufjs/utf8": ^1.1.0
     "@types/node": ">=13.7.0"
     long: ^5.0.0
-  checksum: cfb2a744787f26ee7c82f3e7c4b72cfc000e9bb4c07828ed78eb414db0ea97a340c0cc3264d0e88606592f847b12c0351411f10e9af255b7ba864eec44d7705f
+  checksum: e316eb0df33a64398ce32056de37435d8ea7ef3e06dff32cda2a7156431c029fe2c120e390b7ff066de7632e996d6d5d0540fb606fef223a8480dff25bee6123
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Patches critical RCE vulnerability in `protobufjs` ([GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg), CVSS 9.4) by forcing all transitive installs to `^7.5.5` via Yarn `resolutions`.

Fixes https://linear.app/appsmith/issue/APP-15148/security-critical-arbitrary-code-execution-in-protobufjs-ghsa-xq3m

## Exposure analysis

- **Direct usage in Appsmith:** none. `rg "from \"protobufjs|require\(['\"]protobufjs"` returns zero hits in the source.
- **Transitive path:** 6 lockfile nodes, all through `@opentelemetry/otlp-transformer` (pulled in by `@opentelemetry/exporter-trace-otlp-http` in both the browser client and the RTS workspace).
- **Exploit precondition per advisory:** attacker must control a protobuf definition JSON fed to `Root.fromJSON()` or `protobuf.load()`.
- **Reachable in Appsmith?** No. `otlp-transformer` ships a pre-compiled static schema (`generated/root.js`) and only uses `protobufjs/minimal` — the runtime-only build, which does not include `fromJSON` / reflection / `load()`. Confirmed by `rg 'fromJSON|reflection|parse\.parse|loadSync|load\(' node_modules/@opentelemetry/otlp-transformer` returning zero matches.

## Fix

Single entry added to the existing `resolutions` block in `app/client/package.json`. `yarn install` regenerates the lockfile so all six `@opentelemetry/otlp-transformer` variants now resolve `protobufjs` to `7.5.5` (was `7.3.2`). Range-compatible with every consumer's existing `^7.3.0` / `^7.2.5` constraint; no parent package upgrades required.

```diff
   "resolutions": {
     ...
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "protobufjs": "^7.5.5"
   }
```

## Mitigation verification

Confirmed live against both versions side-by-side before pushing. The upstream patch commit [protobufjs/protobuf.js@535df444ac](https://github.com/protobufjs/protobuf.js/commit/535df444ac) adds a single line in `src/type.js` Type constructor:

```js
name = name.replace(/\W/g, "");
```

This strips non-word characters from type names before they flow into the protobufjs/codegen sink (`new Function(...)`), neutralizing the code-injection vector.

| Input malicious type name | Vulnerable 7.3.2 behavior | Patched 7.5.5 behavior |
|---|---|---|
| `"Evil(){throw 'PWN'};//foo"` | preserved verbatim (reaches codegen) | sanitized to `"EvilthrowPWNfoo"` (safe identifier) |

## Test plan

- [x] `yarn install` completes cleanly (`Done with warnings in 58s`).
- [x] `yarn why protobufjs` shows `7.5.5` for every transitive dependent (6 nodes, all @opentelemetry/otlp-transformer variants).
- [x] `grep -c 'resolution: "protobufjs@npm:' yarn.lock` returns `1` (single unified resolution).
- [x] No `protobufjs@npm:7.3.2` entries remain in the lockfile.
- [x] Upstream patch sanitizer confirmed active in the installed 7.5.5 artifact: `new protobuf.Type("Evil(){throw 'PWN'};//foo").name === "EvilthrowPWNfoo"`.
- [x] OTLP trace serializer module-load + encode smoke test passes on the new lockfile: `ProtobufTraceSerializer.serializeRequest([]).byteLength === 0`.

## Related

- Dependabot alert #583
- Linear: APP-15148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24556337484>
> Commit: e25babb1f94f142202fd6485855f87f1a7b3fae9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24556337484&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 17 Apr 2026 09:54:32 UTC
<!-- end of auto-generated comment: Cypress test results  -->
