### PR TITLE
fix: Move expires_in field after scope in OAuth2 datasource config

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -683,6 +683,21 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        {_.get(formData.authentication, "grantType") ===
+          GrantType.AuthorizationCode && (
+          <FormInputContainer
+            data-location-id={btoa("authentication.expiresIn")}
+          >
+            {this.renderInputTextControlViaFormControl({
+              configProperty: "authentication.expiresIn",
+              label: "Authorization expires in (seconds)",
+              placeholderText: "3600",
+              dataType: "NUMBER",
+              encrypted: false,
+              isRequired: false,
+            })}
+          </FormInputContainer>
+        )}
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +884,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&


### PR DESCRIPTION
## Description
Moves the "Authorization expires in (seconds)" field to appear right after the "Scope(s)" field in the OAuth2 datasource configuration form. This groups all authentication-related fields together for better UX.

## Changes
- Moved expiresIn field from `renderOauth2AuthorizationCode()` to `renderOauth2Common()`
- Added conditional check to only display for Authorization Code grant type
- Field order is now: Scope(s) → Authorization expires in (seconds) → Client Authentication

Fixes #31059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OAuth2 form to conditionally display the "Authorization expires in (seconds)" field when Authorization Code grant type is selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->