### PR TITLE
fix(security): restrict datasource access to the instance's own network address

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
@@ -97,6 +97,28 @@ public final class RestrictedHostFilter {
     private static volatile Set<String> internalRedisHosts = computeInternalRedisHosts();
 
     /**
+     * Hostnames that identify the Appsmith instance itself — seeded at JVM start from the local
+     * hostname ({@link InetAddress#getLocalHost()}) and the {@code HOSTNAME} environment variable.
+     *
+     * <p>Defense-in-depth: the instance's own routable address is always an RFC 1918 / site-local
+     * IP (Docker bridge {@code 172.17.x}, k8s pod {@code 10.x}, etc.), which the filter otherwise
+     * intentionally allows so that legitimate customer datasources on private networks keep
+     * working (see {@link #resolveIfAllowed(String)}). That carve-out means a user-defined
+     * datasource could point at the Appsmith instance itself. Registering the instance's own
+     * hostname(s) here lets the filter resolve and block just its own address(es) — via the
+     * container hostname or the raw own IP — without blocking the rest of the private network.
+     *
+     * <p>Hostnames (not fixed IPs) are stored and resolved live on every check via
+     * {@link #resolveHostsToIps(Set)}, so an instance whose IP changes stays covered with no TTL
+     * bookkeeping — mirroring the internal-Redis mechanism above.
+     *
+     * <p>Volatile + public setter (for tests only) instead of {@code final} so unit tests can
+     * exercise the overlap-detection logic without relying on the JVM's launch environment.
+     * Production code mutates it only via {@link #registerOwnHost(String...)} at startup.
+     */
+    private static volatile Set<String> ownHosts = computeOwnHosts();
+
+    /**
      * Test-only override that lets specific hosts bypass {@link #isHostBlocked(String)}. Used by
      * integration tests that spin up real services on loopback (e.g. Testcontainers-exposed
      * Redis on localhost) where the production block on loopback would otherwise prevent the
@@ -219,6 +241,60 @@ public final class RestrictedHostFilter {
         internalRedisHosts = merged.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(merged);
     }
 
+    private static Set<String> computeOwnHosts() {
+        final Set<String> hosts = new HashSet<>();
+        try {
+            addOwnHostname(hosts, InetAddress.getLocalHost().getHostName());
+        } catch (UnknownHostException e) {
+            log.debug("Could not determine local hostname for the SSRF own-host filter; skipping the seed.");
+        }
+        addOwnHostname(hosts, System.getenv("HOSTNAME"));
+        return hosts.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(hosts);
+    }
+
+    private static void addOwnHostname(Set<String> hosts, String hostname) {
+        if (StringUtils.hasText(hostname)) {
+            // Same canonicalization as the compare side — see addInternalRedisHostFromEnv.
+            hosts.add(normalizeHostForComparisonQuietly(hostname));
+        }
+    }
+
+    /**
+     * Registers additional hostnames that identify the Appsmith instance itself, unioning with the
+     * set seeded at static init from {@link InetAddress#getLocalHost()} and the {@code HOSTNAME}
+     * env var. The server calls this at startup (see {@code RedisConfig}) so the own-host block
+     * reflects the running container even if the static seed missed a name (e.g. local hostname
+     * resolution failed at class-load but succeeds later). Mirrors
+     * {@link #registerInternalRedisHosts(String...)}: unions with — does not replace — the seed,
+     * ignores null/blank entries, and is safe to call before or after the static seed.
+     */
+    public static void registerOwnHost(String... hostnames) {
+        if (hostnames == null || hostnames.length == 0) {
+            return;
+        }
+        final Set<String> merged = new HashSet<>(ownHosts);
+        for (String hostname : hostnames) {
+            addOwnHostname(merged, hostname);
+        }
+        ownHosts = merged.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(merged);
+    }
+
+    /** Visible for testing only. Production code sets the own-host set via {@link #registerOwnHost}. */
+    public static void setOwnHostsForTesting(String... hosts) {
+        if (hosts == null || hosts.length == 0) {
+            ownHosts = Collections.emptySet();
+            return;
+        }
+        final Set<String> normalized = new HashSet<>(hosts.length);
+        for (String host : hosts) {
+            if (StringUtils.hasText(host)) {
+                // Same canonicalization as the compare side — see addInternalRedisHostFromEnv.
+                normalized.add(normalizeHostForComparisonQuietly(host));
+            }
+        }
+        ownHosts = normalized.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(normalized);
+    }
+
     /** Visible for testing only. Production code never mutates the internal Redis hosts set. */
     public static void setInternalRedisHostsForTesting(String... hosts) {
         if (hosts == null || hosts.length == 0) {
@@ -317,9 +393,11 @@ public final class RestrictedHostFilter {
      * Returns {@code true} if {@code host} is definitively in the disallowed set: either the
      * literal/canonical host string is on the static denylist, the literal is a non-routable
      * address class (loopback, any-local, link-local, multicast, IPv6 ULA), the host matches
-     * any configured internal Redis hostname (session store + git Redis), or DNS resolves it
-     * to at least one address that intersects with the denylist, a blocked address class, or
-     * the IPs that any configured internal Redis hostname currently resolves to.
+     * any configured internal Redis hostname (session store + git Redis), the host is the
+     * Appsmith instance's own hostname, or DNS resolves it to at least one address that
+     * intersects with the denylist, a blocked address class, the IPs that any configured
+     * internal Redis hostname currently resolves to, or the IPs the instance's own hostname
+     * currently resolves to (defense-in-depth against a datasource targeting the instance itself).
      *
      * <p>Returns {@code false} for an unresolvable hostname so a transient DNS failure
      * doesn't reject a legitimate but temporarily unreachable host. The driver's own
@@ -358,49 +436,62 @@ public final class RestrictedHostFilter {
     /**
      * Shared deny-logic (1 of 2): is the canonical host string itself blocked, without any DNS?
      * Covers the static denylist (cloud-metadata literals, loopback), a non-routable IP-class
-     * literal, and a literal match against an internal Appsmith Redis hostname. Extracted so
-     * {@link #isHostBlocked(String)} and {@link #firstAllowedRedisAddress(String, InetAddress[])}
-     * evaluate the deny list identically and cannot drift into an SSRF gap.
+     * literal, a literal match against an internal Appsmith Redis hostname, and a literal match
+     * against the Appsmith instance's own hostname. Extracted so {@link #isHostBlocked(String)}
+     * and {@link #firstAllowedRedisAddress(String, InetAddress[])} evaluate the deny list
+     * identically and cannot drift into an SSRF gap.
      */
     private static boolean isCanonicalHostBlocked(String canonicalHost) {
         return DISALLOWED_HOSTS.contains(canonicalHost)
                 || isBlockedIpAddressClass(canonicalHost)
-                || internalRedisHosts.contains(canonicalHost);
+                || internalRedisHosts.contains(canonicalHost)
+                || ownHosts.contains(canonicalHost);
     }
 
     /**
      * Shared deny-logic (2 of 2): does any already-resolved address fall in the denylist, a
-     * blocked address class, or overlap with the IPs an internal Appsmith Redis hostname currently
-     * resolves to? Extracted alongside {@link #isCanonicalHostBlocked(String)} so both callers
-     * share one address-level deny evaluation.
+     * blocked address class, overlap with the IPs an internal Appsmith Redis hostname currently
+     * resolves to, or overlap with the IPs the Appsmith instance's own hostname currently resolves
+     * to? Extracted alongside {@link #isCanonicalHostBlocked(String)} so both callers share one
+     * address-level deny evaluation. The own-host overlap is what blocks a datasource pointed at
+     * the instance's own routable (RFC 1918) address by raw IP literal, since that address class
+     * is otherwise intentionally allowed.
      */
     private static boolean isAnyResolvedAddressBlocked(InetAddress[] resolvedAddresses) {
-        final Set<String> internalRedisIps = resolveInternalRedisIps(internalRedisHosts);
+        final Set<String> internalRedisIps = resolveHostsToIps(internalRedisHosts);
+        final Set<String> ownIps = resolveHostsToIps(ownHosts);
         for (InetAddress addr : resolvedAddresses) {
             final String addrString = normalizeHostForComparisonQuietly(addr.getHostAddress());
             if (DISALLOWED_HOSTS.contains(addrString)
                     || matchesBlockedAddressClass(addr)
-                    || internalRedisIps.contains(addrString)) {
+                    || internalRedisIps.contains(addrString)
+                    || ownIps.contains(addrString)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static Set<String> resolveInternalRedisIps(Set<String> redisHosts) {
-        if (redisHosts.isEmpty()) {
+    /**
+     * Live-resolves a set of registered hostnames (internal Redis or the instance's own host) to
+     * their current IPs, so overlap checks track a changing IP with no TTL bookkeeping.
+     * Unresolvable names are skipped — a literal hostname match still applies via
+     * {@link #isCanonicalHostBlocked(String)}.
+     */
+    private static Set<String> resolveHostsToIps(Set<String> hostsToResolve) {
+        if (hostsToResolve.isEmpty()) {
             return Collections.emptySet();
         }
         final Set<String> ips = new HashSet<>();
-        for (String redisHost : redisHosts) {
+        for (String host : hostsToResolve) {
             try {
-                for (InetAddress addr : InetAddress.getAllByName(redisHost)) {
+                for (InetAddress addr : InetAddress.getAllByName(host)) {
                     ips.add(normalizeHostForComparisonQuietly(addr.getHostAddress()));
                 }
             } catch (UnknownHostException e) {
                 // Hostname doesn't currently resolve — skip it in the overlap check; literal
                 // match still applies for the same hostname string.
-                log.debug("Internal Redis hostname {} could not be resolved; skipping in IP overlap check.", redisHost);
+                log.debug("Registered host {} could not be resolved; skipping in IP overlap check.", host);
             }
         }
         return ips;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
@@ -100,13 +100,19 @@ public final class RestrictedHostFilter {
      * Hostnames that identify the Appsmith instance itself — seeded at JVM start from the local
      * hostname ({@link InetAddress#getLocalHost()}) and the {@code HOSTNAME} environment variable.
      *
-     * <p>Defense-in-depth: the instance's own routable address is always an RFC 1918 / site-local
+     * <p>Defense-in-depth: an instance's own routable address is typically an RFC 1918 / site-local
      * IP (Docker bridge {@code 172.17.x}, k8s pod {@code 10.x}, etc.), which the filter otherwise
      * intentionally allows so that legitimate customer datasources on private networks keep
      * working (see {@link #resolveIfAllowed(String)}). That carve-out means a user-defined
      * datasource could point at the Appsmith instance itself. Registering the instance's own
      * hostname(s) here lets the filter resolve and block just its own address(es) — via the
      * container hostname or the raw own IP — without blocking the rest of the private network.
+     *
+     * <p><b>Scope:</b> this is <em>best-effort</em> coverage of the address(es) the registered own
+     * hostname(s) resolve to — deliberately not a full {@link java.net.NetworkInterface}
+     * enumeration. A multi-homed container's secondary-interface IPs, or a deployment where the
+     * hostname does not resolve to the address plugins actually connect over, are out of scope by
+     * design. The primary/hostname-mapped address is the target this closes.
      *
      * <p>Hostnames (not fixed IPs) are stored and resolved live on every check via
      * {@link #resolveHostsToIps(Set)}, so an instance whose IP changes stays covered with no TTL
@@ -117,6 +123,14 @@ public final class RestrictedHostFilter {
      * Production code mutates it only via {@link #registerOwnHost(String...)} at startup.
      */
     private static volatile Set<String> ownHosts = computeOwnHosts();
+
+    /**
+     * Test-only injection of the IPs the registered own hostname(s) "resolve" to, so the own-IP
+     * overlap logic can be exercised deterministically without live DNS. {@code null} means resolve
+     * the own hostnames live via {@link #resolveHostsToIps(Set)} (the production path); a non-null
+     * set short-circuits that resolution. Never set in production.
+     */
+    private static volatile Set<String> ownResolvedIpsForTesting = null;
 
     /**
      * Test-only override that lets specific hosts bypass {@link #isHostBlocked(String)}. Used by
@@ -295,6 +309,31 @@ public final class RestrictedHostFilter {
         ownHosts = normalized.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(normalized);
     }
 
+    /**
+     * Visible for testing only. Injects the IPs the registered own hostname(s) should be treated as
+     * resolving to, so the own-IP overlap can be tested deterministically without live DNS. Pairs
+     * with {@link #clearOwnResolvedIpsForTesting()}. Production code never calls this — own IPs are
+     * always resolved live from {@link #ownHosts}.
+     */
+    public static void setOwnResolvedIpsForTesting(String... ips) {
+        if (ips == null || ips.length == 0) {
+            ownResolvedIpsForTesting = null;
+            return;
+        }
+        final Set<String> normalized = new HashSet<>(ips.length);
+        for (String ip : ips) {
+            if (StringUtils.hasText(ip)) {
+                normalized.add(normalizeHostForComparisonQuietly(ip));
+            }
+        }
+        ownResolvedIpsForTesting = Collections.unmodifiableSet(normalized);
+    }
+
+    /** Visible for testing only. Restores live own-host resolution. */
+    public static void clearOwnResolvedIpsForTesting() {
+        ownResolvedIpsForTesting = null;
+    }
+
     /** Visible for testing only. Production code never mutates the internal Redis hosts set. */
     public static void setInternalRedisHostsForTesting(String... hosts) {
         if (hosts == null || hosts.length == 0) {
@@ -459,7 +498,7 @@ public final class RestrictedHostFilter {
      */
     private static boolean isAnyResolvedAddressBlocked(InetAddress[] resolvedAddresses) {
         final Set<String> internalRedisIps = resolveHostsToIps(internalRedisHosts);
-        final Set<String> ownIps = resolveHostsToIps(ownHosts);
+        final Set<String> ownIps = resolveOwnIps();
         for (InetAddress addr : resolvedAddresses) {
             final String addrString = normalizeHostForComparisonQuietly(addr.getHostAddress());
             if (DISALLOWED_HOSTS.contains(addrString)
@@ -470,6 +509,35 @@ public final class RestrictedHostFilter {
             }
         }
         return false;
+    }
+
+    /**
+     * Address-level own-host policy shared by every enforcement entry point that works from an
+     * already-canonicalized host string rather than an {@link InetAddress} array — i.e. the
+     * WebClient (Netty) and Elasticsearch resolver hooks via {@link #isDisallowedAndFail(String,
+     * Promise)}. Returns {@code true} when {@code canonicalHost} is a registered own hostname, or
+     * equals one of the IPs a registered own hostname currently resolves to. Centralizing it here
+     * (alongside {@link #isAnyResolvedAddressBlocked(InetAddress[])}, which applies the same own-IP
+     * overlap to the datasource-save and Redis paths) keeps the resolver paths from drifting back
+     * into an own-IP gap.
+     *
+     * <p>Only the <em>own</em> hostnames are resolved here — never the caller's user host — so this
+     * does not re-resolve the user host and cannot reintroduce the DNS-rebinding TOCTOU the
+     * resolver hooks exist to prevent. Callers already hand in the address (pre- or post-DNS) they
+     * are about to use.
+     */
+    private static boolean matchesOwnHost(String canonicalHost) {
+        return ownHosts.contains(canonicalHost) || resolveOwnIps().contains(canonicalHost);
+    }
+
+    /**
+     * The IPs the registered own hostname(s) currently resolve to. Uses the live resolution in
+     * production; a test-injected set ({@link #setOwnResolvedIpsForTesting(String...)}) short-
+     * circuits it so the own-IP overlap can be exercised without depending on live DNS.
+     */
+    private static Set<String> resolveOwnIps() {
+        final Set<String> injected = ownResolvedIpsForTesting;
+        return injected != null ? injected : resolveHostsToIps(ownHosts);
     }
 
     /**
@@ -559,12 +627,14 @@ public final class RestrictedHostFilter {
     /**
      * Literal/canonical-only block check — no DNS, no network I/O. Catches the static denylist
      * (cloud-metadata IPs), literal non-routable IP-class addresses, and a literal match
-     * against any configured internal Redis hostname (session store + git Redis).
+     * against any configured internal Redis hostname (session store + git Redis) or the Appsmith
+     * instance's own hostname.
      *
      * <p>Returns {@code false} for unparseable input and for anything that requires DNS to
-     * decide. Callers that need the DNS-resolved check (IP overlap with the internal Redis,
-     * hostname-resolves-to-loopback, etc.) should use {@link #isHostBlocked(String)} from an
-     * async path that tolerates blocking I/O.
+     * decide. Callers that need the DNS-resolved check (IP overlap with the internal Redis or the
+     * instance's own IP, hostname-resolves-to-loopback, etc.) should use {@link
+     * #isHostBlocked(String)} from an async path that tolerates blocking I/O, or the resolver-hook
+     * path {@link #isDisallowedAndFail(String, Promise)} which applies the own-IP overlap post-DNS.
      *
      * <p>Used by {@link WebClientUtils} request filter as the pre-resolver fast path — the
      * Netty resolver runs the DNS-aware check separately via
@@ -583,7 +653,11 @@ public final class RestrictedHostFilter {
         if (DISALLOWED_HOSTS.contains(canonicalHost) || isBlockedIpAddressClass(canonicalHost)) {
             return true;
         }
-        return internalRedisHosts.contains(canonicalHost);
+        // Literal (no-DNS) block for a URL that literally names an internal Redis or the instance's
+        // own host. The own-IP overlap — a hostname or raw IP that resolves to the own address — is
+        // enforced by the DNS-aware resolver hook via isDisallowedAndFail, so it's intentionally not
+        // resolved on this fast path (which is contractually free of DNS / network I/O).
+        return internalRedisHosts.contains(canonicalHost) || ownHosts.contains(canonicalHost);
     }
 
     public static boolean isDisallowedAndFail(String host, Promise<?> promise) {
@@ -591,7 +665,13 @@ public final class RestrictedHostFilter {
             return false;
         }
         final String canonicalHost = normalizeHostForComparisonQuietly(host);
-        if (DISALLOWED_HOSTS.contains(canonicalHost) || isBlockedIpAddressClass(canonicalHost)) {
+        // matchesOwnHost adds the own-host literal + own-IP overlap so the WebClient (Netty) and
+        // Elasticsearch resolver hooks — which call this both pre-DNS (host) and post-DNS (resolved
+        // address string) — block a datasource pointed at the instance's own routable address by
+        // hostname or raw IP, the same address-level policy firstAllowedRedisAddress applies.
+        if (DISALLOWED_HOSTS.contains(canonicalHost)
+                || isBlockedIpAddressClass(canonicalHost)
+                || matchesOwnHost(canonicalHost)) {
             log.warn("Host {} is disallowed. Failing the request.", host);
             if (promise != null) {
                 promise.setFailure(new UnknownHostException(HOST_NOT_ALLOWED));

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
@@ -114,9 +114,10 @@ public final class RestrictedHostFilter {
      * hostname does not resolve to the address plugins actually connect over, are out of scope by
      * design. The primary/hostname-mapped address is the target this closes.
      *
-     * <p>Hostnames (not fixed IPs) are stored and resolved live on every check via
-     * {@link #resolveHostsToIps(Set)}, so an instance whose IP changes stays covered with no TTL
-     * bookkeeping — mirroring the internal-Redis mechanism above.
+     * <p>Hostnames are stored here; their IPs are resolved off the request hot path (at static init
+     * and at {@link #registerOwnHost(String...)}, which the server runs at startup) and cached in
+     * {@link #ownResolvedIps}, so the enforcement checks stay DNS-free. The own IP is effectively
+     * static for the process lifetime, so a startup resolve suffices with no periodic refresh.
      *
      * <p>Volatile + public setter (for tests only) instead of {@code final} so unit tests can
      * exercise the overlap-detection logic without relying on the JVM's launch environment.
@@ -125,12 +126,16 @@ public final class RestrictedHostFilter {
     private static volatile Set<String> ownHosts = computeOwnHosts();
 
     /**
-     * Test-only injection of the IPs the registered own hostname(s) "resolve" to, so the own-IP
-     * overlap logic can be exercised deterministically without live DNS. {@code null} means resolve
-     * the own hostnames live via {@link #resolveHostsToIps(Set)} (the production path); a non-null
-     * set short-circuits that resolution. Never set in production.
+     * Cached IPs the registered own hostname(s) resolve to. Resolved off the request hot path —
+     * once at static init and again whenever {@link #registerOwnHost(String...)} runs (the server
+     * calls that at startup, before any datasource is served) — so the enforcement checks
+     * ({@link #matchesOwnHost(String)} on the resolver EventLoop, and
+     * {@link #isAnyResolvedAddressBlocked(InetAddress[])} on the datasource-save / Redis paths) are
+     * pure set-membership with no DNS. The own IP is effectively static for the process lifetime (a
+     * re-IP means a restart, which re-seeds this), so a startup resolve is sufficient and there is
+     * no periodic refresh. Tests seed it directly via {@link #setOwnResolvedIpsForTesting(String...)}.
      */
-    private static volatile Set<String> ownResolvedIpsForTesting = null;
+    private static volatile Set<String> ownResolvedIps = resolveHostsToIps(ownHosts);
 
     /**
      * Test-only override that lets specific hosts bypass {@link #isHostBlocked(String)}. Used by
@@ -281,6 +286,10 @@ public final class RestrictedHostFilter {
      * resolution failed at class-load but succeeds later). Mirrors
      * {@link #registerInternalRedisHosts(String...)}: unions with — does not replace — the seed,
      * ignores null/blank entries, and is safe to call before or after the static seed.
+     *
+     * <p>Resolves the own hostname(s) to IPs once here — off the request hot path — and caches them
+     * in {@link #ownResolvedIps}. The server calls this at startup (@PostConstruct) before any
+     * datasource is served, so the resolver hooks never do DNS for the own-host check.
      */
     public static void registerOwnHost(String... hostnames) {
         if (hostnames == null || hostnames.length == 0) {
@@ -291,6 +300,12 @@ public final class RestrictedHostFilter {
             addOwnHostname(merged, hostname);
         }
         ownHosts = merged.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(merged);
+        refreshOwnResolvedIps();
+    }
+
+    /** Resolves the registered own hostnames to their current IPs and caches them. Off the hot path. */
+    private static void refreshOwnResolvedIps() {
+        ownResolvedIps = resolveHostsToIps(ownHosts);
     }
 
     /** Visible for testing only. Production code sets the own-host set via {@link #registerOwnHost}. */
@@ -310,14 +325,13 @@ public final class RestrictedHostFilter {
     }
 
     /**
-     * Visible for testing only. Injects the IPs the registered own hostname(s) should be treated as
-     * resolving to, so the own-IP overlap can be tested deterministically without live DNS. Pairs
-     * with {@link #clearOwnResolvedIpsForTesting()}. Production code never calls this — own IPs are
-     * always resolved live from {@link #ownHosts}.
+     * Visible for testing only. Seeds the cached own-IP set directly, so the own-IP overlap can be
+     * tested deterministically without DNS. Pairs with {@link #clearOwnResolvedIpsForTesting()}.
+     * Production seeds this cache via {@link #registerOwnHost(String...)} at startup instead.
      */
     public static void setOwnResolvedIpsForTesting(String... ips) {
         if (ips == null || ips.length == 0) {
-            ownResolvedIpsForTesting = null;
+            ownResolvedIps = Collections.emptySet();
             return;
         }
         final Set<String> normalized = new HashSet<>(ips.length);
@@ -326,12 +340,12 @@ public final class RestrictedHostFilter {
                 normalized.add(normalizeHostForComparisonQuietly(ip));
             }
         }
-        ownResolvedIpsForTesting = Collections.unmodifiableSet(normalized);
+        ownResolvedIps = Collections.unmodifiableSet(normalized);
     }
 
-    /** Visible for testing only. Restores live own-host resolution. */
+    /** Visible for testing only. Empties the cached own-IP set. */
     public static void clearOwnResolvedIpsForTesting() {
-        ownResolvedIpsForTesting = null;
+        ownResolvedIps = Collections.emptySet();
     }
 
     /** Visible for testing only. Production code never mutates the internal Redis hosts set. */
@@ -490,15 +504,17 @@ public final class RestrictedHostFilter {
     /**
      * Shared deny-logic (2 of 2): does any already-resolved address fall in the denylist, a
      * blocked address class, overlap with the IPs an internal Appsmith Redis hostname currently
-     * resolves to, or overlap with the IPs the Appsmith instance's own hostname currently resolves
-     * to? Extracted alongside {@link #isCanonicalHostBlocked(String)} so both callers share one
+     * resolves to, or overlap with the cached IPs the Appsmith instance's own hostname resolves to?
+     * Extracted alongside {@link #isCanonicalHostBlocked(String)} so both callers share one
      * address-level deny evaluation. The own-host overlap is what blocks a datasource pointed at
      * the instance's own routable (RFC 1918) address by raw IP literal, since that address class
-     * is otherwise intentionally allowed.
+     * is otherwise intentionally allowed. Internal-Redis IPs are resolved live here (this method
+     * only runs on the datasource-save / Redis paths, which tolerate blocking I/O); the own IPs
+     * come from the {@link #ownResolvedIps} cache, shared with the resolver-hook hot path.
      */
     private static boolean isAnyResolvedAddressBlocked(InetAddress[] resolvedAddresses) {
         final Set<String> internalRedisIps = resolveHostsToIps(internalRedisHosts);
-        final Set<String> ownIps = resolveOwnIps();
+        final Set<String> ownIps = ownResolvedIps;
         for (InetAddress addr : resolvedAddresses) {
             final String addrString = normalizeHostForComparisonQuietly(addr.getHostAddress());
             if (DISALLOWED_HOSTS.contains(addrString)
@@ -516,35 +532,25 @@ public final class RestrictedHostFilter {
      * already-canonicalized host string rather than an {@link InetAddress} array — i.e. the
      * WebClient (Netty) and Elasticsearch resolver hooks via {@link #isDisallowedAndFail(String,
      * Promise)}. Returns {@code true} when {@code canonicalHost} is a registered own hostname, or
-     * equals one of the IPs a registered own hostname currently resolves to. Centralizing it here
-     * (alongside {@link #isAnyResolvedAddressBlocked(InetAddress[])}, which applies the same own-IP
-     * overlap to the datasource-save and Redis paths) keeps the resolver paths from drifting back
-     * into an own-IP gap.
+     * equals one of the cached own IPs. Centralizing it here (alongside
+     * {@link #isAnyResolvedAddressBlocked(InetAddress[])}, which applies the same own-IP overlap to
+     * the datasource-save and Redis paths) keeps the resolver paths from drifting back into an
+     * own-IP gap.
      *
-     * <p>Only the <em>own</em> hostnames are resolved here — never the caller's user host — so this
-     * does not re-resolve the user host and cannot reintroduce the DNS-rebinding TOCTOU the
-     * resolver hooks exist to prevent. Callers already hand in the address (pre- or post-DNS) they
-     * are about to use.
+     * <p>Pure set-membership — no DNS. The own IPs are resolved off this path (at startup /
+     * {@link #registerOwnHost(String...)}) and cached in {@link #ownResolvedIps}, so this can run on
+     * the Netty / Elasticsearch resolver EventLoop without blocking it. It never resolves the
+     * caller's user host, so it cannot reintroduce the DNS-rebinding TOCTOU the resolver hooks exist
+     * to prevent — callers hand in the address (pre- or post-DNS) they are about to use.
      */
     private static boolean matchesOwnHost(String canonicalHost) {
-        return ownHosts.contains(canonicalHost) || resolveOwnIps().contains(canonicalHost);
+        return ownHosts.contains(canonicalHost) || ownResolvedIps.contains(canonicalHost);
     }
 
     /**
-     * The IPs the registered own hostname(s) currently resolve to. Uses the live resolution in
-     * production; a test-injected set ({@link #setOwnResolvedIpsForTesting(String...)}) short-
-     * circuits it so the own-IP overlap can be exercised without depending on live DNS.
-     */
-    private static Set<String> resolveOwnIps() {
-        final Set<String> injected = ownResolvedIpsForTesting;
-        return injected != null ? injected : resolveHostsToIps(ownHosts);
-    }
-
-    /**
-     * Live-resolves a set of registered hostnames (internal Redis or the instance's own host) to
-     * their current IPs, so overlap checks track a changing IP with no TTL bookkeeping.
-     * Unresolvable names are skipped — a literal hostname match still applies via
-     * {@link #isCanonicalHostBlocked(String)}.
+     * Resolves a set of registered hostnames (internal Redis, or — off the hot path — the instance's
+     * own host) to their current IPs. Unresolvable names are skipped; a literal hostname match still
+     * applies via {@link #isCanonicalHostBlocked(String)}.
      */
     private static Set<String> resolveHostsToIps(Set<String> hostsToResolve) {
         if (hostsToResolve.isEmpty()) {
@@ -668,7 +674,9 @@ public final class RestrictedHostFilter {
         // matchesOwnHost adds the own-host literal + own-IP overlap so the WebClient (Netty) and
         // Elasticsearch resolver hooks — which call this both pre-DNS (host) and post-DNS (resolved
         // address string) — block a datasource pointed at the instance's own routable address by
-        // hostname or raw IP, the same address-level policy firstAllowedRedisAddress applies.
+        // hostname or raw IP, the same address-level policy firstAllowedRedisAddress applies. It is
+        // pure set-membership against the cached own IPs (no DNS), safe to run on the resolver
+        // EventLoop; the own hostnames are resolved off this path at startup (see registerOwnHost).
         if (DISALLOWED_HOSTS.contains(canonicalHost)
                 || isBlockedIpAddressClass(canonicalHost)
                 || matchesOwnHost(canonicalHost)) {

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
@@ -23,6 +23,9 @@ public class RestrictedHostFilterTest {
         // the kill-switch back. resetSsrfFilterDisabledForTesting() in @AfterAll restores
         // whatever the surefire-set default was.
         RestrictedHostFilter.setSsrfFilterDisabledForTesting(false);
+        // Neutralize the own-host set seeded from the test machine's real hostname so it can't
+        // interfere with the allow-list assertions. Own-host tests set it explicitly.
+        RestrictedHostFilter.setOwnHostsForTesting();
     }
 
     @AfterAll
@@ -38,6 +41,7 @@ public class RestrictedHostFilterTest {
         // — individual tests that toggle it (e.g. the kill-switch tests) still need to flip it
         // back themselves between cases.
         RestrictedHostFilter.setInternalRedisHostsForTesting();
+        RestrictedHostFilter.setOwnHostsForTesting();
         RestrictedHostFilter.clearAlwaysAllowedHostsForTesting();
         RestrictedHostFilter.setSsrfFilterDisabledForTesting(false);
     }
@@ -280,6 +284,74 @@ public class RestrictedHostFilterTest {
         RestrictedHostFilter.registerInternalRedisHosts("redis://property-redis.svc.cluster.local:6379");
         assertTrue(RestrictedHostFilter.isHostBlocked("env-seeded-redis.svc.cluster.local"));
         assertTrue(RestrictedHostFilter.isHostBlocked("property-redis.svc.cluster.local"));
+    }
+
+    // ---------- ownHosts: defense-in-depth block on the instance's own routable IP ----------
+    // The instance's own IP is always RFC 1918 / site-local (Docker bridge 172.17.x, k8s pod
+    // 10.x, ...), which the filter intentionally allows for legitimate private-network
+    // datasources. These tests use a stable public hostname (one.one.one.one -> 1.1.1.1) as a
+    // stand-in for the "own host" so the resolved IP is deterministic without depending on the
+    // test machine's actual hostname/IP — exactly mirroring the internal-Redis overlap tests.
+
+    @Test
+    public void isHostBlocked_blocksOwnIpWhenReachedByRawIpv4Literal() {
+        // Register the own host by name; a datasource pointed at the raw IP that name resolves to
+        // must be blocked via the resolved-address overlap — even though that IP class (a plain
+        // routable address here, RFC 1918 in production) is otherwise allowed.
+        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
+        assertTrue(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
+    }
+
+    @Test
+    public void isHostBlocked_blocksOwnIpViaIpv4MappedIpv6() {
+        // ::ffff:1.1.1.1 canonicalizes to 1.1.1.1 (see normalizeIpAddress) and resolves to the
+        // same address, so the IPv4-mapped IPv6 form is caught by the same overlap check.
+        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
+        assertTrue(RestrictedHostFilter.isHostBlocked("::ffff:1.1.1.1"));
+    }
+
+    @Test
+    public void isHostBlocked_blocksOwnHostByHostnameLiteral() {
+        // Typing the instance's own hostname is blocked via the literal (canonical) match, and
+        // case-insensitively — datasource configs are user-entered.
+        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
+        assertTrue(RestrictedHostFilter.isHostBlocked("one.one.one.one"));
+        assertTrue(RestrictedHostFilter.isHostBlocked("ONE.One.one.ONE"));
+    }
+
+    @Test
+    public void isHostBlocked_doesNotBlockDifferentRfc1918AddressWhenOwnHostConfigured() {
+        // Guardrail: only the instance's OWN address is blocked, not the rest of the private
+        // network. These RFC 1918 hosts don't overlap with the configured own host, so they stay
+        // allowed — proving we didn't over-block legitimate private-network datasources.
+        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
+        assertFalse(RestrictedHostFilter.isHostBlocked("192.168.1.1"));
+        assertFalse(RestrictedHostFilter.isHostBlocked("10.0.0.1"));
+        assertFalse(RestrictedHostFilter.isHostBlocked("172.16.0.1"));
+    }
+
+    @Test
+    public void registerOwnHost_blocksHostAndUnionsWithExistingSet() {
+        // Mirrors the server's startup path (RedisConfig#registerOwnHostWithSsrfFilter): the
+        // registration unions with — does not replace — the existing set, and null/blank entries
+        // are ignored.
+        RestrictedHostFilter.setOwnHostsForTesting("seeded-own.example.internal");
+        RestrictedHostFilter.registerOwnHost("one.one.one.one");
+        RestrictedHostFilter.registerOwnHost((String) null, "", "   ");
+        assertTrue(RestrictedHostFilter.isHostBlocked("seeded-own.example.internal"));
+        assertTrue(RestrictedHostFilter.isHostBlocked("one.one.one.one"));
+        assertTrue(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
+    }
+
+    @Test
+    public void ssrfFilterDisabled_bypassesOwnHostBlock() {
+        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
+        // Sanity: blocked by default.
+        assertTrue(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
+        // Kill-switch on — the own-host block is bypassed like every other check.
+        RestrictedHostFilter.setSsrfFilterDisabledForTesting(true);
+        assertFalse(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
+        assertFalse(RestrictedHostFilter.isHostBlocked("one.one.one.one"));
     }
 
     @Test

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
@@ -26,6 +26,7 @@ public class RestrictedHostFilterTest {
         // Neutralize the own-host set seeded from the test machine's real hostname so it can't
         // interfere with the allow-list assertions. Own-host tests set it explicitly.
         RestrictedHostFilter.setOwnHostsForTesting();
+        RestrictedHostFilter.clearOwnResolvedIpsForTesting();
     }
 
     @AfterAll
@@ -42,6 +43,7 @@ public class RestrictedHostFilterTest {
         // back themselves between cases.
         RestrictedHostFilter.setInternalRedisHostsForTesting();
         RestrictedHostFilter.setOwnHostsForTesting();
+        RestrictedHostFilter.clearOwnResolvedIpsForTesting();
         RestrictedHostFilter.clearAlwaysAllowedHostsForTesting();
         RestrictedHostFilter.setSsrfFilterDisabledForTesting(false);
     }
@@ -287,44 +289,46 @@ public class RestrictedHostFilterTest {
     }
 
     // ---------- ownHosts: defense-in-depth block on the instance's own routable IP ----------
-    // The instance's own IP is always RFC 1918 / site-local (Docker bridge 172.17.x, k8s pod
+    // The instance's own IP is typically RFC 1918 / site-local (Docker bridge 172.17.x, k8s pod
     // 10.x, ...), which the filter intentionally allows for legitimate private-network
-    // datasources. These tests use a stable public hostname (one.one.one.one -> 1.1.1.1) as a
-    // stand-in for the "own host" so the resolved IP is deterministic without depending on the
-    // test machine's actual hostname/IP — exactly mirroring the internal-Redis overlap tests.
+    // datasources. Registered own hostnames are unresolvable *.invalid literals and the "resolved"
+    // own IPs are injected via setOwnResolvedIpsForTesting, so these tests are deterministic and
+    // never depend on live public DNS. 10.123.45.67 stands in for the instance's own RFC 1918 IP.
 
     @Test
     public void isHostBlocked_blocksOwnIpWhenReachedByRawIpv4Literal() {
-        // Register the own host by name; a datasource pointed at the raw IP that name resolves to
-        // must be blocked via the resolved-address overlap — even though that IP class (a plain
-        // routable address here, RFC 1918 in production) is otherwise allowed.
-        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
-        assertTrue(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
+        // A datasource pointed at the raw IP the own host resolves to must be blocked via the
+        // resolved-address overlap — even though that IP class (RFC 1918) is otherwise allowed.
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.123.45.67");
+        assertTrue(RestrictedHostFilter.isHostBlocked("10.123.45.67"));
     }
 
     @Test
     public void isHostBlocked_blocksOwnIpViaIpv4MappedIpv6() {
-        // ::ffff:1.1.1.1 canonicalizes to 1.1.1.1 (see normalizeIpAddress) and resolves to the
-        // same address, so the IPv4-mapped IPv6 form is caught by the same overlap check.
-        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
-        assertTrue(RestrictedHostFilter.isHostBlocked("::ffff:1.1.1.1"));
+        // ::ffff:10.123.45.67 canonicalizes to 10.123.45.67 (see normalizeIpAddress) and resolves
+        // to the same address, so the IPv4-mapped IPv6 form is caught by the same overlap check.
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.123.45.67");
+        assertTrue(RestrictedHostFilter.isHostBlocked("::ffff:10.123.45.67"));
     }
 
     @Test
     public void isHostBlocked_blocksOwnHostByHostnameLiteral() {
         // Typing the instance's own hostname is blocked via the literal (canonical) match, and
-        // case-insensitively — datasource configs are user-entered.
-        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
-        assertTrue(RestrictedHostFilter.isHostBlocked("one.one.one.one"));
-        assertTrue(RestrictedHostFilter.isHostBlocked("ONE.One.one.ONE"));
+        // case-insensitively — datasource configs are user-entered. No DNS needed.
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        assertTrue(RestrictedHostFilter.isHostBlocked("own-host.invalid"));
+        assertTrue(RestrictedHostFilter.isHostBlocked("OWN-Host.INVALID"));
     }
 
     @Test
     public void isHostBlocked_doesNotBlockDifferentRfc1918AddressWhenOwnHostConfigured() {
         // Guardrail: only the instance's OWN address is blocked, not the rest of the private
-        // network. These RFC 1918 hosts don't overlap with the configured own host, so they stay
+        // network. These RFC 1918 hosts don't overlap with the injected own IP, so they stay
         // allowed — proving we didn't over-block legitimate private-network datasources.
-        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.123.45.67");
         assertFalse(RestrictedHostFilter.isHostBlocked("192.168.1.1"));
         assertFalse(RestrictedHostFilter.isHostBlocked("10.0.0.1"));
         assertFalse(RestrictedHostFilter.isHostBlocked("172.16.0.1"));
@@ -335,23 +339,71 @@ public class RestrictedHostFilterTest {
         // Mirrors the server's startup path (RedisConfig#registerOwnHostWithSsrfFilter): the
         // registration unions with — does not replace — the existing set, and null/blank entries
         // are ignored.
-        RestrictedHostFilter.setOwnHostsForTesting("seeded-own.example.internal");
-        RestrictedHostFilter.registerOwnHost("one.one.one.one");
+        RestrictedHostFilter.setOwnHostsForTesting("seeded-own.invalid");
+        RestrictedHostFilter.registerOwnHost("registered-own.invalid");
         RestrictedHostFilter.registerOwnHost((String) null, "", "   ");
-        assertTrue(RestrictedHostFilter.isHostBlocked("seeded-own.example.internal"));
-        assertTrue(RestrictedHostFilter.isHostBlocked("one.one.one.one"));
-        assertTrue(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
+        assertTrue(RestrictedHostFilter.isHostBlocked("seeded-own.invalid"));
+        assertTrue(RestrictedHostFilter.isHostBlocked("registered-own.invalid"));
+    }
+
+    // The own-IP block must be enforced on the actual security entry points, not just isHostBlocked:
+    // isDisallowedAndFail is the shared address-level policy for the WebClient (Netty) and
+    // Elasticsearch resolver hooks; isLiteralBlocked is the WebClient pre-resolver fast path;
+    // firstAllowedRedisAddress is the Redis connect-time path. Missing coverage here is exactly why
+    // an own-IP bypass could ship with isHostBlocked green.
+
+    @Test
+    public void isDisallowedAndFail_blocksOwnHostAndResolvedOwnIp() {
+        // This is the method the WebClient + Elasticsearch resolver hooks call, both pre-DNS (the
+        // host/URL literal) and post-DNS (the resolved address string). Both forms must be blocked.
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.123.45.67");
+        // Own hostname literal (pre-DNS) and raw / resolved own IP (pre- or post-DNS).
+        assertTrue(RestrictedHostFilter.isDisallowedAndFail("own-host.invalid", null));
+        assertTrue(RestrictedHostFilter.isDisallowedAndFail("10.123.45.67", null));
+        assertTrue(RestrictedHostFilter.isDisallowedAndFail("::ffff:10.123.45.67", null));
+        // A different RFC 1918 address is not the own IP — still allowed (no over-block).
+        assertFalse(RestrictedHostFilter.isDisallowedAndFail("10.0.0.9", null));
     }
 
     @Test
-    public void ssrfFilterDisabled_bypassesOwnHostBlock() {
-        RestrictedHostFilter.setOwnHostsForTesting("one.one.one.one");
-        // Sanity: blocked by default.
-        assertTrue(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
+    public void isLiteralBlocked_blocksOwnHostnameLiterally() {
+        // The pre-resolver fast path blocks a URL that literally names the instance's own host,
+        // case-insensitively, without doing DNS. (The own-IP overlap is enforced post-DNS by the
+        // resolver hook via isDisallowedAndFail, covered above.)
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        assertTrue(RestrictedHostFilter.isLiteralBlocked("own-host.invalid"));
+        assertTrue(RestrictedHostFilter.isLiteralBlocked("OWN-Host.INVALID"));
+    }
+
+    @Test
+    public void firstAllowedRedisAddress_blocksResolvedOwnIp() throws Exception {
+        // The Redis connect-time path shares the same address-level policy; a resolved address that
+        // is the instance's own IP is rejected, while a different RFC 1918 address is returned.
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.123.45.67");
+        InetAddress ownAddr = InetAddress.getByName("10.123.45.67");
+        assertTrue(RestrictedHostFilter.firstAllowedRedisAddress("redis-host", new InetAddress[] {ownAddr})
+                .isEmpty());
+        InetAddress otherAddr = InetAddress.getByName("10.0.0.9");
+        assertTrue(RestrictedHostFilter.firstAllowedRedisAddress("redis-host", new InetAddress[] {otherAddr})
+                .isPresent());
+    }
+
+    @Test
+    public void ssrfFilterDisabled_bypassesOwnHostBlockOnAllEntryPoints() {
+        RestrictedHostFilter.setOwnHostsForTesting("own-host.invalid");
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.123.45.67");
+        // Sanity: blocked by default across every entry point.
+        assertTrue(RestrictedHostFilter.isHostBlocked("10.123.45.67"));
+        assertTrue(RestrictedHostFilter.isDisallowedAndFail("10.123.45.67", null));
+        assertTrue(RestrictedHostFilter.isLiteralBlocked("own-host.invalid"));
         // Kill-switch on — the own-host block is bypassed like every other check.
         RestrictedHostFilter.setSsrfFilterDisabledForTesting(true);
-        assertFalse(RestrictedHostFilter.isHostBlocked("1.1.1.1"));
-        assertFalse(RestrictedHostFilter.isHostBlocked("one.one.one.one"));
+        assertFalse(RestrictedHostFilter.isHostBlocked("10.123.45.67"));
+        assertFalse(RestrictedHostFilter.isHostBlocked("own-host.invalid"));
+        assertFalse(RestrictedHostFilter.isDisallowedAndFail("10.123.45.67", null));
+        assertFalse(RestrictedHostFilter.isLiteralBlocked("own-host.invalid"));
     }
 
     @Test

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
@@ -377,6 +377,34 @@ public class RestrictedHostFilterTest {
     }
 
     @Test
+    public void isDisallowedAndFail_ownIpCheckReadsCacheNotLiveDns() {
+        // Proves the resolver-hook hot path does NO DNS: the own hostname is unresolvable, yet an
+        // injected cached own IP is still blocked. If isDisallowedAndFail live-resolved ownHosts,
+        // the unresolvable name would yield no IPs and 10.123.45.67 would pass — so blocking it can
+        // only come from the cache. The check is pure set-membership, safe on the Netty EventLoop.
+        RestrictedHostFilter.setOwnHostsForTesting("unresolvable-own.invalid");
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.123.45.67");
+        assertTrue(RestrictedHostFilter.isDisallowedAndFail("10.123.45.67", null));
+        // Clearing the cache (without touching ownHosts) immediately stops blocking that IP — the
+        // decision is cache-driven, not re-derived from the hostname on each call.
+        RestrictedHostFilter.clearOwnResolvedIpsForTesting();
+        assertFalse(RestrictedHostFilter.isDisallowedAndFail("10.123.45.67", null));
+    }
+
+    @Test
+    public void registerOwnHost_recomputesOwnIpCacheOffHotPath() {
+        // registerOwnHost (the startup @PostConstruct path) recomputes the cached own-IP set from
+        // ownHosts. Seed a stale cached IP, then register an (unresolvable) own host: the refresh
+        // recomputes the cache from ownHosts — which resolves to nothing here — dropping the stale
+        // value. This is where own-hostname resolution happens, off the request hot path.
+        RestrictedHostFilter.setOwnResolvedIpsForTesting("10.1.1.1");
+        RestrictedHostFilter.registerOwnHost("registered-own.invalid");
+        assertFalse(RestrictedHostFilter.isDisallowedAndFail("10.1.1.1", null));
+        // The registered hostname is still blocked literally (no DNS needed).
+        assertTrue(RestrictedHostFilter.isDisallowedAndFail("registered-own.invalid", null));
+    }
+
+    @Test
     public void firstAllowedRedisAddress_blocksResolvedOwnIp() throws Exception {
         // The Redis connect-time path shares the same address-level policy; a resolved address that
         // is the instance's own IP is rejected, while a different RFC 1918 address is returned.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
@@ -81,14 +81,18 @@ public class RedisConfig {
 
     /**
      * Defense-in-depth: teach the SSRF host filter to block datasources that target the Appsmith
-     * instance's own routable address. That address is always an RFC 1918 / site-local IP (Docker
+     * instance's own routable address. That address is typically an RFC 1918 / site-local IP (Docker
      * bridge {@code 172.17.x}, k8s pod {@code 10.x}, etc.), which the filter otherwise intentionally
      * allows so legitimate customer datasources on private networks keep working — leaving the
      * instance reachable from its own datasource layer. Registering the instance's own hostname(s)
      * lets the filter resolve and block just its own address(es), via either the container hostname
-     * or the raw own IP, without blocking the rest of the private network. The filter also seeds
-     * these at static init; re-registering here keeps the set aligned with the running container.
-     * Runs once at startup, before any datasource can be tested.
+     * or the raw own IP, without blocking the rest of the private network.
+     *
+     * <p>Coverage is best-effort: only the address(es) the registered own hostname(s) resolve to are
+     * blocked, not a full network-interface enumeration. A multi-homed container's secondary-interface
+     * IPs are out of scope by design (hostname-scope decision). The filter also seeds these at static
+     * init; re-registering here keeps the set aligned with the running container. Runs once at startup,
+     * before any datasource can be tested.
      */
     @PostConstruct
     public void registerOwnHostWithSsrfFilter() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
@@ -46,7 +46,9 @@ import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.session.data.redis.config.annotation.web.server.EnableRedisWebSession;
 
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -75,6 +77,27 @@ public class RedisConfig {
     @PostConstruct
     public void registerInternalRedisHostsWithSsrfFilter() {
         RestrictedHostFilter.registerInternalRedisHosts(redisURL, redisGitURL);
+    }
+
+    /**
+     * Defense-in-depth: teach the SSRF host filter to block datasources that target the Appsmith
+     * instance's own routable address. That address is always an RFC 1918 / site-local IP (Docker
+     * bridge {@code 172.17.x}, k8s pod {@code 10.x}, etc.), which the filter otherwise intentionally
+     * allows so legitimate customer datasources on private networks keep working — leaving the
+     * instance reachable from its own datasource layer. Registering the instance's own hostname(s)
+     * lets the filter resolve and block just its own address(es), via either the container hostname
+     * or the raw own IP, without blocking the rest of the private network. The filter also seeds
+     * these at static init; re-registering here keeps the set aligned with the running container.
+     * Runs once at startup, before any datasource can be tested.
+     */
+    @PostConstruct
+    public void registerOwnHostWithSsrfFilter() {
+        try {
+            RestrictedHostFilter.registerOwnHost(InetAddress.getLocalHost().getHostName());
+        } catch (UnknownHostException e) {
+            log.debug("Could not resolve local hostname for SSRF own-host registration; relying on static seed.");
+        }
+        RestrictedHostFilter.registerOwnHost(System.getenv("HOSTNAME"));
     }
 
     /**


### PR DESCRIPTION
## What

Adds a defense-in-depth SSRF protection so a user-defined datasource cannot connect
to the Appsmith instance's own network address.

## Why

The SSRF host filter (`RestrictedHostFilter`) intentionally allows private-network
(RFC 1918 / site-local) addresses so that legitimate customer datasources on private
networks keep working. In a typical Docker/Kubernetes deployment the instance's own
routable address is itself a private/site-local address, so it falls inside that
allowed range. As a hardening measure, this change blocks that one target — the
instance's own address — without restricting the rest of the private network.

## How

- Registers the instance's own hostname(s) at startup (from the local hostname and the
  `HOSTNAME` environment variable) and resolves them to their current address(es),
  mirroring the existing internal-Redis host registration. Resolution is live per check,
  so an instance whose address changes stays covered with no cached-address bookkeeping.
- Blocks a datasource whose target is a registered own hostname, or resolves to one of
  the instance's own addresses. Enforced consistently across the datasource egress paths
  — WebClient (REST/GraphQL/SaaS), Elasticsearch, Redis, and datasource validation —
  evaluating the address already resolved by each path, so no additional lookup of the
  user-supplied host is introduced.
- Only the instance's own address(es) are affected; other private-network datasources
  continue to work unchanged.
- Coverage is best-effort for the address(es) the registered hostname(s) resolve to
  (the primary, hostname-mapped address), not a full network-interface enumeration.

## Testing

- Unit tests cover rejection of the own address through each enforcement entry point
  (raw IPv4 literal, IPv4-mapped IPv6, and hostname), confirm other private-network
  addresses stay allowed, and confirm the existing SSRF kill-switch still applies.
  Own-address resolution is injected in tests, so the suite has no external DNS
  dependency.
- `appsmith-interfaces` module tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened SSRF protection by blocking outbound requests that target the application’s own hostname or any resolved IP addresses associated with it.
  * Expanded detection to cover multiple address representations (including IPv4 literals and IPv4-mapped IPv6).
  * Added startup registration of the instance’s own hostname(s) and environment hostname with graceful fallback if resolution fails.
  * Preserved the existing allow/deny behavior for other private network targets and the SSRF bypass setting.
* **Tests**
  * Added deterministic test coverage for own-host blocking, caching behavior, and SSRF bypass across all relevant enforcement paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 1d3d64dc953d7fdf48e1959200396688e9335d35 yet
> <hr>Mon, 13 Jul 2026 19:13:41 UTC
<!-- end of auto-generated comment: Cypress test results  -->
