### PR TITLE
fix: added validation of git repo url

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -85,8 +85,17 @@ public class GitUtils {
                 .matcher(remoteUrl);
         if (matcher.find()) {
             // To trim the postfix and prefix
-            return matcher.group(6).replaceFirst("\\.git$", "").replaceFirst("^(.*[\\\\\\/])", "");
+            final String repoName = matcher.group(6).replaceFirst("\\.git$", "").replaceFirst("^(.*[\\\\\\/])", "");
+            if (".".equals(repoName) || "..".equals(repoName)) {
+                throwInvalidGitConfigurationException();
+            }
+            return repoName;
         }
+        throwInvalidGitConfigurationException();
+        return null;
+    }
+
+    private static void throwInvalidGitConfigurationException() {
         throw new AppsmithException(
                 AppsmithError.INVALID_GIT_CONFIGURATION,
                 "Remote URL is incorrect. "

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -187,7 +187,11 @@ public class GitUtilsTest {
             "host.xz:/path/to/repo.git/",
             "host.xz:~user/path/to/repo.git/",
             "host.xz:path/to/repo.git",
-            "rsync://host.xz/path/to/repo.git/"
+            "rsync://host.xz/path/to/repo.git/",
+            "git@example.com:test/.",
+            "git@example.com:test/..",
+            "git@example.com:test/..git",
+            "git@example.com:test/...git"
         };
 
         for (String url : invalidUrls) {


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

GHSA: GHSA-pf2x-82hw-qqwq

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/26018376398>
> Commit: 38f35836c0e1146c21e4fae3c70867f893e5acc8
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=26018376398&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Mon, 18 May 2026 07:19:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of Git repository URLs to properly reject invalid configurations containing directory path references (`.` or `..`).
  
* **Tests**
  * Expanded test coverage to verify proper handling of malformed Git repository URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41819)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->