### PR TITLE
fix(Switch widget): sync isSwitchedOn meta on programmatic changes

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/Switch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Switch/Switch_spec.js
@@ -154,6 +154,41 @@ describe(
       _.deployMode.NavigateBacktoEditor();
     });
 
+    it("6a. Regression: programmatic defaultSwitchState changes sync isSwitchedOn for dependents (#41566)", function () {
+      // Bind dependent text widget to Switch1.isSwitchedOn
+      cy.openPropertyPane("textwidget");
+      cy.updateCodeInput(
+        ".t--property-control-text",
+        `{{Toggler.isSwitchedOn}}`,
+      );
+
+      // Seed default to true and assert dependent reflects it
+      cy.openPropertyPane("switchwidget");
+      cy.get(".t--property-control-defaultstate input").last().then(($el) => {
+        if (!$el.is(":checked")) cy.wrap($el).click({ force: true });
+      });
+      cy.get(".t--widget-textwidget")
+        .scrollIntoView()
+        .should("contain", "true");
+
+      // User toggles the Switch once so meta.isSwitchedOn starts overriding the default
+      cy.get(`${formWidgetsPage.switchWidget} label`).first().click();
+      cy.get(".t--widget-textwidget")
+        .scrollIntoView()
+        .should("contain", "false");
+
+      // Programmatic change to defaultSwitchState should now propagate to dependents
+      cy.openPropertyPane("switchwidget");
+      cy.get(".t--property-control-defaultstate input").last().click();
+      cy.get(".t--widget-textwidget")
+        .scrollIntoView()
+        .should("contain", "true");
+
+      // Restore binding used by the next test
+      cy.openPropertyPane("textwidget");
+      cy.updateCodeInput(".t--property-control-text", `{{Toggler.isDirty}}`);
+    });
+
     it("6. Check isDirty meta property", function () {
       cy.openPropertyPane("textwidget");
       cy.updateCodeInput(".t--property-control-text", `{{Toggler.isDirty}}`);

--- a/app/client/src/widgets/SwitchWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/widget/index.tsx
@@ -434,10 +434,7 @@ class SwitchWidget extends BaseWidget<SwitchWidgetProps, WidgetState> {
     }
 
     // Sync meta when isSwitchedOn changes programmatically so dependents don't see a stale value.
-    if (
-      this.props.isSwitchedOn !== prevProps.isSwitchedOn &&
-      this.props.onChange
-    ) {
+    if (this.props.isSwitchedOn !== prevProps.isSwitchedOn) {
       this.props.updateWidgetMetaProperty(
         "isSwitchedOn",
         this.props.isSwitchedOn,

--- a/app/client/src/widgets/SwitchWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/widget/index.tsx
@@ -432,6 +432,17 @@ class SwitchWidget extends BaseWidget<SwitchWidgetProps, WidgetState> {
     ) {
       this.props.updateWidgetMetaProperty("isDirty", false);
     }
+
+    // Sync meta when isSwitchedOn changes programmatically so dependents don't see a stale value.
+    if (
+      this.props.isSwitchedOn !== prevProps.isSwitchedOn &&
+      this.props.onChange
+    ) {
+      this.props.updateWidgetMetaProperty(
+        "isSwitchedOn",
+        this.props.isSwitchedOn,
+      );
+    }
   }
 
   onChange = (isSwitchedOn: boolean) => {


### PR DESCRIPTION
## Description

Fixes a stale-binding bug in the Switch widget. Once a user interacts with the widget at least once, its `isSwitchedOn` meta takes precedence over the derived `defaultSwitchState`. Any subsequent programmatic change to `defaultSwitchState` (via `Switch1.setValue(...)`, a bound default state expression, or a ToggleButton driving the switch) updated `defaultSwitchState` but left the stale meta in place. Widgets bound to `Switch1.isSwitchedOn` kept reading the old value.

This PR adds a small `componentDidUpdate` block in `SwitchWidget` that syncs the meta value whenever `isSwitchedOn` changes, mirroring the existing behavior in `CheckboxWidget.componentDidUpdate` (`app/client/src/widgets/CheckboxWidget/widget/index.tsx`).

Fixes #41566

## Automation

/ok-to-test tags="@tag.Switch, @tag.Binding"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

## Testing

Manual repro from the issue:
1. Drop a `Switch`, a `ToggleButton`, and a `Button` on the canvas.
2. Bind `Button.disabled` to `{{Switch1.isSwitchedOn}}`.
3. Wire `ToggleButton.onChange` to `{{Switch1.setValue(!Switch1.isSwitchedOn)}}`.
4. Toggle the `Switch` once directly, then toggle via `ToggleButton` — before the fix, `Button.disabled` goes stale; after the fix it follows the switch consistently.

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switch widget now correctly syncs its on/off state when changed programmatically, ensuring dependent widgets reflect the current state.
* **Tests**
  * Added a regression test to verify programmatic toggles update dependent bindings and prevent test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->