### PR TITLE
fix: stop mangling mailto/tel/ftp hrefs in Text widget links

### DIFF
--- a/app/client/src/widgets/TextWidget/component/helpers.test.ts
+++ b/app/client/src/widgets/TextWidget/component/helpers.test.ts
@@ -1,0 +1,48 @@
+import { addHttpIfMissing } from "./helpers";
+
+describe("addHttpIfMissing", () => {
+  it("prepends http:// to scheme-less URLs", () => {
+    expect(addHttpIfMissing("www.appsmith.com")).toBe(
+      "http://www.appsmith.com",
+    );
+    expect(addHttpIfMissing("appsmith.com/docs")).toBe(
+      "http://appsmith.com/docs",
+    );
+  });
+
+  it("leaves http and https URLs untouched", () => {
+    expect(addHttpIfMissing("http://appsmith.com")).toBe(
+      "http://appsmith.com",
+    );
+    expect(addHttpIfMissing("https://appsmith.com")).toBe(
+      "https://appsmith.com",
+    );
+    expect(addHttpIfMissing("HTTPS://APPSMITH.COM")).toBe(
+      "HTTPS://APPSMITH.COM",
+    );
+  });
+
+  it("leaves mailto links untouched", () => {
+    expect(addHttpIfMissing("mailto:tom@appsmith.com")).toBe(
+      "mailto:tom@appsmith.com",
+    );
+  });
+
+  it("leaves other safe schemes untouched", () => {
+    expect(addHttpIfMissing("tel:+14155550123")).toBe("tel:+14155550123");
+    expect(addHttpIfMissing("sms:+14155550123")).toBe("sms:+14155550123");
+    expect(addHttpIfMissing("ftp://files.appsmith.com")).toBe(
+      "ftp://files.appsmith.com",
+    );
+  });
+
+  it("neutralizes unsafe schemes by prefixing http://", () => {
+    expect(addHttpIfMissing("javascript:alert(1)")).toBe(
+      "http://javascript:alert(1)",
+    );
+  });
+
+  it("returns empty values as-is", () => {
+    expect(addHttpIfMissing("")).toBe("");
+  });
+});

--- a/app/client/src/widgets/TextWidget/component/helpers.test.ts
+++ b/app/client/src/widgets/TextWidget/component/helpers.test.ts
@@ -11,9 +11,7 @@ describe("addHttpIfMissing", () => {
   });
 
   it("leaves http and https URLs untouched", () => {
-    expect(addHttpIfMissing("http://appsmith.com")).toBe(
-      "http://appsmith.com",
-    );
+    expect(addHttpIfMissing("http://appsmith.com")).toBe("http://appsmith.com");
     expect(addHttpIfMissing("https://appsmith.com")).toBe(
       "https://appsmith.com",
     );

--- a/app/client/src/widgets/TextWidget/component/helpers.tsx
+++ b/app/client/src/widgets/TextWidget/component/helpers.tsx
@@ -1,4 +1,12 @@
 /**
+ * Schemes that a link is allowed to carry explicitly. Mirrors the allowlist
+ * in utils/validation/getIsSafeURL.ts. Values with any other scheme (e.g.
+ * "javascript:") or no scheme at all are treated as web URLs missing their
+ * protocol and get "http://" prepended, which also neutralizes them.
+ */
+const SAFE_SCHEME_PATTERN = /^(?:https?|mailto|tel|ftp|file|sms):/i;
+
+/**
  * add http if missing
  *
  * @param url
@@ -9,7 +17,7 @@ export const addHttpIfMissing = (url: string) => {
     return url;
   }
 
-  if (url.indexOf("http") === 0) {
+  if (SAFE_SCHEME_PATTERN.test(url)) {
     return url;
   }
 


### PR DESCRIPTION
## Description

**TL;DR:** `<a href="mailto:...">` (and `tel:`, `ftp:`, `sms:`, `file:` links) in the Text widget rendered as broken `http://mailto:...` hrefs. The link-sanitizing helper now recognizes these safe schemes and leaves them untouched.

The Text widget runs every href in its HTML through a sanitizing `LinkFilter` (`app/client/src/widgets/TextWidget/component/index.tsx`), which calls `addHttpIfMissing`. That helper had exactly one rule: if the value doesn't start with the literal string `"http"`, prepend `http://`. It was written so scheme-less links like `www.appsmith.com` don't get treated as relative URLs, but it had no concept of other protocols — so `mailto:tom@appsmith.com` failed the prefix check and came out as `http://mailto:tom@appsmith.com`. The same mangling hit `tel:`, `ftp:`, etc. The Interweave library the widget uses for rendering explicitly allows `mailto:` links, so this was purely the helper breaking them. The Table widget's HTML cell (TableWidgetV2) reuses the same filter and had the same bug.

**The fix:** `addHttpIfMissing` (`app/client/src/widgets/TextWidget/component/helpers.tsx`) now recognizes an explicit scheme via a case-insensitive allowlist — `http`, `https`, `mailto`, `tel`, `ftp`, `file`, `sms`, mirroring the set already used in `utils/validation/getIsSafeURL.ts` — and leaves those values untouched. Scheme-less values still get `http://` prepended as before, and unsafe schemes like `javascript:` are still neutralized the same way they were (Interweave also refuses to render such anchors, so no XSS regression).

Added `helpers.test.ts` covering safe schemes (including uppercase), scheme-less URLs, `javascript:` neutralization, and empty values.

Fixes: no linked issue — fixes broken `mailto:` links reported in the Text widget.

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29401331502>
> Commit: 3b6b3e5728057f077d7acb21f17501eec08b473c
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29401331502&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 15 Jul 2026 09:47:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PADWnYmHqjAM7nAfXzdPCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PADWnYmHqjAM7nAfXzdPCQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling by preserving explicitly supported URL schemes (including HTTP/HTTPS, email, telephone, SMS, and FTP) unchanged.
  * For unsupported or unsafe schemes, inputs are automatically normalized by prepending `http://` to prevent unexpected behavior.
  * Links without a scheme now reliably receive an `http://` prefix.
  * Empty inputs and already-safe links remain unchanged.
* **Tests**
  * Added Jest coverage to verify the updated scheme-preserving and unsafe-scheme neutralization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->