### PR TITLE
fix(git): surface the real cause of git failures instead of a static message

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/constants/ce/CommonConstantsCE.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/constants/ce/CommonConstantsCE.java
@@ -35,4 +35,13 @@ public class CommonConstantsCE {
 
     public static final String WIDGET_ID = "widgetId";
     public static final String PARENT_ID = "parentId";
+
+    public static final String PUSH_STATUS_PREFIX = "Pushed successfully with status : ";
+
+    /**
+     * Separates the per-ref push status from the remote's own sideband response within the push status string.
+     * JGit exposes the two through different APIs, and only the sideband response explains why a remote rejected
+     * a push, so both are carried back to the service layer.
+     */
+    public static final String REMOTE_RESPONSE_DELIMITER = " | remote response: ";
 }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/FileUtilsCEImpl.java
@@ -139,6 +139,11 @@ public class FileUtilsCEImpl implements FileInterface {
                                 return Mono.just(baseRepo);
                             })
                             .onErrorResume(error -> {
+                                log.warn(
+                                        "Failed to update entities in the git repo, falling back to serialization driven by modified resources. repo={}, branch={}",
+                                        baseRepo,
+                                        branchName,
+                                        error);
                                 return Mono.defer(() -> {
                                     return Mono.just(baseRepo).flatMap(baseRepo1 -> {
                                         try {
@@ -197,8 +202,11 @@ public class FileUtilsCEImpl implements FileInterface {
                                             whiteListedPaths,
                                             baseRepo.relativize(path).toString());
                         } catch (IOException e) {
-                            log.error("Unable to find file details. Please check the file at file path: {}", path);
-                            log.error("Assuming that it does not exist for now ...");
+                            log.error(
+                                    "Unable to read file details, assuming it does not exist. path={}, repo={}",
+                                    path,
+                                    baseRepo,
+                                    e);
                             return false;
                         }
                     })
@@ -235,8 +243,7 @@ public class FileUtilsCEImpl implements FileInterface {
                 Files.deleteIfExists(baseRepo.resolve(filePath));
             } catch (IOException e) {
                 // We ignore files that could not be deleted and expect to come back to this at a later point
-                // Just log the path for now
-                log.error("Unable to delete file at path: {}", filePath);
+                log.error("Unable to delete file. path={}, repo={}", filePath, baseRepo, e);
             }
         });
 
@@ -250,11 +257,15 @@ public class FileUtilsCEImpl implements FileInterface {
                         resourceUpdated = fileOperations.hasFileChanged(
                                 entry.getValue(), filePathToObjectsFromFS.get(key.getFilePath()));
                     } catch (IOException e) {
-                        log.error("Error while checking if file has changed", e);
+                        log.error(
+                                "Error while checking if file has changed, treating it as updated. path={}, repo={}",
+                                key.getFilePath(),
+                                baseRepo,
+                                e);
                     }
 
                     if (resourceUpdated) {
-                        log.info("Resource updated: {}", key.getFilePath());
+                        log.debug("Resource updated: {}", key.getFilePath());
                         String filePath = key.getFilePath();
                         saveResourceCommon(entry.getValue(), baseRepo.resolve(filePath));
 
@@ -296,8 +307,7 @@ public class FileUtilsCEImpl implements FileInterface {
                 Files.deleteIfExists(baseRepo.resolve(filePath));
             } catch (IOException e) {
                 // We ignore files that could not be deleted and expect to come back to this at a later point
-                // Just log the path for now
-                log.error("Unable to delete file at path: {}", filePath);
+                log.error("Unable to delete file. path={}, repo={}", filePath, baseRepo, e);
             }
         });
 
@@ -435,8 +445,7 @@ public class FileUtilsCEImpl implements FileInterface {
             Files.createDirectories(path.getParent());
             return fileOperations.writeToFile(sourceEntity, path);
         } catch (IOException e) {
-            log.error("Error while writing resource to file {} with {}", path, e.getMessage());
-            log.debug(e.getMessage());
+            log.error("Error while writing resource to file. path={}", path, e);
         }
         return false;
     }
@@ -454,8 +463,7 @@ public class FileUtilsCEImpl implements FileInterface {
             }
             fileOperations.writeToFile(sourceEntity, path);
         } catch (IOException e) {
-            log.error("Error while writing resource to file {} with {}", path, e.getMessage());
-            log.debug(e.getMessage());
+            log.error("Error while writing resource to file. path={}", path, e);
         }
     }
 
@@ -490,7 +498,7 @@ public class FileUtilsCEImpl implements FileInterface {
             validatePathIsWithinGitRoot(metadataPath);
             return fileOperations.writeToFile(sourceEntity, metadataPath);
         } catch (IOException e) {
-            log.debug(e.getMessage());
+            log.error("Error while writing action collection to file. path={}, resource={}", path, resourceName, e);
         } finally {
             observationHelper.endSpan(span);
         }
@@ -529,7 +537,7 @@ public class FileUtilsCEImpl implements FileInterface {
             validatePathIsWithinGitRoot(metadataPath);
             return fileOperations.writeToFile(sourceEntity, metadataPath);
         } catch (IOException e) {
-            log.error("Error while reading file {} with message {} with cause", path, e.getMessage(), e.getCause());
+            log.error("Error while writing action to file. path={}, resource={}", path, resourceName, e);
         } finally {
             observationHelper.endSpan(span);
         }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/files/operations/FileOperationsCEv2Impl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/files/operations/FileOperationsCEv2Impl.java
@@ -80,7 +80,7 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
                     objectReader.readTree(sourceEntity.toString()),
                     path.resolve(resourceName + CommonConstants.JSON_EXTENSION));
         } catch (IOException e) {
-            log.debug("Error while writings widgets data to file, {}", e.getMessage());
+            log.error("Error while writing widgets data to file. path={}, resource={}", path, resourceName, e);
         } finally {
             observationHelper.endSpan(span);
         }
@@ -141,7 +141,7 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
         try (FileReader reader = new FileReader(filePath.toFile())) {
             file = objectReader.readValue(reader, Object.class);
         } catch (Exception e) {
-            log.error("Error while reading file {} with message {} with cause", filePath, e.getMessage(), e.getCause());
+            log.error("Error while reading file. path={}", filePath, e);
             return null;
         } finally {
             observationHelper.endSpan(span);
@@ -164,11 +164,7 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
                 try (FileReader reader = new FileReader(file)) {
                     resource.put(file.getName() + keySuffix, objectReader.readValue(reader, Object.class));
                 } catch (Exception e) {
-                    log.error(
-                            "Error while reading file {} with message {} with cause",
-                            file.toPath(),
-                            e.getMessage(),
-                            e.getCause());
+                    log.error("Error while reading file. path={}", file.toPath(), e);
                 }
             });
         }
@@ -192,6 +188,10 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
             return new JSONObject(objectMapper.writeValueAsString(
                     pageJSON.get("unpublishedPage").get("layouts").get(0).get("dsl")));
         } catch (JsonProcessingException e) {
+            log.error(
+                    "Error while extracting the main container from the page DSL. page={}",
+                    pageJSON.path("unpublishedPage").path("name").asText(),
+                    e);
             throw new RuntimeException(e);
         }
     }
@@ -209,8 +209,7 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
             Files.createDirectories(path.getParent());
             return writeToFile(sourceEntity, path);
         } catch (IOException e) {
-            log.error("Error while writing resource to file {} with {}", path, e.getMessage());
-            log.debug(e.getMessage());
+            log.error("Error while writing resource to file. path={}", path, e);
         }
         return false;
     }
@@ -233,7 +232,10 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
                                         pathLocal.getFileName().toString()))
                         .forEach(this::deleteFile);
             } catch (IOException e) {
-                log.error("Error while scanning directory: {}, with error {}", resourceDirectory, e.getMessage());
+                log.error(
+                        "Error while scanning directory for deleted resource files. directory={}",
+                        resourceDirectory,
+                        e);
             }
         }
     }
