### PR TITLE
chore: use netty.version property instead of hardcoded version in mysqlPlugin

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/mysqlPlugin/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>4.1.75.Final</version>
+            <version>${netty.version}</version>
             <classifier>osx-x86_64</classifier>
             <scope>runtime</scope>
         </dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>4.1.75.Final</version>
+            <version>${netty.version}</version>
             <classifier>osx-aarch_64</classifier>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
Fixes #41901

## Problem
The `mysqlPlugin` module hardcoded an outdated Netty version (`4.1.75.Final`) for the `netty-resolver-dns-native-macos` dependency, bypassing the centrally managed `${netty.version}` property in the parent pom.xml. This outdated version is flagged with known CVEs.

## Fix
Replaced the two hardcoded `4.1.75.Final` version strings with `${netty.version}`, which is already pinned to `4.1.135.Final` in the parent pom.xml specifically to address these CVEs. This keeps the dependency in sync with the rest of the project going forward.

## Testing
Ran `mvn -pl appsmith-plugins/mysqlPlugin -am install -DskipTests` — build succeeds with no compilation or dependency resolution issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved consistency for macOS-specific networking components by aligning them with the application’s centrally managed versioning.
  - This helps maintain reliable builds and reduces the risk of compatibility issues across supported macOS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->