### PR TITLE
fix(security): enforce datasource read permission in import helper endpoint (GHSA-93mf-9h52-gfxp)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImpl.java
@@ -23,6 +23,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.imports.importable.ImportableServiceCE;
 import com.appsmith.server.imports.importable.artifactbased.ArtifactBasedImportableService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -48,14 +49,17 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
     private final DatasourceService datasourceService;
     private final WorkspaceService workspaceService;
     private final DatasourceStorageService datasourceStorageService;
+    private final DatasourcePermission datasourcePermission;
 
     public DatasourceImportableServiceCEImpl(
             DatasourceService datasourceService,
             WorkspaceService workspaceService,
-            DatasourceStorageService datasourceStorageService) {
+            DatasourceStorageService datasourceStorageService,
+            DatasourcePermission datasourcePermission) {
         this.datasourceService = datasourceService;
         this.datasourceStorageService = datasourceStorageService;
         this.workspaceService = workspaceService;
+        this.datasourcePermission = datasourcePermission;
     }
 
     @Override
@@ -599,6 +603,6 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
 
     @Override
     public Flux<Datasource> getEntitiesPresentInWorkspace(String workspaceId) {
-        return datasourceService.getAllByWorkspaceIdWithStorages(workspaceId, null);
+        return datasourceService.getAllByWorkspaceIdWithStorages(workspaceId, datasourcePermission.getReadPermission());
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
 import com.appsmith.server.imports.importable.ImportableService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,7 +15,8 @@ public class DatasourceImportableServiceImpl extends DatasourceImportableService
     public DatasourceImportableServiceImpl(
             DatasourceService datasourceService,
             WorkspaceService workspaceService,
-            DatasourceStorageService datasourceStorageService) {
-        super(datasourceService, workspaceService, datasourceStorageService);
+            DatasourceStorageService datasourceStorageService,
+            DatasourcePermission datasourcePermission) {
+        super(datasourceService, workspaceService, datasourceStorageService, datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImplTest.java
@@ -11,6 +11,7 @@ import com.appsmith.external.models.OAuth2;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,12 +38,15 @@ class DatasourceImportableServiceCEImplTest { // Renamed class to match conventi
     @Mock
     DatasourceStorageService datasourceStorageService;
 
+    @Mock
+    DatasourcePermission datasourcePermission;
+
     DatasourceImportableServiceCEImpl importService;
 
     @BeforeEach
     void setUp() {
-        importService =
-                new DatasourceImportableServiceCEImpl(datasourceService, workspaceService, datasourceStorageService);
+        importService = new DatasourceImportableServiceCEImpl(
+                datasourceService, workspaceService, datasourceStorageService, datasourcePermission);
     }
 
     // Helper to call the private method using reflection


### PR DESCRIPTION
## Summary
Fixes a High-severity authorization bypass vulnerability (GHSA-93mf-9h52-gfxp, CVSS 7.7) in the import helper endpoint.

- The `GET /api/v1/applications/import/{workspaceId}/datasources` endpoint fetched workspace datasources with `null` ACL permission, allowing App Viewer users to read sensitive datasource configurations (internal URLs, Bearer tokens, API keys)
- Injects `DatasourcePermission` into `DatasourceImportableServiceCEImpl` and passes `READ_DATASOURCES` permission to `getAllByWorkspaceIdWithStorages` in `getEntitiesPresentInWorkspace()`
- The internal import flow (`importEntities`) is unaffected as it calls `getAllByWorkspaceIdWithStorages` directly with its own permission model

## Root Cause
`DatasourceImportableServiceCEImpl.getEntitiesPresentInWorkspace()` called `datasourceService.getAllByWorkspaceIdWithStorages(workspaceId, null)` — the `null` second parameter means **no ACL check**, so any authenticated user could retrieve all datasources in a workspace through the import helper API.

## Fix
Pass `datasourcePermission.getReadPermission()` (`AclPermission.READ_DATASOURCES`) instead of `null`, so only users with datasource read permission can see datasource details through this endpoint.

## Files Changed
- `DatasourceImportableServiceCEImpl.java` — inject `DatasourcePermission`, enforce read permission
- `DatasourceImportableServiceImpl.java` — pass new constructor dependency
- `DatasourceImportableServiceCEImplTest.java` — add mock for new dependency

## Test Plan
- [ ] Verify App Viewer users can no longer access datasource configs via `GET /api/v1/applications/import/{workspaceId}/datasources`
- [ ] Verify workspace admins/developers with datasource read permission can still use the import helper normally
- [ ] Verify application import/export flows still work (they bypass `getEntitiesPresentInWorkspace`)
- [ ] Existing `DatasourceImportableServiceCEImplTest` unit tests pass

## Advisory
https://github.com/appsmithorg/appsmith/security/advisories/GHSA-93mf-9h52-gfxp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced permission validation for datasource operations to ensure proper access control during import workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->