### PR TITLE
fix(security): return uniform responses on pre-auth email endpoints and remove unused routes

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -218,8 +218,6 @@ public class SecurityConfig {
                                 ServerWebExchangeMatchers.pathMatchers(
                                         HttpMethod.GET, USER_URL + "/verifyPasswordResetToken"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/resetPassword"),
-                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/invite/verify"),
-                                ServerWebExchangeMatchers.pathMatchers(HttpMethod.PUT, USER_URL + "/invite/confirm"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, USER_URL + "/me"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ASSET_URL + "/*"),
                                 ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, ACTION_URL + "/**"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/RateLimitConstants.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/RateLimitConstants.java
@@ -5,4 +5,7 @@ public class RateLimitConstants {
             "Your account is suspended for 24 hours. Please reset your password to continue";
     public static final String BUCKET_KEY_FOR_LOGIN_API = "login";
     public static final String BUCKET_KEY_FOR_TEST_DATASOURCE_API = "test_datasource_or_execute_query";
+
+    // Per-email throttle for the unauthenticated resend-email-verification endpoint (anti-abuse).
+    public static final String BUCKET_KEY_FOR_RESEND_EMAIL_VERIFICATION_API = "resend_email_verification";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/ratelimiting/RateLimitConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/ratelimiting/RateLimitConfig.java
@@ -38,6 +38,10 @@ public class RateLimitConfig {
         apiConfigurationMap.put(
                 RateLimitConstants.BUCKET_KEY_FOR_TEST_DATASOURCE_API,
                 createBucketConfiguration(Duration.ofSeconds(5), 3));
+        // Per-email cap for resend-email-verification: at most 5 requests per email per rolling 24h window.
+        apiConfigurationMap.put(
+                RateLimitConstants.BUCKET_KEY_FOR_RESEND_EMAIL_VERIFICATION_API,
+                createBucketConfiguration(Duration.ofDays(1), 5));
         // Add more API configurations as needed
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -225,8 +225,12 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                             .findByEmailAndOrganizationId(email, organizationId)
                             .switchIfEmpty(repository.findFirstByEmailIgnoreCaseAndOrganizationIdOrderByCreatedAtDesc(
                                     email, organizationId))
-                            .switchIfEmpty(Mono.error(
-                                    new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.USER, email)))
+                            // Anti-enumeration (CWE-204, GHSA-fvrq-g89c-fgg6): do not surface a distinct
+                            // NO_RESOURCE_FOUND (HTTP 404) for an unknown email. When no user matches, this inner
+                            // Mono simply stays empty; the token save and email dispatch below are skipped and
+                            // thenReturn(true) still emits the same generic success (HTTP 200, {"data": true}) that
+                            // the valid path returns. This makes the response for an unknown email indistinguishable
+                            // from a known one, so an unauthenticated caller cannot enumerate registered accounts.
                             .flatMap(user -> {
                                 // an user found with the provided email address
                                 // Generate the password reset link for the user
@@ -240,11 +244,22 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                                             passwordResetToken.setFirstRequestTime(Instant.now());
                                             return Mono.just(passwordResetToken);
                                         }))
-                                        .map(resetToken -> {
-                                            // check the validity of the token
-                                            validateResetLimit(resetToken);
+                                        .flatMap(resetToken -> {
+                                            // Track this request and check the per-account reset limit.
+                                            // Anti-enumeration (CWE-204, GHSA-fvrq-g89c-fgg6): when a known
+                                            // account is over its limit we must NOT surface a distinct 429 —
+                                            // that would tell an unauthenticated caller the account exists.
+                                            // Instead we complete the chain empty (skipping the token save and
+                                            // email dispatch below) so thenReturn(true) emits the same generic
+                                            // success returned for the unknown-user and under-limit cases.
+                                            // Anti-spam: over the limit we deliberately do not issue a fresh
+                                            // reset link or send another email; the request count is still
+                                            // tracked so the limit keeps functioning.
+                                            if (!isWithinResetLimit(resetToken)) {
+                                                return Mono.empty();
+                                            }
                                             resetToken.setTokenHash(passwordEncoder.encode(token));
-                                            return resetToken;
+                                            return Mono.just(resetToken);
                                         });
                             });
                 })
@@ -269,28 +284,40 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
     }
 
     /**
-     * This method checks whether the reset request limit has been exceeded.
-     * If the limit has been exceeded, it raises an Exception.
-     * Otherwise, it'll update the counter and date in the resetToken object
+     * Tracks a password-reset request against the per-account limit (max 3 per rolling 24h window)
+     * and reports whether the caller is still within that limit.
+     * <p>
+     * When under the limit the counter is incremented (and the window start stamped on the first
+     * request); when the 24h window has elapsed the counter is reset and the request is allowed.
+     * When the limit is exceeded within the window this returns {@code false} without mutating the
+     * counter, so the limit keeps functioning across subsequent requests.
+     * <p>
+     * This intentionally no longer throws {@link AppsmithError#TOO_MANY_REQUESTS}: on the
+     * unauthenticated forgot-password endpoint a distinct 429 would reveal that the account exists
+     * (CWE-204). Callers treat {@code false} as "complete with the generic success response and send
+     * no email" rather than surfacing a distinguishable error.
      *
      * @param resetToken {@link PasswordResetToken}
+     * @return {@code true} if the request is within the limit and a reset email may be sent;
+     *     {@code false} if the account is over its limit and no email should be sent
      */
