### PR TITLE
fix(docker): build MongoDB database tools from source with patched x/crypto and x/net

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -17,7 +17,10 @@ RUN go mod edit -require=golang.org/x/crypto@v0.52.0 \
     go mod tidy && \
     go mod vendor
 ENV GOROOT=/usr/local/go
-RUN ./make build -pkgs=mongodump,mongorestore,bsondump,mongoexport,mongofiles,mongoimport,mongostat,mongotop
+RUN ./make build -pkgs=mongodump,mongorestore,bsondump,mongoexport,mongofiles,mongoimport,mongostat,mongotop && \
+    for tool in mongodump mongorestore bsondump mongoexport mongofiles mongoimport mongostat mongotop; do \
+      test -f /tmp/mongo-tools/bin/$tool || (echo "Missing binary: $tool" && exit 1); \
+    done
 
 FROM ubuntu:24.04
 

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -5,6 +5,20 @@ FROM caddy:builder-alpine AS caddybuilder
 RUN xcaddy build \
   --with github.com/mholt/caddy-ratelimit
 
+# Build MongoDB database tools from source with pinned x/crypto and x/net
+# Apt-installed mongodb-database-tools ships x/crypto@0.45.0 with no upstream fix available.
+FROM golang:1.26.3-alpine AS mongotoolsbuilder
+
+RUN apk add --no-cache git make bash
+WORKDIR /tmp/mongo-tools
+RUN git clone --depth 1 --branch 100.17.0 https://github.com/mongodb/mongo-tools.git .
+RUN go mod edit -require=golang.org/x/crypto@v0.52.0 \
+               -require=golang.org/x/net@v0.55.0 && \
+    go mod tidy && \
+    go mod vendor
+ENV GOROOT=/usr/local/go
+RUN ./make build -pkgs=mongodump,mongorestore,bsondump,mongoexport,mongofiles,mongoimport,mongostat,mongotop
+
 FROM ubuntu:24.04
 
 LABEL maintainer="tech@appsmith.com"
@@ -35,7 +49,7 @@ RUN set -o xtrace \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-    mongodb-org \
+    mongodb-org-server mongodb-org-mongos mongodb-mongosh \
     postgresql-14 \
     git tar zstd openssh-client \
   && apt-get clean \
@@ -51,6 +65,10 @@ RUN set -o xtrace \
 # Install Redis from official image to avoid false positive CVE reports from dpkg-based scanners.
 COPY --from=redis-source /usr/local/bin/redis-server /usr/local/bin/redis-server
 COPY --from=redis-source /usr/local/bin/redis-cli /usr/local/bin/redis-cli
+
+# Install MongoDB database tools built from source with patched x/crypto and x/net
+COPY --from=mongotoolsbuilder /tmp/mongo-tools/bin/ /usr/bin/
+
 ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 
 # Install Java


### PR DESCRIPTION
## Description

> **TL;DR:** Builds MongoDB database tools from source with pinned `golang.org/x/crypto@v0.52.0` and `golang.org/x/net@v0.55.0` to eliminate 8 critical CVEs. The apt-installed `mongodb-database-tools` (100.17.0) has no upstream fix available.

### Background

On May 22, 2026, the Go security team published a coordinated batch of critical vulnerability fixes in `golang.org/x/crypto` (SSH subsystem) and `golang.org/x/net` (IDNA Punycode bypass). MongoDB database tools — Go binaries installed via the `mongodb-org` apt metapackage — ship with vulnerable versions (x/crypto@0.45.0, x/net@0.47.0). Even the latest upstream release (100.17.0) and `master` branch have not bumped these dependencies.

### What changed

1. **New `mongotoolsbuilder` stage** — clones mongo-tools 100.17.0, pins x/crypto@v0.52.0 and x/net@v0.55.0 via `go mod edit -require`, rebuilds all 8 tools from source.

2. **Apt install split** — changed from `mongodb-org` (metapackage that pulls `mongodb-database-tools`) to individual components (`mongodb-org-server`, `mongodb-org-mongos`, `mongodb-mongosh`) to avoid installing the vulnerable apt-packaged tools.

3. **Source-built tools copied in** — `COPY --from=mongotoolsbuilder /tmp/mongo-tools/bin/ /usr/bin/`

### Practical risk

Low. The x/crypto CVEs are in the SSH subsystem and the x/net CVE is in IDNA hostname processing. MongoDB tools are database clients connecting to localhost — they don't expose SSH servers or perform security-sensitive hostname authorization. The vulnerable code is compiled in but not reachable.

### CVEs mitigated

- CVE-2026-46595 (10.0), CVE-2026-39830–39834 (9.1), CVE-2026-42508 (9.1) — x/crypto SSH
- CVE-2026-39821 (10.0) — x/net IDNA Punycode bypass

Slack thread: https://theappsmith.slack.com/archives/C09NG5BJ18S/p1779617364316699

Fixes https://linear.app/appsmith/issue/APP-15251/new-critical-cves-identified-in-image-dependencies

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 4e22b6f5d9b8c23a7a7ab2ee4ecd1e9ff71f6862 yet
> <hr>Wed, 27 May 2026 14:34:04 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker image build to include MongoDB database tools built from source and additional MongoDB components, improving consistency and reliability of database tooling in deployed images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appsmithorg/appsmith/pull/41850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->