### PR TITLE
fix(ci): build helm deps natively to avoid bind-mount permission error

### DIFF
--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -26,13 +26,8 @@ jobs:
         with:
           version: v4.1.4
 
-      # Subchart .tgz files are gitignored, so a fresh checkout has no charts/.
-      # Build dependencies so any test that renders a subchart template can
-      # resolve it, and so CI resolves dependencies the same way the publish
-      # job (helm-release.yml, which also runs `helm dep build`) does.
-      # Run natively on the runner, not in the unittest container: the
-      # container's non-root user can't write charts/ into the bind-mounted
-      # workdir, which fails with "mkdir charts: permission denied".
+      # charts/ is gitignored, so pull subcharts before running the tests.
+      # Done here, not in the container, which can't write to the mounted dir.
       - name: Build chart dependencies
         run: helm dependency build
 

--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -21,12 +21,19 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
 
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v4.1.4
+
       # Subchart .tgz files are gitignored, so a fresh checkout has no charts/.
-      # Pull dependencies first so tests that render subchart templates (e.g.
+      # Build dependencies first so tests that render subchart templates (e.g.
       # deriving the redis master host from the redis subchart fullname) pass.
+      # Run natively on the runner (not in the unittest container): the
+      # container user can't write charts/ into the bind-mounted workdir, which
+      # fails with "mkdir charts: permission denied".
       - name: Build chart dependencies
-        run: |
-          docker run --rm -v $(pwd):/apps --entrypoint helm helmunittest/helm-unittest dependency update .
+        run: helm dependency build
 
       - name: Unittest
         run: |

--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -27,11 +27,12 @@ jobs:
           version: v4.1.4
 
       # Subchart .tgz files are gitignored, so a fresh checkout has no charts/.
-      # Build dependencies first so tests that render subchart templates (e.g.
-      # deriving the redis master host from the redis subchart fullname) pass.
-      # Run natively on the runner (not in the unittest container): the
-      # container user can't write charts/ into the bind-mounted workdir, which
-      # fails with "mkdir charts: permission denied".
+      # Build dependencies so any test that renders a subchart template can
+      # resolve it, and so CI resolves dependencies the same way the publish
+      # job (helm-release.yml, which also runs `helm dep build`) does.
+      # Run natively on the runner, not in the unittest container: the
+      # container's non-root user can't write charts/ into the bind-mounted
+      # workdir, which fails with "mkdir charts: permission denied".
       - name: Build chart dependencies
         run: helm dependency build
 


### PR DESCRIPTION
## Description

> [!TIP]
> **TL;DR:** Follow-up to #41926. The dependency-build step it added ran inside the unittest container, where the non-root container user can't write to the bind-mounted workdir on Linux CI (`mkdir charts: permission denied`). This runs `helm dependency build` natively on the runner via `azure/setup-helm`, matching the pattern already used in `helm-release.yml` / `helm-docs.yml`.

#41926 added a `helm dependency update` step so the Helm unit tests have their subcharts available (the `.tgz` files under `deploy/helm/charts/` are gitignored). That step ran helm **inside** the `helmunittest/helm-unittest` container:

```yaml
docker run --rm -v $(pwd):/apps --entrypoint helm helmunittest/helm-unittest dependency update .
```

On the Linux CI runner the container runs as a non-root user that cannot write into the bind-mounted workdir (owned by the runner user), so it failed:

```
Error: mkdir charts: permission denied
```

It passed locally only because Docker Desktop on macOS ignores bind-mount ownership.

**Fix:** install helm on the runner with `azure/setup-helm@v4` (pinned `v4.1.4`) and run `helm dependency build` natively — the same approach already used in `helm-release.yml` and `helm-docs.yml`. The `charts/` dir is then created as the runner user, and the existing unittest container reads it without issue.

```yaml
- name: Setup Helm
  uses: azure/setup-helm@v4
  with:
    version: v4.1.4

- name: Build chart dependencies
  run: helm dependency build
```

## Verification

Ran the new sequence locally against the chart:
- `helm dependency build` (native) → all 5 subcharts resolved (redis, mongodb, postgresql, prometheus, mongodb-kubernetes)
- `helm-unittest .` (docker) → 13 suites, 67 tests, 7 snapshots — all passing

Fixes `N/A` — CI infrastructure fix; follow-up to #41926.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/28547318249>
> Commit: 2b498869330ada6fffe6e6a0efad84faf837965a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=28547318249&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Wed, 01 Jul 2026 21:31:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Helm unit test workflow to install a pinned Helm binary before running tests.
  * Simplified chart dependency preparation in CI to use a runner-native build, improving consistency.
* **Tests**
  * Helm unit tests now run using the pinned Helm version and updated dependency build flow for more reliable chart validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->