-    private void validateResetLimit(PasswordResetToken resetToken) {
+    private boolean isWithinResetLimit(PasswordResetToken resetToken) {
         if (resetToken.getRequestCount() >= 3) {
             Duration duration = Duration.between(resetToken.getFirstRequestTime(), Instant.now());
             long l = duration.toHours();
-            if (l >= 24) { // ok, reset the counter
+            if (l >= 24) { // window elapsed: reset the counter and allow the request
                 resetToken.setRequestCount(1);
                 resetToken.setFirstRequestTime(Instant.now());
-            } else { // too many requests, raise an exception
-                throw new AppsmithException(AppsmithError.TOO_MANY_REQUESTS);
+                return true;
             }
-        } else {
-            resetToken.setRequestCount(resetToken.getRequestCount() + 1);
-            if (resetToken.getFirstRequestTime() == null) {
-                resetToken.setFirstRequestTime(Instant.now());
-            }
+            // too many requests within the window: over the limit
+            return false;
         }
+        resetToken.setRequestCount(resetToken.getRequestCount() + 1);
+        if (resetToken.getFirstRequestTime() == null) {
+            resetToken.setFirstRequestTime(Instant.now());
+        }
+        return true;
     }
 
     private Boolean isEmailVerificationTokenValid(EmailVerificationToken emailVerificationToken) {
@@ -878,16 +905,21 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                                 email, organizationId)))
                 .cache();
 
