### PR TITLE
fix(security): remove unused supervisord admin port (GHSA-v49v-673j-g4vj)

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,10 +33,6 @@
       "APPSMITH_DISABLE_TELEMETRY": {
         "description" : "We want to be transparent and request that you share anonymous usage data with us. This data is purely statistical in nature and helps us understand your needs & provide better support to your self-hosted instance. You can read more about what information is collected in our documentation https://docs.appsmith.com/product/telemetry",
         "value": "false"
-      },
-      "APPSMITH_SUPERVISOR_PASSWORD": {
-        "description": "Basic authentication password to access Supervisor UI - An web interface, which allow you to manage various process",
-        "value": ""
-			}
+      }
    }
 }

--- a/deploy/docker/fs/etc/supervisor/supervisord.conf
+++ b/deploy/docker/fs/etc/supervisor/supervisord.conf
@@ -4,11 +4,6 @@
 file=%(ENV_TMP)s/supervisor.sock   ; (the path to the socket file)
 chmod=0700                       ; sockef file mode (default 0700)
 
-[inet_http_server]         ; inet (TCP) server disabled by default
-port=*:9001        ; (ip_address:port specifier, *:port for all iface)
-username=%(ENV_APPSMITH_SUPERVISOR_USER)s
-password=%(ENV_APPSMITH_SUPERVISOR_PASSWORD)s
-
 [supervisord]
 logfile=%(ENV_APPSMITH_LOG_DIR)s/supervisor/%(ENV_HOSTNAME)s-stdout.log ; (main log file;default $CWD/supervisord.log)
 pidfile=%(ENV_TMP)s/supervisord.pid ; (supervisord pidfile;default supervisord.pid)

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -144,11 +144,6 @@ parts.push(`
     import reverse_proxy 8091
   }
 
-  redir /supervisor /supervisor/
-  handle_path /supervisor/* {
-    import reverse_proxy 9001
-  }
-
   ${isRateLimitingEnabled ? `rate_limit {
     zone dynamic_zone {
       # This key is designed to work irrespective of any load balancers running on the Appsmith container.

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -98,16 +98,12 @@ init_env_file() {
       tr -dc A-Za-z0-9 </dev/urandom | head -c 13
       echo ""
     )
-    local generated_appsmith_supervisor_password=$(
-      tr -dc A-Za-z0-9 </dev/urandom | head -c 13
-      echo ''
-    )
     local generated_appsmith_redis_password=$(
       tr -dc A-Za-z0-9 </dev/urandom | head -c 13
       echo ''
     )
 
-    bash "$TEMPLATES_PATH/docker.env.sh" "$default_appsmith_mongodb_user" "$generated_appsmith_mongodb_password" "$generated_appsmith_encryption_password" "$generated_appsmith_encription_salt" "$generated_appsmith_supervisor_password" "$generated_appsmith_redis_password" > "$ENV_PATH"
+    bash "$TEMPLATES_PATH/docker.env.sh" "$default_appsmith_mongodb_user" "$generated_appsmith_mongodb_password" "$generated_appsmith_encryption_password" "$generated_appsmith_encription_salt" "$generated_appsmith_redis_password" > "$ENV_PATH"
   else
     tlog "Configuration file already exists"
     # Backfill APPSMITH_REDIS_PASSWORD for existing installs that don't have it yet.
@@ -223,12 +219,6 @@ unset_unused_variables() {
     unset APPSMITH_RECAPTCHA_SITE_KEY # If this field is empty is might cause application crash
     unset APPSMITH_RECAPTCHA_SECRET_KEY
     unset APPSMITH_RECAPTCHA_ENABLED
-  fi
-
-  export APPSMITH_SUPERVISOR_USER="${APPSMITH_SUPERVISOR_USER:-appsmith}"
-  if [[ -z "${APPSMITH_SUPERVISOR_PASSWORD-}" ]]; then
-    APPSMITH_SUPERVISOR_PASSWORD="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)"
-    export APPSMITH_SUPERVISOR_PASSWORD
   fi
 }
 

--- a/deploy/docker/fs/opt/appsmith/templates/docker.env.sh
+++ b/deploy/docker/fs/opt/appsmith/templates/docker.env.sh
@@ -5,8 +5,7 @@ MONGO_USER="$1"
 DB_PASSWORD="$2"
 ENCRYPTION_PASSWORD="$3"
 ENCRYPTION_SALT="$4"
-SUPERVISOR_PASSWORD="$5"
-REDIS_PASSWORD="${6:-}"
+REDIS_PASSWORD="${5:-}"
 
 cat <<EOF
 # Sentry
@@ -78,9 +77,6 @@ APPSMITH_JAVA_ARGS=
 # APPSMITH_PLUGIN_MAX_RESPONSE_SIZE_MB=5
 # MAX PAYLOAD SIZE
 # APPSMITH_CODEC_SIZE=
-
-APPSMITH_SUPERVISOR_USER=appsmith
-APPSMITH_SUPERVISOR_PASSWORD=$SUPERVISOR_PASSWORD
 
 # Set this to a space separated list of addresses that should be allowed to load Appsmith in a frame.
 # Example: "https://mydomain.com https://another-trusted-domain.com" will allow embedding on those two domains.


### PR DESCRIPTION
## Summary

The supervisord inet HTTP server on port 9001 is not used by anything internally — supervisorctl (Java backend self-restart, RTS, healthcheck, auto_heal) goes through the Unix socket. The admin port is dead config we don't need.

## Removed

- `[inet_http_server]` block in `supervisord.conf`
- `APPSMITH_SUPERVISOR_USER` / `_PASSWORD` generation in `entrypoint.sh`
- `SUPERVISOR_PASSWORD` positional arg in `docker.env.sh` template (shifts `REDIS_PASSWORD` from `$6` to `$5`)
- `APPSMITH_SUPERVISOR_PASSWORD` entry in `app.json` (Heroku)
- `/supervisor` route in `caddy-reconfigure.mjs`

## Compatibility

`APPSMITH_SUPERVISOR_PASSWORD` set in customer env files will be ignored; the `/supervisor` URL will 404. Docs page covering it will be updated separately.

## Test plan

- [x] CI passes
- [x] Local container build comes up, all processes start under supervisord
- [x] `supervisorctl status` still works inside the container (Unix socket)
- [x] License change / env reload still restarts the JVM (`EnvManagerCEImpl` flow)

Related advisory: [GHSA-v49v-673j-g4vj](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-v49v-673j-g4vj)

Linear: [APP-15170](https://linear.app/appsmith/issue/APP-15170)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Supervisor password authentication configuration.
  * Disabled Supervisor TCP web interface.
  * Updated reverse proxy routing for internal services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 13eacee404fd5fc0d0e7e9b54383c3dcec06e192 yet
> <hr>Tue, 26 May 2026 15:57:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->

