### PR TITLE
fix(datasource): move expires_in field after scope in OAuth2 configuration form (#31059)

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -834,6 +834,16 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
     return (
       <>
         {this.renderOauth2Common()}
+        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+          {this.renderInputTextControlViaFormControl({
+            configProperty: "authentication.expiresIn",
+            label: "Authorization expires in (seconds)",
+            placeholderText: "3600",
+            dataType: "NUMBER",
+            encrypted: false,
+            isRequired: false,
+          })}
+        </FormInputContainer>
         <FormInputContainer
           data-location-id={btoa("authentication.authorizationUrl")}
         >
@@ -869,16 +879,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&


### PR DESCRIPTION
Moves the 'Authorization expires in (seconds)' field to immediately after 'Scope(s)' in the OAuth2 Authorization Code form, so all authentication fields are grouped together. Pure UI reorder — no logic changes.

Before: scope → ... → custom auth params → expires_in
After:  scope → expires_in → authorization URL → ... 

Closes #31059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate authentication expiration field and improved form field organization in REST API datasource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->