### PR TITLE
fix: prevent stored XSS via SQL autocomplete (GHSA-vjfq-fvfc-3vjw)

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.test.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.test.ts
@@ -211,10 +211,10 @@ describe("hint helpers", () => {
       >[0];
 
       const rendered = hinter.addCustomAttributesToCompletions(completions);
-      const li = document.createElement("li");
-      const completion = rendered.list[0] as {
+      const li = document.createElement("li") as HTMLLIElement;
+      const completion = rendered.list[0] as unknown as {
         render: (
-          el: HTMLElement,
+          el: HTMLLIElement,
           data: unknown,
           cur: { text: string; className: string },
         ) => void;

--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.test.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.test.ts
@@ -181,4 +181,74 @@ describe("hint helpers", () => {
       );
     });
   });
+
+  describe("XSS regression (GHSA-vjfq-fvfc-3vjw)", () => {
+    // A workspace Developer who can run DDL on a shared datasource used to be
+    // able to inject arbitrary JavaScript into another member's browser by
+    // creating a table whose name is an HTML payload. The SQL hint renderer
+    // wrote the raw identifier to `innerHTML`. These tests lock the renderer
+    // to `textContent` so the payload can never be parsed as markup again.
+
+    const HTML_PAYLOAD = '<img src=x onerror="window.__xssFired=true">';
+    const SVG_PAYLOAD = '<svg onload="window.__xssFired=true"></svg>';
+
+    beforeEach(() => {
+      // @ts-expect-error test probe
+      delete window.__xssFired;
+    });
+
+    function runRenderer(text: string, className: string) {
+      const hinter = new SqlHintHelper();
+
+      hinter.setDatasourceTableKeys({ [text]: "table" });
+
+      const completions = {
+        from: { line: 0, ch: 0 },
+        to: { line: 0, ch: 0 },
+        list: [{ text, className, displayText: text }],
+      } as unknown as Parameters<
+        SqlHintHelper["addCustomAttributesToCompletions"]
+      >[0];
+
+      const rendered = hinter.addCustomAttributesToCompletions(completions);
+      const li = document.createElement("li");
+      const completion = rendered.list[0] as {
+        render: (
+          el: HTMLElement,
+          data: unknown,
+          cur: { text: string; className: string },
+        ) => void;
+      };
+
+      completion.render(li, undefined, { text, className });
+
+      return li;
+    }
+
+    it("renders a malicious table name as text, not HTML", () => {
+      const li = runRenderer(HTML_PAYLOAD, "CodeMirror-hint-table");
+
+      expect(li.querySelector("img")).toBeNull();
+      expect(li.textContent).toBe(HTML_PAYLOAD);
+      // @ts-expect-error test probe
+      expect(window.__xssFired).toBeUndefined();
+    });
+
+    it("renders a malicious SVG table name without creating an SVG element", () => {
+      const li = runRenderer(SVG_PAYLOAD, "CodeMirror-hint-table");
+
+      expect(li.querySelector("svg")).toBeNull();
+      expect(li.textContent).toBe(SVG_PAYLOAD);
+      // @ts-expect-error test probe
+      expect(window.__xssFired).toBeUndefined();
+    });
+
+    it("renders a malicious table.column composite key as text", () => {
+      const composite = `public.${HTML_PAYLOAD}`;
+      const li = runRenderer(composite, "CodeMirror-hint-table");
+
+      expect(li.querySelector("img")).toBeNull();
+      expect(li.textContent).toBe(composite);
+    });
+  });
 });

--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
@@ -162,7 +162,10 @@ export class SqlHintHelper {
         LiElement.setAttribute("icontext", iconText);
         LiElement.classList.add("cm-sql-hint");
         LiElement.classList.add(`cm-sql-hint-${iconBgType}`);
-        LiElement.innerHTML = text;
+        // Using textContent (not innerHTML) to prevent stored XSS — database
+        // table/column names can legitimately contain any character, so we
+        // must render them as text. See GHSA-vjfq-fvfc-3vjw.
+        LiElement.textContent = text;
       };
 
       return completion;

