### PR TITLE
chore: made discard changes async after ref creation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/GitDiscardChangesEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/GitDiscardChangesEvent.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.events;
 
 import com.appsmith.server.constants.ArtifactType;
+import com.appsmith.server.domains.User;
 import com.appsmith.server.git.central.GitType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,4 +25,7 @@ public class GitDiscardChangesEvent {
 
     @ToString.Exclude
     private String authorEmail;
+
+    @ToString.Exclude
+    private User user;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/GitDiscardChangesEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/GitDiscardChangesEvent.java
@@ -1,0 +1,27 @@
+package com.appsmith.server.events;
+
+import com.appsmith.server.constants.ArtifactType;
+import com.appsmith.server.git.central.GitType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * DTO to pass discard changes data from the request flow to a background job.
+ */
+@Data
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitDiscardChangesEvent {
+
+    private String artifactId;
+    private ArtifactType artifactType;
+    private GitType gitType;
+    private Boolean isValidateAndPublish;
+    private String authorName;
+
+    @ToString.Exclude
+    private String authorEmail;
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/GitDiscardChangesEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/GitDiscardChangesEvent.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.time.Instant;
+
 /**
  * DTO to pass discard changes data from the request flow to a background job.
  */
@@ -28,4 +30,6 @@ public class GitDiscardChangesEvent {
 
     @ToString.Exclude
     private User user;
+
+    private Instant expectedUpdatedAt;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCE.java
@@ -69,6 +69,9 @@ public interface CentralGitServiceCE {
 
     Mono<? extends Artifact> discardChanges(String branchedArtifactId, ArtifactType artifactType, GitType gitType);
 
+    Mono<? extends Artifact> discardChanges(
+            String branchedArtifactId, ArtifactType artifactType, GitType gitType, Boolean isValidateAndPublish);
+
     Mono<GitStatusDTO> getStatus(
             String branchedArtifactId, ArtifactType artifactType, boolean compareRemote, GitType gitType);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCECompatibleImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.exports.internal.ExportService;
 import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
+import com.appsmith.server.git.central.helpers.GitDiscardChangesAsyncEventManager;
 import com.appsmith.server.git.resolver.GitArtifactHelperResolver;
 import com.appsmith.server.git.resolver.GitHandlingServiceResolver;
 import com.appsmith.server.git.utils.GitAnalyticsUtils;
@@ -43,6 +44,7 @@ public class CentralGitServiceCECompatibleImpl extends CentralGitServiceCEImpl
             ImportService importService,
             ExportService exportService,
             GitAutoCommitHelper gitAutoCommitHelper,
+            GitDiscardChangesAsyncEventManager gitDiscardChangesAsyncEventManager,
             TransactionalOperator transactionalOperator,
             ObservationRegistry observationRegistry) {
         super(
@@ -62,6 +64,7 @@ public class CentralGitServiceCECompatibleImpl extends CentralGitServiceCEImpl
                 importService,
                 exportService,
                 gitAutoCommitHelper,
+                gitDiscardChangesAsyncEventManager,
                 transactionalOperator,
                 observationRegistry);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -11,6 +11,7 @@ import com.appsmith.external.git.constants.GitConstants.GitCommandConstants;
 import com.appsmith.external.git.constants.GitSpan;
 import com.appsmith.external.git.constants.ce.RefType;
 import com.appsmith.external.git.dtos.FetchRemoteDTO;
+import com.appsmith.external.models.BaseDomain;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.git.dto.CommitDTO;
@@ -893,7 +894,10 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                                         FALSE,
                                         gitProfile.getAuthorName(),
                                         gitProfile.getAuthorEmail(),
-                                        user));
+                                        user,
+                                        sourceArtifact instanceof BaseDomain baseDomain
+                                                ? baseDomain.getUpdatedAt()
+                                                : null));
                             })
                             .onErrorResume(cleanupEventError -> {
                                 log.warn(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -38,11 +38,13 @@ import com.appsmith.server.dtos.GitConnectDTO;
 import com.appsmith.server.dtos.GitDocsDTO;
 import com.appsmith.server.dtos.GitMergeDTO;
 import com.appsmith.server.dtos.GitPullDTO;
+import com.appsmith.server.events.GitDiscardChangesEvent;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.exports.internal.ExportService;
 import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
+import com.appsmith.server.git.central.helpers.GitDiscardChangesAsyncEventManager;
 import com.appsmith.server.git.dtos.ArtifactJsonTransformationDTO;
 import com.appsmith.server.git.resolver.GitArtifactHelperResolver;
 import com.appsmith.server.git.resolver.GitHandlingServiceResolver;
@@ -134,6 +136,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
     protected final ExportService exportService;
 
     private final GitAutoCommitHelper gitAutoCommitHelper;
+    private final GitDiscardChangesAsyncEventManager gitDiscardChangesAsyncEventManager;
     private final TransactionalOperator transactionalOperator;
     protected final ObservationRegistry observationRegistry;
 
@@ -854,9 +857,8 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
         // Use usingWhen so the git lock is acquired and released exactly once per invocation,
         // regardless of how the pipeline terminates (success, error, or cancellation).
         // The refCreationPipeline (ref creation + import + publish + analytics) all runs under
-        // the lock; discardChanges below runs *after* the lock is released so it never blocks
-        // subsequent git ops on the same base artifact, and is set up as a best-effort cleanup
-        // so we can flip it to fire-and-forget async in a follow-up.
+        // the lock. Source-branch cleanup is published after the lock is released so create-ref
+        // returns without waiting for the expensive discard/import path.
         Mono<? extends Artifact> createBranchMono = Mono.usingWhen(
                         gitRedisUtils.acquireGitLock(
                                 artifactType, baseArtifactId, GitCommandConstants.CREATE_REF, TRUE),
@@ -870,23 +872,32 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                                             releaseError.getMessage());
                                     return Mono.just(TRUE);
                                 }))
