### PR TITLE
fix(helm): reject unsupported redis.auth.password configurations

### DIFF
--- a/deploy/helm/AGENTS.md
+++ b/deploy/helm/AGENTS.md
@@ -26,20 +26,3 @@ Each documented value in `values.yaml` carries up to three comment layers (all p
 - `# @section -- Section Name` — helm-docs groups the value into a named section table
 
 When adding a new value, include at least the `# --` and `# @section --` lines so it lands in the correct README section. The `## @param` line is optional but preferred for consistency.
-
-## Redis auth
-
-`redis.auth.password` is a Bitnami subchart passthrough the Appsmith templates never read
-directly. There is exactly ONE supported way to use it — fully self-managed: set
-`redis.auth.password`, set `redis.auth.existingSecret: ""`, AND set
-`applicationConfig.APPSMITH_REDIS_URL` so the app uses the same credential. Every other use
-is rejected at render time by `appsmith.validateRedisAuth` (in `_helpers.tpl`, invoked from
-`configMap.yaml` so it always evaluates). Leave the password unset for the default
-(hook-bootstrapped secret) or BYO-secret paths.
-
-Gotcha worth remembering: `helm template` cannot catch the self-managed path's runtime hazard.
-When a password is set the bootstrap hook is skipped, so the chart-managed Redis secret never
-exists — any pod referencing it (e.g. the `redis-init-container`'s `REDISCLI_AUTH`) must also be
-skipped on that path (gate on `not applicationConfig.APPSMITH_REDIS_URL`), or the pod wedges in
-`CreateContainerConfigError`. The init-container readiness ping needs no auth regardless:
-`redis-cli ping` against an auth-required server replies `NOAUTH` but exits 0, satisfying the wait.

--- a/deploy/helm/AGENTS.md
+++ b/deploy/helm/AGENTS.md
@@ -26,3 +26,20 @@ Each documented value in `values.yaml` carries up to three comment layers (all p
 - `# @section -- Section Name` — helm-docs groups the value into a named section table
 
 When adding a new value, include at least the `# --` and `# @section --` lines so it lands in the correct README section. The `## @param` line is optional but preferred for consistency.
+
+## Redis auth
+
+`redis.auth.password` is a Bitnami subchart passthrough the Appsmith templates never read
+directly. There is exactly ONE supported way to use it — fully self-managed: set
+`redis.auth.password`, set `redis.auth.existingSecret: ""`, AND set
+`applicationConfig.APPSMITH_REDIS_URL` so the app uses the same credential. Every other use
+is rejected at render time by `appsmith.validateRedisAuth` (in `_helpers.tpl`, invoked from
+`configMap.yaml` so it always evaluates). Leave the password unset for the default
+(hook-bootstrapped secret) or BYO-secret paths.
+
+Gotcha worth remembering: `helm template` cannot catch the self-managed path's runtime hazard.
+When a password is set the bootstrap hook is skipped, so the chart-managed Redis secret never
+exists — any pod referencing it (e.g. the `redis-init-container`'s `REDISCLI_AUTH`) must also be
+skipped on that path (gate on `not applicationConfig.APPSMITH_REDIS_URL`), or the pod wedges in
+`CreateContainerConfigError`. The init-container readiness ping needs no auth regardless:
+`redis-cli ping` against an auth-required server replies `NOAUTH` but exits 0, satisfying the wait.

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -238,6 +238,27 @@ Uses existing secret if provided, otherwise derives "{release}-redis-secret"
 {{- end -}}
 
 {{/*
+Redis: validate the redis.auth.password configuration.
+
+redis.auth.password is a Bitnami subchart passthrough that the Appsmith
+templates never read on their own. There is exactly ONE supported way to use
+it: the fully self-managed path, where the operator also disables the chart's
+bootstrap secret (existingSecret: "") and hands the app a matching connection
+string via applicationConfig.APPSMITH_REDIS_URL. Any other use silently splits
+the password between Redis and the app, so we fail fast instead.
+
+Invoked from a template that always renders (configMap.yaml) so it evaluates on
+every `helm template`/install/upgrade.
+*/}}
+{{- define "appsmith.validateRedisAuth" -}}
+{{- if .Values.redis.auth.password -}}
+{{- if or .Values.redis.auth.existingSecret (not .Values.applicationConfig.APPSMITH_REDIS_URL) -}}
+{{ fail (printf "redis.auth.password is set, which is only supported on the self-managed path. Choose one of:\n  1. Leave redis.auth.password unset and let the chart bootstrap a password (default), or supply your own secret via redis.auth.existingSecret / redis.auth.existingSecretPasswordKey.\n  2. Self-manage the password: set redis.auth.password, set redis.auth.existingSecret: \"\", and set applicationConfig.APPSMITH_REDIS_URL=redis://:<password>@%s-redis-master:6379 so the app uses the same credential." .Release.Name) }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Redis: master service hostname (FQDN inside the cluster).
 Derived from the release name to stay uniform with the chart's other components.
 Assumes the release name does not contain "redis" (otherwise the Bitnami subchart

--- a/deploy/helm/templates/configMap.yaml
+++ b/deploy/helm/templates/configMap.yaml
@@ -6,6 +6,7 @@
 {{- $postgresqlPassword := .Values.postgresql.auth.password -}}
 {{- $postgresqlDatabase := .Values.postgresql.auth.database -}}
 {{- $releaseName := .Release.Name -}}
+{{- include "appsmith.validateRedisAuth" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -80,7 +80,13 @@ spec:
         image: "{{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
       {{- end }}
         command: ['sh', '-c', "until redis-cli -h {{ include "appsmith.redisMasterHost" . }} ping ; do echo waiting for redis; sleep 2; done"]
-        {{- if .Values.redis.auth.enabled }}
+        {{- if and .Values.redis.auth.enabled (not .Values.applicationConfig.APPSMITH_REDIS_URL) }}
+        # Pull the password from the chart-managed Secret so the readiness ping can
+        # authenticate. Skipped when the operator supplies their own APPSMITH_REDIS_URL
+        # (the self-managed redis.auth.password path), because then no chart Secret exists
+        # to reference and an unresolvable secretKeyRef would wedge the pod in
+        # CreateContainerConfigError. The wait still works unauthenticated: `redis-cli ping`
+        # against an auth-required server replies NOAUTH but exits 0, satisfying the loop.
         env:
           - name: REDISCLI_AUTH
             valueFrom:

--- a/deploy/helm/templates/hooks/redis.yaml
+++ b/deploy/helm/templates/hooks/redis.yaml
@@ -14,7 +14,16 @@ secret (or a user who pre-created their own) is left untouched.
 The resulting Secret has no Helm release labels/annotations and no
 ownerReferences, so ArgoCD does not track or diff it.
 */}}
-{{- if and .Values.redis.enabled .Values.redis.auth.enabled }}
+{{/*
+Skip the bootstrap entirely when redis.auth.password is set: on that path the
+operator self-manages the credential (Bitnami uses redis.auth.password directly)
+and there is no chart secret to create. Safe ONLY because appsmith.validateRedisAuth
+(see _helpers.tpl, invoked from configMap.yaml) rejects every redis.auth.password
+configuration except the self-managed one (existingSecret: "" + a matching
+APPSMITH_REDIS_URL) — so this can no longer leave a non-empty existingSecret
+pointing at a secret the hook never creates.
+*/}}
+{{- if and .Values.redis.enabled .Values.redis.auth.enabled (not .Values.redis.auth.password) }}
 {{- $secretName := include "appsmith.redisSecretName" . -}}
 {{- $passwordKey := .Values.redis.auth.existingSecretPasswordKey -}}
 {{- $jobName := printf "%s-redis-password-init" (include "appsmith.fullname" .) | trunc 63 | trimSuffix "-" -}}


### PR DESCRIPTION
Builds on #41874.

`redis.auth.password` is a Bitnami subchart value that the Appsmith chart templates do not read on their own, so setting it currently misconfigures Redis silently — the password ends up split between the Redis server and the application, or is dropped entirely, and only surfaces as a runtime authentication failure.

This change:

- Adds a render-time validation guard (`appsmith.validateRedisAuth`) that fails fast with actionable guidance unless `redis.auth.password` is used in the one supported, fully self-managed shape (`redis.auth.existingSecret: ""` plus a matching `applicationConfig.APPSMITH_REDIS_URL`).
- Skips the password-bootstrap hook on the self-managed path, where no chart-managed secret is needed.
- Fixes the Redis init-container so it does not reference a non-existent secret on the self-managed path (which otherwise wedges the pod in `CreateContainerConfigError`).
- Documents the supported configurations in `deploy/helm/AGENTS.md`.

Verified by rendering the chart across the default, bring-your-own-secret, and self-managed combinations, and by a live install→upgrade test on a k3s cluster: the default path is unaffected, misconfigured upgrades now fail fast with migration guidance, and the self-managed path installs and reconnects cleanly.
