### PR TITLE
fix(client): wait for toast to clear before re-checking identical Mongo replica-set error

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
@@ -172,6 +172,7 @@ describe(
         agHelper.ValidateToastMessage(
           "REPLICA_SET connections should not be given a port. If you are trying to specify all the shards, please add more than one.",
         );
+        agHelper.WaitUntilAllToastsDisappear();
         agHelper.ClearNType(
           dataSources._host(),
           dataManager.dsValues[dataManager.defaultEnviorment].mongo_host,


### PR DESCRIPTION
## Description
`ConnectionErrors_Spec.ts`'s "3. Mongo connection errors" test asserts the exact same toast message twice in a row (`REPLICA_SET connections should not be given a port...`) — once right after switching Connection type to "Replica set", and again right after filling in host/port. Every other repeated-message check in this same spec calls `WaitUntilAllToastsDisappear()` in between; this one didn't.

Toastify doesn't reliably mount a new DOM node for an identical message while the previous instance is still visible/fading, so the second `ValidateToastMessage` call can time out waiting for `div.Toastify__toast` — intermittently, depending on exact timing. This caused a real CI failure on an unrelated release-promotion PR ([EE #9268](https://github.com/appsmithorg/appsmith-ee/pull/9268) / [CE #41961](https://github.com/appsmithorg/appsmith/pull/41961)), reproduced consistently across 3 retries in that run.

Fix: add the same `WaitUntilAllToastsDisappear()` call used elsewhere in this spec before the second identical-message check.

## Root cause detail
From the failing run's logs: the backend correctly returned the `TEST_DATASOURCE_ERROR` action with the replica-set-port error message both times (confirmed via the intercepted `@testDatasource` XHR), so this is a test-timing issue, not a backend regression.

## Test plan
- [ ] `ConnectionErrors_Spec.ts` passes reliably in CI (no test-plugin infra changes required, so no server-side test coverage needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression coverage for MongoDB connection error handling.
  * Added a wait for error notifications to clear before continuing through the rest of the validation flow, making the test more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->