### PR TITLE
feat(client): add user-settable Tab order property to focusable widgets

### DIFF
--- a/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
+++ b/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
@@ -50,6 +50,7 @@ export interface PositionedContainerProps {
   isDisabled?: boolean;
   isVisible?: boolean;
   widgetName: string;
+  tabOrder?: number;
 }
 
 export function PositionedContainer(
@@ -170,6 +171,11 @@ export function PositionedContainer(
     <PositionedWidget
       className={containerClassName}
       data-hidden={!props.isVisible || undefined}
+      data-taborder={
+        typeof props.tabOrder === "number" && props.tabOrder >= 1
+          ? props.tabOrder
+          : undefined
+      }
       data-testid="test-widget"
       data-widgetname-cy={props.widgetName}
       disabled={props.isDisabled}

--- a/app/client/src/layoutSystems/fixedlayout/common/PositionedComponentLayer.tsx
+++ b/app/client/src/layoutSystems/fixedlayout/common/PositionedComponentLayer.tsx
@@ -18,6 +18,7 @@ export const PositionedComponentLayer = (props: BaseWidgetProps) => {
       ref={props.wrapperRef}
       resizeDisabled={props.resizeDisabled}
       selected={props.selected}
+      tabOrder={props.tabOrder}
       topRow={props.topRow}
       widgetId={props.widgetId}
       widgetName={props.widgetName}

--- a/app/client/src/utils/hooks/useWidgetFocus/tabbable.test.ts
+++ b/app/client/src/utils/hooks/useWidgetFocus/tabbable.test.ts
@@ -1,7 +1,225 @@
-import { getNextTabbableDescendant } from "./tabbable";
+import {
+  buildTabSequence,
+  getEntryTabbables,
+  getNextTabbableDescendant,
+  getSiblingTabbables,
+  getTabbableDescendants,
+  sortWidgetsByPosition,
+} from "./tabbable";
+
+interface WidgetOptions {
+  top: number;
+  left: number;
+  tabOrder?: string;
+}
+
+function makeWidget(id: string, { left, tabOrder, top }: WidgetOptions) {
+  const element = document.createElement("div");
+
+  element.className = "positioned-widget";
+  element.id = id;
+
+  if (tabOrder !== undefined) {
+    element.setAttribute("data-taborder", tabOrder);
+  }
+
+  element.getBoundingClientRect = () =>
+    ({
+      top,
+      left,
+      bottom: top + 40,
+      right: left + 100,
+      width: 100,
+      height: 40,
+      x: left,
+      y: top,
+    }) as DOMRect;
+
+  return element;
+}
+
+function ids(elements: HTMLElement[]) {
+  return elements.map((element) => element.id);
+}
 
 describe("getNextTabbableDescendant", () => {
   it("should return undefined if no descendants are passed", () => {
     expect(getNextTabbableDescendant([])).toBeUndefined();
+  });
+});
+
+describe("getSiblingTabbables", () => {
+  it("matches legacy position-based sorting when no widget has a tab order", () => {
+    const active = makeWidget("active", { top: 100, left: 0 });
+    const siblings = [
+      makeWidget("a", { top: 0, left: 0 }),
+      makeWidget("b", { top: 200, left: 0 }),
+      makeWidget("c", { top: 100, left: 50 }),
+    ];
+
+    const legacyForward = sortWidgetsByPosition(
+      { top: 100, left: 0 },
+      siblings,
+      false,
+    );
+    const legacyBackward = sortWidgetsByPosition(
+      { top: 100, left: 0 },
+      siblings,
+      true,
+    );
+
+    expect(ids(getSiblingTabbables(active, siblings, false))).toEqual(
+      ids(legacyForward),
+    );
+    expect(ids(getSiblingTabbables(active, siblings, true))).toEqual(
+      ids(legacyBackward),
+    );
+  });
+
+  it("follows explicit tab order regardless of visual position", () => {
+    const active = makeWidget("active", { top: 0, left: 0, tabOrder: "1" });
+    const siblings = [
+      makeWidget("third", { top: 0, left: 100, tabOrder: "3" }),
+      makeWidget("second", { top: 300, left: 0, tabOrder: "2" }),
+    ];
+
+    expect(ids(getSiblingTabbables(active, siblings, false))).toEqual([
+      "second",
+      "third",
+    ]);
+  });
+
+  it("places explicitly ordered widgets before position-ordered ones (HTML semantics)", () => {
+    const a = makeWidget("a", { top: 0, left: 0 });
+    const b = makeWidget("b", { top: 100, left: 0, tabOrder: "2" });
+    const c = makeWidget("c", { top: 200, left: 0 });
+    const d = makeWidget("d", { top: 300, left: 0, tabOrder: "1" });
+
+    expect(ids(buildTabSequence([a, b, c, d]))).toEqual(["d", "b", "a", "c"]);
+
+    // tabbing forward from the last explicit widget lands on the first implicit one
+    expect(ids(getSiblingTabbables(b, [a, c, d], false))).toEqual(["a", "c"]);
+  });
+
+  it("returns elements before the active widget reversed for shift+tab", () => {
+    const a = makeWidget("a", { top: 0, left: 0 });
+    const b = makeWidget("b", { top: 100, left: 0, tabOrder: "2" });
+    const c = makeWidget("c", { top: 200, left: 0 });
+    const d = makeWidget("d", { top: 300, left: 0, tabOrder: "1" });
+
+    // sequence is d, b, a, c — shift+tab from a goes back to b, then d
+    expect(ids(getSiblingTabbables(a, [b, c, d], true))).toEqual(["b", "d"]);
+
+    // shift+tab from the first widget in the sequence yields nothing,
+    // which triggers the parent-canvas recursion upstream
+    expect(getSiblingTabbables(d, [a, b, c], true)).toEqual([]);
+  });
+
+  it("breaks ties on the same tab order by position", () => {
+    const active = makeWidget("active", { top: 500, left: 0, tabOrder: "2" });
+    const lower = makeWidget("lower", { top: 200, left: 0, tabOrder: "1" });
+    const upper = makeWidget("upper", { top: 100, left: 0, tabOrder: "1" });
+
+    expect(ids(getSiblingTabbables(active, [lower, upper], true))).toEqual([
+      "lower",
+      "upper",
+    ]);
+  });
+
+  it("ignores invalid tab order values and falls back to position-based sorting", () => {
+    const active = makeWidget("active", { top: 100, left: 0, tabOrder: "0" });
+    const siblings = [
+      makeWidget("a", { top: 0, left: 0, tabOrder: "-2" }),
+      makeWidget("b", { top: 200, left: 0, tabOrder: "abc" }),
+      makeWidget("c", { top: 300, left: 0, tabOrder: "1.5" }),
+    ];
+
+    const legacy = sortWidgetsByPosition(
+      { top: 100, left: 0 },
+      siblings,
+      false,
+    );
+
+    expect(ids(getSiblingTabbables(active, siblings, false))).toEqual(
+      ids(legacy),
+    );
+  });
+});
+
+describe("getEntryTabbables", () => {
+  const anchor = { top: 0, left: 0 };
+
+  it("matches legacy position-based sorting when no widget has a tab order", () => {
+    const candidates = [
+      makeWidget("b", { top: 200, left: 0 }),
+      makeWidget("a", { top: 100, left: 0 }),
+    ];
+
+    expect(ids(getEntryTabbables(anchor, candidates, false))).toEqual(
+      ids(sortWidgetsByPosition(anchor, candidates, false)),
+    );
+  });
+
+  it("enters at the lowest tab order first when tabbing forward", () => {
+    const candidates = [
+      makeWidget("a", { top: 0, left: 0 }),
+      makeWidget("b", { top: 100, left: 0, tabOrder: "2" }),
+      makeWidget("c", { top: 200, left: 0, tabOrder: "1" }),
+    ];
+
+    expect(ids(getEntryTabbables(anchor, candidates, false))).toEqual([
+      "c",
+      "b",
+      "a",
+    ]);
+  });
+
+  it("enters at the end of the sequence when tabbing backward", () => {
+    const candidates = [
+      makeWidget("a", { top: 0, left: 0 }),
+      makeWidget("b", { top: 100, left: 0, tabOrder: "2" }),
+      makeWidget("c", { top: 200, left: 0, tabOrder: "1" }),
+    ];
+
+    expect(
+      ids(getEntryTabbables({ top: 300, left: 100 }, candidates, true)),
+    ).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("getTabbableDescendants", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("scopes tab order to siblings within the same canvas", () => {
+    const canvasA = document.createElement("div");
+
+    canvasA.setAttribute("type", "CANVAS_WIDGET");
+
+    const active = makeWidget("active", { top: 0, left: 0, tabOrder: "2" });
+    const siblingInA = makeWidget("siblingInA", {
+      top: 100,
+      left: 0,
+      tabOrder: "3",
+    });
+
+    canvasA.append(active, siblingInA);
+
+    const canvasB = document.createElement("div");
+
+    canvasB.setAttribute("type", "CANVAS_WIDGET");
+
+    // lower tab order, but in another canvas: must not win
+    const widgetInB = makeWidget("widgetInB", {
+      top: 0,
+      left: 0,
+      tabOrder: "1",
+    });
+
+    canvasB.append(widgetInB);
+    document.body.append(canvasA, canvasB);
+
+    expect(ids(getTabbableDescendants(active, false))).toEqual(["siblingInA"]);
   });
 });

--- a/app/client/src/utils/hooks/useWidgetFocus/tabbable.ts
+++ b/app/client/src/utils/hooks/useWidgetFocus/tabbable.ts
@@ -18,6 +18,110 @@ export const FOCUS_SELECTOR =
 export const WIDGET_SELECTOR = `.positioned-widget:is(:not(${NON_FOCUSABLE_WIDGET_CLASS}))`;
 
 /**
+ * returns the explicit tab order of a widget set via the "Tab order"
+ * property (rendered as a data-taborder attribute), or null if unset/invalid
+ *
+ * @param element
+ * @returns
+ */
+function getExplicitTabOrder(element: HTMLElement): number | null {
+  const value = Number(element.dataset.taborder);
+
+  return Number.isInteger(value) && value >= 1 ? value : null;
+}
+
+function hasAnyExplicitTabOrder(elements: HTMLElement[]): boolean {
+  return elements.some((element) => getExplicitTabOrder(element) !== null);
+}
+
+function comparePosition(a: HTMLElement, b: HTMLElement) {
+  const rectA = a.getBoundingClientRect();
+  const rectB = b.getBoundingClientRect();
+
+  return rectA.top - rectB.top || rectA.left - rectB.left;
+}
+
+/**
+ * builds the total tab order of the given widgets following HTML tabindex
+ * semantics: widgets with an explicit tab order come first (ascending,
+ * ties broken by position), followed by the rest in position order
+ *
+ * @param elements
+ * @returns
+ */
+export function buildTabSequence(elements: HTMLElement[]): HTMLElement[] {
+  const explicit = elements
+    .filter((element) => getExplicitTabOrder(element) !== null)
+    .sort(
+      (a, b) =>
+        (getExplicitTabOrder(a) as number) -
+          (getExplicitTabOrder(b) as number) || comparePosition(a, b),
+    );
+  const implicit = elements
+    .filter((element) => getExplicitTabOrder(element) === null)
+    .sort(comparePosition);
+
+  return [...explicit, ...implicit];
+}
+
+/**
+ * returns candidates in traversal order when focus enters a scope
+ * (canvas, modal or container) from its corner
+ *
+ * falls back to the legacy position-based sorting when no candidate
+ * has an explicit tab order
+ *
+ * @param anchor
+ * @param candidates
+ * @param shiftKey
+ * @returns
+ */
+export function getEntryTabbables(
+  anchor: { top: number; left: number },
+  candidates: HTMLElement[],
+  shiftKey = false,
+): HTMLElement[] {
+  if (!hasAnyExplicitTabOrder(candidates)) {
+    return sortWidgetsByPosition(anchor, candidates, shiftKey);
+  }
+
+  const sequence = buildTabSequence(candidates);
+
+  return shiftKey ? sequence.slice().reverse() : sequence;
+}
+
+/**
+ * returns the sibling widgets that come after (or before, for shift+tab)
+ * the active widget in the tab order
+ *
+ * falls back to the legacy position-based sorting when neither the active
+ * widget nor any sibling has an explicit tab order
+ *
+ * @param activeWidget
+ * @param siblings
+ * @param shiftKey
+ * @returns
+ */
+export function getSiblingTabbables(
+  activeWidget: HTMLElement,
+  siblings: HTMLElement[],
+  shiftKey = false,
+): HTMLElement[] {
+  if (!hasAnyExplicitTabOrder([activeWidget, ...siblings])) {
+    const { left, top } = activeWidget.getBoundingClientRect();
+
+    return sortWidgetsByPosition({ top, left }, siblings, shiftKey);
+  }
+
+  const sequence = buildTabSequence([activeWidget, ...siblings]);
+  const currentIndex = sequence.indexOf(activeWidget);
+
+  return shiftKey
+    ? sequence.slice(0, currentIndex).reverse()
+    : sequence.slice(currentIndex + 1);
+}
+
+/**
  * returns the tabbable descendants of the current node
  *
  * @param currentNode
@@ -41,7 +145,7 @@ export function getTabbableDescendants(
 
       const domRect = modal.getBoundingClientRect();
 
-      const sortedTabbableDescendants = sortWidgetsByPosition(
+      const sortedTabbableDescendants = getEntryTabbables(
         {
           top: shiftKey ? domRect.bottom : domRect.top,
           left: shiftKey ? domRect.right : domRect.left,
@@ -61,7 +165,7 @@ export function getTabbableDescendants(
 
       const domRect = currentNode.getBoundingClientRect();
 
-      const sortedTabbableDescendants = sortWidgetsByPosition(
+      const sortedTabbableDescendants = getEntryTabbables(
         {
           top: shiftKey ? domRect.bottom : domRect.top,
           left: shiftKey ? domRect.right : domRect.left,
@@ -75,16 +179,8 @@ export function getTabbableDescendants(
   }
 
   const siblings = getWidgetSiblingsOfNode(activeWidget);
-  const domRect = activeWidget.getBoundingClientRect();
 
-  const sortedSiblings = sortWidgetsByPosition(
-    {
-      top: domRect.top,
-      left: domRect.left,
-    },
-    siblings,
-    shiftKey,
-  );
+  const sortedSiblings = getSiblingTabbables(activeWidget, siblings, shiftKey);
 
   if (sortedSiblings.length) return sortedSiblings;
 
@@ -127,7 +223,7 @@ export function getNextTabbableDescendant(
     const { bottom, left, right, top } =
       nextTabbableDescendant.getBoundingClientRect();
 
-    const sortedTabbableDescendants = sortWidgetsByPosition(
+    const sortedTabbableDescendants = getEntryTabbables(
       {
         top: shiftKey ? bottom : top,
         left: shiftKey ? right : left,

--- a/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
+++ b/app/client/src/widgets/AudioRecorderWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
@@ -148,6 +149,7 @@ class AudioRecorderWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import type { IconName } from "@blueprintjs/icons";
 import { LabelPosition } from "components/constants";
 import type { ExecutionResult } from "constants/AppsmithActionConstants/ActionConstants";
@@ -321,6 +322,7 @@ class BaseInputWidget<
             },
           },
           ...generalProperties,
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -552,6 +552,7 @@ export interface WidgetDisplayProps {
   isVisible?: boolean;
   isLoading: boolean;
   isDisabled?: boolean;
+  tabOrder?: number;
   backgroundColor?: string;
   animateLoading?: boolean;
   deferRender?: boolean;

--- a/app/client/src/widgets/ButtonGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/ButtonGroupWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import type { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import type { IconName } from "@blueprintjs/icons";
 import type { ButtonPlacement, ButtonVariant } from "components/constants";
 import { ButtonPlacementTypes, ButtonVariantTypes } from "components/constants";
@@ -693,6 +694,7 @@ class ButtonGroupWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
     ];

--- a/app/client/src/widgets/ButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import type { IconName } from "@blueprintjs/icons";
 import type {
   ButtonPlacement,
@@ -220,6 +221,7 @@ class ButtonWidget extends BaseWidget<ButtonWidgetProps, ButtonWidgetState> {
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/CameraWidget/widget/index.tsx
+++ b/app/client/src/widgets/CameraWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { WIDGET_PADDING } from "constants/WidgetConstants";
@@ -195,6 +196,7 @@ class CameraWidget extends BaseWidget<CameraWidgetProps, WidgetState> {
               },
             },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/CategorySliderWidget/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/CategorySliderWidget/widget/propertyConfig/contentConfig.ts
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { LabelPosition } from "components/constants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { EvaluationSubstitutionType } from "constants/EvaluationConstants";
@@ -189,6 +190,7 @@ export default [
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
       },
+      TAB_ORDER_PROPERTY_CONFIG,
     ],
   },
   {

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import {
   CheckboxGroupAlignmentTypes,
   LabelPosition,
@@ -414,6 +415,7 @@ class CheckboxGroupWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/CheckboxWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { LabelPosition } from "components/constants";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import type { SetterConfig, Stylesheet } from "entities/AppTheming";
@@ -251,6 +252,7 @@ class CheckboxWidget extends BaseWidget<CheckboxWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/CodeScannerWidget/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/CodeScannerWidget/widget/propertyConfig/contentConfig.ts
@@ -1,4 +1,5 @@
 import type { PropertyPaneConfig } from "constants/PropertyControlConstants";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { isAutoLayout } from "layoutSystems/autolayout/utils/flexWidgetUtils";
 import type { CodeScannerWidgetProps } from "widgets/CodeScannerWidget/constants";
@@ -130,6 +131,7 @@ export default [
           },
         },
       },
+      TAB_ORDER_PROPERTY_CONFIG,
     ],
   },
 

--- a/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
@@ -1,4 +1,5 @@
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import type { TextSize } from "constants/WidgetConstants";
 import React from "react";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
@@ -473,6 +474,7 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -1,4 +1,5 @@
 import type Dashboard from "@uppy/dashboard";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import type { Uppy } from "@uppy/core";
 import type { UppyFile } from "@uppy/utils";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
@@ -346,6 +347,7 @@ class FilePickerWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
 

--- a/app/client/src/widgets/IconButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/IconButtonWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import type { IconName } from "@blueprintjs/icons";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import React from "react";
 
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
@@ -187,6 +188,7 @@ class IconButtonWidget extends BaseWidget<IconButtonWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
     ];

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { ButtonPlacementTypes, ButtonVariantTypes } from "components/constants";
 import type { OnButtonClickProps } from "components/propertyControls/ButtonControl";
 import type { ValidationResponse } from "constants/WidgetValidation";
@@ -435,6 +436,7 @@ export const contentConfig = [
         },
         placeholderText: "1-200",
       },
+      TAB_ORDER_PROPERTY_CONFIG,
     ],
     expandedByDefault: false,
   },

--- a/app/client/src/widgets/MenuButtonWidget/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/MenuButtonWidget/widget/propertyConfig/contentConfig.ts
@@ -1,4 +1,5 @@
 import type { PropertyPaneConfig } from "constants/PropertyControlConstants";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { EvaluationSubstitutionType } from "constants/EvaluationConstants";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
@@ -146,6 +147,7 @@ export default [
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
       },
+      TAB_ORDER_PROPERTY_CONFIG,
     ],
   },
 ] as PropertyPaneConfig[];

--- a/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { LabelPosition } from "components/constants";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { Layers } from "constants/Layers";
@@ -481,6 +482,7 @@ class MultiSelectTreeWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { LabelPosition } from "components/constants";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { Layers } from "constants/Layers";
@@ -585,6 +586,7 @@ class MultiSelectWidget extends BaseWidget<
               );
             },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/NumberSliderWidget/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/NumberSliderWidget/widget/propertyConfig/contentConfig.ts
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 
 import { LabelPosition } from "components/constants";
 import { ValidationTypes } from "constants/WidgetValidation";
@@ -276,6 +277,7 @@ export default [
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
       },
+      TAB_ORDER_PROPERTY_CONFIG,
     ],
   },
   {

--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { compact, isArray, isNumber } from "lodash";
 import React from "react";
 
@@ -521,6 +522,7 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/RangeSliderWidget/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/RangeSliderWidget/widget/propertyConfig/contentConfig.ts
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { LabelPosition } from "components/constants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { AutocompleteDataType } from "utils/autocomplete/AutocompleteDataType";
@@ -317,6 +318,7 @@ export default [
         isTriggerProperty: false,
         validation: { type: ValidationTypes.BOOLEAN },
       },
+      TAB_ORDER_PROPERTY_CONFIG,
     ],
   },
   {

--- a/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { LabelPosition } from "components/constants";
 import Skeleton from "components/utils/Skeleton";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
@@ -332,6 +333,7 @@ class RichTextEditorWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
 

--- a/app/client/src/widgets/SelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/SelectWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { LabelPosition } from "components/constants";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
@@ -596,6 +597,7 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
               );
             },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment } from "@blueprintjs/core";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { LabelPosition } from "components/constants";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { Layers } from "constants/Layers";
@@ -424,6 +425,7 @@ class SingleSelectTreeWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import { Alignment } from "@blueprintjs/core";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
@@ -334,6 +335,7 @@ class SwitchGroupWidget extends BaseWidget<
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/SwitchWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/widget/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TAB_ORDER_PROPERTY_CONFIG } from "widgets/sharedPropertyPaneConfig";
 import type { WidgetProps, WidgetState } from "../../BaseWidget";
 import BaseWidget from "../../BaseWidget";
 import SwitchComponent from "../component";
@@ -212,6 +213,7 @@ class SwitchWidget extends BaseWidget<SwitchWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
           },
+          TAB_ORDER_PROPERTY_CONFIG,
         ],
       },
       {

--- a/app/client/src/widgets/sharedPropertyPaneConfig.ts
+++ b/app/client/src/widgets/sharedPropertyPaneConfig.ts
@@ -1,0 +1,19 @@
+import type { PropertyPaneControlConfig } from "constants/PropertyControlConstants";
+import { ValidationTypes } from "constants/WidgetValidation";
+
+export const TAB_ORDER_PROPERTY_CONFIG: PropertyPaneControlConfig & {
+  placeholderText: string;
+} = {
+  propertyName: "tabOrder",
+  label: "Tab order",
+  helpText:
+    "Sets the keyboard Tab navigation order. Widgets with a tab order are focused first (lowest first); widgets without one follow in position-based order",
+  controlType: "INPUT_TEXT",
+  placeholderText: "1",
+  isBindProperty: true,
+  isTriggerProperty: false,
+  validation: {
+    type: ValidationTypes.NUMBER,
+    params: { natural: true, min: 1 },
+  },
+};


### PR DESCRIPTION
## Description

Adds an optional **Tab order** property (integer ≥ 1) to the General section of all focusable widgets, letting builders control keyboard Tab navigation order in fixed-layout apps (editor canvas and deployed view).

**How it works**
- The property value flows to a `data-taborder` attribute on the `.positioned-widget` wrapper (`PositionedComponentLayer` → `PositionedContainer`).
- The Tab handler (`useWidgetFocus`/`tabbable.ts`) now applies HTML `tabindex` semantics per candidate set: widgets with an explicit order come first (ascending, ties broken by position), followed by widgets without one in the existing position-based order.
- **Backward compatible by construction**: all new logic is gated on "at least one candidate has a valid `data-taborder`". When no widget has a value (i.e., every existing app), the original `sortWidgetsByPosition` code path runs unchanged — no DSL migration needed. Invalid values (0, negatives, non-integers, bad bindings) are treated as unset.
- Modal focus trap, container descent, parent-canvas recursion, and per-canvas scoping are preserved; auto-layout is unaffected (Tab handler already disabled there).

**Scope**
- One shared config (`src/widgets/sharedPropertyPaneConfig.ts`) appended to the General section of 24 files covering 26 widgets (`BaseInputWidget` covers Input/Currency/Phone via inheritance).
- Skipped: deprecated v1 widgets and non-focusable widgets (Text, Rate).

**Testing**
- Rewrote the `tabbable.test.ts` stub with 11 tests: legacy-regression gate (output identical to position sorting when no orders set), explicit ordering, HTML-style interleaving, shift-Tab reverse, ties, invalid values, entry ordering (canvas/modal), and per-canvas scoping. All pass.
- Type check and lint clean on touched files.

Fixes #`Issue Number`

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/27435141159>
> Commit: fce0bd26c97dafdac78bb8b5322f3b67f88ca96c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=27435141159&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 12 Jun 2026 19:34:09 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes
- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)