### PR TITLE
fix: replace misleading 504 with 408 on timeout page (#41544)

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -487,11 +487,11 @@ export const BACK_TO_HOMEPAGE = () => "Go back to homepage";
 // error pages
 export const PAGE_NOT_FOUND_TITLE = () => "404";
 export const PAGE_NOT_FOUND = () => "Page not found";
-export const PAGE_SERVER_TIMEOUT_ERROR_CODE = () => "504";
+export const PAGE_SERVER_TIMEOUT_ERROR_CODE = () => "408";
 export const PAGE_SERVER_TIMEOUT_TITLE = () =>
-  "Appsmith server is taking too long to respond";
+  "Request timed out";
 export const PAGE_SERVER_TIMEOUT_DESCRIPTION = () =>
-  `Please retry after some time`;
+  `The server is taking too long to respond. Please retry after some time`;
 export const PAGE_CLIENT_ERROR_TITLE = () => "Whoops something went wrong!";
 export const PAGE_CLIENT_ERROR_DESCRIPTION = () =>
   "This is embarrassing, please contact Appsmith support for help";


### PR DESCRIPTION
## Description

Fixes https://github.com/appsmithorg/appsmith/issues/41544

### Summary
This PR fixes a misleading timeout error page code shown to users.

### What changed
- Updated timeout error code from `504` to `408`.
- Updated timeout title to `Request timed out`.
- Updated timeout description to:
  `The server is taking too long to respond. Please retry after some time`.

### Why
`504` indicates a gateway/proxy timeout, which is misleading for client-side request timeout scenarios.  
`408` better matches the intended timeout semantics shown on the UI.

### Dependencies
- None

### Testing
- Code-level validation completed in `messages.ts`:
  - `PAGE_SERVER_TIMEOUT_ERROR_CODE = "408"`
  - `PAGE_SERVER_TIMEOUT_TITLE = "Request timed out"`
  - `PAGE_SERVER_TIMEOUT_DESCRIPTION = "The server is taking too long to respond. Please retry after some time"`


## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging for request timeouts. When requests exceed the maximum allowed processing time, users now receive clearer, more informative error messages paired with specific retry guidance. This update improves the user experience by helping users quickly understand what went wrong and take appropriate action to recover from timeout situations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41817)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->