### PR TITLE
perf: removed extra entry from db argument

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/importable/ActionCollectionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/importable/ActionCollectionImportableServiceCEImpl.java
@@ -12,6 +12,7 @@ import com.appsmith.server.dtos.ArtifactExchangeJson;
 import com.appsmith.server.dtos.ImportActionCollectionResultDTO;
 import com.appsmith.server.dtos.ImportingMetaDTO;
 import com.appsmith.server.dtos.MappedImportableResourcesDTO;
+import com.appsmith.server.helpers.GitUtils;
 import com.appsmith.server.imports.importable.ImportableServiceCE;
 import com.appsmith.server.imports.importable.artifactbased.ArtifactBasedImportableService;
 import com.appsmith.server.repositories.ActionCollectionRepository;
@@ -170,10 +171,16 @@ public class ActionCollectionImportableServiceCEImpl implements ImportableServic
                                     .collectMap(ActionCollection::getGitSyncId);
 
                     Mono<Map<String, ActionCollection>> actionCollectionsInBranchesMono;
-                    if (artifact.getGitArtifactMetadata() != null) {
+                    if (GitUtils.isArtifactConnectedToGit(artifact.getGitArtifactMetadata())) {
+
+                        List<String> allOtherBranches = importingMetaDTO.getBranchedArtifactIds().stream()
+                                .filter(branchedArtifactId ->
+                                        !branchedArtifactId.equals(importingMetaDTO.getArtifactId())
+                                                && !branchedArtifactId.equals(artifact.getId()))
+                                .toList();
+
                         actionCollectionsInBranchesMono = artifactBasedImportableService
-                                .getExistingResourcesInOtherBranchesFlux(
-                                        importingMetaDTO.getBranchedArtifactIds(), artifact.getId())
+                                .getExistingResourcesInOtherBranchesFlux(allOtherBranches)
                                 .filter(actionCollection -> actionCollection.getGitSyncId() != null)
                                 .collectMap(ActionCollection::getGitSyncId);
                     } else {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/importable/applications/ActionCollectionApplicationImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/importable/applications/ActionCollectionApplicationImportableServiceCEImpl.java
@@ -22,7 +22,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -58,11 +57,8 @@ public class ActionCollectionApplicationImportableServiceCEImpl
     }
 
     @Override
-    public Flux<ActionCollection> getExistingResourcesInOtherBranchesFlux(
-            List<String> branchedArtifactIds, String currentArtifactId) {
-        return repository
-                .findAllByApplicationIds(branchedArtifactIds, null)
-                .filter(actionCollection -> !Objects.equals(actionCollection.getApplicationId(), currentArtifactId));
+    public Flux<ActionCollection> getExistingResourcesInOtherBranchesFlux(List<String> branchedArtifactIds) {
+        return repository.findAllByApplicationIds(branchedArtifactIds, null);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/artifactbased/ArtifactBasedImportableServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/importable/artifactbased/ArtifactBasedImportableServiceCE.java
@@ -20,7 +20,7 @@ public interface ArtifactBasedImportableServiceCE<T extends BaseDomain, U extend
 
     Flux<T> getExistingResourcesInCurrentArtifactFlux(Artifact artifact);
 
-    Flux<T> getExistingResourcesInOtherBranchesFlux(List<String> branchedArtifactIds, String currentArtifactId);
+    Flux<T> getExistingResourcesInOtherBranchesFlux(List<String> branchedArtifactIds);
 
     void updateArtifactId(T resource, Artifact artifact);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/NewActionImportableServiceCEImpl.java
@@ -19,6 +19,7 @@ import com.appsmith.server.dtos.ImportingMetaDTO;
 import com.appsmith.server.dtos.MappedImportableResourcesDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.GitUtils;
 import com.appsmith.server.helpers.ImportArtifactPermissionProvider;
 import com.appsmith.server.imports.importable.ImportableServiceCE;
 import com.appsmith.server.imports.importable.artifactbased.ArtifactBasedImportableService;
@@ -320,10 +321,15 @@ public class NewActionImportableServiceCEImpl implements ImportableServiceCE<New
 
             // find existing actions in all the branches of this artifact and put them in a map
             Mono<Map<String, NewAction>> actionsInOtherBranchesMono;
-            if (artifact.getGitArtifactMetadata() != null) {
+            if (GitUtils.isArtifactConnectedToGit(artifact.getGitArtifactMetadata())) {
+
+                List<String> allOtherBranches = importingMetaDTO.getBranchedArtifactIds().stream()
+                        .filter(branchedArtifactId -> !branchedArtifactId.equals(importingMetaDTO.getArtifactId())
+                                && !branchedArtifactId.equals(artifact.getId()))
+                        .toList();
+
                 actionsInOtherBranchesMono = artifactBasedImportableService
-                        .getExistingResourcesInOtherBranchesFlux(
-                                importingMetaDTO.getBranchedArtifactIds(), artifact.getId())
+                        .getExistingResourcesInOtherBranchesFlux(allOtherBranches)
                         .filter(newAction -> newAction.getGitSyncId() != null)
                         .collectMap(NewAction::getGitSyncId);
             } else {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/importable/applications/NewActionApplicationImportableServiceCEImpl.java
@@ -22,7 +22,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -58,11 +57,8 @@ public class NewActionApplicationImportableServiceCEImpl
     }
 
     @Override
-    public Flux<NewAction> getExistingResourcesInOtherBranchesFlux(
-            List<String> branchedArtifactIds, String currentArtifactId) {
-        return repository
-                .findAllByApplicationIds(branchedArtifactIds, null)
-                .filter(newAction -> !Objects.equals(newAction.getApplicationId(), currentArtifactId));
+    public Flux<NewAction> getExistingResourcesInOtherBranchesFlux(List<String> branchedArtifactIds) {
+        return repository.findAllByApplicationIds(branchedArtifactIds, null);
     }
 
     @Override


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags="@tag.Git, @tag.ImportExport"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25795345580>
> Commit: d33b2b6e689ad9f389fae9c907436ddeac0a0c02
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25795345580&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git, @tag.ImportExport`
> Spec:
> <hr>Wed, 13 May 2026 11:29:49 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved import handling for actions and action collections in git-connected repositories to better detect and manage existing resources across multiple branches
  * Enhanced how the system identifies and retrieves resources during imports for more consistent and reliable behavior in multi-branch git workflows
  * Streamlined resource detection to ensure accurate handling of existing artifacts when importing in git-connected environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41806)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->