### PR TITLE
chore(git): idempotent ref creation in CentralGitServiceCEImpl

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -691,6 +691,14 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, REF_NAME));
         }
 
+        if (!hasText(referencedArtifactId)) {
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ID));
+        }
+
+        if (artifactType == null) {
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "artifactType"));
+        }
+
         GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
         AclPermission artifactEditPermission = gitArtifactHelper.getArtifactEditPermission();
 
@@ -742,9 +750,6 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
         createRefTransformationDTO.setRefType(refType);
         createRefTransformationDTO.setRefName(refDTO.getRefName());
 
-        Mono<Boolean> acquireGitLockMono = gitRedisUtils.acquireGitLock(
-                artifactType, baseGitMetadata.getDefaultArtifactId(), GitCommandConstants.CREATE_REF, FALSE);
-
         FetchRemoteDTO fetchRemoteDTO = new FetchRemoteDTO();
         fetchRemoteDTO.setRefType(refType);
         fetchRemoteDTO.setIsFetchAll(TRUE);
@@ -753,13 +758,14 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
         Mono<String> fetchRemoteMono =
                 gitHandlingService.fetchRemoteReferences(baseRefTransformationDTO, fetchRemoteDTO, baseGitAuth);
 
-        Mono<? extends Artifact> createBranchMono = acquireGitLockMono
-                .flatMap(ignoreLockAcquisition -> removeDanglingLock
-                        .then(fetchRemoteMono)
-                        .onErrorResume(error -> Mono.error(new AppsmithException(
-                                AppsmithError.GIT_ACTION_FAILED, GitCommandConstants.FETCH_REMOTE, error))))
+        // Core ref-creation pipeline. Executed while the git lock is held by the
+        // surrounding Mono.usingWhen so lock lifecycle is managed in exactly one place.
+        Mono<? extends Artifact> refCreationPipeline = removeDanglingLock
+                .then(fetchRemoteMono)
+                .onErrorResume(error -> Mono.error(new AppsmithException(
+                        AppsmithError.GIT_ACTION_FAILED, GitCommandConstants.FETCH_REMOTE, error)))
                 .flatMap(ignoreFetchString -> gitHandlingService
-                        .listReferences(createRefTransformationDTO, TRUE)
+                        .listReferences(baseRefTransformationDTO, TRUE)
                         .flatMap(gitRefDTOs -> {
                             Mono<? extends ArtifactExchangeJson> artifactExchangeJsonMono =
                                     getArtifactExchangeJsonForRefCreation(sourceArtifact, refType, gitType)
@@ -797,47 +803,94 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                     Mono<String> refCreationMono = gitHandlingService
                             .createGitReference(
                                     baseRefTransformationDTO, createRefTransformationDTO, baseGitMetadata, refDTO)
-                            // TODO: this error could be shipped to handling layer as well?
                             .onErrorResume(error -> Mono.error(new AppsmithException(
-                                    AppsmithError.GIT_ACTION_FAILED, "ref creation preparation", error.getMessage())));
+                                    AppsmithError.GIT_ACTION_FAILED, "ref creation", error.getMessage())));
 
                     return refCreationMono
-                            .flatMap(ignoredString -> {
-                                return importService.importArtifactInWorkspaceFromGit(
-                                        newRefArtifact.getWorkspaceId(),
+                            .flatMap(ignoredString -> importService.importArtifactInWorkspaceFromGit(
+                                    newRefArtifact.getWorkspaceId(),
+                                    newRefArtifact.getId(),
+                                    exportedJson,
+                                    refDTO.getRefName()))
+                            .flatMap(importedArtifact ->
+                                    gitArtifactHelper.publishArtifactPostRefCreation(importedArtifact, refType, TRUE))
+                            // Roll back the DB artifact created by generateArtifactForRefCreation if any
+                            // step between git ref creation and publish fails; otherwise the user cannot
+                            // retry the same ref name because the duplicate-name guard would trip on
+                            // this orphaned DB row.
+                            .onErrorResume(error -> {
+                                log.error(
+                                        "Rolling back new artifact {} after ref creation failure: {}",
                                         newRefArtifact.getId(),
-                                        exportedJson,
-                                        refDTO.getRefName());
-                            })
-                            .flatMap(importedArtifact -> {
-                                return gitArtifactHelper.publishArtifactPostRefCreation(
-                                        importedArtifact, refType, TRUE);
-                            })
-                            .flatMap(newImportedArtifact -> {
-                                if (RefType.tag.equals(refType)) {
-                                    return Mono.just(newImportedArtifact);
-                                }
-
-                                // after a new branch is created, the parent branch should be reset to a
-                                // clean status, i.e. last commit
-                                return discardChanges(sourceArtifact, gitType, FALSE)
-                                        .thenReturn(newImportedArtifact);
+                                        error.getMessage());
+                                return gitArtifactHelper
+                                        .deleteArtifactByResource(newRefArtifact)
+                                        .onErrorResume(rollbackError -> {
+                                            log.error(
+                                                    "Rollback of new artifact {} failed: {}",
+                                                    newRefArtifact.getId(),
+                                                    rollbackError.getMessage(),
+                                                    rollbackError);
+                                            return Mono.empty();
+                                        })
+                                        .then(Mono.error(error));
                             });
                 })
