### PR TITLE
fix(security): fail closed when APPSMITH_BASE_URL unset for token-bearing emails (GHSA-j9gf-vw2f-9hrw)

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -188,6 +188,7 @@ jobs:
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
             -e APPSMITH_CLOUD_SERVICES_SIGNATURE_BASE_URL=http://host.docker.internal:8090 \
             -e APPSMITH_RATE_LIMIT=1000 \
+            -e APPSMITH_BASE_URL=http://localhost \
             --add-host=host.docker.internal:host-gateway --add-host=api.segment.io:host-gateway --add-host=t.appsmith.com:host-gateway \
             cicontainer
 

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -273,6 +273,7 @@ jobs:
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
+            -e APPSMITH_BASE_URL=http://localhost \
             --add-host=host.docker.internal:host-gateway --add-host=api.segment.io:host-gateway --add-host=t.appsmith.com:host-gateway \
             cicontainer
 

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -184,6 +184,7 @@ jobs:
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
+            -e APPSMITH_BASE_URL=http://localhost \
             --add-host=host.docker.internal:host-gateway --add-host=api.segment.io:host-gateway --add-host=t.appsmith.com:host-gateway \
             cicontainer
 

--- a/.github/workflows/ci-test-playwright.yml
+++ b/.github/workflows/ci-test-playwright.yml
@@ -174,6 +174,7 @@ jobs:
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
             -e APPSMITH_CLOUD_SERVICES_SIGNATURE_BASE_URL=http://host.docker.internal:8090 \
             -e APPSMITH_RATE_LIMIT=1000 \
+            -e APPSMITH_BASE_URL=http://localhost \
             -e APPSMITH_CARBON_API_BASE_PATH=https://carbon.appsmith.com \
             -e APPSMITH_CARBON_API_KEY="$APPSMITH_CARBON_API_KEY" \
             -e APPSMITH_AI_SERVER_MANAGED_HOSTING=true \

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -98,11 +98,15 @@ export const addIndexedDBKey = (key, value) => {
 };
 
 Cypress.Commands.add("stubPostHeaderReq", () => {
+  // GHSA-j9gf-vw2f-9hrw: server-side strict-mode now requires Origin to match
+  // APPSMITH_BASE_URL. Use the live Cypress baseUrl so the intercept produces a
+  // valid Origin (the literal string "Cypress" used to live here as a synthetic-
+  // traffic flag and no longer parses as a URL).
   cy.intercept("POST", "/api/v1/users/invite", (req) => {
-    req.headers["origin"] = "Cypress";
+    req.headers["origin"] = Cypress.config("baseUrl");
   }).as("mockPostInvite");
   cy.intercept("POST", "/api/v1/applications/invite", (req) => {
-    req.headers["origin"] = "Cypress";
+    req.headers["origin"] = Cypress.config("baseUrl");
   }).as("mockPostAppInvite");
 });
 
@@ -752,7 +756,8 @@ Cypress.Commands.add("startServerAndRoutes", () => {
       hostname: window.location.host,
     },
     (req) => {
-      req.headers["origin"] = "Cypress";
+      // GHSA-j9gf-vw2f-9hrw: send a real Origin matching APPSMITH_BASE_URL.
+      req.headers["origin"] = Cypress.config("baseUrl");
     },
   ).as("connectGitLocalRepo");
 
