### PR TITLE
fix(git): strip only leading origin prefix

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -138,7 +138,6 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
     protected final ObservationRegistry observationRegistry;
 
     protected static final String ORIGIN = "origin/";
-    protected static final String REMOTE_NAME_REPLACEMENT = "";
 
     private boolean isInvalidSshKeyError(Throwable throwable) {
         // Log the original error for debugging purposes
@@ -517,7 +516,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
         }
 
         String baseArtifactId = baseGitMetadata.getDefaultArtifactId();
-        final String finalRefName = gitRefDTO.getRefName().replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT);
+        final String finalRefName = stripOriginPrefix(gitRefDTO.getRefName());
         ArtifactType artifactType = baseArtifact.getArtifactType();
 
         GitArtifactHelper<?> gitArtifactHelper = gitArtifactHelperResolver.getArtifactHelper(artifactType);
@@ -620,7 +619,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
         final String baseArtifactId = baseGitMetadata.getDefaultArtifactId();
         final String baseRefName = baseGitMetadata.getRefName();
         final String workspaceId = baseArtifact.getWorkspaceId();
-        final String finalRemoteRefName = gitRefDTO.getRefName().replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT);
+        final String finalRemoteRefName = stripOriginPrefix(gitRefDTO.getRefName());
 
         ArtifactJsonTransformationDTO jsonTransformationDTO = new ArtifactJsonTransformationDTO(
                 workspaceId, baseArtifactId, repoName, baseArtifact.getArtifactType());
@@ -909,7 +908,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                 sourceArtifact.getId(), VERSION_CONTROL, sourceArtifact.getArtifactType());
     }
 
