### PR TITLE
fix: preserve Redis credentials during appsmithctl restore

### DIFF
--- a/app/client/packages/rts/src/ctl/backup/backup.test.ts
+++ b/app/client/packages/rts/src/ctl/backup/backup.test.ts
@@ -101,22 +101,28 @@ describe("Backup Tests", () => {
     expect(res).toBe("v0.0.0-SNAPSHOT");
   });
 
-  test("If MONGODB and Encryption env values are being removed", () => {
+  test("If MONGODB, Encryption, and Redis env values are being removed", () => {
     expect(
-      removeSensitiveEnvData(`APPSMITH_REDIS_URL=redis://127.0.0.1:6379\nAPPSMITH_DB_URL=mongodb://appsmith:pass@localhost:27017/appsmith\nAPPSMITH_MONGODB_USER=appsmith\nAPPSMITH_MONGODB_PASSWORD=pass\nAPPSMITH_INSTANCE_NAME=Appsmith\n
+      removeSensitiveEnvData(`APPSMITH_REDIS_URL=redis://:secret@127.0.0.1:6379\nAPPSMITH_REDIS_PASSWORD=secret\nAPPSMITH_DB_URL=mongodb://appsmith:pass@localhost:27017/appsmith\nAPPSMITH_MONGODB_USER=appsmith\nAPPSMITH_MONGODB_PASSWORD=pass\nAPPSMITH_INSTANCE_NAME=Appsmith\n
   `),
-    ).toMatch(
-      `APPSMITH_REDIS_URL=redis://127.0.0.1:6379\nAPPSMITH_INSTANCE_NAME=Appsmith\n`,
-    );
+    ).toMatch(`APPSMITH_INSTANCE_NAME=Appsmith\n`);
   });
 
-  test("If MONGODB and Encryption env values are being removed", () => {
+  test("If MONGODB, Encryption, and Redis env values are being removed (with encryption keys)", () => {
     expect(
-      removeSensitiveEnvData(`APPSMITH_REDIS_URL=redis://127.0.0.1:6379\nAPPSMITH_ENCRYPTION_PASSWORD=dummy-pass\nAPPSMITH_ENCRYPTION_SALT=dummy-salt\nAPPSMITH_DB_URL=mongodb://appsmith:pass@localhost:27017/appsmith\nAPPSMITH_MONGODB_USER=appsmith\nAPPSMITH_MONGODB_PASSWORD=pass\nAPPSMITH_INSTANCE_NAME=Appsmith\n
+      removeSensitiveEnvData(`APPSMITH_REDIS_URL=redis://:secret@127.0.0.1:6379\nAPPSMITH_REDIS_PASSWORD=secret\nAPPSMITH_ENCRYPTION_PASSWORD=dummy-pass\nAPPSMITH_ENCRYPTION_SALT=dummy-salt\nAPPSMITH_DB_URL=mongodb://appsmith:pass@localhost:27017/appsmith\nAPPSMITH_MONGODB_USER=appsmith\nAPPSMITH_MONGODB_PASSWORD=pass\nAPPSMITH_INSTANCE_NAME=Appsmith\n
   `),
-    ).toMatch(
-      `APPSMITH_REDIS_URL=redis://127.0.0.1:6379\nAPPSMITH_INSTANCE_NAME=Appsmith\n`,
+    ).toMatch(`APPSMITH_INSTANCE_NAME=Appsmith\n`);
+  });
+
+  test("removeSensitiveEnvData does not leak the Redis password", () => {
+    const cleaned = removeSensitiveEnvData(
+      `APPSMITH_REDIS_URL=redis://:my-redis-pass@127.0.0.1:6379\nAPPSMITH_REDIS_PASSWORD=my-redis-pass\nAPPSMITH_INSTANCE_NAME=Appsmith\n`,
     );
+
+    expect(cleaned).not.toContain("my-redis-pass");
+    expect(cleaned).not.toContain("APPSMITH_REDIS_URL");
+    expect(cleaned).not.toContain("APPSMITH_REDIS_PASSWORD");
   });
 
   test("Backup Archive Limit when env APPSMITH_BACKUP_ARCHIVE_LIMIT is null", () => {

--- a/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
+++ b/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
@@ -48,14 +48,19 @@ export class EnvFileLink implements Link {
 }
 
 export function removeSensitiveEnvData(content: string): string {
-  // Remove encryption and Mongodb data from docker.env
+  // Strip instance-specific secrets from the backed-up docker.env. Redis values
+  // are stripped (in addition to encryption / MongoDB / DB URL) so the source
+  // instance's Redis password does not overwrite the target's during restore.
+  // These values are re-injected from the restoring instance's environment.
   const output_lines = [];
 
   content.split(/\r?\n/).forEach((line) => {
     if (
       !line.startsWith("APPSMITH_ENCRYPTION") &&
       !line.startsWith("APPSMITH_MONGODB") &&
-      !line.startsWith("APPSMITH_DB_URL=")
+      !line.startsWith("APPSMITH_DB_URL=") &&
+      !line.startsWith("APPSMITH_REDIS_URL=") &&
+      !line.startsWith("APPSMITH_REDIS_PASSWORD=")
     ) {
       output_lines.push(line);
     }

--- a/app/client/packages/rts/src/ctl/restore.ts
+++ b/app/client/packages/rts/src/ctl/restore.ts
@@ -224,6 +224,19 @@ async function restoreDockerEnvFile(
       process.env.APPSMITH_MONGODB_PASSWORD;
   }
 
+  // Preserve the restoring instance's Redis configuration. The backup strips
+  // these (see `removeSensitiveEnvData`) because the source instance's Redis
+  // password does not match the target's embedded Redis `requirepass`.
+  if (process.env.APPSMITH_REDIS_URL) {
+    dockerEnvContent +=
+      "\nAPPSMITH_REDIS_URL=" + process.env.APPSMITH_REDIS_URL;
+  }
+
+  if (process.env.APPSMITH_REDIS_PASSWORD) {
+    dockerEnvContent +=
+      "\nAPPSMITH_REDIS_PASSWORD=" + process.env.APPSMITH_REDIS_PASSWORD;
+  }
+
   await fsPromises.writeFile(dockerEnvFile, dockerEnvContent, "utf8");
 
   console.log("Restoring docker environment file completed");


### PR DESCRIPTION
## Summary

- Since embedded Redis got a per-instance `requirepass` ([0d99237a12](https://github.com/appsmithorg/appsmith/commit/0d99237a12) — _chore: set password on embedded Redis instance_, #41634), `appsmithctl restore` fails immediately after it restarts backend/rts. The container's running Redis enforces the target instance's password, but `restoreDockerEnvFile` blindly overwrites `docker.env` with the backup's contents — which carry the **source** instance's `APPSMITH_REDIS_PASSWORD` (or, for backups taken before #41634, no password at all). Backend/rts come back up and immediately fail with `WRONGPASS`/`NOAUTH`.
- Treat Redis values the same way MongoDB and encryption secrets are already treated: strip them from the backup, then re-append the target instance's values from `process.env` during restore. The entrypoint sources `docker.env` with `set -o allexport` before `supervisord` is exec'd, so `APPSMITH_REDIS_URL` and `APPSMITH_REDIS_PASSWORD` are reliably present in the restore process's env.

### Files

- `app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts` — extend `removeSensitiveEnvData` to drop `APPSMITH_REDIS_URL=` and `APPSMITH_REDIS_PASSWORD=` lines.
- `app/client/packages/rts/src/ctl/restore.ts` — re-append the restoring instance's `APPSMITH_REDIS_URL` and `APPSMITH_REDIS_PASSWORD` after rewriting `docker.env`.
- `app/client/packages/rts/src/ctl/backup/backup.test.ts` — update existing assertions (which previously asserted `APPSMITH_REDIS_URL` was preserved) and add a regression case that confirms the password never leaks into the cleaned content.

### Out of scope (worth follow-ups)

Two other `redis-cli` callsites in the same package hit the embedded Redis without `-a <password>` and will fail the same way once exercised against an auth-enabled instance:

- `app/client/packages/rts/src/ctl/update_branding.ts:325` — `redis-cli -h <host> FLUSHALL`
- `app/client/packages/rts/src/ctl/enable_form_login.ts:62` — `redis-cli -h <host> -p 6379 DEL ...`

The root issue is `parseRedisUrl` in `utils.ts` discarding credentials. `git.sh`'s `redis-exec` wrapper already does this correctly by passing the full URL with `redis-cli -u "$url"` — the right pattern to port to the TS ctl helpers.

## Test plan

- [x] `yarn workspace rts jest backup.test` — 53 tests pass, including the new regression case asserting no Redis password leaks through `removeSensitiveEnvData`.
- [x] Manual: take a backup on an instance running the post-#41634 image, run `appsmithctl restore` on a fresh instance with a different generated Redis password, confirm backend/rts come up healthy and Redis-backed flows work.
- [x] Manual: restore from a pre-#41634 backup (no `APPSMITH_REDIS_PASSWORD` in the backup's `docker.env`) onto a current image; confirm the target's generated password is preserved and Redis-backed flows work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for sensitive environment data removal during backup operations, including verification for Redis credential exclusion.

* **Bug Fixes**
  * Sensitive Redis credentials are now properly excluded from backup files to prevent information leakage.
  * Target instance's Redis configuration is correctly preserved and applied during backup recovery, ensuring proper connectivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->