### PR TITLE
fix(test): resolve flaky DSCrudAndBindings_Spec after-hook cleanup failure

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/ExistingApps/v1.9.24/DSCrudAndBindings_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/ExistingApps/v1.9.24/DSCrudAndBindings_Spec.ts
@@ -70,7 +70,7 @@ describe.skip(
       gitSync.CloseOpsModal();
     });
 
-    it("1. Deploy the app & Validate CRUD pages - Mongo , MySql, Postgres pages", () => {
+    it("1. Deploy the app, validate CRUD pages, widgets & bindings", () => {
       //Mongo CRUD page validation
       //Assert table data
       cy.latestDeployPreview();
@@ -92,7 +92,6 @@ describe.skip(
 
       //MySql CRUD page validation
       agHelper.GetNClickByContains(locators._deployedPage, "CountryFlags");
-      //Assert table data
       agHelper.AssertText(
         locators._widgetInDeployed(draggableWidgets.TEXT),
         "text",
@@ -142,9 +141,8 @@ describe.skip(
       table.ReadTableRowColumnData(0, 4).then(($cellData) => {
         expect($cellData).to.eq("Active");
       });
-    });
 
-    it("2. Validate widgets & bindings", () => {
+      // --- Widgets & bindings validation (same deployed session) ---
       agHelper.GetNClickByContains(locators._deployedPage, "Widgets");
       agHelper.AssertElementVisibility(
         locators._widgetInDeployed(draggableWidgets.AUDIO),
@@ -196,7 +194,9 @@ describe.skip(
       //Slider
       agHelper
         .ScrollIntoView(locators._sliderThumb)
+        .should("be.visible")
         .focus()
+        .should("be.focused")
         .type("{rightArrow}");
 
       agHelper.WaitUntilToastDisappear("Category Value Changed!");
@@ -243,6 +243,7 @@ describe.skip(
       gitSync.DeleteDeployKey(appRepoName, keyId);
       agHelper.WaitUntilAllToastsDisappear();
       deployMode.NavigateToHomeDirectly();
+      homePage.SelectWorkspace(workspaceName);
       homePage.DeleteApplication(appName);
       homePage.DeleteWorkspace(workspaceName);
     });


### PR DESCRIPTION
## Description

The Cypress spec `DSCrudAndBindings_Spec.ts` (Git > ExistingApps > v1.9.24) fails deterministically in EE CI with a 30s timeout in the `after()` hook when `DeleteApplication` cannot find the app card on the home page.

**Root cause:** After returning from deployed mode via `NavigateToHomeDirectly()`, the correct workspace is not selected on the home page. `DeleteApplication` assumes the app card is already visible, but it isn't — unlike `DeleteWorkspace`, which calls `SelectWorkspace` internally.

**Three fixes applied:**

1. **after() hook** — Added `homePage.SelectWorkspace(workspaceName)` before `DeleteApplication` to ensure the correct workspace is visible
2. **Merged two `it()` blocks** — The two tests shared deployed-mode state with no navigation reset between them. Merging eliminates the inter-test state dependency that caused the `after all` hook to fire between tests
3. **Slider focus assertions** — Added `.should("be.visible")` and `.should("be.focused")` to the slider interaction to guard against undetected focus failures

**Evidence:**
- CI run: https://github.com/appsmithorg/appsmith-ee/actions/runs/26162676005/job/76961773370
- Failed 3/3 cypress-repeat-pro retries deterministically (self-reinforcing: each failed cleanup pollutes workspace state for next retry)
- Passes on manual rerun (clean browser state, no workspace pollution)

Fixes https://linear.app/appsmith/issue/APP-15242/fix-flaky-cypress-spec-dscrudandbindings-spects-after-hook-cleanup

## Automation

/ok-to-test tags="@tag.Git"

### :mag: Cypress test results
<!-- This comment is used by Cypress test results action to post results. Do not modify or delete this comment. -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/26168633701>
> Commit: 2466c67fc1d03c704e972d3b07cdbe351da32d84
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=26168633701&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Git`
> Spec:
> <hr>Wed, 20 May 2026 14:43:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->
