### PR TITLE
fix(server): resolve action datasource with action-create permission, not edit

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -615,19 +615,24 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                     datasourceMono =
                             Mono.just(editActionDTO.getDatasource()).flatMap(datasourceService::validateDatasource);
                 } else {
-                    // Data source already exists. Fetch it with edit permission to enforce ACL.
-                    // Using the unchecked findById(String) overload here would bypass workspace
-                    // scoping and allow any authenticated user to resolve a foreign datasource ID
-                    // and trigger updateDatasourcePolicyForPublicAction against it, granting the
-                    // public permission group EXECUTE_DATASOURCES rights on a foreign datasource.
-                    // Fixed in: GHSA-fhgw-q2jf-8fq7
+                    // Data source already exists. Fetch it with the datasource action-create
+                    // permission to enforce ACL. Using the unchecked findById(String) overload here
+                    // would bypass workspace scoping and allow any authenticated user to resolve a
+                    // foreign datasource ID and trigger updateDatasourcePolicyForPublicAction against
+                    // it, granting the public permission group EXECUTE_DATASOURCES rights on a foreign
+                    // datasource. The action-create permission (not edit) is the correct tier: it is
+                    // exactly what a user needs to build a query against a datasource, so it keeps the
+                    // ACL guard closed against foreign datasources while still letting users who can
+                    // create actions — but not manage the datasource — create queries.
+                    // Fixed in: GHSA-fhgw-q2jf-8fq7; permission tier corrected in APP-15717.
 
                     if (isDryOps) {
                         datasourceMono = Mono.just(editActionDTO.getDatasource());
                     } else {
-                        datasourceMono = datasourceService
-                                .findById(
-                                        editActionDTO.getDatasource().getId(), datasourcePermission.getEditPermission())
+                        datasourceMono = datasourcePermission
+                                .getActionCreatePermission()
+                                .flatMap(actionCreatePermission -> datasourceService.findById(
+                                        editActionDTO.getDatasource().getId(), actionCreatePermission))
                                 .switchIfEmpty(Mono.error(new AppsmithException(
                                         AppsmithError.NO_RESOURCE_FOUND,
                                         FieldName.DATASOURCE,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceUnitTest.java
@@ -200,16 +200,18 @@ public class NewActionServiceUnitTest {
      *   (injected as a sentinel to detect the wrong overload) surfaces rather than AppsmithException.
      *
      * GREEN (post-fix) behaviour:
-     *   findById(String, AclPermission.MANAGE_DATASOURCES) is called → returns Mono.empty() →
+     *   findById(String, AclPermission.CREATE_DATASOURCE_ACTIONS) is called → returns Mono.empty() →
      *   switchIfEmpty emits AppsmithException → StepVerifier.expectError(AppsmithException.class) passes.
      */
     @Test
     public void testValidateAction_withForeignDatasourceId_shouldUseScopedFindById_GHSA_fhgw_q2jf_8fq7() {
         String foreignDatasourceId = "foreign-workspace-datasource-id";
 
-        // Mock the edit permission returned by datasourcePermission
-        AclPermission editPermission = AclPermission.MANAGE_DATASOURCES;
-        Mockito.when(datasourcePermission.getEditPermission()).thenReturn(editPermission);
+        // Mock the action-create permission returned by datasourcePermission. This is the tier a
+        // user needs to build a query against a datasource (CREATE_DATASOURCE_ACTIONS in EE); the
+        // getActionCreatePermission() getter is reactive, so it is stubbed to emit the permission.
+        AclPermission actionCreatePermission = AclPermission.CREATE_DATASOURCE_ACTIONS;
+        Mockito.when(datasourcePermission.getActionCreatePermission()).thenReturn(Mono.just(actionCreatePermission));
 
         // Sentinel exception: if the unchecked overload is called, surface this distinct error.
         // In pre-fix code this overload is called; in post-fix code it must never be called.
@@ -221,7 +223,7 @@ public class NewActionServiceUnitTest {
 
         // The ACL-scoped overload returns empty — datasource not accessible to this user/workspace.
         // After the fix, the switchIfEmpty must raise an AppsmithException (not continue with a stub).
-        Mockito.when(datasourceService.findById(eq(foreignDatasourceId), eq(editPermission)))
+        Mockito.when(datasourceService.findById(eq(foreignDatasourceId), eq(actionCreatePermission)))
                 .thenReturn(Mono.empty());
 
         NewAction action = new NewAction();
@@ -243,7 +245,7 @@ public class NewActionServiceUnitTest {
         StepVerifier.create(result).expectError(AppsmithException.class).verify();
 
         // Post-fix assertions: the ACL-scoped overload was called; the unchecked overload was not.
-        Mockito.verify(datasourceService).findById(eq(foreignDatasourceId), eq(editPermission));
+        Mockito.verify(datasourceService).findById(eq(foreignDatasourceId), eq(actionCreatePermission));
         Mockito.verify(datasourceService, Mockito.never()).findById(eq(foreignDatasourceId));
     }
 }


### PR DESCRIPTION
## Summary

The fix for GHSA-fhgw-q2jf-8fq7 (#42018) hardened action create/update by resolving the client-supplied datasource with an ACL-scoped `findById`, but used `datasourcePermission.getEditPermission()` (`MANAGE_DATASOURCES`). That tier is too strong: an RBAC user granted **create query/action** but **not manage/edit datasource** can no longer create queries against an existing datasource, so `POST /api/v1/actions` returns **404** where it should return **201**.

This regressed `EE/Enterprise/RBAC/RBACFunctionalTests/CreatePermission_spec.js` test 2 (a user set up with create-query but not manage-datasource), which has failed 3/3 on every EE CI run since #42018 landed and is deterministic in isolation.

## Fix

Resolve the datasource with `getActionCreatePermission()` instead of `getEditPermission()`. This is polymorphic and minimal:

| | `getEditPermission()` | `getActionCreatePermission()` (this PR) |
| -- | -- | -- |
| CE | `MANAGE_DATASOURCES` | `MANAGE_DATASOURCES` — no change (CE was never broken) |
| EE | `MANAGE_DATASOURCES` | `CREATE_DATASOURCE_ACTIONS` — the correct create-action tier |

The ACL check that closes the GHSA cross-tenant `updateDatasourcePolicyForPublicAction` escalation stays intact in both editions: a caller without create-action permission on a foreign datasource still hits `switchIfEmpty` → `NO_RESOURCE_FOUND`. The change only relaxes the *tier* required, from "manage the datasource" to "create actions on the datasource" — which is exactly what building a query needs.

The GHSA security unit test (`NewActionServiceUnitTest.testValidateAction_withForeignDatasourceId_...`) is updated to assert the scoped overload is invoked with the action-create permission (the unchecked overload is still asserted never-called).

## Testing

- `NewActionServiceUnitTest` covers the mechanism (scoped `findById` called; unchecked overload never called).
- End-to-end validation is the EE `CreatePermission_spec` — it only runs in the EE repo, so it will confirm green after the hourly CE→EE sync carries this over. This CE PR's own suite does not include the EE RBAC spec.

## Security review

Please have @subrata71 review — author of #42018 and owner of `NewActionServiceCEImpl` — to confirm the relaxed tier does not reopen GHSA-fhgw-q2jf-8fq7.

Ticket: https://linear.app/appsmith/issue/APP-15717
Context: found via the Cypress flake loop, https://linear.app/appsmith/issue/APP-15705