### PR TITLE
Add copy response headers action

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionResponse/components/ApiResponseHeaders.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionResponse/components/ApiResponseHeaders.tsx
@@ -1,11 +1,13 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
+import copy from "copy-to-clipboard";
+import styled from "styled-components";
+
 import type { ActionResponse } from "api/ActionAPI";
-import { Callout, Flex } from "@appsmith/ads";
+import { Button, Callout, Flex, toast } from "@appsmith/ads";
 import { CHECK_REQUEST_BODY, createMessage } from "ee/constants/messages";
 import { isArray, isEmpty } from "lodash";
 import ReadOnlyEditor from "components/editorComponents/ReadOnlyEditor";
 import { hasFailed } from "../utils";
-import styled from "styled-components";
 import { NoResponse } from "./NoResponse";
 
 const ResponseDataContainer = styled.div`
@@ -17,6 +19,18 @@ const ResponseDataContainer = styled.div`
   & .CodeEditorTarget {
     overflow: hidden;
   }
+`;
+
+const HeadersToolbar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--ads-v2-spaces-2);
+  border-bottom: 1px solid var(--ads-v2-color-border);
+`;
+
+const HeadersEditorWrapper = styled.div`
+  flex: 1;
+  min-height: 0;
 `;
 
 const headersTransformer = (headers: Record<string, string[]> = {}) => {
@@ -63,6 +77,13 @@ export function ApiResponseHeaders(props: {
     };
   }, [responseHeaders]);
 
+  const copyResponseHeaders = useCallback(() => {
+    copy(headersInput.value);
+    toast.show("Response headers copied to clipboard", {
+      kind: "success",
+    });
+  }, [headersInput.value]);
+
   if (!props.actionResponse) {
     return (
       <Flex className="t--headers-tab" h="100%" w="100%">
@@ -91,7 +112,22 @@ export function ApiResponseHeaders(props: {
               onRunClick={props.onRunClick}
             />
           ) : (
-            <ReadOnlyEditor folding height={"100%"} input={headersInput} />
+            <>
+              <HeadersToolbar>
+                <Button
+                  isDisabled={isEmpty(headersInput.value)}
+                  kind="tertiary"
+                  onClick={copyResponseHeaders}
+                  size="sm"
+                  startIcon="copy-control"
+                >
+                  Copy headers
+                </Button>
+              </HeadersToolbar>
+              <HeadersEditorWrapper>
+                <ReadOnlyEditor folding height={"100%"} input={headersInput} />
+              </HeadersEditorWrapper>
+            </>
           )}
         </ResponseDataContainer>
       )}


### PR DESCRIPTION
## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the API response section with a new "Copy headers" button for improved usability and efficiency. Users can now easily copy all response headers to their clipboard with a single click. A success notification confirms when the copy operation completes successfully, providing clear visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->