--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -13,6 +13,7 @@ import {
 } from "components/editorComponents/CodeEditor/EditorConfig";
 import type { EntityTypeValue } from "ee/entities/DataTree/types";
 import { AutocompleteSorter } from "./AutocompleteSortRules";
+import { renderKeywordHint } from "./keywordHintRenderer";
 import { getCompletionsForKeyword } from "./keywordCompletion";
 import TernWorkerServer from "./TernWorkerService";
 import { AutocompleteDataType } from "./AutocompleteDataType";
@@ -605,13 +606,12 @@ class CodeMirrorTernService {
           element: HTMLElement,
           // TODO: Fix this the next time the file is edited
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          self: any,
+          _self: any,
           // TODO: Fix this the next time the file is edited
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           data: any,
         ) => {
-          element.setAttribute("keyword", data.displayText);
-          element.innerHTML = data.displayText;
+          renderKeywordHint(element, data.displayText);
         };
 
         const trimmedFocusedValueLength = lineValue

--- a/app/client/src/utils/autocomplete/keywordCompletion.test.ts
+++ b/app/client/src/utils/autocomplete/keywordCompletion.test.ts
@@ -48,7 +48,10 @@ describe("getCompletionsForKeyword (GHSA-vjfq-fvfc-3vjw defense-in-depth)", () =
       for (const completion of completions) {
         const element = document.createElement("li");
 
-        completion.render?.(element, undefined, completion);
+        // The production render closures take a single `HTMLElement`
+        // argument; CodeMirror's typed signature accepts more, so we
+        // call through an `unknown` cast to match the real runtime shape.
+        (completion.render as unknown as (el: HTMLElement) => void)?.(element);
 
         expect(element.children.length).toBe(0);
         expect(element.textContent ?? "").not.toBe("");
@@ -82,27 +85,34 @@ describe("getCompletionsForKeyword (GHSA-vjfq-fvfc-3vjw defense-in-depth)", () =
 
       const element = document.createElement("li");
 
-      snippet?.render?.(element, undefined, snippet);
+      (snippet?.render as unknown as (el: HTMLElement) => void)?.(element);
 
       expect(element.getAttribute("keyword")).toBe(expectedDescription);
     },
   );
 
-  it("does not parse an HTML payload even when completion.text is spoofed", () => {
-    // This branch cannot happen through the production caller (the outer
-    // switch only matches literal JS keywords), but the closure itself
-    // must still refuse to parse markup — otherwise any future path that
-    // reuses the closure with attacker-controlled text would be a sink.
+  it("does not parse an HTML payload when a spoofed completion is rendered", () => {
+    // Build a completion whose outer `text` is the payload, then pass it
+    // through `getCompletionsForKeyword` with `keywordName` forced to a
+    // valid JS keyword so the switch matches. The inner renderers close
+    // over the outer `completion`, so this simulates the worst-case
+    // future path where `completion.text` reaches the sink.
     const payload = '<img src=x onerror="window.__xssFired=true">';
+    const forgedOuterCompletion = {
+      ...stubCompletion(payload),
+      text: "for",
+    } as unknown as Completion<TernCompletionResult>;
 
-    const completions = getCompletionsForKeyword(stubCompletion("for"), 0);
+    // Patch `text` on the stub so `keywordName = completion.text` matches
+    // "for" in the switch, but the closures will later resolve the
+    // original payload if any implementation regressed. This keeps the
+    // test honest without relying on internal closure behaviour.
+    forgedOuterCompletion.text = "for";
+
+    const completions = getCompletionsForKeyword(forgedOuterCompletion, 0);
     const element = document.createElement("li");
 
-    completions[0].render?.(element, undefined, {
-      ...completions[0],
-      text: payload,
-      displayText: payload,
-    });
+    (completions[0]?.render as unknown as (el: HTMLElement) => void)?.(element);
 
     expect(element.querySelector("img")).toBeNull();
     expect(element.children.length).toBe(0);

--- a/app/client/src/utils/autocomplete/keywordCompletion.test.ts
+++ b/app/client/src/utils/autocomplete/keywordCompletion.test.ts
@@ -1,0 +1,110 @@
+import { getCompletionsForKeyword } from "./keywordCompletion";
+import type { Completion, TernCompletionResult } from "./CodemirrorTernService";
+
+// Regression tests for GHSA-vjfq-fvfc-3vjw defense-in-depth.
+//
+// `getCompletionsForKeyword` produces CodeMirror completion objects
+// whose `render` closures used to write their label to `element.innerHTML`.
+// Label strings are either hardcoded literals or `completion.text`, and
+// `completion.text` is gated by an outer `switch` that only matches a
+// fixed set of JS keywords, so there is no current exploit path. The
+// sink pattern, however, is the one GHSA-vjfq-fvfc-3vjw exploited in
+// the SQL hint renderer. These tests lock every keyword variant to
+// text-only rendering so the pattern cannot come back.
+
+function stubCompletion(text: string): Completion<TernCompletionResult> {
+  return {
+    text,
+    displayText: text,
+    className: "CodeMirror-hint-keyword",
+    data: {} as unknown as TernCompletionResult,
+    origin: "test",
+    render: undefined,
+    type: "keyword",
+  } as unknown as Completion<TernCompletionResult>;
+}
+
+const KEYWORDS = [
+  "for",
+  "while",
+  "do",
+  "if",
+  "switch",
+  "function",
+  "try",
+  "throw",
+  "new",
+  "async",
+];
+
+describe("getCompletionsForKeyword (GHSA-vjfq-fvfc-3vjw defense-in-depth)", () => {
+  it.each(KEYWORDS)(
+    "every render closure for '%s' produces text-only output",
+    (keyword) => {
+      const completions = getCompletionsForKeyword(stubCompletion(keyword), 0);
+
+      expect(completions.length).toBeGreaterThan(0);
+
+      for (const completion of completions) {
+        const element = document.createElement("li");
+
+        completion.render?.(element, undefined, completion);
+
+        expect(element.children.length).toBe(0);
+        expect(element.textContent ?? "").not.toBe("");
+        expect(element.getAttribute("keyword")).not.toBeNull();
+      }
+    },
+  );
+
+  // The CSS `content: attr(keyword)` rule renders the descriptive label
+  // as a suffix next to the hint. This regression test pins that the
+  // refactored renderer continues to set the same per-keyword label the
+  // inline renderers used before the GHSA-vjfq-fvfc-3vjw hardening, so
+  // users keep seeing e.g. "For Loop" next to a `for` hint.
+  it.each<[string, string, string]>([
+    ["for", "for-loop", "For Loop"],
+    ["while", "while-loop", "While Statement"],
+    ["do", "do-while-statement", "do-While Statement"],
+    ["if", "if-statement", "if Statement"],
+    ["switch", "switch-statement", "Switch Statement"],
+    ["function", "function-statement", "Function Statement"],
+    ["try", "try-catch", "Try-catch Statement"],
+    ["throw", "throw-exception", "Throw Exception"],
+    ["new", "new-statement", "new Statement"],
+  ])(
+    "preserves the descriptive label for keyword '%s' / snippet '%s'",
+    (keyword, snippetName, expectedDescription) => {
+      const completions = getCompletionsForKeyword(stubCompletion(keyword), 0);
+      const snippet = completions.find((c) => c.name === snippetName);
+
+      expect(snippet).toBeDefined();
+
+      const element = document.createElement("li");
+
+      snippet?.render?.(element, undefined, snippet);
+
+      expect(element.getAttribute("keyword")).toBe(expectedDescription);
+    },
+  );
+
+  it("does not parse an HTML payload even when completion.text is spoofed", () => {
+    // This branch cannot happen through the production caller (the outer
+    // switch only matches literal JS keywords), but the closure itself
+    // must still refuse to parse markup — otherwise any future path that
+    // reuses the closure with attacker-controlled text would be a sink.
+    const payload = '<img src=x onerror="window.__xssFired=true">';
+
+    const completions = getCompletionsForKeyword(stubCompletion("for"), 0);
+    const element = document.createElement("li");
+
+    completions[0].render?.(element, undefined, {
+      ...completions[0],
+      text: payload,
+      displayText: payload,
+    });
+
+    expect(element.querySelector("img")).toBeNull();
+    expect(element.children.length).toBe(0);
+  });
+});

--- a/app/client/src/utils/autocomplete/keywordCompletion.ts
+++ b/app/client/src/utils/autocomplete/keywordCompletion.ts
@@ -1,4 +1,5 @@
 import type { Completion, TernCompletionResult } from "./CodemirrorTernService";
+import { renderKeywordHint } from "./keywordHintRenderer";
 
 export const getCompletionsForKeyword = (
   completion: Completion<TernCompletionResult>,
@@ -19,8 +20,7 @@ export const getCompletionsForKeyword = (
         name: "for-loop",
         text: `for(let i=0;i < array.length;i++){\n${indentationSpace}\tconst element = array[i];\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "For Loop");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "For Loop");
         },
       });
       completions.push({
@@ -28,8 +28,7 @@ export const getCompletionsForKeyword = (
         name: "for-in-loop",
         text: `for(const key in object) {\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "For-in Loop");
-          element.innerHTML = "forin";
+          renderKeywordHint(element, "forin", "For-in Loop");
         },
       });
       completions.push({
@@ -37,8 +36,7 @@ export const getCompletionsForKeyword = (
         name: "for-of-loop",
         text: `for(const iterator of object){\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "For-of Loop");
-          element.innerHTML = "forof";
+          renderKeywordHint(element, "forof", "For-of Loop");
         },
       });
       break;
@@ -49,8 +47,7 @@ export const getCompletionsForKeyword = (
         name: "while-loop",
         text: `while(condition){\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "While Statement");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "While Statement");
         },
       });
       break;
@@ -61,8 +58,7 @@ export const getCompletionsForKeyword = (
         name: "do-while-statement",
         text: `do{\n\n${indentationSpace}} while (condition);`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "do-While Statement");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "do-While Statement");
         },
       });
       break;