-                .flatMap(newImportedArtifact -> gitRedisUtils
-                        .releaseFileLock(artifactType, baseArtifactId, TRUE)
-                        .then(gitAnalyticsUtils.addAnalyticsForGitOperation(
+                .flatMap(newImportedArtifact -> gitAnalyticsUtils
+                        .addAnalyticsForGitOperation(
                                 AnalyticsEvents.GIT_CREATE_BRANCH,
                                 newImportedArtifact,
-                                newImportedArtifact.getGitArtifactMetadata().getIsRepoPrivate())))
+                                newImportedArtifact.getGitArtifactMetadata().getIsRepoPrivate())
+                        .onErrorResume(analyticsError -> {
+                            log.warn(
+                                    "Failed to record analytics for GIT_CREATE_BRANCH on artifact {}: {}",
+                                    newImportedArtifact.getId(),
+                                    analyticsError.getMessage());
+                            return Mono.empty();
+                        })
+                        .thenReturn(newImportedArtifact));
+
+        // Use usingWhen so the git lock is acquired and released exactly once per invocation,
+        // regardless of how the pipeline terminates (success, error, or cancellation).
+        // The refCreationPipeline (ref creation + import + publish + analytics) all runs under
+        // the lock; discardChanges below runs *after* the lock is released so it never blocks
+        // subsequent git ops on the same base artifact, and is set up as a best-effort cleanup
+        // so we can flip it to fire-and-forget async in a follow-up.
+        Mono<? extends Artifact> createBranchMono = Mono.usingWhen(
+                        gitRedisUtils.acquireGitLock(
+                                artifactType, baseArtifactId, GitCommandConstants.CREATE_REF, TRUE),
+                        ignoreLockAcquisition -> refCreationPipeline,
+                        ignoreLockAcquisition -> gitRedisUtils
+                                .releaseFileLock(artifactType, baseArtifactId, TRUE)
+                                .onErrorResume(releaseError -> {
+                                    log.warn(
+                                            "Failed to release git lock on artifact {} after create ref: {}",
+                                            baseArtifactId,
+                                            releaseError.getMessage());
+                                    return Mono.just(TRUE);
+                                }))
+                // After the lock is released, reset the source branch to its last commit.
+                // Best-effort: a failure here must NOT convert a successful branch creation into
+                // an error for the caller. Kept synchronous for now so external observers see a
+                // consistent source branch on return, but ready to be fire-and-forget async later.
+                .flatMap(newImportedArtifact -> {
+                    if (RefType.tag.equals(refType)) {
+                        return Mono.just(newImportedArtifact);
+                    }
+                    return discardChanges(sourceArtifact, gitType, FALSE)
+                            .onErrorResume(cleanupError -> {
+                                log.warn(
+                                        "Best-effort discardChanges on source artifact {} after ref creation failed: {}",
+                                        sourceArtifact.getId(),
+                                        cleanupError.getMessage());
+                                return Mono.empty();
+                            })
+                            .then(Mono.just(newImportedArtifact));
+                })
                 .onErrorResume(error -> {
                     log.error("An error occurred while creating reference. error {}", error.getMessage(), error);
-                    return gitRedisUtils
-                            .releaseFileLock(artifactType, baseArtifactId, TRUE)
-                            .then(Mono.error(new AppsmithException(
-                                    AppsmithError.GIT_ACTION_FAILED,
-                                    GitCommandConstants.CREATE_REF,
-                                    error.getMessage())));
+                    return Mono.error(new AppsmithException(
+                            AppsmithError.GIT_ACTION_FAILED, GitCommandConstants.CREATE_REF, error.getMessage()));
                 })
                 .name(GitSpan.OPS_CREATE_BRANCH)
                 .tap(Micrometer.observation(observationRegistry));
@@ -855,6 +908,16 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                 sourceArtifact.getId(), VERSION_CONTROL, sourceArtifact.getArtifactType());
     }
 
