### PR TITLE
docs(security): direct vulnerability reports to GitHub security advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a Vulnerability
 
 We value security for the project very highly. We encourage all users to report any vulnerabilities they discover to us.
-If you find a security vulnerability in the Appsmith project, please report it responsibly by sending an email to security@appsmith.com.
+If you find a security vulnerability in the Appsmith project, please report it responsibly through GitHub's private vulnerability reporting: https://github.com/appsmithorg/appsmith/security/advisories/new.
 
 At this juncture, we don't have a bug bounty program. We are a small team trying to solve a big problem. We urge you to report any vulnerabilities responsibly
 so that we can continue building a secure application for the entire community.


### PR DESCRIPTION
## Summary
- Replace the `security@appsmith.com` mailing list with a link to GitHub's private vulnerability reporting in `SECURITY.md`.

## Test plan
- [ ] Confirm the link in the rendered `SECURITY.md` opens the new-advisory form on `appsmithorg/appsmith`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability reporting instructions to direct reporters to GitHub's private vulnerability reporting form for improved security incident handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->