### PR TITLE
fix(server): prevent open redirect via forged Origin header on login

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
@@ -137,7 +137,7 @@ public class RedirectHelper {
 
         String trustedOrigin = getTrustedOrigin(httpHeaders);
         if (!(redirectUrl.startsWith("http://") || redirectUrl.startsWith("https://"))
-                && !StringUtils.isEmpty(trustedOrigin)) {
+                && StringUtils.hasText(trustedOrigin)) {
             redirectUrl = trustedOrigin + redirectUrl;
         }
 
@@ -200,7 +200,7 @@ public class RedirectHelper {
         }
 
         String origin = getTrustedOrigin(httpHeaders);
-        if (!StringUtils.isEmpty(origin)) {
+        if (StringUtils.hasText(origin)) {
             // Origin-present path: full host + port + scheme-aware port normalization.
             final URI originUri;
             try {
@@ -322,8 +322,13 @@ public class RedirectHelper {
         }
 
         String originHost = originUri.getHost();
-        if (originHost != null && originHost.equalsIgnoreCase(requestHost)) {
-            return origin;
+        if (originHost != null) {
+            if (originHost.startsWith("[") && originHost.endsWith("]")) {
+                originHost = originHost.substring(1, originHost.length() - 1);
+            }
+            if (originHost.equalsIgnoreCase(requestHost)) {
+                return origin;
+            }
         }
 
         log.warn(
@@ -438,7 +443,7 @@ public class RedirectHelper {
         }
         log.warn("Blocked open redirect attempt to: {}", sanitizeForLog(redirectUrl));
         String trustedOrigin = getTrustedOrigin(httpHeaders);
-        return (!StringUtils.isEmpty(trustedOrigin) ? trustedOrigin : "") + DEFAULT_REDIRECT_URL;
+        return (StringUtils.hasText(trustedOrigin) ? trustedOrigin : "") + DEFAULT_REDIRECT_URL;
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
@@ -292,7 +292,8 @@ public class RedirectHelper {
 
     /**
      * Returns the {@code Origin} header value only when it is trustworthy —
-     * i.e. its host matches the request's {@code X-Forwarded-Host} / {@code Host}.
+     * i.e. its host <em>and</em> effective port match the request's
+     * {@code X-Forwarded-Host} / {@code Host} (and {@code X-Forwarded-Port}).
      *
      * <p>If Origin is absent, returns {@code null}. If no request host is
      * available for cross-checking (neither {@code X-Forwarded-Host} nor
@@ -300,7 +301,8 @@ public class RedirectHelper {
      * behaviour for environments that do not set proxy headers.
      *
      * <p>This prevents open redirect attacks where an attacker forges the
-     * {@code Origin} header to an external domain (APP-15347).
+     * {@code Origin} header to an external domain or a different port on the
+     * same host (APP-15347).
      */
     static String getTrustedOrigin(HttpHeaders httpHeaders) {
         String origin = httpHeaders.getOrigin();
@@ -322,20 +324,40 @@ public class RedirectHelper {
         }
 
         String originHost = originUri.getHost();
-        if (originHost != null) {
-            if (originHost.startsWith("[") && originHost.endsWith("]")) {
-                originHost = originHost.substring(1, originHost.length() - 1);
-            }
-            if (originHost.equalsIgnoreCase(requestHost)) {
-                return origin;
+        if (originHost == null) {
+            log.warn(
+                    "Origin header '{}' does not match request host '{}'; treating as untrusted",
+                    sanitizeForLog(origin),
+                    requestHost);
+            return null;
+        }
+
+        if (originHost.startsWith("[") && originHost.endsWith("]")) {
+            originHost = originHost.substring(1, originHost.length() - 1);
+        }
+        if (!originHost.equalsIgnoreCase(requestHost)) {
+            log.warn(
+                    "Origin header '{}' does not match request host '{}'; treating as untrusted",
+                    sanitizeForLog(origin),
+                    requestHost);
+            return null;
+        }
+
+        int originPort = originUri.getPort();
+        int requestPort = extractRequestPort(httpHeaders);
+        if (originPort != -1 || requestPort != -1) {
+            int normalizedOriginPort = normalizePort(originUri.getScheme(), originPort);
+            int normalizedRequestPort = normalizePort(originUri.getScheme(), requestPort);
+            if (normalizedOriginPort != normalizedRequestPort) {
+                log.warn(
+                        "Origin port {} does not match request port {}; treating as untrusted",
+                        normalizedOriginPort,
+                        normalizedRequestPort);
+                return null;
             }
         }
 
-        log.warn(
-                "Origin header '{}' does not match request host '{}'; treating as untrusted",
-                sanitizeForLog(origin),
-                requestHost);
-        return null;
+        return origin;
     }
 
     private static String stripPort(String hostMaybeWithPort) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
@@ -63,7 +63,7 @@ public class RedirectHelper {
 
         } else if (queryParams.getFirst(FORK_APP_ID_QUERY_PARAM) != null) {
             final String forkAppId = queryParams.getFirst(FORK_APP_ID_QUERY_PARAM);
-            final String origin = httpHeaders.getOrigin();
+            final String origin = getTrustedOrigin(httpHeaders);
             if (origin == null) {
                 return Mono.just(DEFAULT_REDIRECT_URL);
             }
@@ -71,8 +71,6 @@ public class RedirectHelper {
             return applicationRepository
                     .findByClonedFromApplicationId(forkAppId, applicationPermission.getReadPermission())
                     .map(application -> {
-                        // Get the default page in the application, or if there's no default page, get the first page
-                        // in the application and redirect to edit that page.
                         String pageId = null;
                         for (final ApplicationPage page : application.getPages()) {
                             if (pageId == null || page.isDefault()) {
@@ -87,12 +85,7 @@ public class RedirectHelper {
                             return defaultRedirectUrl;
                         }
 
-                        return httpHeaders.getOrigin()
-                                + "/applications/"
-                                + application.getId()
-                                + "/pages/"
-                                + pageId
-                                + "/edit";
+                        return origin + "/applications/" + application.getId() + "/pages/" + pageId + "/edit";
                     })
                     .defaultIfEmpty(defaultRedirectUrl)
                     .last();
@@ -142,9 +135,10 @@ public class RedirectHelper {
             redirectUrl = DEFAULT_REDIRECT_URL;
         }
 
+        String trustedOrigin = getTrustedOrigin(httpHeaders);
         if (!(redirectUrl.startsWith("http://") || redirectUrl.startsWith("https://"))
-                && !StringUtils.isEmpty(httpHeaders.getOrigin())) {
-            redirectUrl = httpHeaders.getOrigin() + redirectUrl;
+                && !StringUtils.isEmpty(trustedOrigin)) {
+            redirectUrl = trustedOrigin + redirectUrl;
         }
 
         // Validate that absolute redirect URLs point to the same origin as the request.
@@ -205,7 +199,7 @@ public class RedirectHelper {
             return false;
         }
 
-        String origin = httpHeaders.getOrigin();
+        String origin = getTrustedOrigin(httpHeaders);
         if (!StringUtils.isEmpty(origin)) {
             // Origin-present path: full host + port + scheme-aware port normalization.
             final URI originUri;
@@ -293,6 +287,49 @@ public class RedirectHelper {
                 && !hostAddr.getHostString().isBlank()) {
             return hostAddr.getHostString();
         }
+        return null;
+    }
+
+    /**
+     * Returns the {@code Origin} header value only when it is trustworthy —
+     * i.e. its host matches the request's {@code X-Forwarded-Host} / {@code Host}.
+     *
+     * <p>If Origin is absent, returns {@code null}. If no request host is
+     * available for cross-checking (neither {@code X-Forwarded-Host} nor
+     * {@code Host} is set), Origin is returned as-is to preserve existing
+     * behaviour for environments that do not set proxy headers.
+     *
+     * <p>This prevents open redirect attacks where an attacker forges the
+     * {@code Origin} header to an external domain (APP-15347).
+     */
+    static String getTrustedOrigin(HttpHeaders httpHeaders) {
+        String origin = httpHeaders.getOrigin();
+        if (!StringUtils.hasText(origin)) {
+            return null;
+        }
+
+        String requestHost = extractRequestHost(httpHeaders);
+        if (requestHost == null) {
+            return origin;
+        }
+
+        final URI originUri;
+        try {
+            originUri = new URI(origin);
+        } catch (URISyntaxException e) {
+            log.warn("Failed to parse Origin header: {}", sanitizeForLog(origin));
+            return null;
+        }
+
+        String originHost = originUri.getHost();
+        if (originHost != null && originHost.equalsIgnoreCase(requestHost)) {
+            return origin;
+        }
+
+        log.warn(
+                "Origin header '{}' does not match request host '{}'; treating as untrusted",
+                sanitizeForLog(origin),
+                requestHost);
         return null;
     }
 
@@ -400,8 +437,8 @@ public class RedirectHelper {
             return redirectUrl;
         }
         log.warn("Blocked open redirect attempt to: {}", sanitizeForLog(redirectUrl));
-        String origin = httpHeaders.getOrigin();
-        return (!StringUtils.isEmpty(origin) ? origin : "") + DEFAULT_REDIRECT_URL;
+        String trustedOrigin = getTrustedOrigin(httpHeaders);
+        return (!StringUtils.isEmpty(trustedOrigin) ? trustedOrigin : "") + DEFAULT_REDIRECT_URL;
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/RedirectHelperOpenRedirectTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/RedirectHelperOpenRedirectTest.java
@@ -500,4 +500,23 @@ class RedirectHelperOpenRedirectTest {
         String result = RedirectHelper.sanitizeRedirectUrl(" https://evil.com", headers);
         assertEquals("https://app.appsmith.com/applications", result);
     }
+
+    // --- Forged Origin header (APP-15347) ---
+
+    @Test
+    void testForgedOriginHeaderIsBlockedWhenHostDiffers() {
+        // Pentest finding: attacker sets Origin: https://evil.com on a form login POST.
+        // isSafeRedirectUrl must cross-check Origin against Host/X-Forwarded-Host
+        // and reject when they disagree.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("https://evil.com");
+        headers.setHost(InetSocketAddress.createUnresolved("app.appsmith.com", 0));
+
+        assertFalse(
+                RedirectHelper.isSafeRedirectUrl("https://evil.com/applications", headers),
+                "Redirect matching a forged Origin must be rejected when it differs from the request Host");
+
+        String sanitized = RedirectHelper.sanitizeRedirectUrl("https://evil.com/applications", headers);
+        assertFalse(sanitized.contains("evil.com"), "Sanitized fallback URL must not contain the forged Origin domain");
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/RedirectHelperOpenRedirectTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/RedirectHelperOpenRedirectTest.java
@@ -519,4 +519,14 @@ class RedirectHelperOpenRedirectTest {
         String sanitized = RedirectHelper.sanitizeRedirectUrl("https://evil.com/applications", headers);
         assertFalse(sanitized.contains("evil.com"), "Sanitized fallback URL must not contain the forged Origin domain");
     }
+
+    @Test
+    void testIPv6OriginMatchesRequestHost() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("http://[::1]:8080");
+        headers.set("X-Forwarded-Host", "[::1]:8080");
+        assertTrue(
+                RedirectHelper.isSafeRedirectUrl("http://[::1]:8080/applications", headers),
+                "IPv6 Origin matching X-Forwarded-Host must be accepted");
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/RedirectHelperOpenRedirectTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/RedirectHelperOpenRedirectTest.java
@@ -502,12 +502,16 @@ class RedirectHelperOpenRedirectTest {
     }
 
     // --- Forged Origin header (APP-15347) ---
+    // These tests verify that the Origin header is cross-checked against the
+    // request Host / X-Forwarded-Host before it is used to build or validate
+    // redirect URLs. They exercise isSafeRedirectUrl (validation gate) and
+    // sanitizeRedirectUrl (fallback construction) end-to-end.
 
     @Test
     void testForgedOriginHeaderIsBlockedWhenHostDiffers() {
-        // Pentest finding: attacker sets Origin: https://evil.com on a form login POST.
-        // isSafeRedirectUrl must cross-check Origin against Host/X-Forwarded-Host
-        // and reject when they disagree.
+        // Core pentest finding: attacker sets Origin: https://evil.com on a
+        // form login POST while the real Host is app.appsmith.com. Both the
+        // validation and the fallback must reject the forged domain.
         HttpHeaders headers = new HttpHeaders();
         headers.setOrigin("https://evil.com");
         headers.setHost(InetSocketAddress.createUnresolved("app.appsmith.com", 0));
@@ -521,12 +525,106 @@ class RedirectHelperOpenRedirectTest {
     }
 
     @Test
+    void testForgedOriginViaXForwardedHost() {
+        // Attacker controls both Origin and X-Forwarded-Host but not the
+        // underlying Host header. X-Forwarded-Host takes precedence in
+        // extractRequestHost, so when forged it becomes the trust anchor.
+        // At the helper level this cannot be distinguished from a legitimate
+        // proxy value — the real defence is ForwardedHeaderTransformer stripping
+        // client-supplied forwarded headers before they reach the handler.
+        // This test documents the helper's behaviour: it trusts whichever
+        // X-Forwarded-Host it receives.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("https://evil.com");
+        headers.set("X-Forwarded-Host", "evil.com");
+        headers.setHost(InetSocketAddress.createUnresolved("app.appsmith.com", 0));
+
+        // X-Forwarded-Host wins over Host, so Origin matches it — accepted at
+        // the helper level (runtime protection is ForwardedHeaderTransformer).
+        assertTrue(
+                RedirectHelper.isSafeRedirectUrl("https://evil.com/applications", headers),
+                "X-Forwarded-Host takes precedence; helper trusts it (ForwardedHeaderTransformer is the real guard)");
+    }
+
+    @Test
+    void testLegitimateOriginMatchesXForwardedHostNotHost() {
+        // Standard reverse-proxy setup: X-Forwarded-Host carries the public
+        // hostname while Host carries the internal LB address. Origin matches
+        // the public hostname and must be accepted.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("https://app.appsmith.com");
+        headers.set("X-Forwarded-Host", "app.appsmith.com");
+        headers.setHost(InetSocketAddress.createUnresolved("internal.lb", 0));
+
+        assertTrue(
+                RedirectHelper.isSafeRedirectUrl("https://app.appsmith.com/applications", headers),
+                "Origin matching X-Forwarded-Host must be accepted even when Host differs (proxy setup)");
+    }
+
+    @Test
+    void testSameHostDifferentPortOriginIsRejected() {
+        // Attacker forges Origin to a different port on the same IPv4 host.
+        // A different port means a different service — must be rejected.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("http://localhost:9090");
+        headers.setHost(InetSocketAddress.createUnresolved("localhost", 8080));
+
+        assertFalse(
+                RedirectHelper.isSafeRedirectUrl("http://localhost:9090/applications", headers),
+                "Same host but different port must be rejected — different port means different service");
+
+        String sanitized = RedirectHelper.sanitizeRedirectUrl("http://localhost:9090/applications", headers);
+        assertFalse(sanitized.contains("9090"), "Sanitized fallback must not redirect to the forged port");
+    }
+
+    @Test
+    void testSameHostDifferentPortIPv6OriginIsRejected() {
+        // Same-host different-port attack on IPv6 — exercises bracket stripping
+        // in getTrustedOrigin plus port comparison.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("http://[::1]:9090");
+        headers.set("X-Forwarded-Host", "[::1]:8080");
+
+        assertFalse(
+                RedirectHelper.isSafeRedirectUrl("http://[::1]:9090/applications", headers),
+                "IPv6 same host but different port must be rejected");
+    }
+
+    @Test
     void testIPv6OriginMatchesRequestHost() {
+        // Positive case: IPv6 Origin with matching X-Forwarded-Host (same host
+        // and port) must be accepted. Exercises bracket stripping.
         HttpHeaders headers = new HttpHeaders();
         headers.setOrigin("http://[::1]:8080");
         headers.set("X-Forwarded-Host", "[::1]:8080");
+
         assertTrue(
                 RedirectHelper.isSafeRedirectUrl("http://[::1]:8080/applications", headers),
-                "IPv6 Origin matching X-Forwarded-Host must be accepted");
+                "IPv6 Origin matching X-Forwarded-Host (host + port) must be accepted");
+    }
+
+    @Test
+    void testSameHostMatchingPortOriginIsAccepted() {
+        // Positive case: Origin and Host agree on both hostname and port.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("http://localhost:8080");
+        headers.setHost(InetSocketAddress.createUnresolved("localhost", 8080));
+
+        assertTrue(
+                RedirectHelper.isSafeRedirectUrl("http://localhost:8080/applications", headers),
+                "Origin matching Host on both hostname and port must be accepted");
+    }
+
+    @Test
+    void testImplicitPortsAreAccepted() {
+        // Both Origin and Host omit port (implicit defaults) — common in
+        // production. Must be accepted without false rejection.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin("https://app.appsmith.com");
+        headers.setHost(InetSocketAddress.createUnresolved("app.appsmith.com", 0));
+
+        assertTrue(
+                RedirectHelper.isSafeRedirectUrl("https://app.appsmith.com/applications", headers),
+                "Implicit default ports on both sides must match");
     }
 }


### PR DESCRIPTION
## Summary

Fixes an open redirect vulnerability (APP-15347) where an attacker could forge the `Origin` HTTP header on `POST /api/v1/login` to redirect authenticated users to an external domain.

**Root cause:** `isSafeRedirectUrl()` used the client-supplied `Origin` header as both the redirect URL builder and the trust anchor. A forged `Origin: https://evil.com` passed validation because the redirect host trivially matched the Origin host (`evil.com == evil.com`).

**Fix:** Introduces `getTrustedOrigin()` which cross-checks the `Origin` header against the request's `Host` / `X-Forwarded-Host` (set by the reverse proxy, not the client). All four call sites that previously read Origin directly now use this helper:

- `isSafeRedirectUrl()` — no longer uses forged Origin as the validation baseline
- `fulfillRedirectUrl()` — no longer prepends forged Origin to relative redirect paths
- `sanitizeRedirectUrl()` — no longer uses forged Origin in the fallback URL
- `getRedirectUrl()` (fork-app path) — no longer uses forged Origin for URL construction

When no `Host` / `X-Forwarded-Host` is available (unusual environments without proxy headers), Origin is still trusted to preserve backward compatibility.

## Test plan

- [x] Added unit test `testForgedOriginHeaderIsBlockedWhenHostDiffers` — confirms forged Origin is rejected and sanitized URL does not contain the attacker domain
- [x] All 69 existing `RedirectHelperOpenRedirectTest` tests pass (0 failures, 0 errors)

## Linear ticket

https://linear.app/appsmith/issue/APP-15347/security-low-open-redirect-via-improper-validation-of-origin-header-on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened open-redirect protection by only trusting the `Origin` header when it matches the inbound request host (including effective port), derived from `X-Forwarded-Host`/`Host` (and forwarded port when present).
  * Updated redirect validation and fallback URL generation to prevent forged origin values from being used or leaked.

* **Tests**
  * Added open-redirect regression coverage for forged `Origin` handling, proxy-style `X-Forwarded-Host` behavior, and IPv4/IPv6 same-host different-port edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29393469419>
> Commit: fea4a4aa6f6eba5d1f3a5d88173b5db49f8b3bbb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29393469419&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 15 Jul 2026 07:24:36 UTC
<!-- end of auto-generated comment: Cypress test results  -->
