### PR TITLE
test: add null connection SSL fallback test

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -773,4 +773,19 @@ public class MssqlPluginTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    public void testSslDefaultsToNoVerify_whenConnectionIsNull() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setConnection(null);
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                        assertNotNull(hikariDataSource);
+                        assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
+                })
+                .verifyComplete();
+        }
 }


### PR DESCRIPTION
## Summary

Adds a regression test for the MSSQL SSL fallback fix.

This test verifies that when the DatasourceConfiguration connection object is null, the plugin gracefully defaults to encrypt=false instead of throwing an exception.

## Why this test matters

This test validates the outermost null-guard branch in addSslOptionsToUrlBuilder() and prevents regressions where missing connection configuration could crash datasource creation.

Fixes #41627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for MSSQL plugin's SSL configuration behavior, verifying expected default settings under specific connection conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->