### PR TITLE
fix(helm): allow numeric cpu in resources.requests

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 3.8.0
+version: 3.8.1
 dependencies:
   - condition: redis.enabled
     name: redis

--- a/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/defaults_snapshot_test.yaml.snap
@@ -25,7 +25,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.8.0
+        appsmith.sh/chart: appsmith-3.8.1
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
   3: |
@@ -36,7 +36,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.8.0
+        appsmith.sh/chart: appsmith-3.8.1
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -142,7 +142,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.8.0
+        appsmith.sh/chart: appsmith-3.8.1
       name: RELEASE-NAME-appsmith-headless
       namespace: NAMESPACE
     spec:
@@ -181,7 +181,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.8.0
+        appsmith.sh/chart: appsmith-3.8.1
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     spec:
@@ -202,7 +202,7 @@
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: appsmith
-        appsmith.sh/chart: appsmith-3.8.0
+        appsmith.sh/chart: appsmith-3.8.1
       name: RELEASE-NAME-appsmith
       namespace: NAMESPACE
     secrets:

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -581,7 +581,10 @@
                     "type": "object",
                     "properties": {
                         "cpu": {
-                            "type": "string"
+                            "type": [
+                                "string",
+                                "number"
+                            ]
                         },
                         "memory": {
                             "type": "string"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -475,6 +475,7 @@ resources:
   limits: {}
   # @schema description: Resource requests for the Appsmith container.
   requests:
+     # @schema type: [string, number]
      cpu: 500m
      memory: 3000Mi
 


### PR DESCRIPTION
## Summary
- The auto-generated `values.schema.json` inferred `type: string` for `resources.requests.cpu` from the `500m` default, rejecting plain numeric values like `cpu: 1` or `cpu: 2.5` — both valid Kubernetes CPU quantities.
- Added `# @schema type: [string, number]` directive in `values.yaml` and regenerated the schema so it accepts both forms.
- Bumped chart `3.8.0` → `3.8.1` and refreshed the defaults snapshot.

Note: `resources.limits` remains an unconstrained object, so this only affects the `requests` side.

## Test plan
- [x] `helm schema` regenerated cleanly — only the targeted `cpu.type` field changed
- [x] `helm unittest` passes (13 suites / 67 tests / 7 snapshots)
- [x] CI `helm-schema` job confirms schema and values.yaml are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Helm chart version updated to 3.8.1.
  * Container resource request configuration now supports both string and numeric value formats for CPU specifications, providing greater flexibility in deployment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->