@@ -256,7 +258,10 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
                                 && !validResources.contains(path.getFileName().toString()))
                         .forEach(this::deleteDirectory);
             } catch (IOException e) {
-                log.error("Error while scanning directory {} with error {}", resourceDirectory, e.getMessage());
+                log.error(
+                        "Error while scanning directory for deleted resource directories. directory={}",
+                        resourceDirectory,
+                        e);
             }
         }
     }
@@ -272,7 +277,7 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
             try {
                 FileUtils.deleteDirectory(directory.toFile());
             } catch (IOException e) {
-                log.error("Unable to delete directory for path {} with message {}", directory, e.getMessage());
+                log.error("Unable to delete directory. path={}", directory, e);
             }
         }
     }
@@ -287,9 +292,9 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
         try {
             Files.deleteIfExists(filePath);
         } catch (DirectoryNotEmptyException e) {
-            log.error("Unable to delete non-empty directory at {} with cause", filePath, e.getMessage());
+            log.error("Unable to delete non-empty directory. path={}", filePath, e);
         } catch (IOException e) {
-            log.error("Unable to delete file {} with {}", filePath, e.getMessage());
+            log.error("Unable to delete file. path={}", filePath, e);
         }
     }
 
@@ -307,7 +312,7 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
         try {
             data = FileUtils.readFileToString(filePath.toFile(), "UTF-8");
         } catch (IOException e) {
-            log.error("Error while reading the file from git repo {} ", e.getMessage());
+            log.error("Error while reading the file from the git repo. path={}", filePath, e);
         } finally {
             observationHelper.endSpan(span);
         }
@@ -332,7 +337,8 @@ public class FileOperationsCEv2Impl implements FileOperationsCE {
                 return Mono.just(0L);
             }
         } catch (IOException ex) {
-            log.error("Error reading index.lock file: {}", ex.getMessage());
+            // A lock file left behind here keeps blocking every subsequent git operation on this repo
+            log.warn("Unable to read the git lock file, it could not be cleaned up. path={}", path, ex);
             return Mono.just(0L);
         }
     }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -81,6 +81,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -119,6 +120,11 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
 
     private static final Set<RemoteRefUpdate.Status> ACCEPTED_PUSH_STATUSES =
             EnumSet.of(RemoteRefUpdate.Status.OK, RemoteRefUpdate.Status.UP_TO_DATE);
+
+    private static final Pattern CONTROL_CHARACTERS = Pattern.compile("\\p{Cntrl}+");
+    private static final int MAX_REMOTE_RESPONSE_LENGTH = 1000;
+    private static final String TRUNCATION_SUFFIX = "... (truncated)";
+    private static final String NO_REMOTE_RESPONSE = "<remote sent no message>";
 
     private final ObservationHelper observationHelper;
 
@@ -401,14 +407,16 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
             for (RemoteRefUpdate remoteRefUpdate : pushResult.getRemoteUpdates()) {
                 status.append(remoteRefUpdate.getStatus()).append(",");
                 if (!StringUtils.isEmptyOrNull(remoteRefUpdate.getMessage())) {
-                    status.append(remoteRefUpdate.getMessage()).append(",");
+                    // The per-ref reason is remote-controlled too, not just the sideband response.
+                    status.append(sanitiseRemoteResponse(remoteRefUpdate.getMessage()))
+                            .append(",");
                 }
                 if (!ACCEPTED_PUSH_STATUSES.contains(remoteRefUpdate.getStatus())) {
                     rejections.add(remoteRefUpdate.getStatus());
                 }
             }
             if (!StringUtils.isEmptyOrNull(pushResult.getMessages())) {
-                remoteResponse.append(pushResult.getMessages().trim());
+                remoteResponse.append(pushResult.getMessages());
             }
         }
 
@@ -420,28 +428,47 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
             return pushStatus;
         }
 
-        // This is the single log for a rejected push; callers add context only for what happens next, such as a
-        // failed rollback. repoSuffix is workspaceId/artifactId/repoName, so it carries the correlation ids.
-        String logMessage = "Git push rejected by the remote. repo={}, ref={}, remote={}, status={}, remoteResponse={}";
-        Object[] logArgs = new Object[] {
-            repoSuffix,
-            refName,
-            remoteUrl,
-            pushStatus,
-            remoteResponse.isEmpty() ? "<remote sent no message>" : remoteResponse
-        };
+        String safeRemoteResponse = sanitiseRemoteResponse(remoteResponse.toString());
 
         // A non-fast-forward rejection just means the remote moved on and the user needs to pull, so it is not an
         // Appsmith fault. Every other rejection is a policy or permission decision worth an error.
+        // This is the single log for a rejected push; callers add context only for what happens next, such as a
+        // failed rollback. repoSuffix is workspaceId/artifactId/repoName, so it carries the correlation ids.
         if (rejections.equals(EnumSet.of(RemoteRefUpdate.Status.REJECTED_NONFASTFORWARD))) {
-            log.warn(logMessage, logArgs);
+            log.warn(
+                    "Git push rejected by the remote. repo={}, ref={}, remote={}, status={}, remoteResponse={}",
+                    repoSuffix,
+                    refName,
+                    remoteUrl,
+                    pushStatus,
+                    safeRemoteResponse.isEmpty() ? NO_REMOTE_RESPONSE : safeRemoteResponse);
         } else {
-            log.error(logMessage, logArgs);
+            log.error(
+                    "Git push rejected by the remote. repo={}, ref={}, remote={}, status={}, remoteResponse={}",
+                    repoSuffix,
+                    refName,
+                    remoteUrl,
+                    pushStatus,
+                    safeRemoteResponse.isEmpty() ? NO_REMOTE_RESPONSE : safeRemoteResponse);
         }
 
-        return remoteResponse.isEmpty()
+        return safeRemoteResponse.isEmpty()
                 ? pushStatus
