### PR TITLE
fix(security): Unauthenticated Access to Full OpenAPI Documentation (GHSA-v6jh-fx3m-7xhw)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -213,7 +213,6 @@ public class SecurityConfig {
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/invite/verify"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/invite/confirm"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/me"),
-                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/v3/**"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ASSET_URL + "/*"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_URL + "/**"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_COLLECTION_URL + "/view"),

--- a/app/server/appsmith-server/src/main/resources/application-ce.properties
+++ b/app/server/appsmith-server/src/main/resources/application-ce.properties
@@ -114,3 +114,5 @@ appsmith.index.lock.file.time=${APPSMITH_INDEX_LOCK_FILE_TIME:300}
 
 springdoc.api-docs.path=/v3/docs
 springdoc.swagger-ui.path=/v3/swagger
+springdoc.api-docs.enabled=false
+springdoc.swagger-ui.enabled=false

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/OpenApiDocsAuthTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/OpenApiDocsAuthTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.reactive.context.ReactiveWebApplicationContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity;
@@ -11,8 +12,13 @@ import static org.springframework.security.test.web.reactive.server.SecurityMock
 /**
  * GHSA-v6jh-fx3m-7xhw: Verify that OpenAPI documentation endpoints
  * are not accessible without authentication.
+ *
+ * Springdoc is disabled by default in production. We re-enable it here so
+ * the endpoints register and we can assert the security layer rejects
+ * unauthenticated requests (401) rather than simply not finding them (404).
  */
 @SpringBootTest
+@TestPropertySource(properties = {"springdoc.api-docs.enabled=true", "springdoc.swagger-ui.enabled=true"})
 public class OpenApiDocsAuthTest {
 
     private WebTestClient webTestClient;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/OpenApiDocsAuthTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/OpenApiDocsAuthTest.java
@@ -1,0 +1,36 @@
+package com.appsmith.server.configurations;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.reactive.context.ReactiveWebApplicationContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity;
+
+/**
+ * GHSA-v6jh-fx3m-7xhw: Verify that OpenAPI documentation endpoints
+ * are not accessible without authentication.
+ */
+@SpringBootTest
+public class OpenApiDocsAuthTest {
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setup(ReactiveWebApplicationContext context) {
+        webTestClient = WebTestClient.bindToApplicationContext(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void openApiDocsEndpoint_unauthenticated_returns401() {
+        webTestClient.get().uri("/v3/docs").exchange().expectStatus().isUnauthorized();
+    }
+
+    @Test
+    void swaggerUiEndpoint_unauthenticated_returns401() {
+        webTestClient.get().uri("/v3/swagger-ui.html").exchange().expectStatus().isUnauthorized();
+    }
+}


### PR DESCRIPTION
## Description

fix(security): Unauthenticated Access to Full OpenAPI Documentation (GHSA-v6jh-fx3m-7xhw)

- **Primary fix:** Remove `/v3/**` from the `permitAll()` block in `SecurityConfig.java` so OpenAPI endpoints require authentication
- **Defense-in-depth:** Disable springdoc API docs and Swagger UI by default via `springdoc.api-docs.enabled=false` and `springdoc.swagger-ui.enabled=false` in `application-ce.properties`
- **Test coverage:** Added `OpenApiDocsAuthTest` verifying that unauthenticated requests to `/v3/docs` and `/v3/swagger-ui.html` return 401

Fixes APP-15216

### Vulnerability

| Field | Value |
|-------|-------|
| **GHSA** | [GHSA-v6jh-fx3m-7xhw](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-v6jh-fx3m-7xhw) |
| **CVE** | Not assigned |
| **CVSS** | 5.3 (medium) |
| **CWE** | CWE-200 |
| **Affected component** | Unauthenticated Access to Full OpenAPI Documentation |

### Exposure Analysis

- **Who can exploit:** Any unauthenticated network user. No credentials or special role required.
- **What an attacker achieves:** Full enumeration of every API endpoint, request/response schemas, parameter names, and authentication requirements — significantly accelerating targeted reconnaissance.
- **Exploited in the wild:** No evidence. The standard Caddy reverse proxy mitigates this by only routing `/api/*` to the backend, so the endpoints are not reachable through the proxy. However, self-hosted deployments that expose port 8080 directly or use a different reverse proxy are vulnerable.
- **Blast radius:** Information disclosure only (API surface topology). No data modification or privilege escalation.

### Fix

- **Root cause:** The `springdoc-openapi-starter-webflux-ui` dependency (added in PR #33477 as developer tooling) auto-registers OpenAPI endpoints at `/v3/docs` and `/v3/swagger`. The `/v3/**` path was explicitly added to the `permitAll()` block in `SecurityConfig.java`, bypassing authentication.
- **Fix strategy:** Two defense-in-depth layers at the configuration level: (1) disable springdoc endpoint registration via properties, (2) remove the unauthenticated access exception from Spring Security. The pom.xml dependency is intentionally left in place so developers can re-enable springdoc locally.
- **Intentionally NOT changed:** The springdoc dependency in `pom.xml` — removing it would break local development workflows. The `enabled=false` toggle is the standard springdoc mechanism for production disablement.

### CE/EE sync

CE-only safe: no EE overrides of touched files (`SecurityConfig.java`, `application-ce.properties`). Hourly sync will propagate.

### Disclosure

> **Do not merge until advisory is ready for disclosure coordination.**
>
> After merge:
> 1. Confirm fix is in release branch
> 2. Coordinate with security team on disclosure timeline
> 3. Update advisory with patched version and publish
> 4. Notify reporter

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25784782954>
> Commit: 7b1090c29fcfd4af846253f2d7cead4789b50a49
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25784782954&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 13 May 2026 08:46:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

## Follow-ups

- Integration test (`OpenApiDocsAuthTest`) requires full application context (MongoDB, Redis). Verified locally that it follows the same pattern as existing `AuthGuardTest` and `CsrfTest`. Will run in CI.
- No additional instances of the vulnerable pattern found in codebase audit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API documentation endpoints (OpenAPI/Swagger UI) are no longer publicly accessible and now require authentication.
* **Configuration**
  * API docs and Swagger UI are explicitly disabled by default.
* **Tests**
  * Added tests to verify unauthenticated requests to the API docs and Swagger UI return 401 Unauthorized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41803)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->