### PR TITLE
fix: correct timeout error page status code

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -487,11 +487,11 @@ export const BACK_TO_HOMEPAGE = () => "Go back to homepage";
 // error pages
 export const PAGE_NOT_FOUND_TITLE = () => "404";
 export const PAGE_NOT_FOUND = () => "Page not found";
-export const PAGE_SERVER_TIMEOUT_ERROR_CODE = () => "504";
+export const PAGE_SERVER_TIMEOUT_ERROR_CODE = () => "408";
 export const PAGE_SERVER_TIMEOUT_TITLE = () =>
-  "Appsmith server is taking too long to respond";
+  "Request timed out";
 export const PAGE_SERVER_TIMEOUT_DESCRIPTION = () =>
-  `Please retry after some time`;
+  `The server is taking too long to respond. Please retry after some time`;
 export const PAGE_CLIENT_ERROR_TITLE = () => "Whoops something went wrong!";
 export const PAGE_CLIENT_ERROR_DESCRIPTION = () =>
   "This is embarrassing, please contact Appsmith support for help";


### PR DESCRIPTION
## Summary

This PR fixes the misleading timeout error page status code.

The current timeout page displays 504, which suggests a gateway timeout. However, this error is triggered by a client-side request timeout, so 408 is more appropriate.

## Changes

- Changed timeout error code from 504 to 408
- Updated timeout page title
- Updated timeout page description

Fixes #41544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the server timeout error message and corrected the associated HTTP status code to provide clearer guidance when server requests take too long to complete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41810)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->