### PR TITLE
fix(evalTree): guard against empty parsed updates array

### DIFF
--- a/app/client/src/workers/Evaluation/formEval.ts
+++ b/app/client/src/workers/Evaluation/formEval.ts
@@ -329,7 +329,9 @@ function evaluateFormConfigElements(
         const evaluatedVal = eval(expression);
 
         config[path].output = evaluatedVal;
-      } catch (e) {}
+    } catch (e) {
+      // form config evaluation error — skip this config entry
+    }
     });
   }
 

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -307,8 +307,9 @@ export async function evalTree(
           //for new tree send the whole thing, don't diff at all
           updates = serialiseToBigInt([{ kind: "newTree", rhs: dataTree }]);
           const parsedUpdates = JSON.parse(updates);
-
-          dataTreeEvaluator?.setPrevState(parsedUpdates[0].rhs);
+          if (parsedUpdates.length > 0) {
+            dataTreeEvaluator?.setPrevState(parsedUpdates[0].rhs);
+          }
         } catch (e) {
           updates = "[]";
 

--- a/app/client/src/workers/Evaluation/helpers.ts
+++ b/app/client/src/workers/Evaluation/helpers.ts
@@ -111,6 +111,9 @@ export const stringifyFnsInObject = (
     fnStrings.push(fnValue.toString());
   }
 
+  // Note: JSON round-trip strips Dates, Sets, Maps, RegExps, and undefined values.
+  // Functions are preserved (collected before, re-injected after), but other
+  // non-JSON-safe types may be lost.
   const output = JSON.parse(JSON.stringify(userObject));
 
   for (const [index, parsedFnString] of fnStrings.entries()) {


### PR DESCRIPTION
Empty evaluation tree → parsedUpdates [0] → TypeError. Guard with .length check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when evaluating form expressions that contain errors.
  * Prevented failures when newly created data trees have no updates.
  * Ensured configuration entries with evaluation errors remain unchanged.

* **Refactor**
  * Added clearer documentation around how object cloning handles special data types and functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->