### PR TITLE
fix: Copy to Application dropdown scrolling and datasource note visibility in copy modal

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1952,8 +1952,10 @@ export const COPY_ENTITY_TO_APP_SUCCESS = (
 ) => `Copied ${entityName} to ${appName} / ${pageName}`;
 export const COPY_ENTITY_TO_APP_ERROR = () =>
   "Failed to copy to the selected application";
-export const COPY_ENTITY_TO_APP_NOTE = () =>
+export const COPY_ENTITY_TO_APP_NOTE_ACTION = () =>
   "Datasource credentials and any referenced queries aren't copied. Datasources are set up during import, but you may need to re-enter credentials and recreate any referenced queries before the copied item will work in the target application.";
+export const COPY_ENTITY_TO_APP_NOTE_JS_OBJECT = () =>
+  "Queries, JS objects, and other entities referenced by this JS object aren't copied. You may need to recreate them before the copied JS object will work in the target application.";
 
 export const CLEAN_URL_UPDATE = {
   name: () => "Update URLs",

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1952,10 +1952,8 @@ export const COPY_ENTITY_TO_APP_SUCCESS = (
 ) => `Copied ${entityName} to ${appName} / ${pageName}`;
 export const COPY_ENTITY_TO_APP_ERROR = () =>
   "Failed to copy to the selected application";
-export const COPY_ENTITY_TO_APP_NOTE_ACTION = () =>
+export const COPY_ENTITY_TO_APP_NOTE = () =>
   "Datasource credentials and any referenced queries aren't copied. Datasources are set up during import, but you may need to re-enter credentials and recreate any referenced queries before the copied item will work in the target application.";
-export const COPY_ENTITY_TO_APP_NOTE_JS_OBJECT = () =>
-  "Queries, JS objects, and other entities referenced by this JS object aren't copied. You may need to recreate them before the copied JS object will work in the target application.";
 
 export const CLEAN_URL_UPDATE = {
   name: () => "Update URLs",

--- a/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.test.tsx
+++ b/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.test.tsx
@@ -17,10 +17,12 @@ const applications = [
   { id: "other-app", name: "Other App", pages: [], userPermissions: [] },
 ];
 
+let mockEntityType = "ACTION";
+
 jest.mock("selectors/copyToAppSelectors", () => ({
   getIsCopyToAppModalOpen: () => true,
   getCopyToAppModalEntity: () => ({
-    entityType: "ACTION",
+    entityType: mockEntityType,
     entityId: "a1",
     entityName: "Query1",
     sourcePageId: "p1",
@@ -58,7 +60,10 @@ function openApplicationOptions() {
 }
 
 describe("CopyEntityToAppModal", () => {
-  beforeEach(() => mockDispatch.mockClear());
+  beforeEach(() => {
+    mockDispatch.mockClear();
+    mockEntityType = "ACTION";
+  });
 
   it("excludes the source application from the target application list", () => {
     render(<CopyEntityToAppModal />);
@@ -78,5 +83,23 @@ describe("CopyEntityToAppModal", () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       fetchPagesForCopyTarget("other-app"),
     );
+  });
+
+  it("shows the datasource note when copying a query", () => {
+    render(<CopyEntityToAppModal />);
+
+    expect(
+      screen.getByText(/Datasource credentials and any referenced queries/),
+    ).toBeTruthy();
+  });
+
+  it("shows a JS-specific note without datasource info when copying a JS object", () => {
+    mockEntityType = "JS_OBJECT";
+    render(<CopyEntityToAppModal />);
+
+    expect(
+      screen.getByText(/referenced by this JS object aren't copied/),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Datasource credentials/)).toBeNull();
   });
 });

--- a/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.test.tsx
+++ b/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.test.tsx
@@ -93,13 +93,10 @@ describe("CopyEntityToAppModal", () => {
     ).toBeTruthy();
   });
 
-  it("shows a JS-specific note without datasource info when copying a JS object", () => {
+  it("shows no note when copying a JS object", () => {
     mockEntityType = "JS_OBJECT";
     render(<CopyEntityToAppModal />);
 
-    expect(
-      screen.getByText(/referenced by this JS object aren't copied/),
-    ).toBeTruthy();
     expect(screen.queryByText(/Datasource credentials/)).toBeNull();
   });
 });

--- a/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.tsx
+++ b/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.tsx
@@ -28,8 +28,7 @@ import {
   COPY_ENTITY_TO_APP_NO_APPS,
   COPY_ENTITY_TO_APP_NO_PAGES,
   COPY_ENTITY_TO_APP_NO_WORKSPACES,
-  COPY_ENTITY_TO_APP_NOTE_ACTION,
-  COPY_ENTITY_TO_APP_NOTE_JS_OBJECT,
+  COPY_ENTITY_TO_APP_NOTE,
   COPY_ENTITY_TO_APP_PAGE_LABEL,
   COPY_ENTITY_TO_APP_PAGE_PLACEHOLDER,
   COPY_ENTITY_TO_APP_WORKSPACE_LABEL,
@@ -294,13 +293,12 @@ function CopyEntityToAppModal() {
           </FieldWrapper>
         )}
 
-        <Callout kind="info">
-          {createMessage(
-            entity?.entityType === CopyToAppEntityType.JS_OBJECT
-              ? COPY_ENTITY_TO_APP_NOTE_JS_OBJECT
-              : COPY_ENTITY_TO_APP_NOTE_ACTION,
-          )}
-        </Callout>
+        {/* The datasource note only applies to queries; JS objects have no datasource. */}
+        {entity?.entityType !== CopyToAppEntityType.JS_OBJECT && (
+          <Callout kind="info">
+            {createMessage(COPY_ENTITY_TO_APP_NOTE)}
+          </Callout>
+        )}
 
         <div
           style={{

--- a/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.tsx
+++ b/app/client/src/pages/Editor/Explorer/CopyToApp/CopyEntityToAppModal.tsx
@@ -28,7 +28,8 @@ import {
   COPY_ENTITY_TO_APP_NO_APPS,
   COPY_ENTITY_TO_APP_NO_PAGES,
   COPY_ENTITY_TO_APP_NO_WORKSPACES,
-  COPY_ENTITY_TO_APP_NOTE,
+  COPY_ENTITY_TO_APP_NOTE_ACTION,
+  COPY_ENTITY_TO_APP_NOTE_JS_OBJECT,
   COPY_ENTITY_TO_APP_PAGE_LABEL,
   COPY_ENTITY_TO_APP_PAGE_PLACEHOLDER,
   COPY_ENTITY_TO_APP_WORKSPACE_LABEL,
@@ -52,6 +53,11 @@ import {
   getIsFetchingCopyTargetPages,
 } from "selectors/copyToAppSelectors";
 import { CopyToAppEntityType } from "./types";
+
+// The ADS Modal (Radix Dialog) blocks scroll events outside its content, so
+// dropdowns must render inside the modal instead of portaling to the body.
+const getPopupContainerInModal = (triggerNode: HTMLElement) =>
+  triggerNode.parentNode as HTMLElement;
 
 const FieldWrapper = ({
   children,
@@ -214,6 +220,7 @@ function CopyEntityToAppModal() {
             <Select
               aria-label={createMessage(COPY_ENTITY_TO_APP_WORKSPACE_LABEL)}
               dropdownMatchSelectWidth
+              getPopupContainer={getPopupContainerInModal}
               onSelect={handleWorkspaceSelect}
               placeholder={createMessage(
                 COPY_ENTITY_TO_APP_WORKSPACE_PLACEHOLDER,
@@ -240,6 +247,7 @@ function CopyEntityToAppModal() {
             <Select
               aria-label={createMessage(COPY_ENTITY_TO_APP_APPLICATION_LABEL)}
               dropdownMatchSelectWidth
+              getPopupContainer={getPopupContainerInModal}
               isLoading={isFetchingApplications}
               onSelect={handleApplicationSelect}
               placeholder={createMessage(
@@ -266,6 +274,7 @@ function CopyEntityToAppModal() {
             <Select
               aria-label={createMessage(COPY_ENTITY_TO_APP_PAGE_LABEL)}
               dropdownMatchSelectWidth
+              getPopupContainer={getPopupContainerInModal}
               isLoading={isFetchingPages}
               onSelect={(value: string) => setPageId(value)}
               placeholder={createMessage(COPY_ENTITY_TO_APP_PAGE_PLACEHOLDER)}
@@ -285,7 +294,13 @@ function CopyEntityToAppModal() {
           </FieldWrapper>
         )}
 
-        <Callout kind="info">{createMessage(COPY_ENTITY_TO_APP_NOTE)}</Callout>
+        <Callout kind="info">
+          {createMessage(
+            entity?.entityType === CopyToAppEntityType.JS_OBJECT
+              ? COPY_ENTITY_TO_APP_NOTE_JS_OBJECT
+              : COPY_ENTITY_TO_APP_NOTE_ACTION,
+          )}
+        </Callout>
 
         <div
           style={{


### PR DESCRIPTION
## Description

This PR fixes two issues in the CopyEntityToAppModal component:

1. **Dropdown positioning**: Dropdowns in the modal were being portaled outside the modal container, causing them to be blocked by the Radix Dialog&#39;s scroll event blocking. Added `getPopupContainer` configuration to all Select components to render dropdowns inside the modal instead.

2. **Conditional datasource note**: The datasource credentials note was being shown for all entity types, but it only applies to queries. Added a conditional check to hide the note when copying JS objects, which don&#39;t have datasources.

### Changes Made

**CopyEntityToAppModal.tsx:**
- Added `getPopupContainerInModal` helper function to keep dropdown content within the modal
- Applied `getPopupContainer={getPopupContainerInModal}` to workspace, application, and page Select components
- Wrapped the datasource note in a conditional that only renders for non-JS_OBJECT entity types

**CopyEntityToAppModal.test.tsx:**
- Refactored mock setup to use a mutable `mockEntityType` variable for test flexibility
- Updated `beforeEach` to reset `mockEntityType` to &#34;ACTION&#34;
- Added test case verifying the datasource note appears when copying a query
- Added test case verifying the note is hidden when copying a JS object

## Test Plan

The changes are covered by new unit tests that verify:
- The datasource note displays for query entities
- The datasource note is hidden for JS object entities

Existing tests continue to pass, confirming no regression in other functionality.

## Automation

/ok-to-test tags="@tag.Sanity"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29553745147>
> Commit: 863dc4689ceb25bc6fa8048d459f322dff426029
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29553745147&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Fri, 17 Jul 2026 04:38:25 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
- [ ] Yes
- [x] No

https://claude.ai/code/session_01LCyDSjroZwWqhkBdfd19Sq



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown behavior in the copy dialog so menus remain contained within the modal.
  * Updated the informational datasource note to appear only for applicable entity types.
  * Added coverage for entity-specific messaging and existing target selection behavior.
