### PR TITLE
feat: block new Appsmith AI datasource creation and show deprecation banner

### DIFF
--- a/app/client/src/PluginActionEditor/components/PluginActionForm/components/UQIEditor/UQIEditorForm.tsx
+++ b/app/client/src/PluginActionEditor/components/PluginActionForm/components/UQIEditor/UQIEditorForm.tsx
@@ -4,14 +4,14 @@ import { usePluginActionContext } from "../../../../PluginActionContext";
 import { QUERY_EDITOR_FORM_NAME } from "ee/constants/forms";
 import { reduxForm } from "redux-form";
 import { Flex } from "@appsmith/ads";
+import { PluginPackageName } from "entities/Plugin";
+import AppsmithAIDeprecationCallout from "components/editorComponents/AppsmithAIDeprecationCallout";
 import { useGoogleSheetsSetDefaultProperty } from "./hooks/useGoogleSheetsSetDefaultProperty";
 import { useFormData } from "./hooks/useFormData";
 
 const UQIEditorForm = () => {
-  const {
-    editorConfig,
-    plugin: { uiComponent },
-  } = usePluginActionContext();
+  const { editorConfig, plugin } = usePluginActionContext();
+  const { uiComponent } = plugin;
 
   // Set default values for Google Sheets
   useGoogleSheetsSetDefaultProperty();
@@ -29,6 +29,9 @@ const UQIEditorForm = () => {
       flexDirection="column"
       w="100%"
     >
+      {plugin.packageName === PluginPackageName.APPSMITH_AI && (
+        <AppsmithAIDeprecationCallout />
+      )}
       <FormRender
         editorConfig={editorConfig}
         formData={data}

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -415,6 +415,11 @@ export const CREATE_NEW_DATASOURCE_GRAPHQL_API = () => "GraphQL API";
 export const CREATE_NEW_API_SECTION_HEADER = () => "APIs";
 export const CREATE_NEW_SAAS_SECTION_HEADER = () => "SaaS Integrations";
 export const CREATE_NEW_AI_SECTION_HEADER = () => "AI Integrations";
+// Appsmith AI deprecation (release 2.3): update this date if the shutdown date moves
+export const APPSMITH_AI_KILL_DATE = "September 30, 2026";
+export const APPSMITH_AI_DEPRECATION_MESSAGE = () =>
+  `Appsmith AI is deprecated and will stop working on ${APPSMITH_AI_KILL_DATE}. Migrate to OpenAI, Anthropic, or Google AI with your own API key. Uploaded files (file context) will not be available after this date.`;
+export const APPSMITH_AI_DEPRECATION_LEARN_MORE = () => "Learn how to migrate";
 export const CONNECT_A_DATASOURCE_HEADING = () => "Connect a datasource";
 export const CONNECT_A_DATASOURCE_SUBHEADING = () =>
   "Select a sample datasource or connect your own";

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -419,9 +419,7 @@ export const CREATE_NEW_AI_SECTION_HEADER = () => "AI Integrations";
 export const APPSMITH_AI_KILL_DATE = "September 30, 2026";
 export const APPSMITH_AI_DEPRECATION_MESSAGE = () =>
   `Appsmith AI is deprecated and will stop working on ${APPSMITH_AI_KILL_DATE}. Migrate to OpenAI, Anthropic, or Google AI with your own API key. Uploaded files (file context) will not be available after this date.`;
-// TODO: restore "Learn how to migrate" once the BYOK migration guide is
-// published and DocsLink.APPSMITH_AI_DEPRECATION points to it
-export const APPSMITH_AI_DEPRECATION_LEARN_MORE = () => "Learn more";
+export const APPSMITH_AI_DEPRECATION_LEARN_MORE = () => "Learn how to migrate";
 export const CONNECT_A_DATASOURCE_HEADING = () => "Connect a datasource";
 export const CONNECT_A_DATASOURCE_SUBHEADING = () =>
   "Select a sample datasource or connect your own";

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -419,7 +419,9 @@ export const CREATE_NEW_AI_SECTION_HEADER = () => "AI Integrations";
 export const APPSMITH_AI_KILL_DATE = "September 30, 2026";
 export const APPSMITH_AI_DEPRECATION_MESSAGE = () =>
   `Appsmith AI is deprecated and will stop working on ${APPSMITH_AI_KILL_DATE}. Migrate to OpenAI, Anthropic, or Google AI with your own API key. Uploaded files (file context) will not be available after this date.`;
-export const APPSMITH_AI_DEPRECATION_LEARN_MORE = () => "Learn how to migrate";
+// TODO: restore "Learn how to migrate" once the BYOK migration guide is
+// published and DocsLink.APPSMITH_AI_DEPRECATION points to it
+export const APPSMITH_AI_DEPRECATION_LEARN_MORE = () => "Learn more";
 export const CONNECT_A_DATASOURCE_HEADING = () => "Connect a datasource";
 export const CONNECT_A_DATASOURCE_SUBHEADING = () =>
   "Select a sample datasource or connect your own";

--- a/app/client/src/ce/hooks/datasourceEditorHooks.tsx
+++ b/app/client/src/ce/hooks/datasourceEditorHooks.tsx
@@ -14,6 +14,7 @@ import { Button } from "@appsmith/ads";
 import type { Datasource } from "entities/Datasource";
 import type { ApiDatasourceForm } from "entities/Datasource/RestAPIForm";
 import NewActionButton from "pages/Editor/DataSourceEditor/NewActionButton";
+import { PluginPackageName } from "entities/Plugin";
 import { useShowPageGenerationOnHeader } from "pages/Editor/DataSourceEditor/hooks";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -100,15 +101,17 @@ export const useHeaderActions = (
       );
     };
 
-    const newActionButton = (
-      <NewActionButton
-        datasource={datasource as Datasource}
-        disabled={!canCreateDatasourceActions || !isPluginAuthorized}
-        eventFrom="datasource-pane"
-        isNewQuerySecondaryButton={shouldShowSecondaryGenerateButton}
-        pluginType={pluginType}
-      />
-    );
+    // Appsmith AI is deprecated: creating new queries on its datasources is blocked
+    const newActionButton =
+      plugin?.packageName === PluginPackageName.APPSMITH_AI ? null : (
+        <NewActionButton
+          datasource={datasource as Datasource}
+          disabled={!canCreateDatasourceActions || !isPluginAuthorized}
+          eventFrom="datasource-pane"
+          isNewQuerySecondaryButton={shouldShowSecondaryGenerateButton}
+          pluginType={pluginType}
+        />
+      );
 
     const generatePageButton =
       showGenerateButton && !showReconnectButton && !isAnvilEnabled ? (

--- a/app/client/src/components/editorComponents/AppsmithAIDeprecationCallout.test.tsx
+++ b/app/client/src/components/editorComponents/AppsmithAIDeprecationCallout.test.tsx
@@ -1,15 +1,21 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ThemeProvider } from "styled-components";
 import { BrowserRouter as Router } from "react-router-dom";
 import { lightTheme } from "selectors/themeSelectors";
 import AppsmithAIDeprecationCallout from "./AppsmithAIDeprecationCallout";
+import { DocsLink, openDoc } from "constants/DocumentationLinks";
 import {
   APPSMITH_AI_DEPRECATION_LEARN_MORE,
   APPSMITH_AI_KILL_DATE,
   createMessage,
 } from "ee/constants/messages";
+
+jest.mock("constants/DocumentationLinks", () => ({
+  ...jest.requireActual("constants/DocumentationLinks"),
+  openDoc: jest.fn(),
+}));
 
 const renderCallout = () =>
   render(
@@ -39,5 +45,15 @@ describe("AppsmithAIDeprecationCallout", () => {
     expect(
       screen.getByText(createMessage(APPSMITH_AI_DEPRECATION_LEARN_MORE)),
     ).toBeInTheDocument();
+  });
+
+  it("opens the deprecation docs when the link is clicked", () => {
+    renderCallout();
+
+    fireEvent.click(
+      screen.getByText(createMessage(APPSMITH_AI_DEPRECATION_LEARN_MORE)),
+    );
+
+    expect(openDoc).toHaveBeenCalledWith(DocsLink.APPSMITH_AI_DEPRECATION);
   });
 });

