### PR TITLE
fix(test): wrap PropertyPaneTitle F2 assertion in waitFor

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneTitle.test.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneTitle.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { ThemeProvider } from "styled-components";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import PropertyPaneTitle from "./PropertyPaneTitle";
 import userEvent from "@testing-library/user-event";
 import { lightTheme } from "selectors/themeSelectors";
@@ -21,6 +21,8 @@ describe("<PropertyPaneTitle />", () => {
     const renderResult = render(component);
 
     await userEvent.keyboard("{F2}");
-    expect(renderResult.container.querySelector("input")).toBeVisible();
+    await waitFor(() => {
+      expect(renderResult.container.querySelector("input")).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes a pre-existing flaky test in `PropertyPaneTitle.test.tsx`. The test dispatches F2 via `userEvent.keyboard` which triggers `setIsEditingDefault(true)`. The `querySelector("input")` assertion ran before React flushed the state update, returning null.

Wrapping in `waitFor` allows the async re-render to complete before asserting.

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This comment is used by the CI to post the Cypress test results. Please do not modify -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for property pane interactions to ensure proper async behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->