### PR TITLE
fix(client): move expires_in field after scope in OAuth2 configuratio…

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -596,6 +596,8 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
 
   renderOauth2Common = () => {
     const { formData } = this.props;
+    const isGrantTypeAuthorizationCode =
+      _.get(formData, "authentication.grantType") === GrantType.AuthorizationCode;
 
     return (
       <>
@@ -683,6 +685,20 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        {isGrantTypeAuthorizationCode && (
+          <FormInputContainer
+            data-location-id={btoa("authentication.expiresIn")}
+          >
+            {this.renderInputTextControlViaFormControl({
+              configProperty: "authentication.expiresIn",
+              label: "Authorization expires in (seconds)",
+              placeholderText: "3600",
+              dataType: "NUMBER",
+              encrypted: false,
+              isRequired: false,
+            })}
+          </FormInputContainer>
+        )}
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +885,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&


### PR DESCRIPTION

## Description
TL;DR: Moves the OAuth2 expires_in ("Authorization expires in") input field so that it renders directly below the Scope(s) input field in the Rest API Datasource form.

Motivation & Context: Currently, the expires_in field is placed far down at the end of the authorization code section. Shifting it directly underneath the Scope(s) field keeps all related OAuth2 configuration parameters grouped together, making it much more logical and discoverable for users.


Fixes #31059   
 

## Automation

/ok-to-test tags="@tag.All"


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the OAuth2 **“Authorization expires in (seconds)”** field so it’s displayed consistently with the shared OAuth2 settings.
  * The field no longer appears only in the Authorization Code section; it’s now conditionally shown alongside other common OAuth2 inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->