### PR TITLE
feat(frontend): make client-side timeouts configurable via env vars

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -42,6 +42,16 @@
         const AIRGAPPED = parseConfig('{{env "APPSMITH_AIRGAP_ENABLED"}}');
         const REO_CLIENT_ID = parseConfig('{{env "APPSMITH_REO_CLIENT_ID"}}');
         const DISABLE_BETTERBUGS = parseConfig('{{env "APPSMITH_DISABLE_BETTERBUGS"}}');
+        // Parse a positive integer millisecond value from a config string.
+        // Returns `undefined` when unset or invalid so callers can fall back
+        // to their compiled-in defaults. See issue #41540.
+        const parseTimeoutConfig = (config) => {
+          const raw = parseConfig(config);
+          if (typeof raw !== "string") return undefined;
+          const parsed = parseInt(raw, 10);
+          if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+          return parsed;
+        };
       </script>
     <script>
         window.__APPSMITH_CHUNKS_TO_PRELOAD =
@@ -271,6 +281,32 @@
         pricingUrl:
           parseConfig('{{env "APPSMITH_PRICING_URL"}}') ||
           "https://www.appsmith.com/pricing",
+        // Optional overrides for client-side timeout values (in milliseconds).
+        // Unset / invalid values fall back to compiled-in defaults in
+        // src/ce/constants/ApiConstants.tsx (see issue #41540).
+        timeouts: {
+          REQUEST_TIMEOUT_MS: parseTimeoutConfig(
+            '{{env "APPSMITH_CLIENT_REQUEST_TIMEOUT_MS"}}',
+          ),
+          DEFAULT_ACTION_TIMEOUT: parseTimeoutConfig(
+            '{{env "APPSMITH_CLIENT_DEFAULT_ACTION_TIMEOUT_MS"}}',
+          ),
+          DEFAULT_EXECUTE_ACTION_TIMEOUT_MS: parseTimeoutConfig(
+            '{{env "APPSMITH_CLIENT_EXECUTE_ACTION_TIMEOUT_MS"}}',
+          ),
+          DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS: parseTimeoutConfig(
+            '{{env "APPSMITH_CLIENT_TEST_DATASOURCE_TIMEOUT_MS"}}',
+          ),
+          DEFAULT_APPSMITH_AI_QUERY_TIMEOUT_MS: parseTimeoutConfig(
+            '{{env "APPSMITH_CLIENT_AI_QUERY_TIMEOUT_MS"}}',
+          ),
+          FILE_UPLOAD_TRIGGER_TIMEOUT_MS: parseTimeoutConfig(
+            '{{env "APPSMITH_CLIENT_FILE_UPLOAD_TIMEOUT_MS"}}',
+          ),
+          CONSOLIDATED_API_TIMEOUT_MS: parseTimeoutConfig(
+            '{{env "APPSMITH_CLIENT_CONSOLIDATED_API_TIMEOUT_MS"}}',
+          ),
+        },
       };
     </script>
   </body>

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -45,11 +45,22 @@
         // Parse a positive integer millisecond value from a config string.
         // Returns `undefined` when unset or invalid so callers can fall back
         // to their compiled-in defaults. See issue #41540.
+        // Strict: rejects values like "20000ms" or "1e4" that parseInt would
+        // silently accept, so misconfigured env vars surface as a warning
+        // rather than a half-parsed number.
         const parseTimeoutConfig = (config) => {
           const raw = parseConfig(config);
           if (typeof raw !== "string") return undefined;
-          const parsed = parseInt(raw, 10);
-          if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+          const trimmed = raw.trim();
+          if (!/^\d+$/.test(trimmed)) {
+            console.warn(
+              "Ignoring invalid APPSMITH_CLIENT_*_TIMEOUT_MS value (expected a positive integer):",
+              raw,
+            );
+            return undefined;
+          }
+          const parsed = Number(trimmed);
+          if (!Number.isInteger(parsed) || parsed <= 0) return undefined;
           return parsed;
         };
       </script>

