### PR TITLE
fix: prevent table menu button clipping

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/ColumnTypeMenubutton_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/ColumnTypeMenubutton_spec.js
@@ -1,5 +1,20 @@
 import * as _ from "../../../../../../support/Objects/ObjectsCore";
 
+const assertMenuButtonFitsCell = (rowIndex, colIndex) => {
+  const cellSelector = `.t--widget-tablewidgetv2 .tbody .td[data-rowindex='${rowIndex}'][data-colindex='${colIndex}']`;
+
+  cy.get(cellSelector).then(($cell) => {
+    const cellRect = $cell[0].getBoundingClientRect();
+
+    cy.get(`${cellSelector} .bp3-button`).then(($button) => {
+      const buttonRect = $button[0].getBoundingClientRect();
+
+      expect(buttonRect.left).to.be.at.least(cellRect.left - 1);
+      expect(buttonRect.right).to.be.at.most(cellRect.right + 1);
+    });
+  });
+};
+
 describe(
   "Custom column alias functionality",
   { tags: ["@tag.Widget", "@tag.Table", "@tag.Binding"] },
@@ -162,6 +177,12 @@ describe(
         force: true,
       });
       cy.get(".table-menu-button-popover li a").should("not.exist");
+    });
+
+    it("5. should render menu buttons within the table cell in published mode", () => {
+      _.deployMode.DeployApp();
+
+      assertMenuButtonFitsCell(0, 1);
     });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/ColumnTypeMenubutton_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/ColumnTypeMenubutton_spec.js
@@ -6,12 +6,14 @@ const assertMenuButtonFitsCell = (rowIndex, colIndex) => {
   cy.get(cellSelector).then(($cell) => {
     const cellRect = $cell[0].getBoundingClientRect();
 
-    cy.get(`${cellSelector} .bp3-button`).then(($button) => {
-      const buttonRect = $button[0].getBoundingClientRect();
+    cy.get(`${cellSelector} [data-testid='t--table-menu-button']`).then(
+      ($button) => {
+        const buttonRect = $button[0].getBoundingClientRect();
 
-      expect(buttonRect.left).to.be.at.least(cellRect.left - 1);
-      expect(buttonRect.right).to.be.at.most(cellRect.right + 1);
-    });
+        expect(buttonRect.left).to.be.at.least(cellRect.left - 1);
+        expect(buttonRect.right).to.be.at.most(cellRect.right + 1);
+      },
+    );
   });
 };
 

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/menuButtonTableComponent.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/menuButtonTableComponent.tsx
@@ -313,6 +313,7 @@ function PopoverTargetButton(props: PopoverTargetButtonProps) {
       buttonColor={buttonColor}
       buttonVariant={buttonVariant}
       compactMode={compactMode}
+      data-testid="t--table-menu-button"
       disabled={isDisabled}
       fill
       icon={iconAlign !== Alignment.RIGHT ? iconName : undefined}

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/menuButtonTableComponent.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/menuButtonTableComponent.tsx
@@ -88,6 +88,8 @@ interface BaseStyleProps {
 }
 
 const BaseButton = styled(Button)<ThemeProp & BaseStyleProps>`
+  box-sizing: border-box;
+  width: 100%;
   height: 100%;
   background-image: none !important;
   font-weight: 400;


### PR DESCRIPTION
## Description

Fixes #41578

Prevents Table V2 menu buttons from overflowing their cell box in published apps. The button now uses a border-box width so padding and borders stay inside the cell instead of being clipped by the table cell overflow.

Also adds a Cypress regression check that deploys the app and verifies the menu button remains within the published table cell bounds.

<!-- end of auto-generated comment: Cypress test results  -->

## Validation

- `git diff --check`
- Not run: targeted eslint/prettier/Cypress could not run locally because this checkout has no `node_modules` state file, and available local Node versions are `24.11.1` and `24.14.0` while the project requires `^24.14.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved table menu button sizing and alignment to keep it properly contained within the cell, including in published/deployed views.

- **Tests**
  - Added an end-to-end check that verifies the menu button stays within the target cell bounds (with a small tolerance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->