### PR TITLE
fix(security): strip internal config from tenant endpoint for anonymous users [APP-15344]

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/OrganizationConfigurationCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ce/OrganizationConfigurationCE.java
@@ -104,6 +104,26 @@ public class OrganizationConfigurationCE implements Serializable {
         isAtomicPushAllowed = organizationConfiguration.getIsAtomicPushAllowed();
     }
 
+    /**
+     * Strips fields that should not be visible to unauthenticated (anonymous) users.
+     * Only fields required for the login/signup page are preserved (branding, auth method flags,
+     * instance name, form login state, third-party auth list).
+     * EE subclass overrides this to strip additional EE-specific fields.
+     */
+    public void stripFieldsForAnonymousUser() {
+        this.googleMapsKey = null;
+        this.isSignupDisabled = null;
+        this.emailVerificationEnabled = null;
+        this.isStrongPasswordPolicyEnabled = null;
+        this.isAtomicPushAllowed = null;
+        this.featuresWithPendingMigration = null;
+        this.migrationStatus = MigrationStatus.COMPLETED;
+
+        License minimalLicense = new License();
+        minimalLicense.setPlan(LicensePlan.FREE);
+        this.license = minimalLicense;
+    }
+
     protected static <T> T getComputedValue(T defaultValue, T updatedValue, T currentValue) {
         if (currentValue == null && updatedValue == null) {
             return defaultValue;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -214,7 +214,37 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
     @Override
     public Mono<Organization> getOrganizationConfiguration() {
         Mono<Organization> dbOrganizationMono = getCurrentUserOrganization();
-        return getOrganizationConfiguration(dbOrganizationMono);
+        return getOrganizationConfiguration(dbOrganizationMono).flatMap(this::suppressFieldsForAnonymousUser);
+    }
+
+    /**
+     * Checks if the current user is anonymous and, if so, strips fields from the Organization
+     * response that are not required for the login/signup page. This prevents information
+     * disclosure of internal configuration to unauthenticated users (APP-15344).
+     */
+    protected Mono<Organization> suppressFieldsForAnonymousUser(Organization organization) {
+        return ReactiveSecurityContextHolder.getContext()
+                .flatMap(ctx -> Mono.justOrEmpty(ctx.getAuthentication()))
+                .filter(authentication -> authentication.getPrincipal() instanceof User)
+                .map(authentication -> ((User) authentication.getPrincipal()).isAnonymous())
+                .defaultIfEmpty(true)
+                .map(isAnonymous -> {
+                    if (isAnonymous) {
+                        stripOrganizationFieldsForAnonymousUser(organization);
+                    }
+                    return organization;
+                });
+    }
+
+    /**
+     * Strips Organization-level and configuration fields not needed by anonymous users.
+     * EE overrides this to strip additional EE-specific fields.
+     */
+    protected void stripOrganizationFieldsForAnonymousUser(Organization organization) {
+        if (organization.getOrganizationConfiguration() != null) {
+            organization.getOrganizationConfiguration().stripFieldsForAnonymousUser();
+        }
+        organization.setPricingPlan(null);
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
@@ -251,6 +251,80 @@ class OrganizationServiceCETest {
     }
 
     @Test
+    @WithUserDetails("anonymousUser")
+    void getOrganizationConfig_AnonymousUser_StripsInternalConfiguration() {
+        // APP-15344: unauthenticated callers must not receive internal configuration fields
+        StepVerifier.create(organizationService.getOrganizationConfiguration())
+                .assertNext(organization -> {
+                    OrganizationConfiguration config = organization.getOrganizationConfiguration();
+                    assertThat(config)
+                            .as("organizationConfiguration must be present")
+                            .isNotNull();
+
+                    // Fields that must be stripped for anonymous users
+                    assertThat(config.getGoogleMapsKey())
+                            .as("googleMapsKey must not be exposed to anonymous users")
+                            .isNull();
+                    assertThat(config.getIsStrongPasswordPolicyEnabled())
+                            .as("isStrongPasswordPolicyEnabled must not be exposed")
+                            .isNull();
+                    assertThat(config.getIsAtomicPushAllowed())
+                            .as("isAtomicPushAllowed must not be exposed")
+                            .isNull();
+                    assertThat(config.getFeaturesWithPendingMigration())
+                            .as("featuresWithPendingMigration must not be exposed")
+                            .isNull();
+                    assertThat(config.getIsSignupDisabled())
+                            .as("isSignupDisabled must not be exposed")
+                            .isNull();
+                    assertThat(config.getEmailVerificationEnabled())
+                            .as("emailVerificationEnabled must not be exposed")
+                            .isNull();
+
+                    // License should be minimal (plan=FREE only)
+                    assertThat(config.getLicense())
+                            .as("license must be present")
+                            .isNotNull();
+                    assertThat(config.getLicense().getPlan())
+                            .as("license.plan should be FREE for anonymous users")
+                            .isEqualTo(LicensePlan.FREE);
+
+                    // Organization-level fields that must be stripped
+                    assertThat(organization.getPricingPlan())
+                            .as("pricingPlan must not be exposed")
+                            .isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails("anonymousUser")
+    void getOrganizationConfig_AnonymousUser_PreservesLoginPageFields() {
+        // APP-15344: login-page fields must still be present for anonymous users
+        StepVerifier.create(organizationService.getOrganizationConfiguration())
+                .assertNext(organization -> {
+                    assertThat(organization.getId())
+                            .as("id must be present for anonymous users")
+                            .isNotNull();
+                    assertThat(organization.getOrganizationConfiguration())
+                            .as("organizationConfiguration must be present")
+                            .isNotNull();
+
+                    // License should still be present (minimal)
+                    assertThat(organization.getOrganizationConfiguration().getLicense())
+                            .as("license must be present (minimal)")
+                            .isNotNull();
+                    assertThat(organization
+                                    .getOrganizationConfiguration()
+                                    .getLicense()
+                                    .getPlan())
+                            .as("license plan must be FREE")
+                            .isEqualTo(LicensePlan.FREE);
+                })
+                .verifyComplete();
+    }
+
+    @Test
     @WithUserDetails("api_user")
     void getOrganizationConfig_AuthenticatedUser_ExposesInstanceMetadata() {
         // APP-14994: authenticated users should still receive instanceId and adminEmailDomainHash
@@ -261,6 +335,36 @@ class OrganizationServiceCETest {
                             .isNotNull();
                     assertThat(organization.getAdminEmailDomainHash())
                             .as("adminEmailDomainHash should be present for authenticated users")
+                            .isNotNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails("api_user")
+    void getOrganizationConfig_AuthenticatedUser_ExposesFullConfiguration() {
+        // APP-15344: authenticated users must still receive all configuration fields (no regression)
+        final OrganizationConfiguration changes = new OrganizationConfiguration();
+        changes.setGoogleMapsKey("test-maps-key");
+        changes.setIsStrongPasswordPolicyEnabled(TRUE);
+        changes.setIsAtomicPushAllowed(TRUE);
+
+        StepVerifier.create(organizationService
+                        .updateOrganizationConfiguration(changes)
+                        .then(organizationService.getOrganizationConfiguration()))
+                .assertNext(organization -> {
+                    OrganizationConfiguration config = organization.getOrganizationConfiguration();
+                    assertThat(config.getGoogleMapsKey())
+                            .as("googleMapsKey must be visible to authenticated users")
+                            .isEqualTo("test-maps-key");
+                    assertThat(config.getIsStrongPasswordPolicyEnabled())
+                            .as("isStrongPasswordPolicyEnabled must be visible to authenticated users")
+                            .isTrue();
+                    assertThat(config.getIsAtomicPushAllowed())
+                            .as("isAtomicPushAllowed must be visible to authenticated users")
+                            .isTrue();
+                    assertThat(config.getLicense())
+                            .as("license must be present for authenticated users")
                             .isNotNull();
                 })
                 .verifyComplete();


### PR DESCRIPTION
## Summary

Fixes [APP-15344](https://linear.app/appsmith/issue/APP-15344): the unauthenticated `/api/v1/tenants/current` endpoint was returning internal configuration fields (Google Maps API key, license details, migration status, feature flags) to anonymous callers.

This is the **CE portion** of the fix. The EE superset PR is [appsmith-ee#9305](https://github.com/appsmithorg/appsmith-ee/pull/9305) (all server tests passing).

**Approach:** Service-layer filtering strips post-login-only fields when the current user is anonymous, following the same pattern as APP-14994 (PR #41598). Only fields required by the login/signup page are preserved (branding, auth method flags, instance name, third-party auth list). Authenticated users receive the full unmodified response.

**CE fields stripped for anonymous users:**
- `googleMapsKey` (plaintext API key)
- Full `license` envelope (replaced with minimal `{plan: FREE}`)
- `isSignupDisabled`, `emailVerificationEnabled`, `isStrongPasswordPolicyEnabled`
- `isAtomicPushAllowed`, `featuresWithPendingMigration`, `migrationStatus`
- `pricingPlan` (Organization-level)

**Changes:**
1. `OrganizationConfigurationCE.stripFieldsForAnonymousUser()` — strips CE config fields
2. `OrganizationServiceCEImpl.suppressFieldsForAnonymousUser()` — checks security context, calls strip if anonymous
3. `OrganizationServiceCEImpl.stripOrganizationFieldsForAnonymousUser()` — strips Organization-level fields (overridable by EE)

## Test Plan

- [x] `getOrganizationConfig_AnonymousUser_StripsInternalConfiguration` — verifies sensitive fields are null
- [x] `getOrganizationConfig_AnonymousUser_PreservesLoginPageFields` — verifies login-page fields remain
- [x] `getOrganizationConfig_AuthenticatedUser_ExposesFullConfiguration` — no regression for authenticated users
- [ ] Existing APP-14994 tests pass (instanceId/adminEmailDomainHash stripping)

/ok-to-test tags="@tag.All"


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29452470909>
> Commit: 151a92e4703a197df59ab696fb97cfc1bf1cbaf9
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29452470909&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 15 Jul 2026 22:42:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Anonymous users now receive only minimal organization configuration and license details.
  * Sensitive settings, pricing information, and privilege-related fields are hidden from unauthenticated access.
* **Bug Fixes**
  * Authenticated users continue to receive complete organization configuration details, including updated settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->