### PR TITLE
fix(security): reject actuator basic-auth when internal password is unset (GHSA-xfc5-796c-7hr9)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -166,7 +166,8 @@ public class SecurityConfig {
                     // bypassing authentication on the /actuator/** endpoints (GHSA-xfc5-796c-7hr9).
                     if (INTERNAL_PASSWORD != null
                             && !INTERNAL_PASSWORD.isEmpty()
-                            && INTERNAL_PASSWORD.equals(authentication.getCredentials().toString())) {
+                            && INTERNAL_PASSWORD.equals(
+                                    authentication.getCredentials().toString())) {
                         return Mono.just(UsernamePasswordAuthenticationToken.authenticated(
                                 authentication.getPrincipal(),
                                 authentication.getCredentials(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -159,7 +159,14 @@ public class SecurityConfig {
     public SecurityWebFilterChain internalWebFilterChain(ServerHttpSecurity http) {
         return http.securityMatcher(new PathPatternParserServerWebExchangeMatcher("/actuator/**"))
                 .httpBasic(httpBasicSpec -> httpBasicSpec.authenticationManager(authentication -> {
-                    if (INTERNAL_PASSWORD.equals(authentication.getCredentials().toString())) {
+                    // When no internal password is configured (APPSMITH_INTERNAL_PASSWORD is unset,
+                    // defaulting to an empty string), reject every request instead of treating an
+                    // empty supplied password as a match. Otherwise "".equals("") would grant the
+                    // INTERNAL authority to any caller sending empty Basic Auth credentials,
+                    // bypassing authentication on the /actuator/** endpoints (GHSA-xfc5-796c-7hr9).
+                    if (INTERNAL_PASSWORD != null
+                            && !INTERNAL_PASSWORD.isEmpty()
+                            && INTERNAL_PASSWORD.equals(authentication.getCredentials().toString())) {
                         return Mono.just(UsernamePasswordAuthenticationToken.authenticated(
                                 authentication.getPrincipal(),
                                 authentication.getCredentials(),


### PR DESCRIPTION
## What

The `/actuator/**` management endpoints are protected by HTTP Basic auth that compares the supplied password against `APPSMITH_INTERNAL_PASSWORD`. That variable defaults to an empty string when unset (`application-ce.properties`: `appsmith.internal.password=${APPSMITH_INTERNAL_PASSWORD:}`), so the check `"".equals("")` succeeds for any request sending empty Basic Auth credentials — granting the `INTERNAL` authority and bypassing authentication on the actuator endpoints.

This guards the comparison so an unset/empty configured password never authenticates any caller. All `/actuator/**` requests then return `401` until an operator explicitly sets `APPSMITH_INTERNAL_PASSWORD`.

## Why it matters

- On a default deployment the exposed actuator surface is `prometheus` and `metrics` (per `application-ee.properties`), plus `health` on CE — so the practical pre-fix impact is unauthenticated read access to operational metrics, not secrets.
- Impact escalates if an operator widens `management.endpoints.web.exposure.include` (e.g. to include `env`/`heapdump`).
- Ref: GHSA-xfc5-796c-7hr9 (and duplicate GHSA-8pr2-629w-7q87).

## Change

Single-file change in `SecurityConfig.internalWebFilterChain`. No new imports (uses `String.isEmpty()`), so the hunk applies cleanly to EE via the hourly sync.

## Testing

- Before: `curl -u 'anyuser:' https://<host>/actuator/prometheus` → `200`
- After: same request → `401`; `200` only when `APPSMITH_INTERNAL_PASSWORD` is set and matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access handling for internal actuator endpoints when basic authentication credentials are empty or missing.
  * Prevented empty or unset internal passwords from being treated as a valid match, so requests now correctly follow the unauthenticated path when no valid credentials are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 2b58fc3d129025775b2a1a4045f416de82d9ea89 yet
> <hr>Wed, 08 Jul 2026 02:34:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->
