### PR TITLE
fix(security): bind Caddy admin to local socket (GHSA-8jvv-gwqg-6vjc)

### DIFF
--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -7,6 +7,7 @@ import {X509Certificate} from "crypto"
 // This was the effective behaviour before Caddy.
 const CUSTOM_DOMAIN = (process.env.APPSMITH_CUSTOM_DOMAIN || "").replace(/^https?:\/\/.+$/, "")
 const CaddyfilePath = process.env.TMP + "/Caddyfile"
+const CaddyAdminSocketPath = process.env.TMP + "/caddy.sock"
 const AppsmithCaddy = process.env._APPSMITH_CADDY
 
 // Rate limit environment.
@@ -43,7 +44,7 @@ const parts = []
 parts.push(`
 {
   # Local socket so control scripts can drive caddy reload; not reachable over TCP.
-  admin unix//tmp/appsmith/caddy.sock
+  admin unix/${CaddyAdminSocketPath}
   persist_config off
   acme_ca_root /etc/ssl/certs/ca-certificates.crt
   servers {

--- a/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+++ b/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
@@ -42,15 +42,21 @@ const parts = []
 
 parts.push(`
 {
-  admin 0.0.0.0:2019
+  # Local socket so control scripts can drive caddy reload; not reachable over TCP.
+  admin unix//tmp/appsmith/caddy.sock
   persist_config off
   acme_ca_root /etc/ssl/certs/ca-certificates.crt
   servers {
     protocols h1 h2 h3
     trusted_proxies static 0.0.0.0/0
-    metrics
   }
   ${isRateLimitingEnabled ? "order rate_limit before basicauth" : ""}
+}
+
+# Prometheus metrics on the port the Helm chart targets. This is the only thing
+# exposed on :2019 — every path returns the metrics body.
+:2019 {
+  metrics
 }
 
 (file_server) {


### PR DESCRIPTION
## Summary

Security fix for [GHSA-8jvv-gwqg-6vjc](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-8jvv-gwqg-6vjc). Caddy's admin endpoint now binds to a Unix socket instead of TCP; Prometheus metrics keep their previous port for scrape-config compatibility.

## What changed

`deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs` — admin moved to a Unix socket, dedicated `:2019 { metrics }` block for Prometheus, no Helm changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Admin interface now binds to a local Unix socket instead of a network port, reducing external exposure.
  * Port 2019 is reserved exclusively for Prometheus metrics collection to isolate monitoring traffic.
  * HTTP protocol handling and trusted-proxy/rate-limiting settings in the admin configuration have been tightened for improved security and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD c49fba77dcc51ba1ca98b2fb7f9adf81aa13b225 yet
> <hr>Tue, 26 May 2026 18:54:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->
