### PR TITLE
fix(server): pin maildev/maildev test container to 2.2.1

### DIFF
--- a/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
@@ -54,14 +54,14 @@ public class SmtpPluginTest {
     private static Long port = 25L;
 
     @Container
-    public static final GenericContainer smtp = new GenericContainer(DockerImageName.parse("maildev/maildev"))
+    public static final GenericContainer smtp = new GenericContainer(DockerImageName.parse("maildev/maildev:2.2.1"))
             .withExposedPorts(25)
             .withCommand("bin/maildev --base-pathname /maildev --incoming-user " + username + " --incoming-pass "
                     + password + " -s 25");
 
     @Container
     public static final GenericContainer smtpWithoutAuth = new GenericContainer(
-                    DockerImageName.parse("maildev/maildev"))
+                    DockerImageName.parse("maildev/maildev:2.2.1"))
             .withExposedPorts(1025)
             .withCommand("bin/maildev --base-pathname /maildev --smtp-port 1025 --incoming-user '' --incoming-pass ''");
 


### PR DESCRIPTION
## Description
`SmtpPluginTest` uses the `maildev/maildev` Testcontainers image without a tag, which resolves to `:latest`. Maildev recently published a new RC and tagged it `latest`, and it's broken in our test setup: the container's internal exec-based readiness check fails (`/bin/sh: /bin/bash: not found`, exit 137), and the test connects to the mapped SMTP port before the listener is actually ready, causing intermittent connection failures.

This pins both `GenericContainer` instances in `SmtpPluginTest` to `maildev/maildev:2.2.1`, the last known-good tag (see [tags on Docker Hub](https://hub.docker.com/r/maildev/maildev/tags)), to stop tracking `latest` and avoid future silent breaks from upstream RCs.

### Context
Observed as a repeated CI failure on an EE release-promotion PR (`server-unit-tests` shard 5), reproduced on both the initial run and a retry.

## Test plan
- [ ] `server-unit-tests` (specifically `SmtpPluginTest`) passes reliably in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated SMTP test containers to use a pinned MailDev image version for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->