-                : pushStatus + CommonConstants.REMOTE_RESPONSE_DELIMITER + remoteResponse;
+                : pushStatus + CommonConstants.REMOTE_RESPONSE_DELIMITER + safeRemoteResponse;
+    }
+
+    /**
+     * Neutralises text the remote git server controls before it reaches a log line or a user-facing error.
+     * Carriage returns and other control characters would let a remote forge additional log entries, and an
+     * unbounded response would flood them (CWE-117). Sanitising here rather than at each consumer keeps every
+     * downstream use of the push status safe.
+     */
+    private String sanitiseRemoteResponse(String remoteResponse) {
+        String collapsed =
+                CONTROL_CHARACTERS.matcher(remoteResponse).replaceAll(" ").trim();
+        return collapsed.length() > MAX_REMOTE_RESPONSE_LENGTH
+                ? collapsed.substring(0, MAX_REMOTE_RESPONSE_LENGTH) + TRUNCATION_SUFFIX
+                : collapsed;
     }
 
     /** Clone the repo to the file path : container-volume/workspaceId/defaultAppId/repo/<Data>

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -51,7 +51,9 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevObject;
 import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.transport.TagOpt;
 import org.eclipse.jgit.util.StringUtils;
 import org.springframework.stereotype.Component;
@@ -73,6 +75,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -113,6 +116,10 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
     private static final String TAG_REF = "refs/tags/";
 
     private static final String SUCCESS_MERGE_STATUS = "This branch has no conflicts with the base branch.";
+
+    private static final Set<RemoteRefUpdate.Status> ACCEPTED_PUSH_STATUSES =
+            EnumSet.of(RemoteRefUpdate.Status.OK, RemoteRefUpdate.Status.UP_TO_DATE);
+
     private final ObservationHelper observationHelper;
 
     private final BashService bashService = new BashService();
@@ -280,36 +287,33 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                                         SshTransportConfigCallback.create(
                                                                 privateKey, publicKey, isSshProxyDisabled);
 
-                                                StringBuilder result =
-                                                        new StringBuilder("Pushed successfully with status : ");
-                                                git.push()
+                                                Iterable<PushResult> pushResults = git.push()
                                                         .setAtomic(isAtomicPushAllowed)
                                                         .setTransportConfigCallback(transportConfigCallback)
                                                         .setRemote(remoteUrl)
-                                                        .call()
-                                                        .forEach(pushResult -> pushResult
-                                                                .getRemoteUpdates()
-                                                                .forEach(remoteRefUpdate -> {
-                                                                    result.append(remoteRefUpdate.getStatus())
-                                                                            .append(",");
-                                                                    if (!StringUtils.isEmptyOrNull(
-                                                                            remoteRefUpdate.getMessage())) {
-                                                                        result.append(remoteRefUpdate.getMessage())
-                                                                                .append(",");
-                                                                    }
-                                                                }));
+                                                        .call();
                                                 // We can support username and password in future if needed
                                                 // pushCommand.setCredentialsProvider(new
                                                 // UsernamePasswordCredentialsProvider("username",
                                                 // "password"));
+                                                String pushStatus = summarisePushResult(
+                                                        pushResults, repoSuffix, branchName, remoteUrl);
                                                 processStopwatch.stopAndLogTimeInMillis();
                                                 jgitPushSpan.end();
-                                                return result.substring(0, result.length() - 1);
+                                                return pushStatus;
                                             })
                                             .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
                                             .name(GitSpan.FS_PUSH)
                                             .tap(Micrometer.observation(observationRegistry)),
                                     Git::close)
+                            // Placed outside Mono.using and the timeout so that a failure to open the repository or
+                            // a timeout is logged too, not just a failure raised by the push itself.
+                            .doOnError(error -> log.error(
+                                    "Git push failed before the remote reported a status. repo={}, branch={}, remote={}",
+                                    repoSuffix,
+                                    branchName,
+                                    remoteUrl,
+                                    error))
                             // this subscribeOn on is required because Mono.using
                             // is not deferring the execution of push and for that reason it runs on the
                             // lettuce-nioEventLoop thread instead of boundedElastic
@@ -345,36 +349,99 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                                         SshTransportConfigCallback.create(
                                                                 privateKey, publicKey, isSshProxyDisabled);
 
-                                                StringBuilder result =
-                                                        new StringBuilder("Pushed successfully with status : ");
-                                                git.push()
+                                                Iterable<PushResult> pushResults = git.push()
                                                         .setAtomic(isAtomicPushAllowed)
                                                         .setTransportConfigCallback(transportConfigCallback)
                                                         .setRemote(remoteUrl)
                                                         .setRefSpecs(new RefSpec("refs/tags/*:refs/tags/*"))
-                                                        .call()
-                                                        .forEach(pushResult -> pushResult
-                                                                .getRemoteUpdates()
-                                                                .forEach(remoteRefUpdate -> {
-                                                                    result.append(remoteRefUpdate.getStatus())
-                                                                            .append(",");
-                                                                    if (!StringUtils.isEmptyOrNull(
-                                                                            remoteRefUpdate.getMessage())) {
-                                                                        result.append(remoteRefUpdate.getMessage())
-                                                                                .append(",");
-                                                                    }
-                                                                }));
-                                                return result.substring(0, result.length() - 1);
+                                                        .call();
+                                                return summarisePushResult(pushResults, repoSuffix, refName, remoteUrl);
                                             })
                                             .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
                                             .name(GitSpan.FS_PUSH)
                                             .tap(Micrometer.observation(observationRegistry)),
                                     Git::close)
+                            .doOnError(error -> log.error(
+                                    "Git tag push failed before the remote reported a status. repo={}, tag={}, remote={}",
+                                    repoSuffix,
+                                    refName,
+                                    remoteUrl,
+                                    error))
                             // this subscribeOn on is required because Mono.using
                             // is not deferring the execution of push and for that reason it runs on the
                             // lettuce-nioEventLoop thread instead of boundedElastic
                             .subscribeOn(scheduler);
                 });
+    }
+
+    /**
+     * Builds the push status string and, when the remote refused the push, records why.
+     * <p>
+     * A rejection is reported by JGit in two separate places. {@link RemoteRefUpdate#getMessage()} carries only the
+     * terse report-status reason, which for every server-side hook is the same literal "pre-receive hook declined".
+     * The explanation an operator actually needs — "GitLab: You are not allowed to push code to protected branches
+     * on this project", a push-rule violation, a secret-scanning block — travels on the sideband channel and is
+     * reachable only through {@link PushResult#getMessages()}. Dropping it leaves a rejected push undiagnosable, so
+     * it is logged and appended to the returned status for the service layer to surface.
+     *
+     * @param pushResults results returned by JGit for the push
+     * @param repoSuffix  repository this push belongs to, for correlation
+     * @param refName     branch or tag that was pushed
+     * @param remoteUrl   remote the push was addressed to
+     * @return per-ref push status, followed by the remote's own response when the push was rejected
+     */
+    private String summarisePushResult(
+            Iterable<PushResult> pushResults, Path repoSuffix, String refName, String remoteUrl) {
+
+        StringBuilder status = new StringBuilder(CommonConstants.PUSH_STATUS_PREFIX);
+        StringBuilder remoteResponse = new StringBuilder();
+        Set<RemoteRefUpdate.Status> rejections = EnumSet.noneOf(RemoteRefUpdate.Status.class);
+
+        for (PushResult pushResult : pushResults) {
+            for (RemoteRefUpdate remoteRefUpdate : pushResult.getRemoteUpdates()) {
+                status.append(remoteRefUpdate.getStatus()).append(",");
+                if (!StringUtils.isEmptyOrNull(remoteRefUpdate.getMessage())) {
+                    status.append(remoteRefUpdate.getMessage()).append(",");
+                }
+                if (!ACCEPTED_PUSH_STATUSES.contains(remoteRefUpdate.getStatus())) {
+                    rejections.add(remoteRefUpdate.getStatus());
+                }
+            }
+            if (!StringUtils.isEmptyOrNull(pushResult.getMessages())) {
+                remoteResponse.append(pushResult.getMessages().trim());
+            }
+        }
+
+        String pushStatus = status.charAt(status.length() - 1) == ','
+                ? status.substring(0, status.length() - 1)
+                : status.toString();
+
+        if (rejections.isEmpty()) {
+            return pushStatus;
+        }
+
+        // This is the single log for a rejected push; callers add context only for what happens next, such as a
+        // failed rollback. repoSuffix is workspaceId/artifactId/repoName, so it carries the correlation ids.
+        String logMessage = "Git push rejected by the remote. repo={}, ref={}, remote={}, status={}, remoteResponse={}";
+        Object[] logArgs = new Object[] {
+            repoSuffix,
+            refName,
+            remoteUrl,
+            pushStatus,
+            remoteResponse.isEmpty() ? "<remote sent no message>" : remoteResponse
+        };
+
+        // A non-fast-forward rejection just means the remote moved on and the user needs to pull, so it is not an
+        // Appsmith fault. Every other rejection is a policy or permission decision worth an error.
+        if (rejections.equals(EnumSet.of(RemoteRefUpdate.Status.REJECTED_NONFASTFORWARD))) {
+            log.warn(logMessage, logArgs);
+        } else {
+            log.error(logMessage, logArgs);
+        }
+
+        return remoteResponse.isEmpty()
+                ? pushStatus
+                : pushStatus + CommonConstants.REMOTE_RESPONSE_DELIMITER + remoteResponse;
     }
 
     /** Clone the repo to the file path : container-volume/workspaceId/defaultAppId/repo/<Data>
@@ -1563,7 +1630,11 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
     public Mono<Boolean> resetToLastCommit(Path repoSuffix) {
         return Mono.using(
                 () -> Git.open(createRepoPath(repoSuffix).toFile()),
-                git -> this.resetToLastCommit(git).thenReturn(true).onErrorReturn(false),
+                git -> this.resetToLastCommit(git).thenReturn(true).onErrorResume(e -> {
+                    log.error(
+                            "Reset to last commit failed, the working tree may still be dirty. repo={}", repoSuffix, e);
+                    return Mono.just(false);
+                }),
                 Git::close);
     }
 
@@ -1595,7 +1666,11 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                     return true;
                                 })
                                 .onErrorResume(e -> {
-                                    log.error("Error while resetting the commit, {}", e.getMessage());
+                                    log.error(
+                                            "Hard reset to HEAD~1 failed, the local commit could not be rolled back. repo={}, branch={}",
+                                            repoSuffix,
+                                            branchName,
+                                            e);
                                     return Mono.just(false);
                                 })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/applications/git/GitApplicationHelperCEImpl.java
@@ -234,7 +234,11 @@ public class GitApplicationHelperCEImpl implements GitArtifactHelperCE<Applicati
         return commonGitFileUtils
                 .initializeReadme(readMePath, originHeader + viewModeUrl, originHeader + editModeUrl)
                 .onErrorMap(throwable -> {
-                    log.error("Error while initialising git repo, {0}", throwable);
+                    log.error(
+                            "Error while initialising git repo, application={}, workspace={}",
+                            artifact.getId(),
+                            artifact.getWorkspaceId(),
+                            throwable);
                     return new AppsmithException(
                             AppsmithError.GIT_FILE_SYSTEM_ERROR,
                             Exceptions.unwrap(throwable).getMessage());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/ce/GitRouteAspectCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/ce/GitRouteAspectCE.java
@@ -355,7 +355,8 @@ public class GitRouteAspectCE {
                                     "Git operation {} gave up waiting for the lock on key {} after {} attempts",
                                     gitCommand,
                                     key,
-                                    retrySignal.totalRetries(),
+                                    // totalRetries() counts retries, so it excludes the first attempt
+                                    retrySignal.totalRetries() + 1,
                                     retrySignal.failure());
 
                             if (retrySignal.failure() instanceof AppsmithException) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/ce/GitRouteAspectCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/ce/GitRouteAspectCE.java
@@ -43,6 +43,7 @@ import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -297,12 +298,15 @@ public class GitRouteAspectCE {
 
                     long duration = System.currentTimeMillis() - startTime;
                     log.error(
-                            "Operation : {}, State {} : {}, Error : {}, Time: {}ms",
+                            "Operation : {}, State {} : {}, ArtifactType : {}, {} : {}, Time: {}ms",
                             ctx.getGitRoute().operation(),
                             current,
                             Outcome.FAIL.name(),
-                            e.getMessage(),
-                            duration);
+                            ctx.getGitRoute().artifactType(),
+                            ctx.getGitRoute().fieldName(),
+                            ctx.getFieldValue(),
+                            duration,
+                            e);
                     return run(ctx, config.next(Outcome.FAIL));
                 });
     }
@@ -324,6 +328,13 @@ public class GitRouteAspectCE {
 
             return redis.opsForValue()
                     .get(key)
+                    // This is resubscribed on every lock retry, so per-attempt logging stays at debug and the
+                    // single warn is raised once the retries are exhausted.
+                    .doOnNext(commandName -> log.debug(
+                            "Git operation {} is blocked, the lock for key {} is held by {}",
+                            command,
+                            key,
+                            commandName))
                     .flatMap(commandName ->
                             Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE, command, commandName)));
         });
@@ -340,6 +351,13 @@ public class GitRouteAspectCE {
         return this.setLock(key, gitCommand)
                 .retryWhen(Retry.fixedDelay(MAX_RETRIES, RETRY_DELAY)
                         .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
+                            log.warn(
+                                    "Git operation {} gave up waiting for the lock on key {} after {} attempts",
+                                    gitCommand,
+                                    key,
+                                    retrySignal.totalRetries(),
+                                    retrySignal.failure());
+
                             if (retrySignal.failure() instanceof AppsmithException) {
                                 throw (AppsmithException) retrySignal.failure();
                             }
@@ -681,7 +699,18 @@ public class GitRouteAspectCE {
      * @return Mono emitting true if the lock was released
      */
     protected Mono<?> unlock(Context ctx) {
-        return redis.delete(ctx.getLockKey()).map(count -> count > 0);
+        String key = ctx.getLockKey();
+        return redis.delete(key)
+                .doOnNext(count -> {
+                    if (count > 0) {
+                        log.debug("Released the lock for key {}, deleted keys : {}", key, count);
+                    } else {
+                        log.warn(
+                                "Releasing the lock for key {} deleted no key, the lock had either expired or was never held",
+                                key);
+                    }
+                })
+                .map(count -> count > 0);
     }
 
     /**
@@ -734,6 +763,11 @@ public class GitRouteAspectCE {
                     .orElse(null);
 
             if (paramValue == null) {
+                log.warn(
+                        "Failed to extract target {} because the parameter {} is absent or null, available parameters : {}",
+                        target,
+                        paramName,
+                        Arrays.toString(names));
                 return null;
             }
 
@@ -744,7 +778,13 @@ public class GitRouteAspectCE {
                 Object fieldValue = field.get(paramValue);
                 return fieldValue != null ? String.valueOf(fieldValue) : null;
             } catch (NoSuchFieldException | IllegalAccessException e) {
-                log.warn("Failed to extract nested field {} from parameter {}", fieldName, paramName, e);
+                log.warn(
+                        "Failed to extract nested field {} of target {} from parameter {}, available parameters : {}",
+                        fieldName,
+                        target,
+                        paramName,
+                        Arrays.toString(names),
+                        e);
                 return null;
             }
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/GitRedisUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/GitRedisUtils.java
@@ -48,6 +48,13 @@ public class GitRedisUtils {
                 .addFileLock(key, commandName)
                 .retryWhen(Retry.fixedDelay(numberOfRetries, RETRY_DELAY)
                         .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
+                            log.warn(
+                                    "Git command {} could not acquire the lock for identity {} after {} retries",
+                                    commandName,
+                                    key,
+                                    retrySignal.totalRetries(),
+                                    retrySignal.failure());
+
                             if (retrySignal.failure() instanceof AppsmithException) {
                                 throw (AppsmithException) retrySignal.failure();
                             }
@@ -76,6 +83,8 @@ public class GitRedisUtils {
 
         return redisUtils
                 .releaseFileLock(key)
+                .doOnError(error -> log.warn(
+                        "Failed to release the lock for identity {}, it stays held till it expires", key, error))
                 .name(GitSpan.RELEASE_FILE_LOCK)
                 .tap(Micrometer.observation(observationRegistry));
     }
@@ -121,6 +130,10 @@ public class GitRedisUtils {
             return Mono.just(true);
         }
         if (!Boolean.TRUE.equals(isLockRequired)) {
+            log.debug(
+                    "Skipping the lock release for base artifact {} of type {}, the lock is not held by this operation",
+                    baseArtifactId,
+                    artifactType);
             return Mono.just(Boolean.TRUE);
         }
 
@@ -128,6 +141,8 @@ public class GitRedisUtils {
 
         return redisUtils
                 .releaseFileLock(key)
+                .doOnError(error -> log.warn(
+                        "Failed to release the lock for identity {}, it stays held till it expires", key, error))
                 .name(GitSpan.RELEASE_FILE_LOCK)
                 .tap(Micrometer.observation(observationRegistry));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/AutoCommitSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/AutoCommitSolutionCEImpl.java
@@ -166,6 +166,23 @@ public class AutoCommitSolutionCEImpl implements AutoCommitSolutionCE {
                 .finishAutoCommit(autoCommitEvent.getApplicationId())
                 .flatMap(r -> setProgress(r, autoCommitEvent.getApplicationId(), 100))
                 .flatMap(r -> gitRedisUtils.releaseFileLock(autoCommitEvent.getApplicationId()))
+                .doOnNext(isLockReleased -> {
+                    if (exceptionCaught) {
+                        log.warn(
+                                "auto commit clean up after a failure for application: {}, branch: {}, isCommitMade: {}, isLockReleased: {}",
+                                autoCommitEvent.getApplicationId(),
+                                autoCommitEvent.getBranchName(),
+                                isCommitMade,
+                                isLockReleased);
+                    } else {
+                        log.debug(
+                                "auto commit clean up for application: {}, branch: {}, isCommitMade: {}, isLockReleased: {}",
+                                autoCommitEvent.getApplicationId(),
+                                autoCommitEvent.getBranchName(),
+                                isCommitMade,
+                                isLockReleased);
+                    }
+                })
                 .thenReturn(isCommitMade);
     }
 
@@ -369,6 +386,12 @@ public class AutoCommitSolutionCEImpl implements AutoCommitSolutionCE {
                                     return triggerAnalyticsEvent(
                                             AnalyticsEvents.GIT_PUSH, autoCommitEvent, Map.of("isAutoCommit", TRUE));
                                 }
+
+                                log.error(
+                                        "auto commit push was rejected for application: {}, branch: {}, pushResponse: {}",
+                                        autoCommitEvent.getApplicationId(),
+                                        autoCommitEvent.getBranchName(),
+                                        pushResponse);
                                 return Mono.just(TRUE);
                             });
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitAsyncEventManagerImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitAsyncEventManagerImpl.java
@@ -37,9 +37,17 @@ public class AutoCommitAsyncEventManagerImpl implements AutoCommitAsyncEventMana
                 .startApplicationAutoCommit(baseArtifactId, authorName, authorEmail, event)
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe(
-                        result -> log.info(
-                                "Auto-commit completed successfully for application: {}", event.getApplicationId()),
+                        result -> log.debug(
+                                "Auto-commit finished for application: {}, branch: {}, isCommitMade: {}",
+                                event.getApplicationId(),
+                                event.getBranchName(),
+                                result),
                         error -> log.error(
-                                "Error during auto-commit for application: {}", event.getApplicationId(), error));
+                                "Error during auto-commit for application: {}, branch: {}, repo: {}, workspace: {}",
+                                event.getApplicationId(),
+                                event.getBranchName(),
+                                event.getRepoName(),
+                                event.getWorkspaceId(),
+                                error));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
@@ -41,7 +41,7 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
         Mono<Boolean> isServerMigrationRequiredMonoCached = commonGitFileUtils
                 .getMetadataServerSchemaMigrationVersion(workspaceId, gitMetadata, FALSE, APPLICATION)
                 .map(serverSchemaVersion -> {
-                    log.info(
+                    log.debug(
                             "server schema for application id : {}  and branch name : {} is : {}",
                             defaultApplicationId,
                             refName,
@@ -52,11 +52,11 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
                 .cache();
 
         return Mono.defer(() -> isServerMigrationRequiredMonoCached).onErrorResume(error -> {
-            log.debug(
-                    "error while retrieving the metadata for defaultApplicationId : {}, refName : {} error : {}",
+            log.warn(
+                    "skipping server auto commit because retrieving the metadata failed for defaultApplicationId : {}, refName : {}",
                     defaultApplicationId,
                     refName,
-                    error.getMessage());
+                    error);
             return Mono.just(FALSE);
         });
     }
@@ -84,7 +84,10 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
                 })
                 .defaultIfEmpty(FALSE)
                 .onErrorResume(error -> {
-                    log.debug("Error fetching latest DSL version");
+                    log.warn(
+                            "skipping client auto commit because fetching the latest DSL version failed for page : {}",
+                            pageDTO.getName(),
+                            error);
                     return Mono.just(Boolean.FALSE);
                 });
     }
@@ -103,19 +106,19 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
                 .map(tuple2 -> {
                     Integer latestDslVersion = tuple2.getT1();
                     org.json.JSONObject pageDSL = tuple2.getT2();
-                    log.info("page dsl retrieved from file system");
+                    log.debug("page dsl retrieved from file system for page : {}", pageDTO.getName());
                     return GitUtils.isMigrationRequired(pageDSL, latestDslVersion);
                 })
                 .defaultIfEmpty(FALSE)
                 .cache();
 
         return Mono.defer(() -> isClientMigrationRequired).onErrorResume(error -> {
-            log.debug(
-                    "error while fetching the dsl version for page : {}, defaultApplicationId : {}, refName : {} error : {}",
+            log.warn(
+                    "skipping client auto commit because fetching the dsl version failed for page : {}, defaultApplicationId : {}, refName : {}",
                     pageDTO.getName(),
                     defaultApplicationId,
                     refName,
-                    error.getMessage());
+                    error);
             return Mono.just(FALSE);
         });
     }
@@ -153,6 +156,11 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
                     autoCommitTriggerDTO.setIsAutoCommitRequired((TRUE.equals(serverFlag) || TRUE.equals(clientFlag)));
 
                     return gitRedisUtils.releaseFileLock(defaultApplicationId).then(Mono.just(autoCommitTriggerDTO));
-                });
+                })
+                .doOnError(error -> log.warn(
+                        "auto commit eligibility check failed for baseArtifactId : {}, the {} lock, if it was acquired, stays held till it expires",
+                        defaultApplicationId,
+                        AUTO_COMMIT_ELIGIBILITY,
+                        error));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
@@ -136,40 +136,47 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
                 isServerAutoCommitRequired(workspaceId, gitArtifactMetadata).cache();
 
         return Mono.defer(() -> gitRedisUtils.addFileLock(defaultApplicationId, AUTO_COMMIT_ELIGIBILITY))
-                .then(isClientAutocommitRequiredMono.zipWhen(clientFlag -> {
-                    Mono<Boolean> serverFlagMono = isServerAutocommitRequiredMono;
-                    // if client is required to migrate then,
-                    // there is no requirement to fetch server flag as server is subset of client migration.
-                    if (Boolean.TRUE.equals(clientFlag)) {
-                        serverFlagMono = Mono.just(TRUE);
-                    }
+                .then(isClientAutocommitRequiredMono
+                        .zipWhen(clientFlag -> {
+                            Mono<Boolean> serverFlagMono = isServerAutocommitRequiredMono;
+                            // if client is required to migrate then,
+                            // there is no requirement to fetch server flag as server is subset of client migration.
+                            if (Boolean.TRUE.equals(clientFlag)) {
+                                serverFlagMono = Mono.just(TRUE);
+                            }
 
-                    return serverFlagMono;
-                }))
-                .flatMap(tuple2 -> {
-                    Boolean clientFlag = tuple2.getT1();
-                    Boolean serverFlag = tuple2.getT2();
+                            return serverFlagMono;
+                        })
+                        .flatMap(tuple2 -> {
+                            Boolean clientFlag = tuple2.getT1();
+                            Boolean serverFlag = tuple2.getT2();
 
-                    AutoCommitTriggerDTO autoCommitTriggerDTO = new AutoCommitTriggerDTO();
-                    autoCommitTriggerDTO.setIsClientAutoCommitRequired(TRUE.equals(clientFlag));
-                    autoCommitTriggerDTO.setIsServerAutoCommitRequired(TRUE.equals(serverFlag));
-                    autoCommitTriggerDTO.setIsAutoCommitRequired((TRUE.equals(serverFlag) || TRUE.equals(clientFlag)));
+                            AutoCommitTriggerDTO autoCommitTriggerDTO = new AutoCommitTriggerDTO();
+                            autoCommitTriggerDTO.setIsClientAutoCommitRequired(TRUE.equals(clientFlag));
+                            autoCommitTriggerDTO.setIsServerAutoCommitRequired(TRUE.equals(serverFlag));
+                            autoCommitTriggerDTO.setIsAutoCommitRequired(
+                                    (TRUE.equals(serverFlag) || TRUE.equals(clientFlag)));
 
-                    return gitRedisUtils.releaseFileLock(defaultApplicationId).then(Mono.just(autoCommitTriggerDTO));
-                })
-                // Only the success path released the lock, so a single transient failure left it held until its TTL
-                // expired and suppressed every later eligibility check for the artifact. A release failure is
-                // already logged by GitRedisUtils and must not mask the original error.
-                .onErrorResume(error -> {
-                    log.warn(
-                            "auto commit eligibility check failed for baseArtifactId : {}, releasing the {} lock",
-                            defaultApplicationId,
-                            AUTO_COMMIT_ELIGIBILITY,
-                            error);
-                    return gitRedisUtils
-                            .releaseFileLock(defaultApplicationId)
-                            .onErrorComplete()
-                            .then(Mono.error(error));
-                });
+                            return gitRedisUtils
+                                    .releaseFileLock(defaultApplicationId)
+                                    .then(Mono.just(autoCommitTriggerDTO));
+                        })
+                        // Only the success path released the lock, so a single transient failure left it held until
+                        // its TTL expired and suppressed every later eligibility check for the artifact. This is
+                        // deliberately scoped inside then(), so it cannot run when addFileLock itself lost on
+                        // contention: releaseFileLock deletes the key unconditionally, so releasing there would
+                        // drop the lock held by the request that actually won it. A release failure is already
+                        // logged by GitRedisUtils and must not mask the original error.
+                        .onErrorResume(error -> {
+                            log.warn(
+                                    "auto commit eligibility check failed for baseArtifactId : {}, releasing the {} lock",
+                                    defaultApplicationId,
+                                    AUTO_COMMIT_ELIGIBILITY,
+                                    error);
+                            return gitRedisUtils
+                                    .releaseFileLock(defaultApplicationId)
+                                    .onErrorComplete()
+                                    .then(Mono.error(error));
+                        }));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/AutoCommitEligibilityHelperImpl.java
@@ -114,7 +114,7 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
 
         return Mono.defer(() -> isClientMigrationRequired).onErrorResume(error -> {
             log.warn(
-                    "skipping client auto commit because fetching the dsl version failed for page : {}, defaultApplicationId : {}, refName : {}",
+                    "skipping client auto commit because either the latest dsl version or the page dsl on the file system could not be read for page : {}, defaultApplicationId : {}, refName : {}",
                     pageDTO.getName(),
                     defaultApplicationId,
                     refName,
@@ -157,10 +157,19 @@ public class AutoCommitEligibilityHelperImpl implements AutoCommitEligibilityHel
 
                     return gitRedisUtils.releaseFileLock(defaultApplicationId).then(Mono.just(autoCommitTriggerDTO));
                 })
-                .doOnError(error -> log.warn(
-                        "auto commit eligibility check failed for baseArtifactId : {}, the {} lock, if it was acquired, stays held till it expires",
-                        defaultApplicationId,
-                        AUTO_COMMIT_ELIGIBILITY,
-                        error));
+                // Only the success path released the lock, so a single transient failure left it held until its TTL
+                // expired and suppressed every later eligibility check for the artifact. A release failure is
+                // already logged by GitRedisUtils and must not mask the original error.
+                .onErrorResume(error -> {
+                    log.warn(
+                            "auto commit eligibility check failed for baseArtifactId : {}, releasing the {} lock",
+                            defaultApplicationId,
+                            AUTO_COMMIT_ELIGIBILITY,
+                            error);
+                    return gitRedisUtils
+                            .releaseFileLock(defaultApplicationId)
+                            .onErrorComplete()
+                            .then(Mono.error(error));
+                });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImpl.java
@@ -157,15 +157,15 @@ public class GitAutoCommitHelperImpl implements GitAutoCommitHelper {
                 .flatMap(defaultApplication -> {
                     return isAutoCommitAllowed(defaultApplication, finalBranchName)
                             .flatMap(isEligible -> {
-                                log.info(
-                                        "Auto commit for application {}, and branch name {} is not allowed.",
-                                        defaultApplication.getId(),
-                                        branchName);
                                 if (!Boolean.TRUE.equals(isEligible)) {
+                                    log.info(
+                                            "Auto commit for application {}, and branch name {} is not allowed.",
+                                            defaultApplication.getId(),
+                                            branchName);
                                     return Mono.empty();
                                 }
 
-                                log.info(
+                                log.debug(
                                         "Auto commit for application {}, and branch name {} is applicable",
                                         defaultApplication.getId(),
                                         branchName);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -549,7 +549,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                     .then(gitHandlingService.listReferences(jsonTransformationDTO, FALSE))
                     .flatMap(gitRefs -> {
                         long branchMatchCount = gitRefs.stream()
-                                .filter(gitRef -> gitRef.equals(finalRefName))
+                                .filter(gitRef -> finalRefName.equals(gitRef.getRefName()))
                                 .count();
 
                         if (branchMatchCount == 0) {
@@ -1636,7 +1636,8 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                     log.error(
                             "An error occurred while committing changes to artifact with base id: {} and branch: {}",
                             branchedGitMetadata.getDefaultArtifactId(),
-                            branchedGitMetadata.getRefName());
+                            branchedGitMetadata.getRefName(),
+                            error);
 
                     return gitRedisUtils
                             .releaseFileLock(artifactType, branchedGitMetadata.getDefaultArtifactId(), TRUE)
@@ -3178,12 +3179,12 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                                         })
                                         .onErrorResume(error -> {
                                             log.error(
-                                                    "Error in repo status check for artifact: {}, Details: {}",
+                                                    "Error in repo status check for artifact: {}",
                                                     branchedArtifactId,
-                                                    error.getMessage());
+                                                    error);
 
                                             if (error instanceof AppsmithException) {
-                                                Mono.error(error);
+                                                return Mono.error(error);
                                             }
 
                                             return Mono.error(new AppsmithException(
@@ -3426,7 +3427,7 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                                                     baseArtifactId,
                                                     error);
                                             if (error instanceof AppsmithException) {
-                                                Mono.error(error);
+                                                return Mono.error(error);
                                             }
 
                                             return Mono.error(new AppsmithException(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/fs/GitFSServiceCEImpl.java
@@ -11,6 +11,7 @@ import com.appsmith.external.git.constants.ce.RefType;
 import com.appsmith.external.git.dtos.FetchRemoteDTO;
 import com.appsmith.external.git.handler.FSGitHandler;
 import com.appsmith.git.configurations.GitServiceConfig;
+import com.appsmith.git.constants.CommonConstants;
 import com.appsmith.git.dto.CommitDTO;
 import com.appsmith.server.constants.ArtifactType;
 import com.appsmith.server.domains.Artifact;
@@ -44,6 +45,7 @@ import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.BranchTrackingStatus;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import reactor.core.observability.micrometer.Micrometer;
@@ -598,8 +600,13 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                                             error.getMessage(),
                                             gitData.getIsRepoPrivate())
                                     .flatMap(artifact -> {
-                                        log.error("Error during git push: {}", error.getMessage());
+                                        // The failure is already logged with the repo, remote and stack trace by the
+                                        // git handler, so only the mapping decision is recorded here.
                                         if (error instanceof TransportException) {
+                                            log.warn(
+                                                    "Reporting git push transport failure as an SSH configuration error. artifactId={}, ref={}",
+                                                    branchedArtifact.getId(),
+                                                    gitData.getRefName());
                                             return Mono.error(
                                                     new AppsmithException(AppsmithError.INVALID_GIT_SSH_CONFIGURATION));
                                         }
@@ -611,7 +618,8 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                                     }));
                 })
                 .flatMap(pushResult -> {
-                    log.info(
+                    // A rejected push is already reported, with the remote's own response, by the git handler.
+                    log.debug(
                             "Push result for artifact {} with id {} : {}",
                             branchedArtifact.getName(),
                             branchedArtifact.getId(),
@@ -652,7 +660,7 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
         GitArtifactHelper<?> gitArtifactHelper =
                 gitArtifactHelperResolver.getArtifactHelper(artifact.getArtifactType());
 
-        if (pushResult.contains("REJECTED_NONFASTFORWARD")) {
+        if (pushResult.contains(RemoteRefUpdate.Status.REJECTED_NONFASTFORWARD.name())) {
             return gitAnalyticsUtils
                     .addAnalyticsForGitOperation(
                             AnalyticsEvents.GIT_PUSH,
@@ -662,20 +670,53 @@ public class GitFSServiceCEImpl implements GitHandlingServiceCE {
                             gitMetadata.getIsRepoPrivate())
                     .then(Mono.error(new AppsmithException(AppsmithError.GIT_UPSTREAM_CHANGES)));
 
-        } else if (pushResult.contains("REJECTED_OTHERREASON") || pushResult.contains("pre-receive hook declined")) {
+        } else if (pushResult.contains(RemoteRefUpdate.Status.REJECTED_OTHER_REASON.name())
+                || pushResult.contains(RemoteRefUpdate.Status.REJECTED_NODELETE.name())
+                || pushResult.contains(RemoteRefUpdate.Status.REJECTED_REMOTE_CHANGED.name())) {
 
+            // The rejection itself is already logged with the remote's response by the git handler.
             Path path = gitArtifactHelper.getRepoSuffixPath(
                     artifact.getWorkspaceId(), gitMetadata.getDefaultArtifactId(), gitMetadata.getRepoName());
 
             return fsGitHandler
                     .resetHard(path, gitMetadata.getRefName())
+                    .doOnNext(isReset -> {
+                        if (!Boolean.TRUE.equals(isReset)) {
+                            log.error(
+                                    "Rollback of the local commit failed after a rejected push. The commit exists locally but not on the remote. artifactId={}, ref={}, repo={}",
+                                    artifact.getId(),
+                                    gitMetadata.getRefName(),
+                                    gitMetadata.getRepoName());
+                        }
+                    })
                     .then(Mono.error(new AppsmithException(
                             AppsmithError.GIT_ACTION_FAILED,
                             GitCommandConstants.PUSH,
-                            "Unable to push changes as pre-receive hook declined. Please make sure that you don't have any rules enabled on the branch "
-                                    + gitMetadata.getRefName())));
+                            buildPushRejectionMessage(gitMetadata.getRefName(), pushResult))));
         }
         return Mono.just(pushResult);
+    }
+
+    /**
+     * Explains a rejected push using the remote's own words where possible. The remote's sideband response is the
+     * only place that says whether the push was blocked by a branch rule, a push rule, secret scanning or the
+     * deploy key's permissions, so it is preferred over any guess Appsmith could make. When the remote sent nothing
+     * back, the message names the things worth checking instead of asserting a cause.
+     */
+    private String buildPushRejectionMessage(String refName, String pushResult) {
+        int delimiterIndex = pushResult.indexOf(CommonConstants.REMOTE_RESPONSE_DELIMITER);
+        if (delimiterIndex >= 0) {
+            String remoteResponse = pushResult
+                    .substring(delimiterIndex + CommonConstants.REMOTE_RESPONSE_DELIMITER.length())
+                    .trim();
+            if (StringUtils.hasText(remoteResponse)) {
+                return "The remote repository rejected the push to " + refName + ". Remote response: " + remoteResponse;
+            }
+        }
+
+        return "The remote repository rejected the push to " + refName
+                + ", without returning a reason. Check the branch protection and push rules on the remote, and that the"
+                + " deploy key Appsmith uses has write access to this repository.";
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedisUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedisUtils.java
@@ -44,6 +44,10 @@ public class RedisUtils {
             return redisOperations
                     .opsForValue()
                     .get(key)
+                    // Callers retry this for up to 20 attempts, so a per-attempt warn would emit 20 lines for a
+                    // single blocked operation. The warn that matters is raised once when the retries run out.
+                    .doOnNext(commandName -> log.debug(
+                            "Git command {} is blocked, the lock for key {} is held by {}", command, key, commandName))
                     .flatMap(commandName ->
                             Mono.error(new AppsmithException(AppsmithError.GIT_FILE_IN_USE, command, commandName)));
         });
