### PR TITLE
feat(server): stop CE startup when database was previously EE

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/DeploymentPropertiesCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/DeploymentPropertiesCE.java
@@ -14,6 +14,10 @@ import java.nio.file.Paths;
 @Slf4j
 public class DeploymentPropertiesCE {
 
+    // The edition reported by a Community Edition build. EE overrides getEdition() to return "EE".
+    // Shared so callers that branch on edition (e.g. MongoConfig's EE-downgrade guard) cannot drift.
+    public static final String EDITION_CE = "CE";
+
     private final String INFO_JSON_PATH = "/tmp/appsmith/infra.json";
     private String cloudProvider;
     private String tool;
@@ -22,7 +26,7 @@ public class DeploymentPropertiesCE {
     private String deployedAt;
 
     public String getEdition() {
-        return "CE";
+        return EDITION_CE;
     }
 
     public DeploymentPropertiesCE(ObjectMapper objectMapper) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
@@ -5,6 +5,7 @@ import com.appsmith.external.annotations.encryption.EncryptionMongoEventListener
 import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.server.configurations.mongo.SoftDeleteMongoRepositoryFactoryBean;
 import com.appsmith.server.converters.StringToInstantConverter;
+import com.appsmith.server.helpers.EnterpriseDowngradeGuard;
 import com.appsmith.server.repositories.BaseRepositoryImpl;
 import com.github.cloudyrock.mongock.ChangeLog;
 import com.github.cloudyrock.mongock.ChangeSet;
@@ -170,7 +171,10 @@ public class MongoConfig {
     */
     @Bean
     public MongockInitializingBeanRunner mongockInitializingBeanRunner(
-            ApplicationContext springContext, MongoClient mongoClient, MongoProperties mongoProperties) {
+            ApplicationContext springContext,
+            MongoClient mongoClient,
+            MongoProperties mongoProperties,
+            EnterpriseDowngradeGuard enterpriseDowngradeGuard) {
         MongoReactiveDriver driver =
                 MongoReactiveDriver.withDefaultLock(mongoClient, mongoProperties.getMongoClientDatabase());
         driver.setWriteConcern(WriteConcern.JOURNALED.withJournal(false));
@@ -183,6 +187,9 @@ public class MongoConfig {
                 .setSpringContext(springContext);
 
         checkForbiddenIds(runnerBuilder);
+
+        // Hard-stop CE startup before any migration runs if this database was previously used by EE.
+        enterpriseDowngradeGuard.assertNotEnterpriseDatabase(mongoClient, mongoProperties.getMongoClientDatabase());
 
         return runnerBuilder.buildInitializingBeanRunner();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
@@ -174,7 +174,8 @@ public class MongoConfig {
             ApplicationContext springContext,
             MongoClient mongoClient,
             MongoProperties mongoProperties,
-            EnterpriseDowngradeGuard enterpriseDowngradeGuard) {
+            EnterpriseDowngradeGuard enterpriseDowngradeGuard,
+            DeploymentProperties deploymentProperties) {
         MongoReactiveDriver driver =
                 MongoReactiveDriver.withDefaultLock(mongoClient, mongoProperties.getMongoClientDatabase());
         driver.setWriteConcern(WriteConcern.JOURNALED.withJournal(false));
@@ -188,8 +189,13 @@ public class MongoConfig {
 
         checkForbiddenIds(runnerBuilder);
 
-        // Hard-stop CE startup before any migration runs if this database was previously used by EE.
-        enterpriseDowngradeGuard.assertNotEnterpriseDatabase(mongoClient, mongoProperties.getMongoClientDatabase());
+        // Only a CE build must refuse to start on an EE database. An EE build legitimately runs
+        // against EE data, and DeploymentProperties#getEdition() already returns "EE" there, so the
+        // guard is skipped for EE. This keeps the check entirely in CE with no EE-side override.
+        if (DeploymentPropertiesCE.EDITION_CE.equals(deploymentProperties.getEdition())) {
+            // Runs before any migration: hard-stop if this database was previously used by EE.
+            enterpriseDowngradeGuard.assertNotEnterpriseDatabase(mongoClient, mongoProperties.getMongoClientDatabase());
+        }
 
         return runnerBuilder.buildInitializingBeanRunner();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/EnterpriseDowngradeGuard.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/EnterpriseDowngradeGuard.java
@@ -1,0 +1,5 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.helpers.ce.EnterpriseDowngradeGuardCE;
+
+public interface EnterpriseDowngradeGuard extends EnterpriseDowngradeGuardCE {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/EnterpriseDowngradeGuardImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/EnterpriseDowngradeGuardImpl.java
@@ -1,0 +1,7 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.helpers.ce.EnterpriseDowngradeGuardCEImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnterpriseDowngradeGuardImpl extends EnterpriseDowngradeGuardCEImpl implements EnterpriseDowngradeGuard {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCE.java
@@ -1,0 +1,8 @@
+package com.appsmith.server.helpers.ce;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+
+public interface EnterpriseDowngradeGuardCE {
+
+    void assertNotEnterpriseDatabase(MongoClient mongoClient, String databaseName);
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImpl.java
@@ -12,9 +12,19 @@ import java.util.regex.Pattern;
 @Slf4j
 public class EnterpriseDowngradeGuardCEImpl implements EnterpriseDowngradeGuardCE {
 
-    // EE migrations live under this package. The detection signal depends on every EE migration
-    // FQCN starting with this prefix (verified against the EE repo / enforced by an EE-side CI check).
-    static final String EE_MIGRATION_PACKAGE_PREFIX = "com.appsmith.server.migrations.db.ee.";
+    // How EE migrations are distinguished from CE migrations in the Mongock audit log:
+    //   - CE migrations live in the "...migrations.db.ce." subpackage
+    //     (e.g. com.appsmith.server.migrations.db.ce.Migration003...).
+    //   - EE migrations live in the PARENT "...migrations.db." package and carry an "EE" token in
+    //     their class name (e.g. com.appsmith.server.migrations.db.Migration003EE01...).
+    //   - The legacy EE changelog class "...migrations.DatabaseChangelogEE" predates the db package.
+    // So a changeLogClass under "...migrations.db." that is NOT under "...migrations.db.ce." was
+    // written by EE. Verified against the appsmith-ee repo: 69 EE @ChangeUnit classes, all directly
+    // in the parent package; CE has zero classes directly in that package (all CE ones are in db.ce).
+    // (The earlier ".db.ee." prefix was wrong — EE has no such package — so the guard never fired.)
+    static final String MIGRATIONS_DB_PACKAGE_PREFIX = "com.appsmith.server.migrations.db.";
+    static final String CE_MIGRATIONS_DB_PACKAGE_PREFIX = "com.appsmith.server.migrations.db.ce.";
+    static final String LEGACY_EE_CHANGELOG_CLASS = "com.appsmith.server.migrations.DatabaseChangelogEE";
 
     /**
      * Thrown to abort CE startup when the connected database was previously used by Appsmith
@@ -34,7 +44,18 @@ public class EnterpriseDowngradeGuardCEImpl implements EnterpriseDowngradeGuardC
         // with the EE migration package proves EE ran against this database.
         Document eeChangeLog;
         try {
-            final Bson filter = Filters.regex("changeLogClass", "^" + Pattern.quote(EE_MIGRATION_PACKAGE_PREFIX));
+            // EE = a migration recorded in the parent "...migrations.db." package but NOT in the CE
+            // "...migrations.db.ce." subpackage, OR the legacy EE changelog class. Prefixes are
+            // anchored and escaped via Pattern.quote so only exact package segments match.
+            // Note: $not(regex) also matches docs where changeLogClass is absent/non-string, but it is
+            // AND-ed with the positive parent-package regex (which requires a present, matching string),
+            // so the negation only ever excludes the db.ce subset. Do not split these two clauses.
+            final Bson filter = Filters.or(
+                    Filters.and(
+                            Filters.regex("changeLogClass", "^" + Pattern.quote(MIGRATIONS_DB_PACKAGE_PREFIX)),
+                            Filters.not(Filters.regex(
+                                    "changeLogClass", "^" + Pattern.quote(CE_MIGRATIONS_DB_PACKAGE_PREFIX)))),
+                    Filters.eq("changeLogClass", LEGACY_EE_CHANGELOG_CLASS));
             // No "state" filter: a FAILED/partial EE migration still proves EE ran against this DB.
             // Blocking is acceptable here: this is one-time startup config code and Mongock's own
             // initialization (which runs immediately after) already blocks at this point.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImpl.java
@@ -1,0 +1,98 @@
+package com.appsmith.server.helpers.ce;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.reactivestreams.client.MongoClient;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import reactor.core.publisher.Mono;
+
+import java.util.regex.Pattern;
+
+@Slf4j
+public class EnterpriseDowngradeGuardCEImpl implements EnterpriseDowngradeGuardCE {
+
+    // EE migrations live under this package. The detection signal depends on every EE migration
+    // FQCN starting with this prefix (verified against the EE repo / enforced by an EE-side CI check).
+    static final String EE_MIGRATION_PACKAGE_PREFIX = "com.appsmith.server.migrations.db.ee.";
+
+    /**
+     * Thrown to abort CE startup when the connected database was previously used by Appsmith
+     * Enterprise Edition (EE). Aborting via a thrown {@link RuntimeException} during bean creation
+     * matches the local convention in {@code MongoConfig} (see {@code checkForbiddenIds}).
+     */
+    public static class EnterpriseDowngradeException extends RuntimeException {
+        public EnterpriseDowngradeException(String message) {
+            super(message);
+        }
+    }
+
+    @Override
+    public void assertNotEnterpriseDatabase(MongoClient mongoClient, String databaseName) {
+        // Mongock v5 records every applied (or failed) changeset in this default audit collection
+        // (the matching lock collection is "mongockLock"). A document whose "changeLogClass" starts
+        // with the EE migration package proves EE ran against this database.
+        Document eeChangeLog;
+        try {
+            final Bson filter = Filters.regex("changeLogClass", "^" + Pattern.quote(EE_MIGRATION_PACKAGE_PREFIX));
+            // No "state" filter: a FAILED/partial EE migration still proves EE ran against this DB.
+            // Blocking is acceptable here: this is one-time startup config code and Mongock's own
+            // initialization (which runs immediately after) already blocks at this point.
+            eeChangeLog = Mono.from(mongoClient
+                            .getDatabase(databaseName)
+                            .getCollection("mongockChangeLog")
+                            .find(filter)
+                            .limit(1)
+                            .first())
+                    .block();
+        } catch (Exception e) {
+            // Fail OPEN on infrastructure error: the signal is positive, so EE evidence must be
+            // affirmatively found to justify a hard stop. Treating "couldn't read" as "is EE" would
+            // brick CE operators with a flaky/locked-down Mongo. Mongock runs immediately after and
+            // will itself fail loudly if Mongo is genuinely unreachable.
+            log.warn("Could not run EE->CE downgrade check; proceeding", e);
+            return;
+        }
+
+        // Detection-abort lives OUTSIDE the catch above so the fail-open handler can never swallow it.
+        if (eeChangeLog != null) {
+            final String changeId = stripCrLf(eeChangeLog.getString("changeId"));
+            final String changeLogClass = stripCrLf(eeChangeLog.getString("changeLogClass"));
+
+            // Log the operator-facing banner FIRST so it is the last thing printed before the
+            // framework's BeanCreationException stack trace. CR/LF-stripped, parameterized values
+            // avoid log forging.
+            log.error(
+                    """
+
+                            ################################################################
+                            APPSMITH STARTUP ABORTED  [APPSMITH-EE-DOWNGRADE-BLOCKED]
+                            Enterprise -> Community (EE -> CE) downgrade detected.
+                            This database was previously used by Appsmith Enterprise Edition (EE).
+                            Detected EE migration record in 'mongockChangeLog':
+                              changeId       = {}
+                              changeLogClass = {}
+                            Running Community Edition (CE) against an EE database is not supported and can
+                            corrupt your data. Startup has been stopped to protect the database.
+                            Supported paths forward: run an Appsmith EE build against this database, or
+                            restore a CE backup taken before EE was used.
+                            See: https://docs.appsmith.com/
+                            ################################################################
+                            """,
+                    changeId,
+                    changeLogClass);
+            // TODO(docs): replace the placeholder URL above with the runbook URL for the
+            // APPSMITH-EE-DOWNGRADE-BLOCKED token once the docs team supplies it.
+
+            throw new EnterpriseDowngradeException(
+                    "EE -> CE downgrade detected; startup aborted to protect the database.");
+        }
+    }
+
+    private static String stripCrLf(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replaceAll("[\\r\\n]", "");
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplTest.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.helpers.ce;
 
+import com.mongodb.MongoCommandException;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import org.bson.Document;
@@ -123,9 +124,11 @@ public class EnterpriseDowngradeGuardCEImplTest {
     // Case 3: Empty mongockChangeLog collection -> does NOT throw.
     @Test
     public void assertNotEnterpriseDatabase_whenChangeLogEmpty_doesNotThrow() {
-        // Ensure the collection exists but is empty.
+        // Ensure the collection exists but is empty. Ignore only the "collection already exists"
+        // error (NamespaceExists, code 48); any other failure indicates broken setup and must surface.
         Mono.from(mongoClient.getDatabase(databaseName).createCollection(MONGOCK_CHANGE_LOG))
-                .onErrorResume(e -> Mono.empty())
+                .onErrorResume(
+                        e -> e instanceof MongoCommandException mce && mce.getErrorCode() == 48, e -> Mono.empty())
                 .block();
         clearChangeLog();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplTest.java
@@ -1,0 +1,148 @@
+package com.appsmith.server.helpers.ce;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link EnterpriseDowngradeGuardCEImpl} (the CE implementation of the EE -> CE downgrade
+ * guard). Each case seeds the real Mongock audit collection ("mongockChangeLog") in the embedded
+ * flapdoodle Mongo, runs the guard against the same reactive {@link MongoClient} bean that
+ * {@code MongoConfig} uses, and asserts whether startup would be aborted.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+public class EnterpriseDowngradeGuardCEImplTest {
+
+    private static final String MONGOCK_CHANGE_LOG = "mongockChangeLog";
+
+    @Autowired
+    private MongoClient mongoClient;
+
+    @Autowired
+    private MongoProperties mongoProperties;
+
+    // Test the CE implementation directly. The bean wired into MongoConfig is the EE-overridable
+    // EnterpriseDowngradeGuard; this class verifies the CE behaviour explicitly.
+    private final EnterpriseDowngradeGuardCEImpl guard = new EnterpriseDowngradeGuardCEImpl();
+
+    private String databaseName;
+
+    private MongoCollection<Document> changeLogCollection() {
+        return mongoClient.getDatabase(databaseName).getCollection(MONGOCK_CHANGE_LOG);
+    }
+
+    private void clearChangeLog() {
+        // deleteMany on a missing collection is a no-op; safe regardless of prior state.
+        Mono.from(changeLogCollection().deleteMany(new Document())).block();
+    }
+
+    private void seed(List<Document> docs) {
+        Flux.fromIterable(docs)
+                .flatMap(doc -> Mono.from(changeLogCollection().insertOne(doc)))
+                .blockLast();
+    }
+
+    private void runGuard() {
+        guard.assertNotEnterpriseDatabase(mongoClient, databaseName);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        // Same database name resolution that MongoConfig uses to drive Mongock.
+        databaseName = mongoProperties.getMongoClientDatabase();
+        clearChangeLog();
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        // Drop the collection so no seeded audit record leaks into other tests in the context.
+        Mono.from(changeLogCollection().drop()).block();
+    }
+
+    private Document changeLog(String changeId, String changeLogClass) {
+        return new Document().append("changeId", changeId).append("changeLogClass", changeLogClass);
+    }
+
+    private Document changeLog(String changeId, String changeLogClass, String state) {
+        return changeLog(changeId, changeLogClass).append("state", state);
+    }
+
+    // Case 1: An EE-package changeLogClass present -> guard throws EnterpriseDowngradeException.
+    @Test
+    public void assertNotEnterpriseDatabase_whenEeMigrationRecordPresent_throws() {
+        seed(List.of(changeLog("ee-migration-001", "com.appsmith.server.migrations.db.ee.Migration001", "EXECUTED")));
+
+        assertThatThrownBy(this::runGuard)
+                .isInstanceOf(EnterpriseDowngradeGuardCEImpl.EnterpriseDowngradeException.class);
+    }
+
+    // Case 2: Only CE migration classes (incl. legacy DatabaseChangelog0) -> does NOT throw.
+    @Test
+    public void assertNotEnterpriseDatabase_whenOnlyCeMigrationRecordsPresent_doesNotThrow() {
+        seed(List.of(
+                changeLog(
+                        "ce-migration-003",
+                        "com.appsmith.server.migrations.db.ce.Migration003AddInstanceNameToTenantConfiguration",
+                        "EXECUTED"),
+                changeLog("legacy-changelog-0", "com.appsmith.server.migrations.DatabaseChangelog0", "EXECUTED")));
+
+        assertThatCode(this::runGuard).doesNotThrowAnyException();
+    }
+
+    // Case 3: Empty mongockChangeLog collection -> does NOT throw.
+    @Test
+    public void assertNotEnterpriseDatabase_whenChangeLogEmpty_doesNotThrow() {
+        // Ensure the collection exists but is empty.
+        Mono.from(mongoClient.getDatabase(databaseName).createCollection(MONGOCK_CHANGE_LOG))
+                .onErrorResume(e -> Mono.empty())
+                .block();
+        clearChangeLog();
+
+        assertThatCode(this::runGuard).doesNotThrowAnyException();
+    }
+
+    // Case 4: Missing mongockChangeLog collection (dropped) -> does NOT throw.
+    @Test
+    public void assertNotEnterpriseDatabase_whenChangeLogCollectionMissing_doesNotThrow() {
+        Mono.from(changeLogCollection().drop()).block();
+
+        assertThatCode(this::runGuard).doesNotThrowAnyException();
+    }
+
+    // Case 5: EE record with state "FAILED" -> still throws (detection is state-agnostic).
+    @Test
+    public void assertNotEnterpriseDatabase_whenEeMigrationFailed_stillThrows() {
+        seed(List.of(changeLog("ee-migration-001", "com.appsmith.server.migrations.db.ee.Migration001", "FAILED")));
+
+        assertThatThrownBy(this::runGuard)
+                .isInstanceOf(EnterpriseDowngradeGuardCEImpl.EnterpriseDowngradeException.class);
+    }
+
+    // Case 6: Anchored-prefix near misses -> does NOT throw.
+    //   - "...db.cee.X"     would match a naive unanchored/substring search for "db.ce" but is not CE.
+    //   - "...db.ce.EeThing" contains "Ee" but lives under the CE package, so must not trip EE detection.
+    // Both prove the guard anchors on the exact "com.appsmith.server.migrations.db.ee." prefix.
+    @Test
+    public void assertNotEnterpriseDatabase_whenAnchoredPrefixNearMisses_doesNotThrow() {
+        seed(List.of(
+                changeLog("near-miss-cee", "com.appsmith.server.migrations.db.cee.X", "EXECUTED"),
+                changeLog("near-miss-ce-eething", "com.appsmith.server.migrations.db.ce.EeThing", "EXECUTED")));
+
+        assertThatCode(this::runGuard).doesNotThrowAnyException();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplTest.java
@@ -82,16 +82,31 @@ public class EnterpriseDowngradeGuardCEImplTest {
         return changeLog(changeId, changeLogClass).append("state", state);
     }
 
-    // Case 1: An EE-package changeLogClass present -> guard throws EnterpriseDowngradeException.
+    // Case 1: A real EE migration record present (EE class in the parent migrations.db package)
+    // -> guard throws EnterpriseDowngradeException. Class name matches the actual appsmith-ee
+    // convention "...migrations.db.MigrationNNNEEnn...".
     @Test
     public void assertNotEnterpriseDatabase_whenEeMigrationRecordPresent_throws() {
-        seed(List.of(changeLog("ee-migration-001", "com.appsmith.server.migrations.db.ee.Migration001", "EXECUTED")));
+        seed(List.of(changeLog(
+                "add-delete-user-policy",
+                "com.appsmith.server.migrations.db.Migration003EE01AddDeleteUserPolicyToAllUsersAndAddTenantPolicyToDefaultTenant",
+                "EXECUTED")));
 
         assertThatThrownBy(this::runGuard)
                 .isInstanceOf(EnterpriseDowngradeGuardCEImpl.EnterpriseDowngradeException.class);
     }
 
-    // Case 2: Only CE migration classes (incl. legacy DatabaseChangelog0) -> does NOT throw.
+    // Case 1b: The legacy EE changelog class "...migrations.DatabaseChangelogEE" -> guard throws.
+    @Test
+    public void assertNotEnterpriseDatabase_whenLegacyEeChangelogPresent_throws() {
+        seed(List.of(changeLog("ee-legacy", "com.appsmith.server.migrations.DatabaseChangelogEE", "EXECUTED")));
+
+        assertThatThrownBy(this::runGuard)
+                .isInstanceOf(EnterpriseDowngradeGuardCEImpl.EnterpriseDowngradeException.class);
+    }
+
+    // Case 2: Only CE migration classes (db.ce subpackage + legacy DatabaseChangelog0/1/2)
+    // -> does NOT throw. These are exactly the classes a CE-only database contains.
     @Test
     public void assertNotEnterpriseDatabase_whenOnlyCeMigrationRecordsPresent_doesNotThrow() {
         seed(List.of(
@@ -99,7 +114,8 @@ public class EnterpriseDowngradeGuardCEImplTest {
                         "ce-migration-003",
                         "com.appsmith.server.migrations.db.ce.Migration003AddInstanceNameToTenantConfiguration",
                         "EXECUTED"),
-                changeLog("legacy-changelog-0", "com.appsmith.server.migrations.DatabaseChangelog0", "EXECUTED")));
+                changeLog("legacy-changelog-0", "com.appsmith.server.migrations.DatabaseChangelog0", "EXECUTED"),
+                changeLog("legacy-changelog-2", "com.appsmith.server.migrations.DatabaseChangelog2", "EXECUTED")));
 
         assertThatCode(this::runGuard).doesNotThrowAnyException();
     }
@@ -127,22 +143,44 @@ public class EnterpriseDowngradeGuardCEImplTest {
     // Case 5: EE record with state "FAILED" -> still throws (detection is state-agnostic).
     @Test
     public void assertNotEnterpriseDatabase_whenEeMigrationFailed_stillThrows() {
-        seed(List.of(changeLog("ee-migration-001", "com.appsmith.server.migrations.db.ee.Migration001", "FAILED")));
+        seed(List.of(changeLog(
+                "ee-failed", "com.appsmith.server.migrations.db.Migration042EE01AddWorkflowPlugin", "FAILED")));
 
         assertThatThrownBy(this::runGuard)
                 .isInstanceOf(EnterpriseDowngradeGuardCEImpl.EnterpriseDowngradeException.class);
     }
 
-    // Case 6: Anchored-prefix near misses -> does NOT throw.
-    //   - "...db.cee.X"     would match a naive unanchored/substring search for "db.ce" but is not CE.
-    //   - "...db.ce.EeThing" contains "Ee" but lives under the CE package, so must not trip EE detection.
-    // Both prove the guard anchors on the exact "com.appsmith.server.migrations.db.ee." prefix.
+    // Case 6: CE-package near misses -> does NOT throw. These must NOT be mistaken for EE:
+    //   - "...db.ce.EeThing"  lives under the CE package and contains "Ee" in its name.
+    //   - "...db.ce.Migration075..." is a normal CE migration in the db.ce subpackage.
+    // Proves detection excludes the db.ce subpackage rather than naively matching "db." or "EE".
     @Test
-    public void assertNotEnterpriseDatabase_whenAnchoredPrefixNearMisses_doesNotThrow() {
+    public void assertNotEnterpriseDatabase_whenCePackageNearMisses_doesNotThrow() {
         seed(List.of(
-                changeLog("near-miss-cee", "com.appsmith.server.migrations.db.cee.X", "EXECUTED"),
-                changeLog("near-miss-ce-eething", "com.appsmith.server.migrations.db.ce.EeThing", "EXECUTED")));
+                changeLog("ce-eething", "com.appsmith.server.migrations.db.ce.EeThing", "EXECUTED"),
+                changeLog(
+                        "ce-migration-075",
+                        "com.appsmith.server.migrations.db.ce.Migration075SeedSuperUserSetupLock",
+                        "EXECUTED")));
 
         assertThatCode(this::runGuard).doesNotThrowAnyException();
+    }
+
+    // Case 7: A mixed CE + EE database (the real downgrade scenario) -> throws. An EE record alongside
+    // many CE records must still trip the guard.
+    @Test
+    public void assertNotEnterpriseDatabase_whenCeAndEeRecordsMixed_throws() {
+        seed(List.of(
+                changeLog(
+                        "ce-migration-003",
+                        "com.appsmith.server.migrations.db.ce.Migration003AddInstanceNameToTenantConfiguration",
+                        "EXECUTED"),
+                changeLog(
+                        "ee-add-workflow-plugin",
+                        "com.appsmith.server.migrations.db.Migration042EE01AddWorkflowPlugin",
+                        "EXECUTED")));
+
+        assertThatThrownBy(this::runGuard)
+                .isInstanceOf(EnterpriseDowngradeGuardCEImpl.EnterpriseDowngradeException.class);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/EnterpriseDowngradeGuardCEImplUnitTest.java
@@ -1,0 +1,65 @@
+package com.appsmith.server.helpers.ce;
+
+import com.mongodb.reactivestreams.client.FindPublisher;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Lightweight, pure-Mockito unit tests for {@link EnterpriseDowngradeGuardCEImpl}. Unlike
+ * {@code EnterpriseDowngradeGuardCEImplTest} (which boots a full {@code @SpringBootTest} context with
+ * embedded Mongo), these tests drive the guard with a hand-mocked reactive {@link MongoClient} and so
+ * run with no Spring context, no Mongo, and no Redis.
+ *
+ * <p>The key case here is the <b>fail-open</b> catch branch in
+ * {@link EnterpriseDowngradeGuardCEImpl#assertNotEnterpriseDatabase}: when reading the Mongock audit
+ * collection throws (an infrastructure/query failure), the guard must NOT abort startup.
+ */
+public class EnterpriseDowngradeGuardCEImplUnitTest {
+
+    private static final String DATABASE_NAME = "appsmith";
+
+    private final EnterpriseDowngradeGuardCEImpl guard = new EnterpriseDowngradeGuardCEImpl();
+
+    // Required coverage: getDatabase(...) throws -> the guard fails OPEN (does not throw).
+    @Test
+    public void assertNotEnterpriseDatabase_whenMongoReadThrows_failsOpen() {
+        final MongoClient mongoClient = mock(MongoClient.class);
+        when(mongoClient.getDatabase(anyString())).thenThrow(new RuntimeException("simulated infra failure"));
+
+        assertThatCode(() -> guard.assertNotEnterpriseDatabase(mongoClient, DATABASE_NAME))
+                .doesNotThrowAnyException();
+    }
+
+    // Complementary happy-path: the audit query yields no EE document (first() emits nothing) ->
+    // the guard returns without aborting startup.
+    @Test
+    public void assertNotEnterpriseDatabase_whenNoEeRecordFound_doesNotThrow() {
+        @SuppressWarnings("unchecked")
+        final MongoCollection<Document> collection = mock(MongoCollection.class);
+        @SuppressWarnings("unchecked")
+        final FindPublisher<Document> findPublisher = mock(FindPublisher.class);
+        final MongoDatabase database = mock(MongoDatabase.class);
+        final MongoClient mongoClient = mock(MongoClient.class);
+
+        when(mongoClient.getDatabase(anyString())).thenReturn(database);
+        when(database.getCollection(anyString())).thenReturn(collection);
+        when(collection.find(any(org.bson.conversions.Bson.class))).thenReturn(findPublisher);
+        when(findPublisher.limit(anyInt())).thenReturn(findPublisher);
+        // first() returns an empty Publisher: Mono.from(...).block() resolves to null (no EE evidence).
+        when(findPublisher.first()).thenReturn(Mono.empty());
+
+        assertThatCode(() -> guard.assertNotEnterpriseDatabase(mongoClient, DATABASE_NAME))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary

Running Appsmith **Community Edition (CE)** against a MongoDB that was previously operated by Appsmith **Enterprise Edition (EE)** is an unsupported EE→CE downgrade — CE migrations and CE code then run against EE-shaped data and can corrupt it. Today this happens silently.

This PR adds a startup guard that detects the condition **before any Mongock migration runs** and **hard-stops CE startup** with a clear, operator-facing log message.

## How it works

- **Where:** inside `MongoConfig.mongockInitializingBeanRunner`, immediately before `buildInitializingBeanRunner()` — guaranteed to run before any migration, and where the existing `checkForbiddenIds` already throws-to-abort.
- **CE-only, no EE change:** the guard call is gated on `DeploymentProperties.getEdition() == "CE"`. An EE build already reports edition `"EE"` (hardcoded, binary-determined — not read from config), so EE skips the guard automatically and can never self-block against its own database. The edition value is shared via `DeploymentPropertiesCE.EDITION_CE`.
- **Signal (verified against a live EE→CE database and the EE repo):** query the Mongock audit collection `mongockChangeLog`. EE records its `@ChangeUnit` migrations in the **parent** package `com.appsmith.server.migrations.db.` with an `EE` token in the class name (e.g. `Migration003EE01...`, `Migration042EE01AddWorkflowPlugin`), plus a legacy `com.appsmith.server.migrations.DatabaseChangelogEE`. CE migrations live in the `com.appsmith.server.migrations.db.ce.` subpackage, and CE has **zero** classes directly in the parent `db` package. So the DB was used by EE iff `mongockChangeLog` holds a `changeLogClass` under `...migrations.db.` that is **not** under `...migrations.db.ce.`, or the legacy `DatabaseChangelogEE`. This keys on the package layout (the same split Mongock scans), not an `EE` name token, so a CE class like `db.ce.EeThing` is not misread as EE. Prefixes are anchored and `Pattern.quote`-escaped.
- **On detection (fail-closed):** log an ERROR banner — stable token `APPSMITH-EE-DOWNGRADE-BLOCKED`, with `changeId`/`changeLogClass` passed as CR/LF-stripped SLF4J parameters — then throw to abort startup.
- **On query/infrastructure error (fail-open):** log a warning and proceed, in a catch that does **not** wrap the abort, so a flaky/locked-down Mongo never bricks a healthy CE instance.

> Detection was corrected mid-branch: an earlier revision used a `...migrations.db.ee.` prefix, which does not exist in EE and so never fired. Verified against a real EE→CE database (84 EE records matched, 0 CE false positives; old rule matched 0).

## Testing

- `EnterpriseDowngradeGuardCEImplTest` (embedded Mongo) — **8/8**: real EE class present → abort; legacy `DatabaseChangelogEE` → abort; CE-only (db.ce + legacy `DatabaseChangelog0/2`) → pass; empty collection → pass; missing collection → pass; `FAILED`-state EE record → abort; CE-package near-misses (`db.ce.EeThing`) → pass; mixed CE+EE database → abort.
- `EnterpriseDowngradeGuardCEImplUnitTest` (Mockito) — **2/2**: fail-open when the query throws.
- `spotless:check` and `test-compile` clean. Verified live: CE startup against an EE database now aborts.

## Follow-ups (not in this PR)

1. **CE invariant guard (recommended).** Add a CE test/ArchUnit assertion that CE migrations only ever live in `...migrations.db.ce.` (never directly in the parent `db` package), since the guard treats any parent-`db` class as EE.
2. **Docs:** replace the placeholder runbook URL behind the `APPSMITH-EE-DOWNGRADE-BLOCKED` token (`// TODO(docs)`).
3. **Optional EE-side test:** assert EE `DeploymentProperties.getEdition() == "EE"` so an accidentally-dropped override is caught in CI rather than at startup.

> No EE-repo code change is required — the edition gate keeps the whole feature in CE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Community Edition startup now performs a pre-check for existing Enterprise Edition migration history to prevent incompatible downgrades.
  * If Enterprise migration evidence is detected, startup is stopped with a clear error message/banner.

* **Bug Fixes**
  * Detection includes both current and legacy Enterprise migration markers and handles mixed scenarios.
  * The check is fail-open when audit data can’t be read, avoiding unnecessary startup blocks.

* **Tests**
  * Added unit and integration tests covering blocking vs non-blocking outcomes, including empty or missing audit data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/27768419055>
> Commit: 57f2657a95d7269edcf99424b215eddb03537c5c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=27768419055&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 18 Jun 2026 15:59:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Automation
/ok-to-test tags="@tag.All"
