### PR TITLE
fix(deps): batch security update — 17 CVEs from release image scan

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/pom.xml
+++ b/app/server/appsmith-plugins/amazons3Plugin/pom.xml
@@ -19,7 +19,8 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.261</version>
+                <!-- 1.12.795+ drops the unpatched software.amazon.ion:ion-java dependency (CVE-2024-21634) -->
+                <version>1.12.797</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/app/server/appsmith-plugins/awsLambdaPlugin/pom.xml
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/pom.xml
@@ -18,7 +18,8 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-lambda</artifactId>
-            <version>1.12.622</version>
+            <!-- 1.12.795+ drops the unpatched software.amazon.ion:ion-java dependency (CVE-2024-21634) -->
+            <version>1.12.797</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -29,7 +30,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-osgi</artifactId>
-            <version>1.12.622</version>
+            <version>1.12.797</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -27,8 +27,9 @@
 
     <properties>
         <deploy.disabled>true</deploy.disabled>
-        <jackson-bom.version>2.17.0</jackson-bom.version>
-        <jackson.version>2.17.0</jackson.version>
+        <!-- Pinned to 2.18.8 for CVE-2026-54512 / CVE-2026-54513 -->
+        <jackson-bom.version>2.18.8</jackson-bom.version>
+        <jackson.version>2.18.8</jackson.version>
         <java.version>25</java.version>
         <javadoc.disabled>true</javadoc.disabled>
         <!-- Pin Lombok to 1.18.42 to avoid breaking @FieldNameConstants inner class constructor change in 1.18.44 -->
@@ -37,6 +38,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <mockito.version>4.4.0</mockito.version>
         <mockwebserver.version>5.0.0-alpha.2</mockwebserver.version>
+        <!-- Pinned above the Spring Boot BOM default for CVE-2026-42583/42579/42584/42587/33870/33871/44249/45416/50010/45674/47691 -->
         <netty.version>4.1.135.Final</netty.version>
         <okhttp3.version>4.12.0</okhttp3.version>
         <org.pf4j.version>3.15.0</org.pf4j.version>
@@ -55,6 +57,25 @@
         <spotless.version>3.0.0</spotless.version>
         <testcontainers.version>1.20.1</testcontainers.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force patched versions onto transitive dependencies bundled into plugin jars. -->
+            <dependency>
+                <!-- CVE-2024-47554: databricks-sdk-java pulls 2.13.0 -->
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.20.0</version>
+            </dependency>
+            <dependency>
+                <!-- CVE-2025-67030: transitive 3.2.0 in appsmith-server -->
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.6.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
## Summary

Remediates 17 CRITICAL/HIGH CVEs (57 scanner findings) detected by scanning the `appsmith/appsmith-ee:release` Docker image (digest `597f187a`). All fixes are same-major dependency pins — no code changes.

| Dependency | Change | CVEs |
|---|---|---|
| spring-boot-starter-parent | 3.5.12 → 3.5.14 | CVE-2026-40973 |
| jackson-bom / jackson | 2.17.0 → 2.18.8 | CVE-2026-54512, CVE-2026-54513 |
| netty (pinned over Boot BOM) | → 4.1.135.Final | CVE-2026-42583, CVE-2026-42579, CVE-2026-42584, CVE-2026-42587, CVE-2026-33870, CVE-2026-33871, CVE-2026-44249, CVE-2026-45416, CVE-2026-50010, CVE-2026-45674, CVE-2026-47691 |
| commons-io (dependencyManagement) | → 2.20.0 | CVE-2024-47554 (transitive via databricks-sdk-java) |
| plexus-utils (dependencyManagement) | → 3.6.1 | CVE-2025-67030 |
| aws-java-sdk (amazons3Plugin, awsLambdaPlugin) | 1.12.261 / 1.12.622 → 1.12.797 | CVE-2024-21634 (drops unpatched `software.amazon.ion:ion-java` entirely) |

### Verification

- `mvn clean install -DskipTests` passes on this branch (CE) and on EE with this commit cherry-picked (sync simulation applied cleanly — no conflicts).
- Trivy re-scan of the built server + all plugin jars (CE and EE builds) confirms every targeted CVE is gone. Remaining findings are all known non-actionable: `com.appsmith:*` self-advisories (already handled via GHSA lifecycle), `mssql-jdbc` (false positive — installed `11.2.4.jre11` **is** the patched version; scanner drops the `.jre11` suffix), `ini4j` (no fixed version exists upstream), and jackson 2.16.0 shaded **inside** the `databricks-jdbc` fat jar (not resolvable via Maven; needs a databricks-jdbc 2.6.40 → 2.7.x bump, deferred as a separate follow-up).
- `mvn spotless:check` clean; pre-commit hooks passed.

### Out of scope (image-level, tracked separately)

Keycloak jars (`opt/keycloak/**`), Temporal go binaries (`opt/temporal/**`), Node's bundled `undici`, and RTS `nodemailer` (major bump) — these are not fixable from this repo's poms.

## Automation
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/28682481837>
> Commit: 06ae9ccbba4608ebc585036e38d11b45c4f9510a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=28682481837&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 03 Jul 2026 21:42:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several bundled library versions to address known security vulnerabilities.
  * Improved dependency consistency across the app to reduce the risk of runtime issues caused by outdated transitive packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->