### PR TITLE
fix(ci): add non-root USER to cypress snapshot Dockerfile

### DIFF
--- a/app/client/cypress/Dockerfile
+++ b/app/client/cypress/Dockerfile
@@ -6,6 +6,9 @@ FROM cypress/factory:4.0.2
 
 # Install chromium in this way since there is no browsers in the docker container for the arm64 architecture
 # https://github.com/cypress-io/cypress-docker-images/issues/695
-RUN apt update && apt install -y chromium
+RUN apt update && apt install -y chromium \
+    && rm -rf /var/lib/apt/lists/*
+
+USER node
 
 ENTRYPOINT ["yarn", "cypress:snapshot"]


### PR DESCRIPTION
## Description

Switch to the built-in `node` user (provided by the `cypress/factory` base image) before the ENTRYPOINT to avoid running the container process as root.

The `cypress/factory` image already sets `chmod 777 /root` so the Cypress binary cache at `/root/.cache/Cypress` remains accessible to non-root users. This is the officially supported pattern from the Cypress Docker images project.

Also cleans up `apt lists` after installing chromium to reduce image layer size.

Fixes https://linear.app/appsmith/issue/APP-15224/triage-semgrep-finding-781859531-missing-non-root-user-in

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This comment will be updated by the CI -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Cypress test container Docker image to reduce size by streamlining installation steps and removing temporary package lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/26184866538>
> Commit: 8bf6885e2644f669dbfefe1c2ad67d613fc2e934
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=26184866538&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 20 May 2026 20:03:46 UTC
<!-- end of auto-generated comment: Cypress test results  -->