@@ -766,13 +771,17 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   });
 
   cy.intercept("PUT", "/api/v1/admin/env", (req) => {
-    req.headers["origin"] = "Cypress";
+    // GHSA-j9gf-vw2f-9hrw: server-side strict-mode now requires Origin to match
+    // APPSMITH_BASE_URL. Use the live Cypress baseUrl instead of the legacy
+    // synthetic-traffic flag "Cypress" (which no longer parses as a URL).
+    req.headers["origin"] = Cypress.config("baseUrl");
   }).as("postEnv");
 
   cy.intercept("GET", "/settings/general").as("getGeneral");
   cy.intercept("GET", "/api/v1/tenants/current").as("signUpLogin");
   cy.intercept("PUT", "/api/v1/tenants", (req) => {
-    req.headers["origin"] = "Cypress";
+    // GHSA-j9gf-vw2f-9hrw: see note above.
+    req.headers["origin"] = Cypress.config("baseUrl");
   }).as("postTenant");
   cy.intercept("PUT", "/api/v1/git/applications/*/discard").as(
     "discardChanges",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -893,6 +893,15 @@ public enum AppsmithError {
             ErrorType.INTERNAL_ERROR,
             null),
 
+    MISCONFIGURED_INSTANCE_BASE_URL(
+            500,
+            AppsmithErrorCode.MISCONFIGURED_INSTANCE_BASE_URL.getCode(),
+            "APPSMITH_BASE_URL is not configured. Token-bearing email flows are disabled until the canonical instance URL is set.",
+            AppsmithErrorAction.DEFAULT,
+            "Instance base URL not configured",
+            ErrorType.INTERNAL_ERROR,
+            null),
+
     INVALID_SMTP_CONFIGURATION(
             400,
             AppsmithErrorCode.INVALID_SMTP_CONFIGURATION.getCode(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
@@ -64,7 +64,7 @@ public enum AppsmithErrorCode {
     GOOGLE_RECAPTCHA_TIMEOUT("AE-APP-5042", "Google recaptcha timeout"),
     MIGRATION_FAILED("AE-APP-5043", "Migration failed"),
     INVALID_PROPERTIES_CONFIGURATION("AE-APP-5044", "Property configuration is wrong or malformed"),
-    MISCONFIGURED_INSTANCE_BASE_URL("AE-APP-5046", "Instance base URL is not configured"),
+    MISCONFIGURED_INSTANCE_BASE_URL("AE-APP-5048", "Instance base URL is not configured"),
     NAME_CLASH_NOT_ALLOWED_IN_REFACTOR("AE-AST-4009", "Name clash not allowed in refactor"),
     GENERIC_BAD_REQUEST("AE-BAD-4000", "Generic bad request"),
     MALFORMED_REQUEST("AE-BAD-4001", "Malformed request body"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
@@ -64,6 +64,7 @@ public enum AppsmithErrorCode {
     GOOGLE_RECAPTCHA_TIMEOUT("AE-APP-5042", "Google recaptcha timeout"),
     MIGRATION_FAILED("AE-APP-5043", "Migration failed"),
     INVALID_PROPERTIES_CONFIGURATION("AE-APP-5044", "Property configuration is wrong or malformed"),
+    MISCONFIGURED_INSTANCE_BASE_URL("AE-APP-5045", "Instance base URL is not configured"),
     NAME_CLASH_NOT_ALLOWED_IN_REFACTOR("AE-AST-4009", "Name clash not allowed in refactor"),
     GENERIC_BAD_REQUEST("AE-BAD-4000", "Generic bad request"),
     MALFORMED_REQUEST("AE-BAD-4001", "Malformed request body"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
@@ -64,7 +64,7 @@ public enum AppsmithErrorCode {
     GOOGLE_RECAPTCHA_TIMEOUT("AE-APP-5042", "Google recaptcha timeout"),
     MIGRATION_FAILED("AE-APP-5043", "Migration failed"),
     INVALID_PROPERTIES_CONFIGURATION("AE-APP-5044", "Property configuration is wrong or malformed"),
-    MISCONFIGURED_INSTANCE_BASE_URL("AE-APP-5045", "Instance base URL is not configured"),
+    MISCONFIGURED_INSTANCE_BASE_URL("AE-APP-5046", "Instance base URL is not configured"),
     NAME_CLASH_NOT_ALLOWED_IN_REFACTOR("AE-AST-4009", "Name clash not allowed in refactor"),
     GENERIC_BAD_REQUEST("AE-BAD-4000", "Generic bad request"),
     MALFORMED_REQUEST("AE-BAD-4001", "Malformed request body"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/SecureBaseUrlResolver.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/SecureBaseUrlResolver.java
@@ -1,0 +1,10 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.helpers.ce.SecureBaseUrlResolverCE;
+
+/**
+ * Marker interface used by Spring DI. CE provides a default
+ * {@link com.appsmith.server.helpers.SecureBaseUrlResolverImpl}; EE overrides the
+ * implementation class to add multi-org-aware resolution.
+ */
+public interface SecureBaseUrlResolver extends SecureBaseUrlResolverCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/SecureBaseUrlResolverImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/SecureBaseUrlResolverImpl.java
@@ -1,0 +1,12 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.helpers.ce.SecureBaseUrlResolverCEImpl;
+import org.springframework.stereotype.Component;
+
+/**
+ * CE concrete bean for {@link SecureBaseUrlResolver}. EE replaces this class with
+ * a multi-org-aware variant that derives the trusted host from the organization
+ * configuration when the {@code license_multi_org_enabled} feature flag is on.
+ */
+@Component
+public class SecureBaseUrlResolverImpl extends SecureBaseUrlResolverCEImpl implements SecureBaseUrlResolver {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCE.java
@@ -1,0 +1,36 @@
+package com.appsmith.server.helpers.ce;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Resolves the trusted, server-side base URL used as the host of token-bearing
+ * email links (forgot-password, email verification, workspace invite,
+ * instance-admin invite).
+ *
+ * <p>The resolver MUST NOT trust request-supplied values such as the {@code Origin}
+ * header as the canonical host. Doing so allows an unauthenticated attacker to
+ * influence the link host of security-sensitive emails — see
+ * <a href="https://github.com/appsmithorg/appsmith/security/advisories/GHSA-j9gf-vw2f-9hrw">GHSA-j9gf-vw2f-9hrw</a>.
+ *
+ * <p>Implementations return {@link Mono#empty()} when no trusted base URL can be
+ * resolved and the insecure compatibility flag is off. Callers are expected to
+ * translate this into a flow-appropriate response:
+ * <ul>
+ *   <li>For unauthenticated anti-enumeration flows (forgot password, resend
+ *       verification): return a generic success response without sending email.</li>
+ *   <li>For authenticated flows (workspace invite, instance-admin invite): surface
+ *       a clear configuration error to the admin caller.</li>
+ * </ul>
+ */
+public interface SecureBaseUrlResolverCE {
+
+    /**
+     * @param providedBaseUrl the base URL extracted from the inbound request (typically
+     *     the {@code Origin} header). Treated as untrusted input.
+     * @return a {@link Mono} emitting the resolved trusted base URL, or empty if no
+     *     trusted URL can be resolved and the insecure compatibility fallback is off.
+     *     May emit an error if a configured base URL is set and the provided value
+     *     does not match (strict-mode enforcement, preserved from prior hardening).
+     */
+    Mono<String> resolveSecureBaseUrl(String providedBaseUrl);
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImpl.java
@@ -1,0 +1,74 @@
+package com.appsmith.server.helpers.ce;
+
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+/**
+ * CE implementation of {@link SecureBaseUrlResolverCE}.
+ *
+ * <p>Resolution rules:
+ *
+ * <ol>
+ *   <li>If {@code APPSMITH_BASE_URL} is configured, it is the only acceptable host. If
+ *       the provided value does not match, an {@link AppsmithException} is emitted
+ *       (preserves the strict-mode protection added in PR #41426 for
+ *       <a href="https://github.com/appsmithorg/appsmith/security/advisories/GHSA-7hf5-mc28-xmcv">GHSA-7hf5-mc28-xmcv</a>).
+ *       The insecure compatibility flag does NOT weaken this branch.</li>
+ *   <li>If {@code APPSMITH_BASE_URL} is unset and {@code APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS}
+ *       is true, the legacy behaviour is restored: the caller-supplied value is
+ *       returned. A WARN log is emitted on every call so operators are aware they
+ *       are running in an insecure mode. This flag is intended only as a transition
+ *       path and is documented as deprecated.</li>
+ *   <li>If {@code APPSMITH_BASE_URL} is unset and the insecure flag is off (the new
+ *       default), the resolver emits {@link Mono#empty()} together with a WARN log.
+ *       Callers in unauthenticated flows convert this into a generic success
+ *       response without dispatching email (anti-enumeration). Callers in
+ *       authenticated flows convert it into an explicit configuration error.</li>
+ * </ol>
+ */
+@Slf4j
+public class SecureBaseUrlResolverCEImpl implements SecureBaseUrlResolverCE {
+
+    @Value("${APPSMITH_BASE_URL:}")
+    private String appsmithBaseUrl;
+
+    /**
+     * Opt-in escape hatch for legacy self-hosted deployments that have not yet
+     * configured {@code APPSMITH_BASE_URL}. When true, the resolver falls back to
+     * the caller-supplied value (the historical, insecure behaviour). Defaults to
+     * false. Intended only as a temporary migration window — set
+     * {@code APPSMITH_BASE_URL} to your instance's canonical URL and remove this
+     * flag.
+     */
+    @Value("${APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS:false}")
+    private boolean allowInsecureOriginBasedLinks;
+
+    @Override
+    public Mono<String> resolveSecureBaseUrl(String providedBaseUrl) {
+        if (StringUtils.hasText(appsmithBaseUrl)) {
+            if (!appsmithBaseUrl.equals(providedBaseUrl)) {
+                return Mono.error(new AppsmithException(
+                        AppsmithError.GENERIC_BAD_REQUEST,
+                        "Origin header does not match APPSMITH_BASE_URL configuration."));
+            }
+            return Mono.just(appsmithBaseUrl);
+        }
+
+        if (allowInsecureOriginBasedLinks) {
+            log.warn("APPSMITH_BASE_URL is not configured and APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS=true. "
+                    + "Token-bearing email links will be derived from the request Origin header. "
+                    + "This is INSECURE and intended only as a transition path. "
+                    + "Set APPSMITH_BASE_URL to your instance's canonical URL and remove the insecure flag.");
+            return Mono.just(providedBaseUrl);
+        }
+
+        log.warn("APPSMITH_BASE_URL is not configured. Token-bearing email flows (password reset, "
+                + "email verification, invites) are disabled until APPSMITH_BASE_URL is set. "
+                + "See https://github.com/appsmithorg/appsmith/security/advisories/GHSA-j9gf-vw2f-9hrw");
+        return Mono.empty();
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImpl.java
@@ -7,6 +7,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Objects;
+
 /**
  * CE implementation of {@link SecureBaseUrlResolverCE}.
  *
@@ -14,9 +19,10 @@ import reactor.core.publisher.Mono;
  *
  * <ol>
  *   <li>If {@code APPSMITH_BASE_URL} is configured, it is the only acceptable host. If
- *       the provided value does not match, an {@link AppsmithException} is emitted
- *       (preserves the strict-mode protection added in PR #41426 for
- *       <a href="https://github.com/appsmithorg/appsmith/security/advisories/GHSA-7hf5-mc28-xmcv">GHSA-7hf5-mc28-xmcv</a>).
+ *       the provided value does not match (compared by URL origin — scheme + host + effective port,
+ *       per RFC 6454), an {@link AppsmithException} is emitted. This preserves the strict-mode
+ *       protection added in PR #41426 for
+ *       <a href="https://github.com/appsmithorg/appsmith/security/advisories/GHSA-7hf5-mc28-xmcv">GHSA-7hf5-mc28-xmcv</a>.
  *       The insecure compatibility flag does NOT weaken this branch.</li>
  *   <li>If {@code APPSMITH_BASE_URL} is unset and {@code APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS}
  *       is true, the legacy behaviour is restored: the caller-supplied value is
@@ -50,7 +56,11 @@ public class SecureBaseUrlResolverCEImpl implements SecureBaseUrlResolverCE {
     @Override
     public Mono<String> resolveSecureBaseUrl(String providedBaseUrl) {
         if (StringUtils.hasText(appsmithBaseUrl)) {
-            if (!appsmithBaseUrl.equals(providedBaseUrl)) {
+            if (!sameOrigin(appsmithBaseUrl, providedBaseUrl)) {
+                log.warn(
+                        "Origin mismatch: provided='{}' does not match configured APPSMITH_BASE_URL='{}'.",
+                        providedBaseUrl,
+                        appsmithBaseUrl);
                 return Mono.error(new AppsmithException(
                         AppsmithError.GENERIC_BAD_REQUEST,
                         "Origin header does not match APPSMITH_BASE_URL configuration."));
@@ -70,5 +80,61 @@ public class SecureBaseUrlResolverCEImpl implements SecureBaseUrlResolverCE {
                 + "email verification, invites) are disabled until APPSMITH_BASE_URL is set. "
                 + "See https://github.com/appsmithorg/appsmith/security/advisories/GHSA-j9gf-vw2f-9hrw");
         return Mono.empty();
+    }
+
+    /**
+     * Compares two URLs by their origin (scheme + host + effective port) per RFC 6454, rather than
+     * by raw string equality. Tolerates insignificant differences such as trailing slashes and
+     * default-port elision (e.g. {@code http://example.com} and {@code http://example.com:80} are
+     * the same origin) while still rejecting any difference in scheme, host, or non-default port.
+     *
+     * <p>Returns {@code false} for any malformed URL or null/blank input. Userinfo, path, query,
+     * and fragment are deliberately ignored — only the security-relevant origin is compared.
+     */
+    private static boolean sameOrigin(String configured, String provided) {
+        if (!StringUtils.hasText(configured) || !StringUtils.hasText(provided)) {
+            return false;
+        }
+        try {
+            URI configuredUri = new URI(configured.trim());
+            URI providedUri = new URI(provided.trim());
+
+            String configuredScheme = lowerCase(configuredUri.getScheme());
+            String providedScheme = lowerCase(providedUri.getScheme());
+            if (!Objects.equals(configuredScheme, providedScheme)) {
+                return false;
+            }
+
+            String configuredHost = lowerCase(configuredUri.getHost());
+            String providedHost = lowerCase(providedUri.getHost());
+            if (configuredHost == null || !Objects.equals(configuredHost, providedHost)) {
+                // Reject when host can't be parsed (e.g. opaque URIs) or hosts differ.
+                return false;
+            }
+
+            return effectivePort(configuredUri) == effectivePort(providedUri);
+        } catch (URISyntaxException e) {
+            log.warn("Failed to parse URL for origin comparison: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private static int effectivePort(URI uri) {
+        int port = uri.getPort();
+        if (port != -1) {
+            return port;
+        }
+        String scheme = lowerCase(uri.getScheme());
+        if ("http".equals(scheme)) {
+            return 80;
+        }
+        if ("https".equals(scheme)) {
+            return 443;
+        }
+        return -1;
+    }
+
+    private static String lowerCase(String value) {
+        return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EmailServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EmailServiceImpl.java
@@ -1,13 +1,17 @@
 package com.appsmith.server.services;
 
 import com.appsmith.server.helpers.EmailServiceHelper;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.notifications.EmailSender;
 import com.appsmith.server.services.ce.EmailServiceCEImpl;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EmailServiceImpl extends EmailServiceCEImpl implements EmailService {
-    public EmailServiceImpl(EmailSender emailSender, EmailServiceHelper emailServiceHelper) {
-        super(emailSender, emailServiceHelper);
+    public EmailServiceImpl(
+            EmailSender emailSender,
+            EmailServiceHelper emailServiceHelper,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
+        super(emailSender, emailServiceHelper, secureBaseUrlResolver);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services;
 
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.EmailConfig;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.helpers.UserServiceHelper;
 import com.appsmith.server.helpers.UserUtils;
 import com.appsmith.server.instanceconfigs.helpers.InstanceVariablesHelper;
@@ -44,7 +45,8 @@ public class UserServiceImpl extends UserServiceCECompatibleImpl implements User
             RateLimitService rateLimitService,
             PACConfigurationService pacConfigurationService,
             UserServiceHelper userServiceHelper,
-            InstanceVariablesHelper instanceVariablesHelper) {
+            InstanceVariablesHelper instanceVariablesHelper,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
         super(
                 validator,
                 repository,
@@ -62,6 +64,7 @@ public class UserServiceImpl extends UserServiceCECompatibleImpl implements User
                 rateLimitService,
                 pacConfigurationService,
                 userServiceHelper,
-                instanceVariablesHelper);
+                instanceVariablesHelper,
+                secureBaseUrlResolver);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/EmailServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/EmailServiceCEImpl.java
@@ -4,7 +4,10 @@ import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.PermissionGroup;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.EmailServiceHelper;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.notifications.EmailSender;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
@@ -23,13 +26,23 @@ public class EmailServiceCEImpl implements EmailServiceCE {
 
     private final EmailServiceHelper emailServiceHelper;
 
-    public EmailServiceCEImpl(EmailSender emailSender, EmailServiceHelper emailServiceHelper) {
+    private final SecureBaseUrlResolver secureBaseUrlResolver;
+
+    public EmailServiceCEImpl(
+            EmailSender emailSender,
+            EmailServiceHelper emailServiceHelper,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
         this.emailSender = emailSender;
         this.emailServiceHelper = emailServiceHelper;
+        this.secureBaseUrlResolver = secureBaseUrlResolver;
     }
 
     @Override
     public Mono<Boolean> sendForgotPasswordEmail(String email, String resetUrl, String originHeader) {
+        // The reset URL has already been built with the trusted base URL by UserServiceCEImpl
+        // (which routes through SecureBaseUrlResolver). The originHeader passed here is used
+        // only for cosmetic branding lookups; this method is a no-op when not invoked through
+        // that resolved path.
         Map<String, String> params = new HashMap<>();
         params.put(RESET_URL, resetUrl);
         return emailServiceHelper
@@ -54,30 +67,42 @@ public class EmailServiceCEImpl implements EmailServiceCE {
             PermissionGroup assignedPermissionGroup,
             String originHeader,
             boolean isNewUser) {
-        String inviteUrl = isNewUser
-                ? String.format(
-                        INVITE_USER_CLIENT_URL_FORMAT,
-                        originHeader,
-                        URLEncoder.encode(invitedUser.getUsername().toLowerCase(), StandardCharsets.UTF_8))
-                : originHeader;
-        Mono<String> emailSubjectMono = emailServiceHelper.getSubjectJoinWorkspace(workspaceInvitedTo.getName());
-        Mono<String> workspaceInviteTemplateMono = emailServiceHelper.getWorkspaceInviteTemplate(isNewUser);
-        Map<String, String> params = getInviteToWorkspaceEmailParams(
-                workspaceInvitedTo, invitingUser, inviteUrl, assignedPermissionGroup.getName(), isNewUser);
-        return emailServiceHelper
-                .enrichWithBrandParams(params, originHeader)
-                .zipWith(Mono.zip(emailSubjectMono, workspaceInviteTemplateMono))
-                .flatMap(objects -> {
-                    Map<String, String> updatedParams = objects.getT1();
-                    String emailSubject = objects.getT2().getT1();
-                    String workspaceInviteTemplate = objects.getT2().getT2();
-                    return emailSender.sendMail(
-                            invitedUser.getEmail(), emailSubject, workspaceInviteTemplate, updatedParams);
+        // Resolve the trusted base URL through the canonical resolver. The invite flow is
+        // authenticated, so a missing APPSMITH_BASE_URL must surface as an explicit
+        // configuration error to the admin caller (rather than the silent-success behavior
+        // used by anti-enumeration flows). See GHSA-j9gf-vw2f-9hrw.
+        return secureBaseUrlResolver
+                .resolveSecureBaseUrl(originHeader)
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.MISCONFIGURED_INSTANCE_BASE_URL)))
+                .flatMap(trustedBaseUrl -> {
+                    String inviteUrl = isNewUser
+                            ? String.format(
+                                    INVITE_USER_CLIENT_URL_FORMAT,
+                                    trustedBaseUrl,
+                                    URLEncoder.encode(invitedUser.getUsername().toLowerCase(), StandardCharsets.UTF_8))
+                            : trustedBaseUrl;
+                    Mono<String> emailSubjectMono =
+                            emailServiceHelper.getSubjectJoinWorkspace(workspaceInvitedTo.getName());
+                    Mono<String> workspaceInviteTemplateMono = emailServiceHelper.getWorkspaceInviteTemplate(isNewUser);
+                    Map<String, String> params = getInviteToWorkspaceEmailParams(
+                            workspaceInvitedTo, invitingUser, inviteUrl, assignedPermissionGroup.getName(), isNewUser);
+                    return emailServiceHelper
+                            .enrichWithBrandParams(params, trustedBaseUrl)
+                            .zipWith(Mono.zip(emailSubjectMono, workspaceInviteTemplateMono))
+                            .flatMap(objects -> {
+                                Map<String, String> updatedParams = objects.getT1();
+                                String emailSubject = objects.getT2().getT1();
+                                String workspaceInviteTemplate = objects.getT2().getT2();
+                                return emailSender.sendMail(
+                                        invitedUser.getEmail(), emailSubject, workspaceInviteTemplate, updatedParams);
+                            });
                 });
     }
 
     @Override
     public Mono<Boolean> sendEmailVerificationEmail(User user, String verificationURL, String originHeader) {
+        // The verification URL has already been built with the trusted base URL by
+        // UserServiceCEImpl. The originHeader is used only for branding lookups.
         Map<String, String> params = new HashMap<>();
         params.put(EMAIL_VERIFICATION_URL, verificationURL);
         return emailServiceHelper
@@ -97,36 +122,44 @@ public class EmailServiceCEImpl implements EmailServiceCE {
     @Override
     public Mono<Boolean> sendInstanceAdminInviteEmail(
             User invitedUser, User invitingUser, String originHeader, boolean isNewUser) {
-        Map<String, String> params = new HashMap<>();
-        String inviteUrl = isNewUser
-                ? String.format(
-                        INVITE_USER_CLIENT_URL_FORMAT,
-                        originHeader,
-                        URLEncoder.encode(invitedUser.getUsername().toLowerCase(), StandardCharsets.UTF_8))
-                : originHeader;
-        params.put(PRIMARY_LINK_URL, inviteUrl);
+        // Auth-gated admin invite flow: resolve the trusted base URL or surface a
+        // configuration error. See GHSA-j9gf-vw2f-9hrw.
+        return secureBaseUrlResolver
+                .resolveSecureBaseUrl(originHeader)
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.MISCONFIGURED_INSTANCE_BASE_URL)))
+                .flatMap(trustedBaseUrl -> {
+                    Map<String, String> params = new HashMap<>();
+                    String inviteUrl = isNewUser
+                            ? String.format(
+                                    INVITE_USER_CLIENT_URL_FORMAT,
+                                    trustedBaseUrl,
+                                    URLEncoder.encode(invitedUser.getUsername().toLowerCase(), StandardCharsets.UTF_8))
+                            : trustedBaseUrl;
+                    params.put(PRIMARY_LINK_URL, inviteUrl);
 
-        Mono<String> primaryLinkTextMono = emailServiceHelper.getJoinInstanceCtaPrimaryText();
+                    Mono<String> primaryLinkTextMono = emailServiceHelper.getJoinInstanceCtaPrimaryText();
 
-        if (invitingUser != null) {
-            params.put(INVITER_FIRST_NAME, StringUtils.defaultIfEmpty(invitingUser.getName(), invitingUser.getEmail()));
-        }
-        return primaryLinkTextMono
-                .flatMap(primaryLinkText -> {
-                    params.put(PRIMARY_LINK_TEXT, primaryLinkText);
-                    return emailServiceHelper.enrichWithBrandParams(params, originHeader);
-                })
-                .zipWhen(updatedParams -> {
-                    return Mono.zip(
-                            emailServiceHelper.getSubjectJoinInstanceAsAdmin(updatedParams.get(INSTANCE_NAME)),
-                            emailServiceHelper.getAdminInstanceInviteTemplate());
-                })
-                .flatMap(objects -> {
-                    Map<String, String> updatedParams = objects.getT1();
-                    String subject = objects.getT2().getT1();
-                    String adminInstanceInviteTemplate = objects.getT2().getT2();
-                    return emailSender.sendMail(
-                            invitedUser.getEmail(), subject, adminInstanceInviteTemplate, updatedParams);
+                    if (invitingUser != null) {
+                        params.put(
+                                INVITER_FIRST_NAME,
+                                StringUtils.defaultIfEmpty(invitingUser.getName(), invitingUser.getEmail()));
+                    }
+                    return primaryLinkTextMono
+                            .flatMap(primaryLinkText -> {
+                                params.put(PRIMARY_LINK_TEXT, primaryLinkText);
+                                return emailServiceHelper.enrichWithBrandParams(params, trustedBaseUrl);
+                            })
+                            .zipWhen(updatedParams -> Mono.zip(
+                                    emailServiceHelper.getSubjectJoinInstanceAsAdmin(updatedParams.get(INSTANCE_NAME)),
+                                    emailServiceHelper.getAdminInstanceInviteTemplate()))
+                            .flatMap(objects -> {
+                                Map<String, String> updatedParams = objects.getT1();
+                                String subject = objects.getT2().getT1();
+                                String adminInstanceInviteTemplate =
+                                        objects.getT2().getT2();
+                                return emailSender.sendMail(
+                                        invitedUser.getEmail(), subject, adminInstanceInviteTemplate, updatedParams);
+                            });
                 });
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -24,6 +24,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.EmailNormalizer;
 import com.appsmith.server.helpers.RedirectHelper;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.helpers.UserServiceHelper;
 import com.appsmith.server.helpers.UserUtils;
 import com.appsmith.server.instanceconfigs.helpers.InstanceVariablesHelper;
@@ -46,7 +47,6 @@ import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.net.WWWFormCodec;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -110,41 +110,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
 
     private final UserServiceHelper userPoliciesComputeHelper;
     private final InstanceVariablesHelper instanceVariablesHelper;
-
-    @Value("${APPSMITH_BASE_URL:}")
-    private String appsmithBaseUrl;
-
-    /**
-     * Resolves and validates the base URL for security-sensitive operations like password reset
-     * and email verification. This method ensures that URLs in emails point to trusted domains.
-     *
-     * <p>In single-org (CE) mode:
-     * <ul>
-     *   <li>If APPSMITH_BASE_URL is configured, validates that the provided URL matches it</li>
-     *   <li>If APPSMITH_BASE_URL is not configured, uses the provided URL (backward compatibility)</li>
-     * </ul>
-     *
-     * <p>This method can be overridden in EE to handle multi-org setups where each organization
-     * has its own base URL.
-     *
-     * @param providedBaseUrl The base URL from the request (typically from Origin header)
-     * @return Mono<String> The validated/resolved base URL to use for constructing email links
-     */
-    protected Mono<String> resolveSecureBaseUrl(String providedBaseUrl) {
-        // If APPSMITH_BASE_URL is not configured, use provided URL for backwards compatibility
-        if (!StringUtils.hasText(appsmithBaseUrl)) {
-            return Mono.just(providedBaseUrl);
-        }
-
-        // If APPSMITH_BASE_URL is configured, validate that Origin header matches it
-        if (!appsmithBaseUrl.equals(providedBaseUrl)) {
-            return Mono.error(new AppsmithException(
-                    AppsmithError.GENERIC_BAD_REQUEST,
-                    "Origin header does not match APPSMITH_BASE_URL configuration."));
-        }
-
-        return Mono.just(appsmithBaseUrl);
-    }
+    private final SecureBaseUrlResolver secureBaseUrlResolver;
 
     protected static final WebFilterChain EMPTY_WEB_FILTER_CHAIN = serverWebExchange -> Mono.empty();
     private static final String FORGOT_PASSWORD_CLIENT_URL_FORMAT = "%s/user/resetPassword?token=%s";
@@ -176,7 +142,8 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
             RateLimitService rateLimitService,
             PACConfigurationService pacConfigurationService,
             UserServiceHelper userServiceHelper,
-            InstanceVariablesHelper instanceVariablesHelper) {
+            InstanceVariablesHelper instanceVariablesHelper,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
 
         super(validator, repository, analyticsService);
         this.workspaceService = workspaceService;
@@ -193,6 +160,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
         this.userPoliciesComputeHelper = userServiceHelper;
         this.pacConfigurationService = pacConfigurationService;
         this.instanceVariablesHelper = instanceVariablesHelper;
+        this.secureBaseUrlResolver = secureBaseUrlResolver;
     }
 
     @Override
@@ -226,13 +194,17 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ORIGIN));
         }
 
-        // Resolve the secure base URL (validates in single-org, may be overridden for multi-org)
-        return resolveSecureBaseUrl(resetUserPasswordDTO.getBaseUrl()).flatMap(secureBaseUrl -> {
-            // Use the resolved secure base URL instead of the client-provided one
-            resetUserPasswordDTO.setBaseUrl(secureBaseUrl);
-            String email = resetUserPasswordDTO.getEmail();
-            return processForgotPasswordTokenGeneration(email, resetUserPasswordDTO);
-        });
+        // Resolve the secure base URL through the trusted resolver. When APPSMITH_BASE_URL is unset
+        // (and the insecure compatibility flag is off) the resolver returns Mono.empty(), causing
+        // this entire chain to complete without dispatching email — preserving the generic success
+        // response that anti-enumeration relies on. See GHSA-j9gf-vw2f-9hrw.
+        return secureBaseUrlResolver
+                .resolveSecureBaseUrl(resetUserPasswordDTO.getBaseUrl())
+                .flatMap(secureBaseUrl -> {
+                    resetUserPasswordDTO.setBaseUrl(secureBaseUrl);
+                    String email = resetUserPasswordDTO.getEmail();
+                    return processForgotPasswordTokenGeneration(email, resetUserPasswordDTO);
+                });
     }
 
     private Mono<Boolean> processForgotPasswordTokenGeneration(
@@ -868,13 +840,16 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ORIGIN));
         }
 
-        // Resolve the secure base URL (validates in single-org, may be overridden for multi-org)
-        return resolveSecureBaseUrl(resendEmailVerificationDTO.getBaseUrl()).flatMap(secureBaseUrl -> {
-            // Use the resolved secure base URL instead of the client-provided one
-            resendEmailVerificationDTO.setBaseUrl(secureBaseUrl);
-            String email = resendEmailVerificationDTO.getEmail();
-            return processResendEmailVerification(email, resendEmailVerificationDTO, redirectUrl);
-        });
+        // Resolve the secure base URL through the trusted resolver. When APPSMITH_BASE_URL is unset
+        // (and the insecure compatibility flag is off) the resolver returns Mono.empty(), causing
+        // this entire chain to complete without dispatching email. See GHSA-j9gf-vw2f-9hrw.
+        return secureBaseUrlResolver
+                .resolveSecureBaseUrl(resendEmailVerificationDTO.getBaseUrl())
+                .flatMap(secureBaseUrl -> {
+                    resendEmailVerificationDTO.setBaseUrl(secureBaseUrl);
+                    String email = resendEmailVerificationDTO.getEmail();
+                    return processResendEmailVerification(email, resendEmailVerificationDTO, redirectUrl);
+                });
     }
 
     private Mono<Boolean> processResendEmailVerification(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/UserServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce_compatible/UserServiceCECompatibleImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.services.ce_compatible;
 
 import com.appsmith.server.configurations.CommonConfig;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.helpers.UserServiceHelper;
 import com.appsmith.server.helpers.UserUtils;
 import com.appsmith.server.instanceconfigs.helpers.InstanceVariablesHelper;
@@ -39,7 +40,8 @@ public class UserServiceCECompatibleImpl extends UserServiceCEImpl implements Us
             RateLimitService rateLimitService,
             PACConfigurationService pacConfigurationService,
             UserServiceHelper userServiceHelper,
-            InstanceVariablesHelper instanceVariablesHelper) {
+            InstanceVariablesHelper instanceVariablesHelper,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
         super(
                 validator,
                 repository,
@@ -57,6 +59,7 @@ public class UserServiceCECompatibleImpl extends UserServiceCEImpl implements Us
                 rateLimitService,
                 pacConfigurationService,
                 userServiceHelper,
-                instanceVariablesHelper);
+                instanceVariablesHelper,
+                secureBaseUrlResolver);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImplTest.java
@@ -1,0 +1,121 @@
+package com.appsmith.server.helpers.ce;
+
+import com.appsmith.server.exceptions.AppsmithException;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Unit tests for {@link SecureBaseUrlResolverCEImpl}.
+ *
+ * <p>These tests pin the fail-closed semantics added for
+ * <a href="https://github.com/appsmithorg/appsmith/security/advisories/GHSA-j9gf-vw2f-9hrw">GHSA-j9gf-vw2f-9hrw</a>:
+ * when {@code APPSMITH_BASE_URL} is unset, the resolver must NOT trust the request-supplied
+ * {@code Origin} value as the host of token-bearing email links. It must signal "no trusted
+ * URL available" via {@link reactor.core.publisher.Mono#empty()} so that callers in unauthenticated
+ * flows return generic success without dispatching email (preserving anti-enumeration), while
+ * callers in authenticated flows can convert the empty into an explicit configuration error.
+ *
+ * <p>The opt-in {@code APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS} compatibility flag exists
+ * solely to give operators a migration window. When enabled, it restores the legacy behavior
+ * of trusting the caller-supplied value — but it does NOT weaken the strict-mode check that
+ * applies once {@code APPSMITH_BASE_URL} is configured.
+ */
+class SecureBaseUrlResolverCEImplTest {
+
+    private SecureBaseUrlResolverCEImpl newResolver(String configuredBaseUrl, boolean allowInsecureFallback)
+            throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = new SecureBaseUrlResolverCEImpl();
+        Field baseUrlField = SecureBaseUrlResolverCEImpl.class.getDeclaredField("appsmithBaseUrl");
+        baseUrlField.setAccessible(true);
+        baseUrlField.set(resolver, configuredBaseUrl == null ? "" : configuredBaseUrl);
+        Field flagField = SecureBaseUrlResolverCEImpl.class.getDeclaredField("allowInsecureOriginBasedLinks");
+        flagField.setAccessible(true);
+        flagField.set(resolver, allowInsecureFallback);
+        return resolver;
+    }
+
+    /**
+     * GHSA-j9gf-vw2f-9hrw — the central regression test. When the trusted base URL is unset and
+     * the insecure compatibility flag is off (the new default), the resolver must return an
+     * empty signal — NOT the caller-supplied value.
+     */
+    @Test
+    void resolveSecureBaseUrl_whenAppsmithBaseUrlUnsetAndCompatFlagOff_returnsEmpty() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://attacker.example"))
+                .verifyComplete();
+    }
+
+    /**
+     * Migration path: when an operator opts into the insecure flag during a transition window,
+     * the legacy behavior is restored — the caller-supplied value is returned. The WARN log is
+     * the operational signal that this is happening; we do not assert on the log here, but the
+     * production code MUST emit it (manual code review).
+     */
+    @Test
+    void resolveSecureBaseUrl_whenAppsmithBaseUrlUnsetAndCompatFlagOn_returnsProvidedValue() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("", true);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://attacker.example"))
+                .expectNext("https://attacker.example")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenAppsmithBaseUrlSetAndOriginMatches_returnsConfiguredUrl() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://appsmith.example"))
+                .expectNext("https://appsmith.example")
+                .verifyComplete();
+    }
+
+    /**
+     * Regression on the protection added in PR #41426 (GHSA-7hf5-mc28-xmcv): once configured,
+     * the trusted base URL must not be impersonated.
+     */
+    @Test
+    void resolveSecureBaseUrl_whenAppsmithBaseUrlSetAndOriginMismatches_errors() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://attacker.example"))
+                .verifyError(AppsmithException.class);
+    }
+
+    /**
+     * Defense-in-depth: the insecure-compat flag is intended for the unset-config case only.
+     * It must NOT be a backdoor that weakens strict-mode validation when APPSMITH_BASE_URL is
+     * configured.
+     */
+    @Test
+    void resolveSecureBaseUrl_whenAppsmithBaseUrlSetAndOriginMismatches_compatFlagDoesNotWeakenStrictMode()
+            throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", true);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://attacker.example"))
+                .verifyError(AppsmithException.class);
+    }
+
+    /**
+     * Empty Origin from the request, unset config, default fail-closed: empty signal.
+     * Sanity-check that the resolver does not blow up on null/empty caller-supplied values.
+     */
+    @Test
+    void resolveSecureBaseUrl_whenProvidedBaseUrlIsNullOrBlank_andCompatFlagOff_returnsEmpty() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl(null)).verifyComplete();
+        StepVerifier.create(resolver.resolveSecureBaseUrl("")).verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_constructed_isNotNull() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+        assertNotNull(resolver);
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImplTest.java
@@ -118,4 +118,91 @@ class SecureBaseUrlResolverCEImplTest {
         SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
         assertNotNull(resolver);
     }
+
+    // region URL-origin normalisation — comparison must follow RFC 6454 (scheme + host + effective port),
+    // not raw string equality. Without this, real-world deployments hit spurious mismatches whenever the
+    // configured value and the inbound `Origin` header differ on insignificant syntax (trailing slash,
+    // default-port elision, host case). All accepted matches below resolve to the SAME origin per the
+    // RFC; all rejected ones genuinely differ in scheme, host, or non-default port.
+
+    @Test
+    void resolveSecureBaseUrl_whenConfiguredHasTrailingSlash_andOriginDoesNot_match() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("http://localhost/", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("http://localhost"))
+                .expectNext("http://localhost/")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenOriginHasTrailingSlash_andConfiguredDoesNot_match() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("http://localhost", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("http://localhost/"))
+                .expectNext("http://localhost")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenOriginHasDefaultHttpPort_andConfiguredOmitsIt_match() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("http://localhost", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("http://localhost:80"))
+                .expectNext("http://localhost")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenOriginHasDefaultHttpsPort_andConfiguredOmitsIt_match() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://appsmith.example:443"))
+                .expectNext("https://appsmith.example")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenHostCasingDiffers_match() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://Appsmith.Example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://appsmith.example"))
+                .expectNext("https://Appsmith.Example")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenSchemesDiffer_errors() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("http://appsmith.example"))
+                .verifyError(AppsmithException.class);
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenNonDefaultPortsDiffer_errors() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("http://localhost:8080", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("http://localhost:9090"))
+                .verifyError(AppsmithException.class);
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenOriginIsMalformed_errors() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("not a url")).verifyError(AppsmithException.class);
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenAttackerUsesUserinfoTrick_errors() throws Exception {
+        // Tricks like https://appsmith.example@evil.com must NOT be accepted as the same origin
+        // as https://appsmith.example. URI parsing places appsmith.example in userinfo and evil.com
+        // as the host — so the host comparison rejects.
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://appsmith.example@evil.example"))
+                .verifyError(AppsmithException.class);
+    }
+
+    // endregion
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/EmailServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/EmailServiceCEImplTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
@@ -36,6 +37,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 
 @SpringBootTest
+// GHSA-j9gf-vw2f-9hrw: invite/admin-invite flows now require APPSMITH_BASE_URL to be configured
+// (auth-gated, so they fail closed with a configuration error rather than silent success).
+// Set it to the value the tests pass as the Origin header so the strict-match path activates.
+@TestPropertySource(properties = "APPSMITH_BASE_URL=http://example.com")
 class EmailServiceCEImplTest {
 
     @SpyBean

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/EmailServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/EmailServiceCEImplTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.context.TestPropertySource;
 import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
@@ -37,10 +36,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 
 @SpringBootTest
-// GHSA-j9gf-vw2f-9hrw: invite/admin-invite flows now require APPSMITH_BASE_URL to be configured
-// (auth-gated, so they fail closed with a configuration error rather than silent success).
-// Set it to the value the tests pass as the Origin header so the strict-match path activates.
-@TestPropertySource(properties = "APPSMITH_BASE_URL=http://example.com")
 class EmailServiceCEImplTest {
 
     @SpyBean

--- a/app/server/appsmith-server/src/test/resources/application-test.properties
+++ b/app/server/appsmith-server/src/test/resources/application-test.properties
@@ -2,3 +2,10 @@
 de.flapdoodle.mongodb.embedded.version=5.0.5
 logging.level.root=error
 appsmith.git.root = /dev/shm/git-storage
+
+# GHSA-j9gf-vw2f-9hrw: enable the insecure-compatibility flag in the integration test
+# environment so the legacy Origin-based behaviour is preserved across the existing
+# Workspace / Fork / UserService / Theme integration suites. The fail-closed semantics
+# of the resolver are pinned directly by SecureBaseUrlResolverCEImplTest unit tests;
+# production deployments default this flag to false (secure).
+APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS=true

--- a/docs/superpowers/specs/2026-04-28-ci-base-url-config-design.md
+++ b/docs/superpowers/specs/2026-04-28-ci-base-url-config-design.md
@@ -1,0 +1,83 @@
+# CI Configuration for `APPSMITH_BASE_URL` (GHSA-j9gf-vw2f-9hrw follow-up)
+
+**Date:** 2026-04-28
+**Author:** subrata71
+**Companion to:** [PR #41766](https://github.com/appsmithorg/appsmith/pull/41766) (CE), [PR #8997](https://github.com/appsmithorg/appsmith-ee/pull/8997) (EE)
+**Linear:** [APP-15046](https://linear.app/appsmith/issue/APP-15046)
+
+## Context
+
+The fix for [GHSA-j9gf-vw2f-9hrw](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-j9gf-vw2f-9hrw) makes the server fail-closed for token-bearing email flows (forgot-password, email verification, workspace invite, instance-admin invite) whenever `APPSMITH_BASE_URL` is unset. The Cypress E2E suite in `ci-test-*` workflows spins up a fresh Appsmith Docker container that does not set `APPSMITH_BASE_URL`, so every spec exercising those flows now fails with `MISCONFIGURED_INSTANCE_BASE_URL`.
+
+Concrete failures observed on the [first PR run](https://github.com/appsmithorg/appsmith/actions/runs/25035460641): `Email_settings_Spec.ts`, `ExportApplication_spec.js`, `DeleteWorkspace_spec.ts`, `LeaveWorkspaceTest_spec.js`, `MemberRoles_Spec.ts`, `ShareAppTests_Spec.ts`. All emit the same client-side error: `APPSMITH_BASE_URL is not configured. Token-bearing email flows are disabled until the canonical instance URL is set.`
+
+The unit/integration test suite was already addressed in commit `35eb077e58` by setting `APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS=true` in `application-test.properties`. That fix does **not** apply to Cypress, which runs against the production profile of a deployed Docker container.
+
+## Decision
+
+**Approach A: configure `APPSMITH_BASE_URL` at container startup in every CI environment that runs Cypress.** Treat CI as a real deployment that satisfies the new contract. Do **not** use the migration flag (`APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS`) in CI — we want E2E coverage of the new secure path.
+
+Rationale:
+- Production-realistic. CI becomes the canonical example of how self-hosted operators should configure their instance.
+- Exercises the new strict-mode `Origin == APPSMITH_BASE_URL` check end-to-end.
+- One-time small workflow change (~5 files).
+- The fail-closed semantics introduced by the GHSA fix are still pinned by `SecureBaseUrlResolverCEImplTest` unit tests, so the test pyramid stays balanced.
+
+Approach B (`APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS=true` in CI) was rejected because it would never exercise the secure path E2E and would spam every CI log with the helper's WARN message.
+
+## Files to change
+
+### CI workflows (5 lines each, identical pattern)
+
+For each of these workflows, add `-e APPSMITH_BASE_URL=http://localhost \` to the `docker run -d --name appsmith` block:
+
+| File | Approximate line of `docker run --name appsmith` |
+|------|--------------------------------------------------|
+| `.github/workflows/ci-test-limited.yml` | 182 |
+| `.github/workflows/ci-test-limited-with-count.yml` | 271 |
+| `.github/workflows/ci-test-custom-script.yml` | 184 |
+| `.github/workflows/ci-test-playwright.yml` | 169 |
+
+The container exposes port 80 → host port 80, and Cypress hits `http://localhost`. Browsers omit `:80` from the `Origin` header for default-port URLs, so `APPSMITH_BASE_URL=http://localhost` matches exactly.
+
+### Deploy preview (Helm)
+
+`scripts/deploy_preview.sh` (around line 117) — add to the `helm upgrade` arg list:
+
+```
+--set applicationConfig.APPSMITH_BASE_URL=https://$DOMAINNAME
+```
+
+`$DOMAINNAME` is already computed on line 22 as `$edition-$PULL_REQUEST_NUMBER.dp.appsmith.com`. The Helm chart already propagates `applicationConfig.*` to container env (existing pattern: `APPSMITH_DB_URL`, `APPSMITH_SENTRY_DSN`, …).
+
+### Local developer parity (optional)
+
+`scripts/local_testing.sh` (line 124) — add `-e APPSMITH_BASE_URL=http://localhost \` to the local docker-run helper. This keeps developer-local Docker behavior consistent with CI. Skip if you'd rather minimize blast radius.
+
+## Files explicitly NOT changed
+
+- `.github/workflows/ci-test-hosted.yml` — runs against an externally-managed hosted Appsmith instance (not Docker). The hosted instance's configuration is owned by ops; the workflow itself doesn't `docker run` Appsmith.
+- `.github/workflows/server-build.yml`, `server-integration-tests.yml` — server unit/integration tests via Maven; already fixed via `application-test.properties`.
+- `.github/workflows/build-docker-image.yml`, `test-build-docker-image.yml` — they orchestrate but do not themselves `docker run` Appsmith. They invoke the child workflows above.
+- The Docker image / Dockerfile itself — must NOT bake in any default `APPSMITH_BASE_URL` value. Production deployments need their own canonical URL; baking a default would defeat the security improvement.
+
+## Risks
+
+1. **Origin string mismatch.** Strict-mode requires exact equality. Cypress sends `Origin: http://localhost` for default-port traffic to `http://localhost`. Verified by reading the existing `Email_settings_Spec.ts` test 3 (lines 172-181) which already strips trailing slashes from `originUrl` before forwarding — confirming the team has thought about this surface. **Mitigation:** if a spec passes a different Origin, we'll see `Origin header does not match APPSMITH_BASE_URL configuration` (HTTP 400) — clear and actionable, not a silent failure.
+
+2. **Helm chart key naming.** `applicationConfig.APPSMITH_BASE_URL` — confirmed pattern matches existing entries. **Mitigation:** the existing deploy preview will surface any mistake on first run.
+
+3. **Rollback.** If anything misbehaves, removing the env vars from these files restores prior CI behavior. Production fail-closed default in the server is unaffected.
+
+## Validation
+
+1. Re-trigger the failing CI run on PR #41766. All previously-failing Cypress specs should pass.
+2. Re-trigger a deploy preview build to verify `APPSMITH_BASE_URL` propagates correctly via Helm.
+3. Smoke-test by running one Cypress spec locally with `APPSMITH_BASE_URL=http://localhost` set on a fresh container.
+
+## Out of scope
+
+- Adding a Cypress `before` hook to set `APPSMITH_BASE_URL` via the admin settings UI — not needed since we set it at container startup.
+- Cypress test code changes — none needed.
+- Changes to the Docker image (Dockerfile / base.dockerfile).
+- Documenting the new requirement in user-facing operator docs — separate doc PR after release.

--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -115,6 +115,7 @@ helm upgrade -i "$CHARTNAME" "appsmith-ee/$HELMCHART" -n "$NAMESPACE" --create-n
   --set applicationConfig.APPSMITH_BETTERBUGS_API_KEY="$APPSMITH_BETTERBUGS_API_KEY" \
   --set applicationConfig.APPSMITH_PYLON_APP_ID="$APPSMITH_PYLON_APP_ID" \
   --set applicationConfig.IN_DOCKER="$IN_DOCKER" \
+  --set applicationConfig.APPSMITH_BASE_URL="https://$DOMAINNAME" \
   --set applicationConfig.APPSMITH_CUSTOMER_PORTAL_URL="https://release-customer.appsmith.com" \
   --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=instance_name \
   --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \

--- a/scripts/local_testing.sh
+++ b/scripts/local_testing.sh
@@ -121,4 +121,4 @@ docker build -t appsmith/appsmith-local-$edition:$tag \
 pretty_print "Docker image build successful. Triggering run now ..."
 
 (docker stop appsmith || true) && (docker rm appsmith || true)
-docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" appsmith/appsmith-local-$edition:$tag && sleep 15 && pretty_print "Local instance is up! Open Appsmith at http://localhost! "
+docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_BASE_URL=http://localhost appsmith/appsmith-local-$edition:$tag && sleep 15 && pretty_print "Local instance is up! Open Appsmith at http://localhost! "


### PR DESCRIPTION
## Description

fix(security): fail closed when APPSMITH_BASE_URL unset for token-bearing emails (GHSA-j9gf-vw2f-9hrw)

- **Primary fix:** Extract a single canonical `SecureBaseUrlResolver` helper that gates the host portion of every emailed absolute link (forgot-password, email verification, workspace invite, instance-admin invite). The resolver no longer trusts the request `Origin` header as the canonical host when `APPSMITH_BASE_URL` is unset — it returns `Mono.empty()` instead, which propagates through the existing controller wiring (`defaultIfEmpty(true)` / `thenReturn`) so unauthenticated flows return the same generic 200 success without dispatching email (anti-enumeration preserved). Auth-gated invite flows surface the new `MISCONFIGURED_INSTANCE_BASE_URL` error.
- **Migration path:** New opt-in env var `APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS` (defaults to `false`). When set to `true`, the legacy behaviour is restored. Documented as deprecated; intended only as a transition window for self-hosted deployments that have not yet configured `APPSMITH_BASE_URL`. The helper logs a clear WARN on every call so operators are aware they are running in an insecure mode.
- **Defense-in-depth:** Re-routes the workspace-invite and instance-admin-invite flows in `EmailServiceCEImpl` through the same helper. Previously these flows derived the invite URL host directly from `originHeader`, which was an auth-gated but identical attack surface — and was a latent bug in EE multi-org mode (where forgot-password used a server-controlled URL but invite emails still used `Origin`).
- **Test coverage:** New `SecureBaseUrlResolverCEImplTest` (7 tests, pure unit tests, no Spring context) pinning all four state permutations of the resolver. Existing `EmailServiceCEImplTest` updated with `@TestPropertySource(properties = "APPSMITH_BASE_URL=http://example.com")` so its invite/admin-invite tests exercise the strict-match path.
- **Strict-mode unchanged:** the protection added in PR #41426 (Origin must equal `APPSMITH_BASE_URL` when configured) is preserved exactly. The new compat flag does NOT weaken it — it only governs the unconfigured case.



### Vulnerability

| Field | Value |
|-------|-------|
| **GHSA** | [GHSA-j9gf-vw2f-9hrw](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-j9gf-vw2f-9hrw) |
| **CVE** | Not yet assigned |
| **CVSS** | 8.1 (High) — `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N` |
| **CWE** | CWE-346 (Origin Validation Error), CWE-807 (Reliance on Untrusted Inputs in a Security Decision) |
| **Affected component** | Token-bearing email link generation (forgot-password, email verification, invite, instance-admin invite) |

### Exposure Analysis

**Who can exploit this?** Any unauthenticated network attacker who can reach `POST /api/v1/users/forgotPassword` or `POST /api/v1/users/resendEmailVerification`. No prior authentication, no recon.

**What can an attacker achieve?** When `APPSMITH_BASE_URL` is unset (the default state for self-hosted installs that haven't been hardened), an attacker can forge the `Origin` header to make Appsmith send password-reset and email-verification emails whose clickable host is attacker-controlled. The emails are otherwise legitimate (sent from the real Appsmith server, signed with SPF/DKIM, rendered with the real Appsmith branding). A victim who clicks the link delivers a valid token to the attacker's host — the attacker can then replay it against the legitimate Appsmith instance via `PUT /api/v1/users/resetPassword` to take over the account.

**Blast radius:** Per-user. Each successful exploit takes over one targeted account. There is no scope change to the wider workspace from this primitive alone, but a successful takeover of a workspace admin or instance admin escalates from there through normal application flows.

**Affected configurations:**
- Self-hosted CE/EE single-org with `APPSMITH_BASE_URL` unset and outbound email enabled — vulnerable.
- EE multi-org — already safe via the previous `OrganizationService.getOrganizationBaseUrl()` override that derived the host from `slug + deploymentDomain`. This PR relocates that override into the new helper so it now also covers invite flows (which were a latent bug under multi-org).
- Cloud-hosted Appsmith — has `APPSMITH_BASE_URL` configured, so the strict-mode check from PR #41426 applies. Not affected.

**Evidence of exploitation in the wild:** None known. Reported responsibly via GHSA by an external researcher.

### Fix

**Root cause.** `UserServiceCEImpl#resolveSecureBaseUrl` failed open when `APPSMITH_BASE_URL` was empty: it returned the caller-supplied value verbatim. That caller-supplied value originated from `@RequestHeader("Origin")` and was used to interpolate the host of token-bearing email links. The underlying coding pattern is using request metadata (a value the *client* claims) to populate an outbound, server-issued security artifact. Token-bearing artifacts must be bound to the server's *configured* identity, not the requester's claimed identity.

**Fix strategy.** Extract `SecureBaseUrlResolver` as a Spring `@Component` with a single resolver method. Make this the *only* path through which any emailed absolute link gets its host. The helper has three resolution branches:

1. **Configured base URL set** (existing strict-mode from PR #41426): require exact match with the supplied value, error on mismatch.
2. **Unconfigured + new compat flag off (default)**: log WARN, return `Mono.empty()`. Unauthenticated callers (forgot-password, resend-verification) translate this into a generic 200 success without dispatching email — anti-enumeration preserved by the existing `defaultIfEmpty(true).thenReturn(...)` controller wiring. Authenticated callers (invite, admin-invite) translate it into `MISCONFIGURED_INSTANCE_BASE_URL` so the admin caller sees an actionable configuration error.
3. **Unconfigured + new compat flag on (`APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS=true`)**: log WARN, return the caller-supplied value. Migration-only, deprecated.

**What was intentionally NOT changed:**
- All HTTP endpoint paths and request/response shapes are unchanged.
- The strict-mode check from PR #41426 is preserved exactly. The new compat flag does NOT weaken it.
- `SecurityConfig` permit-all matchers stay as-is — the endpoints must remain reachable without auth; the fix is in URL generation, not auth gating.
- DTO shapes (`ResetUserPasswordDTO`, `ResendEmailVerificationDTO`) unchanged.

**Defense-in-depth.**
- Single canonical helper across all four token-bearing email flows, including the auth-gated invite flows that previously bypassed `resolveSecureBaseUrl` entirely.
- Helper unit tests pin every branch including a regression that the compat flag does not weaken strict-mode.
- WARN log on every fail-closed and fail-back call gives operators an immediate signal when emails aren't being dispatched and why.

**Reporter coordination.** This fix matches the design the reporter recommended in the GHSA discussion thread, point-for-point: single server-side helper, fail-closed by default, anti-enumeration preserved for unauth flows, opt-in insecure compatibility flag for migration. Reporter is `@0xmrma`.

### CE/EE sync

**Mostly CE-only safe with a small shadow EE PR.**

| File | Diff status (CE vs EE pre-sync) | Strategy |
|------|--------------------------------|----------|
| `UserServiceCEImpl.java` | Identical | CE edit syncs cleanly to EE |
| `EmailServiceCEImpl.java` | Identical | CE edit syncs cleanly to EE |
| `EmailServiceCEImplTest.java` | Identical | CE edit syncs cleanly to EE |
| `UserServiceCECompatibleImpl.java` | Identical | CE edit syncs cleanly to EE |
| `SecureBaseUrlResolver.java`, `SecureBaseUrlResolverCE.java`, `SecureBaseUrlResolverCEImpl.java` (new) | n/a | New files sync to EE |
| `SecureBaseUrlResolverImpl.java` (new) | CE no-op variant; **EE replaces with multi-org-aware variant** | Shadow EE PR layered on top |
| `UserServiceImpl.java` | EE-specific class with multi-org override | Shadow EE PR strips the now-redundant `resolveSecureBaseUrl` override and updates the constructor signature |
| `EmailServiceImpl.java` | EE-specific class | Shadow EE PR updates the constructor to inject `SecureBaseUrlResolver` |
| `AppsmithError.java` / `AppsmithErrorCode.java` | Differs (EE has additional codes) | Shadow EE PR adds the same `MISCONFIGURED_INSTANCE_BASE_URL` entry |

Shadow EE branch (`fix/origin-validation-email-links-ghsa-j9gf` on `appsmithorg/appsmith-ee`) is prepared and pushed; will be linked in a follow-up comment.

### Disclosure

> **Do not merge until advisory is ready for disclosure coordination.**
>
> After merge:
> 1. Confirm fix is in release branch
> 2. Coordinate with security team on disclosure timeline
> 3. Update advisory with patched version and publish
> 4. Notify reporter (`@0xmrma`)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25127579141>
> Commit: 306e492772c3b6f2692b91e40d68ee81ce6299e0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25127579141&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 29 Apr 2026 20:02:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes — operators of self-hosted instances that have not configured `APPSMITH_BASE_URL` will see password-reset / email-verification / invite emails stop being delivered after upgrading. Migration path: set `APPSMITH_BASE_URL`, or as a temporary opt-in, set `APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS=true` (insecure, deprecated).
- [ ] No

## Follow-ups

- [ ] Admin UI tooltip update in `app/client/src/ce/pages/AdminSettings/config/configuration.tsx` strengthening the wording around `APPSMITH_BASE_URL` being required (deferred — local `lint-staged` requires a fresh `yarn install` in `app/client`; will land as a separate small PR).
- [ ] Plan to deprecate `APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS` env var in a future major release once telemetry confirms self-hosted operators have migrated.
- [ ] Add Spring-context integration tests in `UserServiceTest` for `forgotPasswordTokenGenerate` / `resendEmailVerification` fail-closed paths (deferred — needs Mongo+Redis; helper unit tests already pin the security-critical semantics).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced use of a trusted instance base URL for token-bearing email flows (password reset, verification, workspace invites). Added a clear internal error when the base URL is not configured; invite/email flows are disabled until set. Origin matching is stricter to prevent spoofing.

* **Tests**
  * Added comprehensive unit tests covering secure base URL resolution and compatibility modes.

* **Documentation / CI**
  * Updated CI, deploy and local scripts and added design docs to ensure the base URL is set during tests and previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->