### PR TITLE
Fix/41627 mssql ssl handshake failure

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -643,20 +643,16 @@ public class MssqlPlugin extends BasePlugin {
     private static void addSslOptionsToUrlBuilder(
             DatasourceConfiguration datasourceConfiguration, StringBuilder urlBuilder) throws AppsmithPluginException {
         /*
-         * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
+         * - When SSL configuration is absent, default to disabling encryption so that
+         *   connections to servers that do not require encryption work out of the box.
          */
         if (datasourceConfiguration.getConnection() == null
                 || datasourceConfiguration.getConnection().getSsl() == null
                 || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
-            throw new AppsmithPluginException(
-                    AppsmithPluginError.PLUGIN_ERROR,
-                    "Appsmith server has failed to fetch SSL configuration from datasource configuration form. "
-                            + "Please reach out to Appsmith customer support to resolve this.");
+            urlBuilder.append("encrypt=false;");
+            return;
         }
 
-        /*
-         * - By default, the driver configures SSL in the no verify mode.
-         */
         SSLDetails.AuthType sslAuthType =
                 datasourceConfiguration.getConnection().getSsl().getAuthType();
         switch (sslAuthType) {

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -102,6 +102,8 @@ public class MssqlPlugin extends BasePlugin {
 
     private static final long MS_SQL_DEFAULT_PORT = 1433L;
 
+    private static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 60;
+
     public static final MssqlDatasourceUtils mssqlDatasourceUtils = new MssqlDatasourceUtils();
 
     public MssqlPlugin(PluginWrapper wrapper) {
@@ -417,6 +419,11 @@ public class MssqlPlugin extends BasePlugin {
                 }
             }
 
+            int connectionTimeout = getConnectionTimeoutSeconds(datasourceConfiguration);
+            if (connectionTimeout < 0) {
+                invalids.add(MssqlErrorMessages.DS_INVALID_CONNECTION_TIMEOUT_ERROR_MSG);
+            }
+
             return invalids;
         }
 
@@ -626,6 +633,10 @@ public class MssqlPlugin extends BasePlugin {
 
         addSslOptionsToUrlBuilder(datasourceConfiguration, urlBuilder);
 
+        int timeoutSeconds = getConnectionTimeoutSeconds(datasourceConfiguration);
+        urlBuilder.append("loginTimeout=").append(timeoutSeconds).append(";");
+        hikariConfig.setConnectionTimeout(timeoutSeconds * 1000L);
+
         hikariConfig.setJdbcUrl(urlBuilder.toString());
 
         try {
@@ -638,6 +649,26 @@ public class MssqlPlugin extends BasePlugin {
         }
 
         return hikariDatasource;
+    }
+
+    /**
+     * Extracts the connection timeout (in seconds) from the datasource properties.
+     * Returns the default timeout if no value is configured or the value is not a valid number.
+     */
+    static int getConnectionTimeoutSeconds(DatasourceConfiguration datasourceConfiguration) {
+        List<Property> properties = datasourceConfiguration.getProperties();
+        if (properties != null && !properties.isEmpty()) {
+            Property timeoutProperty = properties.get(0);
+            if (timeoutProperty != null && timeoutProperty.getValue() != null) {
+                try {
+                    return Integer.parseInt(
+                            String.valueOf(timeoutProperty.getValue()).trim());
+                } catch (NumberFormatException e) {
+                    // fall through to default
+                }
+            }
+        }
+        return DEFAULT_CONNECTION_TIMEOUT_SECONDS;
     }
 
     private static void addSslOptionsToUrlBuilder(

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/exceptions/MssqlErrorMessages.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/exceptions/MssqlErrorMessages.java
@@ -34,4 +34,7 @@ public class MssqlErrorMessages extends BasePluginErrorMessages {
     public static final String DS_MISSING_USERNAME_ERROR_MSG = "Missing username for authentication.";
 
     public static final String DS_MISSING_PASSWORD_ERROR_MSG = "Missing password for authentication.";
+
+    public static final String DS_INVALID_CONNECTION_TIMEOUT_ERROR_MSG =
+            "Connection timeout must be a non-negative number (in seconds).";
 }

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
@@ -82,7 +82,7 @@
           "label": "SSL mode",
           "configProperty": "datasourceConfiguration.connection.ssl.authType",
           "controlType": "DROP_DOWN",
-          "initialValue": "NO_VERIFY",
+          "initialValue": "DISABLE",
           "options": [
             {
               "label": "Disable",

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
@@ -47,6 +47,21 @@
           "controlType": "INPUT_TEXT",
           "placeholderText": "Database name",
           "initialValue": "admin"
+        },
+        {
+          "label": "Connection timeout (seconds)",
+          "configProperty": "datasourceConfiguration.properties[0].key",
+          "initialValue": "connectionTimeout",
+          "hidden": true,
+          "controlType": "INPUT_TEXT"
+        },
+        {
+          "label": "Connection timeout (seconds)",
+          "configProperty": "datasourceConfiguration.properties[0].value",
+          "controlType": "INPUT_TEXT",
+          "dataType": "NUMBER",
+          "initialValue": "60",
+          "placeholderText": "60"
         }
       ]
     },

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -15,6 +15,7 @@ import com.appsmith.external.models.Property;
 import com.appsmith.external.models.PsParameterDTO;
 import com.appsmith.external.models.RequestParamDTO;
 import com.appsmith.external.models.SSLDetails;
+import com.external.plugins.exceptions.MssqlErrorMessages;
 import com.external.plugins.exceptions.MssqlPluginError;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -772,5 +773,116 @@ public class MssqlPluginTest {
                     assertEquals("localhost_1433", endpointIdentifier);
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    public void testSslDefaultsToDisable_whenConnectionIsNull() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setConnection(null);
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                    assertNotNull(hikariDataSource);
+                    assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testSslDefaultsToDisable_whenSslDetailsAreNull() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.getConnection().setSsl(null);
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                    assertNotNull(hikariDataSource);
+                    assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testSslDefaultsToDisable_whenAuthTypeIsNull() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.getConnection().getSsl().setAuthType(null);
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                    assertNotNull(hikariDataSource);
+                    assertTrue(hikariDataSource.getJdbcUrl().contains("encrypt=false"));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testConnectionTimeout_defaultAppliedWhenNoPropertySet() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        // No properties set — default timeout should be used
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                    assertNotNull(hikariDataSource);
+                    String jdbcUrl = hikariDataSource.getJdbcUrl();
+                    assertTrue(
+                            jdbcUrl.contains("loginTimeout=60"),
+                            "JDBC URL should contain default loginTimeout=60 but was: " + jdbcUrl);
+                    assertEquals(
+                            60000L,
+                            hikariDataSource.getConnectionTimeout(),
+                            "HikariCP connectionTimeout should be 60000ms");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testConnectionTimeout_customValueApplied() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setProperties(List.of(new Property("connectionTimeout", "30")));
+
+        Mono<HikariDataSource> dsConnectionMono = mssqlPluginExecutor.datasourceCreate(dsConfig);
+
+        StepVerifier.create(dsConnectionMono)
+                .assertNext(hikariDataSource -> {
+                    assertNotNull(hikariDataSource);
+                    String jdbcUrl = hikariDataSource.getJdbcUrl();
+                    assertTrue(
+                            jdbcUrl.contains("loginTimeout=30"),
+                            "JDBC URL should contain loginTimeout=30 but was: " + jdbcUrl);
+                    assertEquals(
+                            30000L,
+                            hikariDataSource.getConnectionTimeout(),
+                            "HikariCP connectionTimeout should be 30000ms");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testConnectionTimeout_negativeValueFailsValidation() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setProperties(List.of(new Property("connectionTimeout", "-5")));
+
+        Set<String> invalids = mssqlPluginExecutor.validateDatasource(dsConfig);
+        assertTrue(
+                invalids.contains(MssqlErrorMessages.DS_INVALID_CONNECTION_TIMEOUT_ERROR_MSG),
+                "Validation should reject negative timeout values");
+    }
+
+    @Test
+    public void testConnectionTimeout_zeroValuePassesValidation() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration(container);
+        dsConfig.setProperties(List.of(new Property("connectionTimeout", "0")));
+
+        Set<String> invalids = mssqlPluginExecutor.validateDatasource(dsConfig);
+        assertTrue(
+                !invalids.contains(MssqlErrorMessages.DS_INVALID_CONNECTION_TIMEOUT_ERROR_MSG),
+                "Validation should accept zero timeout (meaning no timeout)");
     }
 }


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable connection timeout for MSSQL datasources with 60-second default

* **Bug Fixes**
  * Improved SSL configuration handling to gracefully default when settings are incomplete
  * Enhanced connection timeout validation with clearer error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->