### PR TITLE
ci: skip apt-get update in Chrome install

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -257,11 +257,6 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
-          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
-          # and rely on the runner image's existing apt cache to resolve Chrome's
-          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
-          # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
           wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb --show-progress
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -257,9 +257,13 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          sudo apt-get remove google-chrome-stable
+          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
+          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
+          # and rely on the runner image's existing apt cache to resolve Chrome's
+          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
+          # change between weekly runner image rebuilds.
+          sudo apt-get remove -y google-chrome-stable || true
           wget -q https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb --show-progress
-          sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -263,7 +263,7 @@ jobs:
           # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
           # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
-          wget -q https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb --show-progress
+          wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb --show-progress
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -139,11 +139,6 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
-          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
-          # and rely on the runner image's existing apt cache to resolve Chrome's
-          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
-          # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
           wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -139,9 +139,13 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          sudo apt-get remove google-chrome-stable
+          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
+          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
+          # and rely on the runner image's existing apt cache to resolve Chrome's
+          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
+          # change between weekly runner image rebuilds.
+          sudo apt-get remove -y google-chrome-stable || true
           wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
-          sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -145,7 +145,7 @@ jobs:
           # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
           # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
-          wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
+          wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -310,9 +310,13 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          sudo apt-get remove google-chrome-stable
+          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
+          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
+          # and rely on the runner image's existing apt cache to resolve Chrome's
+          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
+          # change between weekly runner image rebuilds.
+          sudo apt-get remove -y google-chrome-stable || true
           wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
-          sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -310,11 +310,6 @@ jobs:
 
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
-          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
-          # and rely on the runner image's existing apt cache to resolve Chrome's
-          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
-          # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
           wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -316,7 +316,7 @@ jobs:
           # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
           # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
-          wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
+          wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -221,11 +221,6 @@ jobs:
           
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
-          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
-          # and rely on the runner image's existing apt cache to resolve Chrome's
-          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
-          # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
           wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -221,9 +221,13 @@ jobs:
           
       - name: Install Google Chrome 129.0.6668.100
         run: |
-          sudo apt-get remove google-chrome-stable
+          # apt-get update has been hanging on Azure-backed WarpBuild runners due to
+          # ongoing azure.archive.ubuntu.com mirror flakiness. Skip the index refresh
+          # and rely on the runner image's existing apt cache to resolve Chrome's
+          # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
+          # change between weekly runner image rebuilds.
+          sudo apt-get remove -y google-chrome-stable || true
           wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
-          sudo apt-get update
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -227,7 +227,7 @@ jobs:
           # transitive deps — they're stable libs (libnss3, libgbm1, etc.) and don't
           # change between weekly runner image rebuilds.
           sudo apt-get remove -y google-chrome-stable || true
-          wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_129.0.6668.100-1_amd64.deb
+          wget -q --timeout=30 --tries=3 https://appsmith-github-chrome-129-debian.s3.us-east-2.amazonaws.com/google-chrome-stable_129.0.6668.100-1_amd64.deb
           sudo apt-get install -y ./google-chrome-stable_129.0.6668.100-1_amd64.deb
           echo "BROWSER_PATH=$(which google-chrome)" >> $GITHUB_ENV
           google-chrome --version


### PR DESCRIPTION
## Summary
- WarpBuild provisions runners across both AWS and Azure. Ubuntu cloud-init auto-configures the apt mirror based on the host cloud, so Azure-hosted runners use `azure.archive.ubuntu.com` (configured in `/etc/apt/apt-mirrors.txt` as priority 1) — which has been hanging connections (not erroring) due to ongoing Canonical mirror flakiness. Affected matrix shards stall on `apt-get update` for hours instead of failing fast.
- Skip `apt-get update` entirely. `apt-get install ./chrome.deb` uses the runner image's existing apt cache (populated at image-provision time) to resolve Chrome's stable transitive deps (libnss3, libgbm1, libxkbcommon0, etc.).

## Verification
Verified on the EE counterpart ([appsmithorg/appsmith-ee#9034](https://github.com/appsmithorg/appsmith-ee/pull/9034)): all 60 matrix shards completed Chrome install in 12–42s (avg 16s) with zero hangs. The 4 test failures in that run were unrelated Cypress flakes (Chrome installed cleanly on every shard).

Touches the 4 Cypress CI workflows that install Chrome 129:
- `ci-test-custom-script.yml`
- `ci-test-hosted.yml`
- `ci-test-limited.yml`
- `ci-test-limited-with-count.yml`

## Test plan
- [ ] Trigger a `ci-test` run and confirm matrix shards complete Chrome install in well under a minute, regardless of cloud provider
- [ ] Verify `google-chrome --version` still prints `129.0.6668.100` post-install
- [ ] Confirm no `apt-get update` errors (since we no longer run it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI Chrome installation steps across workflows: removed apt index refresh, made Chrome removal tolerant of failures, standardized a fixed Chrome version download, and added timeout/retry options.
  * Switched some download sources to hosted/artifact mirrors and added minor workflow comments; overall CI logic and other steps remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD e666968758c394389b1c230c80aac5170a34677a yet
> <hr>Wed, 06 May 2026 19:08:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->
