### PR TITLE
fix(security): stop shipping a wildcard frame-ancestors default

### DIFF
--- a/.github/workflows/caddy-routes-test.yml
+++ b/.github/workflows/caddy-routes-test.yml
@@ -12,4 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: docker.env.sh default frame-ancestors is safe
+        run: deploy/docker/tests/docker-env-defaults-test.sh
+
       - run: deploy/docker/route-tests/run.sh

--- a/deploy/docker/fs/opt/appsmith/templates/docker.env.sh
+++ b/deploy/docker/fs/opt/appsmith/templates/docker.env.sh
@@ -80,9 +80,11 @@ APPSMITH_JAVA_ARGS=
 
 # Set this to a space separated list of addresses that should be allowed to load Appsmith in a frame.
 # Example: "https://mydomain.com https://another-trusted-domain.com" will allow embedding on those two domains.
-# Default value, if commented or not set, is "'none'", which disables embedding completely.
+# Default value, if commented or not set, is "'self'", which allows framing only by the Appsmith
+# instance itself (same origin) and blocks all cross-origin framing. Use "'none'" to block framing
+# entirely, or "*" to allow any origin (not recommended: exposes published apps to clickjacking).
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-APPSMITH_ALLOWED_FRAME_ANCESTORS="'self' *"
+#APPSMITH_ALLOWED_FRAME_ANCESTORS=
 
 APPSMITH_DISABLE_IFRAME_WIDGET_SANDBOX=false
 

--- a/deploy/docker/tests/docker-env-defaults-test.sh
+++ b/deploy/docker/tests/docker-env-defaults-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Unit test for the generated docker.env defaults produced by
+# deploy/docker/fs/opt/appsmith/templates/docker.env.sh.
+#
+# docker.env.sh renders the default docker.env only on FIRST install (see
+# init_env_file() in deploy/docker/fs/opt/appsmith/entrypoint.sh). This test
+# renders the template directly (no container needed) and asserts the shipped
+# frame-ancestors default is safe: it must not ship a permissive wildcard, so
+# that a fresh install falls through to the "'self'" default applied by
+# caddy-reconfigure.mjs. Guards APP-15353 (clickjacking hardening).
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+template="$script_dir/../fs/opt/appsmith/templates/docker.env.sh"
+
+if [[ ! -e "$template" ]]; then
+  echo "FAILED: template not found at $template"
+  exit 1
+fi
+
+# Render with dummy positional args (mongo user, db pw, enc pw, enc salt, redis pw, temporal pw).
+rendered="$(bash "$template" appsmith dbpw encpw encsalt redispw temporalpw)"
+
+fail=0
+
+# The rendered env must not set an uncommented APPSMITH_ALLOWED_FRAME_ANCESTORS that permits any origin.
+# A leading "#" (optionally indented) means the line is commented out and therefore not shipped as a value.
+permissive="$(printf '%s\n' "$rendered" \
+  | grep -E '^[[:space:]]*APPSMITH_ALLOWED_FRAME_ANCESTORS=' \
+  | grep -F '*' || true)"
+
+if [[ -n "$permissive" ]]; then
+  echo "FAILED: docker.env.sh ships a permissive wildcard frame-ancestors default:"
+  echo "  $permissive"
+  fail=$((fail + 1))
+else
+  echo "OK: no permissive wildcard frame-ancestors default is shipped"
+fi
+
+# There must be no uncommented assignment at all, so the runtime default ("'self'") applies.
+active="$(printf '%s\n' "$rendered" \
+  | grep -E '^[[:space:]]*APPSMITH_ALLOWED_FRAME_ANCESTORS=' || true)"
+
+if [[ -n "$active" ]]; then
+  echo "FAILED: docker.env.sh sets APPSMITH_ALLOWED_FRAME_ANCESTORS; it should be commented out so the safe 'self' runtime default applies:"
+  echo "  $active"
+  fail=$((fail + 1))
+else
+  echo "OK: APPSMITH_ALLOWED_FRAME_ANCESTORS is not set, runtime default 'self' applies"
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "SUCCEEDED!!!"
+  exit 0
+else
+  echo "FAILED!!!"
+  exit 1
+fi

--- a/deploy/docker/tests/docker-env-defaults-test.sh
+++ b/deploy/docker/tests/docker-env-defaults-test.sh
@@ -22,8 +22,9 @@ if [[ ! -e "$template" ]]; then
   exit 1
 fi
 
-# Render with dummy positional args (mongo user, db pw, enc pw, enc salt, redis pw, temporal pw).
-rendered="$(bash "$template" appsmith dbpw encpw encsalt redispw temporalpw)"
+# Render with dummy positional args matching entrypoint.sh's init_env_file() invocation:
+# mongo user, mongo pw, encryption pw, encryption salt, redis pw.
+rendered="$(bash "$template" appsmith dbpw encpw encsalt redispw)"
 
 fail=0
 


### PR DESCRIPTION
## What & why

`deploy/docker/fs/opt/appsmith/templates/docker.env.sh` shipped a permissive default:

```
APPSMITH_ALLOWED_FRAME_ANCESTORS="'self' *"
```

The `*` meant every self-hosted instance allowed **any** origin to frame its published apps by default, exposing published-app viewer routes to clickjacking (UI redressing) unless an operator explicitly tightened the setting. Reported in the Astra 2026 pentest.

This change stops shipping the wildcard value. The assignment is now commented out, so **fresh installs fall through to the safe `'self'` default** that `caddy-reconfigure.mjs` already applies when the variable is empty/unset. `'self'` permits only same-origin framing (the instance framing itself, e.g. the embed-settings preview) and blocks all cross-origin framing.

Also:
- Fixes the stale comment that wrongly claimed the default was `'none'`.
- Adds `deploy/docker/tests/docker-env-defaults-test.sh` (wired into the Caddy route-tests workflow) that renders the template and asserts it ships no permissive wildcard frame-ancestors default.

## Scope

Fresh-install default **value** only. The runtime fallback in `caddy-reconfigure.mjs` is unchanged, and route-matching (`@framed`/`@embeddable`) is untouched. Existing installs are handled separately (see below).

## ⚠️ RELEASE NOTES / BREAKING (behavior change for NEW installs only)

- **Existing installs are unchanged.** `docker.env` is generated once on first install and preserved across upgrades (`init_env_file()` regenerates it only when the file is absent), so any previously-persisted `APPSMITH_ALLOWED_FRAME_ANCESTORS` value is kept as-is.
- **New installs now default to same-origin-only framing** (`'self'`). Published apps can no longer be embedded on external origins out of the box.
- **Operators who want open or cross-origin embedding must set it explicitly**, either via **Admin Settings → Embed settings → "Allow embedding everywhere"** (or "Limit embedding" with a list of trusted URLs), or by setting the `APPSMITH_ALLOWED_FRAME_ANCESTORS` env var.

## Testing

- New `docker-env-defaults-test.sh` passes on the updated template and fails against the old `'self' *` value (verified). Wired into `.github/workflows/caddy-routes-test.yml`.
- Existing Caddy route-tests already assert `'self'` as the effective default when the var is unset/empty (specs 1 and 7) and remain green.

Linear: https://linear.app/appsmith/issue/APP-15353


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the default framing policy to allow embedding only from the same origin.
  * Removed the permissive wildcard framing default.

* **Tests**
  * Added automated validation to prevent unsafe framing defaults from being introduced.
  * Integrated the validation into the continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Automation
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29981189434>
> Commit: 0c1f2046e5ba05cc8fcc6e0787fdb6fad2a06836
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29981189434&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 23 Jul 2026 06:18:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->
