### PR TITLE
fix: use hostname for SMTP TLS verification while pinning the connection to the SSRF-validated address

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -847,6 +847,9 @@ public class EnvManagerCEImpl implements EnvManagerCE {
         // Never fall back to an unpinned plain socket if the factory fails — that would
         // silently reopen the DNS-rebinding hole. (Angus 2.x defaults to false; be explicit.)
         props.put("mail.smtp.socketFactory.fallback", "false");
+        // TLS server identity checking is the lynchpin of this configuration — don't rely on
+        // the library default (it differed between JavaMail and Angus Mail generations).
+        props.put("mail.smtp.ssl.checkserveridentity", "true");
 
         if (requestDTO.getSmtpPort() == 465) {
             props.put("mail.smtp.ssl.enable", "true");
@@ -856,7 +859,9 @@ public class EnvManagerCEImpl implements EnvManagerCE {
                     "mail.smtp.starttls.enable", requestDTO.getStarttlsEnabled().toString());
         }
 
-        props.put("mail.smtp.timeout", 7000); // 7 seconds
+        props.put("mail.smtp.timeout", 7000); // read timeout, 7 seconds
+        props.put("mail.smtp.connectiontimeout", 7000); // 7 seconds
+        props.put("mail.smtp.writetimeout", 7000); // 7 seconds
 
         if (StringUtils.hasLength(requestDTO.getUsername())) {
             props.put("mail.smtp.auth", "true");
@@ -865,7 +870,10 @@ public class EnvManagerCEImpl implements EnvManagerCE {
         } else {
             props.put("mail.smtp.auth", "false");
         }
-        props.put("mail.debug", "true");
+        // The SMTP transcript (server banners, recipient, username) shouldn't hit stdout on
+        // every call. Angus suppresses the AUTH exchange itself by default (mail.debug.auth),
+        // so this gates noise, not the password.
+        props.put("mail.debug", String.valueOf(log.isDebugEnabled()));
 
         return mailSender;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -51,9 +51,14 @@ import reactor.core.scheduler.Schedulers;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
+import javax.net.SocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -808,6 +813,116 @@ public class EnvManagerCEImpl implements EnvManagerCE {
     private static final String SMTP_GENERIC_ERROR =
             "Failed to connect to the SMTP server. Please verify the host, " + "port, and credentials are correct.";
 
+    /**
+     * Builds the JavaMail sender for the test email. The sender host is the user-entered
+     * hostname — not the resolved IP — because TLS (STARTTLS on 587/2525, implicit SSL on 465)
+     * performs SNI and certificate identity checks against the sender host, and server
+     * certificates carry hostnames; connecting by IP fails with
+     * "No subject alternative names matching IP address" (APP-15713).
+     *
+     * <p>The DNS-rebinding TOCTOU that {@link RestrictedHostFilter#resolveIfAllowed(String)}
+     * closes is instead prevented by pinning the TCP connection to the validated address via
+     * the {@code mail.smtp.socketFactory} property: JavaMail asks the factory for an
+     * unconnected socket and then connects it to (host, port) itself, and the pinned socket
+     * ignores the re-resolved endpoint address and connects to the validated one. The
+     * implicit-SSL path on port 465 is pinned too in Angus Mail 2.0.5: with no
+     * {@code mail.smtp.ssl.socketFactory} configured, {@code SocketFetcher} falls back to the
+     * plain {@code mail.smtp.socketFactory} for the TCP connect and layers TLS over the
+     * already-connected socket. Should that fallback ever stop applying (an Angus upgrade, or
+     * someone configuring an ssl.socketFactory), 465 still fails closed: it is
+     * handshake-first against the hostname with server identity checking on by default, so a
+     * rebound DNS answer fails certificate verification before any SMTP dialogue can occur.
+     *
+     * <p>Visible for testing.
+     */
+    public static JavaMailSenderImpl buildMailSender(
+            TestEmailConfigRequestDTO requestDTO, InetAddress resolvedAddress) {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(requestDTO.getSmtpHost());
+        mailSender.setPort(requestDTO.getSmtpPort());
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.socketFactory", pinnedSocketFactory(resolvedAddress));
+        // Never fall back to an unpinned plain socket if the factory fails — that would
+        // silently reopen the DNS-rebinding hole. (Angus 2.x defaults to false; be explicit.)
+        props.put("mail.smtp.socketFactory.fallback", "false");
+
+        if (requestDTO.getSmtpPort() == 465) {
+            props.put("mail.smtp.ssl.enable", "true");
+            props.put("mail.smtp.starttls.enable", "false");
+        } else {
+            props.put(
+                    "mail.smtp.starttls.enable", requestDTO.getStarttlsEnabled().toString());
+        }
+
+        props.put("mail.smtp.timeout", 7000); // 7 seconds
+
+        if (StringUtils.hasLength(requestDTO.getUsername())) {
+            props.put("mail.smtp.auth", "true");
+            mailSender.setUsername(requestDTO.getUsername());
+            mailSender.setPassword(requestDTO.getPassword());
+        } else {
+            props.put("mail.smtp.auth", "false");
+        }
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+
+    /**
+     * A {@link SocketFactory} whose sockets always connect to {@code pinnedAddress} (keeping the
+     * endpoint's port), regardless of the host the caller passes. This is what keeps the SSRF
+     * validation and the actual connection on the same address — JavaMail never re-resolves the
+     * hostname into something the filter didn't check.
+     */
+    private static SocketFactory pinnedSocketFactory(InetAddress pinnedAddress) {
+        return new SocketFactory() {
+            @Override
+            public Socket createSocket() {
+                return new Socket() {
+                    @Override
+                    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+                        if (endpoint instanceof InetSocketAddress inetEndpoint) {
+                            endpoint = new InetSocketAddress(pinnedAddress, inetEndpoint.getPort());
+                        }
+                        super.connect(endpoint, timeout);
+                    }
+                };
+            }
+
+            @Override
+            public Socket createSocket(String host, int port) throws IOException {
+                return connectPinned(port, null, 0);
+            }
+
+            @Override
+            public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+                return connectPinned(port, localHost, localPort);
+            }
+
+            @Override
+            public Socket createSocket(InetAddress host, int port) throws IOException {
+                return connectPinned(port, null, 0);
+            }
+
+            @Override
+            public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+                    throws IOException {
+                return connectPinned(port, localAddress, localPort);
+            }
+
+            private Socket connectPinned(int port, InetAddress localAddress, int localPort) throws IOException {
+                Socket socket = createSocket();
+                if (localAddress != null) {
+                    socket.bind(new InetSocketAddress(localAddress, localPort));
+                }
+                socket.connect(new InetSocketAddress(pinnedAddress, port));
+                return socket;
+            }
+        };
+    }
+
     @Override
     public Mono<Boolean> sendTestEmail(TestEmailConfigRequestDTO requestDTO) {
         return verifyCurrentUserIsSuper().flatMap(user -> {
@@ -822,32 +937,7 @@ public class EnvManagerCEImpl implements EnvManagerCE {
                         new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Invalid SMTP configuration."));
             }
 
-            JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-            mailSender.setHost(resolvedAddress.get().getHostAddress());
-            mailSender.setPort(requestDTO.getSmtpPort());
-
-            Properties props = mailSender.getJavaMailProperties();
-            props.put("mail.transport.protocol", "smtp");
-
-            if (requestDTO.getSmtpPort() == 465) {
-                props.put("mail.smtp.ssl.enable", "true");
-                props.put("mail.smtp.starttls.enable", "false");
-            } else {
-                props.put(
-                        "mail.smtp.starttls.enable",
-                        requestDTO.getStarttlsEnabled().toString());
-            }
-
-            props.put("mail.smtp.timeout", 7000); // 7 seconds
-
-            if (StringUtils.hasLength(requestDTO.getUsername())) {
-                props.put("mail.smtp.auth", "true");
-                mailSender.setUsername(requestDTO.getUsername());
-                mailSender.setPassword(requestDTO.getPassword());
-            } else {
-                props.put("mail.smtp.auth", "false");
-            }
-            props.put("mail.debug", "true");
+            JavaMailSenderImpl mailSender = buildMailSender(requestDTO, resolvedAddress.get());
 
             SimpleMailMessage message = new SimpleMailMessage();
             message.setFrom(requestDTO.getFromEmail());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -465,6 +465,9 @@ public class EnvManagerTest {
         Properties props = sender.getJavaMailProperties();
         assertThat(props.getProperty("mail.smtp.starttls.enable")).isEqualTo("true");
         assertThat(props.get("mail.smtp.socketFactory")).isInstanceOf(SocketFactory.class);
+        assertThat(props.getProperty("mail.smtp.socketFactory.fallback")).isEqualTo("false");
+        assertThat(props.getProperty("mail.smtp.ssl.checkserveridentity")).isEqualTo("true");
+        assertThat(props.get("mail.smtp.connectiontimeout")).isNotNull();
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -20,6 +20,7 @@ import com.appsmith.server.services.OrganizationService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserService;
+import com.appsmith.server.solutions.ce.EnvManagerCEImpl;
 import com.appsmith.util.RestrictedHostFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -31,12 +32,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import javax.net.SocketFactory;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -440,6 +448,96 @@ public class EnvManagerTest {
                     assertThat(e.getMessage()).contains("Invalid SMTP configuration");
                 })
                 .verify();
+    }
+
+    @Test
+    public void buildMailSender_UsesHostnameForTls_NotResolvedIp() throws Exception {
+        TestEmailConfigRequestDTO dto = buildDto("smtp.example.com", 587);
+        dto.setStarttlsEnabled(true);
+        InetAddress resolved = InetAddress.getByAddress("smtp.example.com", new byte[] {(byte) 192, 0, 2, 10});
+
+        JavaMailSenderImpl sender = EnvManagerCEImpl.buildMailSender(dto, resolved);
+
+        // TLS SNI + certificate identity checks run against the sender host, so it must be the
+        // hostname the user entered — connecting by IP fails with
+        // "No subject alternative names matching IP address" (APP-15713).
+        assertThat(sender.getHost()).isEqualTo("smtp.example.com");
+        Properties props = sender.getJavaMailProperties();
+        assertThat(props.getProperty("mail.smtp.starttls.enable")).isEqualTo("true");
+        assertThat(props.get("mail.smtp.socketFactory")).isInstanceOf(SocketFactory.class);
+    }
+
+    @Test
+    public void buildMailSender_Port465_EnablesImplicitSslWithHostname() throws Exception {
+        TestEmailConfigRequestDTO dto = buildDto("smtp.example.com", 465);
+        InetAddress resolved = InetAddress.getByAddress("smtp.example.com", new byte[] {(byte) 192, 0, 2, 10});
+
+        JavaMailSenderImpl sender = EnvManagerCEImpl.buildMailSender(dto, resolved);
+
+        assertThat(sender.getHost()).isEqualTo("smtp.example.com");
+        Properties props = sender.getJavaMailProperties();
+        assertThat(props.getProperty("mail.smtp.ssl.enable")).isEqualTo("true");
+        assertThat(props.getProperty("mail.smtp.starttls.enable")).isEqualTo("false");
+    }
+
+    @Test
+    public void buildMailSender_StarttlsDisabled_KeepsPlaintextProps() throws Exception {
+        TestEmailConfigRequestDTO dto = buildDto("smtp.example.com", 587);
+        InetAddress resolved = InetAddress.getByAddress("smtp.example.com", new byte[] {(byte) 192, 0, 2, 10});
+
+        JavaMailSenderImpl sender = EnvManagerCEImpl.buildMailSender(dto, resolved);
+
+        Properties props = sender.getJavaMailProperties();
+        assertThat(props.getProperty("mail.smtp.starttls.enable")).isEqualTo("false");
+        assertThat(props.getProperty("mail.smtp.ssl.enable")).isNull();
+    }
+
+    @Test
+    public void buildMailSender_AuthProps_FollowUsernamePresence() throws Exception {
+        InetAddress resolved = InetAddress.getByAddress("smtp.example.com", new byte[] {(byte) 192, 0, 2, 10});
+
+        TestEmailConfigRequestDTO withAuth = buildDto("smtp.example.com", 587);
+        withAuth.setUsername("mailer");
+        withAuth.setPassword("secret");
+        JavaMailSenderImpl authSender = EnvManagerCEImpl.buildMailSender(withAuth, resolved);
+        assertThat(authSender.getJavaMailProperties().getProperty("mail.smtp.auth"))
+                .isEqualTo("true");
+        assertThat(authSender.getUsername()).isEqualTo("mailer");
+        assertThat(authSender.getPassword()).isEqualTo("secret");
+
+        TestEmailConfigRequestDTO noAuth = buildDto("smtp.example.com", 587);
+        JavaMailSenderImpl noAuthSender = EnvManagerCEImpl.buildMailSender(noAuth, resolved);
+        assertThat(noAuthSender.getJavaMailProperties().getProperty("mail.smtp.auth"))
+                .isEqualTo("false");
+        assertThat(noAuthSender.getUsername()).isNull();
+    }
+
+    @Test
+    public void buildMailSender_SocketFactory_ConnectsToValidatedAddressNotEndpoint() throws Exception {
+        // The SSRF fix must keep connecting to the address RestrictedHostFilter validated, even
+        // though the sender host is now the hostname. JavaMail asks the socket factory for an
+        // unconnected socket and then connects it to (host, port) itself — mimic that here, with
+        // an endpoint pointing at an unroutable TEST-NET address. The pinned socket must ignore
+        // it and reach the validated (loopback) listener instead.
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            TestEmailConfigRequestDTO dto = buildDto("smtp.example.com", 587);
+            dto.setStarttlsEnabled(true);
+
+            JavaMailSenderImpl sender = EnvManagerCEImpl.buildMailSender(dto, InetAddress.getLoopbackAddress());
+            SocketFactory factory =
+                    (SocketFactory) sender.getJavaMailProperties().get("mail.smtp.socketFactory");
+
+            try (Socket socket = factory.createSocket()) {
+                socket.connect(new InetSocketAddress("192.0.2.1", server.getLocalPort()), 2000);
+                assertThat(socket.getInetAddress().isLoopbackAddress()).isTrue();
+            }
+            server.accept().close(); // drain the backlog before the next connect
+
+            // The pre-connected overloads must pin the same way.
+            try (Socket socket = factory.createSocket("192.0.2.1", server.getLocalPort())) {
+                assertThat(socket.getInetAddress().isLoopbackAddress()).isTrue();
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description

**Problem** (APP-15713 / #42024): SMTP test emails from Admin Settings fail whenever TLS is enabled — STARTTLS on 587/2525 and implicit SSL on 465 — with:

```
jakarta.mail.MessagingException: Could not convert socket to TLS
javax.net.ssl.SSLHandshakeException: (certificate_unknown) No subject alternative names matching IP address
```

Plaintext SMTP (e.g. 2525 with TLS off) works, which matches the reporter's port matrix exactly.

**Root cause**: the SSRF fix for GHSA-vvxf-f8q9-86gh (#41666) made `EnvManagerCEImpl.sendTestEmail` connect to the DNS-resolved IP (`setHost(resolvedAddress.getHostAddress())`) to close a DNS-rebinding TOCTOU. But JavaMail performs SNI and certificate identity checking against the connect host, and server certificates carry hostnames, not IPs — so every TLS handshake fails.

**Fix**: `buildMailSender` now sets the sender host to the user-entered hostname (restoring correct SNI + certificate identity checking) while pinning the TCP connection to the `RestrictedHostFilter.resolveIfAllowed`-validated address via a custom `mail.smtp.socketFactory`. Angus Mail asks the factory for an unconnected socket and connects it to `(host, port)` itself; the pinned socket ignores the re-resolved endpoint address and connects to the validated one. Both security properties of the original fix are preserved:

- **DNS-rebinding TOCTOU stays closed** on the plain/STARTTLS paths (25/587/2525): the validated address is the one connected to; the hostname is never re-resolved into something the filter didn't check.
- **Port 465 (implicit SSL) is pinned too**: with no `mail.smtp.ssl.socketFactory` configured, Angus falls back to the plain `mail.smtp.socketFactory` for the TCP connect and layers TLS over the already-connected socket (verified against Angus Mail 2.0.5 `SocketFetcher` bytecode). If that fallback ever stops applying, the path still fails closed — it is handshake-first with `mail.smtp.ssl.checkserveridentity` on by default, so a rebound DNS answer dies at certificate verification before any SMTP dialogue.
- `mail.smtp.socketFactory.fallback=false` is set explicitly so a factory failure can never silently fall back to an unpinned socket.

The superuser-only authorization, port allowlist, and `RestrictedHostFilter` validation are unchanged and still run before any socket is built.

**Tests**: 6 new unit tests in `EnvManagerTest` — hostname-based host for TLS (fails on the old IP-connecting code), 465 implicit-SSL props, STARTTLS-disabled props, auth on/off props, and socket-factory pinning (a factory socket pointed at an unroutable TEST-NET endpoint must land on the validated listener, for both the unconnected-then-connect path JavaMail uses and the pre-connected overloads). `mvn test -Dtest=EnvManagerTest`: 29/29 pass.

**Maintainer note**: the pinning relies on Angus Mail's socket-factory calling convention (documented in the `buildMailSender` javadoc). When upgrading the mail library, re-verify that `SocketFetcher` still consults `mail.smtp.socketFactory` and connects the factory's unconnected socket itself.

## Manual verification

Verified on a live deploy preview of this PR via Admin Settings → Email → "Send test email", against real providers:

| Case | Provider(s) | Result |
|---|---|---|
| 587 + TLS on (STARTTLS) — the reported repro | Mailtrap sandbox, Brevo | ✅ succeeds, email delivered |
| 465 + TLS on (implicit SSL) | Brevo | ✅ succeeds, email delivered |
| 2525 + TLS off (plaintext, no-regression check) | Mailtrap sandbox | ✅ succeeds |
| Host `169.254.169.254` (SSRF guard) | — | ✅ still rejected with the generic "Invalid SMTP configuration" (filter fires before any socket is opened) |

Additionally verified off-DP by driving the real Angus Mail stack through `buildMailSender` against live `smtp.gmail.com`: the 587-STARTTLS and 465-implicit-SSL handshakes succeed with this fix, and rebuilding the sender the pre-fix way (host = resolved IP) reproduces the exact reported failure (`Could not convert socket to TLS`) — same machine, same server, hostname-vs-IP being the only variable.

Note for anyone re-testing: Mailtrap's sandbox does **not** speak implicit TLS on port 465 (it greets in plaintext on that port), so 465 must be verified with a provider that does, e.g. Brevo or Gmail. That failure mode is a provider quirk, not this code path.

Fixes https://github.com/appsmithorg/appsmith/issues/42024
Linear: https://linear.app/appsmith/issue/APP-15713

## Automation

/ok-to-test tags="@tag.All"

<!-- end of auto-generated comment: Cypress test results  -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SMTP test-email behavior to use the SSRF-validated destination while keeping the original SMTP hostname for TLS/SNI and certificate hostname checks.
  - Centralized mail-sender configuration (TLS/SSL, StartTLS, auth, and timeouts) for consistent, correct settings.
  - Disabled socket-factory fallback to reduce risk of bypassing address validation.

- **Tests**
  - Added unit tests covering hostname vs resolved IP handling, port 465 SSL behavior, StartTLS-disabled plaintext mode, conditional auth properties, and pinned socket connections to the validated address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/30640681435>
> Commit: d5301eba3dbcc461af48498f1b1ace473da6191b
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=30640681435&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 31 Jul 2026 16:05:29 UTC
<!-- end of auto-generated comment: Cypress test results  -->
