### PR TITLE
feat: add version & build metadata to Pylon support chat

### DIFF
--- a/app/client/src/utils/bootPylon.ts
+++ b/app/client/src/utils/bootPylon.ts
@@ -18,7 +18,7 @@ export function isPylonChatAvailable(): boolean {
 // is fully populated. Pylon reads chat_settings at SDK init time and exposes
 // no API to update identity post-init, so we must delay script loading until
 // the authenticated user's email_hash is on window.pylon.
-function injectPylonScriptOnce(appId: string) {
+function injectPylonScriptOnce(appId: string, onReady?: () => void) {
   const src = `https://widget.usepylon.com/widget/${appId}`;
 
   // Guard against duplicate injection (HMR, multiple boot callers, etc.) by
@@ -33,9 +33,61 @@ function injectPylonScriptOnce(appId: string) {
   script.type = "text/javascript";
   script.async = true;
   script.src = src;
+
+  // Pylon defines window.Pylon during script execution, so onReady (fired on
+  // the load event) is the earliest point custom fields can be attached. This
+  // lets us set issue metadata once at SDK boot, so it applies to issues
+  // created from ANY entry point — not just the Help-menu path that calls
+  // updatePylonChatIdentity.
+  if (onReady) {
+    script.addEventListener("load", onReady);
+  }
+
   const firstScript = document.getElementsByTagName("script")[0];
 
   firstScript.parentNode?.insertBefore(script, firstScript);
+}
+
+// Attach version/build/deployment metadata to every new Pylon issue. All values
+// come from getAppsmithConfigs() (no user needed), so this can run at SDK boot
+// to cover all entry points. instanceId is only available on the Help-menu path
+// (updatePylonChatIdentity), so it is passed in there and omitted at boot.
+//
+// NOTE: each key below must exist as a matching custom-field *slug* in the
+// Pylon dashboard, or Pylon silently drops the value (no client-side error).
+// appsmith_edition intentionally duplicates the edition embedded in
+// appsmith_version — the latter is a human-readable display string, the former
+// a discrete, filterable field for support triage.
+// Remember the instanceId once updatePylonChatIdentity has provided it, so a
+// later boot-time call (e.g. if the SDK "load" handler runs after the Help-menu
+// path) still carries instance_id. Pylon does not document whether
+// setNewIssueCustomFields merges or replaces across calls, so we never rely on a
+// prior call's instance_id surviving — we re-send it every time it is known.
+let cachedInstanceId: string | undefined;
+
+function setPylonNewIssueCustomFields(instanceId?: string) {
+  if (instanceId) {
+    cachedInstanceId = instanceId;
+  }
+
+  if (typeof window.Pylon !== "function") {
+    return;
+  }
+
+  const { appVersion, cloudHosting } = getAppsmithConfigs();
+  const effectiveInstanceId = instanceId ?? cachedInstanceId;
+
+  window.Pylon("setNewIssueCustomFields", {
+    appsmith_version: `Appsmith ${
+      !cloudHosting ? appVersion.edition : ""
+    } ${appVersion.id}`,
+    appsmith_edition: appVersion.edition,
+    build_sha: appVersion.sha,
+    build_date: appVersion.releaseDate,
+    deployment_type: cloudHosting ? "cloud" : "self-hosted",
+    ...(effectiveInstanceId ? { instance_id: effectiveInstanceId } : {}),
+    license_id: getLicenseKey() ?? "",
+  });
 }
 
 export default function bootPylon(user?: User) {
@@ -70,7 +122,9 @@ export default function bootPylon(user?: User) {
   // present prevents the widget from booting in unverified mode and then
   // getting 401s on message send.
   if (emailHash) {
-    injectPylonScriptOnce(pylonAppID);
+    // Set issue metadata as soon as the SDK is ready so it covers issues
+    // created from any entry point, not just the Help menu.
+    injectPylonScriptOnce(pylonAppID, () => setPylonNewIssueCustomFields());
   }
 }
 
@@ -79,7 +133,7 @@ export const updatePylonChatIdentity = (instanceId: string, user?: User) => {
     return;
   }
 
-  const { appVersion, cloudHosting, pylonAppID } = getAppsmithConfigs();
+  const { pylonAppID } = getAppsmithConfigs();
 
   const email: string | undefined = user?.email;
   const username =
@@ -106,23 +160,13 @@ export const updatePylonChatIdentity = (instanceId: string, user?: User) => {
   };
 
   if (sdkNotYetLoaded) {
-    injectPylonScriptOnce(pylonAppID);
+    injectPylonScriptOnce(pylonAppID, () =>
+      setPylonNewIssueCustomFields(instanceId),
+    );
   }
 
-  // NOTE: each key below must exist as a matching custom-field *slug* in the
-  // Pylon dashboard, or Pylon silently drops the value (no client-side error).
-  // appsmith_edition intentionally duplicates the edition embedded in
-  // appsmith_version — the latter is a human-readable display string, the
-  // former a discrete, filterable field for support triage.
-  window.Pylon("setNewIssueCustomFields", {
-    appsmith_version: `Appsmith ${
-      !cloudHosting ? appVersion.edition : ""
-    } ${appVersion.id}`,
-    appsmith_edition: appVersion.edition,
-    build_sha: appVersion.sha,
-    build_date: appVersion.releaseDate,
-    deployment_type: cloudHosting ? "cloud" : "self-hosted",
-    instance_id: instanceId,
-    license_id: getLicenseKey() ?? "",
-  });
+  // On this path the SDK is already loaded (gated by isPylonChatAvailable), so
+  // set the fields directly and include instance_id, which is only available
+  // here.
+  setPylonNewIssueCustomFields(instanceId);
 };

--- a/app/client/src/utils/bootPylon.ts
+++ b/app/client/src/utils/bootPylon.ts
@@ -109,10 +109,19 @@ export const updatePylonChatIdentity = (instanceId: string, user?: User) => {
     injectPylonScriptOnce(pylonAppID);
   }
 
+  // NOTE: each key below must exist as a matching custom-field *slug* in the
+  // Pylon dashboard, or Pylon silently drops the value (no client-side error).
+  // appsmith_edition intentionally duplicates the edition embedded in
+  // appsmith_version — the latter is a human-readable display string, the
+  // former a discrete, filterable field for support triage.
   window.Pylon("setNewIssueCustomFields", {
     appsmith_version: `Appsmith ${
       !cloudHosting ? appVersion.edition : ""
     } ${appVersion.id}`,
+    appsmith_edition: appVersion.edition,
+    build_sha: appVersion.sha,
+    build_date: appVersion.releaseDate,
+    deployment_type: cloudHosting ? "cloud" : "self-hosted",
     instance_id: instanceId,
     license_id: getLicenseKey() ?? "",
   });


### PR DESCRIPTION
## Description

Adds version and build metadata to the Pylon support-chat integration so support can immediately see which release/build a customer is on, on tickets created from **every** Pylon entry point.

Four new custom fields are attached to new Pylon issues:

| Pylon custom-field slug | Value | Source |
|---|---|---|
| `appsmith_edition` | `CE` / `EE` | `appVersion.edition` |
| `build_sha` | git commit SHA | `appVersion.sha` |
| `build_date` | release date | `appVersion.releaseDate` |
| `deployment_type` | `cloud` / `self-hosted` | `cloudHosting` |

Values come from `getAppsmithConfigs()`. The pre-existing `appsmith_version`, `instance_id`, and `license_id` fields are unchanged. `account_external_id` remains intentionally omitted to preserve Pylon `email_hash` identity verification.

### How it works (covers all entry points)

The fields are set via a shared `setPylonNewIssueCustomFields()` helper in `app/client/src/utils/bootPylon.ts`, called from two places:

1. **At SDK boot** — via a `load`-event handler on the injected Pylon script (`bootPylon`). Every chat-capable surface calls `bootPylon` before chat can be shown, so this covers issues created from the debugger contextual menu, repo-limit modal, homepage search, onboarding help menu, and datasource auth error — which previously carried **no** metadata.
2. **On the Help-menu path** (`updatePylonChatIdentity`) — additionally includes `instance_id`, which is only available there.

`instance_id` is cached module-side so a later boot-time call still carries it — the value cannot be dropped regardless of whether Pylon merges or replaces custom fields across calls.

## ⚠️ Required Pylon dashboard setup

These new field **slugs must be created in the Pylon workspace** (exact slugs, not labels) or Pylon silently drops the values — no client-side error:

- `appsmith_edition`
- `build_sha`
- `build_date`
- `deployment_type`

(`appsmith_version`, `instance_id`, `license_id` already exist.) The code is safe to merge independently but is inert until the slugs exist in Pylon.

## Type of change

- New feature (non-breaking, additive, no feature flag)

## How Has This Been Tested?

- `yarn run check-types` → pass (exit 0)
- `yarn eslint src/utils/bootPylon.ts` → pass (exit 0)
- Manual verification of the payload sent to Pylon is pending in a Pylon-configured environment (`REACT_APP_PYLON_APP_ID` set, authenticated user): open chat from multiple entry points and inspect the `setNewIssueCustomFields` payload / `chatwidget/issue` request; confirm `email_hash` identity still verifies (no 401).

## Reviewer notes

- Client-only, single file (`bootPylon.ts`). Both changed helpers (`injectPylonScriptOnce`, `setPylonNewIssueCustomFields`) are module-private; exported signatures are unchanged.
- No secrets/PII added — commit SHA is public (OSS); identity flow untouched. `license_id` now reaches Pylon at SDK boot for verified users (Pylon is already trusted with `email_hash`); flagged as a data-minimization consideration, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29098954808>
> Commit: a5c77c217349fe376bd970ecb27111cde774f600
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29098954808&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 10 Jul 2026 15:30:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->
