### PR TITLE
test: stub flaky BetterBugs CDN scripts in Cypress

### DIFF
--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -770,6 +770,17 @@ Cypress.Commands.add("startServerAndRoutes", () => {
     });
   });
 
+  // Stub the BetterBugs recording-link scripts that index.html injects on every
+  // page load. They play no role in tests, and when the fetch from the external
+  // CDN flakes the browser evaluates the error response as JS and throws a
+  // "SyntaxError: Unexpected token" that fails unrelated specs across shards.
+  // Serve an empty body so the fetch never leaves the CI network.
+  cy.intercept("GET", "https://pkg.betterbugs.io/**", {
+    statusCode: 200,
+    body: "",
+    headers: { "content-type": "application/javascript" },
+  });
+
   cy.intercept("PUT", "/api/v1/admin/env", (req) => {
     // GHSA-j9gf-vw2f-9hrw: server-side strict-mode now requires Origin to match
     // APPSMITH_BASE_URL. Use the live Cypress baseUrl instead of the legacy


### PR DESCRIPTION
## Summary

`app/client/public/index.html` injects two BetterBugs recording-link scripts from `https://pkg.betterbugs.io` (`logs-capture.js`, `recorder.js`) on every page load. They play no role in the Cypress suite. When that external CDN fetch flakes under CI, the browser evaluates the error response as JavaScript and throws `SyntaxError: Unexpected token (1:N)`, which fails whichever spec happens to be running on that shard.

This stubs the fetch with an empty 200 in `startServerAndRoutes` — right next to the existing `api.segment.io` stub — so the flaky third-party request never leaves the CI network. It affects the Cypress-run client only; production behavior is unchanged.

## Evidence

The `SyntaxError: Unexpected token` signature, always co-occurring with a failed fetch of the BetterBugs `logs-capture.js` script, has been mined across six-plus unrelated specs on different shards:

- `EE/Enterprise/Module/InterModuleReference_spec.ts` (shard 48)
- `EE/Enterprise/MultipleEnv/ME_CustomEnv_spec.ts` (shard 2)
- `Regression/ClientSide/Widgets/ListV2/Listv2_BasicServerSideData_spec.js` (shard 21)
- `Regression/Apps/CommunityIssues_Spec.ts` (shard 1)
- `Regression/ClientSide/Git/GitImport/GitImport_spec.js` (shard 47)
- `Sanity/Datasources/DatasourceForm_spec.js` (shard 13)

`correlate_spec.py` shows passing upstream neighbours in each case, ruling out a spec-to-spec state leak — the common factor is the external script, not a polluter. As of 2026-07-24 this stopped being a hidden retry (recover-on-retry) and began reddening release runs outright: `Listv2_BasicServerSideData` (3/3 persistent) and `CommunityIssues` (2/2 persistent) failed all retries on runs 30061106112, 30071754997, and 30085427662, all carrying this signature.

## Why a stub rather than a spec change

Six specs failing on the same third-party fetch is one shared cause, not six flaky specs. A per-spec wait or retry would paper over it. Stubbing the external dependency in shared support removes the failure mode for the whole suite at once, mirroring the existing segment.io stub.

## Note on verification

The trigger is an intermittent external-network failure, so it cannot be reproduced red-on-demand in a limited-tests run. A green full suite here confirms the stub does not break anything; it cannot positively prove the flake is gone (the victims pass most runs anyway). Merging removes the external dependency regardless.

## Automation

/ok-to-test tags="@tag.All"

Ref: https://linear.app/appsmith/issue/APP-15705

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/30092616104>
> Commit: d42d2f4fa04a3fe689873da9d41aa1d36367ad01
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=30092616104&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 24 Jul 2026 15:35:58 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test stability by safely handling external BetterBugs recording scripts during page loads.
  * Prevented browser errors caused by unavailable or incompatible third-party scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->