### PR TITLE
fix(security): upgrade postgresql-jdbc to 42.7.11 to remediate CVE-2026-42198

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/DateTime_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Postgres_DataTypes/DateTime_Spec.ts
@@ -130,19 +130,13 @@ describe(
       agHelper.RenameQuery("intervalRecords");
       dataSources.RunQuery();
       dataSources.ReadQueryTableResponse(0).then(($cellData) => {
-        expect($cellData).to.eq(
-          "0 years 11 mons 29 days 23 hours 0 mins 0.0 secs",
-        );
+        expect($cellData).to.eq("11 mons 29 days 23 hours");
       });
       dataSources.ReadQueryTableResponse(1).then(($cellData) => {
-        expect($cellData).to.eq(
-          "0 years 1 mons 0 days 0 hours 0 mins 0.0 secs",
-        );
+        expect($cellData).to.eq("1 mons");
       });
       dataSources.ReadQueryTableResponse(2).then(($cellData) => {
-        expect($cellData).to.eq(
-          "0 years 0 mons 1 days 0 hours 0 mins 0.0 secs",
-        );
+        expect($cellData).to.eq("1 days");
       });
       dataSources.ReadQueryTableResponse(3).then(($cellData) => {
         expect($cellData).to.eq("21");
@@ -186,9 +180,7 @@ describe(
         expect($cellData).to.eq("16:05:00"); //time format
       });
       table.ReadTableRowColumnData(0, 6, "v1", 200).then(($cellData) => {
-        expect($cellData).to.eq(
-          "6 years 5 mons 4 days 3 hours 2 mins 1.0 secs",
-        ); //Interval format!
+        expect($cellData).to.eq("6 years 5 mons 4 days 3 hours 2 mins 1 secs"); //Interval format!
       });
       table.ReadTableRowColumnData(0, 7).then(($cellData) => {
         expect($cellData).to.eq("19.01.1989");
@@ -228,9 +220,7 @@ describe(
         expect($cellData).to.eq("04:05:00");
       });
       table.ReadTableRowColumnData(1, 6, "v1", 200).then(($cellData) => {
-        expect($cellData).to.eq(
-          "0 years 0 mons 3 days 4 hours 5 mins 6.0 secs",
-        );
+        expect($cellData).to.eq("3 days 4 hours 5 mins 6 secs");
       });
       table.ReadTableRowColumnData(1, 7, "v1", 200).then(($cellData) => {
         expect($cellData).to.eq("29.12.2045");
@@ -270,9 +260,7 @@ describe(
         expect($cellData).to.eq("04:05:06.789");
       });
       table.ReadTableRowColumnData(1, 6, "v1", 200).then(($cellData) => {
-        expect($cellData).to.eq(
-          "1 years 3 mons 2 days 6 hours 4 mins 5.0 secs",
-        );
+        expect($cellData).to.eq("1 years 3 mons 2 days 6 hours 4 mins 5 secs");
       });
       table.ReadTableRowColumnData(1, 7, "v1", 200).then(($cellData) => {
         expect($cellData).to.eq("17.03.2014");
@@ -322,9 +310,7 @@ describe(
         expect($cellData).to.eq("18:14:16");
       });
       table.ReadTableRowColumnData(1, 6, "v1", 200).then(($cellData) => {
-        expect($cellData).to.eq(
-          "1 years 2 mons 0 days 0 hours 0 mins 0.0 secs",
-        );
+        expect($cellData).to.eq("1 years 2 mons");
       });
       table.ReadTableRowColumnData(1, 7, "v1", 200).then(($cellData) => {
         expect($cellData).to.eq("08.01.1999");

--- a/app/server/appsmith-plugins/postgresPlugin/pom.xml
+++ b/app/server/appsmith-plugins/postgresPlugin/pom.xml
@@ -20,8 +20,10 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <!-- Overriding version to get fix for CVE-2024-1597. Remove once spring-boot is at least at 3.1.9 or 3.2.3 -->
-            <version>42.6.1</version>
+            <!-- Overriding Spring Boot's managed version (42.7.10) to pull in the fix for CVE-2026-42198
+                 (SCRAM-SHA-256 PBKDF2 client-side DoS via malicious PostgreSQL servers).
+                 Remove once Spring Boot manages org.postgresql:postgresql >= 42.7.11. -->
+            <version>42.7.11</version>
         </dependency>
 
         <dependency>

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -695,9 +695,7 @@ public class PostgresPluginTest {
                     assertEquals("2018-11-30T20:45:15Z", node.get("created_on").asText());
                     assertEquals(
                             "2018-11-30T19:45:15Z", node.get("created_on_tz").asText());
-                    assertEquals(
-                            "1 years 5 mons 0 days 2 hours 0 mins 0.0 secs",
-                            node.get("interval1").asText());
+                    assertEquals("1 years 5 mons 2 hours", node.get("interval1").asText());
                     Assertions.assertThat(node.get("spouse_dob")).isEqualTo(NullNode.getInstance());
 
                     // Check the order of the columns.
@@ -1070,9 +1068,7 @@ public class PostgresPluginTest {
                     assertEquals("2018-11-30T20:45:15Z", node.get("created_on").asText());
                     assertEquals(
                             "2018-11-30T19:45:15Z", node.get("created_on_tz").asText());
-                    assertEquals(
-                            "1 years 5 mons 0 days 2 hours 0 mins 0.0 secs",
-                            node.get("interval1").asText());
+                    assertEquals("1 years 5 mons 2 hours", node.get("interval1").asText());
                     assertTrue(node.get("spouse_dob").isNull());
                     assertEquals(1.0, node.get("rating").asDouble(), 0.0);
 
@@ -1149,9 +1145,7 @@ public class PostgresPluginTest {
                     assertEquals("2018-11-30T20:45:15Z", node.get("created_on").asText());
                     assertEquals(
                             "2018-11-30T19:45:15Z", node.get("created_on_tz").asText());
-                    assertEquals(
-                            "1 years 5 mons 0 days 2 hours 0 mins 0.0 secs",
-                            node.get("interval1").asText());
+                    assertEquals("1 years 5 mons 2 hours", node.get("interval1").asText());
                     assertTrue(node.get("spouse_dob").isNull());
 
                     // Check the order of the columns.
@@ -1239,9 +1233,7 @@ public class PostgresPluginTest {
                     assertEquals("2018-11-30T20:45:15Z", node.get("created_on").asText());
                     assertEquals(
                             "2018-11-30T19:45:15Z", node.get("created_on_tz").asText());
-                    assertEquals(
-                            "1 years 5 mons 0 days 2 hours 0 mins 0.0 secs",
-                            node.get("interval1").asText());
+                    assertEquals("1 years 5 mons 2 hours", node.get("interval1").asText());
                     assertTrue(node.get("spouse_dob").isNull());
 
                     // Check the order of the columns.


### PR DESCRIPTION
Linear: [APP-15219](https://linear.app/appsmith/issue/APP-15219/ce-fix-cve-2026-42198-upgrade-postgresql-jdbc-to-42711-in)

## Summary

- **CVE-2026-42198** (CVSS 7.5, HIGH) is a client-side denial-of-service in the PostgreSQL JDBC driver's SCRAM-SHA-256 handshake that affects every release in the range `42.2.0 ≤ v < 42.7.11`. A malicious or compromised PostgreSQL server can respond with an arbitrarily large PBKDF2 iteration count, causing the JDBC client to burn an entire CPU core inside PBKDF2 with no effective cap. `loginTimeout` does **not** mitigate the issue.
- The vulnerable driver is shipped inside `postgresPlugin` and is used to connect to **every** Appsmith user's Postgres datasource. Any authenticated user with datasource-creation rights can point a datasource at a hostile PG server and wedge Appsmith server CPU / Hikari pool — so blast radius is broader than typical infra-side CVEs.
- Bumps the pinned `org.postgresql:postgresql` override in `postgresPlugin` from `42.6.1` → `42.7.11`, which introduces the new `scramMaxIterations` connection property (default `100_000`) that caps iterations **before** the PBKDF2 computation runs.

The previous comment on this override (`Remove once spring-boot is at least at 3.1.9 or 3.2.3`) was already stale — we're on Spring Boot 3.5.12, whose BOM manages `org.postgresql:postgresql` to **42.7.10**, which is also in the vulnerable range. The override is refreshed to reflect the new floor for removal (Spring Boot managing ≥ 42.7.11).

## ⚠️ Breaking change for release notes coordination

`pgjdbc 42.7.9` ([pgjdbc#3866](https://github.com/pgjdbc/pgjdbc/pull/3866)) rewrote `PGInterval.getValue()` for ~32× throughput. As a side effect, the string representation now **omits zero-valued components**. The postgres plugin emits this exact string for `INTERVAL` columns (`PostgresPlugin.java`, `INTERVAL_TYPE_NAME` branch: `resultSet.getObject(i).toString()`), so user-visible query results change shape:

| | Before (42.6.1) | After (42.7.11) |
|---|---|---|
| `1 year 5 months 2 hours` | `1 years 5 mons 0 days 2 hours 0 mins 0.0 secs` | `1 years 5 mons 2 hours` |
| `0 seconds` | `0 years 0 mons 0 days 0 hours 0 mins 0.0 secs` | `0.0 secs` |

**Impact for users:** Any Appsmith app that regexes / equality-checks the string representation of an `INTERVAL` column will need to adapt. Apps that just display the value in a widget will show a more compact label.

**Action for release notes:** explicit "Breaking change" callout under the postgres plugin, including the before/after example, so customers can audit their queries before upgrading.

The 4 `PostgresPluginTest` assertions that pinned the legacy 6-field shape are updated to match.

## Test plan

- [x] `mvn -pl appsmith-plugins/postgresPlugin -am compile` — clean
- [x] `mvn -pl appsmith-plugins/postgresPlugin -am test-compile` — clean
- [x] `mvn -pl appsmith-plugins/postgresPlugin test` (testcontainers PG) — **66 tests, 0 failures**
- [x] `mvn -pl appsmith-plugins/postgresPlugin dependency:tree` confirms `org.postgresql:postgresql:jar:42.7.11:compile`
- [ ] Deploy preview / DP smoke: create a Postgres datasource (Supabase or managed PG), run `SELECT now() - '...'::interval AS d` style queries, confirm result shape is the new compact form and the connection still completes successfully
- [ ] Release-notes ticket filed alongside this PR

## References

- CVE: <https://nvd.nist.gov/vuln/detail/CVE-2026-42198>
- pgjdbc 42.7.11 release notes: <https://jdbc.postgresql.org/changelogs/2026-04-28-42/>
- PGInterval format-change PR: <https://github.com/pgjdbc/pgjdbc/pull/3866>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL driver to v42.7.11 with security and SCRAM-SHA-256 improvements.

* **Bug Fixes**
  * Interval/DateTime output now uses a more compact, consistent formatting (removes redundant zero components and fractional seconds).

* **Tests**
  * Regression and unit tests updated to reflect the new interval display format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41812)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/25859949356>
> Commit: a9b1412355bfe2485088205e5858ffcddae9e394
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=25859949356&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 14 May 2026 13:52:44 UTC
<!-- end of auto-generated comment: Cypress test results  -->
