### PR TITLE
chore(docker): bind bundled internal services to loopback

### DIFF
--- a/app/client/packages/rts/src/server.ts
+++ b/app/client/packages/rts/src/server.ts
@@ -2,7 +2,7 @@ import server from "./ee/server";
 import log from "loglevel";
 import { VERSION as buildVersion } from "./version"; // release version of the api
 
-const APPSMITH_RTS_PORT = process.env.APPSMITH_RTS_PORT || 8091;
+const APPSMITH_RTS_PORT = Number(process.env.APPSMITH_RTS_PORT) || 8091;
 
 server.listen(APPSMITH_RTS_PORT, "127.0.0.1", () => {
   log.info(

--- a/app/client/packages/rts/src/server.ts
+++ b/app/client/packages/rts/src/server.ts
@@ -3,8 +3,10 @@ import log from "loglevel";
 import { VERSION as buildVersion } from "./version"; // release version of the api
 
 const APPSMITH_RTS_PORT = Number(process.env.APPSMITH_RTS_PORT) || 8091;
+// Bind to loopback by default; override with APPSMITH_RTS_HOST for non-Docker deployments.
+const APPSMITH_RTS_HOST = process.env.APPSMITH_RTS_HOST || "127.0.0.1";
 
-server.listen(APPSMITH_RTS_PORT, "127.0.0.1", () => {
+server.listen(APPSMITH_RTS_PORT, APPSMITH_RTS_HOST, () => {
   log.info(
     `RTS version ${buildVersion} running at http://localhost:${APPSMITH_RTS_PORT}`,
   );

--- a/app/client/packages/rts/src/server.ts
+++ b/app/client/packages/rts/src/server.ts
@@ -4,7 +4,6 @@ import { VERSION as buildVersion } from "./version"; // release version of the a
 
 const APPSMITH_RTS_PORT = process.env.APPSMITH_RTS_PORT || 8091;
 
-// Bind to loopback so RTS is not reachable via the container bridge IP.
 server.listen(APPSMITH_RTS_PORT, "127.0.0.1", () => {
   log.info(
     `RTS version ${buildVersion} running at http://localhost:${APPSMITH_RTS_PORT}`,

--- a/app/client/packages/rts/src/server.ts
+++ b/app/client/packages/rts/src/server.ts
@@ -4,7 +4,8 @@ import { VERSION as buildVersion } from "./version"; // release version of the a
 
 const APPSMITH_RTS_PORT = process.env.APPSMITH_RTS_PORT || 8091;
 
-server.listen(APPSMITH_RTS_PORT, () => {
+// Bind to loopback so RTS is not reachable via the container bridge IP.
+server.listen(APPSMITH_RTS_PORT, "127.0.0.1", () => {
   log.info(
     `RTS version ${buildVersion} running at http://localhost:${APPSMITH_RTS_PORT}`,
   );

--- a/app/server/appsmith-server/src/main/resources/application-ce.properties
+++ b/app/server/appsmith-server/src/main/resources/application-ce.properties
@@ -1,5 +1,7 @@
 spring.application.name=appsmith-server
 server.port=${PORT:8080}
+# Bind the backend to loopback by default so it is not reachable via the container bridge IP.
+server.address=${APPSMITH_SERVER_ADDRESS:127.0.0.1}
 # Allow the Spring context to close all active requests before shutting down the server
 # Please ref: https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/spring-boot-features.html#boot-features-graceful-shutdown
 server.shutdown=graceful

--- a/app/server/appsmith-server/src/main/resources/application-ce.properties
+++ b/app/server/appsmith-server/src/main/resources/application-ce.properties
@@ -1,6 +1,5 @@
 spring.application.name=appsmith-server
 server.port=${PORT:8080}
-# Bind the backend to loopback by default so it is not reachable via the container bridge IP.
 server.address=${APPSMITH_SERVER_ADDRESS:127.0.0.1}
 # Allow the Spring context to close all active requests before shutting down the server
 # Please ref: https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/spring-boot-features.html#boot-features-graceful-shutdown

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -162,7 +162,7 @@ docker-compose exec appsmith-ce supervisorctl restart backend
 
 ## Supervisor
 
-The container runs multiple processes, including the Appsmith server, Nginx, MongoDB etc., inside a single Docker container. These processes are started and managed by [supervisord](http://supervisord.org/).
+The container runs multiple processes, including the Appsmith server, Caddy, MongoDB etc., inside a single Docker container. These processes are started and managed by [supervisord](http://supervisord.org/).
 
 Supervisord comes with a web interface for managing the various processes, available at <http://localhost/supervisor/>, as well as a command line interface towards the same goal.
 
@@ -172,7 +172,7 @@ Here's a screenshot of the web interface listing all the processes managed:
   <img src="https://raw.githubusercontent.com/appsmithorg/appsmith/release/deploy/docker/images/appsmith_supervisord_ui.png" width="80%">
 </p>
 
-The command line interface can also be used to perform operations like restarting the Appsmith server, or restarting Nginx etc. For example, the following command (run in the installation folder) can be used to get a status of all running processes:
+The command line interface can also be used to perform operations like restarting the Appsmith server, or restarting Caddy etc. For example, the following command (run in the installation folder) can be used to get a status of all running processes:
 
 ```sh
 docker-compose exec appsmith-ce supervisorctl status

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -516,7 +516,6 @@ save 15 1
 dir /appsmith-stacks/data/redis
 daemonize no
 logfile ""
-# Listen only on loopback so Redis is not reachable via the container bridge IP.
 bind 127.0.0.1 -::1
 requirepass ${APPSMITH_REDIS_PASSWORD:-}
 REDIS_CONF

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -516,6 +516,8 @@ save 15 1
 dir /appsmith-stacks/data/redis
 daemonize no
 logfile ""
+# Listen only on loopback so Redis is not reachable via the container bridge IP.
+bind 127.0.0.1 -::1
 requirepass ${APPSMITH_REDIS_PASSWORD:-}
 REDIS_CONF
       chmod 600 "$TMP/redis.conf"


### PR DESCRIPTION
**Linear:** [APP-15350](https://linear.app/appsmith/issue/APP-15350)

## Summary

Defense-in-depth hardening of the Docker image. The bundled internal services are bound to the loopback interface (`127.0.0.1`) by default so they only accept connections from within the container and are not reachable over the container's bridge network interface.

## Changes

- **RTS** (`server.ts`): bind the RTS listener to `127.0.0.1`.
- **Backend server** (`application-ce.properties`): default `server.address` to `127.0.0.1` (overridable via `APPSMITH_SERVER_ADDRESS`).
- **Redis** (`entrypoint.sh`): add `bind 127.0.0.1 -::1` to the generated Redis config.

These services are internal to the image and are fronted by the in-container Caddy proxy, so they do not need to listen on the container's external interfaces.

## Testing

All services continue to be reached through the existing in-container proxy paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RTS server now binds to an explicit configured host by defaulting to loopback (`127.0.0.1`) and using the configured RTS port.
  * App server now defaults to loopback (`127.0.0.1`) unless overridden by `APPSMITH_SERVER_ADDRESS`.
  * Redis now listens only on loopback (`127.0.0.1`/`::1`) by default for safer local-only access.
* **Documentation**
  * Updated Docker documentation to reflect **Caddy** supervision and restart examples instead of **Nginx**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD d685989def1f13d725b71e95a076020674889382 yet
> <hr>Wed, 08 Jul 2026 14:59:26 UTC
<!-- end of auto-generated comment: Cypress test results  -->


