### PR TITLE
fix(server): validate origin before persisting invited users (APP-15239)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserAndAccessManagementServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserAndAccessManagementServiceImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.solutions;
 
 import com.appsmith.server.configurations.CommonConfig;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.helpers.UserOrganizationHelper;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.AnalyticsService;
@@ -30,7 +31,8 @@ public class UserAndAccessManagementServiceImpl extends UserAndAccessManagementS
             EmailService emailService,
             CommonConfig commonConfig,
             UserOrganizationHelper userOrganizationHelper,
-            CaptchaService captchaService) {
+            CaptchaService captchaService,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
         super(
                 sessionUserService,
                 permissionGroupService,
@@ -42,6 +44,7 @@ public class UserAndAccessManagementServiceImpl extends UserAndAccessManagementS
                 emailService,
                 commonConfig,
                 userOrganizationHelper,
-                captchaService);
+                captchaService,
+                secureBaseUrlResolver);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceCEImpl.java
@@ -9,6 +9,7 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.helpers.UserOrganizationHelper;
 import com.appsmith.server.helpers.ValidationUtils;
 import com.appsmith.server.repositories.UserRepository;
@@ -49,6 +50,7 @@ public class UserAndAccessManagementServiceCEImpl implements UserAndAccessManage
     private final PermissionGroupPermission permissionGroupPermission;
     private final EmailService emailService;
     private final UserOrganizationHelper userOrganizationHelper;
+    private final SecureBaseUrlResolver secureBaseUrlResolver;
 
     private final CaptchaService captchaService;
 
@@ -63,7 +65,8 @@ public class UserAndAccessManagementServiceCEImpl implements UserAndAccessManage
             EmailService emailService,
             CommonConfig commonConfig,
             UserOrganizationHelper userOrganizationHelper,
-            CaptchaService captchaService) {
+            CaptchaService captchaService,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
 
         this.sessionUserService = sessionUserService;
         this.permissionGroupService = permissionGroupService;
@@ -75,6 +78,7 @@ public class UserAndAccessManagementServiceCEImpl implements UserAndAccessManage
         this.permissionGroupPermission = permissionGroupPermission;
         this.userOrganizationHelper = userOrganizationHelper;
         this.captchaService = captchaService;
+        this.secureBaseUrlResolver = secureBaseUrlResolver;
     }
 
     @Override
@@ -124,6 +128,18 @@ public class UserAndAccessManagementServiceCEImpl implements UserAndAccessManage
             }
             usernames.add(username.toLowerCase());
         }
+
+        // Pre-flight origin validation: verify that the Origin header matches
+        // APPSMITH_BASE_URL BEFORE any user creation or permission-group writes.
+        // Without this, a mismatched origin would only fail at the email-sending
+        // stage, after the user has already been persisted in the workspace.
+        return secureBaseUrlResolver
+                .resolveSecureBaseUrl(originHeader)
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.MISCONFIGURED_INSTANCE_BASE_URL)))
+                .flatMap(validatedOrigin -> doInviteUsers(inviteUsersDTO, originHeader, usernames));
+    }
+
+    private Mono<List<User>> doInviteUsers(InviteUsersDTO inviteUsersDTO, String originHeader, Set<String> usernames) {
 
         Map<String, Object> eventData = new HashMap<>();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce_compatible/UserAndAccessManagementServiceCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce_compatible/UserAndAccessManagementServiceCECompatibleImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.solutions.ce_compatible;
 
 import com.appsmith.server.configurations.CommonConfig;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
 import com.appsmith.server.helpers.UserOrganizationHelper;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.AnalyticsService;
@@ -29,7 +30,8 @@ public class UserAndAccessManagementServiceCECompatibleImpl extends UserAndAcces
             EmailService emailService,
             CommonConfig commonConfig,
             UserOrganizationHelper userOrganizationHelper,
-            CaptchaService captchaService) {
+            CaptchaService captchaService,
+            SecureBaseUrlResolver secureBaseUrlResolver) {
         super(
                 sessionUserService,
                 permissionGroupService,
@@ -41,6 +43,7 @@ public class UserAndAccessManagementServiceCECompatibleImpl extends UserAndAcces
                 emailService,
                 commonConfig,
                 userOrganizationHelper,
-                captchaService);
+                captchaService,
+                secureBaseUrlResolver);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/UserUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/UserUtilsTest.java
@@ -111,15 +111,13 @@ class UserUtilsTest {
                     PermissionGroup instanceAdminPG = tuple.getT1();
                     PermissionGroup organizationAdminPG = tuple.getT2();
 
-                    // Verify user is still assigned exactly once
+                    // Verify user is still assigned exactly once (no duplicates)
                     assertThat(instanceAdminPG.getAssignedToUserIds())
-                            .contains(user1.getId())
-                            .hasSize(1)
+                            .containsOnlyOnce(user1.getId())
                             .as("User should be assigned exactly once to instance admin group");
 
                     assertThat(organizationAdminPG.getAssignedToUserIds())
-                            .contains(user1.getId())
-                            .hasSize(1)
+                            .containsOnlyOnce(user1.getId())
                             .as("User should be assigned exactly once to organization admin group");
                 })
                 .verifyComplete();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceOriginValidationTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceOriginValidationTest.java
