### PR TITLE
feat(client): docs link tooltip on Appsmith Base URL setting + trailing-slash normalization

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/configuration.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/configuration.tsx
@@ -15,6 +15,7 @@ import isUndefined from "lodash/isUndefined";
 import { AppsmithFrameAncestorsSetting } from "pages/Applications/EmbedSnippet/Constants/constants";
 import { formatEmbedSettings } from "pages/Applications/EmbedSnippet/Utils/utils";
 import { isAirgapped } from "ee/utils/airgapHelpers";
+import { APPSMITH_BASE_URL_SETUP_DOC } from "constants/ThirdPartyConstants";
 
 const isAirgappedInstance = isAirgapped();
 
@@ -44,6 +45,8 @@ export const APPSMITH_BASE_URL: Setting = {
   controlType: SettingTypes.TEXTINPUT,
   controlSubType: SettingSubtype.TEXT,
   label: "Appsmith Base URL",
+  helpText: "Learn more about configuring Appsmith Base URL.",
+  helpTextLink: APPSMITH_BASE_URL_SETUP_DOC,
   subText:
     "* The base URL where Appsmith is accessible. This is required for password reset and email verification links to work correctly.",
   placeholder: "https://appsmith.example.com",

--- a/app/client/src/ce/pages/AdminSettings/config/types.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/types.ts
@@ -62,6 +62,7 @@ export type Setting = ControlType & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parse?: (value: any) => any;
   helpText?: string;
+  helpTextLink?: string;
   label?: React.ReactNode;
   name?: string;
   placeholder?: string;

--- a/app/client/src/constants/ThirdPartyConstants.tsx
+++ b/app/client/src/constants/ThirdPartyConstants.tsx
@@ -10,6 +10,8 @@ export const GET_RELEASE_NOTES_URL = (tagName: string) =>
   `${GITHUB_RELEASE_URL}/${tagName}`;
 export const SELF_HOSTING_DOC =
   "https://docs.appsmith.com/getting-started/setup";
+export const APPSMITH_BASE_URL_SETUP_DOC =
+  "https://docs.appsmith.com/getting-started/setup/environment-variables#appsmith_base_url";
 export const GOOGLE_MAPS_SETUP_DOC =
   "https://docs.appsmith.com/getting-started/setup/instance-configuration/google-maps";
 export const GOOGLE_SIGNUP_SETUP_DOC =

--- a/app/client/src/pages/AdminSettings/FormGroup/Common.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/Common.tsx
@@ -93,6 +93,7 @@ export function FormGroup({ children, className, setting }: FieldHelperProps) {
                   <Link
                     data-testid="admin-settings-form-group-helptext-link"
                     kind="primary"
+                    rel="noopener noreferrer"
                     target="_blank"
                     to={setting.helpTextLink}
                   >

--- a/app/client/src/pages/AdminSettings/FormGroup/Common.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/Common.tsx
@@ -1,4 +1,4 @@
-import { createMessage } from "ee/constants/messages";
+import { createMessage, LEARN_MORE } from "ee/constants/messages";
 import React from "react";
 import styled from "styled-components";
 import { Icon, Tooltip, Text, Link } from "@appsmith/ads";
@@ -57,6 +57,12 @@ export const StyledLink = styled(Link)`
   margin-top: 8px;
 `;
 
+const StyledHelpTextTooltipContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--ads-v2-spaces-2);
+`;
+
 export function FormGroup({ children, className, setting }: FieldHelperProps) {
   return (
     <StyledFormGroup
@@ -79,7 +85,26 @@ export function FormGroup({ children, className, setting }: FieldHelperProps) {
           </Text>
         )}
         {setting.helpText && (
-          <Tooltip content={createMessage(() => setting.helpText || "")}>
+          <Tooltip
+            content={
+              setting.helpTextLink ? (
+                <StyledHelpTextTooltipContent>
+                  <span>{createMessage(() => setting.helpText || "")}</span>
+                  <Link
+                    data-testid="admin-settings-form-group-helptext-link"
+                    kind="primary"
+                    target="_blank"
+                    to={setting.helpTextLink}
+                  >
+                    {createMessage(LEARN_MORE)}
+                  </Link>
+                </StyledHelpTextTooltipContent>
+              ) : (
+                createMessage(() => setting.helpText || "")
+              )
+            }
+            mouseLeaveDelay={0.3}
+          >
             <Icon
               className={"help-icon"}
               color="var(--ads-v2-color-fg)"

--- a/app/client/src/pages/AdminSettings/FormGroup/common.test.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/common.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "test/testUtils";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import type { Setting } from "ee/pages/AdminSettings/config/types";
 import { SettingTypes } from "ee/pages/AdminSettings/config/types";
@@ -84,5 +85,33 @@ describe("FormGroup", () => {
     );
 
     expect(formGroupChild).toHaveLength(1);
+  });
+
+  it("does not render a tooltip docs link when helpTextLink is unset", async () => {
+    setting.helpText = "some help text";
+    setting.helpTextLink = undefined;
+    renderComponent();
+    const helpIcon = screen.getByTestId("admin-settings-form-group-helptext");
+
+    await userEvent.hover(helpIcon);
+    expect(
+      screen.queryByTestId("admin-settings-form-group-helptext-link"),
+    ).toBeNull();
+  });
+
+  it("renders a tooltip docs link when helpTextLink is set", async () => {
+    setting.helpText = "some help text";
+    setting.helpTextLink = "https://docs.appsmith.com/example";
+    renderComponent();
+    const helpIcon = screen.getByTestId("admin-settings-form-group-helptext");
+
+    await userEvent.hover(helpIcon);
+    const tooltipLink = await screen.findByTestId(
+      "admin-settings-form-group-helptext-link",
+    );
+
+    expect(tooltipLink).toHaveAttribute("href", setting.helpTextLink);
+    expect(tooltipLink).toHaveAttribute("target", "_blank");
+    expect(tooltipLink.textContent).toBe("Learn more");
   });
 });

--- a/app/client/src/pages/AdminSettings/FormGroup/common.test.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/common.test.tsx
@@ -31,6 +31,12 @@ describe("FormGroup", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
+    // Reset shared fixture so test outcomes don't depend on order (CodeRabbit
+    // flagged cross-test state leakage; new tests below add helpTextLink which
+    // compounded the issue).
+    setting.helpText = "";
+    setting.subText = "";
+    setting.helpTextLink = undefined;
   });
 
   it("is rendered", () => {

--- a/app/client/src/pages/AdminSettings/FormGroup/common.test.tsx
+++ b/app/client/src/pages/AdminSettings/FormGroup/common.test.tsx
@@ -110,8 +110,8 @@ describe("FormGroup", () => {
       "admin-settings-form-group-helptext-link",
     );
 
-    expect(tooltipLink).toHaveAttribute("href", setting.helpTextLink);
-    expect(tooltipLink).toHaveAttribute("target", "_blank");
+    expect(tooltipLink.getAttribute("href")).toBe(setting.helpTextLink);
+    expect(tooltipLink.getAttribute("target")).toBe("_blank");
     expect(tooltipLink.textContent).toBe("Learn more");
   });
 });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.helpers.ce;
 
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.StringUtils;
@@ -52,6 +53,21 @@ public class SecureBaseUrlResolverCEImpl implements SecureBaseUrlResolverCE {
      */
     @Value("${APPSMITH_ALLOW_INSECURE_ORIGIN_BASED_LINKS:false}")
     private boolean allowInsecureOriginBasedLinks;
+
+    /**
+     * Strip trailing slash(es) from the configured base URL once, at bean initialization, so that
+     * downstream {@code "%s/path"} formatting in email templates does not produce
+     * {@code "https://host//path"}. Doubled slashes are silently passed through by Caddy in the
+     * standard self-hosted image and break SPA routing on the client (React-Router does not
+     * collapse empty path segments). One-time normalization here avoids a class of footgun for
+     * operators who copy-paste a URL ending in {@code /}.
+     */
+    @PostConstruct
+    public void init() {
+        if (StringUtils.hasText(appsmithBaseUrl)) {
+            appsmithBaseUrl = appsmithBaseUrl.replaceAll("/+$", "");
+        }
+    }
 
     @Override
     public Mono<String> resolveSecureBaseUrl(String providedBaseUrl) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/SecureBaseUrlResolverCEImplTest.java
@@ -35,6 +35,9 @@ class SecureBaseUrlResolverCEImplTest {
         Field flagField = SecureBaseUrlResolverCEImpl.class.getDeclaredField("allowInsecureOriginBasedLinks");
         flagField.setAccessible(true);
         flagField.set(resolver, allowInsecureFallback);
+        // Trigger the @PostConstruct hook so trailing-slash normalization runs in tests, mirroring
+        // the runtime Spring lifecycle.
+        resolver.init();
         return resolver;
     }
 
@@ -126,11 +129,33 @@ class SecureBaseUrlResolverCEImplTest {
     // RFC; all rejected ones genuinely differ in scheme, host, or non-default port.
 
     @Test
-    void resolveSecureBaseUrl_whenConfiguredHasTrailingSlash_andOriginDoesNot_match() throws Exception {
+    void resolveSecureBaseUrl_whenConfiguredHasTrailingSlash_isNormalizedAndOriginStillMatches() throws Exception {
+        // Trailing slash on the configured value is stripped at @PostConstruct so that downstream
+        // "%s/path" formatting in email templates does not produce "//path". The origin check
+        // still tolerates the mismatched-slash inbound Origin header per RFC 6454.
         SecureBaseUrlResolverCEImpl resolver = newResolver("http://localhost/", false);
 
         StepVerifier.create(resolver.resolveSecureBaseUrl("http://localhost"))
-                .expectNext("http://localhost/")
+                .expectNext("http://localhost")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenConfiguredHasMultipleTrailingSlashes_allAreStripped() throws Exception {
+        SecureBaseUrlResolverCEImpl resolver = newResolver("http://localhost///", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("http://localhost"))
+                .expectNext("http://localhost")
+                .verifyComplete();
+    }
+
+    @Test
+    void resolveSecureBaseUrl_whenConfiguredHasNoTrailingSlash_isReturnedVerbatim() throws Exception {
+        // Pin the no-op path: normalization must not alter URLs that don't end in a slash.
+        SecureBaseUrlResolverCEImpl resolver = newResolver("https://appsmith.example", false);
+
+        StepVerifier.create(resolver.resolveSecureBaseUrl("https://appsmith.example"))
+                .expectNext("https://appsmith.example")
                 .verifyComplete();
     }
 


### PR DESCRIPTION
## Summary

Two related changes to the `APPSMITH_BASE_URL` setting under **Settings → Configuration**:

1. **Docs link tooltip** — adds an optional `helpTextLink` field to the admin `Setting` type and extends the shared `FormGroup` so the (?) icon next to the label renders the help text plus a `<Link target="_blank">Learn more</Link>` to docs (when both `helpText` and `helpTextLink` are set). Wires this onto `APPSMITH_BASE_URL` pointing at `https://docs.appsmith.com/getting-started/setup/environment-variables#appsmith_base_url`. Mirrors the existing tooltip-with-link pattern already used by `RadioField`'s embed-settings option, so the convention stays consistent across setting types. Pure additive — when `helpTextLink` is absent, behavior is unchanged.

2. **Server-side trailing-slash normalization** — operators frequently configure `APPSMITH_BASE_URL` with a trailing slash (e.g. `https://app.example.com/`). The resolver previously returned the configured value verbatim, so downstream `"%s/path"` formatting in email templates produced `"https://host//path"` — a doubled slash that React-Router on the SPA does not collapse, breaking password-reset, email-verification, and invite links on standard Caddy-only deployments. Add a one-shot `@PostConstruct` hook on `SecureBaseUrlResolverCEImpl` that strips trailing slash(es) from the configured value once at bean init. `sameOrigin` was already RFC 6454-tolerant, so the security check is unaffected — only the returned/persisted value changes.

## Why two pieces in one PR

They are both follow-ups to the GHSA-j9gf-vw2f-9hrw fail-closed work that just landed (PR #41767). The tooltip surfaces docs at the point of configuration; the normalization closes the foot-gun the docs would otherwise warn against. Together they make the setting genuinely safe to use without requiring a docs round-trip.

Originally drafted as EE-only PR <https://github.com/appsmithorg/appsmith-ee/pull/9036> before realizing every file is CE-side or shared. This CE PR is the byte-for-byte equivalent; the EE PR will be closed once this lands and the hourly sync carries it across.

## Test plan

- [x] `mvn ... SecureBaseUrlResolverCEImplTest test` — **20/20 pass** (18 existing + 2 new normalization-pinning cases). `newResolver()` test helper updated to invoke `init()` after the reflection-injected fields, mirroring the runtime Spring lifecycle.
- [x] `app/server/build.sh -DskipTests -T 8` — BUILD SUCCESS
- [x] `common.test.tsx` — 2 new cases: `helpTextLink` absent → no link rendered; `helpTextLink` set → link with correct `href`, `target="_blank"`, and "Learn more" text
- [x] `yarn check-types` — green
- [x] `yarn lint-staged` (eslint --fix --cache + gitleaks) — green

## Linear

Resolves [APP-15205](https://linear.app/appsmith/issue/APP-15205/task-add-docs-link-in-the-appsmith-base-url-env-var-settings-page).

## Automation
/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25478869120>
> Commit: 012149f56ca4fe50e1da1b8860826ba481731392
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25478869120&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Thu, 07 May 2026 06:47:53 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a contextual "Learn More" link in Admin Settings for the Appsmith Base URL help text.
  * Base URL setting now normalizes trailing slashes to prevent URL/path formatting issues.

* **Tests**
  * Expanded tests for Base URL normalization and conditional rendering of the help-text "Learn More" link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->