### PR TITLE
chore(helm): upgrade bundled Redis from 7.0.15 to 7.4.9

### DIFF
--- a/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
@@ -108,7 +108,7 @@
                 - sh
                 - -c
                 - until redis-cli -h RELEASE-NAME-redis-master.NAMESPACE.svc.cluster.local ping ; do echo waiting for redis; sleep 2; done
-              image: docker.io/redis:7.0.15
+              image: docker.io/redis:7.4.9
               name: redis-init-container
             - command:
                 - sh

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -23,7 +23,7 @@ redis: # @schema additionalProperties: true
   image:
     registry: docker.io
     repository: redis
-    tag: 7.0.15
+    tag: 7.4.9
 
 ## MongoDB parameters
 ## Values are passed through to the Bitnami mongodb subchart; not validated by this schema.
@@ -242,7 +242,7 @@ strategyType: RollingUpdate
 # @schema description: Init container image overrides for bundled redis/mongodb/postgresql dependencies.
 initContainer: {}
   # redis:
-  #   image: docker.io/redis:7.0.15
+  #   image: docker.io/redis:7.4.9
   # mongodb:
   #   image:  docker.io/bitnami/mongodb:5.0.21-debian-11-r5
   # postgresql:


### PR DESCRIPTION
## Summary
- Bumps the default Redis image tag in the Helm chart from `7.0.15` to `7.4.9` to address accumulated CVEs in the 7.0.x line
- Also updates the example comment in the `initContainer` section to match

## Test plan
- [x] Test on non-prod deployments and verify cluster status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis dependency to version 7.4.9.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41792)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 1cf4fdbf76f9d082a5a31f7e22b3f39609f9175f yet
> <hr>Mon, 11 May 2026 18:40:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->
