### PR TITLE
fix(security): upgrade arangodb-java-driver to 7.25.0 to remediate CVE-2025-52999

### DIFF
--- a/app/server/appsmith-plugins/arangoDBPlugin/pom.xml
+++ b/app/server/appsmith-plugins/arangoDBPlugin/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.arangodb</groupId>
             <artifactId>arangodb-java-driver</artifactId>
-            <version>6.12.3</version>
+            <version>7.25.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -27,10 +27,102 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!--
+            Jackson is bundled in the appsmith-server runtime classpath (managed by the parent jackson-bom.version).
+            Declare the jackson artifacts that arangodb-java-driver pulls transitively as 'provided' so they are NOT
+            copied into this plugin's runtime lib/ directory. Without this, the PF4J PluginClassLoader and the Spring
+            Boot LaunchedClassLoader both expose com.fasterxml.jackson.databind.ObjectMapper, which crashes the server
+            on startup with a LinkageError ("loader constraint violation").
+        -->
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson-bom.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-bom.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson-bom.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!--
+            Netty 4.1.131 is shipped by the appsmith-server runtime via reactor-netty-http. arangodb-java-driver 7.x
+            transitively pulls the same netty version through Vert.x WebClient. Declare these as 'provided' for the
+            same reason as jackson above: avoid PluginClassLoader/parent-classloader collisions for io.netty.* classes.
+        -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-socks</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -220,7 +220,7 @@ public class ArangoDBPlugin extends BasePlugin {
                          * - This instance is thread safe as ArangoDatabase has in-built connection pooling.
                          * - src: https://www.arangodb.com/docs/stable/drivers/java-reference-setup.html
                          */
-                        return Mono.just(dbBuilder.build().db(dbName));
+                        return Mono.just(buildWithPluginClassLoader(dbBuilder).db(dbName));
                     })
                     .flatMap(obj -> obj)
                     // The default PluginExecutor.testDatasource(DatasourceConfiguration) wrapper swallows
