### PR TITLE
fix(scripts): exclude supervisor logs from deploy-preview recreate wipe

### DIFF
--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -47,7 +47,8 @@ if [[ -n "${RECREATE-}" ]]; then
   # execute this db.dropDatabase() from the k8s cluster because there's network restrictions on Atlas cluster.
   # The \$ is used to escape the $ character in the APPSMITH_DB_URL environment variable so it's interpolated inside the kubectl exec command.
   kubectl exec "$pod_name" -n "$NAMESPACE" -- bash -c "mongosh \$APPSMITH_DB_URL --eval 'db.dropDatabase()'"
-  kubectl exec "$pod_name" -n "$NAMESPACE" -- bash -c "supervisorctl stop all && rm -rf /appsmith-stacks/*"
+  # supervisord itself keeps running and holds files in logs/supervisor open, so exclude it from the wipe.
+  kubectl exec "$pod_name" -n "$NAMESPACE" -- bash -c "supervisorctl stop all && find /appsmith-stacks -mindepth 1 -maxdepth 1 ! -name logs -exec rm -rf {} + && find /appsmith-stacks/logs -mindepth 1 -maxdepth 1 ! -name supervisor -exec rm -rf {} +"
   kubectl delete ns "$NAMESPACE" || true
   kubectl patch pv "$NAMESPACE-appsmith" -p '{"metadata":{"finalizers":null}}' || true
   kubectl delete pv "$NAMESPACE-appsmith" --grace-period=0 --force || true


### PR DESCRIPTION
## Summary

- The `RECREATE` path in `scripts/deploy_preview.sh` runs `rm -rf /appsmith-stacks/*` after `supervisorctl stop all`, but `supervisord` itself keeps running and holds files in `/appsmith-stacks/logs/supervisor` open. The directory cannot be removed, so the `kubectl exec` step fails with `rm: cannot remove '/appsmith-stacks/logs/supervisor': Directory not empty` and the GitHub Actions job aborts before the helm upgrade ever runs.
- Replace the single `rm -rf /appsmith-stacks/*` with two `find` invocations that walk the tree and skip `logs/supervisor`, clearing everything else under `/appsmith-stacks`.

## Test plan

- [ ] Re-trigger a deploy preview with `recreate=true` on a PR and confirm the wipe step now completes and the workflow proceeds into the helm upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved preview deployment reset process with more selective cleanup that safely removes unnecessary data while preserving important logs and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->