### PR TITLE
fix(security): bump nodemailer to 8.0.5

### DIFF
--- a/app/client/packages/rts/package.json
+++ b/app/client/packages/rts/package.json
@@ -31,7 +31,7 @@
     "llamaindex": "0.9.0",
     "loglevel": "^1.8.1",
     "mongodb": "^5.8.0",
-    "nodemailer": "6.9.9",
+    "nodemailer": "7.0.11",
     "readline-sync": "1.4.10",
     "simple-git": "^3.32.3"
   },
@@ -39,7 +39,7 @@
     "@types/express": "^4.17.14",
     "@types/jest": "^29.2.3",
     "@types/node": "*",
-    "@types/nodemailer": "^6.4.17",
+    "@types/nodemailer": "^7.0.11",
     "@types/readline-sync": "^1.4.8",
     "jest": "^29.3.1",
     "supertest": "^6.3.3",

--- a/app/client/packages/rts/package.json
+++ b/app/client/packages/rts/package.json
@@ -31,7 +31,7 @@
     "llamaindex": "0.9.0",
     "loglevel": "^1.8.1",
     "mongodb": "^5.8.0",
-    "nodemailer": "7.0.11",
+    "nodemailer": "8.0.5",
     "readline-sync": "1.4.10",
     "simple-git": "^3.32.3"
   },
@@ -39,7 +39,7 @@
     "@types/express": "^4.17.14",
     "@types/jest": "^29.2.3",
     "@types/node": "*",
-    "@types/nodemailer": "^7.0.11",
+    "@types/nodemailer": "^8.0.0",
     "@types/readline-sync": "^1.4.8",
     "jest": "^29.3.1",
     "supertest": "^6.3.3",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11595,12 +11595,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/nodemailer@npm:^6.4.17":
-  version: 6.4.17
-  resolution: "@types/nodemailer@npm:6.4.17"
+"@types/nodemailer@npm:^7.0.11":
+  version: 7.0.11
+  resolution: "@types/nodemailer@npm:7.0.11"
   dependencies:
     "@types/node": "*"
-  checksum: 498b702575111494a42cf9cdd3d399f0308c3b3b0244e7f53008924327955a16b39ba0bf99a5ccf17af9fd2bc50a61a76ae7e8a75498a426ea2f828a05202eab
+  checksum: 4932a898e34f2ed0f2fd65b5c2f16a0a6054e39e1e50335916e9b9b7477e5be59946e7f3d5f54eb846cb0a1942cdc86cbf3a48787304327316f6514be6333e4d
   languageName: node
   linkType: hard
 
@@ -13621,7 +13621,7 @@ __metadata:
     "@types/express": ^4.17.14
     "@types/jest": ^29.2.3
     "@types/node": "*"
-    "@types/nodemailer": ^6.4.17
+    "@types/nodemailer": ^7.0.11
     "@types/readline-sync": ^1.4.8
     axios: ^1.15.0
     dotenv: 10.0.0
@@ -13632,7 +13632,7 @@ __metadata:
     llamaindex: 0.9.0
     loglevel: ^1.8.1
     mongodb: ^5.8.0
-    nodemailer: 6.9.9
+    nodemailer: 7.0.11
     readline-sync: 1.4.10
     simple-git: ^3.32.3
     supertest: ^6.3.3
@@ -26454,10 +26454,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:6.9.9":
-  version: 6.9.9
-  resolution: "nodemailer@npm:6.9.9"
-  checksum: 9af862b497273796ad6ba7ca9eac23a7d69737554f6dd51cfd3557f60902c56344158192672f1208daf00340a47a9e1805bd809965edc191011b35dd98a74be1
+"nodemailer@npm:7.0.11":
+  version: 7.0.11
+  resolution: "nodemailer@npm:7.0.11"
+  checksum: 02940a5a620e219522c049f54f69af7abdc99c2ec168f592d3c67e26980a9857d7c45c65989cbd835af2c0ffabc66c20198aff484197566385594b2653069cb8
   languageName: node
   linkType: hard
 

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11595,12 +11595,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/nodemailer@npm:^7.0.11":
-  version: 7.0.11
-  resolution: "@types/nodemailer@npm:7.0.11"
+"@types/nodemailer@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@types/nodemailer@npm:8.0.0"
   dependencies:
     "@types/node": "*"
-  checksum: 4932a898e34f2ed0f2fd65b5c2f16a0a6054e39e1e50335916e9b9b7477e5be59946e7f3d5f54eb846cb0a1942cdc86cbf3a48787304327316f6514be6333e4d
+  checksum: 9d3e762737c54df69538b9ecb14730499131c3573c6dd64dee3057553303b507dc3072489ce55ecda863c13b5ca9f713540885ae113f015e2a241bdc6e8a7ff3
   languageName: node
   linkType: hard
 
@@ -13621,7 +13621,7 @@ __metadata:
     "@types/express": ^4.17.14
     "@types/jest": ^29.2.3
     "@types/node": "*"
-    "@types/nodemailer": ^7.0.11
+    "@types/nodemailer": ^8.0.0
     "@types/readline-sync": ^1.4.8
     axios: ^1.15.0
     dotenv: 10.0.0
@@ -13632,7 +13632,7 @@ __metadata:
     llamaindex: 0.9.0
     loglevel: ^1.8.1
     mongodb: ^5.8.0
-    nodemailer: 7.0.11
+    nodemailer: 8.0.5
     readline-sync: 1.4.10
     simple-git: ^3.32.3
     supertest: ^6.3.3
@@ -26454,10 +26454,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:7.0.11":
-  version: 7.0.11
-  resolution: "nodemailer@npm:7.0.11"
-  checksum: 02940a5a620e219522c049f54f69af7abdc99c2ec168f592d3c67e26980a9857d7c45c65989cbd835af2c0ffabc66c20198aff484197566385594b2653069cb8
+"nodemailer@npm:8.0.5":
+  version: 8.0.5
+  resolution: "nodemailer@npm:8.0.5"
+  checksum: 72f3ba14b11b047caec0d850e241fefb52e13230cd99babb7e9c3f481c2ba76ea58c82a6a47351022fb630d5b9192a8c275af1d185634f88d1a83209cfb78608
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `nodemailer` from 6.9.9 to 8.0.5 to address all 4 known vulnerabilities:
  - **CVE-2025-14874** — CVSS 7.5 High
  - **CVE-2025-13033** — CVSS 5.5 Medium
  - **GHSA-vvjj-xcjg** — CVSS 4.9 Medium
  - **GHSA-c7w3-x9** — CVSS 2.3 Low
- Updates `@types/nodemailer` from ^6.4.17 to ^8.0.0
- Only breaking changes across v7 and v8 are SES SDK removal (we use SMTP) and an error code rename (we don't check error codes) — no impact on our usage

## Test plan
- [x] CI passes (build, lint, type-check, unit tests)
- [ ] Verify nodemailer 8.0.5 is present in the EE image after sync
- [ ] Smoke-test backup failure email on EE deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD f6a3d3fcef5498e9c8bde39c132e4f31645a82bf yet
> <hr>Thu, 14 May 2026 14:06:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the email-sending library and its TypeScript type definitions to a newer major release, improving email reliability, compatibility, and security across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41809)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->