+    private String stripOriginPrefix(String refName) {
+        if (refName == null) {
+            return "";
+        }
+        if (refName.startsWith(ORIGIN)) {
+            return refName.substring(ORIGIN.length());
+        }
+        return refName;
+    }
+
     protected Mono<Boolean> isValidationForRefCreationComplete(
             Artifact baseArtifact,
             Artifact parentArtifact,
@@ -870,11 +933,14 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
 
         // We are only supporting origin as the remote name so this is safe
         // but needs to be altered if we start supporting user defined remote
-        // names
+        // names. Strip the leading "origin/" as a prefix only; a substring-based
+        // replace (e.g. via String.replaceFirst) would corrupt ref names that
+        // happen to contain "origin/" in the middle of the name.
+        String normalisedIncomingRefName = stripOriginPrefix(incomingGitRefDTO.getRefName());
         Boolean isDuplicateName = fetchedGitRefDTOS.stream()
                 .map(GitRefDTO::getRefName)
-                .anyMatch(refName -> refName.replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT)
-                        .equals(incomingGitRefDTO.getRefName().replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT)));
+                .map(this::stripOriginPrefix)
+                .anyMatch(normalisedIncomingRefName::equals);
 
         if (TRUE.equals(isDuplicateName)) {
             return Mono.error(new AppsmithException(


### PR DESCRIPTION
## Description

> [!TIP]
> **TL;DR** — Tightens `CentralGitServiceCEImpl.createReference(...)` so branch creation is idempotent and does not silently convert a successful branch into an error response. Fixes an orphaned DB artifact on partial failure, a Redis lock that was never actually acquired (`acquireGitLock(..., FALSE)`), a double lock release, analytics/release failures masquerading as git failures, a false-positive duplicate-name check, a wrong DTO in `listReferences`, a misleading error label, and missing null guards in the public overload.

Tightens the branch-creation flow in `CentralGitServiceCEImpl.createReference(...)`. No behavior change on the happy path; the changes fix partial-failure handling and add the guard rails needed to make the operation safely retryable.

### Fixes applied to `CentralGitServiceCEImpl.java`

- **Lock lifecycle** — `acquireGitLock` was being called with `isLockRequired = FALSE`, which `GitRedisUtils` short-circuits to a no-op (the create-branch flow never actually held a lock). Flipped to `TRUE` and wrapped acquire/release in `Mono.usingWhen(...)` so the Redis lock is acquired and released exactly once per invocation, regardless of success, error, or cancellation. The outer `onErrorResume` no longer touches the lock, eliminating the prior double-release.
- **Analytics no longer fails a successful branch creation** — `addAnalyticsForGitOperation` now runs inside `.onErrorResume(err -> Mono.empty()).thenReturn(newImportedArtifact)` so an analytics or lock-release failure can't convert a fully-completed branch creation into a `GIT_ACTION_FAILED` response.
- **Rollback the orphaned DB artifact** — If `createGitReference → importArtifactInWorkspaceFromGit → publishArtifactPostRefCreation` fails after `generateArtifactForRefCreation` has already persisted a new artifact, we now call `gitArtifactHelper.deleteArtifactByResource(newRefArtifact)` before re-raising. Rollback failures are logged and swallowed so they don't mask the original git error. Scope deliberately stops before `discardChanges` on the source branch — by that point the remote ref already exists and deleting the DB row would orphan it.
- **`listReferences` uses the right DTO** — Switched from `createRefTransformationDTO` (the not-yet-existing target ref) to `baseRefTransformationDTO` (the source ref) when listing refs for the duplicate-name check.
- **Correct error label** — Errors from `createGitReference` are now wrapped as `"ref creation"` instead of the misleading `"ref creation preparation"`.
- **Duplicate-name check no longer does un-anchored regex strip** — Replaced `refName.replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT)` with a new `stripOriginPrefix(...)` helper that only strips `origin/` when it appears as a prefix. Ref names like `feat/origin/thing` vs `feat/thing` are no longer falsely reported as duplicates.
- **Null/empty guards in the public overload** — Added `INVALID_PARAMETER` guards for `referencedArtifactId` and `artifactType` to fail fast instead of NPE'ing inside `getArtifactHelper`.

### Followups (out of scope for this PR)

The same un-anchored `.replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT)` pattern still exists at a few other sites in `CentralGitServiceCEImpl` (lines 519, 622, 2642, 3206), `GitFSServiceCEImpl.java`, and `CommonGitServiceCEImpl.java`. A separate sweep can convert those to the shared `stripOriginPrefix` helper.

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened input validation for reference creation with early error detection for missing artifact IDs and null artifact types.
  * Improved error recovery with automatic rollback when import or publish operations fail.
  * Made analytics logging non-fatal to prevent operation interruption.

* **Improvements**
  * Enhanced reference name normalization for more consistent duplicate detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24778917502>
> Commit: eddfad10918d7d4f157eb9e59b6f068573c6bbdb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24778917502&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Wed, 22 Apr 2026 13:08:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->
