### PR TITLE
fix(security): defense-in-depth for env injection RCE (GHSA-h6hh-wqxc-5hw9)

### DIFF
--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Source the helper script
+# Source the helper scripts
 source pg-utils.sh
+source safe-env-loader.sh
 
 set -e
 
@@ -129,10 +130,10 @@ init_env_file() {
 
   tlog "Load environment configuration"
 
-  # Load the ones in `docker.env` in the stacks folder.
-  set -o allexport
-  . "$ENV_PATH"
-  set +o allexport
+  # Validate docker.env for shell metacharacters left by pre-v1.99 exploits,
+  # then load it safely without Bash source/eval (GHSA-h6hh-wqxc-5hw9).
+  validate_env_file "$ENV_PATH" || sanitize_env_file "$ENV_PATH"
+  safe_source_env "$ENV_PATH"
 
   if [[ -n "$APPSMITH_MONGODB_URI" ]]; then
     export APPSMITH_DB_URL="$APPSMITH_MONGODB_URI"
@@ -140,9 +141,7 @@ init_env_file() {
   fi
 
   # Load the ones set from outside, should take precedence, and so will overwrite anything from `docker.env` above.
-  set -o allexport
-  . "$TMP/pre-define.env"
-  set +o allexport
+  safe_source_env "$TMP/pre-define.env"
 }
 
 init_env_file

--- a/deploy/docker/fs/opt/appsmith/run-with-env.sh
+++ b/deploy/docker/fs/opt/appsmith/run-with-env.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+source safe-env-loader.sh
+
 ENV_PATH="/appsmith-stacks/configuration/docker.env"
 PRE_DEFINED_ENV_PATH="$TMP/pre-define.env"
 tlog 'Load environment configuration'
-set -o allexport
-. "$ENV_PATH"
-. "$PRE_DEFINED_ENV_PATH"
-set +o allexport
+validate_env_file "$ENV_PATH" || sanitize_env_file "$ENV_PATH"
+safe_source_env "$ENV_PATH"
+safe_source_env "$PRE_DEFINED_ENV_PATH"
 
 if [[ -z "${APPSMITH_MAIL_ENABLED}" ]]; then
   unset APPSMITH_MAIL_ENABLED # If this field is empty is might cause application crash

--- a/deploy/docker/fs/opt/appsmith/safe-env-loader.sh
+++ b/deploy/docker/fs/opt/appsmith/safe-env-loader.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# safe-env-loader.sh — Defense-in-depth for GHSA-h6hh-wqxc-5hw9
+#
+# Provides safe_source_env() as a drop-in replacement for `. "$ENV_PATH"`.
+# Parses KEY=VALUE lines with shell quoting (single/double quotes) WITHOUT
+# evaluating command substitution, backticks, or any other shell constructs.
+#
+# Also provides validate_env_file() and sanitize_env_file() for startup-time
+# detection and remediation of poisoned env files from previously exploited
+# instances.
+
+# Pattern matching shell metacharacters that indicate command injection
+# when found outside of single quotes in an env value.
+readonly _DANGEROUS_UNQUOTED_PATTERN='(\$\(|`|\$\(\(|\$\{[A-Za-z_])'
+
+# safe_source_env — Parse a KEY=VALUE env file and export variables without
+# using Bash `source`/`.`. Handles single-quote, double-quote, and the
+# escapeForShell '"'"' pattern. Never evaluates $(), backticks, or ${}.
+#
+# Usage: safe_source_env /path/to/env-file
+safe_source_env() {
+  local env_file="$1"
+  [[ -f "$env_file" ]] || return 0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip blank lines and comments
+    [[ "$line" =~ ^[[:space:]]*($|#) ]] && continue
+
+    # Split on first '='
+    local key="${line%%=*}"
+    local raw_value="${line#*=}"
+
+    # If no '=' was found, key == line; skip
+    [[ "$key" == "$line" ]] && continue
+
+    # Validate key is a legal env var name
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+
+    # Parse the value: handle shell quoting character by character
+    local value=""
+    local i=0
+    local len=${#raw_value}
+
+    while (( i < len )); do
+      local ch="${raw_value:i:1}"
+      case "$ch" in
+        "'")
+          # Single-quoted segment: everything until next ' is literal
+          (( i++ ))
+          while (( i < len )); do
+            ch="${raw_value:i:1}"
+            if [[ "$ch" == "'" ]]; then
+              (( i++ ))
+              break
+            fi
+            value+="$ch"
+            (( i++ ))
+          done
+          ;;
+        '"')
+          # Double-quoted segment: literal except for \" escape
+          (( i++ ))
+          while (( i < len )); do
+            ch="${raw_value:i:1}"
+            if [[ "$ch" == '"' ]]; then
+              (( i++ ))
+              break
+            fi
+            if [[ "$ch" == '\' ]] && (( i + 1 < len )); then
+              local next="${raw_value:i+1:1}"
+              if [[ "$next" == '"' || "$next" == '\' ]]; then
+                value+="$next"
+                (( i += 2 ))
+                continue
+              fi
+            fi
+            value+="$ch"
+            (( i++ ))
+          done
+          ;;
+        *)
+          # Unquoted: take the character literally (no expansion)
+          value+="$ch"
+          (( i++ ))
+          ;;
+      esac
+    done
+
+    export "$key=$value"
+  done < "$env_file"
+}
+
+# validate_env_file — Scan an env file for dangerous shell metacharacters
+# in unquoted value contexts. Returns 0 if safe, 1 if dangerous patterns found.
+#
+# Usage: validate_env_file /path/to/env-file
+validate_env_file() {
+  local env_file="$1"
+  local found_dangerous=0
+
+  [[ -f "$env_file" ]] || return 0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ ^[[:space:]]*($|#) ]] && continue
+
+    local key="${line%%=*}"
+    local raw_value="${line#*=}"
+    [[ "$key" == "$line" ]] && continue
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+
+    # If the value starts with a single quote, it's properly escaped by
+    # escapeForShell — single-quoted strings are safe in Bash.
+    [[ "$raw_value" == "'"* ]] && continue
+
+    # Check the raw (unquoted) value for dangerous patterns
+    if [[ "$raw_value" =~ $'\x60' ]] || [[ "$raw_value" =~ '$(' ]]; then
+      echo "SECURITY WARNING: Dangerous shell metacharacters in $key" >&2
+      found_dangerous=1
+    fi
+  done < "$env_file"
+
+  return "$found_dangerous"
+}
+
+# sanitize_env_file — Rewrite an env file to single-quote-wrap any values
+# that contain dangerous shell metacharacters. Safe values are left unchanged.
+#
+# Usage: sanitize_env_file /path/to/env-file
+sanitize_env_file() {
+  local env_file="$1"
+  local tmp_file
+  tmp_file="$(mktemp "${env_file}.sanitize.XXXXXX")"
+  local count=0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Pass through comments and blank lines unchanged
+    if [[ "$line" =~ ^[[:space:]]*($|#) ]]; then
+      echo "$line" >> "$tmp_file"
+      continue
+    fi
+
+    local key="${line%%=*}"
+    local raw_value="${line#*=}"
+
+    # If not a valid KEY=VALUE line, pass through
+    if [[ "$key" == "$line" ]] || ! [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      echo "$line" >> "$tmp_file"
+      continue
+    fi
+
+    # If already single-quoted, pass through
+    if [[ "$raw_value" == "'"* ]]; then
+      echo "$line" >> "$tmp_file"
+      continue
+    fi
+
+    # Check for dangerous patterns
+    if [[ "$raw_value" =~ $'\x60' ]] || [[ "$raw_value" =~ '$(' ]]; then
+      # Single-quote-wrap the value, escaping any embedded single quotes
+      local escaped_value="${raw_value//\'/\'\"\'\"\'}"
+      echo "${key}='${escaped_value}'" >> "$tmp_file"
+      (( count++ ))
+    else
+      echo "$line" >> "$tmp_file"
+    fi
+  done < "$env_file"
+
+  if (( count > 0 )); then
+    mv "$tmp_file" "$env_file"
+    echo "SECURITY WARNING: Sanitized $count env value(s) with shell metacharacters in $env_file" >&2
+  else
+    rm -f "$tmp_file"
+  fi
+}

--- a/deploy/docker/tests/test-safe-env-loader.sh
+++ b/deploy/docker/tests/test-safe-env-loader.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Tests for GHSA-h6hh-wqxc-5hw9 defense-in-depth: safe env file loading
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOADER_SCRIPT="$SCRIPT_DIR/../fs/opt/appsmith/safe-env-loader.sh"
+
+PASS=0
+FAIL=0
+TEST_TMPDIR=""
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+assert_equals() {
+  local actual="$1" expected="$2" msg="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "    FAIL: $msg"
+    echo "      expected: '$expected'"
+    echo "      actual:   '$actual'"
+    return 1
+  fi
+  return 0
+}
+
+assert_not_exists() {
+  local path="$1" msg="$2"
+  if [[ -e "$path" ]]; then
+    echo "    FAIL: $msg (file should not exist: $path)"
+    return 1
+  fi
+  return 0
+}
+
+run_test() {
+  local test_name="$1"
+  setup
+  local result=0
+  "$test_name" || result=$?
+  teardown
+  if [[ "$result" -eq 0 ]]; then
+    echo "  PASS: $test_name"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "  FAIL: $test_name"
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+# --- safe_source_env tests ---
+
+test_simple_unquoted_values() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_DB_URL=mongodb://localhost:27017
+APPSMITH_REDIS_URL=redis://127.0.0.1:6379
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_DB_URL|\$APPSMITH_REDIS_URL\"
+  ")
+  assert_equals "$result" "mongodb://localhost:27017|redis://127.0.0.1:6379" "simple unquoted values"
+}
+
+test_single_quoted_values() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_DB_URL='mongodb://localhost:27017/appsmith'
+APPSMITH_INSTANCE_NAME='My Instance'
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_DB_URL|\$APPSMITH_INSTANCE_NAME\"
+  ")
+  assert_equals "$result" "mongodb://localhost:27017/appsmith|My Instance" "single-quoted values"
+}
+
+test_double_quoted_values() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_INSTANCE_NAME="My Instance"
+APPSMITH_DB_URL="mongodb://localhost:27017"
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_INSTANCE_NAME|\$APPSMITH_DB_URL\"
+  ")
+  assert_equals "$result" "My Instance|mongodb://localhost:27017" "double-quoted values"
+}
+
+test_embedded_single_quotes() {
+  # escapeForShell produces: 'Sponge-bob'"'"'s Instance'
+  cat > "$TEST_TMPDIR/env" <<'ENDOFFILE'
+APPSMITH_INSTANCE_NAME='Sponge-bob'"'"'s Instance'
+ENDOFFILE
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_INSTANCE_NAME\"
+  ")
+  assert_equals "$result" "Sponge-bob's Instance" "embedded single quote via shell escape"
+}
+
+test_empty_values() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_DB_URL=
+APPSMITH_INSTANCE_NAME=
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"db=[\$APPSMITH_DB_URL] name=[\$APPSMITH_INSTANCE_NAME]\"
+  ")
+  assert_equals "$result" "db=[] name=[]" "empty values"
+}
+
+test_comments_and_blank_lines_skipped() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+# This is a comment
+APPSMITH_DB_URL=value1
+
+# Another comment
+APPSMITH_REDIS_URL=value2
+
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_DB_URL|\$APPSMITH_REDIS_URL\"
+  ")
+  assert_equals "$result" "value1|value2" "comments and blank lines skipped"
+}
+
+test_command_substitution_not_executed() {
+  local marker="$TEST_TMPDIR/pwned_cmd"
+  cat > "$TEST_TMPDIR/env" <<EOF
+APPSMITH_INSTANCE_NAME=\$(touch ${marker})Appsmith
+EOF
+  bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+  " 2>/dev/null
+  assert_not_exists "$marker" "command substitution must NOT execute"
+}
+
+test_backtick_substitution_not_executed() {
+  local marker="$TEST_TMPDIR/pwned_bt"
+  printf 'APPSMITH_INSTANCE_NAME=`touch %s`Appsmith\n' "$marker" > "$TEST_TMPDIR/env"
+  bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+  " 2>/dev/null
+  assert_not_exists "$marker" "backtick substitution must NOT execute"
+}
+
+test_semicolon_not_executed() {
+  local marker="$TEST_TMPDIR/pwned_semi"
+  cat > "$TEST_TMPDIR/env" <<EOF
+APPSMITH_INSTANCE_NAME=safe; touch ${marker}
+EOF
+  bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+  " 2>/dev/null
+  assert_not_exists "$marker" "semicolon command must NOT execute"
+}
+
+test_dollar_brace_not_expanded() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_INSTANCE_NAME=${HOME}rest
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_INSTANCE_NAME\"
+  ")
+  assert_equals "$result" '${HOME}rest' "dollar-brace must be literal"
+}
+
+test_safe_quoted_command_substitution_is_literal() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_INSTANCE_NAME='$(touch /tmp/pwned)'
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_INSTANCE_NAME\"
+  ")
+  assert_equals "$result" '$(touch /tmp/pwned)' "single-quoted cmd sub is literal"
+}
+
+# --- validate_env_file tests ---
+
+test_validate_clean_file_passes() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_DB_URL='mongodb://localhost:27017'
+APPSMITH_INSTANCE_NAME=MyInstance
+APPSMITH_REDIS_URL=redis://localhost:6379
+EOF
+  bash -c "
+    source '$LOADER_SCRIPT'
+    validate_env_file '$TEST_TMPDIR/env'
+  " 2>/dev/null
+}
+
+test_validate_detects_unquoted_command_substitution() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_INSTANCE_NAME=$(touch /tmp/pwned)Appsmith
+EOF
+  if bash -c "
+    source '$LOADER_SCRIPT'
+    validate_env_file '$TEST_TMPDIR/env'
+  " 2>/dev/null; then
+    echo "    FAIL: should detect unquoted command substitution"
+    return 1
+  fi
+  return 0
+}
+
+test_validate_detects_backtick() {
+  printf 'APPSMITH_INSTANCE_NAME=`id`\n' > "$TEST_TMPDIR/env"
+  if bash -c "
+    source '$LOADER_SCRIPT'
+    validate_env_file '$TEST_TMPDIR/env'
+  " 2>/dev/null; then
+    echo "    FAIL: should detect backtick substitution"
+    return 1
+  fi
+  return 0
+}
+
+test_validate_allows_quoted_dangerous_values() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_INSTANCE_NAME='$(touch /tmp/pwned)'
+EOF
+  bash -c "
+    source '$LOADER_SCRIPT'
+    validate_env_file '$TEST_TMPDIR/env'
+  " 2>/dev/null
+}
+
+# --- sanitize_env_file tests ---
+
+test_sanitize_wraps_dangerous_values() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_DB_URL=safe_value
+APPSMITH_INSTANCE_NAME=$(touch /tmp/pwned)Appsmith
+EOF
+  bash -c "
+    source '$LOADER_SCRIPT'
+    sanitize_env_file '$TEST_TMPDIR/env'
+  " 2>/dev/null
+  # After sanitization the file should pass validation
+  if ! bash -c "
+    source '$LOADER_SCRIPT'
+    validate_env_file '$TEST_TMPDIR/env'
+  " 2>/dev/null; then
+    echo "    FAIL: sanitized file should pass validation"
+    return 1
+  fi
+  # Safe value should remain unchanged
+  if ! grep -q "^APPSMITH_DB_URL=safe_value$" "$TEST_TMPDIR/env"; then
+    echo "    FAIL: safe value should remain unchanged after sanitize"
+    return 1
+  fi
+  return 0
+}
+
+test_values_exported_to_environment() {
+  cat > "$TEST_TMPDIR/env" <<'EOF'
+APPSMITH_TEST_EXPORT_VAR='hello world'
+EOF
+  local result
+  result=$(bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+    echo \"\$APPSMITH_TEST_EXPORT_VAR\"
+  ")
+  assert_equals "$result" "hello world" "variable must be exported"
+}
+
+test_ifs_trick_not_executed() {
+  local marker="$TEST_TMPDIR/pwned_ifs"
+  # The actual PoC payload shape from the advisory
+  cat > "$TEST_TMPDIR/env" <<EOF
+APPSMITH_INSTANCE_NAME=\$(echo\${IFS}dG91Y2ggJHttYXJrZXJ9|base64\${IFS}-d|bash)Appsmith
+EOF
+  bash -c "
+    source '$LOADER_SCRIPT'
+    safe_source_env '$TEST_TMPDIR/env'
+  " 2>/dev/null
+  assert_not_exists "$marker" "IFS-based payload must NOT execute"
+}
+
+# --- Run all tests ---
+
+echo "========================================"
+echo "GHSA-h6hh-wqxc-5hw9 Safe Env Loader Tests"
+echo "========================================"
+echo ""
+
+if [[ ! -f "$LOADER_SCRIPT" ]]; then
+  echo "FATAL: safe-env-loader.sh not found at $LOADER_SCRIPT"
+  exit 1
+fi
+
+run_test test_simple_unquoted_values
+run_test test_single_quoted_values
+run_test test_double_quoted_values
+run_test test_embedded_single_quotes
+run_test test_empty_values
+run_test test_comments_and_blank_lines_skipped
+run_test test_command_substitution_not_executed
+run_test test_backtick_substitution_not_executed
+run_test test_semicolon_not_executed
+run_test test_dollar_brace_not_expanded
+run_test test_safe_quoted_command_substitution_is_literal
+run_test test_validate_clean_file_passes
+run_test test_validate_detects_unquoted_command_substitution
+run_test test_validate_detects_backtick
+run_test test_validate_allows_quoted_dangerous_values
+run_test test_sanitize_wraps_dangerous_values
+run_test test_values_exported_to_environment
+run_test test_ifs_trick_not_executed
+
+echo ""
+echo "========================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "========================================"
+
+if (( FAIL > 0 )); then
+  exit 1
+fi


### PR DESCRIPTION
## Description

**TL;DR:** Replace Bash `source` of `docker.env` with a safe parser to prevent RCE via command injection, and add startup validation to detect/sanitize poisoned env files from previously exploited instances.

### Background

[GHSA-h6hh-wqxc-5hw9](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-h6hh-wqxc-5hw9) (Critical, CVSS 9.1) describes an authenticated RCE where a super-admin injects `$(...)` command substitution into env values via `PUT /api/v1/admin/env`. The container's `entrypoint.sh` then sources `docker.env` with `. "$ENV_PATH"`, which evaluates the payload on restart.

The core fix (`escapeForShell()` in `EnvManagerCEImpl`) shipped in v1.99. This PR adds **defense-in-depth** on top of that fix.

### What changed

1. **New `safe-env-loader.sh`** — provides three functions:
   - `safe_source_env()` — parses `KEY=VALUE` lines with a character-by-character state machine that handles single/double quoting without ever evaluating `$()`, backticks, or `${}`
   - `validate_env_file()` — scans for dangerous shell metacharacters in unquoted value contexts
   - `sanitize_env_file()` — rewrites poisoned values with single-quote wrapping

2. **`entrypoint.sh`** — replaced `. "$ENV_PATH"` and `. "$TMP/pre-define.env"` with `safe_source_env()`. Added `validate_env_file || sanitize_env_file` before loading.

3. **`run-with-env.sh`** — same treatment as entrypoint.sh.

4. **18 tests** covering: quoting variants (single, double, embedded quotes), injection payloads (`$(...)`, backticks, semicolons, `${IFS}` trick from the actual PoC), validation detection, and sanitization.

### Why defense-in-depth matters

- **Sink removal:** Even if `escapeForShell()` were to regress, the `source` sink no longer exists — the safe parser treats all values as data.
- **Upgrade protection:** Instances exploited before v1.99 still have poisoned `docker.env` on the persistent volume. The startup validator catches and sanitizes these on first run after upgrade.

Linear: [APP-15243](https://linear.app/appsmith/issue/APP-15243)

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- tag: do not remove -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 37ccaf0531beec38d598d281d1a70a7ab91c0be1 yet
> <hr>Wed, 20 May 2026 18:35:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Docker deployment security with improved environment configuration handling, including validation and sanitization of external variables to prevent injection vulnerabilities.

* **Chores**
  * Updated Docker entry point scripts to utilize safer environment loading mechanisms.

* **Tests**
  * Added test suite for environment file processing and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->