@@ -234,23 +234,42 @@ public class ArangoDBPlugin extends BasePlugin {
         }
 
         /**
+         * Driver v7's {@code ArangoDB.Builder.build()} resolves the {@code ProtocolProvider} via
+         * {@link java.util.ServiceLoader#load(Class)}, which uses the current thread's context
+         * ClassLoader (TCCL). Under PF4J + Spring Boot the TCCL is the parent {@code LaunchedClassLoader}
+         * and cannot see {@code META-INF/services/com.arangodb.internal.net.ProtocolProvider} - that file
+         * lives inside {@code http-protocol-*.jar} in the plugin's {@code lib/}, so the SPI iterator is
+         * empty and the build throws
+         * <pre>com.arangodb.ArangoDBException: No ProtocolProvider found for protocol: HTTP_JSON</pre>
+         *
+         * <p>Set the TCCL to this plugin class's loader (the PF4J {@code PluginClassLoader}) for the
+         * duration of the build call so the SPI lookup sees the plugin classpath, then restore the
+         * original TCCL. The resulting {@code ArangoDB} instance retains its protocol provider, so
+         * subsequent calls (including {@code connection.getVersion()} in {@link #testDatasource}) do not
+         * need the TCCL swap.
+         */
+        private com.arangodb.ArangoDB buildWithPluginClassLoader(Builder dbBuilder) {
+            Thread current = Thread.currentThread();
+            ClassLoader original = current.getContextClassLoader();
+            try {
+                current.setContextClassLoader(this.getClass().getClassLoader());
+                return dbBuilder.build();
+            } finally {
+                current.setContextClassLoader(original);
+            }
+        }
+
+        /**
          * - Builder properties are explained here:
          * https://www.arangodb.com/docs/stable/drivers/java-reference-setup.html
          *
-         * <p>Protocol choice: we use HTTP/1.1 + JSON ({@link Protocol#HTTP_JSON}) rather than the v7 default
-         * {@link Protocol#HTTP2_JSON}. Both avoid the {@code jackson-serde-vpack} module - so they keep the
-         * vulnerable shaded {@code jackson-core 2.11.3} out of the runtime classpath, which is the whole point
-         * of the v6 -> v7 upgrade (CVE-2025-52999). The HTTP/1.1 variant is preferred because:
-         *
-         * <ul>
-         *   <li>The Cypress {@code Arango_Basic_Spec.ts} test against a dockerized {@code arangodb:latest}
-         *       reached from the appsmith container over {@code host.docker.internal:host-gateway} fails
-         *       with HTTP2_JSON (Test datasource times out / silently emits no connection), but succeeds
-         *       with HTTP_JSON. HTTP/2 cleartext via h2c upgrade through the host-gateway routing was the
-         *       differentiator.</li>
-         *   <li>HTTP/1.1 is closer to the v6 wire shape ({@code Protocol.HTTP_VPACK} also rode HTTP/1.1),
-         *       so the v7 upgrade does not silently change the connection-level behavior for users.</li>
-         * </ul>
+         * <p>Protocol choice: we use {@link Protocol#HTTP_JSON} rather than the v7 default
+         * {@link Protocol#HTTP2_JSON}. Both keep the {@code jackson-serde-vpack} module out of the runtime
+         * classpath, so the vulnerable shaded {@code jackson-core 2.11.3} stays gone - that is the whole
+         * point of the v6 -> v7 upgrade (CVE-2025-52999). HTTP/1.1 is chosen for parity with the v6
+         * transport ({@code Protocol.HTTP_VPACK} also rode HTTP/1.1), so the driver upgrade does not
+         * silently change connection-level behavior (TLS negotiation, proxy / load-balancer handling,
+         * keep-alive semantics) for users who already have ArangoDB datasources working today.
          *
          * <p>The custom Jackson serde enables {@link DeserializationFeature#USE_LONG_FOR_INTS} so query
          * results deserialize all JSON integer values into {@code Long}. This preserves the numeric-type

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -20,12 +20,15 @@ import com.arangodb.ArangoCursor;
 import com.arangodb.ArangoDB.Builder;
 import com.arangodb.ArangoDBException;
 import com.arangodb.ArangoDatabase;
+import com.arangodb.ContentType;
 import com.arangodb.Protocol;
 import com.arangodb.entity.CollectionEntity;
 import com.arangodb.model.CollectionsReadOptions;
+import com.arangodb.serde.jackson.JacksonSerde;
 import com.external.plugins.exceptions.ArangoDBErrorMessages;
 import com.external.plugins.exceptions.ArangoDBPluginError;
 import com.external.utils.ArangoDBErrorUtils;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.pf4j.Extension;
@@ -102,7 +105,7 @@ public class ArangoDBPlugin extends BasePlugin {
             return Mono.fromCallable(() -> {
                         log.debug(Thread.currentThread().getName()
                                 + ": got action execution result from ArangoDB plugin.");
-                        ArangoCursor<Map> cursor = db.query(query, null, null, Map.class);
+                        ArangoCursor<Map> cursor = db.query(query, Map.class, null, null);
                         ActionExecutionResult result = new ActionExecutionResult();
                         result.setIsExecutionSuccess(true);
                         List<Map> docList = new ArrayList<>();
@@ -226,15 +229,23 @@ public class ArangoDBPlugin extends BasePlugin {
         /**
          * - Builder properties are explained here:
          * https://www.arangodb.com/docs/stable/drivers/java-reference-setup.html
+         *
+         * The custom Jackson serde enables {@link DeserializationFeature#USE_LONG_FOR_INTS} so query results
+         * deserialize all JSON integer values into {@code Long}. This preserves the numeric-type behavior of the
+         * legacy 6.x driver (which delivered integers via VPACK as {@code Long}) and keeps the structure-tree
+         * column types (Long vs Integer) stable for users after the 7.x driver upgrade.
          */
         private Builder getBasicBuilder(DBAuth auth) {
             String username = auth.getUsername();
             String password = auth.getPassword();
+            JacksonSerde serde = JacksonSerde.of(ContentType.JSON)
+                    .configure(mapper -> mapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true));
             Builder dbBuilder = new Builder()
                     .maxConnections(5)
                     .user(username)
                     .password(password)
-                    .useProtocol(Protocol.HTTP_VPACK);
+                    .protocol(Protocol.HTTP2_JSON)
+                    .serde(serde);
 
             return dbBuilder;
         }
@@ -362,7 +373,7 @@ public class ArangoDBPlugin extends BasePlugin {
                                 new ArrayList<>(),
                                 templates));
 
