### PR TITLE
chore(rts): upgrade nodemailer to fix 8 Dependabot alerts

### DIFF
--- a/app/client/packages/rts/package.json
+++ b/app/client/packages/rts/package.json
@@ -31,7 +31,7 @@
     "llamaindex": "0.9.0",
     "loglevel": "^1.8.1",
     "mongodb": "^5.8.0",
-    "nodemailer": "6.9.9",
+    "nodemailer": "8.0.10",
     "readline-sync": "1.4.10",
     "simple-git": "^3.32.3"
   },
@@ -39,7 +39,7 @@
     "@types/express": "^4.17.14",
     "@types/jest": "^29.2.3",
     "@types/node": "*",
-    "@types/nodemailer": "^6.4.17",
+    "@types/nodemailer": "^8.0.0",
     "@types/readline-sync": "^1.4.8",
     "jest": "^29.3.1",
     "supertest": "^6.3.3",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11617,12 +11617,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/nodemailer@npm:^6.4.17":
-  version: 6.4.17
-  resolution: "@types/nodemailer@npm:6.4.17"
+"@types/nodemailer@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@types/nodemailer@npm:8.0.0"
   dependencies:
     "@types/node": "*"
-  checksum: 498b702575111494a42cf9cdd3d399f0308c3b3b0244e7f53008924327955a16b39ba0bf99a5ccf17af9fd2bc50a61a76ae7e8a75498a426ea2f828a05202eab
+  checksum: 9d3e762737c54df69538b9ecb14730499131c3573c6dd64dee3057553303b507dc3072489ce55ecda863c13b5ca9f713540885ae113f015e2a241bdc6e8a7ff3
   languageName: node
   linkType: hard
 
@@ -13652,7 +13652,7 @@ __metadata:
     "@types/express": ^4.17.14
     "@types/jest": ^29.2.3
     "@types/node": "*"
-    "@types/nodemailer": ^6.4.17
+    "@types/nodemailer": ^8.0.0
     "@types/readline-sync": ^1.4.8
     axios: ^1.15.0
     dotenv: 10.0.0
@@ -13663,7 +13663,7 @@ __metadata:
     llamaindex: 0.9.0
     loglevel: ^1.8.1
     mongodb: ^5.8.0
-    nodemailer: 6.9.9
+    nodemailer: 8.0.10
     readline-sync: 1.4.10
     simple-git: ^3.32.3
     supertest: ^6.3.3
@@ -26502,10 +26502,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:6.9.9":
-  version: 6.9.9
-  resolution: "nodemailer@npm:6.9.9"
-  checksum: 9af862b497273796ad6ba7ca9eac23a7d69737554f6dd51cfd3557f60902c56344158192672f1208daf00340a47a9e1805bd809965edc191011b35dd98a74be1
+"nodemailer@npm:8.0.10":
+  version: 8.0.10
+  resolution: "nodemailer@npm:8.0.10"
+  checksum: 491b14ca67a60b90006af953518d2ccaf352ae9ef086c3bf01cf1d7bd7dba5b5fdc8ef46a008244cef0cc233f82dde56508e01c6797b4589bf5cfca1239b79c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Upgrades `nodemailer` from **6.9.9 → 8.0.10** and `@types/nodemailer` from **^6.4.17 → ^8.0.0** in the RTS package to resolve all 8 open Dependabot security alerts.

### What changed
- `app/client/packages/rts/package.json`: bumped `nodemailer` to `8.0.10`, `@types/nodemailer` to `^8.0.0`
- `app/client/yarn.lock`: regenerated

### Why 8.x (not 7.x)
The highest-severity alerts (#574, #575) require patches only available in `>= 8.0.5`. To fix **all** alerts with a single version bump, 8.x is required.

### Impact assessment
- **Blast radius**: RTS only — `nodemailer` is declared solely in `app/client/packages/rts/package.json`
- **Usage**: Single file (`app/client/packages/rts/src/ctl/mailer.ts`) using only `createTransport` + `sendMail` with basic SMTP options — core APIs unchanged across major versions
- **Risk**: Minimal — the upgrade is a drop-in replacement for the usage patterns in this codebase

### Dependabot alerts resolved
| Alert | Severity | Min patch | Fixed by |
|-------|----------|-----------|----------|
| [#432](https://github.com/appsmithorg/appsmith/security/dependabot/432) | medium | >= 7.0.7 | 8.0.10 |
| [#433](https://github.com/appsmithorg/appsmith/security/dependabot/433) | medium | >= 7.0.7 | 8.0.10 |
| [#451](https://github.com/appsmithorg/appsmith/security/dependabot/451) | high | >= 7.0.11 | 8.0.10 |
| [#452](https://github.com/appsmithorg/appsmith/security/dependabot/452) | high | >= 7.0.11 | 8.0.10 |
| [#544](https://github.com/appsmithorg/appsmith/security/dependabot/544) | low | >= 8.0.4 | 8.0.10 |
| [#545](https://github.com/appsmithorg/appsmith/security/dependabot/545) | low | >= 8.0.4 | 8.0.10 |
| [#574](https://github.com/appsmithorg/appsmith/security/dependabot/574) | medium | >= 8.0.5 | 8.0.10 |
| [#575](https://github.com/appsmithorg/appsmith/security/dependabot/575) | medium | >= 8.0.5 | 8.0.10 |

Fixes https://linear.app/appsmith/issue/APP-15271

Slack thread: https://theappsmith.slack.com/archives/C09NG5BJ18S/p1780304878402439

## Automation

/ok-to-test tags="@tag.All"

## Communication

Should the DevRel and Marketing teams be informed?

- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated core project dependencies to their latest versions for enhanced compatibility and improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/26889525244>
> Commit: 09278de2ad60cd4a6151a4077c9998579e5fa8e9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=26889525244&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 03 Jun 2026 15:03:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->
