### PR TITLE
fix(security): validate page belongs to application in partial export (GHSA-9xfc-9f97-x524)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/partial/PartialExportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/partial/PartialExportServiceCEImpl.java
@@ -88,7 +88,22 @@ public class PartialExportServiceCEImpl implements PartialExportServiceCE {
                         AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, branchedApplicationId)))
                 .cache();
 
-        return applicationMono
+        Mono<String> validatedPageIdMono = applicationMono.flatMap(application -> newPageService
+                .findById(branchedPageId, null)
+                .switchIfEmpty(Mono.error(
+                        new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.PAGE, branchedPageId)))
+                .flatMap(page -> {
+                    if (!application.getId().equals(page.getApplicationId())) {
+                        return Mono.error(new AppsmithException(
+                                AppsmithError.PAGE_DOESNT_BELONG_TO_APPLICATION,
+                                branchedPageId,
+                                branchedApplicationId));
+                    }
+                    return Mono.just(branchedPageId);
+                }));
+
+        return validatedPageIdMono
+                .then(applicationMono)
                 .flatMap(application -> {
                     applicationJson.setExportedApplication(application);
                     return pluginExportableService

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/partial/PartialExportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/partial/PartialExportServiceCEImpl.java
@@ -88,21 +88,24 @@ public class PartialExportServiceCEImpl implements PartialExportServiceCE {
                         AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, branchedApplicationId)))
                 .cache();
 
-        Mono<String> validatedPageIdMono = applicationMono.flatMap(application -> newPageService
-                .findById(branchedPageId, null)
-                .switchIfEmpty(Mono.error(
-                        new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.PAGE, branchedPageId)))
-                .flatMap(page -> {
-                    if (!application.getId().equals(page.getApplicationId())) {
-                        return Mono.error(new AppsmithException(
-                                AppsmithError.PAGE_DOESNT_BELONG_TO_APPLICATION,
-                                branchedPageId,
-                                branchedApplicationId));
-                    }
-                    return Mono.just(branchedPageId);
-                }));
+        // Single page lookup: validates ownership and extracts the page name for resource mapping
+        Mono<String> validatedPageNameMono = applicationMono
+                .flatMap(application -> newPageService
+                        .findById(branchedPageId, null)
+                        .switchIfEmpty(Mono.error(
+                                new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.PAGE, branchedPageId)))
+                        .flatMap(page -> {
+                            if (!application.getId().equals(page.getApplicationId())) {
+                                return Mono.error(new AppsmithException(
+                                        AppsmithError.PAGE_DOESNT_BELONG_TO_APPLICATION,
+                                        branchedPageId,
+                                        branchedApplicationId));
+                            }
+                            return Mono.just(page.getUnpublishedPage().getName());
+                        }))
+                .cache();
 
-        return validatedPageIdMono
+        return validatedPageNameMono
                 .then(applicationMono)
                 .flatMap(application -> {
                     applicationJson.setExportedApplication(application);
@@ -131,8 +134,12 @@ public class PartialExportServiceCEImpl implements PartialExportServiceCE {
                         return Mono.just(branchedPageId);
                     }
                 })