-                // After the lock is released, reset the source branch to its last commit.
-                // Best-effort: a failure here must NOT convert a successful branch creation into
-                // an error for the caller. Kept synchronous for now so external observers see a
-                // consistent source branch on return, but ready to be fire-and-forget async later.
+                // After the lock is released, reset the source branch to its last commit in the
+                // background. Best-effort: a failure here must NOT convert a successful branch
+                // creation into an error for the caller.
                 .flatMap(newImportedArtifact -> {
                     if (RefType.tag.equals(refType)) {
                         return Mono.just(newImportedArtifact);
                     }
-                    return discardChanges(sourceArtifact, gitType, FALSE)
-                            .onErrorResume(cleanupError -> {
+
+                    return userDataService
+                            .getGitProfileForCurrentUser(baseArtifactId)
+                            .doOnNext(gitProfile ->
+                                    gitDiscardChangesAsyncEventManager.publishAsyncEvent(new GitDiscardChangesEvent(
+                                            sourceArtifact.getId(),
+                                            artifactType,
+                                            gitType,
+                                            FALSE,
+                                            gitProfile.getAuthorName(),
+                                            gitProfile.getAuthorEmail())))
+                            .onErrorResume(cleanupEventError -> {
                                 log.warn(
-                                        "Best-effort discardChanges on source artifact {} after ref creation failed: {}",
+                                        "Failed to publish async discardChanges event for source artifact {} after ref creation: {}",
                                         sourceArtifact.getId(),
-                                        cleanupError.getMessage());
+                                        cleanupEventError.getMessage());
                                 return Mono.empty();
                             })
-                            .then(Mono.just(newImportedArtifact));
+                            .thenReturn(newImportedArtifact);
                 })
                 .onErrorResume(error -> {
                     log.error("An error occurred while creating reference. error {}", error.getMessage(), error);
@@ -2324,6 +2335,12 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
     @Override
     public Mono<? extends Artifact> discardChanges(
             String branchedArtifactId, ArtifactType artifactType, GitType gitType) {
+        return discardChanges(branchedArtifactId, artifactType, gitType, TRUE);
+    }
+
+    @Override
+    public Mono<? extends Artifact> discardChanges(
+            String branchedArtifactId, ArtifactType artifactType, GitType gitType, Boolean isValidateAndPublish) {
 
         if (!hasText(branchedArtifactId)) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ARTIFACT_ID));
@@ -2334,7 +2351,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
 
         return gitArtifactHelper
                 .getArtifactById(branchedArtifactId, artifactEditPermission)
-                .flatMap(branchedArtifact -> discardChanges(branchedArtifact, gitType));
+                .flatMap(branchedArtifact -> discardChanges(branchedArtifact, gitType, isValidateAndPublish));
     }
 
     protected Mono<? extends Artifact> discardChanges(Artifact branchedArtifact, GitType gitType) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -880,16 +880,21 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                         return Mono.just(newImportedArtifact);
                     }
 
