### PR TITLE
fix(security): apply full non-routable IP-class filter on WebClient (GHSA-v49v-673j-g4vj, GHSA-m23h-pvf3-2m7p)

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
@@ -251,7 +251,8 @@ public class WebClientUtils {
     }
 
     public static boolean isDisallowedAndFail(String host, Promise<?> promise) {
-        if (DISALLOWED_HOSTS.contains(normalizeHostForComparisonQuietly(host))) {
+        final String canonicalHost = normalizeHostForComparisonQuietly(host);
+        if (DISALLOWED_HOSTS.contains(canonicalHost) || isBlockedAddressClassInDocker(canonicalHost)) {
             log.warn("Host {} is disallowed. Failing the request.", host);
             if (promise != null) {
                 promise.setFailure(new UnknownHostException(HOST_NOT_ALLOWED));
@@ -279,9 +280,36 @@ public class WebClientUtils {
                     AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, "IP Address resolution is invalid"));
         }
 
-        return DISALLOWED_HOSTS.contains(canonicalHost)
+        return (DISALLOWED_HOSTS.contains(canonicalHost) || isBlockedAddressClassInDocker(canonicalHost))
                 ? Mono.error(new UnknownHostException(HOST_NOT_ALLOWED))
                 : Mono.just(request);
+    }
+
+    static boolean isBlockedIpAddressClass(String canonicalHost) {
+        if (!isValidIpAddress(canonicalHost)) {
+            return false;
+        }
+        try {
+            final InetAddress address = InetAddress.getByName(canonicalHost);
+            if (address.isLoopbackAddress()
+                    || address.isAnyLocalAddress()
+                    || address.isLinkLocalAddress()
+                    || address.isMulticastAddress()) {
+                return true;
+            }
+            if (address instanceof Inet6Address) {
+                // fc00::/7 — IPv6 Unique Local Addresses
+                byte firstByte = address.getAddress()[0];
+                return (firstByte & (byte) 0xFE) == (byte) 0xFC;
+            }
+            return false;
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    private static boolean isBlockedAddressClassInDocker(String canonicalHost) {
+        return "1".equals(System.getenv("IN_DOCKER")) && isBlockedIpAddressClass(canonicalHost);
     }
 
     private static boolean isValidIpAddress(String host) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/WebClientUtils.java
@@ -230,19 +230,8 @@ public class WebClientUtils {
         }
 
         for (InetAddress addr : resolved) {
-            if (DISALLOWED_HOSTS.contains(normalizeHostForComparisonQuietly(addr.getHostAddress()))) {
-                return Optional.empty();
-            }
-            if (addr instanceof Inet6Address) {
-                byte firstByte = addr.getAddress()[0];
-                if ((firstByte & (byte) 0xFE) == (byte) 0xFC) {
-                    return Optional.empty();
-                }
-            }
-            if (addr.isLoopbackAddress()
-                    || addr.isLinkLocalAddress()
-                    || addr.isAnyLocalAddress()
-                    || addr.isMulticastAddress()) {
+            if (DISALLOWED_HOSTS.contains(normalizeHostForComparisonQuietly(addr.getHostAddress()))
+                    || matchesBlockedAddressClass(addr)) {
                 return Optional.empty();
             }
         }
@@ -290,22 +279,25 @@ public class WebClientUtils {
             return false;
         }
         try {
-            final InetAddress address = InetAddress.getByName(canonicalHost);
-            if (address.isLoopbackAddress()
-                    || address.isAnyLocalAddress()
-                    || address.isLinkLocalAddress()
-                    || address.isMulticastAddress()) {
-                return true;
-            }
-            if (address instanceof Inet6Address) {
-                // fc00::/7 — IPv6 Unique Local Addresses
-                byte firstByte = address.getAddress()[0];
-                return (firstByte & (byte) 0xFE) == (byte) 0xFC;
-            }
-            return false;
+            return matchesBlockedAddressClass(InetAddress.getByName(canonicalHost));
         } catch (UnknownHostException e) {
             return false;
         }
+    }
+
+    private static boolean matchesBlockedAddressClass(InetAddress address) {
+        if (address.isLoopbackAddress()
+                || address.isAnyLocalAddress()
+                || address.isLinkLocalAddress()
+                || address.isMulticastAddress()) {
+            return true;
+        }
+        if (address instanceof Inet6Address) {
+            // fc00::/7 — IPv6 Unique Local Addresses
+            byte firstByte = address.getAddress()[0];
+            return (firstByte & (byte) 0xFE) == (byte) 0xFC;
+        }
+        return false;
     }
 
     private static boolean isBlockedAddressClassInDocker(String canonicalHost) {

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/WebClientUtilsTest.java
@@ -15,6 +15,7 @@ import java.net.UnknownHostException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WebClientUtilsTest {
@@ -92,6 +93,57 @@ public class WebClientUtilsTest {
         Optional<InetAddress> result = WebClientUtils.resolveIfAllowed("smtp.gmail.com");
         assertTrue(result.isPresent());
         assertTrue(result.get().getHostAddress().matches("\\d+\\.\\d+\\.\\d+\\.\\d+"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                // Loopback
+                "127.0.0.1",
+                "127.0.0.2",
+                "127.0.0.254",
+                "127.1.2.3",
+                "127.255.255.255",
+                "::1",
+                // Any-local
+                "0.0.0.0",
+                "::",
+                // Link-local
+                "169.254.0.1",
+                "169.254.169.254",
+                "fe80::1",
+                // Multicast
+                "224.0.0.1",
+                "239.255.255.250",
+                "ff02::1",
+                // IPv6 ULA (fc00::/7)
+                "fc00::1",
+                "fd00::1",
+                "fdff::ffff",
+            })
+    public void isBlockedIpAddressClass_recognizesNonRoutableClasses(String host) {
+        assertTrue(
+                WebClientUtils.isBlockedIpAddressClass(host),
+                "Expected " + host + " to be recognized as a blocked address class");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "1.1.1.1",
+                "8.8.8.8",
+                // RFC 1918 site-local — intentionally allowed for internal REST API targets
+                "192.168.1.1",
+                "10.0.0.1",
+                "172.16.0.1",
+                // Non-literals
+                "smtp.gmail.com",
+                "localhost",
+            })
+    public void isBlockedIpAddressClass_doesNotMatchOtherHosts(String host) {
+        assertFalse(
+                WebClientUtils.isBlockedIpAddressClass(host),
+                "Did not expect " + host + " to be recognized as a blocked address class");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Extend the `WebClientUtils` host filter (REST API / GraphQL / OAuth2 plugin paths) to reject the same set of non-routable IP address classes that the SMTP code path already rejects via `resolveIfAllowed`: loopback (`127.0.0.0/8`, `::1`), any-local (`0.0.0.0`, `::`), link-local (`169.254.0.0/16`, `fe80::/10`), multicast, and IPv6 Unique Local Addresses (`fc00::/7`). RFC 1918 site-local ranges remain allowed (same intentional exception as `resolveIfAllowed`).

Addresses:
- [GHSA-v49v-673j-g4vj](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-v49v-673j-g4vj)
- [GHSA-m23h-pvf3-2m7p](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-m23h-pvf3-2m7p)

## Approach

`requestFilterFn` and `isDisallowedAndFail` now `OR` an additional check against the existing exact-match `DISALLOWED_HOSTS` lookup: an IP-literal helper that returns true when `InetAddress.isLoopbackAddress()`, `isAnyLocalAddress()`, `isLinkLocalAddress()`, or `isMulticastAddress()` is true, or when the address is IPv6 in the `fc00::/7` ULA range. The existing canonicalization (IPv4-mapped IPv6 literals normalized to IPv4) handles literal variants.

## Test plan

- [x] `mvn -pl appsmith-interfaces test -Dtest=WebClientUtilsTest` (48/48, +24 parameterized cases over `isBlockedIpAddressClass`).
- [x] `mvn -pl appsmith-interfaces spotless:check` clean.
- [x] Validated end-to-end on a deploy preview: REST API requests to literals in the blocked classes return `Host not allowed` rather than attempting the outbound connection. RFC 1918 and external hosts continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened outbound request validation for Docker deployments: expanded blocking to additional non-routable and special IP classes (loopback, any-local, link-local, multicast and IPv6 unique local ranges) to prevent connections to disallowed addresses.

* **Tests**
  * Added parameterized tests covering the expanded IP blocking logic, validating recognition of blocked address classes and ensuring other hosts remain allowed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/26515121230>
> Commit: 7c75fbad86a6bcaf34367e9f4cb657d9982864e4
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=26515121230&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 27 May 2026 15:22:15 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Automation
/ok-to-test tags="@tag.All"