@@ -1,0 +1,142 @@
+package com.appsmith.server.solutions.ce;
+
+import com.appsmith.server.domains.PermissionGroup;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.domains.Workspace;
+import com.appsmith.server.dtos.InviteUsersDTO;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.MockPluginExecutor;
+import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
+import com.appsmith.server.repositories.PermissionGroupRepository;
+import com.appsmith.server.repositories.UserRepository;
+import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.UserAndAccessManagementService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.appsmith.server.constants.FieldName.ADMINISTRATOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that origin validation (APPSMITH_BASE_URL vs request Origin header) runs
+ * BEFORE any user creation or permission-group assignment in the invite flow.
+ *
+ * <p>Uses {@code @SpyBean} on {@link SecureBaseUrlResolver} to simulate origin
+ * mismatch without requiring a separate Spring context with custom property overrides.
+ */
+@SpringBootTest
+@DirtiesContext
+@ActiveProfiles("test")
+@Slf4j
+public class UserAndAccessManagementServiceOriginValidationTest {
+
+    private static final String MISMATCHED_ORIGIN = "http://different-origin.example.com";
+
+    @Autowired
+    private UserAndAccessManagementService userAndAccessManagementService;
+
+    @Autowired
+    private WorkspaceService workspaceService;
+
+    @Autowired
+    private PermissionGroupRepository permissionGroupRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private PluginExecutorHelper pluginExecutorHelper;
+
+    @SpyBean
+    private SecureBaseUrlResolver secureBaseUrlResolver;
+
+    @BeforeEach
+    public void setup() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+    }
+
+    /**
+     * When the Origin header does not match APPSMITH_BASE_URL, the invite flow must
+     * fail with a "Bad request" error AND must NOT persist the invited user in the
+     * workspace's permission group. This test verifies the atomicity guarantee: no
+     * side-effects on validation failure.
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void inviteUsers_originMismatch_shouldNotPersistUserInPermissionGroup() {
+        String uniqueEmail = "invite-origin-test-" + UUID.randomUUID() + "@usertest.com";
+
+        // Simulate origin mismatch: resolver rejects the mismatched origin
+        Mockito.doReturn(Mono.error(new AppsmithException(
+                        AppsmithError.GENERIC_BAD_REQUEST,
+                        "Origin header does not match APPSMITH_BASE_URL configuration.")))
+                .when(secureBaseUrlResolver)
+                .resolveSecureBaseUrl(MISMATCHED_ORIGIN);
+
+        Workspace toCreate = new Workspace();
+        toCreate.setName("OriginValidationTest Workspace " + UUID.randomUUID());
+        toCreate.setDomain("example.com");
+        toCreate.setWebsite("https://example.com");
+
+        Workspace workspace = workspaceService.create(toCreate).block();
+        assertThat(workspace).isNotNull();
+
+        List<PermissionGroup> permissionGroups = permissionGroupRepository
+                .findAllById(workspace.getDefaultPermissionGroups())
+                .collectList()
+                .block();
+
+        String adminPermissionGroupId = permissionGroups.stream()
+                .filter(pg -> pg.getName().startsWith(ADMINISTRATOR))
+                .findFirst()
+                .orElseThrow()
+                .getId();
+
+        InviteUsersDTO inviteUsersDTO = new InviteUsersDTO();
+        inviteUsersDTO.setUsernames(new ArrayList<>(List.of(uniqueEmail)));
+        inviteUsersDTO.setPermissionGroupId(adminPermissionGroupId);
+
+        // Act: invoke invite with a mismatched Origin header
+        StepVerifier.create(userAndAccessManagementService.inviteUsers(inviteUsersDTO, MISMATCHED_ORIGIN))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error.getMessage())
+                            .contains("Origin header does not match APPSMITH_BASE_URL configuration");
+                })
+                .verify();
+
+        // Assert: the invited user must NOT have been created in the DB
+        User invitedUser = userRepository.findByEmail(uniqueEmail).block();
+        assertThat(invitedUser)
+                .as("Invited user should not be persisted when origin validation fails")
+                .isNull();
+
+        // Assert: the permission group must NOT contain the invited user
+        PermissionGroup adminPgAfter =
+                permissionGroupRepository.findById(adminPermissionGroupId).block();
+        assertThat(adminPgAfter).isNotNull();
+
+        if (invitedUser != null) {
+            assertThat(adminPgAfter.getAssignedToUserIds())
+                    .as("Permission group should not contain the invited user on origin mismatch")
+                    .doesNotContain(invitedUser.getId());
+        }
+    }
+}


### PR DESCRIPTION
## Description

When `APPSMITH_BASE_URL` is set to a value that differs from the actual base URL of an Appsmith instance, the invite users flow (`POST /api/v1/users/invite`) returns an error ("Origin header does not match APPSMITH_BASE_URL configuration"), but the invited user is **still added to the workspace's permission group** in MongoDB. If the invited user later signs up and logs in, they can see the workspace they were invited to.

**Root cause:** The invite flow in `UserAndAccessManagementServiceCEImpl.inviteUsers()` executes user creation and permission-group assignment BEFORE origin validation, which only runs at the email-sending stage (`EmailServiceCEImpl`). Since there is no transactional rollback across the reactive chain, the writes persist even when the email step errors.

**Fix:** Inject `SecureBaseUrlResolver` into `UserAndAccessManagementServiceCEImpl` and call `resolveSecureBaseUrl(originHeader)` as a pre-flight check at the beginning of `inviteUsers()`, before any DB writes. If origin validation fails, the entire flow short-circuits — no user is created, no permission group is modified.

**TDD verification:**
- **Red phase:** Without the fix, the test `inviteUsers_originMismatch_shouldNotPersistUserInPermissionGroup` fails with `expected: null but was: User(email=...)` — proving the user gets persisted despite the error
- **Green phase:** With the fix, the test passes — no user persisted on origin mismatch
- **Regression:** `WorkspaceServiceTest#addNewUserToWorkspaceAsAdmin` passes — existing invite flow unaffected

Fixes https://linear.app/appsmith/issue/APP-15239/invite-users-flow-adds-users-to-workspace-even-when-origin-validation

Slack thread: https://theappsmith.slack.com/archives/C09NG5BJ18S/p1779119152961779

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results -->
<!-- end of auto-generated comment: Cypress test results -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation workflow now validates the Origin header up front and rejects invalid origins, preventing partial or orphaned invitations and ensuring atomicity.

* **Tests**
  * Added integration test to confirm invalid Origin headers block user persistence and side effects.
  * Strengthened unit test assertions to ensure invited users are not duplicated in admin groups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 726b03e945190b2ea549987ca410a2d6c46cb428 yet
> <hr>Wed, 20 May 2026 07:37:39 UTC
<!-- end of auto-generated comment: Cypress test results  -->
