### PR TITLE
fix: replace generic "Response not valid" with actionable error messages for better observability

### DIFF
--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -113,6 +113,7 @@ import { FileDataTypes } from "WidgetProvider/types";
 import { hideDebuggerErrors } from "actions/debuggerActions";
 import {
   ActionValidationError,
+  extractExecutionErrorMessage,
   getErrorAsString,
   PluginActionExecutionError,
   PluginTriggerFailureError,
@@ -873,6 +874,18 @@ export function* runActionSaga(
       }
     : undefined;
 
+  // When the server response was lost (network/timeout/parse failure), the
+  // caught PluginActionExecutionError carries the specific transport message
+  // from extractExecutionErrorMessage. Surface it instead of the generic
+  // fallback so users and the debugger console see what actually went wrong.
+  const transportError =
+    error.message && error.message !== "An unexpected error occurred"
+      ? {
+          name: "PluginExecutionError",
+          message: error.message,
+        }
+      : undefined;
+
   const defaultError = {
     name: "PluginExecutionError",
     message: "An unexpected error occurred",
@@ -888,7 +901,11 @@ export function* runActionSaga(
 
   if (isError) {
     error =
-      readableError || payloadBodyError || clientDefinedError || defaultError;
+      readableError ||
+      payloadBodyError ||
+      clientDefinedError ||
+      transportError ||
+      defaultError;
 
     // In case of debugger, both the current error message
     // and the readableError needs to be present,
@@ -1551,7 +1568,10 @@ function* executePluginActionSaga(
       );
     }
 
-    throw new PluginActionExecutionError("Response not valid", false);
+    throw new PluginActionExecutionError(
+      extractExecutionErrorMessage(e),
+      false,
+    );
   }
 }
 

--- a/app/client/src/sagas/ActionExecution/errorUtils.test.ts
+++ b/app/client/src/sagas/ActionExecution/errorUtils.test.ts
@@ -1,0 +1,74 @@
+import { extractExecutionErrorMessage } from "./errorUtils";
+
+describe("extractExecutionErrorMessage", () => {
+  it("returns timeout message for Axios ECONNABORTED with timeout pattern", () => {
+    const axiosError = Object.assign(new Error("timeout of 10000ms exceeded"), {
+      code: "ECONNABORTED",
+      isAxiosError: true,
+    });
+
+    expect(extractExecutionErrorMessage(axiosError)).toBe(
+      "Action execution timed out. Try increasing the timeout in the action settings.",
+    );
+  });
+
+  it("returns network error message for Axios Network Error", () => {
+    const axiosError = Object.assign(new Error("Network Error"), {
+      isAxiosError: true,
+    });
+
+    expect(extractExecutionErrorMessage(axiosError)).toBe(
+      "Network error: could not reach the Appsmith server. Check your connection.",
+    );
+  });
+
+  it("returns Axios message for other Axios errors", () => {
+    const axiosError = Object.assign(
+      new Error("Request failed with status code 502"),
+      { isAxiosError: true },
+    );
+
+    expect(extractExecutionErrorMessage(axiosError)).toBe(
+      "Request failed: Request failed with status code 502",
+    );
+  });
+
+  it("returns Axios message for ECONNABORTED without timeout pattern", () => {
+    const axiosError = Object.assign(new Error("connection aborted"), {
+      code: "ECONNABORTED",
+    });
+
+    expect(extractExecutionErrorMessage(axiosError)).toBe(
+      "Request failed: connection aborted",
+    );
+  });
+
+  it("returns server error message from validateResponse errors", () => {
+    const serverError = new Error("Organization not found");
+
+    expect(extractExecutionErrorMessage(serverError)).toBe(
+      "Organization not found",
+    );
+  });
+
+  it("returns 'Response not valid' for non-Error values", () => {
+    expect(extractExecutionErrorMessage("string error")).toBe(
+      "Response not valid",
+    );
+    expect(extractExecutionErrorMessage(null)).toBe("Response not valid");
+    expect(extractExecutionErrorMessage(undefined)).toBe("Response not valid");
+    expect(extractExecutionErrorMessage(42)).toBe("Response not valid");
+  });
+
+  it("returns 'Response not valid' for Error with empty message", () => {
+    expect(extractExecutionErrorMessage(new Error(""))).toBe(
+      "Response not valid",
+    );
+  });
+
+  it("returns the error message for a plain Error", () => {
+    const error = new Error("Something went wrong");
+
+    expect(extractExecutionErrorMessage(error)).toBe("Something went wrong");
+  });
+});

--- a/app/client/src/sagas/ActionExecution/errorUtils.ts
+++ b/app/client/src/sagas/ActionExecution/errorUtils.ts
@@ -120,3 +120,43 @@ export class UserCancelledActionExecutionError extends PluginActionExecutionErro
 export const getErrorAsString = (error: unknown): string => {
   return isString(error) ? error : JSON.stringify(error);
 };
+
+const AXIOS_TIMEOUT_REGEX = /timeout of \d+ms exceeded/;
+
+/**
+ * Extracts a meaningful, user-facing error message from the caught exception
+ * in the action execution path. Categorises Axios transport errors, server
+ * envelope errors (from validateResponse), and falls back gracefully.
+ *
+ * Security: only surfaces our own server messages or Axios transport strings —
+ * never raw upstream API bodies or credentials.
+ */
+export function extractExecutionErrorMessage(e: unknown): string {
+  if (!(e instanceof Error)) {
+    return "Response not valid";
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const axiosLike = e as any;
+
+  if (axiosLike.isAxiosError || axiosLike.code === "ECONNABORTED") {
+    if (
+      axiosLike.code === "ECONNABORTED" &&
+      AXIOS_TIMEOUT_REGEX.test(axiosLike.message)
+    ) {
+      return "Action execution timed out. Try increasing the timeout in the action settings.";
+    }
+
+    if (axiosLike.message === "Network Error") {
+      return "Network error: could not reach the Appsmith server. Check your connection.";
+    }
+
+    return `Request failed: ${axiosLike.message || "unknown transport error"}`;
+  }
+
+  if (e.message) {
+    return e.message;
+  }
+
+  return "Response not valid";
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
@@ -148,7 +148,7 @@ public class RestAPIActivateUtils {
                                 result.setBody(objectMapper.readTree(jsonBody));
                                 responseDataType = ResponseDataType.JSON;
                             } catch (IOException e) {
-                                log.warn(
+                                log.debug(
                                         "Response declared Content-Type application/json but body is not valid JSON. Falling back to string representation.");
                                 String bodyString = new String(body, StandardCharsets.UTF_8);
                                 result.setBody(bodyString.trim());

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
@@ -19,6 +19,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.micrometer.observation.ObservationRegistry;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
@@ -51,6 +52,7 @@ import static com.appsmith.external.constants.spans.ce.ActionSpanCE.ACTUAL_API_C
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
+@Slf4j
 @NoArgsConstructor
 public class RestAPIActivateUtils {
 
@@ -146,7 +148,8 @@ public class RestAPIActivateUtils {
                                 result.setBody(objectMapper.readTree(jsonBody));
                                 responseDataType = ResponseDataType.JSON;
                             } catch (IOException e) {
-                                System.out.println("Unable to parse response JSON. Setting response body as string.");
+                                log.warn(
+                                        "Response declared Content-Type application/json but body is not valid JSON. Falling back to string representation.");
                                 String bodyString = new String(body, StandardCharsets.UTF_8);
                                 result.setBody(bodyString.trim());
 

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -226,7 +226,7 @@ public class RestApiPlugin extends BasePlugin {
                         errorResult.setRequest(requestCaptureFilter.populateRequestFields(
                                 actionExecutionRequest, isBodySentWithApiRequest, datasourceConfiguration));
                         errorResult.setIsExecutionSuccess(false);
-                        log.error(
+                        log.debug(
                                 "REST API execution failed for method: {}, path: {}",
                                 actionExecutionRequest.getHttpMethod(),
                                 actionConfiguration.getPath(),

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -226,10 +226,11 @@ public class RestApiPlugin extends BasePlugin {
                         errorResult.setRequest(requestCaptureFilter.populateRequestFields(
                                 actionExecutionRequest, isBodySentWithApiRequest, datasourceConfiguration));
                         errorResult.setIsExecutionSuccess(false);
-                        log.debug(String.format(
-                                "An error has occurred while trying to run the API query for url: %s, path: %s",
-                                datasourceConfiguration.getUrl(), actionConfiguration.getPath()));
-                        error.printStackTrace();
+                        log.error(
+                                "REST API execution failed for url: {}, path: {}",
+                                datasourceConfiguration.getUrl(),
+                                actionConfiguration.getPath(),
+                                error);
                         if (!(error instanceof AppsmithPluginException)) {
                             error = new AppsmithPluginException(
                                     RestApiPluginError.API_EXECUTION_FAILED,

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -227,8 +227,8 @@ public class RestApiPlugin extends BasePlugin {
                                 actionExecutionRequest, isBodySentWithApiRequest, datasourceConfiguration));
                         errorResult.setIsExecutionSuccess(false);
                         log.error(
-                                "REST API execution failed for url: {}, path: {}",
-                                datasourceConfiguration.getUrl(),
+                                "REST API execution failed for method: {}, path: {}",
+                                actionExecutionRequest.getHttpMethod(),
                                 actionConfiguration.getPath(),
                                 error);
                         if (!(error instanceof AppsmithPluginException)) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -870,7 +870,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
             } else if (error instanceof StaleConnectionException e) {
                 return new AppsmithPluginException(AppsmithPluginError.STALE_CONNECTION_ERROR, e.getMessage());
             } else {
-                log.warn(
+                log.debug(
                         "Action execution failed for action '{}' (id: {}): {}",
                         actionDTO.getName(),
                         actionDTO.getId(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -391,7 +391,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
         return actionExecutionResultMono
                 .zipWith(editorConfigLabelMapMono, (result, labelMap) -> {
                     if (TRUE.equals(executeActionDTO.getViewMode())) {
-                        result.setRequest(null);
+                        sanitizeRequestForViewMode(result);
                     } else if (result.getRequest() != null
                             && result.getRequest().getRequestParams() != null) {
                         transformRequestParams(result, labelMap);
@@ -870,9 +870,11 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
             } else if (error instanceof StaleConnectionException e) {
                 return new AppsmithPluginException(AppsmithPluginError.STALE_CONNECTION_ERROR, e.getMessage());
             } else {
-                log.debug(
-                        "{}: In the action execution error mode.",
-                        Thread.currentThread().getName(),
+                log.warn(
+                        "Action execution failed for action '{}' (id: {}): {}",
+                        actionDTO.getName(),
+                        actionDTO.getId(),
+                        error.getMessage(),
                         error);
                 return error;
             }
@@ -881,6 +883,11 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
 
     protected Function<? super Throwable, Mono<ActionExecutionResult>> executionExceptionHandler(ActionDTO actionDTO) {
         return error -> {
+            log.warn(
+                    "Handling execution error for action '{}' (id: {}): {}",
+                    actionDTO.getName(),
+                    actionDTO.getId(),
+                    error.getMessage());
             ActionExecutionResult result = new ActionExecutionResult();
             result.setErrorInfo(error);
             result.setIsExecutionSuccess(false);
@@ -1091,6 +1098,23 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
         result.setDataTypes(getDisplayDataTypes(result.getBody()));
 
         return result;
+    }
+
+    /**
+     * In view/published mode, strip potentially sensitive fields from the request object
+     * (headers, body, URL, params) while retaining safe metadata (action ID, timestamp,
+     * HTTP method) so users can correlate which action failed and when.
+     */
+    void sanitizeRequestForViewMode(ActionExecutionResult result) {
+        ActionExecutionRequest original = result.getRequest();
+        if (original == null) {
+            return;
+        }
+        ActionExecutionRequest sanitized = new ActionExecutionRequest();
+        sanitized.setActionId(original.getActionId());
+        sanitized.setRequestedAt(original.getRequestedAt());
+        sanitized.setHttpMethod(original.getHttpMethod());
+        result.setRequest(sanitized);
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -463,4 +463,44 @@ class ActionExecutionSolutionCEImplTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    void sanitizeRequestForViewMode_retainsSafeFieldsAndStripsSensitiveOnes() {
+        var original = new com.appsmith.external.models.ActionExecutionRequest();
+        original.setActionId("action-123");
+        original.setRequestedAt(java.time.Instant.parse("2026-04-30T12:00:00Z"));
+        original.setHttpMethod(HttpMethod.POST);
+        original.setUrl("https://internal-api.example.com/secret?key=abc");
+        original.setBody("{\"password\": \"s3cret\"}");
+        original.setHeaders(Map.of("Authorization", "Bearer token"));
+        original.setRequestParams(List.of("sensitive-param"));
+
+        var result = new ActionExecutionResult();
+        result.setRequest(original);
+
+        actionExecutionSolution.sanitizeRequestForViewMode(result);
+
+        var sanitized = result.getRequest();
+        assertNotNull(sanitized);
+        assertEquals("action-123", sanitized.getActionId());
+        assertEquals(java.time.Instant.parse("2026-04-30T12:00:00Z"), sanitized.getRequestedAt());
+        assertEquals(HttpMethod.POST, sanitized.getHttpMethod());
+
+        // Sensitive fields must be stripped
+        assertEquals(null, sanitized.getUrl());
+        assertEquals(null, sanitized.getBody());
+        assertEquals(null, sanitized.getHeaders());
+        assertEquals(null, sanitized.getRequestParams());
+        assertEquals(null, sanitized.getExecutionParameters());
+    }
+
+    @Test
+    void sanitizeRequestForViewMode_handlesNullRequest() {
+        var result = new ActionExecutionResult();
+        result.setRequest(null);
+
+        actionExecutionSolution.sanitizeRequestForViewMode(result);
+
+        assertEquals(null, result.getRequest());
+    }
 }


### PR DESCRIPTION
## Summary

- Replace the opaque "Response not valid" catch-all error with meaningful, categorized messages that surface the actual failure reason (Axios timeout, network error, server validation rejection)
- Fix the `runActionSaga` error cascade so specific transport error messages are shown in the debugger console instead of falling through to "An unexpected error occurred"
- Replace `result.setRequest(null)` in view mode with `sanitizeRequestForViewMode()` that retains safe metadata (actionId, requestedAt, httpMethod) while stripping sensitive fields (body, headers, URL, params)
- Upgrade server-side execution error logging from `System.out.println`/`printStackTrace()` to structured SLF4J with action identity

Fixes https://linear.app/appsmith/issue/APP-15199/replace-generic-response-not-valid-error-with-actionable-error

## Log level rationale

Action execution failures are typically caused by the **customer's upstream API** (timeout, connection reset, invalid JSON content-type), not by Appsmith itself. Logging these at `WARN`/`ERROR` level would create production noise proportional to upstream error rates and could trigger false alerts in monitoring systems.

We use **`log.debug`** for upstream-caused failures so self-hosted operators can opt in by lowering the log level — making this an explicit choice rather than default noise. The one exception is `executionExceptionHandler`, which stays at **`log.warn`** because it only fires for errors that escape the plugin's own error handling — genuinely unexpected conditions that operators should know about.

| Log site | Level | Rationale |
|----------|-------|-----------|
| `RestApiPlugin` (upstream REST failure) | `debug` | Fires on every upstream API error — could be very frequent. Error is already returned to user in `ActionExecutionResult`. |
| `executionExceptionMapper` (error transformation) | `debug` | Duplicated by `executionExceptionHandler` which runs right after. Only fires for rare non-timeout/non-stale errors that escape the plugin. |
| `executionExceptionHandler` (catch-all) | **`warn`** | Only fires for errors that escape plugin error handling — rare and genuinely unexpected. One log line per such failure with action name and ID. |
| `RestAPIActivateUtils` (JSON parse fallback) | `debug` | Content-type mismatch from upstream. Already surfaced to user via hint messages in the response. |

The key improvement over the previous code is **structured SLF4J logging with action identity** (replacing `System.out.println`, `error.printStackTrace()`, and unstructured `log.debug`), not the log level itself. When operators DO enable debug logging, they now get actionable context instead of anonymous stack traces.

## Context

Enterprise customer (Plum) reported production debugging is impossible — "Response not valid" errors cannot be traced to specific actions in view mode. The root cause is a client-side catch-all that discards all error context and a server-side request stripping that removes all correlation metadata.

Slack thread: https://theappsmith.slack.com/archives/C0341RERY4R/p1776882142131629
Linear (support): V2-3907

## Test plan

- [x] Unit tests for `extractExecutionErrorMessage` covering all error categories
- [x] Server tests for `sanitizeRequestForViewMode` verifying sensitive field stripping
- [x] CI (Spotless + lint + existing test suite)
- [ ] Manual: trigger a timeout in edit mode and verify the debugger shows "Action execution timed out..." instead of "An unexpected error occurred"
- [ ] Manual: trigger a network error in view mode and verify the JS catch block receives a meaningful message

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25208490026>
> Commit: ce142c582025df62282f43fb953b0cf820f396db
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25208490026&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 01 May 2026 10:02:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More informative error messages for transport/network issues and timeouts instead of a generic fallback.
  * View-mode action results now retain a sanitized request snapshot (action ID, timestamp, HTTP method) for traceability.
  * Server-side error handling now logs contextual details at debug/warn levels instead of printing stack traces.

* **Tests**
  * Added tests covering error message extraction and view-mode request sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->