### PR TITLE
fix(WidgetOperation): avoid empty string for missing list widget container

### DIFF
--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -1876,7 +1876,7 @@ const updateListWidgetBindings = (
   Object.keys(widgets).forEach((widgetId) => {
     if (widgets[widgetId].parentId === listWidgetId) {
       mainCanvasId = widgetId;
-      mainContainerId = widgets[widgetId].children?.[0] ?? "";
+      mainContainerId = widgets[widgetId].children?.[0] ?? undefined;
     }
   });
 

--- a/app/client/src/workers/Evaluation/formEval.ts
+++ b/app/client/src/workers/Evaluation/formEval.ts
@@ -329,7 +329,9 @@ function evaluateFormConfigElements(
         const evaluatedVal = eval(expression);
 
         config[path].output = evaluatedVal;
-      } catch (e) {}
+    } catch (e) {
+      // form config evaluation error — skip this config entry
+    }
     });
   }
 

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -307,8 +307,9 @@ export async function evalTree(
           //for new tree send the whole thing, don't diff at all
           updates = serialiseToBigInt([{ kind: "newTree", rhs: dataTree }]);
           const parsedUpdates = JSON.parse(updates);
-
-          dataTreeEvaluator?.setPrevState(parsedUpdates[0].rhs);
+          if (parsedUpdates.length > 0) {
+            dataTreeEvaluator?.setPrevState(parsedUpdates[0].rhs);
+          }
         } catch (e) {
           updates = "[]";
 

--- a/app/client/src/workers/Evaluation/helpers.ts
+++ b/app/client/src/workers/Evaluation/helpers.ts
@@ -111,6 +111,9 @@ export const stringifyFnsInObject = (
     fnStrings.push(fnValue.toString());
   }
 
+  // Note: JSON round-trip strips Dates, Sets, Maps, RegExps, and undefined values.
+  // Functions are preserved (collected before, re-injected after), but other
+  // non-JSON-safe types may be lost.
   const output = JSON.parse(JSON.stringify(userObject));
 
   for (const [index, parsedFnString] of fnStrings.entries()) {


### PR DESCRIPTION
Empty string as widget container ID causes silent failures downstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when pasting list widget bindings by handling missing container references correctly.
  * Prevented evaluation errors when update data is empty.
  * Evaluation now safely skips invalid configuration entries without interrupting processing.

* **Documentation**
  * Added clarification around how object values and functions are handled during evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->