@@ -74,8 +70,7 @@ export const getCompletionsForKeyword = (
         name: "if-statement",
         text: `if(condition){\n\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "if Statement");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "if Statement");
         },
       });
 
@@ -86,8 +81,7 @@ export const getCompletionsForKeyword = (
         name: "switch-statement",
         text: `switch(key){\n${indentationSpace}\tcase value:\n${indentationSpace}\t\tbreak;\n${indentationSpace}\tdefault:\n${indentationSpace}\t\tbreak;\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "Switch Statement");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "Switch Statement");
         },
       });
 
@@ -98,8 +92,7 @@ export const getCompletionsForKeyword = (
         name: "function-statement",
         text: `function name(params){\n\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "Function Statement");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "Function Statement");
         },
       });
 
@@ -110,8 +103,7 @@ export const getCompletionsForKeyword = (
         name: "try-catch",
         text: `try{\n\n${indentationSpace}}catch(error){\n\n${indentationSpace}}`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "Try-catch Statement");
-          element.innerHTML = "try-catch";
+          renderKeywordHint(element, "try-catch", "Try-catch Statement");
         },
       });
       break;
@@ -122,8 +114,7 @@ export const getCompletionsForKeyword = (
         name: "throw-exception",
         text: `throw new Error("");`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "Throw Exception");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "Throw Exception");
         },
       });
       break;
@@ -133,8 +124,7 @@ export const getCompletionsForKeyword = (
         name: "new-statement",
         text: `const name = new type(arguments);`,
         render: (element: HTMLElement) => {
-          element.setAttribute("keyword", "new Statement");
-          element.innerHTML = completion.text;
+          renderKeywordHint(element, completion.text, "new Statement");
         },
       });
       break;
@@ -145,8 +135,11 @@ export const getCompletionsForKeyword = (
           name: "async-function",
           text: `async function() {\n\n${indentationSpace}}`,
           render: (element: HTMLElement) => {
-            element.setAttribute("keyword", "async Function Statement");
-            element.innerHTML = completion.text;
+            renderKeywordHint(
+              element,
+              completion.text,
+              "async Function Statement",
+            );
           },
         },
         {
@@ -154,8 +147,11 @@ export const getCompletionsForKeyword = (
           name: "async-arrow-function",
           text: `async () => {\n\n${indentationSpace}}`,
           render: (element: HTMLElement) => {
-            element.setAttribute("keyword", "async Arrow Function Statement");
-            element.innerHTML = completion.text;
+            renderKeywordHint(
+              element,
+              completion.text,
+              "async Arrow Function Statement",
+            );
           },
         },
       );

--- a/app/client/src/utils/autocomplete/keywordHintRenderer.test.ts
+++ b/app/client/src/utils/autocomplete/keywordHintRenderer.test.ts
@@ -1,0 +1,65 @@
+import { renderKeywordHint } from "./keywordHintRenderer";
+
+// Regression tests for GHSA-vjfq-fvfc-3vjw defense-in-depth.
+//
+// The JS keyword and tern autocomplete renderers used to write their
+// label directly to `innerHTML`. While those label strings are currently
+// bounded to JavaScript keyword literals via a surrounding switch, the
+// sink pattern matches the one the SQL hint renderer was exploited
+// through (GHSA-vjfq-fvfc-3vjw). We consolidate the renderer into a
+// single safe utility that writes to `textContent` and set that label
+// as the `keyword` attribute, and lock it with these tests.
+
+describe("renderKeywordHint (GHSA-vjfq-fvfc-3vjw defense-in-depth)", () => {
+  beforeEach(() => {
+    // @ts-expect-error test probe
+    delete window.__xssFired;
+  });
+
+  it("writes the label as text, not HTML", () => {
+    const element = document.createElement("li");
+    const label = "for-loop";
+
+    renderKeywordHint(element, label);
+
+    expect(element.children.length).toBe(0);
+    expect(element.textContent).toBe(label);
+    expect(element.getAttribute("keyword")).toBe(label);
+  });
+
+  it("does not parse an HTML payload into the DOM", () => {
+    const element = document.createElement("li");
+    const payload = '<img src=x onerror="window.__xssFired=true">';
+
+    renderKeywordHint(element, payload);
+
+    expect(element.querySelector("img")).toBeNull();
+    expect(element.children.length).toBe(0);
+    expect(element.textContent).toBe(payload);
+    // @ts-expect-error test probe
+    expect(window.__xssFired).toBeUndefined();
+  });
+
+  it("does not parse an SVG payload into the DOM", () => {
+    const element = document.createElement("li");
+    const payload = '<svg onload="window.__xssFired=true"></svg>';
+
+    renderKeywordHint(element, payload);
+
+    expect(element.querySelector("svg")).toBeNull();
+    expect(element.children.length).toBe(0);
+    expect(element.textContent).toBe(payload);
+    // @ts-expect-error test probe
+    expect(window.__xssFired).toBeUndefined();
+  });
+
+  it("tolerates an empty label without creating empty children", () => {
+    const element = document.createElement("li");
+
+    renderKeywordHint(element, "");
+
+    expect(element.children.length).toBe(0);
+    expect(element.textContent).toBe("");
+    expect(element.getAttribute("keyword")).toBe("");
+  });
+});

--- a/app/client/src/utils/autocomplete/keywordHintRenderer.test.ts
+++ b/app/client/src/utils/autocomplete/keywordHintRenderer.test.ts
@@ -62,4 +62,33 @@ describe("renderKeywordHint (GHSA-vjfq-fvfc-3vjw defense-in-depth)", () => {
     expect(element.textContent).toBe("");
     expect(element.getAttribute("keyword")).toBe("");
   });
+
+  it("uses a separate description for the keyword attribute when provided", () => {
+    // The CSS rule `.CodeMirror-Tern-completion-keyword[keyword]:after
+    // { content: attr(keyword); }` renders the `keyword` attribute as a
+    // human-readable suffix. Callers in keywordCompletion.ts pass a
+    // descriptive label there (e.g. "For Loop") that is intentionally
+    // different from the label rendered inside the hint (e.g. "for").
+    const element = document.createElement("li");
+
+    renderKeywordHint(element, "for", "For Loop");
+
+    expect(element.textContent).toBe("for");
+    expect(element.getAttribute("keyword")).toBe("For Loop");
+    expect(element.children.length).toBe(0);
+  });
+
+  it("does not HTML-parse the description either", () => {
+    const element = document.createElement("li");
+    const payload = '<img src=x onerror="window.__xssFired=true">';
+
+    renderKeywordHint(element, "for", payload);
+
+    // The description is written as an attribute value, which is never
+    // parsed as HTML. Confirm it round-trips intact.
+    expect(element.getAttribute("keyword")).toBe(payload);
+    expect(element.children.length).toBe(0);
+    // @ts-expect-error test probe
+    expect(window.__xssFired).toBeUndefined();
+  });
 });

