### PR TITLE
fix(husky): stage server files from worktree root in pre-commit hook

### DIFF
--- a/app/client/.husky/check-staged-files.sh
+++ b/app/client/.husky/check-staged-files.sh
@@ -5,10 +5,14 @@ is_client_change=$(git diff --cached --name-only | grep -c "app/client")
 
 is_merge_commit=$(git rev-parse -q --verify MERGE_HEAD)
 
-# Function to apply Spotless and only commit staged files
+# Function to apply Spotless and only commit staged files.
+# Runs mvn in a subshell so we don't pushd the script's cwd into app/server.
+# Staging from the worktree root with full paths avoids a worktree-only bug:
+# git invokes hooks with GIT_DIR set but GIT_WORK_TREE unset, so `git add` from
+# a subdirectory treats cwd as the worktree root and stages files at the wrong path.
 apply_spotless_and_commit_staged_files() {
-  staged_server_files=$(git diff --cached --name-only | grep "app/server"| sed 's|app/server/||')
-  mvn spotless:apply
+  staged_server_files=$(git diff --cached --name-only | grep "app/server")
+  (cd app/server && mvn spotless:apply)
    # Check if Spotless succeeded
   if [ $? -ne 0 ]; then
     echo "Spotless apply failed, Please run mvn spotless:apply"
@@ -23,9 +27,7 @@ if [ "$is_merge_commit" ]; then
 else
   if [ "$is_server_change" -ge 1 ]; then
     echo "Applying Spotless to server files..."
-    pushd app/server > /dev/null
     apply_spotless_and_commit_staged_files
-    popd > /dev/null
   else
     echo "Skipping server side check..."
   fi


### PR DESCRIPTION
## Summary
- Pre-commit hook stages server files at the wrong path when committing from a linked git worktree, creating an orphan tree at the worktree root in addition to the correct entry.
- Root cause: git invokes hooks with `GIT_DIR` set but `GIT_WORK_TREE` unset. After `pushd app/server`, `git add` falls back to treating cwd as the worktree root, so `xargs git add appsmith-interfaces/...` (with the `app/server/` prefix stripped) stages files at the wrong location. Only affects worktrees, not the main checkout.
- Fix: run `mvn spotless:apply` in a subshell (so the script's cwd stays at worktree root), and stage with full `app/server/...` paths via the unchanged path list. Same behavior in the main checkout; correct behavior in worktrees.

## Reproduction
In a linked worktree with a staged change under `app/server/`, the hook stages the file twice — once correctly and once at the worktree root without the `app/server/` prefix. Verified by simulating the hook env (`GIT_DIR` set, cwd at `app/server/`) and running the old vs new `git add` invocation; old path produces the duplicate orphan entry, new path produces only the correct entry.

## Test plan
- [ ] Commit a server file change from a linked git worktree (`git worktree add ...`); confirm `git status` after commit shows no orphan entries at the worktree root.
- [ ] Commit a server file change from the main checkout; confirm spotless still runs and re-staging works as before.
- [ ] Commit a client-only change; confirm `lint-staged` still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code formatting automation to improve developer workflow efficiency.

---

**Note:** This release contains no user-facing changes. The update addresses internal development tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->