### PR TITLE
fix(git): distinguish missing default branch from SSH key misconfiguration

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -370,6 +370,15 @@ public enum AppsmithError {
             "SSH key not configured",
             ErrorType.GIT_CONFIGURATION_ERROR,
             ErrorReferenceDocUrl.GIT_DEPLOY_KEY.getDocUrl()),
+    GIT_DEFAULT_BRANCH_NOT_FOUND(
+            400,
+            AppsmithErrorCode.GIT_DEFAULT_BRANCH_NOT_FOUND.getCode(),
+            "Couldn''t find a default branch in the remote repository. Set a default branch (for example main or master) "
+                    + "in your Git provider''s repository settings, then try again.",
+            AppsmithErrorAction.DEFAULT,
+            "No default branch found",
+            ErrorType.GIT_CONFIGURATION_ERROR,
+            null),
     INVALID_GIT_REPO(
             400,
             AppsmithErrorCode.INVALID_GIT_REPO.getCode(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
@@ -96,6 +96,7 @@ public enum AppsmithErrorCode {
     GIT_UPSTREAM_CHANGES("AE-GIT-4048", "Git upstream changes"),
     INVALID_GIT_SSH_URL("AE-GIT-4050", "Invalid git ssh url"),
     REPOSITORY_NOT_FOUND("AE-GIT-4051", "Repository not found"),
+    GIT_DEFAULT_BRANCH_NOT_FOUND("AE-GIT-4052", "Git default branch not found"),
     GIT_FILE_SYSTEM_ERROR("AE-GIT-5013", "Git file system error"),
     GIT_EXECUTION_TIMEOUT("AE-GIT-5014", "Git execution timeout"),
     GIT_GENERIC_ERROR("AE-GIT-5016", "Git generic error"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -153,6 +153,22 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
         return !StringUtils.hasText(gitAuth.getPrivateKey()) || !StringUtils.hasText(gitAuth.getPublicKey());
     }
 
+    /**
+     * JGit throws a TransportException with message "Remote branch ''HEAD'' not found in upstream origin"
+     * when the remote repo has no checkout-able default branch. That is not an SSH problem, so we detect it
+     * here to avoid the misleading "SSH key misconfiguration" error.
+     */
+    static boolean isRemoteDefaultBranchMissing(Throwable error) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            String msg = t.getMessage();
+            if (msg != null && msg.toLowerCase().contains("not found in upstream")) {
+                log.debug("Remote clone failed: repository has no default branch. JGit message: {}", msg);
+                return true;
+            }
+        }
+        return false;
+    }
+
     public Mono<String> fetchRemoteRepository(
             GitConnectDTO gitConnectDTO, GitAuth gitAuth, ArtifactJsonTransformationDTO jsonTransformationDTO) {
         String workspaceId = jsonTransformationDTO.getWorkspaceId();
@@ -176,8 +192,10 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                             .then(commonGitFileUtils.deleteLocalRepo(temporaryStorage))
                             .flatMap(isDeleted -> {
                                 if (error instanceof TransportException) {
-                                    return Mono.error(
-                                            new AppsmithException(AppsmithError.INVALID_GIT_SSH_CONFIGURATION));
+                                    AppsmithError transportError = isRemoteDefaultBranchMissing(error)
+                                            ? AppsmithError.GIT_DEFAULT_BRANCH_NOT_FOUND
+                                            : AppsmithError.INVALID_GIT_SSH_CONFIGURATION;
+                                    return Mono.error(new AppsmithException(transportError));
                                 } else if (error instanceof InvalidRemoteException) {
                                     return Mono.error(
                                             new AppsmithException(AppsmithError.INVALID_PARAMETER, "remote url"));
@@ -260,7 +278,9 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                     AppsmithException appsmithException;
 
                     if (error instanceof TransportException) {
-                        appsmithException = new AppsmithException(AppsmithError.INVALID_GIT_SSH_CONFIGURATION);
+                        appsmithException = isRemoteDefaultBranchMissing(error)
+                                ? new AppsmithException(AppsmithError.GIT_DEFAULT_BRANCH_NOT_FOUND)
+                                : new AppsmithException(AppsmithError.INVALID_GIT_SSH_CONFIGURATION);
                     } else if (error instanceof InvalidRemoteException) {
                         appsmithException = new AppsmithException(AppsmithError.INVALID_PARAMETER, "remote url");
                     } else if (error instanceof TimeoutException) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -157,11 +157,15 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
      * JGit throws a TransportException with message "Remote branch ''HEAD'' not found in upstream origin"
      * when the remote repo has no checkout-able default branch. That is not an SSH problem, so we detect it
      * here to avoid the misleading "SSH key misconfiguration" error.
+     * <p>
+     * We match specifically on the {@code HEAD} ref rather than the broader "not found in upstream" phrasing,
+     * which JGit also emits for a genuinely missing named branch/SHA (e.g. "Remote branch 'foo' not found in
+     * upstream origin"). This keeps the helper safe to reuse from branch-specific fetch/checkout paths.
      */
     static boolean isRemoteDefaultBranchMissing(Throwable error) {
         for (Throwable t = error; t != null; t = t.getCause()) {
             String msg = t.getMessage();
-            if (msg != null && msg.toLowerCase().contains("not found in upstream")) {
+            if (msg != null && msg.toLowerCase().contains("branch 'head' not found in upstream")) {
                 log.debug("Remote clone failed: repository has no default branch. JGit message: {}", msg);
                 return true;
             }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/fs/GitFSServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/fs/GitFSServiceCEImplTest.java
@@ -1,0 +1,46 @@
+package com.appsmith.server.git.fs;
+
+import org.eclipse.jgit.api.errors.TransportException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitFSServiceCEImplTest {
+
+    @Test
+    void isRemoteDefaultBranchMissing_returnsTrue_forJGitNoDefaultBranchMessage() {
+        Throwable error = new TransportException("Remote branch 'HEAD' not found in upstream origin");
+        assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isTrue();
+    }
+
+    @Test
+    void isRemoteDefaultBranchMissing_returnsTrue_whenMessageIsInCausalChain() {
+        Throwable cause = new TransportException("Remote branch 'HEAD' not found in upstream origin");
+        Throwable error = new RuntimeException("clone failed", cause);
+        assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isTrue();
+    }
+
+    @Test
+    void isRemoteDefaultBranchMissing_returnsFalse_forAuthFailure() {
+        Throwable error = new TransportException("Auth fail");
+        assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isFalse();
+    }
+
+    @Test
+    void isRemoteDefaultBranchMissing_returnsFalse_forNullMessage() {
+        Throwable error = new RuntimeException();
+        assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isFalse();
+    }
+
+    @Test
+    void isRemoteDefaultBranchMissing_isCaseInsensitive() {
+        Throwable error = new TransportException("Remote branch 'HEAD' NOT FOUND IN UPSTREAM origin");
+        assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isTrue();
+    }
+
+    @Test
+    void isRemoteDefaultBranchMissing_returnsFalse_forOtherNotFoundMessage() {
+        Throwable error = new TransportException("Repository not found");
+        assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isFalse();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/fs/GitFSServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/fs/GitFSServiceCEImplTest.java
@@ -43,4 +43,10 @@ class GitFSServiceCEImplTest {
         Throwable error = new TransportException("Repository not found");
         assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isFalse();
     }
+
+    @Test
+    void isRemoteDefaultBranchMissing_returnsFalse_forMissingNamedBranch() {
+        Throwable error = new TransportException("Remote branch 'feature-x' not found in upstream origin");
+        assertThat(GitFSServiceCEImpl.isRemoteDefaultBranchMissing(error)).isFalse();
+    }
 }


### PR DESCRIPTION
## Description

Importing or connecting an Appsmith app to a self-hosted Git repository over SSH failed with a misleading **"SSH key misconfiguration"** banner (`AE-GIT-4032`) when the remote repository had **no default branch** (no checkout-able `HEAD`) — even though the SSH key was valid and the handshake succeeded.

**Root cause:** JGit's `CloneCommand` throws a `TransportException` with message `Remote branch 'HEAD' not found in upstream origin` when the cloned repo has no default branch. Both `fetchRemoteRepository` overloads in `GitFSServiceCEImpl` blanket-mapped **any** `TransportException` to `AppsmithError.INVALID_GIT_SSH_CONFIGURATION`, so this case was reported as an SSH key problem and sent users down the wrong troubleshooting path (rotating deploy keys) instead of setting a default branch.

**Fix (backend-only):**
- Added `AppsmithError.GIT_DEFAULT_BRANCH_NOT_FOUND` (`AE-GIT-4052`) with an actionable message: _"Couldn't find a default branch in the remote repository. Set a default branch (for example main or master) in your Git provider's repository settings, then try again."_
- Added a `isRemoteDefaultBranchMissing(Throwable)` helper that walks the cause chain and matches the stable substring `not found in upstream`, routing that case to the new error in **both** `fetchRemoteRepository` overloads (import flow and connect-existing-app flow). Genuine SSH auth failures still map to `INVALID_GIT_SSH_CONFIGURATION`.
- **No frontend change required:** the deploy-key step already renders any non-`AE-GIT-4032`/`4033` backend error message in its generic error callout.

Added `GitFSServiceCEImplTest` with unit coverage for the helper (matching message, cause-chain nesting, case-insensitivity, auth-failure negative, other "not found" negative, null message).

Fixes https://github.com/appsmithorg/appsmith/issues/41938

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/28546840957>
> Commit: 5c9b8324f08697097da257871cc61288f1890611
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=28546840957&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 01 Jul 2026 22:02:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git import/clone error handling to detect when a remote default branch is missing, instead of treating it as an SSH configuration problem.
  * Added a clearer, dedicated error for “No default branch found” when the remote repository’s default branch can’t be determined.
* **Tests**
  * Added unit test coverage for identifying the missing-remote-default-branch scenario across direct and nested exception messages, including case-insensitive matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->