### PR TITLE
fix: default MSSQL SSL mode to disable and handle missing SSL config (#41627)

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -643,20 +643,15 @@ public class MssqlPlugin extends BasePlugin {
     private static void addSslOptionsToUrlBuilder(
             DatasourceConfiguration datasourceConfiguration, StringBuilder urlBuilder) throws AppsmithPluginException {
         /*
-         * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
+         * - When SSL configuration is absent, default to disabling encryption so that
+         *   connections to servers that do not require encryption work out of the box.
          */
         if (datasourceConfiguration.getConnection() == null
                 || datasourceConfiguration.getConnection().getSsl() == null
                 || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
-            throw new AppsmithPluginException(
-                    AppsmithPluginError.PLUGIN_ERROR,
-                    "Appsmith server has failed to fetch SSL configuration from datasource configuration form. "
-                            + "Please reach out to Appsmith customer support to resolve this.");
+            urlBuilder.append("encrypt=false;");
+            return;
         }
-
-        /*
-         * - By default, the driver configures SSL in the no verify mode.
-         */
         SSLDetails.AuthType sslAuthType =
                 datasourceConfiguration.getConnection().getSsl().getAuthType();
         switch (sslAuthType) {

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
@@ -82,7 +82,7 @@
           "label": "SSL mode",
           "configProperty": "datasourceConfiguration.connection.ssl.authType",
           "controlType": "DROP_DOWN",
-          "initialValue": "NO_VERIFY",
+          "initialValue": "DISABLE",
           "options": [
             {
               "label": "Disable",


### PR DESCRIPTION
## Description

### TL;DR
MSSQL datasource now defaults SSL mode to `DISABLE` instead of `NO_VERIFY`, and missing SSL config no longer throws an exception; it falls back to `encrypt=false;` so non-encrypted servers can connect successfully.

### Motivation / Context
When connecting to MSSQL servers that do not require encryption, connection tests could fail due to SSL handshake errors.
Root causes:
1. New datasource default SSL mode was `NO_VERIFY` (which sets `encrypt=true`).
2. Missing SSL config path threw a plugin exception instead of applying a fallback.

This caused avoidable failures for common MSSQL setups where encryption is not enforced.

### Changes
1. Updated MSSQL form default SSL mode:
- `app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json`
- `"initialValue": "NO_VERIFY"` -> `"initialValue": "DISABLE"`

2. Updated MSSQL plugin SSL handling:
- `app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java`
- When SSL config/auth type is missing, use fallback:
  - append `encrypt=false;`
  - `return;`
- Removed exception throw in that missing-config path.

### Why this is safe
- Does not remove SSL support.
- Users who need SSL can still explicitly choose SSL-enabled options.
- Improves compatibility for legacy/API-created datasources with missing SSL config.

### Dependencies
None.

### Related docs/design links
None.

Fixes #41627

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSSQL database connection SSL configuration handling. The system now gracefully defaults to encryption disabled when SSL settings are incomplete, preventing connection failures.
  * Updated the default SSL mode setting from NO_VERIFY to DISABLE for new MSSQL database connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41818)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->