### PR TITLE
fix(datasource): move expiresIn after Scope in OAuth2 form (closes #31059)

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -834,6 +834,16 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
     return (
       <>
         {this.renderOauth2Common()}
+        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+          {this.renderInputTextControlViaFormControl({
+            configProperty: "authentication.expiresIn",
+            label: "Authorization expires in (seconds)",
+            placeholderText: "3600",
+            dataType: "NUMBER",
+            encrypted: false,
+            isRequired: false,
+          })}
+        </FormInputContainer>
         <FormInputContainer
           data-location-id={btoa("authentication.authorizationUrl")}
         >
@@ -869,16 +879,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&


### PR DESCRIPTION
## Summary

Closes #31059.

Moves the **Authorization expires in (seconds)** input in the OAuth2 *Authorization Code* datasource form so it renders directly after the common OAuth2 fields (which ends with **Scope(s)**), keeping all authentication-related inputs grouped together as requested in the issue.

## Before vs after

Only touches `RestAPIDatasourceForm.tsx -> renderOauth2AuthorizationCode()`. The order changes from:

1. Common (client id/secret, scope, client auth method)
2. Authorization URL
3. Redirect URL (read-only)
4. Custom Authentication Parameters
5. **Authorization expires in (seconds)**
6. Advanced (conditional)

to:

1. Common (client id/secret, scope, client auth method)
2. **Authorization expires in (seconds)**  ← moved here
3. Authorization URL
4. Redirect URL (read-only)
5. Custom Authentication Parameters
6. Advanced (conditional)

`expiresIn` is intentionally kept inside `renderOauth2AuthorizationCode` (not `renderOauth2Common`) so it does **not** show up for the *Client Credentials* grant type, matching the current behavior.

## Test plan

- [ ] `Settings → Datasources → Create → Authenticated API → Authentication type: OAuth 2.0 → Grant type: Authorization Code` — verify `Authorization expires in (seconds)` now appears immediately after `Scope(s)` / `Client Authentication`.
- [ ] Switch grant type to **Client Credentials** — the `expiresIn` field is still hidden (unchanged behaviour).
- [ ] Save a datasource, reload, confirm the stored `authentication.expiresIn` value is preserved.
- [ ] No lint / TS errors in `app/client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized form field layout in the REST API datasource authentication settings for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->