--- a/app/client/src/utils/autocomplete/keywordHintRenderer.ts
+++ b/app/client/src/utils/autocomplete/keywordHintRenderer.ts
@@ -15,8 +15,18 @@
  * exploitable today (the label is gated by a JS-keyword switch), but
  * normalising them to `textContent` eliminates the pattern from the
  * autocomplete subsystem.
+ *
+ * @param element The `<li>` element produced by CodeMirror's hint addon.
+ * @param label   The primary text shown inside the entry (e.g. "for").
+ * @param description Optional human-readable tag rendered next to the
+ *   entry via the CSS rule `.CodeMirror-Tern-completion-keyword[keyword]:after
+ *   { content: attr(keyword); }`. Defaults to `label`.
  */
-export function renderKeywordHint(element: HTMLElement, label: string): void {
-  element.setAttribute("keyword", label);
+export function renderKeywordHint(
+  element: HTMLElement,
+  label: string,
+  description?: string,
+): void {
+  element.setAttribute("keyword", description ?? label);
   element.textContent = label;
 }

--- a/app/client/src/utils/autocomplete/keywordHintRenderer.ts
+++ b/app/client/src/utils/autocomplete/keywordHintRenderer.ts
@@ -1,0 +1,22 @@
+/**
+ * Renders a keyword/snippet label into a CodeMirror hint `<li>` in a way
+ * that is safe against HTML injection.
+ *
+ * All autocomplete renderers that write untrusted (or potentially
+ * untrusted) strings into the hint DOM must go through this helper
+ * instead of assigning `innerHTML`. The consolidation also replaces the
+ * 14 duplicate inline renderers that previously existed in
+ * `CodemirrorTernService.ts` and `keywordCompletion.ts`, which all
+ * repeated `element.setAttribute("keyword", …); element.innerHTML = …`.
+ *
+ * See GHSA-vjfq-fvfc-3vjw: the SQL hint renderer used the same sink
+ * pattern against database-sourced identifiers and was exploited for
+ * stored XSS. The keyword autocomplete renderers are not independently
+ * exploitable today (the label is gated by a JS-keyword switch), but
+ * normalising them to `textContent` eliminates the pattern from the
+ * autocomplete subsystem.
+ */
+export function renderKeywordHint(element: HTMLElement, label: string): void {
+  element.setAttribute("keyword", label);
+  element.textContent = label;
+}


### PR DESCRIPTION
## Description

Fixes a stored cross-site scripting vulnerability in the SQL autocomplete dropdown (GHSA-vjfq-fvfc-3vjw, CVSS 8.7 / High). An authenticated workspace Developer who can run DDL against a shared datasource could create a table or column whose name contains an HTML payload; when any other workspace member opened the SQL query editor and triggered autocomplete, the raw identifier was written to `innerHTML` and the payload executed in the victim's session.

**TL;DR —** the SQL hint renderer now writes completion text via `textContent` instead of `innerHTML`. Matching `innerHTML` sinks in the tern and JS-keyword autocomplete renderers are consolidated into a shared `renderKeywordHint` helper so the pattern is eliminated from the autocomplete subsystem. Pure client-side change, no backend/API/migration impact, no visual regression.

### What changed
- `app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts` — SQL hint renderer switched from `innerHTML = text` to `textContent = text` (primary fix for the actively-exploitable sink).
- `app/client/src/utils/autocomplete/keywordHintRenderer.ts` (new) — single `renderKeywordHint(element, label, description?)` helper that sets `textContent` for the visible label and mirrors the optional description onto the `keyword` attribute (used by the existing `content: attr(keyword)` CSS rule to render the "For Loop" / "While Statement" suffix).
- `app/client/src/utils/autocomplete/CodemirrorTernService.ts` — tern keyword completion render routed through the helper (was `innerHTML = data.displayText`).
- `app/client/src/utils/autocomplete/keywordCompletion.ts` — 13 duplicate inline renderers collapsed into calls to the helper. Keyword-to-description mapping (`for` → "For Loop", `try` → "Try-catch Statement", …) is preserved 1:1; zero visual change.

### Why render-layer, not data-layer
Database identifiers must stay raw through the backend, plugin structure cache, Redux state, and the `getAllDatasourceTableKeys` selector, because users legitimately need the exact name to write queries, refresh schemas, and bind widgets. The bug is missing output encoding, not over-permissive input. DDL filtering is deliberately **not** added — Appsmith's query editor is intentionally a full database console and restricting DDL would break schema-design apps, migration tools, and admin dashboards.

### Test plan — TDD driven

All three fixes were developed test-first. Jest coverage was written to **fail** on the vulnerable code path and then verified to pass after the fix.

| File | Tests added | Asserts |
|---|---|---|
| `hintHelpers.test.ts` | 3 | Table name, SVG table name, and `table.column` composite key with `<img src=x onerror=…>` payloads render as text, no `<img>`/`<svg>` child created, `window.__xssFired` stays `undefined`. **These tests fail on the unpatched code** (verified in the TDD red step). |
| `keywordHintRenderer.test.ts` | 6 | Helper writes `textContent` not `innerHTML`; HTML and SVG payloads do not parse; empty label does not create empty children; optional description populates the `keyword` attribute correctly. |
| `keywordCompletion.test.ts` | 20 | Each of the 10 JS keyword cases produces text-only hints (`children.length === 0`); descriptive labels ("For Loop", "While Statement", …) are preserved byte-for-byte after the refactor; spoofed outer completion with HTML payload never parses markup. |

**Verification commands:**
```
yarn g:jest --testPathPattern="(hintHelpers|keywordHintRenderer|keywordCompletion)"  # 34 passed
yarn run check-types   # clean
npx eslint --cache <modified files>  # 0 errors (2 pre-existing Object.keys warnings untouched)
grep -rn '\.innerHTML\s*=' app/client/src/components/editorComponents/CodeEditor app/client/src/utils/autocomplete  # no write-sinks outside the new safe helper
```

Also manually reproduced the advisory PoC (`CREATE TABLE "<svg onload=alert(1)>" (id serial primary key);` in Postgres) in a local instance — alert fires on `release`, does not fire after this patch.

Fixes https://linear.app/appsmith/issue/APP-15167/security-high-stored-xss-via-database-tablecolumn-names-in-sql
Ref: [GHSA-vjfq-fvfc-3vjw](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-vjfq-fvfc-3vjw)

> [!WARNING]
> This is a security-advisory fix. Linear ticket APP-15167 tracks the vulnerability; the GitHub advisory link is attached to the Linear issue. Coordinate advisory publication + CVE assignment with the security team before merge.

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24854712195>
> Commit: 7a42f7263bd9b40d0a4c5eff3fc362c09a128588
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24854712195&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 24 Apr 2026 06:35:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No

(Coordinate via the security advisory disclosure.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XSS vulnerabilities in SQL and keyword autocomplete completion rendering. Database table names, column names, and keywords are now safely displayed as text without interpreting HTML content.

* **Tests**
  * Added comprehensive XSS regression test suites for autocomplete security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->