### PR TITLE
fix: Move expires_in field after scope in OAuth2 datasource form

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -683,6 +683,16 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+          {this.renderInputTextControlViaFormControl({
+            configProperty: "authentication.expiresIn",
+            label: "Authorization expires in (seconds)",
+            placeholderText: "3600",
+            dataType: "NUMBER",
+            encrypted: false,
+            isRequired: false,
+          })}
+        </FormInputContainer>
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +879,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&


### PR DESCRIPTION
This is an independent contribution and is not affiliated with any hackathon or competition.

**Summary**
The `expires_in` input field in the OAuth2 datasource configuration form was placed below Custom Authentication Parameters, separated from the other authentication fields. This made it harder for users to discover.

**Root Cause**
The `expires_in` field was rendered inside `renderOauth2AdvancedSettings`, after Custom Authentication Parameters, rather than alongside the related authentication fields in `renderOauth2Common`.

**Fix**
Moved the `expires_in` input field from `renderOauth2AdvancedSettings` to `renderOauth2Common`, placing it directly after the Scope(s) field. All authentication fields are now adjacent for improved discoverability.

**Testing**
- Verified the field renders in the correct position after Scope(s)
- Confirmed no duplicate rendering (old location removed)
- Change is a pure JSX reorder with no logic modification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized OAuth2 configuration form to make the authorization expiration setting available across all OAuth2 authentication types instead of specific flows only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->