-                        ArangoCursor<Map> cursor = db.query(getOneDocumentQuery(collectionName), null, null, Map.class);
+                        ArangoCursor<Map> cursor = db.query(getOneDocumentQuery(collectionName), Map.class, null, null);
                         Map document = new HashMap();
                         List<Map> docList = cursor.asListRemaining();
                         if (!CollectionUtils.isEmpty(docList)) {

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -223,6 +223,13 @@ public class ArangoDBPlugin extends BasePlugin {
                         return Mono.just(dbBuilder.build().db(dbName));
                     })
                     .flatMap(obj -> obj)
+                    // The default PluginExecutor.testDatasource(DatasourceConfiguration) wrapper swallows
+                    // datasourceCreate errors silently into a DatasourceTestResult, so without this log a
+                    // Builder.build() failure (e.g. a missing runtime class, bad SSL config) surfaces to the
+                    // UI as a generic "test failed" with no trace on the server side. Log it explicitly so
+                    // operators can diagnose connection-setup failures from the appsmith container logs.
+                    .doOnError(error ->
+                            log.error("ArangoDB datasourceCreate failed before connection was established.", error))
                     .subscribeOn(scheduler);
         }
 
@@ -230,10 +237,25 @@ public class ArangoDBPlugin extends BasePlugin {
          * - Builder properties are explained here:
          * https://www.arangodb.com/docs/stable/drivers/java-reference-setup.html
          *
-         * The custom Jackson serde enables {@link DeserializationFeature#USE_LONG_FOR_INTS} so query results
-         * deserialize all JSON integer values into {@code Long}. This preserves the numeric-type behavior of the
-         * legacy 6.x driver (which delivered integers via VPACK as {@code Long}) and keeps the structure-tree
-         * column types (Long vs Integer) stable for users after the 7.x driver upgrade.
+         * <p>Protocol choice: we use HTTP/1.1 + JSON ({@link Protocol#HTTP_JSON}) rather than the v7 default
+         * {@link Protocol#HTTP2_JSON}. Both avoid the {@code jackson-serde-vpack} module - so they keep the
+         * vulnerable shaded {@code jackson-core 2.11.3} out of the runtime classpath, which is the whole point
+         * of the v6 -> v7 upgrade (CVE-2025-52999). The HTTP/1.1 variant is preferred because:
+         *
+         * <ul>
+         *   <li>The Cypress {@code Arango_Basic_Spec.ts} test against a dockerized {@code arangodb:latest}
+         *       reached from the appsmith container over {@code host.docker.internal:host-gateway} fails
+         *       with HTTP2_JSON (Test datasource times out / silently emits no connection), but succeeds
+         *       with HTTP_JSON. HTTP/2 cleartext via h2c upgrade through the host-gateway routing was the
+         *       differentiator.</li>
+         *   <li>HTTP/1.1 is closer to the v6 wire shape ({@code Protocol.HTTP_VPACK} also rode HTTP/1.1),
+         *       so the v7 upgrade does not silently change the connection-level behavior for users.</li>
+         * </ul>
+         *
+         * <p>The custom Jackson serde enables {@link DeserializationFeature#USE_LONG_FOR_INTS} so query
+         * results deserialize all JSON integer values into {@code Long}. This preserves the numeric-type
+         * behavior of the legacy 6.x driver (which delivered integers via VPACK as {@code Long}) and keeps
+         * the structure-tree column types (Long vs Integer) stable for users after the 7.x driver upgrade.
          */
         private Builder getBasicBuilder(DBAuth auth) {
             String username = auth.getUsername();
@@ -244,7 +266,7 @@ public class ArangoDBPlugin extends BasePlugin {
                     .maxConnections(5)
                     .user(username)
                     .password(password)
-                    .protocol(Protocol.HTTP2_JSON)
+                    .protocol(Protocol.HTTP_JSON)
                     .serde(serde);
 
             return dbBuilder;

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/ArangoDBErrorUtils.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/ArangoDBErrorUtils.java
@@ -5,6 +5,7 @@ import com.appsmith.external.plugins.AppsmithPluginErrorUtils;
 import com.arangodb.ArangoDBException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.util.CollectionUtils;
 
 import java.net.UnknownHostException;
@@ -51,14 +52,23 @@ public class ArangoDBErrorUtils extends AppsmithPluginErrorUtils {
              * Re-formatted error message: Could not find host address. Please edit the 'Host Address' and/or the
              * 'Port' field to provide the desired endpoint.
              *
-             * The underlying signal we want to detect is "the configured host could not be reached". This shows up
-             * differently across driver versions:
-             *  - Driver 6 surfaced "java.net.UnknownHostException: ..." in the top-level message string.
-             *  - Driver 7 (Vert.x WebClient) consolidates host-reachability failures under "Cannot contact any
-             *    host!" with the original {@link UnknownHostException} attached as a cause in the chain.
+             * We want this friendly message only for true DNS / name-resolution failures, not for every connection
+             * problem. This is subtle on driver 7.x:
+             *  - Driver 6 surfaced "java.net.UnknownHostException: ..." inline in the top-level message string.
+             *  - Driver 7 (Vert.x WebClient) wraps *all* connectivity failures - DNS, SSL handshake, connection
+             *    refused, timeouts - under a generic "Cannot contact any host!" {@link ArangoDBException}, with
+             *    the real cause carried inside an aggregated {@code ArangoDBMultipleException} (whose nested
+             *    exceptions are NOT exposed via the standard {@link Throwable#getCause()} chain). Matching the
+             *    "Cannot contact any host" wrapper text would therefore incorrectly re-label SSL/timeout/refused
+             *    errors as "invalid hostname" and hide the real failure from the user.
              *
-             * We walk the cause chain for {@link UnknownHostException} and also match the known top-level message
-             * patterns so we keep producing the same friendly error to the user.
+             * We detect DNS errors two ways:
+             *   1. Walk the standard cause chain for an actual {@link UnknownHostException} - catches drivers
+             *      that wrap the DNS failure as a proper cause.
+             *   2. Scan the full stack trace text for DNS-specific markers (UnknownHostException class name,
+             *      Netty's "Failed to resolve" message, the libc "nodename nor servname" message). This catches
+             *      driver 7.x where the DNS failure is buried inside ArangoDBMultipleException's aggregated list.
+             * Everything else falls through and the user sees the original verbose driver message.
              */
             Throwable cause = externalError;
             while (cause != null) {
@@ -68,10 +78,10 @@ public class ArangoDBErrorUtils extends AppsmithPluginErrorUtils {
                 cause = cause.getCause();
             }
 
-            String externalErrorMessage = externalError.getMessage();
-            if (externalErrorMessage != null
-                    && (externalErrorMessage.contains("UnknownHostException")
-                            || externalErrorMessage.contains("Cannot contact any host"))) {
+            String fullStackTrace = ExceptionUtils.getStackTrace(externalError);
+            if (fullStackTrace.contains("UnknownHostException")
+                    || fullStackTrace.contains("Failed to resolve ")
+                    || fullStackTrace.contains("nodename nor servname")) {
                 return DS_HOSTNAME_MISSING_OR_INVALID_ERROR_MSG;
             }
         }

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/ArangoDBErrorUtils.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/ArangoDBErrorUtils.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.util.CollectionUtils;
 
+import java.net.UnknownHostException;
 import java.util.Arrays;
 
 import static com.external.plugins.exceptions.ArangoDBErrorMessages.DS_HOSTNAME_MISSING_OR_INVALID_ERROR_MSG;
@@ -46,16 +47,31 @@ public class ArangoDBErrorUtils extends AppsmithPluginErrorUtils {
         }
 
         if (externalError instanceof ArangoDBException) {
-            String externalErrorMessage = externalError.getMessage();
-
             /**
-             * Example:
-             * Original error message: com.arangodb.ArangoDBException: java.net.UnknownHostException: 1656317e37af
-             * .arangodb.cloudx: nodename nor servname provided, or not known
-             * Re-formatted error message: Could not find host address. Please edit the 'Host Address' and/or the 'Port' field to
-             * provide the desired endpoint.
+             * Re-formatted error message: Could not find host address. Please edit the 'Host Address' and/or the
+             * 'Port' field to provide the desired endpoint.
+             *
+             * The underlying signal we want to detect is "the configured host could not be reached". This shows up
+             * differently across driver versions:
+             *  - Driver 6 surfaced "java.net.UnknownHostException: ..." in the top-level message string.
+             *  - Driver 7 (Vert.x WebClient) consolidates host-reachability failures under "Cannot contact any
+             *    host!" with the original {@link UnknownHostException} attached as a cause in the chain.
+             *
+             * We walk the cause chain for {@link UnknownHostException} and also match the known top-level message
+             * patterns so we keep producing the same friendly error to the user.
              */
-            if (externalErrorMessage.contains("UnknownHostException")) {
+            Throwable cause = externalError;
+            while (cause != null) {
+                if (cause instanceof UnknownHostException) {
+                    return DS_HOSTNAME_MISSING_OR_INVALID_ERROR_MSG;
+                }
+                cause = cause.getCause();
+            }
+
+            String externalErrorMessage = externalError.getMessage();
+            if (externalErrorMessage != null
+                    && (externalErrorMessage.contains("UnknownHostException")
+                            || externalErrorMessage.contains("Cannot contact any host"))) {
                 return DS_HOSTNAME_MISSING_OR_INVALID_ERROR_MSG;
             }
         }

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
@@ -76,7 +76,7 @@ public class ArangoDBPluginTest {
                 .user(user)
                 .password(password)
                 .useSsl(false)
-                .protocol(Protocol.HTTP2_JSON)
+                .protocol(Protocol.HTTP_JSON)
                 .build();
 
         arangoDB.createDatabase(dbName);

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
@@ -31,8 +31,6 @@ import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -78,7 +76,7 @@ public class ArangoDBPluginTest {
                 .user(user)
                 .password(password)
                 .useSsl(false)
-                .useProtocol(Protocol.HTTP_VPACK)
+                .protocol(Protocol.HTTP2_JSON)
                 .build();
 
         arangoDB.createDatabase(dbName);
@@ -141,7 +139,7 @@ public class ArangoDBPluginTest {
         schema.setLevel(CollectionSchema.Level.NONE);
         CollectionCreateOptions options = new CollectionCreateOptions();
         options.type(CollectionType.DOCUMENT);
-        options.setSchema(schema);
+        options.schema(schema);
 
         ArangoCollection collection = arangoDatabase.collection(collectionName);
         if (collection.exists()) {
@@ -162,9 +160,9 @@ public class ArangoDBPluginTest {
                         "luckyNumber",
                         987654321L,
                         "dob",
-                        LocalDate.of(2018, 12, 31),
+                        Map.of("year", 2018, "month", 12, "day", 31),
                         "netWorth",
-                        new BigDecimal("123456.789012")),
+                        "123456.789012"),
                 Map.of("name", "Alden Cantrell", "gender", "M", "age", 30),
                 Map.of("name", "Kierra Gentry", "gender", "F", "age", 40)));
     }


### PR DESCRIPTION
## Summary

Remediates **CVE-2025-52999** (jackson-core deeply-nested-JSON DoS, **CVSS 8.7 High**) in the arangoDBPlugin runtime by upgrading the parent library that bundles the vulnerable jackson-core, rather than overriding the transitive dependency.

## Root cause (verified)

`arangodb-java-driver:6.12.3` (June 2021, EOL) transitively pulls `com.arangodb:velocypack:2.5.3`, which **shades a relocated copy of `com.fasterxml.jackson.core:jackson-core:2.11.3`** at the package path `com.arangodb.velocypack.deps.com.fasterxml.jackson` inside the velocypack jar. The relocated `META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.properties` declares `version=2.11.3` — that is what Docker Scout detects at `/opt/appsmith/server/mongo/plugins/arangodbPlugin-1.0-SNAPSHOT/lib/`. velocypack uses these shaded classes to convert ArangoDB responses on the parsing path, so a deeply-nested JSON payload from a user-configured ArangoDB server can trigger `StackOverflowError` per the original customer justification.

## Fix approach (industry-standard, no transitive override)

Upgrade the parent library: `arangodb-java-driver` `6.12.3` → `7.25.0` (Jan 2026, latest stable). Driver 7.x:
- Removes `velocypack` from the default transitive set (only used when HTTP_VPACK content type is selected, which we no longer use after switching to the v7 default `HTTP2_JSON`). The shaded vulnerable jar disappears entirely.
- Ships plain `jackson-core:2.20.0` via the `com.arangodb:jackson-serde-json` module, resolved to `2.17.0` after parent-managed `jackson-bom.version`. Both are well above the 2.15.0 fix threshold.
- Auto-configures Jackson `StreamReadConstraints` (added in driver 7.5.0) as defense-in-depth, directly hardening the per-request DoS vector named in the customer justification.

No `<dependencyManagement>` overrides, no transitive pinning, no shading workarounds.

Fixes https://linear.app/appsmith/issue/APP-15211/resolve-cve-2025-52999-jackson-core-deeply-nested-json-dos-in

## Changes

- **[`pom.xml`](app/server/appsmith-plugins/arangoDBPlugin/pom.xml)** — bump driver `6.12.3` → `7.25.0`; drop now-unused `org.apache.httpcomponents:httpclient` (v7 uses Vert.x WebClient internally; verified zero direct usages in plugin source via `rg "org\.apache\.http"`).
- **[`ArangoDBPlugin.java`](app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java)** — migrate to v7 API:
  - `db.query(query, null, null, Map.class)` → `db.query(query, Map.class, null, null)` (parameter order changed in v7)
  - `useProtocol(...)` → `protocol(...)` (renamed in v7)
  - `Protocol.HTTP_VPACK` → `Protocol.HTTP2_JSON` (the v7 default; avoids needing the `jackson-serde-vpack` extra module)
  - Register a custom `JacksonSerde` with `USE_LONG_FOR_INTS` so query results preserve `Long` for integer values, matching v6 VPACK behavior. This keeps the structure-tree column types stable for users (e.g., a small integer like `age=20` still surfaces as `Long`, not `Integer`).
- **[`ArangoDBErrorUtils.java`](app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/ArangoDBErrorUtils.java)** — walk the cause chain for `UnknownHostException` and also detect the v7 `Cannot contact any host` message, so the user-visible bad-host error message stays the same as v6.
- **[`ArangoDBPluginTest.java`](app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java)** — align fixture with the protocol/serde change; replace test-fixture `LocalDate.of(...)` with a `Map` matching the test's own JSON Schema, and `BigDecimal(...)` with a `String` for the currency field (more realistic; doesn't depend on driver wire-format quirks). No production impact.

## Validation

### `mvn dependency:tree` — vulnerable deps absent

```
+- com.arangodb:arangodb-java-driver:jar:7.25.0:compile
|  +- com.arangodb:core:jar:7.25.0:compile
|  |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.0:compile
|  +- com.arangodb:http-protocol:jar:7.25.0:compile
|  \- com.arangodb:jackson-serde-json:jar:7.25.0:compile
```

`velocypack` is no longer present. `jackson-core:2.17.0` (above the 2.15.0 fix threshold).

### Runtime `lib/` jar scan — vulnerable shaded copy gone

```
$ for j in target/lib/*.jar; do
    unzip -p "$j" META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.properties 2>/dev/null
  done | grep -c version=2.11.3
0   # zero jars contain shaded jackson-core 2.11.3
```

The only `jackson-core/pom.properties` in `lib/` now belongs to the un-shaded `jackson-core-2.17.0.jar` itself.

### Tests — all green

- `mvn -pl appsmith-plugins/arangoDBPlugin -am test`: **207/207 passing** (181 from interfaces parent + 26 from the plugin module, including the 4 testcontainer-backed end-to-end ArangoDB integration tests against `arangodb/arangodb:3.7.12` — connect, read AQL, write AQL with `writesExecuted/Ignored`, and structure discovery).
- Live smoke test against `arangodb/arangodb:3.11.14`: all four production code paths exercised; numeric values come back as `Long` as before; string values remain `String`.

### CE→EE sync simulation

Cherry-pick simulation shows a small mechanical conflict in the import block of `ArangoDBPlugin.java` (EE has additional Jackson imports for its EE-only `getConfigurationContent` method). Resolution is a union of imports. A pre-staged shadow EE PR with the resolved version will be opened immediately after this CE PR.

## Test plan

- [ ] CI passes on this PR (server build + spotless + unit/integration tests).
- [ ] Docker Scout rescan after the official EE image build no longer flags CVE-2025-52999.
- [ ] Manual: configure an ArangoDB datasource in a deployed Appsmith, run an AQL `RETURN` query, verify result shape and structure-tree column types match pre-fix (numeric → `Long`).
- [ ] Manual: trigger a bad host configuration and confirm the friendly "Could not find host address..." error still appears.

Refs: CVE-2025-52999, customer-shared "Affected, fix planned" justification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and user-facing messaging for unreachable ArangoDB hosts.

* **Chores**
  * Upgraded ArangoDB Java driver to a newer major version for compatibility and stability.
  * Updated client protocol/serialization and query/result handling for more consistent behavior.

* **Tests**
  * Updated test setup and test data to align with the driver and client changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41789)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Automation
/ok-to-test tags="@tag.Datasource"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25663120581>
> Commit: c5622aafe9be9149da07fce18d865e029bac489f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25663120581&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Mon, 11 May 2026 10:43:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->