-        return userMono.switchIfEmpty(
-                        Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.USER, email)))
-                .flatMap(user -> {
+        // Verification-email dispatch chain. Anti-enumeration (CWE-204): the unknown-email,
+        // already-verified and verification-not-enabled branches all complete empty instead of throwing a
+        // distinct error (previously 404 / 400), so the thenReturn(true) at the end emits the same generic
+        // success (HTTP 200, {"data": true}) for every case and no email is dispatched. An unauthenticated
+        // caller therefore cannot tell whether the address is registered, already verified, or whether
+        // verification is enabled at the instance level.
+        Mono<Boolean> dispatchMono = userMono.flatMap(user -> {
                     if (TRUE.equals(user.getEmailVerified())) {
-                        return Mono.error(new AppsmithException(AppsmithError.USER_ALREADY_VERIFIED));
+                        // Already verified: send no email, but keep the response indistinguishable.
+                        return Mono.<EmailVerificationToken>empty();
                     }
                     return instanceVariablesHelper.isEmailVerificationEnabled().flatMap(emailVerificationEnabled -> {
-                        // Email verification not enabled at instance level
+                        // Email verification not enabled at instance level: send no email, response unchanged.
                         if (!TRUE.equals(emailVerificationEnabled)) {
-                            return Mono.error(new AppsmithException(AppsmithError.EMAIL_VERIFICATION_NOT_ENABLED));
+                            return Mono.<EmailVerificationToken>empty();
                         }
                         return emailVerificationTokenRepository
                                 .findByEmail(user.getEmail())
@@ -936,6 +968,22 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                             user, verificationUrl, resendEmailVerificationDTO.getBaseUrl());
                 })
                 .thenReturn(true);
+
+        // Per-email rate limit (anti-abuse). Applied uniformly on the submitted address so behaviour does
+        // not vary by account existence. Over the limit we skip dispatch and still return the same generic
+        // success — surfacing a distinct 429 here would re-introduce an enumeration oracle on this
+        // unauthenticated endpoint.
+        return rateLimitService
+                .tryIncreaseCounter(
+                        RateLimitConstants.BUCKET_KEY_FOR_RESEND_EMAIL_VERIFICATION_API, email.toLowerCase())
+                .flatMap(withinLimit -> TRUE.equals(withinLimit) ? dispatchMono : Mono.just(true))
+                // Fail open: if the limiter itself errors (e.g. Redis is unreachable), do not block a
+                // legitimate verification email. This runs the same dispatch path regardless of account
+                // state, so it does not reintroduce an enumeration oracle.
+                .onErrorResume(error -> {
+                    log.error("Resend email verification rate limiter errored; failing open.", error);
+                    return dispatchMono;
+                });
     }
 
     private String getEmailVerificationErrorRedirectUrl(AppsmithError appsmithError, String userEmail, Object... args) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerForgotPasswordTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerForgotPasswordTest.java
@@ -1,0 +1,106 @@
+package com.appsmith.server.controllers;
+
+import com.appsmith.server.configurations.RedisTestContainerConfig;
+import com.appsmith.server.configurations.SecurityTestConfig;
+import com.appsmith.server.helpers.RedisUtils;
+import com.appsmith.server.services.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Controller-level anti-enumeration guard (CWE-204, GHSA-fvrq-g89c-fgg6) for the unauthenticated
+ * {@code POST /api/v1/users/forgotPassword} endpoint.
+ *
+ * <p>The property under test is indistinguishability: the HTTP response (status line AND body) must be
+ * identical whether the email is a known account under its reset limit, a known account over its limit, or
+ * an unknown address. The full end-to-end rate-limit behaviour (counter accumulation, over-limit, window
+ * reset) is covered at the service layer by {@code UserServiceTest}; here the service is mocked so the
+ * controller's own response contract is what is pinned. Post-fix the service yields the same generic
+ * success ({@code true}) for all three cases, so all three must produce byte-identical HTTP responses. A
+ * regression that let any case surface a distinct error (e.g. a 404 or 429 from a thrown exception) would
+ * change that case's status and body and fail this test.
+ *
+ * <p>Note on the body: this endpoint is annotated {@code @JsonView(Views.Public.class)} and returns a bare
+ * {@code Boolean}; under the application's view-based serialization the success body is empty (the client
+ * only depends on the 200 status). This test therefore asserts the full response is identical across cases
+ * rather than pinning a particular JSON envelope — identical status + body is the anti-enumeration bar.
+ */
+@SpringBootTest
+@AutoConfigureWebTestClient
+@Import({SecurityTestConfig.class, RedisUtils.class, RedisTestContainerConfig.class})
+public class UserControllerForgotPasswordTest {
+
+    @MockBean
+    UserService userService;
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    private EntityExchangeResult<byte[]> forgotPassword(String email) {
+        return webTestClient
+                .post()
+                .uri("/api/v1/users/forgotPassword")
+                .header(HttpHeaders.ORIGIN, "https://my-instance.example.com")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue("{\"email\":\"" + email + "\"}"))
+                .exchange()
+                .expectBody()
+                .returnResult();
+    }
+
+    @Test
+    public void forgotPassword_returnsIdenticalResponse_forKnownUnderLimit_knownOverLimit_andUnknown() {
+        // Post-fix the service yields the same generic success for every one of these cases; an over-limit
+        // or unknown email no longer surfaces a distinct error (404 / 429) to the controller.
+        Mockito.when(userService.forgotPasswordTokenGenerate(any())).thenReturn(Mono.just(true));
+
+        EntityExchangeResult<byte[]> knownUnderLimit = forgotPassword("api_user");
+        EntityExchangeResult<byte[]> knownOverLimit = forgotPassword("api_user");
+        EntityExchangeResult<byte[]> unknown = forgotPassword("nobody-does-not-exist@example.com");
+
+        // All three succeed with HTTP 200 ...
+        assertEquals(HttpStatus.OK, knownUnderLimit.getStatus());
+        assertEquals(HttpStatus.OK, knownOverLimit.getStatus());
+        assertEquals(HttpStatus.OK, unknown.getStatus());
+
+        // ... and their bodies are byte-identical, so the caller cannot tell the cases apart.
+        byte[] under = normalize(knownUnderLimit.getResponseBody());
+        assertArrayEquals(under, normalize(knownOverLimit.getResponseBody()));
+        assertArrayEquals(under, normalize(unknown.getResponseBody()));
+    }
+
+    @Test
+    public void forgotPassword_emptyServiceCompletion_returnsSameSuccessResponse() {
+        // Base-URL-unresolved path (Root Cause 1): the service completes empty; the controller's
+        // defaultIfEmpty(true) must still produce the same HTTP 200 success as the value-emitting path.
+        Mockito.when(userService.forgotPasswordTokenGenerate(any())).thenReturn(Mono.just(true));
+        EntityExchangeResult<byte[]> emitted = forgotPassword("api_user");
+
+        Mockito.when(userService.forgotPasswordTokenGenerate(any())).thenReturn(Mono.empty());
+        EntityExchangeResult<byte[]> empty = forgotPassword("api_user");
+
+        assertEquals(HttpStatus.OK, emitted.getStatus());
+        assertEquals(HttpStatus.OK, empty.getStatus());
+        assertArrayEquals(normalize(emitted.getResponseBody()), normalize(empty.getResponseBody()));
+    }
+
+    private static byte[] normalize(byte[] body) {
+        return body == null ? new byte[0] : body;
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerResendEmailVerificationTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerResendEmailVerificationTest.java
@@ -83,6 +83,24 @@ public class UserControllerResendEmailVerificationTest {
         assertArrayEquals(baseline, normalize(unknown.getResponseBody()));
     }
 
+    @Test
+    public void resendEmailVerification_emptyServiceCompletion_returnsSameSuccessResponse() {
+        // Guards the controller's empty-completion handling: the service completes empty when the flow is
+        // short-circuited (e.g. the secure base URL is unresolved). The controller chains
+        // .thenReturn(ResponseDTO) on the service Mono, and thenReturn emits its value on an empty upstream
+        // completion just as it does on a value-emitting one, so an empty completion must produce the exact
+        // same HTTP 200 response as the value-emitting path — not an empty body that would be observable.
+        Mockito.when(userService.resendEmailVerification(any(), any())).thenReturn(Mono.just(true));
+        EntityExchangeResult<byte[]> emitted = resend("unverified@example.com");
+
+        Mockito.when(userService.resendEmailVerification(any(), any())).thenReturn(Mono.empty());
+        EntityExchangeResult<byte[]> empty = resend("unverified@example.com");
+
+        assertEquals(HttpStatus.OK, emitted.getStatus());
+        assertEquals(HttpStatus.OK, empty.getStatus());
+        assertArrayEquals(normalize(emitted.getResponseBody()), normalize(empty.getResponseBody()));
+    }
+
     private static byte[] normalize(byte[] body) {
         return body == null ? new byte[0] : body;
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerResendEmailVerificationTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerResendEmailVerificationTest.java
@@ -1,0 +1,89 @@
+package com.appsmith.server.controllers;
+
+import com.appsmith.server.configurations.RedisTestContainerConfig;
+import com.appsmith.server.configurations.SecurityTestConfig;
+import com.appsmith.server.helpers.RedisUtils;
+import com.appsmith.server.services.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Controller-level anti-enumeration guard (CWE-204) for the unauthenticated
+ * {@code POST /api/v1/users/resendEmailVerification} endpoint.
+ *
+ * <p>The property under test is indistinguishability: the HTTP response (status line AND body) must be
+ * identical whether the email is a known unverified account, a known already-verified account, or an
+ * unknown address. Before the fix these produced HTTP 200 vs 400 (USER_ALREADY_VERIFIED) vs 404
+ * (NO_RESOURCE_FOUND) respectively, leaking both account existence and verified-state. The service layer
+ * now yields the same generic success ({@code true}) for all of them (see {@code UserServiceTest}), so with
+ * the service mocked here the controller must produce byte-identical HTTP responses. A regression that let
+ * any case surface a distinct error would change that case's status and body and fail this test.
+ *
+ * <p>Note on the body: this endpoint is annotated {@code @JsonView(Views.Public.class)} and returns a bare
+ * {@code Boolean}; under the application's view-based serialization the success body is empty (the client
+ * only depends on the 200 status). This test therefore asserts the full response is identical across cases.
+ */
+@SpringBootTest
+@AutoConfigureWebTestClient
+@Import({SecurityTestConfig.class, RedisUtils.class, RedisTestContainerConfig.class})
+public class UserControllerResendEmailVerificationTest {
+
+    @MockBean
+    UserService userService;
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    private EntityExchangeResult<byte[]> resend(String email) {
+        return webTestClient
+                .post()
+                .uri("/api/v1/users/resendEmailVerification")
+                .header(HttpHeaders.ORIGIN, "https://my-instance.example.com")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue("{\"email\":\"" + email + "\"}"))
+                .exchange()
+                .expectBody()
+                .returnResult();
+    }
+
+    @Test
+    public void resendEmailVerification_returnsIdenticalResponse_forKnownUnverified_knownVerified_andUnknown() {
+        // Post-fix the service yields the same generic success for every one of these cases; a verified
+        // or unknown email no longer surfaces a distinct error (400 / 404) to the controller.
+        Mockito.when(userService.resendEmailVerification(any(), any())).thenReturn(Mono.just(true));
+
+        EntityExchangeResult<byte[]> knownUnverified = resend("unverified@example.com");
+        EntityExchangeResult<byte[]> knownVerified = resend("verified@example.com");
+        EntityExchangeResult<byte[]> unknown = resend("nobody-does-not-exist@example.com");
+
+        // All three succeed with HTTP 200 ...
+        assertEquals(HttpStatus.OK, knownUnverified.getStatus());
+        assertEquals(HttpStatus.OK, knownVerified.getStatus());
+        assertEquals(HttpStatus.OK, unknown.getStatus());
+
+        // ... and their bodies are byte-identical, so the caller cannot tell the cases apart.
+        byte[] baseline = normalize(knownUnverified.getResponseBody());
+        assertArrayEquals(baseline, normalize(knownVerified.getResponseBody()));
+        assertArrayEquals(baseline, normalize(unknown.getResponseBody()));
+    }
+
+    private static byte[] normalize(byte[] body) {
+        return body == null ? new byte[0] : body;
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceResendEmailVerificationRateLimitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceResendEmailVerificationRateLimitTest.java
@@ -1,0 +1,106 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.configurations.RedisTestContainerConfig;
+import com.appsmith.server.domains.Organization;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.ResendEmailVerificationDTO;
+import com.appsmith.server.helpers.RedisUtils;
+import com.appsmith.server.instanceconfigs.helpers.InstanceVariablesHelper;
+import com.appsmith.server.repositories.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithUserDetails;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+import static com.appsmith.server.constants.Appsmith.DEFAULT_ORIGIN_HEADER;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Exercises the in-service per-email throttle on {@code resendEmailVerification} against a real Redis
+ * (testcontainer) bucket4j bucket, complementing the mocked-limiter unit coverage in {@code UserServiceTest}.
+ *
+ * <p>Pins two properties:
+ * <ol>
+ *   <li>The throttle triggers: after the configured per-email cap (5 / 24h) is reached, further resend
+ *       requests for that address stop dispatching verification emails.</li>
+ *   <li>The throttle is silent (anti-enumeration, CWE-204): an over-limit request returns the exact same
+ *       generic success ({@code true}) as an under-limit one, so an unauthenticated caller cannot observe
+ *       that the limit was hit — no distinguishable 429 is surfaced.</li>
+ * </ol>
+ */
+@Slf4j
+@SpringBootTest
+@Import({RedisTestContainerConfig.class, RedisUtils.class})
+public class UserServiceResendEmailVerificationRateLimitTest {
+
+    // Must match RateLimitConfig registration for BUCKET_KEY_FOR_RESEND_EMAIL_VERIFICATION_API.
+    private static final int PER_EMAIL_LIMIT = 5;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    OrganizationService organizationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    // Spied so the under-limit successes do not attempt a real email send, and so send attempts can be counted.
+    @SpyBean
+    EmailService emailService;
+
+    // Spied to enable instance-level email verification (it is read from the instance-variables config doc,
+    // not the organization config) without mutating shared instance state.
+    @SpyBean
+    InstanceVariablesHelper instanceVariablesHelper;
+
+    private ResendEmailVerificationDTO dtoFor(String email) {
+        ResendEmailVerificationDTO dto = new ResendEmailVerificationDTO();
+        dto.setEmail(email);
+        dto.setBaseUrl(DEFAULT_ORIGIN_HEADER);
+        return dto;
+    }
+
+    @Test
+    @WithUserDetails("api_user")
+    public void resendEmailVerification_perEmailThrottle_triggersSilentlyAndStopsSendingAfterLimit() {
+        // A fresh, unverified account in the current org, with instance-level verification enabled.
+        String email = "resend-throttle-" + UUID.randomUUID() + "@example.com";
+
+        Organization organization =
+                organizationService.getCurrentUserOrganization().block();
+
+        User newUser = new User();
+        newUser.setEmail(email);
+        newUser.setEmailVerified(Boolean.FALSE);
+        newUser.setOrganizationId(organization.getId());
+        userRepository.save(newUser).block();
+
+        // Email verification is gated on the instance-variables config, not the org config; enable it here.
+        Mockito.doReturn(Mono.just(true)).when(instanceVariablesHelper).isEmailVerificationEnabled();
+        Mockito.doReturn(Mono.just(true)).when(emailService).sendEmailVerificationEmail(any(), any(), any());
+
+        // Under the limit: each request returns the generic success AND dispatches a verification email.
+        for (int i = 0; i < PER_EMAIL_LIMIT; i++) {
+            StepVerifier.create(userService.resendEmailVerification(dtoFor(email), null))
+                    .expectNext(true)
+                    .verifyComplete();
+        }
+        Mockito.verify(emailService, Mockito.times(PER_EMAIL_LIMIT)).sendEmailVerificationEmail(any(), any(), any());
+
+        // Over the limit: same generic success, but no further email is dispatched — the throttle is silent.
+        Mockito.clearInvocations(emailService);
+        StepVerifier.create(userService.resendEmailVerification(dtoFor(email), null))
+                .expectNext(true)
+                .verifyComplete();
+        Mockito.verify(emailService, Mockito.never()).sendEmailVerificationEmail(any(), any(), any());
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -6,6 +6,7 @@ import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.WithMockAppsmithUser;
 import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.constants.RateLimitConstants;
 import com.appsmith.server.domains.LoginSource;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.OrganizationConfiguration;
@@ -23,6 +24,9 @@ import com.appsmith.server.dtos.UserSignupDTO;
 import com.appsmith.server.dtos.UserUpdateDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.SecureBaseUrlResolver;
+import com.appsmith.server.instanceconfigs.helpers.InstanceVariablesHelper;
+import com.appsmith.server.ratelimiting.RateLimitService;
 import com.appsmith.server.repositories.EmailVerificationTokenRepository;
 import com.appsmith.server.repositories.PasswordResetTokenRepository;
 import com.appsmith.server.repositories.PermissionGroupRepository;
@@ -57,6 +61,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
 import static com.appsmith.server.acl.AclPermission.RESET_PASSWORD_USERS;
@@ -67,6 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 @Slf4j
 @SpringBootTest
@@ -103,6 +110,26 @@ public class UserServiceTest {
     @MockBean
     EmailVerificationTokenRepository emailVerificationTokenRepository;
 
+    // Spied so forgot-password tests can pin a resolved base URL and verify email dispatch without
+    // actually sending mail. Real behaviour is preserved for every other test in this class.
+    @SpyBean
+    SecureBaseUrlResolver secureBaseUrlResolver;
+
+    @SpyBean
+    EmailService emailService;
+
+    // Mocked so the in-service per-email resend throttle does not reach Redis in these unit tests; the
+    // throttle's real behaviour (limit trigger + non-distinguishability) is covered against a Redis
+    // testcontainer in UserServiceResendEmailVerificationRateLimitTest. Defaults to "within limit".
+    @MockBean
+    RateLimitService rateLimitService;
+
+    // Spied so the resend "verification disabled" test can pin the real gate — email verification is gated
+    // on InstanceVariablesHelper.isEmailVerificationEnabled (the instance-variables config), not the
+    // OrganizationConfiguration. Real behaviour is preserved for every other test.
+    @SpyBean
+    InstanceVariablesHelper instanceVariablesHelper;
+
     @Autowired
     OrganizationService organizationService;
 
@@ -120,6 +147,12 @@ public class UserServiceTest {
     @BeforeEach
     public void setup() {
         userMono = userService.findByEmail("usertest@usertest.com");
+        // Default the resend per-email throttle to "within limit" so it is transparent to tests that are
+        // not specifically exercising it.
+        Mockito.lenient()
+                .when(rateLimitService.tryIncreaseCounter(
+                        Mockito.eq(RateLimitConstants.BUCKET_KEY_FOR_RESEND_EMAIL_VERIFICATION_API), any()))
+                .thenReturn(Mono.just(true));
     }
     // Test the update workspace flow.
     @Test
@@ -603,23 +636,233 @@ public class UserServiceTest {
                 .verifyComplete();
     }
 
+    /**
+     * Regression for the secondary enumeration oracle (CWE-204, GHSA-fvrq-g89c-fgg6): a known account
+     * driven over its reset limit (4th request within 24h) previously surfaced HTTP 429
+     * (TOO_MANY_REQUESTS), which distinguished it from the HTTP 200 generic success returned for an
+     * unknown email. The over-limit case must now return the same generic success, must NOT send another
+     * reset email, and must NOT persist a fresh (usable) reset token — while the request-count tracking
+     * still keeps the limit in force.
+     */
     @Test
-    public void forgotPasswordTokenGenerate_AfterTrying3TimesIn24Hours_ThrowsException() {
-        String testEmail = "test-email-for-password-reset";
-        PasswordResetToken passwordResetToken = new PasswordResetToken();
-        passwordResetToken.setRequestCount(3);
-        passwordResetToken.setFirstRequestTime(Instant.now());
+    @WithUserDetails(value = "api_user")
+    public void forgotPasswordTokenGenerate_whenKnownAccountOverResetLimit_returnsGenericSuccessWithoutSendingEmail() {
+        String baseUrl = "https://my-instance.example.com";
+        String knownEmail = "api_user";
 
-        // mock the passwordResetTokenRepository to return request count 3 in 24 hours
+        Mockito.doReturn(Mono.just(baseUrl)).when(secureBaseUrlResolver).resolveSecureBaseUrl(baseUrl);
+
+        // Existing token that is already over the limit (3 requests) within the 24h window.
+        PasswordResetToken overLimitToken = new PasswordResetToken();
+        overLimitToken.setEmail(knownEmail);
+        overLimitToken.setRequestCount(3);
+        overLimitToken.setFirstRequestTime(Instant.now());
         Mockito.when(passwordResetTokenRepository.findByEmailAndOrganizationId(any(), any()))
-                .thenReturn(Mono.just(passwordResetToken));
+                .thenReturn(Mono.just(overLimitToken));
+        Mockito.when(passwordResetTokenRepository.save(any()))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        Mockito.doReturn(Mono.just(true)).when(emailService).sendForgotPasswordEmail(any(), any(), any());
 
-        ResetUserPasswordDTO resetUserPasswordDTO = new ResetUserPasswordDTO();
-        resetUserPasswordDTO.setEmail("test-email-for-password-reset");
+        ResetUserPasswordDTO dto = new ResetUserPasswordDTO();
+        dto.setEmail(knownEmail);
+        dto.setBaseUrl(baseUrl);
 
-        StepVerifier.create(userService.forgotPasswordTokenGenerate(resetUserPasswordDTO))
-                .expectError(AppsmithException.class)
-                .verify();
+        // Same generic success as the under-limit and unknown cases — no distinguishable 429.
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(dto))
+                .expectNext(true)
+                .verifyComplete();
+
+        // Anti-spam: over the limit, no new email is sent and no fresh reset token is persisted.
+        Mockito.verify(emailService, Mockito.never()).sendForgotPasswordEmail(any(), any(), any());
+        Mockito.verify(passwordResetTokenRepository, Mockito.never()).save(any());
+    }
+
+    /**
+     * Full anti-enumeration invariant across all three branches: a known email under its reset limit, the
+     * same known email over its limit, and an unknown email must all return the identical generic success
+     * (HTTP 200, {@code {"data": true}}). Only the under-limit case may send an email or persist a token.
+     * NOTE: a timing side-channel can still remain because the under-limit path does more work; equalizing
+     * timing is intentionally out of scope for this fix — identical status + body is the bar being enforced.
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void forgotPasswordTokenGenerate_underLimit_overLimit_andUnknown_returnIdenticalGenericSuccess() {
+        String baseUrl = "https://my-instance.example.com";
+        String knownEmail = "api_user";
+        String unknownEmail = "no-such-user-" + UUID.randomUUID() + "@example.com";
+
+        Mockito.doReturn(Mono.just(baseUrl)).when(secureBaseUrlResolver).resolveSecureBaseUrl(baseUrl);
+        Mockito.when(passwordResetTokenRepository.save(any()))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        Mockito.doReturn(Mono.just(true)).when(emailService).sendForgotPasswordEmail(any(), any(), any());
+
+        ResetUserPasswordDTO knownDto = new ResetUserPasswordDTO();
+        knownDto.setEmail(knownEmail);
+        knownDto.setBaseUrl(baseUrl);
+
+        ResetUserPasswordDTO unknownDto = new ResetUserPasswordDTO();
+        unknownDto.setEmail(unknownEmail);
+        unknownDto.setBaseUrl(baseUrl);
+
+        // 1) Known, under limit: existing token with 1 request in the window -> success + email + save.
+        PasswordResetToken underLimitToken = new PasswordResetToken();
+        underLimitToken.setEmail(knownEmail);
+        underLimitToken.setRequestCount(1);
+        underLimitToken.setFirstRequestTime(Instant.now());
+        Mockito.when(passwordResetTokenRepository.findByEmailAndOrganizationId(any(), any()))
+                .thenReturn(Mono.just(underLimitToken));
+
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(knownDto))
+                .expectNext(true)
+                .verifyComplete();
+        Mockito.verify(emailService, Mockito.times(1)).sendForgotPasswordEmail(eq(knownEmail), any(), eq(baseUrl));
+        Mockito.verify(passwordResetTokenRepository, Mockito.times(1)).save(any());
+
+        // 2) Known, over limit: existing token with 3 requests in the window -> success, no email, no save.
+        Mockito.clearInvocations(emailService, passwordResetTokenRepository);
+        PasswordResetToken overLimitToken = new PasswordResetToken();
+        overLimitToken.setEmail(knownEmail);
+        overLimitToken.setRequestCount(3);
+        overLimitToken.setFirstRequestTime(Instant.now());
+        Mockito.when(passwordResetTokenRepository.findByEmailAndOrganizationId(any(), any()))
+                .thenReturn(Mono.just(overLimitToken));
+
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(knownDto))
+                .expectNext(true)
+                .verifyComplete();
+        Mockito.verify(emailService, Mockito.never()).sendForgotPasswordEmail(any(), any(), any());
+        Mockito.verify(passwordResetTokenRepository, Mockito.never()).save(any());
+
+        // 3) Unknown email: user lookup empty -> success, no email, no token persisted.
+        Mockito.clearInvocations(emailService, passwordResetTokenRepository);
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(unknownDto))
+                .expectNext(true)
+                .verifyComplete();
+        Mockito.verify(emailService, Mockito.never()).sendForgotPasswordEmail(any(), any(), any());
+        Mockito.verify(passwordResetTokenRepository, Mockito.never()).save(any());
+    }
+
+    /**
+     * Anti-enumeration invariant (CWE-204, GHSA-fvrq-g89c-fgg6): the forgot-password flow must return
+     * the exact same generic success (HTTP 200, {@code {"data": true}}) for a non-existent email as it
+     * does for a registered one, so an unauthenticated caller cannot distinguish valid from invalid
+     * accounts. A reset email must be dispatched only for the account that actually exists.
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void forgotPasswordTokenGenerate_unknownEmail_isIndistinguishableFromKnownEmailAndSendsNoEmail() {
+        String baseUrl = "https://my-instance.example.com";
+        String knownEmail = "api_user";
+        String unknownEmail = "no-such-user-" + UUID.randomUUID() + "@example.com";
+
+        // Pin a resolved base URL so the flow proceeds past the secure base URL resolver to the user lookup.
+        Mockito.doReturn(Mono.just(baseUrl)).when(secureBaseUrlResolver).resolveSecureBaseUrl(baseUrl);
+
+        // No pre-existing reset token; save echoes back the token it is given.
+        Mockito.when(passwordResetTokenRepository.findByEmailAndOrganizationId(any(), any()))
+                .thenReturn(Mono.empty());
+        Mockito.when(passwordResetTokenRepository.save(any()))
+                .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        // Stub email dispatch so the valid path does not attempt to send a real email.
+        Mockito.doReturn(Mono.just(true)).when(emailService).sendForgotPasswordEmail(any(), any(), any());
+
+        ResetUserPasswordDTO knownDto = new ResetUserPasswordDTO();
+        knownDto.setEmail(knownEmail);
+        knownDto.setBaseUrl(baseUrl);
+
+        ResetUserPasswordDTO unknownDto = new ResetUserPasswordDTO();
+        unknownDto.setEmail(unknownEmail);
+        unknownDto.setBaseUrl(baseUrl);
+
+        // Both existent and non-existent emails yield the identical generic success response.
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(knownDto))
+                .expectNext(true)
+                .verifyComplete();
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(unknownDto))
+                .expectNext(true)
+                .verifyComplete();
+
+        // A reset email is sent only for the registered account; none for the unknown one.
+        Mockito.verify(emailService, Mockito.times(1)).sendForgotPasswordEmail(eq(knownEmail), any(), eq(baseUrl));
+        Mockito.verify(emailService, Mockito.never()).sendForgotPasswordEmail(eq(unknownEmail), any(), any());
+    }
+
+    /**
+     * Full counter-sequence regression pinning the per-account reset-limit invariant end to end. Backs the
+     * {@code passwordResetTokenRepository} mock with an in-memory store so the request counter actually
+     * accumulates across calls (the real production behaviour):
+     * <ul>
+     *   <li>requests 1, 2, 3 for a known email each succeed — token saved, email sent;</li>
+     *   <li>the 4th request within the 24h window is over the limit — generic success, NO email, NO new
+     *       token save (and the counter is not mutated, so the block holds);</li>
+     *   <li>a repeated request while still over the limit stays over the limit — same generic success, still
+     *       no email / no save;</li>
+     *   <li>once the 24h window has elapsed the next request is allowed again — the counter resets to 1 and
+     *       an email is sent.</li>
+     * </ul>
+     * Every call returns the identical generic success so the rate limit is never observable to the caller
+     * (CWE-204, GHSA-fvrq-g89c-fgg6).
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void forgotPasswordTokenGenerate_resetLimitCounterSequence_neverLeaksAndResetsAfterWindow() {
+        String baseUrl = "https://my-instance.example.com";
+        String knownEmail = "api_user";
+
+        Mockito.doReturn(Mono.just(baseUrl)).when(secureBaseUrlResolver).resolveSecureBaseUrl(baseUrl);
+
+        // In-memory store so the reset-token counter persists across calls, like the real repository.
+        final AtomicReference<PasswordResetToken> store = new AtomicReference<>();
+        Mockito.when(passwordResetTokenRepository.findByEmailAndOrganizationId(any(), any()))
+                .thenAnswer(invocation -> store.get() == null ? Mono.empty() : Mono.just(store.get()));
+        Mockito.when(passwordResetTokenRepository.save(any())).thenAnswer(invocation -> {
+            PasswordResetToken saved = invocation.getArgument(0);
+            store.set(saved);
+            return Mono.just(saved);
+        });
+        Mockito.doReturn(Mono.just(true)).when(emailService).sendForgotPasswordEmail(any(), any(), any());
+
+        ResetUserPasswordDTO dto = new ResetUserPasswordDTO();
+        dto.setEmail(knownEmail);
+        dto.setBaseUrl(baseUrl);
+
+        // Requests 1, 2, 3: under the limit — each succeeds, saves the token, and sends an email.
+        for (int i = 1; i <= 3; i++) {
+            StepVerifier.create(userService.forgotPasswordTokenGenerate(dto))
+                    .expectNext(true)
+                    .verifyComplete();
+        }
+        Mockito.verify(emailService, Mockito.times(3)).sendForgotPasswordEmail(eq(knownEmail), any(), eq(baseUrl));
+        Mockito.verify(passwordResetTokenRepository, Mockito.times(3)).save(any());
+        assertEquals(3, store.get().getRequestCount());
+
+        // Request 4 within the window: over the limit — generic success, no email, no new save.
+        Mockito.clearInvocations(emailService, passwordResetTokenRepository);
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(dto))
+                .expectNext(true)
+                .verifyComplete();
+        Mockito.verify(emailService, Mockito.never()).sendForgotPasswordEmail(any(), any(), any());
+        Mockito.verify(passwordResetTokenRepository, Mockito.never()).save(any());
+        assertEquals(3, store.get().getRequestCount()); // counter not mutated while over the limit
+
+        // Request 5 (repeat while still over the limit): stays over the limit — same generic success.
+        Mockito.clearInvocations(emailService, passwordResetTokenRepository);
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(dto))
+                .expectNext(true)
+                .verifyComplete();
+        Mockito.verify(emailService, Mockito.never()).sendForgotPasswordEmail(any(), any(), any());
+        Mockito.verify(passwordResetTokenRepository, Mockito.never()).save(any());
+
+        // Simulate the 24h window elapsing, then the next request is allowed again and the counter resets.
+        store.get().setFirstRequestTime(Instant.now().minusSeconds(25 * 3600));
+        Mockito.clearInvocations(emailService, passwordResetTokenRepository);
+        StepVerifier.create(userService.forgotPasswordTokenGenerate(dto))
+                .expectNext(true)
+                .verifyComplete();
+        Mockito.verify(emailService, Mockito.times(1)).sendForgotPasswordEmail(eq(knownEmail), any(), eq(baseUrl));
+        Mockito.verify(passwordResetTokenRepository, Mockito.times(1)).save(any());
+        assertEquals(1, store.get().getRequestCount()); // counter reset for the new window
     }
 
     @Test
@@ -763,42 +1006,52 @@ public class UserServiceTest {
         return resendEmailVerificationDTO;
     }
 
+    /**
+     * Anti-enumeration (CWE-204): when instance-level email verification is disabled, the resend endpoint
+     * must return the same generic success (HTTP 200, {@code true}) as the happy path and send no email,
+     * rather than surfacing a distinct EMAIL_VERIFICATION_NOT_ENABLED error that would leak the account's
+     * (and the instance config's) state to an unauthenticated caller.
+     *
+     * <p>The gate under test is the real one — {@link InstanceVariablesHelper#isEmailVerificationEnabled()},
+     * read from the instance-variables config — not {@code OrganizationConfiguration}. It is stubbed to
+     * {@code false} directly so the test pins the actual code path (a fresh, unverified account that reaches
+     * the gate) rather than incidentally relying on the instance default.
+     */
     @Test
     @WithUserDetails("api_user")
-    public void emailVerificationTokenGenerate_WhenInstanceEmailVerificationIsNotEnabled_ThrowsException() {
+    public void
+            resendEmailVerification_WhenInstanceEmailVerificationIsNotEnabled_ReturnsGenericSuccessWithoutSendingEmail() {
         String testEmail = "test-email-for-verification";
 
-        Mono<Organization> currentUserOrganizationMono =
-                organizationService.getCurrentUserOrganization().cache();
-        // create user
+        // A fresh, unverified account so the flow passes the already-verified check and reaches the
+        // instance-level verification gate.
+        Organization organization =
+                organizationService.getCurrentUserOrganization().block();
         User newUser = new User();
         newUser.setEmail(testEmail);
-        Mono<User> userMono = currentUserOrganizationMono.flatMap(organization -> {
-            newUser.setOrganizationId(organization.getId());
-            return userRepository.save(newUser);
-        });
+        newUser.setEmailVerified(Boolean.FALSE);
+        newUser.setOrganizationId(organization.getId());
+        userRepository.save(newUser).block();
 
-        // Setting Organization Config emailVerificationEnabled to FALSE
-        Mono<Organization> organizationMono = currentUserOrganizationMono.flatMap(organization -> {
-            OrganizationConfiguration organizationConfiguration = organization.getOrganizationConfiguration();
-            organizationConfiguration.setEmailVerificationEnabled(Boolean.FALSE);
-            organization.setOrganizationConfiguration(organizationConfiguration);
-            return organizationService.update(organization.getId(), organization);
-        });
+        // Pin the real gate to disabled (instance-variables config, not OrganizationConfiguration).
+        Mockito.doReturn(Mono.just(false)).when(instanceVariablesHelper).isEmailVerificationEnabled();
 
-        Mono<Boolean> emailVerificationMono =
-                userService.resendEmailVerification(getResendEmailVerificationDTO(testEmail), null);
+        Mockito.clearInvocations(emailService);
+        StepVerifier.create(userService.resendEmailVerification(getResendEmailVerificationDTO(testEmail), null))
+                .expectNext(true)
+                .verifyComplete();
 
-        Mono<Boolean> resultMono = userMono.then(organizationMono).then(emailVerificationMono);
-
-        StepVerifier.create(resultMono)
-                .expectErrorMessage(AppsmithError.EMAIL_VERIFICATION_NOT_ENABLED.getMessage())
-                .verify();
+        Mockito.verify(emailService, Mockito.never()).sendEmailVerificationEmail(any(), any(), any());
     }
 
+    /**
+     * Anti-enumeration (CWE-204): when the account already has a verified email, the resend endpoint must
+     * return the same generic success (HTTP 200, {@code true}) and send no email, rather than a distinct
+     * USER_ALREADY_VERIFIED error that would confirm the address exists and is verified.
+     */
     @Test
     @WithUserDetails("api_user")
-    public void emailVerificationTokenGenerate_WhenUserEmailAlreadyVerified_ThrowsException() {
+    public void resendEmailVerification_WhenUserEmailAlreadyVerified_ReturnsGenericSuccessWithoutSendingEmail() {
         String testEmail = "test-email-for-verification-user-already-verified";
 
         // Get current organization first
@@ -819,12 +1072,41 @@ public class UserServiceTest {
         organization.setOrganizationConfiguration(organizationConfiguration);
         organizationService.update(organization.getId(), organization).block();
 
+        Mockito.clearInvocations(emailService);
         Mono<Boolean> emailVerificationMono =
                 userService.resendEmailVerification(getResendEmailVerificationDTO(testEmail), null);
 
-        StepVerifier.create(emailVerificationMono)
-                .expectErrorMessage(AppsmithError.USER_ALREADY_VERIFIED.getMessage())
-                .verify();
+        StepVerifier.create(emailVerificationMono).expectNext(true).verifyComplete();
+
+        Mockito.verify(emailService, Mockito.never()).sendEmailVerificationEmail(any(), any(), any());
+    }
+
+    /**
+     * Anti-enumeration (CWE-204): a resend request for an address that is not registered must return the
+     * same generic success (HTTP 200, {@code true}) as a known unverified account and send no email, so an
+     * unauthenticated caller cannot distinguish registered from unregistered addresses.
+     */
+    @Test
+    @WithUserDetails("api_user")
+    public void resendEmailVerification_WhenEmailUnknown_ReturnsGenericSuccessWithoutSendingEmail() {
+        String unknownEmail = "no-such-user-" + UUID.randomUUID() + "@example.com";
+
+        // Ensure instance-level verification is enabled so the only reason no email is sent is the unknown
+        // address (i.e. we are exercising the unknown-user branch, not the disabled-verification branch).
+        Organization organization =
+                organizationService.getCurrentUserOrganization().block();
+        OrganizationConfiguration organizationConfiguration = organization.getOrganizationConfiguration();
+        organizationConfiguration.setEmailVerificationEnabled(Boolean.TRUE);
+        organization.setOrganizationConfiguration(organizationConfiguration);
+        organizationService.update(organization.getId(), organization).block();
+
+        Mockito.clearInvocations(emailService);
+        Mono<Boolean> emailVerificationMono =
+                userService.resendEmailVerification(getResendEmailVerificationDTO(unknownEmail), null);
+
+        StepVerifier.create(emailVerificationMono).expectNext(true).verifyComplete();
+
+        Mockito.verify(emailService, Mockito.never()).sendEmailVerificationEmail(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## What
Makes two unauthenticated email endpoints return a consistent response regardless of
whether an account exists, and removes two unused public routes.

## Why
`POST /users/forgotPassword` and `POST /users/resendEmailVerification` returned
different responses for a known vs unknown email (and, for resend, also revealed
verified state). This let an unauthenticated caller determine which email addresses
have accounts.

## Changes
- **forgotPassword** — unknown email and over-limit both return the same generic
  success (HTTP 200), sending no email. The per-account reset limit is unchanged.
- **resendEmailVerification** — unknown, already-verified, and verification-disabled
  cases all return the same generic success, sending no email. Adds a per-email send
  limit: over the limit it still returns the generic success (so it can't be used to
  probe), and it fails open if the limiter is unavailable so legitimate verification
  emails are never blocked.
- Removes two `permitAll` routes (`GET /users/invite/verify`, `PUT /users/invite/confirm`)
  that have no server handler.

## Testing
- Controller + service tests assert identical status and body across
  known-under-limit / known-over-limit / known-verified / unknown / verification-disabled
  for both endpoints, plus the silent per-email limit and its fail-open path.
- Relevant server module tests pass.


Fixes https://linear.app/appsmith/issue/APP-15349/security-medium-user-enumeration-via-forgot-password

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29493040653>
> Commit: 6017e794408d53a16f62b0735c2c3cbe66c5aef6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29493040653&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 16 Jul 2026 19:50:33 UTC
<!-- end of auto-generated comment: Cypress test results  -->



## Automation
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Password reset and email verification requests now return consistent responses, reducing the ability to determine whether an email address is registered.
  * Added silent throttling for repeated password reset and verification-email requests.
  * Verification-email resends are limited to five requests per email within 24 hours.
  * Invite verification endpoints now require authentication.

* **Tests**
  * Added coverage for consistent responses and throttling across account states and request limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->