-                    return userDataService
-                            .getGitProfileForCurrentUser(baseArtifactId)
-                            .doOnNext(gitProfile ->
-                                    gitDiscardChangesAsyncEventManager.publishAsyncEvent(new GitDiscardChangesEvent(
-                                            sourceArtifact.getId(),
-                                            artifactType,
-                                            gitType,
-                                            FALSE,
-                                            gitProfile.getAuthorName(),
-                                            gitProfile.getAuthorEmail())))
+                    return Mono.zip(
+                                    userDataService.getGitProfileForCurrentUser(baseArtifactId),
+                                    sessionUserService.getCurrentUser())
+                            .doOnNext(tuple -> {
+                                GitProfile gitProfile = tuple.getT1();
+                                User user = tuple.getT2();
+                                gitDiscardChangesAsyncEventManager.publishAsyncEvent(new GitDiscardChangesEvent(
+                                        sourceArtifact.getId(),
+                                        artifactType,
+                                        gitType,
+                                        FALSE,
+                                        gitProfile.getAuthorName(),
+                                        gitProfile.getAuthorEmail(),
+                                        user));
+                            })
                             .onErrorResume(cleanupEventError -> {
                                 log.warn(
                                         "Failed to publish async discardChanges event for source artifact {} after ref creation: {}",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.exports.internal.ExportService;
 import com.appsmith.server.git.GitRedisUtils;
 import com.appsmith.server.git.autocommit.helpers.GitAutoCommitHelper;
+import com.appsmith.server.git.central.helpers.GitDiscardChangesAsyncEventManager;
 import com.appsmith.server.git.resolver.GitArtifactHelperResolver;
 import com.appsmith.server.git.resolver.GitHandlingServiceResolver;
 import com.appsmith.server.git.utils.GitAnalyticsUtils;
@@ -42,6 +43,7 @@ public class CentralGitServiceImpl extends CentralGitServiceCECompatibleImpl imp
             ImportService importService,
             ExportService exportService,
             GitAutoCommitHelper gitAutoCommitHelper,
+            GitDiscardChangesAsyncEventManager gitDiscardChangesAsyncEventManager,
             TransactionalOperator transactionalOperator,
             ObservationRegistry observationRegistry) {
         super(
@@ -61,6 +63,7 @@ public class CentralGitServiceImpl extends CentralGitServiceCECompatibleImpl imp
                 importService,
                 exportService,
                 gitAutoCommitHelper,
+                gitDiscardChangesAsyncEventManager,
                 transactionalOperator,
                 observationRegistry);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManager.java
@@ -1,0 +1,22 @@
+package com.appsmith.server.git.central.helpers;
+
+import com.appsmith.server.constants.ArtifactType;
+import com.appsmith.server.domains.Artifact;
+import com.appsmith.server.events.GitDiscardChangesEvent;
+import com.appsmith.server.git.central.GitType;
+import reactor.core.publisher.Mono;
+
+public interface GitDiscardChangesAsyncEventManager {
+
+    void publishAsyncEvent(GitDiscardChangesEvent event);
+
+    void discardChangesEventListener(GitDiscardChangesEvent event);
+
+    Mono<? extends Artifact> discardChanges(
+            String branchedArtifactId,
+            String authorName,
+            String authorEmail,
+            ArtifactType artifactType,
+            GitType gitType,
+            Boolean isValidateAndPublish);
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManager.java
@@ -6,6 +6,8 @@ import com.appsmith.server.events.GitDiscardChangesEvent;
 import com.appsmith.server.git.central.GitType;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
+
 public interface GitDiscardChangesAsyncEventManager {
 
     void publishAsyncEvent(GitDiscardChangesEvent event);
@@ -18,5 +20,6 @@ public interface GitDiscardChangesAsyncEventManager {
             String authorEmail,
             ArtifactType artifactType,
             GitType gitType,
-            Boolean isValidateAndPublish);
+            Boolean isValidateAndPublish,
+            Instant expectedUpdatedAt);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
@@ -1,0 +1,76 @@
+package com.appsmith.server.git.central.helpers;
+
+import com.appsmith.server.annotations.GitRoute;
+import com.appsmith.server.constants.ArtifactType;
+import com.appsmith.server.domains.Artifact;
+import com.appsmith.server.events.GitDiscardChangesEvent;
+import com.appsmith.server.git.central.CentralGitService;
+import com.appsmith.server.git.central.GitType;
+import com.appsmith.server.git.constants.GitRouteOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChangesAsyncEventManager {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ObjectProvider<CentralGitService> centralGitServiceProvider;
+    private final ObjectProvider<GitDiscardChangesAsyncEventManager> gitDiscardChangesAsyncEventManagerProvider;
+
+    @Override
+    public void publishAsyncEvent(GitDiscardChangesEvent event) {
+        log.info("published event for git discard changes: {}", event);
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    @Async
+    @EventListener
+    @Override
+    public void discardChangesEventListener(GitDiscardChangesEvent event) {
+        log.info("received event for git discard changes: {}", event);
+
+        gitDiscardChangesAsyncEventManagerProvider
+                .getObject()
+                .discardChanges(
+                        event.getArtifactId(),
+                        event.getAuthorName(),
+                        event.getAuthorEmail(),
+                        event.getArtifactType(),
+                        event.getGitType(),
+                        event.getIsValidateAndPublish())
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(
+                        result -> log.info(
+                                "Git discard changes completed successfully for artifact: {}", event.getArtifactId()),
+                        error -> log.error(
+                                "Error during git discard changes for artifact: {}", event.getArtifactId(), error));
+    }
+
+    @Override
+    @GitRoute(
+            artifactType = ArtifactType.APPLICATION,
+            operation = GitRouteOperation.DISCARD_CHANGES,
+            fieldName = "branchedArtifactId",
+            authorName = "authorName",
+            authorEmail = "authorEmail")
+    public Mono<? extends Artifact> discardChanges(
+            String branchedArtifactId,
+            String authorName,
+            String authorEmail,
+            ArtifactType artifactType,
+            GitType gitType,
+            Boolean isValidateAndPublish) {
+        return centralGitServiceProvider
+                .getObject()
+                .discardChanges(branchedArtifactId, artifactType, gitType, isValidateAndPublish);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
@@ -13,6 +13,9 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -38,6 +41,9 @@ public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChanges
     public void discardChangesEventListener(GitDiscardChangesEvent event) {
         log.info("received event for git discard changes: {}", event);
 
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                event.getUser(), null, event.getUser().getAuthorities());
+
         gitDiscardChangesAsyncEventManagerProvider
                 .getObject()
                 .discardChanges(
@@ -47,6 +53,7 @@ public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChanges
                         event.getArtifactType(),
                         event.getGitType(),
                         event.getIsValidateAndPublish())
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe(
                         result -> log.info(
@@ -58,7 +65,7 @@ public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChanges
     @Override
     @GitRoute(
             artifactType = ArtifactType.APPLICATION,
-            operation = GitRouteOperation.DISCARD_CHANGES,
+            operation = GitRouteOperation.ASYNC_DISCARD,
             fieldName = "branchedArtifactId",
             authorName = "authorName",
             authorEmail = "authorEmail")

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
@@ -35,7 +34,6 @@ public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChanges
         applicationEventPublisher.publishEvent(event);
     }
 
-    @Async
     @EventListener
     @Override
     public void discardChangesEventListener(GitDiscardChangesEvent event) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.git.central.helpers;
 
+import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.annotations.GitRoute;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.domains.Artifact;
@@ -7,6 +8,8 @@ import com.appsmith.server.events.GitDiscardChangesEvent;
 import com.appsmith.server.git.central.CentralGitService;
 import com.appsmith.server.git.central.GitType;
 import com.appsmith.server.git.constants.GitRouteOperation;
+import com.appsmith.server.git.resolver.GitArtifactHelperResolver;
+import com.appsmith.server.services.GitArtifactHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -19,6 +22,9 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.time.Instant;
+import java.util.Objects;
+
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -27,6 +33,7 @@ public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChanges
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ObjectProvider<CentralGitService> centralGitServiceProvider;
     private final ObjectProvider<GitDiscardChangesAsyncEventManager> gitDiscardChangesAsyncEventManagerProvider;
+    private final GitArtifactHelperResolver gitArtifactHelperResolver;
 
     @Override
     public void publishAsyncEvent(GitDiscardChangesEvent event) {
@@ -50,7 +57,8 @@ public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChanges
                         event.getAuthorEmail(),
                         event.getArtifactType(),
                         event.getGitType(),
-                        event.getIsValidateAndPublish())
+                        event.getIsValidateAndPublish(),
+                        event.getExpectedUpdatedAt())
                 .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe(
@@ -73,9 +81,31 @@ public class GitDiscardChangesAsyncEventManagerImpl implements GitDiscardChanges
             String authorEmail,
             ArtifactType artifactType,
             GitType gitType,
-            Boolean isValidateAndPublish) {
-        return centralGitServiceProvider
-                .getObject()
-                .discardChanges(branchedArtifactId, artifactType, gitType, isValidateAndPublish);
+            Boolean isValidateAndPublish,
+            Instant expectedUpdatedAt) {
+        GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
+
+        return gitArtifactHelper
+                .getArtifactById(branchedArtifactId, gitArtifactHelper.getArtifactEditPermission())
+                .flatMap(currentArtifact -> {
+                    if (hasArtifactChanged(currentArtifact, expectedUpdatedAt)) {
+                        log.info(
+                                "Skipping async discardChanges for artifact {} because it changed after event publication",
+                                branchedArtifactId);
+                        return Mono.just(currentArtifact);
+                    }
+
+                    return centralGitServiceProvider
+                            .getObject()
+                            .discardChanges(branchedArtifactId, artifactType, gitType, isValidateAndPublish);
+                });
+    }
+
+    private boolean hasArtifactChanged(Artifact artifact, Instant expectedUpdatedAt) {
+        if (!(artifact instanceof BaseDomain baseDomain)) {
+            return false;
+        }
+
+        return !Objects.equals(baseDomain.getUpdatedAt(), expectedUpdatedAt);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/constants/GitRouteOperation.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/constants/GitRouteOperation.java
@@ -20,6 +20,7 @@ public enum GitRouteOperation {
     MERGE(true),
     MERGE_STATUS(true),
     DELETE_REF(true),
+    ASYNC_DISCARD(true),
     DISCARD_CHANGES(true),
     LIST_REFS(true),
     AUTO_COMMIT(true),

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImplTest.java
@@ -6,6 +6,8 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.events.GitDiscardChangesEvent;
 import com.appsmith.server.git.central.CentralGitService;
 import com.appsmith.server.git.central.GitType;
+import com.appsmith.server.git.resolver.GitArtifactHelperResolver;
+import com.appsmith.server.services.GitArtifactHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
@@ -14,6 +16,7 @@ import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Proxy;
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,7 +37,7 @@ class GitDiscardChangesAsyncEventManagerImplTest {
     void setUp() {
         applicationEventPublisher = publishedEvent::set;
         manager = new GitDiscardChangesAsyncEventManagerImpl(
-                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider);
+                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider, null);
     }
 
     private static <T> ObjectProvider<T> providerFor(T object) {
@@ -68,8 +71,30 @@ class GitDiscardChangesAsyncEventManagerImplTest {
         return user;
     }
 
+    @SuppressWarnings("unchecked")
+    private static GitArtifactHelperResolver resolverFor(Application application) {
+        GitArtifactHelper<Application> gitArtifactHelper = (GitArtifactHelper<Application>) Proxy.newProxyInstance(
+                GitArtifactHelper.class.getClassLoader(),
+                new Class<?>[] {GitArtifactHelper.class},
+                (proxy, method, args) -> {
+                    if ("getArtifactById".equals(method.getName())) {
+                        return Mono.just(application);
+                    }
+                    if ("getArtifactEditPermission".equals(method.getName())) {
+                        return null;
+                    }
+                    if ("toString".equals(method.getName())) {
+                        return "gitArtifactHelper";
+                    }
+                    throw new UnsupportedOperationException(method.toString());
+                });
+
+        return new GitArtifactHelperResolver(null, gitArtifactHelper);
+    }
+
     @Test
     void publishAsyncEvent_publishesGitDiscardChangesEvent() {
+        Instant expectedUpdatedAt = Instant.now();
         GitDiscardChangesEvent event = new GitDiscardChangesEvent(
                 "artifact-id",
                 ArtifactType.APPLICATION,
@@ -77,7 +102,8 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                 FALSE,
                 "author",
                 "author@example.com",
-                user());
+                user(),
+                expectedUpdatedAt);
 
         manager.publishAsyncEvent(event);
 
@@ -87,6 +113,7 @@ class GitDiscardChangesAsyncEventManagerImplTest {
     @Test
     void discardChangesEventListener_discardsChangesThroughAnnotatedProxyWithEventParameters() throws Exception {
         User user = user();
+        Instant expectedUpdatedAt = Instant.now();
         GitDiscardChangesEvent event = new GitDiscardChangesEvent(
                 "artifact-id",
                 ArtifactType.APPLICATION,
@@ -94,7 +121,8 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                 FALSE,
                 "author",
                 "author@example.com",
-                user);
+                user,
+                expectedUpdatedAt);
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
         AtomicReference<Object> capturedPrincipal = new AtomicReference<>();
@@ -114,9 +142,16 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                             String authorEmail,
                             ArtifactType artifactType,
                             GitType gitType,
-                            Boolean isValidateAndPublish) {
+                            Boolean isValidateAndPublish,
+                            Instant eventExpectedUpdatedAt) {
                         capturedArgs.set(new Object[] {
-                            branchedArtifactId, authorName, authorEmail, artifactType, gitType, isValidateAndPublish
+                            branchedArtifactId,
+                            authorName,
+                            authorEmail,
+                            artifactType,
+                            gitType,
+                            isValidateAndPublish,
+                            eventExpectedUpdatedAt
                         });
                         return ReactiveSecurityContextHolder.getContext()
                                 .doOnNext(context -> capturedPrincipal.set(
@@ -127,7 +162,7 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                 };
         gitDiscardChangesAsyncEventManagerProvider = providerFor(gitDiscardChangesAsyncEventManager);
         manager = new GitDiscardChangesAsyncEventManagerImpl(
-                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider);
+                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider, null);
 
         manager.discardChangesEventListener(event);
 
@@ -139,12 +174,16 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                         "author@example.com",
                         ArtifactType.APPLICATION,
                         GitType.FILE_SYSTEM,
-                        FALSE);
+                        FALSE,
+                        expectedUpdatedAt);
         assertThat(capturedPrincipal.get()).isSameAs(user);
     }
 
     @Test
     void discardChanges_delegatesToCentralGitService() {
+        Instant expectedUpdatedAt = Instant.now();
+        Application application = new Application();
+        application.setUpdatedAt(expectedUpdatedAt);
         AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
         CentralGitService centralGitService = (CentralGitService) Proxy.newProxyInstance(
                 CentralGitService.class.getClassLoader(),
@@ -161,7 +200,10 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                 });
         centralGitServiceProvider = providerFor(centralGitService);
         manager = new GitDiscardChangesAsyncEventManagerImpl(
-                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider);
+                applicationEventPublisher,
+                centralGitServiceProvider,
+                gitDiscardChangesAsyncEventManagerProvider,
+                resolverFor(application));
 
         manager.discardChanges(
                         "artifact-id",
@@ -169,10 +211,50 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                         "author@example.com",
                         ArtifactType.APPLICATION,
                         GitType.FILE_SYSTEM,
-                        FALSE)
+                        FALSE,
+                        expectedUpdatedAt)
                 .block();
 
         assertThat(capturedArgs.get())
                 .containsExactly("artifact-id", ArtifactType.APPLICATION, GitType.FILE_SYSTEM, FALSE);
+    }
+
+    @Test
+    void discardChanges_skipsCentralDiscardWhenArtifactChangedAfterEventPublication() {
+        Instant expectedUpdatedAt = Instant.now();
+        Application application = new Application();
+        application.setUpdatedAt(expectedUpdatedAt.plusSeconds(1));
+        AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+        CentralGitService centralGitService = (CentralGitService) Proxy.newProxyInstance(
+                CentralGitService.class.getClassLoader(),
+                new Class<?>[] {CentralGitService.class},
+                (proxy, method, args) -> {
+                    if ("discardChanges".equals(method.getName()) && args.length == 4) {
+                        capturedArgs.set(args);
+                        return Mono.just(new Application());
+                    }
+                    if ("toString".equals(method.getName())) {
+                        return "centralGitService";
+                    }
+                    throw new UnsupportedOperationException(method.toString());
+                });
+        centralGitServiceProvider = providerFor(centralGitService);
+        manager = new GitDiscardChangesAsyncEventManagerImpl(
+                applicationEventPublisher,
+                centralGitServiceProvider,
+                gitDiscardChangesAsyncEventManagerProvider,
+                resolverFor(application));
+
+        manager.discardChanges(
+                        "artifact-id",
+                        "author",
+                        "author@example.com",
+                        ArtifactType.APPLICATION,
+                        GitType.FILE_SYSTEM,
+                        FALSE,
+                        expectedUpdatedAt)
+                .block();
+
+        assertThat(capturedArgs.get()).isNull();
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImplTest.java
@@ -2,6 +2,7 @@ package com.appsmith.server.git.central.helpers;
 
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.domains.Application;
+import com.appsmith.server.domains.User;
 import com.appsmith.server.events.GitDiscardChangesEvent;
 import com.appsmith.server.git.central.CentralGitService;
 import com.appsmith.server.git.central.GitType;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Proxy;
@@ -59,10 +61,23 @@ class GitDiscardChangesAsyncEventManagerImplTest {
         };
     }
 
+    private static User user() {
+        User user = new User();
+        user.setEmail("author@example.com");
+        user.setName("author");
+        return user;
+    }
+
     @Test
     void publishAsyncEvent_publishesGitDiscardChangesEvent() {
         GitDiscardChangesEvent event = new GitDiscardChangesEvent(
-                "artifact-id", ArtifactType.APPLICATION, GitType.FILE_SYSTEM, FALSE, "author", "author@example.com");
+                "artifact-id",
+                ArtifactType.APPLICATION,
+                GitType.FILE_SYSTEM,
+                FALSE,
+                "author",
+                "author@example.com",
+                user());
 
         manager.publishAsyncEvent(event);
 
@@ -71,10 +86,18 @@ class GitDiscardChangesAsyncEventManagerImplTest {
 
     @Test
     void discardChangesEventListener_discardsChangesThroughAnnotatedProxyWithEventParameters() throws Exception {
+        User user = user();
         GitDiscardChangesEvent event = new GitDiscardChangesEvent(
-                "artifact-id", ArtifactType.APPLICATION, GitType.FILE_SYSTEM, FALSE, "author", "author@example.com");
+                "artifact-id",
+                ArtifactType.APPLICATION,
+                GitType.FILE_SYSTEM,
+                FALSE,
+                "author",
+                "author@example.com",
+                user);
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+        AtomicReference<Object> capturedPrincipal = new AtomicReference<>();
         GitDiscardChangesAsyncEventManager gitDiscardChangesAsyncEventManager =
                 new GitDiscardChangesAsyncEventManager() {
 
@@ -95,8 +118,11 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                         capturedArgs.set(new Object[] {
                             branchedArtifactId, authorName, authorEmail, artifactType, gitType, isValidateAndPublish
                         });
-                        latch.countDown();
-                        return Mono.just(new Application());
+                        return ReactiveSecurityContextHolder.getContext()
+                                .doOnNext(context -> capturedPrincipal.set(
+                                        context.getAuthentication().getPrincipal()))
+                                .thenReturn(new Application())
+                                .doOnSuccess(ignored -> latch.countDown());
                     }
                 };
         gitDiscardChangesAsyncEventManagerProvider = providerFor(gitDiscardChangesAsyncEventManager);
@@ -114,6 +140,7 @@ class GitDiscardChangesAsyncEventManagerImplTest {
                         ArtifactType.APPLICATION,
                         GitType.FILE_SYSTEM,
                         FALSE);
+        assertThat(capturedPrincipal.get()).isSameAs(user);
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/helpers/GitDiscardChangesAsyncEventManagerImplTest.java
@@ -1,0 +1,151 @@
+package com.appsmith.server.git.central.helpers;
+
+import com.appsmith.server.constants.ArtifactType;
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.events.GitDiscardChangesEvent;
+import com.appsmith.server.git.central.CentralGitService;
+import com.appsmith.server.git.central.GitType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.Boolean.FALSE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitDiscardChangesAsyncEventManagerImplTest {
+
+    private ApplicationEventPublisher applicationEventPublisher;
+    private ObjectProvider<CentralGitService> centralGitServiceProvider;
+    private ObjectProvider<GitDiscardChangesAsyncEventManager> gitDiscardChangesAsyncEventManagerProvider;
+
+    private GitDiscardChangesAsyncEventManagerImpl manager;
+    private final AtomicReference<Object> publishedEvent = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() {
+        applicationEventPublisher = publishedEvent::set;
+        manager = new GitDiscardChangesAsyncEventManagerImpl(
+                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider);
+    }
+
+    private static <T> ObjectProvider<T> providerFor(T object) {
+        return new ObjectProvider<>() {
+            @Override
+            public T getObject() {
+                return object;
+            }
+
+            @Override
+            public T getObject(Object... args) {
+                return object;
+            }
+
+            @Override
+            public T getIfAvailable() {
+                return object;
+            }
+
+            @Override
+            public T getIfUnique() {
+                return object;
+            }
+        };
+    }
+
+    @Test
+    void publishAsyncEvent_publishesGitDiscardChangesEvent() {
+        GitDiscardChangesEvent event = new GitDiscardChangesEvent(
+                "artifact-id", ArtifactType.APPLICATION, GitType.FILE_SYSTEM, FALSE, "author", "author@example.com");
+
+        manager.publishAsyncEvent(event);
+
+        assertThat(publishedEvent.get()).isSameAs(event);
+    }
+
+    @Test
+    void discardChangesEventListener_discardsChangesThroughAnnotatedProxyWithEventParameters() throws Exception {
+        GitDiscardChangesEvent event = new GitDiscardChangesEvent(
+                "artifact-id", ArtifactType.APPLICATION, GitType.FILE_SYSTEM, FALSE, "author", "author@example.com");
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+        GitDiscardChangesAsyncEventManager gitDiscardChangesAsyncEventManager =
+                new GitDiscardChangesAsyncEventManager() {
+
+                    @Override
+                    public void publishAsyncEvent(GitDiscardChangesEvent event) {}
+
+                    @Override
+                    public void discardChangesEventListener(GitDiscardChangesEvent event) {}
+
+                    @Override
+                    public Mono<Application> discardChanges(
+                            String branchedArtifactId,
+                            String authorName,
+                            String authorEmail,
+                            ArtifactType artifactType,
+                            GitType gitType,
+                            Boolean isValidateAndPublish) {
+                        capturedArgs.set(new Object[] {
+                            branchedArtifactId, authorName, authorEmail, artifactType, gitType, isValidateAndPublish
+                        });
+                        latch.countDown();
+                        return Mono.just(new Application());
+                    }
+                };
+        gitDiscardChangesAsyncEventManagerProvider = providerFor(gitDiscardChangesAsyncEventManager);
+        manager = new GitDiscardChangesAsyncEventManagerImpl(
+                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider);
+
+        manager.discardChangesEventListener(event);
+
+        assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(capturedArgs.get())
+                .containsExactly(
+                        "artifact-id",
+                        "author",
+                        "author@example.com",
+                        ArtifactType.APPLICATION,
+                        GitType.FILE_SYSTEM,
+                        FALSE);
+    }
+
+    @Test
+    void discardChanges_delegatesToCentralGitService() {
+        AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+        CentralGitService centralGitService = (CentralGitService) Proxy.newProxyInstance(
+                CentralGitService.class.getClassLoader(),
+                new Class<?>[] {CentralGitService.class},
+                (proxy, method, args) -> {
+                    if ("discardChanges".equals(method.getName()) && args.length == 4) {
+                        capturedArgs.set(args);
+                        return Mono.just(new Application());
+                    }
+                    if ("toString".equals(method.getName())) {
+                        return "centralGitService";
+                    }
+                    throw new UnsupportedOperationException(method.toString());
+                });
+        centralGitServiceProvider = providerFor(centralGitService);
+        manager = new GitDiscardChangesAsyncEventManagerImpl(
+                applicationEventPublisher, centralGitServiceProvider, gitDiscardChangesAsyncEventManagerProvider);
+
+        manager.discardChanges(
+                        "artifact-id",
+                        "author",
+                        "author@example.com",
+                        ArtifactType.APPLICATION,
+                        GitType.FILE_SYSTEM,
+                        FALSE)
+                .block();
+
+        assertThat(capturedArgs.get())
+                .containsExactly("artifact-id", ArtifactType.APPLICATION, GitType.FILE_SYSTEM, FALSE);
+    }
+}


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25729896761>
> Commit: 8c1924576903ca433cd7a956f23ac53adb65c952
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25729896761&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Tue, 12 May 2026 11:15:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discard-changes now runs asynchronously in the background for faster responses.
  * New option to skip validation and publishing during discard operations.

* **Behavior Change**
  * Post-branch creation cleanup is best-effort async so branch creation completes without waiting.

* **Tests**
  * Added unit tests covering async discard-changes event publication and handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41785)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->