### PR TITLE
fix(test): wait for email HTML body in Email_settings spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
@@ -202,6 +202,7 @@ describe(
             timeout: TIMEOUT,
             targetSubject: resetPassSubject,
             targetEmail: emailOne,
+            requireHtml: true,
           })
           .then((email) => {
             if (email) {
@@ -209,7 +210,7 @@ describe(
               expect(email.headers.subject).to.equal(resetPassSubject);
               expect(email.headers.to).to.equal(emailOne);
 
-              const emailHtml = email.html || ""; // Store the email HTML content
+              const emailHtml = email.html; // Store the email HTML content
               const resetPasswordLinkMatch = emailHtml.match(
                 /href="([^"]*resetPassword[^"]*)"/,
               );
@@ -282,6 +283,7 @@ describe(
             timeout: TIMEOUT,
             targetSubject: inviteEmailSubject,
             targetEmail: emailTwo,
+            requireHtml: true,
           })
           .then((email) => {
             if (email) {
@@ -289,7 +291,7 @@ describe(
               expect(email.headers.subject).to.include(inviteEmailSubject);
               expect(email.headers.to).to.equal(emailTwo);
 
-              const emailHtml = email.html || ""; // Store the email HTML content
+              const emailHtml = email.html; // Store the email HTML content
               const inviteLinkMatch = emailHtml.match(
                 /href="([^"]*applications[^"]*)"/,
               ); // Extract the link using regex
@@ -362,6 +364,7 @@ describe(
             timeout: TIMEOUT,
             targetSubject: inviteEmailSubject,
             targetEmail: emailThree,
+            requireHtml: true,
           })
           .then((email) => {
             if (email) {
@@ -370,7 +373,7 @@ describe(
               expect(email.headers.subject).to.include(inviteEmailSubject);
               expect(email.headers.to).to.include(emailThree);
 
-              const emailHtml = email.html || ""; // Store the email HTML content
+              const emailHtml = email.html; // Store the email HTML content
 
               // Match all href links inside the <body>
               const bodyMatch = emailHtml.match(
@@ -464,6 +467,7 @@ describe(
             timeout: TIMEOUT,
             targetSubject: inviteEmailSubject,
             targetEmail: emailFour,
+            requireHtml: true,
           })
           .then((email) => {
             if (email) {
@@ -480,7 +484,7 @@ describe(
                 console.log("Recipient does not match expected email.");
               }
 
-              const emailHtml = email.html || "";
+              const emailHtml = email.html;
 
               const bodyMatch = emailHtml.match(
                 /<body[^>]*>([\s\S]*?)<\/body>/i,

--- a/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
@@ -209,7 +209,7 @@ describe(
               expect(email.headers.subject).to.equal(resetPassSubject);
               expect(email.headers.to).to.equal(emailOne);
 
-              const emailHtml = email.html; // Store the email HTML content
+              const emailHtml = email.html || ""; // Store the email HTML content
               const resetPasswordLinkMatch = emailHtml.match(
                 /href="([^"]*resetPassword[^"]*)"/,
               );
@@ -289,7 +289,7 @@ describe(
               expect(email.headers.subject).to.include(inviteEmailSubject);
               expect(email.headers.to).to.equal(emailTwo);
 
-              const emailHtml = email.html; // Store the email HTML content
+              const emailHtml = email.html || ""; // Store the email HTML content
               const inviteLinkMatch = emailHtml.match(
                 /href="([^"]*applications[^"]*)"/,
               ); // Extract the link using regex
@@ -370,7 +370,7 @@ describe(
               expect(email.headers.subject).to.include(inviteEmailSubject);
               expect(email.headers.to).to.include(emailThree);
 
-              const emailHtml = email.html; // Store the email HTML content
+              const emailHtml = email.html || ""; // Store the email HTML content
 
               // Match all href links inside the <body>
               const bodyMatch = emailHtml.match(
@@ -480,7 +480,7 @@ describe(
                 console.log("Recipient does not match expected email.");
               }
 
-              const emailHtml = email.html;
+              const emailHtml = email.html || "";
 
               const bodyMatch = emailHtml.match(
                 /<body[^>]*>([\s\S]*?)<\/body>/i,

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
+cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 #cypress/e2e/Regression/ClientSide/Anvil/Widgets/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,5 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
+cypress/e2e/Regression/ServerSide/Postgres_DataTypes/BooleanEnum_Spec.ts
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 #cypress/e2e/Regression/ClientSide/Anvil/Widgets/*

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -2025,10 +2025,10 @@ export class AggregateHelper {
 
   public waitForEmail({
     pollInterval,
+    requireHtml = false,
     targetEmail,
     targetSubject,
     timeout,
-    requireHtml = false,
   }: {
     pollInterval: number;
     timeout: number;

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -2028,11 +2028,13 @@ export class AggregateHelper {
     targetEmail,
     targetSubject,
     timeout,
+    requireHtml = false,
   }: {
     pollInterval: number;
     timeout: number;
     targetSubject: string;
     targetEmail?: string;
+    requireHtml?: boolean;
   }): Cypress.Chainable<any> {
     const endTime = Date.now() + timeout;
     let latestEmail: any = null;
@@ -2058,6 +2060,7 @@ export class AggregateHelper {
               from: string;
             };
             text: string;
+            html?: string;
           }> = res.body;
 
           const matchingEmails = emails.filter((email) => {
@@ -2066,14 +2069,21 @@ export class AggregateHelper {
               .toLowerCase()
               .includes(targetSubject.trim().toLowerCase());
 
-            if (targetEmail) {
-              const emailTo = email.headers.to.trim().toLowerCase();
-              return (
-                subjectMatch && emailTo === targetEmail.trim().toLowerCase()
-              );
-            }
+            const recipientMatch = targetEmail
+              ? email.headers.to.trim().toLowerCase() ===
+                targetEmail.trim().toLowerCase()
+              : true;
 
-            return subjectMatch;
+            // When the caller needs the HTML body, treat a matched email whose
+            // body has not been populated yet as "not yet delivered" and keep
+            // polling, rather than returning it and letting the caller throw on
+            // email.html. Maildev can surface an email's metadata before its
+            // HTML part is parsed, especially under load.
+            const htmlReady =
+              !requireHtml ||
+              (typeof email.html === "string" && email.html.length > 0);
+
+            return subjectMatch && recipientMatch && htmlReady;
           });
 
           if (matchingEmails.length > 0) {


### PR DESCRIPTION
## Summary

`Email_settings_Spec` fails intermittently in CI (~25-35% of runs) when it shares a duration-balanced shard with heavy specs. It's a null-handling bug in the spec's email flow, exposed under maildev/SMTP contention.

## Root cause

`waitForEmail` matches an email by subject + recipient, then hands it to the test. Under contention maildev can surface an email's metadata before its HTML part is parsed, so the matched email's `.html` is `undefined`. Tests #3–#6 then do:

```js
const emailHtml = email.html;          // undefined
const match = emailHtml.match(/.../);  // TypeError, thrown inside .then()
```

That throw is an unhandled promise rejection that aborts the test (the wrapping `try/catch` is inert against async Cypress failures). Captured CI stack: `Email_settings_Spec.ts` test #4 (`To verify invite workspace email`); the same `email.html` → `.match` pattern is in tests #3, #5 and #6.

## Fix

Fix it at the source rather than masking it. Add an opt-in `requireHtml` flag to `waitForEmail`: when set, a matched email whose HTML body isn't populated yet is treated as **not yet delivered**, so polling continues until the body arrives (or the existing timeout). Tests #3–#6 opt in; their email-body assertions then run for real on a complete email.

(An earlier revision of this PR used `email.html || ""`, but that only stopped the crash by silently skipping the invite-link verification when the body was missing — masking the flake. Reverted in favor of the helper-level fix.)

`waitForEmail` is identical in CE and EE, so this lands in CE and the hourly sync carries it to EE. The new flag is optional and defaults to current behavior, so other callers (including this spec's test #2, which reads `email.text`) are unaffected.

## Validation

Attribution and the fix were verified on appsmith-ee via amplified `/ci-test-limit` runs (multiple copies of the spec downstream of a heavy git spec in one shard): the unfixed baseline reproduced the failure at the exact line above.

Ref APP-15291

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/27509234477>
> Commit: 56deaca5230eec74bbe33359d8436569c2afe061
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=27509234477&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Email`
> Spec:
> <hr>Sun, 14 Jun 2026 19:36:07 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved email-related test robustness: four end-to-end flows (password reset, workspace invite, application invite — developer role, and application invite — view role) now explicitly require the HTML portion of delivered emails, reducing flakiness and better validating email content.
* **Chores**
  * Updated limited-test configuration to run the client-side email regression spec during focused CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation
/ok-to-test tags="@tag.Email"