### PR TITLE
feat: add MSSQL datasource configuration summary

### DIFF
--- a/app/client/packages/design-system/ads/src/Toast/Toast.styles.tsx
+++ b/app/client/packages/design-system/ads/src/Toast/Toast.styles.tsx
@@ -58,6 +58,7 @@ export const ToastBody = styled(Text)`
   color: var(--ads-v2-colors-response-label-default-fg);
   gap: var(--ads-v2-spaces-3);
   word-break: break-word;
+  white-space: pre-line;
 `;
 
 export const StyledButton = styled(Button)`

--- a/app/client/src/ce/sagas/DatasourcesSagas.ts
+++ b/app/client/src/ce/sagas/DatasourcesSagas.ts
@@ -962,12 +962,6 @@ export function* testDatasourceSaga(actionPayload: ReduxAction<Datasource>) {
 
       if (responseData.messages && responseData.messages.length) {
         messages = responseData.messages;
-
-        if (responseData.success) {
-          toast.show(createMessage(DATASOURCE_VALID, payload.name), {
-            kind: "success",
-          });
-        }
       }
 
       if (responseData.invalids && responseData.invalids.length) {
@@ -1010,7 +1004,12 @@ export function* testDatasourceSaga(actionPayload: ReduxAction<Datasource>) {
           environmentName: currentEnvDetails.name,
           pluginName: plugin?.name,
         });
-        toast.show(createMessage(DATASOURCE_VALID, payload.name), {
+        const successMessage = [
+          createMessage(DATASOURCE_VALID, payload.name),
+          ...messages,
+        ].join("\n");
+
+        toast.show(successMessage, {
           kind: "success",
         });
         yield put({

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -17,6 +17,7 @@ import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStructure;
+import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.MustacheBindingToken;
 import com.appsmith.external.models.Param;
@@ -65,6 +66,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -383,6 +385,76 @@ public class MssqlPlugin extends BasePlugin {
         }
 
         @Override
+        public Mono<DatasourceTestResult> testDatasource(DatasourceConfiguration datasourceConfiguration) {
+            return this.datasourceCreate(datasourceConfiguration)
+                    .flatMap(connection -> this.testDatasource(connection)
+                            .map(testResult -> {
+                                testResult.setMessages(buildDatasourceConfigurationSummary(datasourceConfiguration));
+                                return testResult;
+                            })
+                            .doFinally(signal -> this.datasourceDestroy(connection)))
+                    .onErrorResume(error -> {
+                        final String errorMessage = error.getMessage() == null
+                                ? AppsmithPluginError.PLUGIN_DATASOURCE_TEST_GENERIC_ERROR.getMessage()
+                                : error.getMessage();
+                        if (error instanceof AppsmithPluginException
+                                && StringUtils.hasLength(((AppsmithPluginException) error).getDownstreamErrorMessage())) {
+                            return Mono.just(new DatasourceTestResult(
+                                    ((AppsmithPluginException) error).getDownstreamErrorMessage(), errorMessage));
+                        }
+                        return Mono.just(new DatasourceTestResult(errorMessage));
+                    })
+                    .subscribeOn(Schedulers.boundedElastic());
+        }
+
+        private Set<String> buildDatasourceConfigurationSummary(DatasourceConfiguration datasourceConfiguration) {
+            Set<String> summary = new LinkedHashSet<>();
+            summary.add("Summary");
+            summary.add("Database: MSSQL");
+
+            if (!isEmpty(datasourceConfiguration.getEndpoints())) {
+                Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
+                summary.add("Host: " + endpoint.getHost());
+                summary.add("Port: " + getPort(endpoint));
+            }
+
+            SSLDetails.AuthType sslAuthType = datasourceConfiguration.getConnection() != null
+                    && datasourceConfiguration.getConnection().getSsl() != null
+                    ? datasourceConfiguration.getConnection().getSsl().getAuthType()
+                    : null;
+            SSLDetails.AuthType resolvedSslAuthType =
+                    ObjectUtils.defaultIfNull(sslAuthType, SSLDetails.AuthType.DISABLE);
+            summary.add("SSL: " + getSslDisplayName(resolvedSslAuthType));
+
+            DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
+            if (authentication != null && authentication.getAuthType() != null) {
+                summary.add("Authentication: " + getAuthenticationDisplayName(authentication.getAuthType()));
+            }
+
+            return summary;
+        }
+
+        private String getSslDisplayName(SSLDetails.AuthType sslAuthType) {
+            switch (sslAuthType) {
+                case DISABLE:
+                    return "Disabled";
+                case NO_VERIFY:
+                    return "Enabled with no verify";
+                default:
+                    return sslAuthType.name();
+            }
+        }
+
+        private String getAuthenticationDisplayName(DBAuth.Type authType) {
+            switch (authType) {
+                case USERNAME_PASSWORD:
+                    return "Username/Password";
+                default:
+                    return authType.name();
+            }
+        }
+
+        @Override
         public void datasourceDestroy(HikariDataSource connection) {
             if (connection != null) {
                 connection.close();
@@ -646,7 +718,8 @@ public class MssqlPlugin extends BasePlugin {
          * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
          */
         if (datasourceConfiguration.getConnection() == null
-                || datasourceConfiguration.getConnection().getSsl() == null) {
+                || datasourceConfiguration.getConnection().getSsl() == null
+                || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
             throw new AppsmithPluginException(
                     AppsmithPluginError.PLUGIN_ERROR,
                     "Appsmith server has failed to fetch SSL configuration from datasource configuration form. "
@@ -656,8 +729,8 @@ public class MssqlPlugin extends BasePlugin {
         /*
          * - By default, the driver configures SSL in the no verify mode.
          */
-        SSLDetails.AuthType sslAuthType = ObjectUtils.defaultIfNull(
-                datasourceConfiguration.getConnection().getSsl().getAuthType(), SSLDetails.AuthType.DISABLE);
+        SSLDetails.AuthType sslAuthType =
+                datasourceConfiguration.getConnection().getSsl().getAuthType();
         switch (sslAuthType) {
             case DISABLE:
                 urlBuilder.append("encrypt=false;");

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -646,8 +646,7 @@ public class MssqlPlugin extends BasePlugin {
          * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
          */
         if (datasourceConfiguration.getConnection() == null
-                || datasourceConfiguration.getConnection().getSsl() == null
-                || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
+                || datasourceConfiguration.getConnection().getSsl() == null) {
             throw new AppsmithPluginException(
                     AppsmithPluginError.PLUGIN_ERROR,
                     "Appsmith server has failed to fetch SSL configuration from datasource configuration form. "
@@ -657,8 +656,8 @@ public class MssqlPlugin extends BasePlugin {
         /*
          * - By default, the driver configures SSL in the no verify mode.
          */
-        SSLDetails.AuthType sslAuthType =
-                datasourceConfiguration.getConnection().getSsl().getAuthType();
+        SSLDetails.AuthType sslAuthType = ObjectUtils.defaultIfNull(
+                datasourceConfiguration.getConnection().getSsl().getAuthType(), SSLDetails.AuthType.DISABLE);
         switch (sslAuthType) {
             case DISABLE:
                 urlBuilder.append("encrypt=false;");

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -773,4 +773,18 @@ public class MssqlPluginTest {
                 })
                 .verifyComplete();
     }
+    @Test
+    public void testSslDefaultsToDisable_whenAuthTypeIsNull() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.getConnection().getSsl().setAuthType(null);
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                        assertNotNull(hikariDataSource);
+                        assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
+                })
+                .verifyComplete();
+        }
 }

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -143,6 +143,15 @@ public class MssqlPluginTest {
                     assertNotNull(datasourceTestResult);
                     assertTrue(datasourceTestResult.isSuccess());
                     assertTrue(datasourceTestResult.getInvalids().isEmpty());
+                    assertEquals(
+                            List.of(
+                                    "Summary",
+                                    "Database: MSSQL",
+                                    "Host: " + container.getHost(),
+                                    "Port: " + container.getMappedPort(1433),
+                                    "SSL: Enabled with no verify",
+                                    "Authentication: Username/Password"),
+                            new ArrayList<>(datasourceTestResult.getMessages()));
                 })
                 .verifyComplete();
     }
@@ -770,21 +779,6 @@ public class MssqlPluginTest {
         StepVerifier.create(endPointIdentifierMono)
                 .assertNext(endpointIdentifier -> {
                     assertEquals("localhost_1433", endpointIdentifier);
-                })
-                .verifyComplete();
-    }
-
-    @Test
-    public void testSslDefaultsToDisable_whenAuthTypeIsNull() {
-        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
-        dsConfig.getConnection().getSsl().setAuthType(null);
-
-        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
-
-        StepVerifier.create(dsConnectionMono)
-                .assertNext(hikariDataSource -> {
-                    assertNotNull(hikariDataSource);
-                    assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -773,6 +773,7 @@ public class MssqlPluginTest {
                 })
                 .verifyComplete();
     }
+
     @Test
     public void testSslDefaultsToDisable_whenAuthTypeIsNull() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
@@ -782,9 +783,9 @@ public class MssqlPluginTest {
 
         StepVerifier.create(dsConnectionMono)
                 .assertNext(hikariDataSource -> {
-                        assertNotNull(hikariDataSource);
-                        assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
+                    assertNotNull(hikariDataSource);
+                    assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
                 })
                 .verifyComplete();
-        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds a datasource configuration summary for successful MSSQL connection tests.

After a successful connection test, the success message now includes:
- Database type
- Host
- Port
- SSL mode
- Authentication mode

## Why

This helps users confirm which datasource configuration was tested instead of only seeing a generic success message.

## Testing

- `./build.sh -DskipTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Datasource test results now display SSL configuration status and authentication type details.
  * Enhanced datasource test notifications with detailed server configuration information.

* **Improvements**
  * Toast messages now properly preserve line breaks for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->