### PR TITLE
chore(plugins): upgrade mssql-jdbc to fix Dependabot alert

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/mssqlPlugin/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>11.2.1.jre17</version>
+            <version>11.2.4.jre11</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Single-line version bump of `com.microsoft.sqlserver:mssql-jdbc` from `11.2.1.jre17` to `11.2.4.jre11` in the mssqlPlugin to resolve CVE-2025-59250 (improper input validation).

**Why `jre11` instead of `jre17`?** Microsoft never published `11.2.4.jre17` — they stopped releasing the `jre17` classifier after `11.2.3`. The `jre11` classifier denotes the *minimum* supported JRE version and is fully compatible with JRE 17+.

## Verification
- Maven compilation passes: `mvn compile -pl appsmith-plugins/mssqlPlugin -am`
- Only 1 file changed: `app/server/appsmith-plugins/mssqlPlugin/pom.xml`

## References
- Resolves Dependabot alert [#440](https://github.com/appsmithorg/appsmith/security/dependabot/440) (high severity)
- CVE-2025-59250: JDBC Driver for SQL Server has improper input validation issue
- Fixes https://linear.app/appsmith/issue/APP-15271
- Slack thread: https://theappsmith.slack.com/archives/C09NG5BJ18S/p1780304878402439

## Automation
/ok-to-test tags="@tag.All"

## Communication
Should the Dev No-Code or No-Code App Devs Slack channel be notified of this change?
- **NO** — internal dependency bump only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Microsoft SQL Server database driver for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/27135835566>
> Commit: 4c99c19796595bcfe94bbd0dd206aa2af6f5466a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=27135835566&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 08 Jun 2026 13:22:40 UTC
<!-- end of auto-generated comment: Cypress test results  -->