-    private String stripOriginPrefix(String refName) {
+    static String stripOriginPrefix(String refName) {
         if (refName == null) {
             return "";
         }
@@ -940,7 +939,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
         String normalisedIncomingRefName = stripOriginPrefix(incomingGitRefDTO.getRefName());
         Boolean isDuplicateName = fetchedGitRefDTOS.stream()
                 .map(GitRefDTO::getRefName)
-                .map(this::stripOriginPrefix)
+                .map(CentralGitServiceCEImpl::stripOriginPrefix)
                 .anyMatch(normalisedIncomingRefName::equals);
 
         if (TRUE.equals(isDuplicateName)) {
@@ -2651,7 +2650,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                             }
 
                             // remove `origin/` prefix from the remote branch name
-                            String branchName = gitRefDTO.getRefName().replace(ORIGIN, REMOTE_NAME_REPLACEMENT);
+                            String branchName = stripOriginPrefix(gitRefDTO.getRefName());
                             branchesToCheckout.add(branchName);
 
                             // TODO: base artifact wouldn't be cloned if from remote the default branch is changed,
@@ -3214,8 +3213,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                                                             workspaceId,
                                                             destinationArtifact.getId(),
                                                             artifactExchangeJson,
-                                                            destinationBranch.replaceFirst(
-                                                                    ORIGIN, REMOTE_NAME_REPLACEMENT))
+                                                            stripOriginPrefix(destinationBranch))
                                                     .flatMap(importedDestinationArtifact -> {
                                                         CommitDTO commitDTO = new CommitDTO();
                                                         commitDTO.setMessage(DEFAULT_COMMIT_MESSAGE

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
@@ -2912,7 +2912,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                         for (GitBranchDTO gitBranchDTO : gitBranchDTOList) {
                             if (gitBranchDTO.getBranchName().startsWith("origin/")) {
                                 // remove origin/ prefix from the remote branch name
-                                String branchName = gitBranchDTO.getBranchName().replace("origin/", "");
+                                String branchName = stripOriginPrefix(gitBranchDTO.getBranchName());
                                 // The root defaultArtifact is always there, no need to check out it again
                                 if (!branchName.equals(gitArtifactMetadata.getRefName())) {
                                     branchesToCheckout.add(branchName);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/common/CommonGitServiceCEImpl.java
@@ -145,7 +145,16 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
     private final GitAutoCommitHelper gitAutoCommitHelper;
 
     private static final String ORIGIN = "origin/";
-    private static final String REMOTE_NAME_REPLACEMENT = "";
+
+    static String stripOriginPrefix(String refName) {
+        if (refName == null) {
+            return "";
+        }
+        if (refName.startsWith(ORIGIN)) {
+            return refName.substring(ORIGIN.length());
+        }
+        return refName;
+    }
 
     private Mono<Boolean> addFileLock(String baseArtifactId, String commandName, boolean isLockRequired) {
         if (!Boolean.TRUE.equals(isLockRequired)) {
@@ -1343,7 +1352,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
         }
 
         String baseArtifactId = baseGitMetadata.getDefaultArtifactId();
-        final String finalBranchName = branchToBeCheckedOut.replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT);
+        final String finalBranchName = stripOriginPrefix(branchToBeCheckedOut);
 
         GitArtifactHelper<?> gitArtifactHelper = getArtifactGitService(baseArtifact.getArtifactType());
 
@@ -1420,7 +1429,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
         final String baseArtifactId = baseGitMetadata.getDefaultArtifactId();
         final String baseBranchName = baseGitMetadata.getRefName();
         final String workspaceId = baseArtifact.getWorkspaceId();
-        final String finalRemoteBranchName = remoteBranchName.replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT);
+        final String finalRemoteBranchName = stripOriginPrefix(remoteBranchName);
 
         Path repoSuffixPath = gitArtifactHelper.getRepoSuffixPath(workspaceId, baseArtifactId, repoName);
 
@@ -1650,8 +1659,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                                                 // We are only supporting origin as the remote name so this is safe
                                                 //  but needs to be altered if we start supporting user defined remote
                                                 // names
-                                                .anyMatch(branch -> branch.getBranchName()
-                                                        .replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT)
+                                                .anyMatch(branch -> stripOriginPrefix(branch.getBranchName())
                                                         .equals(branchDTO.getBranchName()));
 
                                         if (isDuplicateName) {
@@ -2462,7 +2470,7 @@ public class CommonGitServiceCEImpl implements CommonGitServiceCE {
                                                 workspaceId,
                                                 destinationArtifact.getId(),
                                                 artifactExchangeJson,
-                                                destinationBranch.replaceFirst(ORIGIN, REMOTE_NAME_REPLACEMENT))
+                                                stripOriginPrefix(destinationBranch))
                                         .flatMap(importedDestinationArtifact -> {
                                             GitCommitDTO commitDTO = new GitCommitDTO();
                                             commitDTO.setDoPush(true);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/CentralGitServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/central/CentralGitServiceCEImplTest.java
@@ -1,0 +1,18 @@
+package com.appsmith.server.git.central;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CentralGitServiceCEImplTest {
+
+    @Test
+    void stripOriginPrefix_stripsOnlyLeadingOriginSegment() {
+        assertThat(CentralGitServiceCEImpl.stripOriginPrefix("origin/main")).isEqualTo("main");
+        assertThat(CentralGitServiceCEImpl.stripOriginPrefix("feature/origin/main"))
+                .isEqualTo("feature/origin/main");
+        assertThat(CentralGitServiceCEImpl.stripOriginPrefix("origin/feature/origin/main"))
+                .isEqualTo("feature/origin/main");
+        assertThat(CentralGitServiceCEImpl.stripOriginPrefix(null)).isEmpty();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/common/CommonGitServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/common/CommonGitServiceCEImplTest.java
@@ -1,0 +1,18 @@
+package com.appsmith.server.git.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommonGitServiceCEImplTest {
+
+    @Test
+    void stripOriginPrefix_stripsOnlyLeadingOriginSegment() {
+        assertThat(CommonGitServiceCEImpl.stripOriginPrefix("origin/main")).isEqualTo("main");
+        assertThat(CommonGitServiceCEImpl.stripOriginPrefix("feature/origin/main"))
+                .isEqualTo("feature/origin/main");
+        assertThat(CommonGitServiceCEImpl.stripOriginPrefix("origin/feature/origin/main"))
+                .isEqualTo("feature/origin/main");
+        assertThat(CommonGitServiceCEImpl.stripOriginPrefix(null)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Description
> [!TIP]
> **TL;DR** — Completes the `origin/` prefix-normalization follow-up from #41758 so branch names that contain `origin/` after the prefix are not corrupted.

Related to #41758.

#41758 introduced `stripOriginPrefix(...)` in `CentralGitServiceCEImpl` because `replaceFirst(ORIGIN, "")` can remove `origin/` from the middle of a ref name. Its follow-up notes called out the remaining Central/Common service sites for a separate sweep.

This PR applies the same anchored-prefix behavior to the remaining `CentralGitServiceCEImpl` and `CommonGitServiceCEImpl` paths that were still using `replaceFirst(ORIGIN, "")` or `replace(ORIGIN, "")`. For example:

- `origin/feature/origin/main` still normalizes to `feature/origin/main`
- `feature/origin/main` stays `feature/origin/main`

It also adds focused unit coverage for the shared helper behavior in both service packages.

## Automation



### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

## Tests

- `git diff --check`
- Not run locally: `mvn -pl appsmith-server -Dtest=CentralGitServiceCEImplTest,CommonGitServiceCEImplTest -DskipITs test` because this environment does not have `mvn` installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated git branch reference normalization for consistent handling across checkouts, branch creation, repository re-cloning/enumeration, and merges; normalization now robustly handles nulls and only removes leading remote prefixes.

* **Tests**
  * Added unit tests covering reference name normalization, including leading-remote removal, non-leading occurrences, and null inputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41793)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->