### PR TITLE
fix: prevent onCheckChange from firing during programmatic updates

### DIFF
--- a/app/client/src/widgets/CheckboxWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxWidget/widget/index.tsx
@@ -427,15 +427,6 @@ class CheckboxWidget extends BaseWidget<CheckboxWidgetProps, WidgetState> {
       this.props.updateWidgetMetaProperty("isDirty", false);
     }
 
-    // Handle programmatic changes
-    if (
-      this.props.isChecked !== prevProps.isChecked &&
-      this.props.onCheckChange
-    ) {
-      this.props.updateWidgetMetaProperty("isChecked", this.props.isChecked);
-    }
-  }
-
   static getSetterConfig(): SetterConfig {
     return {
       __setters: {


### PR DESCRIPTION
Closes #41505
Removes the programmatic update handling block from CheckboxWidget that could cause onCheckChange behavior during non-user-triggered state updates.

The checkbox change event should only fire from direct user interaction through the checkbox component's onChange handler, not from programmatic property synchronization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended checkbox state synchronization that occurred when properties changed, preventing unexpected updates to the checkbox state in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->