### PR TITLE
fix(security): Appsmith App Viewer datasource configuration leak via import helper (GHSA-93mf-9h52-gfxp)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImpl.java
@@ -603,7 +603,6 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
 
     @Override
     public Flux<Datasource> getEntitiesPresentInWorkspace(String workspaceId) {
-        return datasourceService.getAllByWorkspaceIdWithStorages(
-                workspaceId, datasourcePermission.getReadPermission());
+        return datasourceService.getAllByWorkspaceIdWithStorages(workspaceId, datasourcePermission.getReadPermission());
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImpl.java
@@ -23,6 +23,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.imports.importable.ImportableServiceCE;
 import com.appsmith.server.imports.importable.artifactbased.ArtifactBasedImportableService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -48,14 +49,17 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
     private final DatasourceService datasourceService;
     private final WorkspaceService workspaceService;
     private final DatasourceStorageService datasourceStorageService;
+    private final DatasourcePermission datasourcePermission;
 
     public DatasourceImportableServiceCEImpl(
             DatasourceService datasourceService,
             WorkspaceService workspaceService,
-            DatasourceStorageService datasourceStorageService) {
+            DatasourceStorageService datasourceStorageService,
+            DatasourcePermission datasourcePermission) {
         this.datasourceService = datasourceService;
         this.datasourceStorageService = datasourceStorageService;
         this.workspaceService = workspaceService;
+        this.datasourcePermission = datasourcePermission;
     }
 
     @Override
@@ -599,6 +603,7 @@ public class DatasourceImportableServiceCEImpl implements ImportableServiceCE<Da
 
     @Override
     public Flux<Datasource> getEntitiesPresentInWorkspace(String workspaceId) {
-        return datasourceService.getAllByWorkspaceIdWithStorages(workspaceId, null);
+        return datasourceService.getAllByWorkspaceIdWithStorages(
+                workspaceId, datasourcePermission.getReadPermission());
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
 import com.appsmith.server.imports.importable.ImportableService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,7 +15,8 @@ public class DatasourceImportableServiceImpl extends DatasourceImportableService
     public DatasourceImportableServiceImpl(
             DatasourceService datasourceService,
             WorkspaceService workspaceService,
-            DatasourceStorageService datasourceStorageService) {
-        super(datasourceService, workspaceService, datasourceStorageService);
+            DatasourceStorageService datasourceStorageService,
+            DatasourcePermission datasourcePermission) {
+        super(datasourceService, workspaceService, datasourceStorageService, datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImplTest.java
@@ -259,9 +259,7 @@ class DatasourceImportableServiceCEImplTest { // Renamed class to match conventi
         Flux<Datasource> result = importService.getEntitiesPresentInWorkspace(workspaceId);
 
         // Then
-        StepVerifier.create(result)
-                .expectNextCount(1)
-                .verifyComplete();
+        StepVerifier.create(result).expectNextCount(1).verifyComplete();
         verify(datasourceService).getAllByWorkspaceIdWithStorages(workspaceId, AclPermission.READ_DATASOURCES);
         verify(datasourceService, never()).getAllByWorkspaceIdWithStorages(eq(workspaceId), isNull());
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/datasources/importable/DatasourceImportableServiceCEImplTest.java
@@ -4,18 +4,24 @@ import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.BasicAuth;
 import com.appsmith.external.models.BearerTokenAuth;
 import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.external.models.DecryptedSensitiveFields;
 import com.appsmith.external.models.OAuth2;
+import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 
 import java.lang.reflect.Method;
 
@@ -24,6 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DatasourceImportableServiceCEImplTest { // Renamed class to match convention
@@ -37,12 +48,15 @@ class DatasourceImportableServiceCEImplTest { // Renamed class to match conventi
     @Mock
     DatasourceStorageService datasourceStorageService;
 
+    @Mock
+    DatasourcePermission datasourcePermission;
+
     DatasourceImportableServiceCEImpl importService;
 
     @BeforeEach
     void setUp() {
-        importService =
-                new DatasourceImportableServiceCEImpl(datasourceService, workspaceService, datasourceStorageService);
+        importService = new DatasourceImportableServiceCEImpl(
+                datasourceService, workspaceService, datasourceStorageService, datasourcePermission);
     }
 
     // Helper to call the private method using reflection
@@ -227,5 +241,28 @@ class DatasourceImportableServiceCEImplTest { // Renamed class to match conventi
         callUpdateAuthenticationDTOWithReflection(storage, decryptedFields);
 
         assertNull(dsConfig.getAuthentication(), "Authentication should not be set if authType is null");
+    }
+
+    @Test
+    @DisplayName("GHSA-93mf-9h52-gfxp: getEntitiesPresentInWorkspace must enforce READ_DATASOURCES permission")
+    void should_enforceReadPermission_when_getEntitiesPresentInWorkspace_isCalled() {
+        // Given
+        String workspaceId = "workspace1";
+        Datasource ds = new Datasource();
+        ds.setId("ds1");
+        ds.setName("TestDS");
+        when(datasourcePermission.getReadPermission()).thenReturn(AclPermission.READ_DATASOURCES);
+        when(datasourceService.getAllByWorkspaceIdWithStorages(workspaceId, AclPermission.READ_DATASOURCES))
+                .thenReturn(Flux.just(ds));
+
+        // When
+        Flux<Datasource> result = importService.getEntitiesPresentInWorkspace(workspaceId);
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextCount(1)
+                .verifyComplete();
+        verify(datasourceService).getAllByWorkspaceIdWithStorages(workspaceId, AclPermission.READ_DATASOURCES);
+        verify(datasourceService, never()).getAllByWorkspaceIdWithStorages(eq(workspaceId), isNull());
     }
 }


### PR DESCRIPTION
## Summary

fix(security): Appsmith App Viewer datasource configuration leak via import helper (GHSA-93mf-9h52-gfxp)

- **Primary fix:** `DatasourceImportableServiceCEImpl.getEntitiesPresentInWorkspace()` was calling `getAllByWorkspaceIdWithStorages(workspaceId, null)` — passing `null` as the ACL permission, which bypasses authorization entirely. Changed to enforce `datasourcePermission.getReadPermission()` (`READ_DATASOURCES`), consistent with the standard datasource listing endpoint.
- **Constructor update:** Injected `DatasourcePermission` into both `DatasourceImportableServiceCEImpl` and `DatasourceImportableServiceImpl` constructors (Spring auto-wires the bean).
- **Test coverage:** Added a regression test (`should_enforceReadPermission_when_getEntitiesPresentInWorkspace_isCalled`) annotated with GHSA ID, verifying that `READ_DATASOURCES` permission is always passed and `null` is never used.

## Vulnerability

| Field | Value |
|-------|-------|
| **GHSA** | [GHSA-93mf-9h52-gfxp](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-93mf-9h52-gfxp) |
| **CVSS** | 7.7 (high) |
| **CWE** | CWE-200, CWE-862 |
| **Affected component** | `DatasourceImportableServiceCEImpl.getEntitiesPresentInWorkspace()` |

## Exposure Analysis

- **Who can exploit this:** Any authenticated user with `App Viewer` access to a workspace. This is the lowest privilege role — no admin, developer, or owner access required.
- **What an attacker can achieve:** Full read access to datasource configuration for all datasources in the workspace, including internal URLs, custom headers (e.g., `Authorization: Bearer <token>`), custom properties (e.g., API keys), and connection metadata. This is a confidentiality breach of backend infrastructure credentials.
- **Evidence of exploitation:** No evidence of exploitation in the wild. Discovered via security advisory report.
- **Blast radius:** All datasources in the target workspace are exposed. The attack is per-workspace — an App Viewer in workspace A cannot access workspace B's datasources. However, within a workspace, ALL datasource secrets are leaked regardless of which application they belong to.

## Fix

- **Root cause:** `DatasourceImportableServiceCEImpl.getEntitiesPresentInWorkspace()` (line 602) called `datasourceService.getAllByWorkspaceIdWithStorages(workspaceId, null)`. When `AclPermission` is `null`, the MongoDB repository layer skips ACL filtering and returns all matching documents, bypassing the policy-based permission model.
- **Fix strategy:** Inject `DatasourcePermission` into the service and replace `null` with `datasourcePermission.getReadPermission()` (`AclPermission.READ_DATASOURCES`). This is the same permission used by the standard `GET /api/v1/datasources?workspaceId=` endpoint — consistent, minimal, and at the correct layer.
- **Intentionally NOT changed:** (1) `importEntities()` in the same class (line 117) also uses `null` permission — this is intentional because the import pipeline has its own authorization layer (edit permission on existing datasources, create permission on workspace). (2) `DatasourceForkableServiceCEImpl.getExistingEntitiesInTarget()` also uses `null` — fork operations require higher-level permissions upstream.
- **Defense-in-depth:** The fix is at the data-access layer, which is the correct boundary. All callers of `getEntitiesPresentInWorkspace()` automatically inherit the permission enforcement.

## Test plan

- [x] Failing test for the exploit scenario passes after fix
- [x] All existing tests in affected modules pass (no regressions) — 9/9 tests green
- [x] Codebase audit: grepped for `getAllByWorkspaceIdWithStorages.*null` — remaining instances are in authorized internal pipelines
- [x] Compilation clean (`mvn compile -DskipTests`)
- [ ] Manual reproduction of advisory PoC confirms the fix

## CE/EE sync

CE-only safe: the modified files (`DatasourceImportableServiceCEImpl.java`, `DatasourceImportableServiceImpl.java`) are CE files that EE inherits. The hourly CE→EE sync will propagate the fix. The EE repo already has identical changes as uncommitted modifications, confirming alignment.

## Disclosure

> **Do not merge until advisory is ready for disclosure coordination.**
>
> After merge:
> 1. Confirm fix is in release branch
> 2. Coordinate with security team on disclosure timeline
> 3. Update advisory with patched version and publish
> 4. Notify reporter

## Follow-ups

- No additional vulnerable locations found during codebase audit — no follow-up PRs needed.


Fixes APP-15189
Fixes https://linear.app/appsmith/issue/APP-15045/security-high-app-viewer-datasource-configuration-leak-via-import


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Datasource listings now respect computed read permissions so users only see workspace datasources they are allowed to access.

* **Tests**
  * Added tests validating read-permission enforcement for datasource visibility to prevent unauthorized exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/24981307163>
> Commit: 54b3c7fb763f50c3d25ed09c34859cbfe562b68c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=24981307163&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 27 Apr 2026 08:09:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->