@@ -67,7 +71,17 @@ public class RedisUtils {
         if (gitServiceConfig.isGitInMemory()) {
             return Mono.just(true);
         }
-        return redisOperations.opsForValue().delete(key);
+        return redisOperations.opsForValue().delete(key).doOnNext(isDeleted -> {
+            if (Boolean.TRUE.equals(isDeleted)) {
+                log.debug("Released the file lock for key {}", key);
+            } else {
+                // Release is idempotent and several error paths release the same lock defensively, so an absent
+                // key is normal rather than a problem worth warning about.
+                log.debug(
+                        "Releasing the file lock for key {} deleted no key, the lock had either expired, was already released, or was never held",
+                        key);
+            }
+        });
     }
 
     public Mono<Boolean> hasKey(String key) {
@@ -136,8 +150,9 @@ public class RedisUtils {
                                 });
                             })
                             .then()
-                            .doOnSuccess(v -> log.info("Total Redis keys processed: {}", deletedKeysCount.get()))
-                            .doOnError(error -> log.error("Redis key deletion error: {}", error.getMessage()));
+                            .doOnSuccess(v -> log.debug("Total Redis keys processed: {}", deletedKeysCount.get()))
+                            .doOnError(error ->
+                                    log.error("Redis key deletion error after {} keys", deletedKeysCount.get(), error));
                 })
                 .then();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/CommonGitFileUtilsCE.java
