### PR TITLE
fix: cap Rating widget maxCount to 100 to prevent browser crash (#14833)

### DIFF
--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -475,7 +475,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
   }
 
   getWidgetView() {
-    const safeMaxCount = Math.min(this.props.maxCount || 0, 100);
+    const safeMaxCount = Math.min(this.props.maxCount || 5, 100);
     return (
       (this.props.rate || this.props.rate === 0) && (
         <RateComponent

--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -246,7 +246,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: {
               type: ValidationTypes.NUMBER,
-              params: { natural: true },
+              params: { natural: true, max: 100 },
             },
           },
           {
@@ -475,6 +475,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
   }
 
   getWidgetView() {
+    const safeMaxCount = Math.min(this.props.maxCount || 0, 100);
     return (
       (this.props.rate || this.props.rate === 0) && (
         <RateComponent
@@ -484,7 +485,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
           isDisabled={this.props.isDisabled}
           isLoading={this.props.isLoading}
           key={this.props.widgetId}
-          maxCount={this.props.maxCount}
+          maxCount={safeMaxCount}
           minHeight={this.props.minHeight}
           onValueChanged={this.valueChangedHandler}
           readonly={this.props.isReadOnly}


### PR DESCRIPTION
## Description

When a large number (e.g., 1000000) is provided as the max value for the Rating widget — either hardcoded or via data binding — the browser attempts to render millions of SVG star elements, causing an "Aw, snap!" crash with no way to recover.

Based on the requirements outlined by @dilippitchika in the issue comments:

1. **Property pane validation:** Added `max: 100` to the `maxCount` validation params so the property pane shows an error for values greater than 100.
2. **Render-time safety:** Capped `maxCount` to 100 in `getWidgetView()` using `Math.min()` to safely handle data-binding edge cases where the bound value exceeds 100.

Fixes #14833

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate Widget now enforces a maximum count limit of 100. Property pane validation prevents entering higher values, and the widget automatically caps any configured values above this threshold. This ensures consistent display and predictable behavior across the UI, avoiding unexpected counts and configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->