### PR TITLE
fix(security): add path traversal validation to widget save path (GHSA-r553-q33m-v7pf)

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
@@ -509,6 +509,8 @@ public class FileUtilsCEImpl implements FileInterface {
 
                     Path path = Paths.get(
                             String.valueOf(pageSpecificDirectory.resolve(CommonConstants.WIDGETS)), childPath);
+                    validatePathIsWithinGitRoot(path);
+                    validatePathIsWithinGitRoot(path.resolve(widgetName + CommonConstants.JSON_EXTENSION));
                     validWidgetToParentMap.put(widgetName, path.toFile().toString());
                     fileOperations.saveWidgets(jsonObject, widgetName, path);
                 });

--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
@@ -1,5 +1,6 @@
 package com.appsmith.git.helpers;
 
+import com.appsmith.external.dtos.ModifiedResources;
 import com.appsmith.external.git.handler.FSGitHandler;
 import com.appsmith.external.git.operations.FileOperations;
 import com.appsmith.external.helpers.ObservationHelper;
@@ -11,6 +12,8 @@ import com.appsmith.git.service.GitExecutorImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +25,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -199,6 +203,134 @@ public class FileUtilsImplTest {
         Object result =
                 fileUtils.reconstructMetadataFromGitRepository(validRepoSuffix).block();
         Assertions.assertNotNull(result);
+    }
+
+    /**
+     * GHSA-r553-q33m-v7pf: Path traversal via malicious widgetName during Git serialization.
+     * A widget with a name containing path traversal sequences (e.g., "../../../../tmp/evil")
+     * must be rejected by validatePathIsWithinGitRoot before any file write occurs.
+     */
+    @Test
+    public void saveApplicationRef_pathTraversalInWidgetName_throwsSecurityException_GHSA_r553()
+            throws GitAPIException, IOException {
+
+        Mockito.when(gitExecutor.resetToLastCommit(Mockito.any(Path.class), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(true));
+
+        Files.createDirectories(localTestDirectoryPath);
+
+        ModifiedResources modifiedResources = new ModifiedResources();
+        modifiedResources.putResource("pageList", "TestPage");
+
+        String maliciousWidgetName = "../../../../tmp/ghsa-r553-traversal-test";
+
+        JSONObject maliciousWidget = new JSONObject();
+        maliciousWidget.put("widgetName", maliciousWidgetName);
+        maliciousWidget.put("type", "BUTTON_WIDGET");
+        maliciousWidget.put("widgetId", "exploit123");
+
+        JSONObject canvasWidget = new JSONObject();
+        canvasWidget.put("widgetName", "Canvas1");
+        canvasWidget.put("type", "CANVAS_WIDGET");
+        canvasWidget.put("children", new JSONArray().put(maliciousWidget));
+
+        JSONObject mainContainer = new JSONObject();
+        mainContainer.put("widgetName", "MainContainer");
+        mainContainer.put("type", "CANVAS_WIDGET");
+        mainContainer.put("widgetId", "0");
+        mainContainer.put("children", new JSONArray().put(canvasWidget));
+
+        ApplicationGitReference appRef = new ApplicationGitReference();
+        appRef.setApplication(new Object());
+        appRef.setTheme(new Object());
+        appRef.setMetadata(new Object());
+        appRef.setModifiedResources(modifiedResources);
+
+        Map<String, Object> pages = new HashMap<>();
+        pages.put("TestPage", new Object());
+        appRef.setPages(pages);
+
+        Map<String, String> pageDsl = new HashMap<>();
+        pageDsl.put("TestPage", mainContainer.toString());
+        appRef.setPageDsl(pageDsl);
+
+        appRef.setActions(new HashMap<>());
+        appRef.setActionCollections(new HashMap<>());
+        appRef.setDatasources(new HashMap<>());
+        appRef.setJsLibraries(new HashMap<>());
+
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            fileUtils
+                    .saveApplicationToGitRepo(Path.of(""), appRef, "branch", false)
+                    .block();
+        });
+
+        Assertions.assertFalse(
+                Files.exists(Path.of("/tmp/ghsa-r553-traversal-test.json")),
+                "Path traversal: file was created outside git root");
+    }
+
+    /**
+     * GHSA-r553-q33m-v7pf: Verify that legitimate widget names still serialize correctly.
+     */
+    @Test
+    public void saveApplicationRef_legitimateWidgetName_doesNotThrow_GHSA_r553() throws GitAPIException, IOException {
+
+        Mockito.when(gitExecutor.resetToLastCommit(Mockito.any(Path.class), Mockito.any(), Mockito.anyBoolean()))
+                .thenReturn(Mono.just(true));
+
+        Files.createDirectories(localTestDirectoryPath);
+
+        ModifiedResources modifiedResources = new ModifiedResources();
+        modifiedResources.putResource("pageList", "TestPage");
+
+        JSONObject safeWidget = new JSONObject();
+        safeWidget.put("widgetName", "Button1");
+        safeWidget.put("type", "BUTTON_WIDGET");
+        safeWidget.put("widgetId", "safe123");
+
+        JSONObject canvasWidget = new JSONObject();
+        canvasWidget.put("widgetName", "Canvas1");
+        canvasWidget.put("type", "CANVAS_WIDGET");
+        canvasWidget.put("children", new JSONArray().put(safeWidget));
+
+        JSONObject mainContainer = new JSONObject();
+        mainContainer.put("widgetName", "MainContainer");
+        mainContainer.put("type", "CANVAS_WIDGET");
+        mainContainer.put("widgetId", "0");
+        mainContainer.put("children", new JSONArray().put(canvasWidget));
+
+        ApplicationGitReference appRef = new ApplicationGitReference();
+        appRef.setApplication(new Object());
+        appRef.setTheme(new Object());
+        appRef.setMetadata(new Object());
+        appRef.setModifiedResources(modifiedResources);
+
+        Map<String, Object> pages = new HashMap<>();
+        pages.put("TestPage", new Object());
+        appRef.setPages(pages);
+
+        Map<String, String> pageDsl = new HashMap<>();
+        pageDsl.put("TestPage", mainContainer.toString());
+        appRef.setPageDsl(pageDsl);
+
+        appRef.setActions(new HashMap<>());
+        appRef.setActionCollections(new HashMap<>());
+        appRef.setDatasources(new HashMap<>());
+        appRef.setJsLibraries(new HashMap<>());
+
+        Assertions.assertDoesNotThrow(() -> {
+            fileUtils
+                    .saveApplicationToGitRepo(Path.of(""), appRef, "branch", false)
+                    .block();
+        });
+
+        Path widgetFile = localTestDirectoryPath
+                .resolve(PAGE_DIRECTORY)
+                .resolve("TestPage")
+                .resolve("widgets")
+                .resolve("Button1.json");
+        Assertions.assertTrue(Files.exists(widgetFile), "Legitimate widget file should exist");
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes the path traversal vulnerability in Git widget serialization reported in [GHSA-r553-q33m-v7pf](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-r553-q33m-v7pf).

**Root cause:** `FileUtilsCEImpl.updateEntitiesInRepo()` writes widget files to disk using user-controlled `widgetName` values without calling `validatePathIsWithinGitRoot()`. All other Git file write helpers in the same class (`saveResource()`, `saveActions()`, `saveActionCollection()`, `saveResourceCommon()`) already validate paths, but the widget save path was the only one that skipped this check.

**Attack:** An authenticated user with edit access to a Git-connected application can set `widgetName` to a path traversal payload (e.g., `../../../../tmp/evil`) via the layout update API. When Git serialization is triggered (status/commit/auto-commit), the widget JSON is written outside the Git repository to an arbitrary location on the server filesystem.

**Fix:** Add `validatePathIsWithinGitRoot()` calls on both the widget directory path and the final file path before calling `fileOperations.saveWidgets()`, consistent with the established pattern used by every other write helper in `FileUtilsCEImpl`.

## Fixes
- https://github.com/appsmithorg/appsmith/security/advisories/GHSA-r553-q33m-v7pf
- Linear: [APP-15247](https://linear.app/appsmith/issue/APP-15247)

## Testing
- [x] Added regression test: `saveApplicationRef_pathTraversalInWidgetName_throwsSecurityException_GHSA_r553` — constructs a DSL with a path traversal widget name, verifies `AppsmithPluginException` is thrown, verifies no file is created outside git root
- [x] Added positive test: `saveApplicationRef_legitimateWidgetName_doesNotThrow_GHSA_r553` — verifies legitimate widget names still serialize correctly
- [x] Full `appsmith-git` test suite: 72/72 tests pass
- [x] Full server compilation: clean

## CE/EE Impact
CE-only change. The EE `FileUtilsImpl` calls `super.updateEntitiesInRepo()` so the fix propagates automatically. No EE-specific changes needed.

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/26449019786>
> Commit: eff0ba7b9ffd989f0d78467c9a9f3ddfe4b3d32b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=26449019786&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 26 May 2026 14:07:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added path validation when saving applications to Git repositories, preventing unauthorized file access during the save process.

* **Tests**
  * Added security tests verifying path validation correctly handles both legitimate and malicious widget names during application serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


/test all