@@ -646,6 +646,7 @@ public class CommonGitFileUtilsCE {
     public Mono<Path> initializeReadme(Path baseRepoSuffix, String viewModeUrl, String editModeUrl) throws IOException {
         return fileUtils
                 .initializeReadme(baseRepoSuffix, viewModeUrl, editModeUrl)
+                // Callers log this failure with their artifact context; the cause is carried on the exception.
                 .onErrorResume(e -> Mono.error(new AppsmithException(AppsmithError.GIT_FILE_SYSTEM_ERROR, e)));
     }
 
@@ -660,9 +661,10 @@ public class CommonGitFileUtilsCE {
     }
 
     public Mono<Boolean> checkIfDirectoryIsEmpty(Path baseRepoSuffix) throws IOException {
-        return fileUtils
-                .checkIfDirectoryIsEmpty(baseRepoSuffix)
-                .onErrorResume(e -> Mono.error(new AppsmithException(AppsmithError.GIT_FILE_SYSTEM_ERROR, e)));
+        return fileUtils.checkIfDirectoryIsEmpty(baseRepoSuffix).onErrorResume(e -> {
+            log.error("Error while checking if the cloned repo is empty. repo={}", baseRepoSuffix, e);
+            return Mono.error(new AppsmithException(AppsmithError.GIT_FILE_SYSTEM_ERROR, e));
+        });
     }
 
     /**
@@ -714,8 +716,16 @@ public class CommonGitFileUtilsCE {
         return fileUtils
                 .reconstructMetadataFromGitRepo(
                         workspaceId, applicationId, repoName, branchName, baseRepoSuffix, isResetToLastCommitRequired)
-                .onErrorResume(error -> Mono.error(
-                        new AppsmithException(AppsmithError.GIT_ACTION_FAILED, CHECKOUT_BRANCH, error.getMessage())))
+                .onErrorResume(error -> {
+                    log.error(
+                            "Error while reconstructing the metadata from the git repo. repo={}, artifactId={}, branch={}",
+                            baseRepoSuffix,
+                            applicationId,
+                            branchName,
+                            error);
+                    return Mono.error(new AppsmithException(
+                            AppsmithError.GIT_ACTION_FAILED, CHECKOUT_BRANCH, error.getMessage()));
+                })
                 .map(metadata -> {
                     Gson gson = new Gson();
                     JsonObject metadataJsonObject =
@@ -746,7 +756,11 @@ public class CommonGitFileUtilsCE {
                         return Files.move(currentGitPath, targetPath, REPLACE_EXISTING);
 
                     } catch (IOException exception) {
-                        log.error("File IO exception while moving repository. {}", exception.getMessage());
+                        log.error(
+                                "File IO exception while moving repository. source={}, target={}",
+                                currentGitPath,
+                                targetPath,
+                                exception);
                         throw new AppsmithException(AppsmithError.GIT_FILE_SYSTEM_ERROR, exception.getMessage());
                     }
                 })
@@ -889,8 +903,17 @@ public class CommonGitFileUtilsCE {
         Mono<JSONObject> jsonObjectMono = keepWorkingDirChangesMono
                 .flatMap(keepWorkingDirChanges -> fileUtils.reconstructPageFromGitRepo(
                         pageDTO.getName(), refName, baseRepoSuffix, isResetToLastCommitRequired, keepWorkingDirChanges))
-                .onErrorResume(error -> Mono.error(
-                        new AppsmithException(AppsmithError.GIT_ACTION_FAILED, RECONSTRUCT_PAGE, error.getMessage())))
+                .onErrorResume(error -> {
+                    log.error(
+                            "Error while reconstructing the page from the git repo. repo={}, pageId={}, page={}, branch={}",
+                            baseRepoSuffix,
+                            pageDTO.getId(),
+                            pageDTO.getName(),
+                            refName,
+                            error);
+                    return Mono.error(new AppsmithException(
+                            AppsmithError.GIT_ACTION_FAILED, RECONSTRUCT_PAGE, error.getMessage()));
+                })
                 .map(pageJson -> {
                     return fileOperations.getMainContainer(pageJson);
                 });
@@ -956,13 +979,14 @@ public class CommonGitFileUtilsCE {
                     try {
                         Files.deleteIfExists(lockFile);
                     } catch (IOException ioException) {
-                        log.warn("Error deleting git lock file {}: {}", lockFile, ioException.getMessage());
+                        // A lock left behind here keeps blocking every subsequent git operation on this repo
+                        log.warn("Error deleting git lock file. path={}", lockFile, ioException);
                     }
 
                     try {
                         Files.deleteIfExists(indexFile);
                     } catch (IOException ioException) {
-                        log.warn("Error deleting git index file {}: {}", indexFile, ioException.getMessage());
+                        log.warn("Error deleting git index file. path={}", indexFile, ioException);
                     }
 
                     return TRUE;


### PR DESCRIPTION
Fixes APP-15731

Slack thread that prompted this: https://theappsmith.slack.com/archives/C09GSB3APNU/p1784892702257989

## Why

A customer's push to a self-hosted GitLab was rejected. The ticket ran for three days with support checking branch protection, push rules and deploy-key permissions in turn, because Appsmith never showed the reason. It could not: the reason was thrown away before it was ever logged.

JGit reports a rejected push in two separate places. `RemoteRefUpdate.getMessage()` carries the terse report-status reason, which for every server-side hook is the same literal `pre-receive hook declined`. The explanation an operator actually needs — "GitLab: You are not allowed to push code to protected branches on this project", a push-rule violation, a secret-scanning block — travels on the sideband channel and is reachable only through `PushResult.getMessages()`. We read the first and dropped the second, then replaced the failure with a hardcoded guess: *"make sure you don't have any rules enabled on the branch X"*. No log level recovered it.

That same shape — swallow the real error, emit a static string — recurs across the git flows. This PR fixes the class, not just the instance.

## What changed

**The remote's own words now reach both the logs and the user.** `FSGitHandlerCEImpl.summarisePushResult` captures the sideband response, logs it once with repo, ref and remote, and carries it to `GitFSServiceCEImpl`, which puts it in the error the user sees instead of the guess. When the remote sends nothing back, the message names what to check rather than asserting a cause.

**Stack traces survive.** Around 20 sites used `log.error("...", e.getMessage())`. SLF4J only captures a stack trace when the `Throwable` is the final argument, so these produced one line and nothing else.

**Silent recovery is now visible.** `resetHard` logged a message and returned `false`, and the caller ignored it. After a rejected push nobody could tell whether the local rollback worked, so a commit could exist locally and nowhere else with no trace.

**Lock lifecycle is diagnosable.** Contention, retry exhaustion and release logged nothing. "Another git operation is in progress" had no diagnostics at all. Per-attempt contention is at `debug` so a blocked operation does not emit 20 warnings; a single warning is raised when the retries run out.

**Auto-commit stops failing invisibly.** It runs in the background, so eligibility errors logged at `debug` and rejected pushes logged not at all were effectively undetectable. `GitAutoCommitHelperImpl` also logged "is not allowed" unconditionally *before* the eligibility check, so every successful auto-commit logged the opposite of what happened.

**Correlation ids** (artifact, ref, repo, workspace) added to existing git error logs.

## Behaviour changes

Three genuine bugs surfaced during the audit and are fixed here:

- The rejection check tested for `REJECTED_OTHERREASON`; JGit's enum is `REJECTED_OTHER_REASON`. The branch was dead, so any rejection whose message was not literally "pre-receive hook declined" fell through and **was reported to the user as a successful push** while the commit never left the server.
- Two `Mono.error(error)` results in the merge flows were constructed but never returned, so an `AppsmithException` was replaced by a generic one.
- The checkout guard compared a `GitRefDTO` to a `String` and so never matched, leaking JGit's raw `Ref <name> already exists` to the user instead of Appsmith's message.

The user-facing text for a rejected push changes deliberately, from the hardcoded branch-rules guess to the remote's actual response.

## Not in this PR

Deliberately kept out to stay reviewable: `ObservabilityLogger` emits the stack twice (SLF4J plus `printStackTrace`), and `GlobalExceptionHandler.getResponseDTOMono` releases the lock using a bare application id while `GitRedisUtils` stores it under `application-<id>`, so that defensive release never matches. Both are filed separately.

## Relationship to the EE PR

EE counterpart: https://github.com/appsmithorg/appsmith-ee/pull/9373

This PR carries the 15 files shared between CE and EE. The EE PR additionally covers EE-only surfaces with no CE equivalent: package git, the SSH key service, the continuous-delivery publish path, and EE's `FileUtilsImpl`.

## Test plan

- [ ] `mvn -pl appsmith-server -am compile` passes (verified locally, BUILD SUCCESS)
- [ ] Spotless clean (verified locally)
- [ ] Reject a push on a deploy preview with a protected branch on the remote, and confirm the remote's message appears in the server log and in the UI error
- [ ] Confirm a successful commit and push emits no new INFO lines
- [ ] Hold a git lock and confirm one warning on retry exhaustion, not twenty
- [ ] Confirm auto-commit no longer logs "is not allowed" for an eligible run


## Automation
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/30426486864>
> Commit: 67dc29fd3ae6af6456e851619132ebcb3b90010f
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=30426486864&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 29 Jul 2026 14:28:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git push status reporting with centralized accepted/rejected handling and clearer remote rejection diagnostics.
  * Fixed remote reference matching during checkout to avoid incorrect “already exists” results.
  * Enhanced push rejection recovery messaging for non-fast-forward and other remote rejection cases.

* **Reliability**
  * Strengthened contextual error logging across git file/repo operations, including richer path and exception details.
  * Improved Redis lock acquisition/release and auto-commit eligibility/cleanup diagnostics, including outcomes when lock cleanup is skipped or fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->