### PR TITLE
test: add null SSL details fallback test

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -773,4 +773,18 @@ public class MssqlPluginTest {
                 })
                 .verifyComplete();
     }
+    @Test
+    public void testSslDefaultsToDisable_whenSslDetailsAreNull() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.getConnection().setSsl(null);
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                        assertNotNull(hikariDataSource);
+                        assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
+                })
+                .verifyComplete();
+        }
 }


### PR DESCRIPTION
## Summary

Adds a regression test for the MSSQL SSL fallback fix.

This test verifies that when the SSLDetails object is null, the plugin gracefully defaults to encrypt=false instead of throwing an exception.

## Why this test matters

This test validates the intermediate null-guard branch in addSslOptionsToUrlBuilder() and ensures datasource creation remains robust even when SSL configuration is partially initialized.

Fixes #41627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify SSL encryption defaults to disabled when datasource SSL configuration is not provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->