-                // update page name in meta and exportable DTO for resource to name mapping
-                .flatMap(branchedPageId1 -> updatePageNameInResourceMapDTO(branchedPageId, mappedResourcesDTO))
+                // Populate page name in resource map using the already-fetched page
+                .flatMap(branchedPageId1 -> validatedPageNameMono.map(pageName -> {
+                    mappedResourcesDTO.getContextIdToNameMap().put(branchedPageId + EDIT, pageName);
+                    mappedResourcesDTO.getContextIdToNameMap().put(branchedPageId + VIEW, pageName);
+                    return branchedPageId;
+                }))
                 // export actions
                 // export js objects
                 .flatMap(branchedPageId1 -> {
@@ -266,14 +273,5 @@ public class PartialExportServiceCEImpl implements PartialExportServiceCE {
                     applicationJson.setActionCollectionList(updatedActionCollectionList);
                     return Mono.just(applicationJson);
                 });
-    }
-
-    private Mono<String> updatePageNameInResourceMapDTO(
-            String pageId, MappedExportableResourcesDTO mappedResourcesDTO) {
-        return newPageService.getNameByPageId(pageId, false).flatMap(pageName -> {
-            mappedResourcesDTO.getContextIdToNameMap().put(pageId + EDIT, pageName);
-            mappedResourcesDTO.getContextIdToNameMap().put(pageId + VIEW, pageName);
-            return Mono.just(pageId);
-        });
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialExportServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialExportServiceTest.java
@@ -435,15 +435,16 @@ public class PartialExportServiceTest {
         actionConfig.setHttpMethod(HttpMethod.GET);
         victimAction.setActionConfiguration(actionConfig);
         victimAction.setDatasource(datasourceMap.get("DS1"));
-        ActionDTO savedVictimAction =
-                layoutActionService.createSingleAction(victimAction, Boolean.FALSE).block();
+        ActionDTO savedVictimAction = layoutActionService
+                .createSingleAction(victimAction, Boolean.FALSE)
+                .block();
 
         // Attempt partial export: use App A's ID with App B's page ID (BOLA attack)
         PartialExportFileDTO partialExportFileDTO = new PartialExportFileDTO();
         partialExportFileDTO.setActionList(List.of(savedVictimAction.getId()));
 
-        Mono<ApplicationJson> result = partialExportService.getPartialExportResources(
-                appA.getId(), victimPage.getId(), partialExportFileDTO);
+        Mono<ApplicationJson> result =
+                partialExportService.getPartialExportResources(appA.getId(), victimPage.getId(), partialExportFileDTO);
 
         StepVerifier.create(result)
                 .expectErrorSatisfies(error -> {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialExportServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/PartialExportServiceTest.java
@@ -21,6 +21,8 @@ import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.PartialExportFileDTO;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.exports.internal.partial.PartialExportService;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
@@ -399,5 +401,56 @@ public class PartialExportServiceTest {
                     assertThat(newAction.getId()).isEqualTo("Page 2_validAction");
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testGetPartialExport_crossApplicationPageId_rejected() {
+        Mockito.when(pluginService.findAllByIdsWithoutPermission(Mockito.anySet(), Mockito.anyList()))
+                .thenReturn(Flux.fromIterable(List.of(installedPlugin, installedJsPlugin)));
+
+        // Create Application A (the "attacker's" app)
+        Application appA = new Application();
+        appA.setName("GHSA-9xfc-appA-attacker");
+        appA.setWorkspaceId(workspaceId);
+        appA = applicationPageService.createApplication(appA, workspaceId).block();
+
+        // Create Application B (the "victim's" app)
+        Application appB = new Application();
+        appB.setName("GHSA-9xfc-appB-victim");
+        appB.setWorkspaceId(workspaceId);
+        appB = applicationPageService.createApplication(appB, workspaceId).block();
+
+        // Create a page in Application B
+        PageDTO victimPage = new PageDTO();
+        victimPage.setName("VictimPage");
+        victimPage.setApplicationId(appB.getId());
+        victimPage = applicationPageService.createPage(victimPage).block();
+
+        // Create an action in Application B's page
+        ActionDTO victimAction = new ActionDTO();
+        victimAction.setName("secretAction");
+        victimAction.setPageId(victimPage.getId());
+        ActionConfiguration actionConfig = new ActionConfiguration();
+        actionConfig.setHttpMethod(HttpMethod.GET);
+        victimAction.setActionConfiguration(actionConfig);
+        victimAction.setDatasource(datasourceMap.get("DS1"));
+        ActionDTO savedVictimAction =
+                layoutActionService.createSingleAction(victimAction, Boolean.FALSE).block();
+
+        // Attempt partial export: use App A's ID with App B's page ID (BOLA attack)
+        PartialExportFileDTO partialExportFileDTO = new PartialExportFileDTO();
+        partialExportFileDTO.setActionList(List.of(savedVictimAction.getId()));
+
+        Mono<ApplicationJson> result = partialExportService.getPartialExportResources(
+                appA.getId(), victimPage.getId(), partialExportFileDTO);
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(AppsmithException.class);
+                    assertThat(((AppsmithException) error).getAppErrorCode())
+                            .isEqualTo(AppsmithError.PAGE_DOESNT_BELONG_TO_APPLICATION.getAppErrorCode());
+                })
+                .verify();
     }
 }


### PR DESCRIPTION
## Description

Fixes a BOLA/IDOR vulnerability (GHSA-9xfc-9f97-x524, CVSS 6.5 Medium) in the partial application export endpoint.

**Root cause:** `POST /api/v1/applications/export/partial/{branchedApplicationId}/{branchedPageId}` authorized the `branchedApplicationId` but used the attacker-controlled `branchedPageId` to fetch page-scoped resources (actions, JS collections, page names) without verifying the page belongs to the authorized application. An authenticated user could mix their own application ID with a victim's page ID to export private resources from another application.

**Fix:** Add page-application relationship validation in `PartialExportServiceCEImpl.getPartialExportResources()`. After authorizing the application, the page is looked up and verified to belong to that application. If the page doesn't belong, the request is rejected with `PAGE_DOESNT_BELONG_TO_APPLICATION` (400 Bad Request). This mirrors the established pattern in `ApplicationPageServiceCEImpl.makePageDefault()`.

**Files changed:**
- `PartialExportServiceCEImpl.java` — add `validatedPageIdMono` step before page-scoped operations
- `PartialExportServiceTest.java` — add regression test: cross-application page ID is rejected

Fixes [APP-15244](https://linear.app/appsmith/issue/APP-15244)

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This comment is used by github actions. Do not modify or delete! -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/27190272335>
> Commit: e34415957d4711345e65a896ba7d885c41528e8f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=27190272335&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 09 Jun 2026 08:18:33 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partial export now validates that selected pages exist and belong to the specified application. Missing pages and pages from other applications are rejected with clear, specific error responses.

* **Tests**
  * Added test coverage to verify partial export rejects pages that belong to different applications and surfaces the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->