### PR TITLE
fix: correct "occured" → "occurred" typo (app error boundary + logo error logs)

### DIFF
--- a/app/client/src/ce/sagas/WorkspaceSagas.ts
+++ b/app/client/src/ce/sagas/WorkspaceSagas.ts
@@ -420,7 +420,7 @@ export function* uploadWorkspaceLogoSaga(
       }
     }
   } catch (error) {
-    log.error("Error occured while uploading the logo", error);
+    log.error("Error occurred while uploading the logo", error);
   }
 }
 
@@ -454,7 +454,7 @@ export function* deleteWorkspaceLogoSaga(action: ReduxAction<{ id: string }>) {
       }
     }
   } catch (error) {
-    log.error("Error occured while removing the logo", error);
+    log.error("Error occurred while removing the logo", error);
   }
 }
 

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -42,7 +42,7 @@ appInitializer();
 
 function App() {
   return (
-    <FaroErrorBoundary fallback={<div>An error has occured</div>}>
+    <FaroErrorBoundary fallback={<div>An error has occurred</div>}>
       <Provider store={store}>
         <LayersContext.Provider value={Layers}>
           <ThemedAppWithProps />


### PR DESCRIPTION
## Description

Fixes the misspelling `occured` → `occurred` (double `r`) in three places:

- `app/client/src/index.tsx` — the top-level `FaroErrorBoundary` fallback shown to users when the app crashes: `An error has occured` → `An error has occurred` (**user-facing**)
- `app/client/src/ce/sagas/WorkspaceSagas.ts` — two `log.error` messages for logo upload/remove failures

Text-only change; no logic, props, or behavior affected.

## Type of change

- [x] Chore (typo / non-functional copy fix)

## Testing

No functional change — corrected English spelling in display/log strings only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling in error messages displayed during logo upload and removal operations.
  * Fixed spelling error in the application's error fallback message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->