### PR TITLE
fix(ci): avoid "Argument list too long" in client-build changed-files step

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -71,6 +71,7 @@ jobs:
         uses: tj-actions/changed-files@v46
         with:
           files: "app/client/**"
+          write_output_files: true
 
       # - name: Updating the client changed file variable
       #   id: changed-files-specific
@@ -78,11 +79,10 @@ jobs:
 
       - name: Run step if any file(s) in the client folder change
         if: steps.changed-files-specific.outputs.any_changed == 'true'
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
         run: |
-          echo "One or more files in the server folder has changed."
-          echo "List all the files that have changed: $ALL_CHANGED_FILES"
+          echo "One or more files in the client folder has changed."
+          echo "List all the files that have changed:"
+          cat "${{ github.workspace }}/.github/outputs/all_changed_files.txt"
 
       - name: Check compliance
         if: inputs.pr != 0 && steps.changed-files-specific.outputs.any_changed == 'true'


### PR DESCRIPTION
## Description

The client-build job fails with `Argument list too long` on PRs with a large divergence (most recently the release-to-master promotion in EE). The "Run step if any file(s) in the client folder change" step passes `steps.changed-files-specific.outputs.all_changed_files` through an env var solely to echo it; when the list exceeds the 128KiB per-string exec limit, bash cannot be started and the job fails before doing any work.

This switches the step to the file-output pattern `server-build.yml` already uses: `write_output_files: true` on the tj-actions/changed-files step, and `cat` of `.github/outputs/all_changed_files.txt` instead of the env var. The `any_changed` gating used by the rest of the workflow is unchanged.

Linear: https://linear.app/appsmith/issue/APP-15724

## Automation

CI-workflow-only change; Cypress not applicable.

/ok-to-test tags=""

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved client build workflow handling for changed-file detection.
  * Changed files are now consistently recorded and displayed during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->