### PR TITLE
fix(frontend): remove misleading 504 code on client-side timeout page

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -487,7 +487,6 @@ export const BACK_TO_HOMEPAGE = () => "Go back to homepage";
 // error pages
 export const PAGE_NOT_FOUND_TITLE = () => "404";
 export const PAGE_NOT_FOUND = () => "Page not found";
-export const PAGE_SERVER_TIMEOUT_ERROR_CODE = () => "504";
 export const PAGE_SERVER_TIMEOUT_TITLE = () =>
   "Appsmith server is taking too long to respond";
 export const PAGE_SERVER_TIMEOUT_DESCRIPTION = () =>

--- a/app/client/src/pages/common/ErrorPages/ServerTimeout.tsx
+++ b/app/client/src/pages/common/ErrorPages/ServerTimeout.tsx
@@ -5,7 +5,6 @@ import Page from "./Page";
 import {
   createMessage,
   PAGE_SERVER_TIMEOUT_DESCRIPTION,
-  PAGE_SERVER_TIMEOUT_ERROR_CODE,
   PAGE_SERVER_TIMEOUT_TITLE,
 } from "ee/constants/messages";
 
@@ -23,7 +22,6 @@ function ServerTimeout() {
         </Button>
       }
       description={createMessage(PAGE_SERVER_TIMEOUT_DESCRIPTION)}
-      errorCode={createMessage(PAGE_SERVER_TIMEOUT_ERROR_CODE)}
       title={createMessage(PAGE_SERVER_TIMEOUT_TITLE)}
     />
   );


### PR DESCRIPTION
## Summary
- Client-side Axios timeouts (`ECONNABORTED`) render the `ServerTimeout` error page, which was displaying **504** as the status badge even though no HTTP response is ever received. This misled admins into searching proxy/server logs for a 504 that never occurred.
- Removes the fake status code from the timeout page and deletes the now-unused `PAGE_SERVER_TIMEOUT_ERROR_CODE` constant.
- Title and description on the page are unchanged; only the misleading numeric badge is removed.

## Files changed
- `app/client/src/pages/common/ErrorPages/ServerTimeout.tsx` — drop `errorCode` prop + import
- `app/client/src/ce/constants/messages.ts` — remove unused `PAGE_SERVER_TIMEOUT_ERROR_CODE` export

Closes #41541

## Test plan
- [ ] Trigger a client-side timeout (e.g. the `slow-proxy.py` repro in the issue) and confirm the error page no longer shows the `504` badge.
- [ ] Normal error pages (404 / 503 / generic) still render their status codes unchanged.
- [ ] `yarn tsc` / client build passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused internal constant from error handling utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->