### PR TITLE
fix: entity naming regex escaping, visibility division-by-zero, widget null guard

### DIFF
--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -65,7 +65,8 @@ export const getNextEntityName = (
   existingNames: string[],
   startWithoutIndex?: boolean,
 ) => {
-  const regex = new RegExp(`^${prefix}(\\d+)$`);
+  const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escapedPrefix}(\\d+)$`);
 
   const usedIndices: number[] = existingNames.map((name) => {
     if (name && regex.test(name)) {
@@ -96,7 +97,8 @@ export const getNextEntityName = (
 
 export const getDuplicateName = (prefix: string, existingNames: string[]) => {
   const trimmedPrefix = prefix.replace(/ /g, "");
-  const regex = new RegExp(`^${trimmedPrefix}(\\d+)$`);
+  const escapedPrefix = trimmedPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escapedPrefix}(\\d+)$`);
   const usedIndices: number[] = existingNames.map((name) => {
     if (name && regex.test(name)) {
       const matches = name.match(regex);

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -304,6 +304,7 @@ function isElementVisibleInContainer(
 
   // Calculate the percentage of the element that is visible
   const elementArea = element.clientWidth * element.clientHeight;
+  if (elementArea === 0) return false;
   const visiblePercentage = (visibleArea / elementArea) * 100;
 
   // Return whether the visible percentage is greater than or equal to the desired percentage
@@ -327,6 +328,7 @@ function getWidgetElementToScroll(
   canvasWidgets: CanvasWidgetsReduxState,
 ): HTMLElement | null {
   const widget = canvasWidgets[widgetId];
+  if (!widget) return null;
   const parentId = widget.parentId;
 
   // If the widget doesn't have a parent, scroll to the widget itself


### PR DESCRIPTION
## Summary

Three utility bug fixes in the Appsmith frontend.

### 1. Regex special characters in entity naming cause incorrect auto-numbering (`utils/AppsmithUtils.tsx`)
`getNextEntityName` and `getDuplicateName` construct `new RegExp(`^${prefix}(\d+)$`)` without escaping regex metacharacters in the prefix. If a widget/entity name prefix contains `.`, `$`, `*`, `+`, `?`, `^`, `{`, `}`, `(`, `)`, `[`, `]`, `|`, or `\`, these are interpreted as regex operators, causing incorrect index calculation and potential name collisions. Fix: escape regex special characters before constructing the pattern.

### 2. Division by zero in `isElementVisibleInContainer` (`utils/helpers.tsx`)
When an element has zero dimensions (hidden via `display:none`, not yet rendered, or 0px width/height), `elementArea` is `0`. The division `visibleArea / 0` produces `Infinity` or `NaN`, both of which pass the `>= percentage` check, falsely reporting hidden elements as visible. Fix: return `false` when `elementArea === 0`.

### 3. TypeError on stale widget ID in `getWidgetElementToScroll` (`utils/helpers.tsx`)
`canvasWidgets[widgetId]` returns `undefined` if the widget was deleted between URL parsing and the deferred `requestIdleCallback` scroll handler. Accessing `.parentId` on `undefined` throws an uncaught TypeError. Fix: return `null` when widget is not found.

## Testing
- TypeScript compilation passes
- Existing utility logic preserved (prefix escaping is transparent for normal names)
- Edge cases verified: zero-area elements, stale/deleted widget IDs, regex metacharacters in prefixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic naming when prefixes contain special characters.
  * Corrected visibility detection for elements with no measurable area.
  * Prevented errors when attempting to scroll to a widget that is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->