### PR TITLE
docs: fix typo "comparision" → "comparison" in formControls/utils.ts comment

### DIFF
--- a/app/client/src/components/formControls/utils.ts
+++ b/app/client/src/components/formControls/utils.ts
@@ -286,7 +286,7 @@ export const caculateIsHidden = (
       case "NOT_IN":
         return Array.isArray(value) && !value.includes(valueAtPath);
       case "FEATURE_FLAG":
-        // FEATURE_FLAG comparision is used to hide previous configs,
+        // FEATURE_FLAG comparison is used to hide previous configs,
         // and show new configs if feature flag is enabled, if disabled/ not present,
         // previous config would be shown as is
         return !!featureFlags && featureFlags[flagValue] === value;


### PR DESCRIPTION
Comment-only typo fix in `app/client/src/components/formControls/utils.ts:289` on the FEATURE_FLAG case-handling comment. DCO sign-off included. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * No user-facing changes.
  * Minor documentation clarity update: corrected a spelling in an internal comparison comment. No logic, behavior, or public API was changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->