### PR TITLE
fix: properly encode sheet names with special characters in Google Sheets integration

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetStructureMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetStructureMethod.java
@@ -6,6 +6,7 @@ import com.appsmith.external.services.FilterDataService;
 import com.external.constants.ErrorMessages;
 import com.external.domains.RowObject;
 import com.external.plugins.exceptions.GSheetsPluginError;
+import com.external.utils.GoogleSheetsApiEncoding;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class GetStructureMethod implements ExecutionMethod, TriggerMethod {
@@ -67,15 +69,17 @@ public class GetStructureMethod implements ExecutionMethod, TriggerMethod {
     public WebClient.RequestHeadersSpec<?> getExecutionClient(WebClient webClient, MethodConfig methodConfig) {
 
         final List<String> ranges = validateInputs(methodConfig);
+        final List<String> encodedRanges =
+                ranges.stream().map(GoogleSheetsApiEncoding::encodeQueryParameter).collect(Collectors.toList());
 
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(
                 this.BASE_SHEETS_API_URL, methodConfig.getSpreadsheetId() /* spreadsheet Id */ + "/values:batchGet");
         uriBuilder.queryParam("majorDimension", "ROWS");
-        uriBuilder.queryParam("ranges", ranges);
+        uriBuilder.queryParam("ranges", encodedRanges);
 
         return webClient
                 .method(HttpMethod.GET)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.empty());
     }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetStructureMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetStructureMethod.java
@@ -65,6 +65,11 @@ public class GetStructureMethod implements ExecutionMethod, TriggerMethod {
         return true;
     }
 
+    /**
+     * Builds the GET request for {@code spreadsheets.values.batchGet} used to infer sheet structure.
+     * Range strings are encoded with {@link GoogleSheetsApiEncoding#encodeQueryParameter(String)}
+     * so sheet names containing characters such as '+' are sent correctly in the query string.
+     */
     @Override
     public WebClient.RequestHeadersSpec<?> getExecutionClient(WebClient webClient, MethodConfig methodConfig) {
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/RowsGetMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/RowsGetMethod.java
@@ -95,6 +95,11 @@ public class RowsGetMethod implements ExecutionMethod, TemplateMethod, TriggerMe
         return true;
     }
 
+    /**
+     * Builds the GET request for {@code spreadsheets.values.batchGet} to fetch row data.
+     * Range strings are encoded with {@link GoogleSheetsApiEncoding#encodeQueryParameter(String)}
+     * so sheet names containing characters such as '+' are sent correctly in the query string.
+     */
     @Override
     public WebClient.RequestHeadersSpec<?> getExecutionClient(WebClient webClient, MethodConfig methodConfig) {
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/RowsGetMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/RowsGetMethod.java
@@ -8,6 +8,7 @@ import com.appsmith.external.services.FilterDataService;
 import com.external.constants.ErrorMessages;
 import com.external.domains.RowObject;
 import com.external.plugins.exceptions.GSheetsPluginError;
+import com.external.utils.GoogleSheetsApiEncoding;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -24,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * API reference: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get
@@ -97,15 +99,17 @@ public class RowsGetMethod implements ExecutionMethod, TemplateMethod, TriggerMe
     public WebClient.RequestHeadersSpec<?> getExecutionClient(WebClient webClient, MethodConfig methodConfig) {
 
         final List<String> ranges = validateInputs(methodConfig);
+        final List<String> encodedRanges =
+                ranges.stream().map(GoogleSheetsApiEncoding::encodeQueryParameter).collect(Collectors.toList());
 
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(
                 this.BASE_SHEETS_API_URL, methodConfig.getSpreadsheetId() /* spreadsheet Id */ + "/values:batchGet");
         uriBuilder.queryParam("majorDimension", "ROWS");
-        uriBuilder.queryParam("ranges", ranges);
+        uriBuilder.queryParam("ranges", encodedRanges);
 
         return webClient
                 .method(HttpMethod.GET)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.empty());
     }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/utils/GoogleSheetsApiEncoding.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/utils/GoogleSheetsApiEncoding.java
@@ -1,0 +1,21 @@
+package com.external.utils;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Encoding helpers for Google Sheets HTTP APIs. Query parameters are often parsed as
+ * {@code application/x-www-form-urlencoded}, where a literal '+' must be sent as {@code %2B}.
+ */
+public final class GoogleSheetsApiEncoding {
+
+    private GoogleSheetsApiEncoding() {}
+
+    /**
+     * Encodes a string for use as a Google Sheets API query parameter value (e.g. {@code ranges}
+     * on {@code spreadsheets.values.batchGet}).
+     */
+    public static String encodeQueryParameter(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/utils/GoogleSheetsApiEncoding.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/utils/GoogleSheetsApiEncoding.java
@@ -4,18 +4,39 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Encoding helpers for Google Sheets HTTP APIs. Query parameters are often parsed as
- * {@code application/x-www-form-urlencoded}, where a literal '+' must be sent as {@code %2B}.
+ * Utility class providing URL encoding helpers for Google Sheets API query parameters.
+ * <p>
+ * Google Sheets API range parameters (e.g., A1 notation with sheet names containing
+ * special characters like '+') must be percent-encoded before being appended as query
+ * parameters. Standard URI builders may leave '+' unencoded, causing the API to
+ * misinterpret it as a space.
+ * </p>
  */
 public final class GoogleSheetsApiEncoding {
 
-    private GoogleSheetsApiEncoding() {}
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     *
+     * @throws UnsupportedOperationException always, since this class should not be instantiated
+     */
+    private GoogleSheetsApiEncoding() {
+        throw new UnsupportedOperationException("Utility class — do not instantiate");
+    }
 
     /**
-     * Encodes a string for use as a Google Sheets API query parameter value (e.g. {@code ranges}
-     * on {@code spreadsheets.values.batchGet}).
+     * Encodes a string for safe use as a Google Sheets API query parameter value.
+     * <p>
+     * Uses {@link URLEncoder#encode(String, java.nio.charset.Charset)} with UTF-8
+     * and additionally replaces '+' (which URLEncoder uses for spaces) with '%20'
+     * so the value can be placed inside a URI that is already considered pre-encoded
+     * (i.e., built with {@code UriComponentsBuilder.build(true)}).
+     * </p>
+     *
+     * @param value the raw query parameter value to encode; must not be {@code null}
+     * @return the percent-encoded value safe for URI query parameters
      */
     public static String encodeQueryParameter(String value) {
-        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+        return URLEncoder.encode(value, StandardCharsets.UTF_8)
+                .replace("+", "%20");
     }
 }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/utils/GoogleSheetsApiEncodingTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/utils/GoogleSheetsApiEncodingTest.java
@@ -1,0 +1,16 @@
+package com.external.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GoogleSheetsApiEncodingTest {
+
+    @Test
+    public void encodeQueryParameter_plusInSheetName_usesPercent2BNotLiteralPlus() {
+        String encoded = GoogleSheetsApiEncoding.encodeQueryParameter("'Data+A'!1:1");
+        assertTrue(encoded.contains("%2B"), encoded);
+        assertFalse(encoded.contains("+"), encoded);
+    }
+}


### PR DESCRIPTION
## Problem

Google Sheets `spreadsheets.values.batchGet` requests send sheet ranges via repeated `ranges` query parameters. Spring built those URIs with default encoding, which left a literal `+` in an A1 range (for example in the quoted sheet title). Many servers decode `+` as a space in query strings, so the API saw the wrong sheet name.

## Change

- Encode each range with `application/x-www-form-urlencoded` rules (`URLEncoder`) before attaching it as a query parameter, so `+` is sent as `%2B`.
- Call `UriComponentsBuilder.build(true)` so values are not double-encoded (consistent with other methods in this plugin that combine encoded path segments with query params).

## Testing

- Added `GoogleSheetsApiEncodingTest` asserting encoded output contains `%2B` and no literal `+` for a sample range.

Fixes #41536.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of special characters in Google Sheets range parameters to ensure proper encoding in API queries, resolving issues with sheets containing characters like "+".

* **Tests**
  * Added test coverage for query parameter encoding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->