### PR TITLE
fix: disable MSSQL encryption by default

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -643,17 +643,15 @@ public class MssqlPlugin extends BasePlugin {
     private static void addSslOptionsToUrlBuilder(
             DatasourceConfiguration datasourceConfiguration, StringBuilder urlBuilder) throws AppsmithPluginException {
         /*
-         * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
+         * - When SSL configuration is absent, default to disabling encryption.
          */
         if (datasourceConfiguration.getConnection() == null
                 || datasourceConfiguration.getConnection().getSsl() == null
                 || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
-            throw new AppsmithPluginException(
-                    AppsmithPluginError.PLUGIN_ERROR,
-                    "Appsmith server has failed to fetch SSL configuration from datasource configuration form. "
-                            + "Please reach out to Appsmith customer support to resolve this.");
+            urlBuilder.append("encrypt=false;");
+            return;
         }
-
+        
         /*
          * - By default, the driver configures SSL in the no verify mode.
          */

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
@@ -82,7 +82,7 @@
           "label": "SSL mode",
           "configProperty": "datasourceConfiguration.connection.ssl.authType",
           "controlType": "DROP_DOWN",
-          "initialValue": "NO_VERIFY",
+          "initialValue": "DISABLE",
           "options": [
             {
               "label": "Disable",


### PR DESCRIPTION
## Summary

This PR fixes MSSQL connection failures caused by the default SSL setting.

Currently, new MSSQL datasources default to NO_VERIFY, which generates encrypt=true in the JDBC URL. This can cause SSL handshake failures when the SQL Server does not require encryption.

## Changes

- Changed the default SSL mode from NO_VERIFY to DISABLE
- Added graceful fallback when SSL configuration is missing
- Default to encrypt=false when SSL settings are absent

Fixes #41627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSSQL database connection handling when SSL configuration is missing; connections now default to disabled encryption instead of throwing an error.
  * Updated default SSL authentication type for MSSQL connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41811)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->