--- a/app/client/src/components/editorComponents/AppsmithAIDeprecationCallout.test.tsx
+++ b/app/client/src/components/editorComponents/AppsmithAIDeprecationCallout.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "styled-components";
+import { BrowserRouter as Router } from "react-router-dom";
+import { lightTheme } from "selectors/themeSelectors";
+import AppsmithAIDeprecationCallout from "./AppsmithAIDeprecationCallout";
+import {
+  APPSMITH_AI_DEPRECATION_LEARN_MORE,
+  APPSMITH_AI_KILL_DATE,
+  createMessage,
+} from "ee/constants/messages";
+
+const renderCallout = () =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <Router>
+        <AppsmithAIDeprecationCallout />
+      </Router>
+    </ThemeProvider>,
+  );
+
+describe("AppsmithAIDeprecationCallout", () => {
+  it("renders the deprecation message with the kill date", () => {
+    renderCallout();
+
+    expect(
+      screen.getByTestId("t--appsmith-ai-deprecation-callout"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Appsmith AI is deprecated/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(APPSMITH_AI_KILL_DATE)),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the migration docs link", () => {
+    renderCallout();
+
+    expect(
+      screen.getByText(createMessage(APPSMITH_AI_DEPRECATION_LEARN_MORE)),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/client/src/components/editorComponents/AppsmithAIDeprecationCallout.tsx
+++ b/app/client/src/components/editorComponents/AppsmithAIDeprecationCallout.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import styled from "styled-components";
+import { Callout } from "@appsmith/ads";
+import { DocsLink, openDoc } from "constants/DocumentationLinks";
+import {
+  APPSMITH_AI_DEPRECATION_LEARN_MORE,
+  APPSMITH_AI_DEPRECATION_MESSAGE,
+  createMessage,
+} from "ee/constants/messages";
+
+const CalloutWrapper = styled.div`
+  width: 100%;
+  margin-bottom: var(--ads-v2-spaces-4);
+`;
+
+/**
+ * Deprecation notice for the managed Appsmith AI plugin (release 2.3).
+ * Shown on existing Appsmith AI datasources and queries; creating new
+ * Appsmith AI datasources is blocked separately (client filter + server guard).
+ */
+function AppsmithAIDeprecationCallout() {
+  return (
+    <CalloutWrapper data-testid="t--appsmith-ai-deprecation-callout">
+      <Callout
+        kind="warning"
+        links={[
+          {
+            children: createMessage(APPSMITH_AI_DEPRECATION_LEARN_MORE),
+            onClick: () => openDoc(DocsLink.APPSMITH_AI_DEPRECATION),
+          },
+        ]}
+      >
+        {createMessage(APPSMITH_AI_DEPRECATION_MESSAGE)}
+      </Callout>
+    </CalloutWrapper>
+  );
+}
+
+export default AppsmithAIDeprecationCallout;

--- a/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.test.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.test.ts
@@ -1,5 +1,6 @@
 import { useFilteredAndSortedFileOperations } from "./GlobalSearchHooks";
 import type { Datasource } from "entities/Datasource";
+import { type Plugin, PluginPackageName } from "entities/Plugin";
 import { SEARCH_ITEM_TYPES } from "./utils";
 
 describe("getFilteredAndSortedFileOperations", () => {
@@ -124,6 +125,53 @@ describe("getFilteredAndSortedFileOperations", () => {
       expect.objectContaining({
         title: "New Other datasource query",
       }),
+    );
+  });
+
+  it("does not offer query creation on deprecated Appsmith AI datasources", () => {
+    const appsmithAiPlugin = {
+      id: "appsmith-ai-plugin-id",
+      packageName: PluginPackageName.APPSMITH_AI,
+    } as Plugin;
+
+    const makeDatasource = (name: string, pluginId: string): Datasource => ({
+      datasourceStorages: {},
+      id: `${name}-id`,
+      pluginId,
+      workspaceId: "",
+      name,
+    });
+
+    const fileOptions = useFilteredAndSortedFileOperations({
+      query: "",
+      allDatasources: [
+        makeDatasource("Appsmith AI datasource", appsmithAiPlugin.id),
+        makeDatasource("Postgres datasource", "postgres-plugin-id"),
+      ],
+      plugins: [appsmithAiPlugin],
+      recentlyUsedDSMap: {},
+      canCreateActions: true,
+      canCreateDatasource: true,
+    });
+
+    const titles = fileOptions.map((option) => option.title);
+
+    expect(titles).toContain("New Postgres datasource query");
+    expect(titles).not.toContain("New Appsmith AI datasource query");
+
+    const aiOnlyFileOptions = useFilteredAndSortedFileOperations({
+      query: "",
+      allDatasources: [
+        makeDatasource("Appsmith AI datasource", appsmithAiPlugin.id),
+      ],
+      plugins: [appsmithAiPlugin],
+      recentlyUsedDSMap: {},
+      canCreateActions: true,
+      canCreateDatasource: true,
+    });
+
+    expect(aiOnlyFileOptions.map((option) => option.title)).not.toContain(
+      "Create a query",
     );
   });
 

--- a/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/GlobalSearchHooks.tsx
@@ -174,13 +174,23 @@ export const useFilteredAndSortedFileOperations = ({
     moduleOptions.map((moduleOp) => fileOperations.push(moduleOp));
   }
 
+  // Appsmith AI is deprecated: creating new queries on its datasources is blocked
+  const pluginsById = keyBy(plugins, "id");
+  const queryableDatasources = allDatasources.filter(
+    (ds) =>
+      pluginsById[ds.pluginId]?.packageName !== PluginPackageName.APPSMITH_AI,
+  );
+
   // Add app datasources
-  if (allDatasources.length > 0) {
+  if (queryableDatasources.length > 0) {
     fileOperations.push(createQueryOption);
   }
 
   // Sort datasources based on recency
-  const datasources = getSortedDatasources(allDatasources, recentlyUsedDSMap);
+  const datasources = getSortedDatasources(
+    queryableDatasources,
+    recentlyUsedDSMap,
+  );
 
   const createQueryAction =
     (dsId: string) =>

--- a/app/client/src/constants/DocumentationLinks.ts
+++ b/app/client/src/constants/DocumentationLinks.ts
@@ -23,9 +23,7 @@ const LinkData: Record<DocsLink, string> = {
     "https://docs.appsmith.com/help-and-support/troubleshooting-guide",
   QUERY_SETTINGS:
     "https://docs.appsmith.com/connect-data/reference/query-settings",
-  // TODO: replace with the dedicated Appsmith AI → BYOK migration guide once
-  // published, and restore the "Learn how to migrate" label in messages.ts
-  // (APPSMITH_AI_DEPRECATION_LEARN_MORE)
+  // This URL hosts the Appsmith AI → BYOK migration guide (appsmith-docs#3025)
   APPSMITH_AI_DEPRECATION:
     "https://docs.appsmith.com/connect-data/reference/appsmith-ai",
 };

--- a/app/client/src/constants/DocumentationLinks.ts
+++ b/app/client/src/constants/DocumentationLinks.ts
@@ -7,6 +7,7 @@ export enum DocsLink {
   QUERY = "QUERY",
   TROUBLESHOOT_ERROR = "TROUBLESHOOT_ERROR",
   QUERY_SETTINGS = "QUERY_SETTINGS",
+  APPSMITH_AI_DEPRECATION = "APPSMITH_AI_DEPRECATION",
 }
 
 const LinkData: Record<DocsLink, string> = {
@@ -22,6 +23,9 @@ const LinkData: Record<DocsLink, string> = {
     "https://docs.appsmith.com/help-and-support/troubleshooting-guide",
   QUERY_SETTINGS:
     "https://docs.appsmith.com/connect-data/reference/query-settings",
+  // TODO: replace with the dedicated Appsmith AI → BYOK migration guide once published
+  APPSMITH_AI_DEPRECATION:
+    "https://docs.appsmith.com/connect-data/reference/appsmith-ai",
 };
 
 export const openDoc = (type: DocsLink, link?: string, subType?: string) => {

--- a/app/client/src/constants/DocumentationLinks.ts
+++ b/app/client/src/constants/DocumentationLinks.ts
@@ -23,7 +23,9 @@ const LinkData: Record<DocsLink, string> = {
     "https://docs.appsmith.com/help-and-support/troubleshooting-guide",
   QUERY_SETTINGS:
     "https://docs.appsmith.com/connect-data/reference/query-settings",
-  // TODO: replace with the dedicated Appsmith AI → BYOK migration guide once published
+  // TODO: replace with the dedicated Appsmith AI → BYOK migration guide once
+  // published, and restore the "Learn how to migrate" label in messages.ts
+  // (APPSMITH_AI_DEPRECATION_LEARN_MORE)
   APPSMITH_AI_DEPRECATION:
     "https://docs.appsmith.com/connect-data/reference/appsmith-ai",
 };

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -85,6 +85,7 @@ import { formValuesToDatasource } from "PluginActionEditor/transformers/RestAPID
 import { DSFormHeader } from "./DSFormHeader";
 import type { PluginType } from "entities/Plugin";
 import { DatasourceComponentTypes, PluginPackageName } from "entities/Plugin";
+import AppsmithAIDeprecationCallout from "components/editorComponents/AppsmithAIDeprecationCallout";
 import DSDataFilter from "ee/components/DSDataFilter";
 import { DEFAULT_ENV_ID } from "ee/api/ApiUtils";
 import { isStorageEnvironmentCreated } from "ee/utils/Environments";
@@ -1031,6 +1032,11 @@ class DatasourceEditorRouter extends React.Component<Props, State> {
               showingTabsOnViewMode && "db-form-resizer-content-show-tabs"
             }`}
           >
+            {/* Mounted above DSEditorWrapper: the wrapper is a row flex, so a
+                child callout would render as a side column instead of a banner */}
+            {pluginPackageName === PluginPackageName.APPSMITH_AI && (
+              <AppsmithAIDeprecationCallout />
+            )}
             <DSEditorWrapper
               className={!!isOnboardingFlow ? "onboarding-flow" : ""}
               isCreatingAiAgent={

--- a/app/client/src/pages/Editor/IntegrationEditor/AIPlugins.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/AIPlugins.tsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { createTempDatasourceFromForm } from "actions/datasourceActions";
 import type { DefaultRootState } from "react-redux";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
-import { type Plugin, PluginType } from "entities/Plugin";
+import { type Plugin, PluginPackageName, PluginType } from "entities/Plugin";
 import { getAssetUrl, isAirgapped } from "ee/utils/airgapHelpers";
 import {
   DatasourceContainer,
@@ -93,7 +93,12 @@ const mapStateToProps = (state: DefaultRootState) => {
         // Sort the AI plugins alphabetically
         return a.name.localeCompare(b.name);
       })
-      .filter((plugin) => plugin.type === PluginType.AI),
+      .filter(
+        (plugin) =>
+          plugin.type === PluginType.AI &&
+          // Appsmith AI is deprecated — creating new datasources for it is blocked
+          plugin.packageName !== PluginPackageName.APPSMITH_AI,
+      ),
     searchedPlugin,
   ) as Plugin[];
 

--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -19,6 +19,7 @@ import { getGenerateCRUDEnabledPluginMap } from "ee/selectors/entitiesSelector";
 import {
   type GenerateCRUDEnabledPluginMap,
   type Plugin,
+  PluginPackageName,
   PluginType,
 } from "entities/Plugin";
 import AnalyticsUtil from "ee/utils/AnalyticsUtil";
@@ -298,9 +299,10 @@ function DatasourceCard(props: DatasourceCardProps) {
     (envSupportedDs ? isEnvironmentConfigured(datasource, currentEnv) : true)
   );
 
-  const showCreateNewActionButton = envSupportedDs
-    ? doesAnyDsConfigExist(datasource)
-    : true;
+  // Appsmith AI is deprecated: creating new queries on its datasources is blocked
+  const showCreateNewActionButton =
+    plugin.packageName !== PluginPackageName.APPSMITH_AI &&
+    (envSupportedDs ? doesAnyDsConfigExist(datasource) : true);
 
   return (
     <Wrapper

--- a/app/client/src/pages/Editor/IntegrationEditor/__tests__/aiPlugins.test.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/__tests__/aiPlugins.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { ReduxActionTypes } from "ee/constants/ReduxActionConstants";
+import store from "store";
+import { render } from "test/testUtils";
+import { PluginPackageName } from "entities/Plugin";
+import AIPlugins from "../AIPlugins";
+
+const aiPlugins = [
+  {
+    id: "appsmith-ai-plugin-id",
+    name: "Appsmith AI",
+    type: "AI",
+    packageName: PluginPackageName.APPSMITH_AI,
+    iconLocation: "",
+  },
+  {
+    id: "openai-plugin-id",
+    name: "OpenAI",
+    type: "AI",
+    packageName: "openai-plugin",
+    iconLocation: "",
+  },
+];
+
+describe("AIPlugins create-new list", () => {
+  it("hides deprecated Appsmith AI but keeps other AI plugins", () => {
+    store.dispatch({
+      type: ReduxActionTypes.FETCH_PLUGINS_SUCCESS,
+      payload: aiPlugins,
+    });
+
+    const { container } = render(
+      <AIPlugins pageId="pageId" showUnsupportedPluginDialog={() => {}} />,
+    );
+
+    // BYOK AI plugins must remain creatable
+    expect(
+      container.querySelector(".t--createBlankApi-openai-plugin"),
+    ).not.toBeNull();
+    // The deprecated managed Appsmith AI plugin must not be offered for creation
+    expect(
+      container.querySelector(
+        `.t--createBlankApi-${PluginPackageName.APPSMITH_AI}`,
+      ),
+    ).toBeNull();
+  });
+});

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCE.java
@@ -71,6 +71,15 @@ public interface DatasourceServiceCE {
      */
     Mono<Datasource> createWithoutDeprecationCheck(Datasource datasource);
 
+    /**
+     * Errors with {@code DEPRECATED_PLUGIN_QUERY_CREATION} when the given action datasource belongs to a
+     * deprecated plugin — resolved by id for saved datasources (permission-scoped read) or by the payload's
+     * pluginId for embedded ones. Used to block creating new queries on such datasources; existing queries keep
+     * working. Completes empty for a null datasource or one that can't be resolved, so downstream validation
+     * reports the usual errors.
+     */
+    Mono<Void> validateNewQueryCreationAllowed(Datasource datasource);
+
     Mono<Datasource> createWithoutPermissions(Datasource datasource);
 
     Mono<Datasource> createWithoutPermissions(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCE.java
@@ -65,6 +65,12 @@ public interface DatasourceServiceCE {
 
     Mono<Datasource> create(Datasource datasource);
 
+    /**
+     * Same as {@link #create(Datasource)} but skips the deprecated-plugin creation guard. Meant for internal flows
+     * (e.g. forking an application) that must keep working for datasources of deprecated plugins that already exist.
+     */
+    Mono<Datasource> createWithoutDeprecationCheck(Datasource datasource);
+
     Mono<Datasource> createWithoutPermissions(Datasource datasource);
 
     Mono<Datasource> createWithoutPermissions(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
@@ -174,6 +174,28 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
                         new AppsmithException(AppsmithError.DEPRECATED_DATASOURCE_PLUGIN, plugin.getName())));
     }
 
+    @Override
+    public Mono<Void> validateNewQueryCreationAllowed(Datasource datasource) {
+        if (datasource == null) {
+            return Mono.empty();
+        }
+
+        // Saved datasources are resolved by id with a permission-scoped read so this guard can't be used to probe
+        // datasources the user can't see; embedded ones (blank id) are checked by the pluginId on the payload so a
+        // crafted embedded Appsmith AI datasource can't slip past the block. A datasource with neither falls
+        // through to the usual downstream validation.
+        Mono<Datasource> datasourceMono = hasText(datasource.getId())
+                ? findById(datasource.getId(), datasourcePermission.getReadPermission())
+                : Mono.just(datasource);
+
+        return datasourceMono
+                .filter(resolvedDatasource -> hasText(resolvedDatasource.getPluginId()))
+                .flatMap(resolvedDatasource -> pluginService.findById(resolvedDatasource.getPluginId()))
+                .filter(plugin -> getDeprecatedPluginPackageNames().contains(plugin.getPackageName()))
+                .flatMap(plugin -> Mono.<Void>error(
+                        new AppsmithException(AppsmithError.DEPRECATED_PLUGIN_QUERY_CREATION, plugin.getName())));
+    }
+
     // TODO: Check usage
     @Override
     public Mono<Datasource> createWithoutPermissions(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/base/DatasourceServiceCEImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.datasources.base;
 
 import com.appsmith.external.constants.AnalyticsEvents;
+import com.appsmith.external.constants.PluginConstants;
 import com.appsmith.external.enums.FeatureFlagEnum;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
@@ -139,9 +140,38 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
 
     @Override
     public Mono<Datasource> create(Datasource datasource) {
+        return validatePluginNotDeprecated(datasource)
+                .then(Mono.defer(() -> createWithoutDeprecationCheck(datasource)));
+    }
+
+    @Override
+    public Mono<Datasource> createWithoutDeprecationCheck(Datasource datasource) {
         return workspacePermission
                 .getDatasourceCreatePermission()
                 .flatMap(permission -> createEx(datasource, permission, false, null));
+    }
+
+    /**
+     * Plugins for which creating new datasources is blocked because the plugin is deprecated.
+     * EE overrides this to extend the blocked list (e.g. appsmith-agent-plugin).
+     */
+    protected Set<String> getDeprecatedPluginPackageNames() {
+        return Set.of(PluginConstants.PackageName.APPSMITH_AI_PLUGIN);
+    }
+
+    private Mono<Void> validatePluginNotDeprecated(Datasource datasource) {
+        // Only block brand-new datasources. Calls that carry an id are storage-saves for datasources that already
+        // exist and must keep working so users can keep using them until they migrate. A missing pluginId falls
+        // through to the INVALID_PARAMETER validation in createEx.
+        if (hasText(datasource.getId()) || !hasText(datasource.getPluginId())) {
+            return Mono.empty();
+        }
+
+        return pluginService
+                .findById(datasource.getPluginId())
+                .filter(plugin -> getDeprecatedPluginPackageNames().contains(plugin.getPackageName()))
+                .flatMap(plugin -> Mono.<Void>error(
+                        new AppsmithException(AppsmithError.DEPRECATED_DATASOURCE_PLUGIN, plugin.getName())));
     }
 
     // TODO: Check usage

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/fork/DatasourceForkableServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/datasources/fork/DatasourceForkableServiceCEImpl.java
@@ -157,13 +157,17 @@ public class DatasourceForkableServiceCEImpl implements ForkableServiceCE<Dataso
     private Mono<Datasource> createSuffixedDatasource(Datasource datasource, String name, int suffix) {
         final String actualName = name + (suffix == 0 ? "" : " (" + suffix + ")");
         datasource.setName(actualName);
-        return datasourceService.create(datasource).onErrorResume(DuplicateKeyException.class, error -> {
-            if (error.getMessage() != null
-                    && error.getMessage().contains("workspace_datasource_deleted_compound_index")) {
-                // The duplicate key error is because of the `name` field.
-                return createSuffixedDatasource(datasource, name, 1 + suffix);
-            }
-            throw error;
-        });
+        // Forking must keep working for apps that already contain datasources of deprecated plugins,
+        // so skip the deprecated-plugin creation guard here.
+        return datasourceService
+                .createWithoutDeprecationCheck(datasource)
+                .onErrorResume(DuplicateKeyException.class, error -> {
+                    if (error.getMessage() != null
+                            && error.getMessage().contains("workspace_datasource_deleted_compound_index")) {
+                        // The duplicate key error is because of the `name` field.
+                        return createSuffixedDatasource(datasource, name, 1 + suffix);
+                    }
+                    throw error;
+                });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -525,6 +525,16 @@ public enum AppsmithError {
             "Plugin deprecated",
             ErrorType.BAD_REQUEST,
             null),
+    DEPRECATED_PLUGIN_QUERY_CREATION(
+            400,
+            AppsmithErrorCode.DEPRECATED_PLUGIN_QUERY_CREATION.getCode(),
+            "Creating new queries on {0} datasources is not supported because the plugin is deprecated."
+                    + " Please create an OpenAI, Anthropic, or Google AI datasource with your own API key"
+                    + " and query that instead.",
+            AppsmithErrorAction.DEFAULT,
+            "Plugin deprecated",
+            ErrorType.BAD_REQUEST,
+            null),
     WORKSPACE_ID_NOT_GIVEN(
             400,
             AppsmithErrorCode.WORKSPACE_ID_NOT_GIVEN.getCode(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -516,6 +516,15 @@ public enum AppsmithError {
             "Datasource cannot be deleted",
             ErrorType.BAD_REQUEST,
             null),
+    DEPRECATED_DATASOURCE_PLUGIN(
+            400,
+            AppsmithErrorCode.DEPRECATED_DATASOURCE_PLUGIN.getCode(),
+            "Creating new datasources with the {0} plugin is not supported because the plugin is deprecated."
+                    + " Please create an OpenAI, Anthropic, or Google AI datasource with your own API key instead.",
+            AppsmithErrorAction.DEFAULT,
+            "Plugin deprecated",
+            ErrorType.BAD_REQUEST,
+            null),
     WORKSPACE_ID_NOT_GIVEN(
             400,
             AppsmithErrorCode.WORKSPACE_ID_NOT_GIVEN.getCode(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
@@ -83,6 +83,7 @@ public enum AppsmithErrorCode {
     INVALID_DATASOURCE_CONFIGURATION("AE-DTS-4015", "Invalid datasource configuration"),
     DATASOURCE_HAS_ACTIONS("AE-DTS-4030", "Datasource has actions"),
     DEPRECATED_DATASOURCE_PLUGIN("AE-DTS-4031", "Datasource creation is blocked for a deprecated plugin"),
+    DEPRECATED_PLUGIN_QUERY_CREATION("AE-DTS-4032", "Query creation is blocked on a deprecated plugin's datasource"),
     APPLICATION_FORKING_NOT_ALLOWED("AE-FRK-4034", "Application forking not allowed"),
     INVALID_GIT_CONFIGURATION("AE-GIT-4031", "Invalid git configuration"),
     INVALID_GIT_SSH_CONFIGURATION("AE-GIT-4032", "Invalid git ssh configuration"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithErrorCode.java
@@ -82,6 +82,7 @@ public enum AppsmithErrorCode {
     INVALID_DATASOURCE("AE-DTS-4013", "Invalid datasource"),
     INVALID_DATASOURCE_CONFIGURATION("AE-DTS-4015", "Invalid datasource configuration"),
     DATASOURCE_HAS_ACTIONS("AE-DTS-4030", "Datasource has actions"),
+    DEPRECATED_DATASOURCE_PLUGIN("AE-DTS-4031", "Datasource creation is blocked for a deprecated plugin"),
     APPLICATION_FORKING_NOT_ALLOWED("AE-FRK-4034", "Application forking not allowed"),
     INVALID_GIT_CONFIGURATION("AE-GIT-4031", "Invalid git configuration"),
     INVALID_GIT_SSH_CONFIGURATION("AE-GIT-4032", "Invalid git ssh configuration"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -402,7 +402,14 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                     createActionMetaDTO.setIsJsAction(isJsAction);
                     createActionMetaDTO.setNewPage(newPage);
                     createActionMetaDTO.setEventContext(eventContext);
-                    return createAction(actionDTO, createActionMetaDTO);
+
+                    // Block user-driven query creation on deprecated-plugin datasources. Internal flows (clone,
+                    // fork, import) call createAction(actionDTO, meta) directly and are intentionally not guarded.
+                    Mono<Void> deprecationCheckMono = Boolean.TRUE.equals(isJsAction)
+                            ? Mono.empty()
+                            : datasourceService.validateNewQueryCreationAllowed(actionDTO.getDatasource());
+
+                    return deprecationCheckMono.then(Mono.defer(() -> createAction(actionDTO, createActionMetaDTO)));
                 });
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services;
 
+import com.appsmith.external.constants.PluginConstants;
 import com.appsmith.external.helpers.EncryptionHelper;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionDTO;
@@ -12,6 +13,7 @@ import com.appsmith.external.models.DatasourceStorageDTO;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.OAuth2;
+import com.appsmith.external.models.PluginType;
 import com.appsmith.external.models.Policy;
 import com.appsmith.external.models.SSLDetails;
 import com.appsmith.external.models.UploadedFile;
@@ -34,6 +36,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.plugins.base.PluginService;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.repositories.PermissionGroupRepository;
+import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
 import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.EnvironmentPermission;
@@ -108,6 +111,9 @@ public class DatasourceServiceTest {
 
     @Autowired
     PermissionGroupRepository permissionGroupRepository;
+
+    @Autowired
+    PluginRepository pluginRepository;
 
     @MockBean
     PluginExecutorHelper pluginExecutorHelper;
@@ -292,6 +298,95 @@ public class DatasourceServiceTest {
                                 .getMessage()
                                 .equals(AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.DATASOURCE)))
                 .verify();
+    }
+
+    private Plugin getOrCreateAppsmithAiPlugin() {
+        Plugin aiPlugin = pluginService
+                .findByPackageName(PluginConstants.PackageName.APPSMITH_AI_PLUGIN)
+                .block();
+
+        if (aiPlugin == null) {
+            aiPlugin = new Plugin();
+            aiPlugin.setName(PluginConstants.PluginName.APPSMITH_AI_PLUGIN_NAME);
+            aiPlugin.setType(PluginType.AI);
+            aiPlugin.setPackageName(PluginConstants.PackageName.APPSMITH_AI_PLUGIN);
+            aiPlugin = pluginRepository.save(aiPlugin).block();
+        }
+
+        return aiPlugin;
+    }
+
+    private Datasource buildAppsmithAiDatasource(Plugin aiPlugin, String name) {
+        Datasource datasource = new Datasource();
+        datasource.setName(name);
+        datasource.setWorkspaceId(workspaceId);
+        datasource.setPluginId(aiPlugin.getId());
+        HashMap<String, DatasourceStorageDTO> storages = new HashMap<>();
+        storages.put(defaultEnvironmentId, new DatasourceStorageDTO(null, defaultEnvironmentId, null));
+        datasource.setDatasourceStorages(storages);
+        return datasource;
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createDatasource_withDeprecatedAppsmithAiPlugin_throwsException() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Plugin aiPlugin = getOrCreateAppsmithAiPlugin();
+        Datasource datasource = buildAppsmithAiDatasource(aiPlugin, "Deprecated Appsmith AI DS");
+
+        StepVerifier.create(datasourceService.create(datasource))
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && throwable
+                                .getMessage()
+                                .equals(AppsmithError.DEPRECATED_DATASOURCE_PLUGIN.getMessage(aiPlugin.getName())))
+                .verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createWithoutDeprecationCheck_withDeprecatedAppsmithAiPlugin_succeeds() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Plugin aiPlugin = getOrCreateAppsmithAiPlugin();
+        Datasource datasource = buildAppsmithAiDatasource(aiPlugin, "Existing Appsmith AI DS");
+
+        // This is the path fork uses; it must keep working for already-existing datasources.
+        StepVerifier.create(datasourceService.createWithoutDeprecationCheck(datasource))
+                .assertNext(createdDatasource -> {
+                    assertThat(createdDatasource.getId()).isNotEmpty();
+                    assertThat(createdDatasource.getPluginId()).isEqualTo(aiPlugin.getId());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createDatasource_existingAppsmithAiDatasource_storageSaveAllowed() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Plugin aiPlugin = getOrCreateAppsmithAiPlugin();
+        Datasource datasource = buildAppsmithAiDatasource(aiPlugin, "Existing Appsmith AI DS for storage save");
+
+        Datasource savedDatasource =
+                datasourceService.createWithoutDeprecationCheck(datasource).block();
+        assertThat(savedDatasource).isNotNull();
+        assertThat(savedDatasource.getId()).isNotEmpty();
+
+        // Calls that carry an id are storage-saves for existing datasources and must bypass the deprecation guard.
+        Datasource existingDatasource = new Datasource();
+        existingDatasource.setId(savedDatasource.getId());
+        existingDatasource.setWorkspaceId(workspaceId);
+        existingDatasource.setPluginId(aiPlugin.getId());
+        existingDatasource.setDatasourceStorages(new HashMap<>(savedDatasource.getDatasourceStorages()));
+
+        StepVerifier.create(datasourceService.create(existingDatasource))
+                .assertNext(
+                        resultDatasource -> assertThat(resultDatasource.getId()).isEqualTo(savedDatasource.getId()))
+                .verifyComplete();
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services.ce;
 
+import com.appsmith.external.constants.PluginConstants;
 import com.appsmith.external.dtos.DslExecutableDTO;
 import com.appsmith.external.helpers.AppsmithEventContext;
 import com.appsmith.external.helpers.AppsmithEventContextType;
@@ -9,6 +10,7 @@ import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStorageDTO;
 import com.appsmith.external.models.PaginationType;
+import com.appsmith.external.models.PluginType;
 import com.appsmith.external.models.Policy;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.RunBehaviourEnum;
@@ -1188,6 +1190,117 @@ public class ActionServiceCE_Test {
                 .assertNext(createdAction -> {
                     // executeOnLoad is expected to be set to false in case of default context
                     assertThat(createdAction.getRunBehaviour()).isEqualTo(RunBehaviourEnum.ON_PAGE_LOAD);
+                })
+                .verifyComplete();
+    }
+
+    private Plugin getOrCreateAppsmithAiPlugin() {
+        Plugin aiPlugin = pluginRepository
+                .findByPackageName(PluginConstants.PackageName.APPSMITH_AI_PLUGIN)
+                .block();
+
+        if (aiPlugin == null) {
+            aiPlugin = new Plugin();
+            aiPlugin.setName(PluginConstants.PluginName.APPSMITH_AI_PLUGIN_NAME);
+            aiPlugin.setType(PluginType.AI);
+            aiPlugin.setPackageName(PluginConstants.PackageName.APPSMITH_AI_PLUGIN);
+            aiPlugin = pluginRepository.save(aiPlugin).block();
+        }
+
+        return aiPlugin;
+    }
+
+    private Datasource createSavedAppsmithAiDatasource(Plugin aiPlugin, String name) {
+        Datasource aiDatasource = new Datasource();
+        aiDatasource.setName(name);
+        aiDatasource.setWorkspaceId(workspaceId);
+        aiDatasource.setPluginId(aiPlugin.getId());
+        HashMap<String, DatasourceStorageDTO> storages = new HashMap<>();
+        storages.put(
+                defaultEnvironmentId,
+                new DatasourceStorageDTO(null, defaultEnvironmentId, new DatasourceConfiguration()));
+        aiDatasource.setDatasourceStorages(storages);
+        // Existing Appsmith AI datasources are created via the fork path, which bypasses the creation guard.
+        return datasourceService.createWithoutDeprecationCheck(aiDatasource).block();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createSingleAction_onDeprecatedAppsmithAiDatasource_throwsException() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Plugin aiPlugin = getOrCreateAppsmithAiPlugin();
+        Datasource savedAiDatasource = createSavedAppsmithAiDatasource(aiPlugin, "Deprecated AI DS for new query");
+
+        ActionDTO action = new ActionDTO();
+        action.setName("newQueryOnDeprecatedAiDatasource");
+        action.setPageId(testPage.getId());
+        action.setActionConfiguration(new ActionConfiguration());
+        action.setDatasource(savedAiDatasource);
+
+        StepVerifier.create(layoutActionService.createSingleAction(action, Boolean.FALSE))
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && throwable
+                                .getMessage()
+                                .equals(AppsmithError.DEPRECATED_PLUGIN_QUERY_CREATION.getMessage(aiPlugin.getName())))
+                .verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createSingleAction_onEmbeddedDeprecatedAppsmithAiDatasource_throwsException() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Plugin aiPlugin = getOrCreateAppsmithAiPlugin();
+
+        // A crafted payload with an id-less (embedded) Appsmith AI datasource must not slip past the guard.
+        Datasource embeddedAiDatasource = new Datasource();
+        embeddedAiDatasource.setName("Embedded Appsmith AI DS");
+        embeddedAiDatasource.setWorkspaceId(workspaceId);
+        embeddedAiDatasource.setPluginId(aiPlugin.getId());
+
+        ActionDTO action = new ActionDTO();
+        action.setName("newQueryOnEmbeddedDeprecatedAiDatasource");
+        action.setPageId(testPage.getId());
+        action.setActionConfiguration(new ActionConfiguration());
+        action.setDatasource(embeddedAiDatasource);
+
+        StepVerifier.create(layoutActionService.createSingleAction(action, Boolean.FALSE))
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && throwable
+                                .getMessage()
+                                .equals(AppsmithError.DEPRECATED_PLUGIN_QUERY_CREATION.getMessage(aiPlugin.getName())))
+                .verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createAction_clonePageContext_onDeprecatedAppsmithAiDatasource_succeeds() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Plugin aiPlugin = getOrCreateAppsmithAiPlugin();
+        Datasource savedAiDatasource = createSavedAppsmithAiDatasource(aiPlugin, "Deprecated AI DS for clone");
+
+        ActionDTO action = new ActionDTO();
+        action.setName("clonedQueryOnDeprecatedAiDatasource");
+        action.setPageId(testPage.getId());
+        action.setActionConfiguration(new ActionConfiguration());
+        action.setDatasource(savedAiDatasource);
+
+        // Internal flows (clone, fork, import) use the meta overload and must keep working for existing
+        // Appsmith AI queries.
+        AppsmithEventContext eventContext = new AppsmithEventContext(AppsmithEventContextType.CLONE_PAGE);
+        CreateActionMetaDTO createActionMetaDTO = new CreateActionMetaDTO();
+        createActionMetaDTO.setEventContext(eventContext);
+        createActionMetaDTO.setIsJsAction(Boolean.FALSE);
+
+        StepVerifier.create(layoutActionService.createAction(action, createActionMetaDTO))
+                .assertNext(createdAction -> {
+                    assertThat(createdAction.getId()).isNotEmpty();
+                    assertThat(createdAction.getDatasource().getId()).isEqualTo(savedAiDatasource.getId());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

**TL;DR:** First shipping step of the Appsmith AI deprecation (release 2.3): users can no longer create new Appsmith AI (`appsmithai-plugin`) datasources **or new queries against existing ones** — the tile is hidden in the create-new flow, query-creation affordances are hidden, and the API rejects both with a clear 400 — while existing Appsmith AI datasources and queries keep working and now show a deprecation banner with the shutdown date (September 30, 2026) and BYOK migration guidance.

Appsmith pays for LLM tokens behind the managed Appsmith AI plugin (proxied through Cloud Services with Appsmith-owned credentials). Per the deprecation plan, 2.3 blocks new adoption and tells existing users to migrate to the OpenAI / Anthropic / Google AI datasources with their own API keys. Managed credentials are revoked ~60 days after GA as the hard stop.

**Server**
- New `DEPRECATED_DATASOURCE_PLUGIN` error (400, `AE-DTS-4031`) with an actionable message naming the BYOK alternatives.
- `DatasourceServiceCEImpl.create()` rejects brand-new datasources whose plugin package is in `getDeprecatedPluginPackageNames()` — a `protected` method (CE = `appsmithai-plugin`) so the EE repo can extend the blocklist with `appsmith-agent-plugin` without CE changes.
- The previous `create()` body moved to a new `createWithoutDeprecationCheck()`; the fork service now uses it.
- Storage-saves for existing datasources (id present) bypass the guard — existing Appsmith AI datasources remain fully editable/executable until shutdown.

**Client**
- Appsmith AI filtered out of the "AI Integrations" create-new list (`AIPlugins.tsx`); OpenAI / Anthropic / Google AI remain.
- New `AppsmithAIDeprecationCallout` (ADS `Callout`, warning, non-dismissible, "Learn how to migrate" docs link) mounted on the datasource editor (view + edit) and on the Appsmith AI query editor. Copy explicitly calls out that uploaded files (file context) will not be available after the shutdown date.

**Explicit decisions (per product direction)**
- **Import and fork intentionally bypass the guard.** Importing or forking apps that already contain an Appsmith AI datasource must keep working; the T+60 credential revoke is the hard stop for non-migrated usage. (Import uses `createWithoutPermissions`, which never routed through `create()`; fork uses `createWithoutDeprecationCheck`.)
- **No feature flag.** The deprecation is unconditional and restrictive-only; rollback is a clean revert (no data migration).
- **Appsmith AI query creation is now also blocked** (originally deferred to a later phase, pulled in per product direction). Server: `DEPRECATED_PLUGIN_QUERY_CREATION` (400, `AE-DTS-4032`) from a guard in `LayoutActionServiceCEImpl.createSingleAction`, running after page-permission resolution; saved datasources are resolved with a permission-scoped read, and embedded (id-less) payloads are checked by `pluginId` so a crafted payload can't bypass the block. The `createAction(dto, meta)` overload used by clone/fork/import is intentionally unguarded so existing Appsmith AI queries survive those flows (pinned by test). Client: Appsmith AI datasources are filtered from all query-creation lists (omnibar, query add pane, explorer files) and the New query button is hidden on the datasource page and card.
- **Copy/Duplicate of an existing Appsmith AI query now fails with the same 400** — a copy is a new query. The context-menu items remain visible; hiding them is a possible follow-up if product prefers.
- **Accepted risks** (deprecation gate, not a security boundary; the T+60 credential revoke is the real control): re-pointing an existing query to an Appsmith AI datasource via action *update* is not blocked (blocking updates would break editing existing AI queries); JS actions skip the guard (they never execute against the AI plugin).

**Follow-ups tracked**
- EE companion PR: override `getDeprecatedPluginPackageNames()` to add `appsmith-agent-plugin`; EE banners for Agent/RAG surfaces.
- ~~Docs: publish the BYOK migration guide and repoint `DocsLink.APPSMITH_AI_DEPRECATION`.~~ Done: appsmithorg/appsmith-docs#3025 replaces the Appsmith AI reference page with the migration guide at the same URL, so no repoint is needed — merge that PR before or with this one.
- Optional analytics on `DEPRECATED_DATASOURCE_PLUGIN` rejections to measure migration ahead of the kill date.

**Tests**
- Server (`DatasourceServiceTest`): create with `appsmithai-plugin` rejected; `createWithoutDeprecationCheck` succeeds (fork path); existing-datasource storage-save allowed. All 3 green locally with CI-equivalent env.
- Server (`ActionServiceCE_Test`): new query on a saved Appsmith AI datasource rejected; embedded (id-less) Appsmith AI datasource payload rejected; clone-context creation on an Appsmith AI datasource succeeds. Green locally, plus `CurlImporterServiceTest` (32) and `CreateDBTablePageSolutionTests` (17) as regression checks on the guarded path.
- Client (jest): callout renders message/kill date/link and opens the right doc on click; create-list filter hides Appsmith AI but keeps other AI plugins; query-creation file operations exclude Appsmith AI datasources (and omit "Create a query" when only AI datasources exist). `yarn check-types` and ESLint clean.

Fixes https://linear.app/appsmith/issue/APP-15696/disable-appsmith-ai-datasource-breaking-change

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/29837761810>
> Commit: ac8c527ee0d0f50a19cf29da220409839b9cfab6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=29837761810&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 21 Jul 2026 15:20:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [x] Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AN5jb73MFwozkWuB4jvs6W


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Appsmith AI deprecation callout to the datasource, plugin, and action editors, including kill-date messaging and a “Learn more” docs link.
* **Bug Fixes**
  * Hid “create new action”/“create query” options and excluded deprecated Appsmith AI plugins from relevant UI flows.
  * Blocked query creation for deprecated-plugin datasources while allowing existing datasources and internal clone flows to continue working.
* **Tests**
  * Added UI tests for visibility rules and callout behavior, plus backend tests for deprecated-plugin datasource and query creation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
