### PR TITLE
test(git): de-flake GitUtilsTest.isRepoPrivate by mocking the HTTP call

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -5,8 +5,14 @@ import com.appsmith.server.domains.AutoCommitConfig;
 import com.appsmith.server.domains.GitArtifactMetadata;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.util.WebClientUtils;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.test.StepVerifier;
 
 import java.util.UUID;
@@ -87,22 +93,34 @@ public class GitUtilsTest {
     }
 
     @Test
-    public void isRepoPrivate() {
+    public void isRepoPrivate() throws Exception {
+        // isRepoPrivate performs a live HTTP GET against the repo URL (2xx => public, otherwise/error => private).
+        // Mock WebClientUtils.create so the request hits a local MockWebServer instead of reaching out to
+        // github.com. The previous version asserted against real URLs, which made this test flaky whenever CI
+        // could not reach GitHub within the 2s timeout (rate-limits, DNS blips) and the error path defaulted to
+        // "private". WebClientUtils.create is mocked (rather than pointing straight at the server) because it wraps
+        // every WebClient in an SSRF host filter that would block a loopback address.
+        MockWebServer mockServer = new MockWebServer();
+        mockServer.start();
+        try (MockedStatic<WebClientUtils> webClientUtilsMock = Mockito.mockStatic(WebClientUtils.class)) {
+            webClientUtilsMock
+                    .when(() -> WebClientUtils.create(Mockito.anyString()))
+                    .thenReturn(WebClient.create(mockServer.url("/").toString()));
 
-        StepVerifier.create(GitUtils.isRepoPrivate(
-                        GitUtils.convertSshUrlToBrowserSupportedUrl("git@github.com:test/testRepo.git")))
-                .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.TRUE))
-                .verifyComplete();
+            // A reachable repo that responds 2xx is treated as public.
+            mockServer.enqueue(new MockResponse().setResponseCode(200));
+            StepVerifier.create(GitUtils.isRepoPrivate("https://git.example.com/org/public-repo.git"))
+                    .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.FALSE))
+                    .verifyComplete();
 
-        StepVerifier.create(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl(
-                        "ssh://git@example.test.net/user/test/tests/testRepo.git")))
-                .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.TRUE))
-                .verifyComplete();
-
-        StepVerifier.create(GitUtils.isRepoPrivate(
-                        GitUtils.convertSshUrlToBrowserSupportedUrl("git@github.com:appsmithorg/appsmith.git")))
-                .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.FALSE))
-                .verifyComplete();
+            // A repo that responds non-2xx (e.g. 404 because it requires auth) is treated as private.
+            mockServer.enqueue(new MockResponse().setResponseCode(404));
+            StepVerifier.create(GitUtils.isRepoPrivate("https://git.example.com/org/private-repo.git"))
+                    .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.TRUE))
+                    .verifyComplete();
+        } finally {
+            mockServer.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

`GitUtilsTest.isRepoPrivate` intermittently fails in CI with `expected: false`. The test asserted against **real** URLs — including `github.com/appsmithorg/appsmith` — and `GitUtils.isRepoPrivate` performs a **live HTTP GET** against the repo URL (2xx ⇒ public, otherwise/error ⇒ private) with a **2-second timeout**:

```java
return WebClientUtils.create(remoteHttpsUrl).get()
        .httpRequest(r -> r.getNativeRequest().responseTimeout(Duration.ofSeconds(2)))
        .exchange()
        .flatMap(resp -> Mono.just(!resp.statusCode().is2xxSuccessful()))
        .onErrorResume(t -> Mono.just(Boolean.TRUE)); // error ⇒ assume private
```

So whenever the CI runner can't reach GitHub within 2s (shared-runner rate-limits, DNS blips), the error path returns `TRUE` (private) and the `expected: false` (public) assertion fails — non-deterministically, independent of the change under test. This is almost certainly the flake behind the intermittently-red scheduled release builds too.

## Fix

Make the test hermetic: mock `WebClientUtils.create` so the request hits a local `MockWebServer` instead of the internet, and assert the real branching logic deterministically — **200 ⇒ public**, **404 ⇒ private**.

`WebClientUtils.create` is mocked (rather than pointing `isRepoPrivate` straight at the loopback server) because it wraps every `WebClient` in an SSRF host filter that would block a loopback address. URL-conversion coverage is untouched — `convertSshUrlToBrowserSupportedUrl` has its own dedicated test.

No new dependencies (`mockwebserver` + `mockito-inline` are already test deps). Verified locally on JDK 25: `Tests run: 18, Failures: 0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated repository privacy checks to use fully mocked HTTP responses instead of real network calls.
  * Added coverage for both accessible and inaccessible repository responses, improving test reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->