### PR TITLE
docs(helpers): document non-JSON type loss in stringifyFnsInObject

### DIFF
--- a/app/client/src/workers/Evaluation/helpers.ts
+++ b/app/client/src/workers/Evaluation/helpers.ts
@@ -111,6 +111,9 @@ export const stringifyFnsInObject = (
     fnStrings.push(fnValue.toString());
   }
 
+  // Note: JSON round-trip strips Dates, Sets, Maps, RegExps, and undefined values.
+  // Functions are preserved (collected before, re-injected after), but other
+  // non-JSON-safe types may be lost.
   const output = JSON.parse(JSON.stringify(userObject));
 
   for (const [index, parsedFnString] of fnStrings.entries()) {


### PR DESCRIPTION
## Summary

`stringifyFnsInObject` uses `JSON.parse(JSON.stringify(userObject))` for its serialization round-trip. This strips `Date`, `Set`, `Map`, `RegExp`, and `undefined` values — all of which become `{}` or `null` silently.

Functions are preserved (collected before serialization, re-injected after), but any other non-JSON-safe types in the user's data tree are silently corrupted with no warning.

**Fix:** Added documentation comment to warn callers about this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comments clarifying how function values and non-JSON-safe types are handled during object serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->