--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -43,6 +43,15 @@ export interface INJECTED_CONFIGS {
   disableIframeWidgetSandbox: boolean;
   pricingUrl: string;
   customerPortalUrl: string;
+  timeouts?: {
+    REQUEST_TIMEOUT_MS?: number;
+    DEFAULT_ACTION_TIMEOUT?: number;
+    DEFAULT_EXECUTE_ACTION_TIMEOUT_MS?: number;
+    DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS?: number;
+    DEFAULT_APPSMITH_AI_QUERY_TIMEOUT_MS?: number;
+    FILE_UPLOAD_TRIGGER_TIMEOUT_MS?: number;
+    CONSOLIDATED_API_TIMEOUT_MS?: number;
+  };
 }
 
 const capitalizeText = (text: string) => {

--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -43,6 +43,11 @@ export interface INJECTED_CONFIGS {
   disableIframeWidgetSandbox: boolean;
   pricingUrl: string;
   customerPortalUrl: string;
+  // Optional runtime overrides for client-side timeouts. Keys mirror the
+  // constants in `constants/ApiConstants.tsx`, which consumes this object
+  // directly from `window.APPSMITH_FEATURE_CONFIGS` at module load. These
+  // values are intentionally NOT surfaced through `getConfigsFromEnvVars` /
+  // `getAppsmithConfigs` — no plumbing exists here on purpose.
   timeouts?: {
     REQUEST_TIMEOUT_MS?: number;
     DEFAULT_ACTION_TIMEOUT?: number;

--- a/app/client/src/ce/constants/ApiConstants.tsx
+++ b/app/client/src/ce/constants/ApiConstants.tsx
@@ -2,13 +2,56 @@ import type { CreateAxiosDefaults } from "axios";
 import { ID_EXTRACTION_REGEX } from "constants/routes";
 import { UNUSED_ENV_ID } from "constants/EnvironmentContants";
 
-export const REQUEST_TIMEOUT_MS = 20000;
-export const DEFAULT_ACTION_TIMEOUT = 10000;
-export const DEFAULT_EXECUTE_ACTION_TIMEOUT_MS = 15000;
-export const DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS = 30000;
-export const DEFAULT_APPSMITH_AI_QUERY_TIMEOUT_MS = 60000;
-export const FILE_UPLOAD_TRIGGER_TIMEOUT_MS = 60000;
-export const CONSOLIDATED_API_TIMEOUT_MS = 60000;
+// Default client-side timeout values (in milliseconds).
+// These can be overridden at runtime via `window.APPSMITH_FEATURE_CONFIGS.timeouts`,
+// which is populated from environment variables in `public/index.html`.
+// See issue #41540 for rationale.
+export const DEFAULT_TIMEOUTS = {
+  REQUEST_TIMEOUT_MS: 20000,
+  DEFAULT_ACTION_TIMEOUT: 10000,
+  DEFAULT_EXECUTE_ACTION_TIMEOUT_MS: 15000,
+  DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS: 30000,
+  DEFAULT_APPSMITH_AI_QUERY_TIMEOUT_MS: 60000,
+  FILE_UPLOAD_TRIGGER_TIMEOUT_MS: 60000,
+  CONSOLIDATED_API_TIMEOUT_MS: 60000,
+} as const;
+
+type TimeoutKey = keyof typeof DEFAULT_TIMEOUTS;
+
+// Resolve a timeout value from the runtime-injected config, falling back to the
+// compiled-in default when no override is provided or the value is invalid.
+// Safe to call in both the main thread and web workers.
+const resolveTimeout = (key: TimeoutKey): number => {
+  const fallback = DEFAULT_TIMEOUTS[key];
+
+  if (typeof window === "undefined") return fallback;
+
+  const override = window.APPSMITH_FEATURE_CONFIGS?.timeouts?.[key];
+
+  if (typeof override !== "number" || !Number.isFinite(override) || override <= 0) {
+    return fallback;
+  }
+
+  return override;
+};
+
+export const REQUEST_TIMEOUT_MS = resolveTimeout("REQUEST_TIMEOUT_MS");
+export const DEFAULT_ACTION_TIMEOUT = resolveTimeout("DEFAULT_ACTION_TIMEOUT");
+export const DEFAULT_EXECUTE_ACTION_TIMEOUT_MS = resolveTimeout(
+  "DEFAULT_EXECUTE_ACTION_TIMEOUT_MS",
+);
+export const DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS = resolveTimeout(
+  "DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS",
+);
+export const DEFAULT_APPSMITH_AI_QUERY_TIMEOUT_MS = resolveTimeout(
+  "DEFAULT_APPSMITH_AI_QUERY_TIMEOUT_MS",
+);
+export const FILE_UPLOAD_TRIGGER_TIMEOUT_MS = resolveTimeout(
+  "FILE_UPLOAD_TRIGGER_TIMEOUT_MS",
+);
+export const CONSOLIDATED_API_TIMEOUT_MS = resolveTimeout(
+  "CONSOLIDATED_API_TIMEOUT_MS",
+);
 
 export const DEFAULT_AXIOS_CONFIG: CreateAxiosDefaults = {
   baseURL: "/api/",


### PR DESCRIPTION
## Summary

- Replaces the hardcoded timeout constants in `app/client/src/ce/constants/ApiConstants.tsx` with values resolved at runtime from `window.APPSMITH_FEATURE_CONFIGS.timeouts`, populated from new `APPSMITH_CLIENT_*_TIMEOUT_MS` environment variables in `public/index.html`.
- Each constant falls back to its existing default (same numeric value) whenever the env var is unset, zero, or non-numeric, so existing deployments are unaffected.
- Follows the same runtime-injection pattern already used for Sentry DSN, Segment key, etc.

Fixes #41540

## New environment variables

| Env var | Overrides | Default |
| --- | --- | --- |
| `APPSMITH_CLIENT_REQUEST_TIMEOUT_MS` | `REQUEST_TIMEOUT_MS` | 20000 |
| `APPSMITH_CLIENT_DEFAULT_ACTION_TIMEOUT_MS` | `DEFAULT_ACTION_TIMEOUT` | 10000 |
| `APPSMITH_CLIENT_EXECUTE_ACTION_TIMEOUT_MS` | `DEFAULT_EXECUTE_ACTION_TIMEOUT_MS` | 15000 |
| `APPSMITH_CLIENT_TEST_DATASOURCE_TIMEOUT_MS` | `DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS` | 30000 |
| `APPSMITH_CLIENT_AI_QUERY_TIMEOUT_MS` | `DEFAULT_APPSMITH_AI_QUERY_TIMEOUT_MS` | 60000 |
| `APPSMITH_CLIENT_FILE_UPLOAD_TIMEOUT_MS` | `FILE_UPLOAD_TRIGGER_TIMEOUT_MS` | 60000 |
| `APPSMITH_CLIENT_CONSOLIDATED_API_TIMEOUT_MS` | `CONSOLIDATED_API_TIMEOUT_MS` | 60000 |

## Test plan

- [ ] Build the client with no env vars set — timeouts equal their prior hardcoded values.
- [ ] Set `APPSMITH_CLIENT_REQUEST_TIMEOUT_MS=45000`, rebuild/re-render `index.html`, reload the app, and confirm axios requests time out at ~45s.
- [ ] Set an invalid value (e.g. `APPSMITH_CLIENT_REQUEST_TIMEOUT_MS=abc` or `0`) — value falls back to the default without errors.
- [ ] Run the client unit/type-check pipeline to confirm no type regressions on `window.APPSMITH_FEATURE_CONFIGS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client timeout values (API requests, actions, executes, data-source tests, AI queries, file uploads, consolidated calls) can be overridden at runtime via feature config values exposed to the client.
  * Invalid or unset overrides are ignored and automatically fall back to built-in defaults; misformatted overrides emit a console warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->