### PR TITLE
chore: improve external contributor CI flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,16 +11,24 @@ Fixes `Issue URL`
 > [!WARNING]  
 > _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._
 
-## Automation
+## Testing
 
-/ok-to-test tags=""
+> [!NOTE]
+> Pull requests from forks run credential-free formatting, lint, type, and unit
+> checks after GitHub's workflow approval. A maintainer will start integration
+> tests or a deploy preview when needed. External contributors do not need to
+> add an `ok-to-test` label or run a slash command.
 
-### :mag: Cypress test results
-<!-- This is an auto-generated comment: Cypress test results  -->
-> [!CAUTION]  
-> If you modify the content in this section, you are likely to disrupt the CI result for your PR.
+Select the validation relevant to this change:
 
-<!-- end of auto-generated comment: Cypress test results  -->
+- [ ] Client unit tests
+- [ ] Server unit tests
+- [ ] Cypress
+- [ ] Playwright
+- [ ] Deploy preview
+- [ ] Not applicable
+
+Suggested Cypress tags or specs:
 
 
 ## Communication

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,12 @@ Fixes `Issue URL`
 ## Testing
 
 > [!NOTE]
-> Pull requests from forks run credential-free formatting, lint, type, and unit
-> checks after GitHub's workflow approval. A maintainer will start integration
-> tests or a deploy preview when needed. External contributors do not need to
-> add an `ok-to-test` label or run a slash command.
+> **How CI runs on fork PRs — no action needed from you.**
+> 1. **Workflow approval.** GitHub holds the first run on fork PRs until a maintainer approves it, so a pause before any check appears is expected.
+> 2. **Credential-free checks.** Once approved, format, lint, typecheck, unit tests, cyclic-dependency and compile-only build checks run without repository secrets. Only the checks relevant to what you changed (client / server / RTS) will run, and their logs are safe to debug against.
+> 3. **Maintainer-triggered checks.** Cypress, Playwright, Docker builds and deploy previews need secrets, so a maintainer starts them with `/approve-ci`, and `/build-deploy-preview` when hands-on testing is needed. Approval is pinned to one commit — pushing again requires fresh approval.
+>
+> The `awaiting-maintainer` / `awaiting-contributor` labels show whose turn it is. You do **not** need `ok-to-test` or any slash command. Full detail: [Pull request check states](https://github.com/appsmithorg/appsmith/blob/release/contributions/CodeContributionsGuidelines.md#pull-request-check-states).
 
 Select the validation relevant to this change:
 

--- a/.github/workflows/build-chromatic.yml
+++ b/.github/workflows/build-chromatic.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   chromatic-deployment:
+    # Internal PRs only: the Chromatic project token is not available to fork
+    # PRs, so this job would always fail for external contributors.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -117,9 +117,11 @@ jobs:
       - name: Get the diff from base branch
         continue-on-error: true
         id: files
+        env:
+          BASE_REF: ${{ github.event.client_payload.pull_request.base.ref }}
         run: |
-          git fetch origin release
-          git diff --name-only --diff-filter=A remotes/origin/release...HEAD -- 'app/client/cypress/e2e' > diff
+          git fetch origin "$BASE_REF"
+          git diff --name-only --diff-filter=A "remotes/origin/${BASE_REF}...HEAD" -- 'app/client/cypress/e2e' > diff
           echo "files_added=$(cat diff)" >> $GITHUB_OUTPUT
           cat diff
 

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -40,14 +40,24 @@ jobs:
           APPROVED_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
           current_head_sha="$(
             gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha
           )"
           checked_out_head_sha="$(git rev-parse HEAD^2)"
 
+          if [[ "$EVENT_ACTION" == "approve-ci-command" ]]; then
+            command_name="/approve-ci"
+          else
+            command_name="/ci-test-limit"
+          fi
+
           if [[ "$current_head_sha" != "$APPROVED_HEAD_SHA" ]]; then
-            echo "::error::PR head changed after /approve-ci was issued. A maintainer must approve the new commit."
+            echo "::error::PR head changed after ${command_name} was issued. Re-run ${command_name} on the current commit."
+            if [[ "$EVENT_ACTION" == "approve-ci-command" ]]; then
+              gh pr comment "$PR_NUMBER" --body "Approval expired: the PR head changed after \`/approve-ci\` was issued (approved \`${APPROVED_HEAD_SHA:0:7}\`, current \`${current_head_sha:0:7}\`). Please re-run \`/approve-ci\` on the latest commit. If Cypress should run on that approval, keep the \`ok-to-test\` label (and optional \`tags=\` on the command or in the PR body)."
+            fi
             exit 1
           fi
 
@@ -153,6 +163,156 @@ jobs:
             [Cypress dashboard](https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}&selectiontype=test&testsstatus=failed&specsstatus=fail)
             PR: #${{ fromJson(steps.args.outputs.pr) }}.
 
+
+  cypress-scope:
+    needs: [file-check]
+    if: success()
+    runs-on: ubuntu-latest
+    outputs:
+      run_full_cypress: ${{ steps.scope.outputs.run_full_cypress }}
+      tags: ${{ steps.scope.outputs.tags }}
+      spec: ${{ steps.scope.outputs.spec }}
+      cypress_matrix: ${{ steps.scope.outputs.cypress_matrix }}
+    steps:
+      # Trusted checkout: the tag grammar and tag list must never come from the fork.
+      - uses: actions/checkout@v4
+        with:
+          repository: appsmithorg/appsmith
+
+      - name: Resolve Cypress scope for approved CI
+        id: scope
+        env:
+          NODE_PATH: ${{ github.workspace }}/.github/workflows/scripts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.client_payload.pull_request.number;
+            const isApproveCi = context.payload.action === "approve-ci-command";
+
+            const labels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue,
+              { owner, repo, issue_number },
+            );
+            const hasOkToTest = labels.some((label) => label.name === "ok-to-test");
+            const commandTags = (
+              context.payload.client_payload.slash_command?.args?.named?.tags || ""
+            ).trim();
+
+            // Full Cypress only on /approve-ci when the label is present and/or tags= is given.
+            const runFull = isApproveCi && (hasOkToTest || commandTags.length > 0);
+            core.setOutput("run_full_cypress", runFull ? "true" : "false");
+
+            if (!runFull) {
+              core.setOutput("tags", "");
+              core.setOutput("spec", "");
+              core.setOutput("cypress_matrix", "[0]");
+              return;
+            }
+
+            const { data: freshPr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issue_number,
+            });
+
+            // Precedence: command args → PR body → @tag.All (label default).
+            let bodyForParse = freshPr.body || "";
+            if (commandTags) {
+              bodyForParse = `/ok-to-test tags="${commandTags}"\n`;
+            }
+
+            const captured = { tags: "", its: "", spec: "" };
+            let failedMessage = null;
+            const shimCore = {
+              setOutput(name, value) {
+                captured[name] = value ?? "";
+              },
+              setFailed(message) {
+                failedMessage = message;
+              },
+            };
+
+            // Suppress write-cypress-status side effects on the fall-through path
+            // (invalid body tags → default @tag.All) so we don't warn then run All.
+            const shimGithub = commandTags
+              ? github
+              : {
+                  ...github,
+                  rest: {
+                    ...github.rest,
+                    pulls: {
+                      ...github.rest.pulls,
+                      async get(...args) {
+                        return github.rest.pulls.get(...args);
+                      },
+                      async update() {
+                        return { data: {} };
+                      },
+                    },
+                    issues: {
+                      ...github.rest.issues,
+                      async createComment() {
+                        return { data: {} };
+                      },
+                    },
+                  },
+                };
+
+            if (bodyForParse.trim()) {
+              require("test-tag-parser.js")({
+                core: shimCore,
+                context: {
+                  ...context,
+                  payload: {
+                    ...context.payload,
+                    pull_request: {
+                      ...freshPr,
+                      body: bodyForParse,
+                    },
+                  },
+                },
+                github: shimGithub,
+              });
+            }
+
+            if (failedMessage) {
+              if (commandTags) {
+                // Explicit tags on the command must be valid.
+                core.setFailed(failedMessage);
+                return;
+              }
+              // Unparseable PR body falls through to the label default without warning.
+              console.log(`PR body tag parse skipped: ${failedMessage}`);
+            }
+
+            let tags = captured.tags || "";
+            const spec = captured.spec || "";
+
+            if (!tags && !spec) {
+              tags = "@tag.All";
+            }
+
+            let cypress_matrix;
+            if (spec) {
+              cypress_matrix = "[0]";
+            } else if (tags === "@tag.All") {
+              cypress_matrix =
+                "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]";
+            } else {
+              cypress_matrix =
+                "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]";
+            }
+
+            core.setOutput("tags", tags);
+            core.setOutput("spec", spec);
+            core.setOutput("cypress_matrix", cypress_matrix);
+            console.log(
+              `Cypress scope: run_full=${runFull} tags=${tags || "(none)"} spec=${spec || "(none)"}`,
+            );
+
+
   server-build:
     name: server-build
     needs: [file-check]
@@ -198,9 +358,9 @@ jobs:
       checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
 
   ci-test-limited:
-    needs: [file-check, build-docker-image]
-    # Only run if the build step is successful
-    if: success() && needs.file-check.outputs.runId == '0'
+    needs: [file-check, cypress-scope, build-docker-image]
+    # Only run if the build step is successful and full Cypress was not selected
+    if: success() && needs.file-check.outputs.runId == '0' && needs.cypress-scope.outputs.run_full_cypress != 'true'
     name: ci-test-limited
     uses: ./.github/workflows/ci-test-limited.yml
     secrets: inherit
@@ -208,10 +368,24 @@ jobs:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
       checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
 
+  ci-test-full:
+    needs: [file-check, cypress-scope, build-docker-image]
+    # Sharded Cypress suite for /approve-ci when ok-to-test and/or tags= are present
+    if: success() && needs.file-check.outputs.runId == '0' && needs.cypress-scope.outputs.run_full_cypress == 'true'
+    name: ci-test-full
+    uses: ./.github/workflows/ci-test-custom-script.yml
+    secrets: inherit
+    with:
+      pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
+      tags: ${{ needs.cypress-scope.outputs.tags }}
+      spec: ${{ needs.cypress-scope.outputs.spec }}
+      matrix: ${{ needs.cypress-scope.outputs.cypress_matrix }}
+
   ci-test-limited-existing-docker-image:
-    needs: [file-check]
-    # Only run if the previous run-id is provided
-    if: success() && needs.file-check.outputs.runId != '0'
+    needs: [file-check, cypress-scope]
+    # Only for /ci-test-limit with a prior runId — not used for full Cypress
+    if: success() && needs.file-check.outputs.runId != '0' && needs.cypress-scope.outputs.run_full_cypress != 'true'
     name: ci-test-limited-existing-image
     uses: ./.github/workflows/ci-test-limited.yml
     secrets: inherit
@@ -221,9 +395,9 @@ jobs:
       previous-workflow-run-id: ${{ fromJson(needs.file-check.outputs.runId) }}
 
   ci-test-limited-result:
-    needs: [file-check, ci-test-limited]
-    # Only run if the file-check.runId == 0
-    if: always() && needs.file-check.outputs.runId == '0'
+    needs: [file-check, cypress-scope, ci-test-limited]
+    # Only run if the file-check.runId == 0 and limited path was selected
+    if: always() && needs.file-check.outputs.runId == '0' && needs.cypress-scope.outputs.run_full_cypress != 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -338,10 +512,128 @@ jobs:
         if: needs.ci-test-limited.result != 'success'
         run: exit 1
 
+  ci-test-full-result:
+    needs: [file-check, cypress-scope, ci-test-full]
+    # Only run if the file-check.runId == 0 and full Cypress path was selected
+    if: always() && needs.file-check.outputs.runId == '0' && needs.cypress-scope.outputs.run_full_cypress == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Setup node
+        if: needs.ci-test-full.result != 'success'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+
+      - name: install pg
+        if: needs.ci-test-full.result != 'success'
+        run: npm install pg
+
+      - name: Fetch the failed specs
+        if: needs.ci-test-full.result != 'success'
+        id: failed_specs
+        env:
+          DB_HOST: ${{ secrets.CYPRESS_DB_HOST }}
+          DB_NAME: ${{ secrets.CYPRESS_DB_NAME }}
+          DB_USER: ${{ secrets.CYPRESS_DB_USER }}
+          DB_PWD: ${{ secrets.CYPRESS_DB_PWD }}
+          RUN_ID: ${{ github.run_id }}
+          ATTEMPT_NUMBER: ${{ github.run_attempt }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { Pool } = require("pg");
+            const { DB_HOST, DB_NAME, DB_USER, DB_PWD, RUN_ID, ATTEMPT_NUMBER } = process.env
+
+            const client = await new Pool({
+              user: DB_USER,
+              host: DB_HOST,
+              database: DB_NAME,
+              password: DB_PWD,
+              port: 5432,
+              connectionTimeoutMillis: 60000,
+            }).connect();
+
+            const result = await client.query(
+              `SELECT DISTINCT name FROM public."specs"
+                WHERE "matrixId" IN
+                (SELECT id FROM public."matrix"
+                WHERE "attemptId" = (
+                  SELECT id FROM public."attempt" WHERE "workflowId" = $1 and "attempt" = $2
+                  )
+                ) AND status = 'fail'`,
+              [RUN_ID, ATTEMPT_NUMBER],
+            );
+            client.release();
+            return result.rows.map((spec) => spec.name);
+
+      # In case for any ci job failure, create combined failed spec
+      - name: combine all specs for CI
+        id: combine_ci
+        if: needs.ci-test-full.result != 'success'
+        run: |
+          failed_specs=$(echo ${{steps.failed_specs.outputs.result}} | sed 's/\[\|\]//g' | tr -d ' ' | tr ',' '\n')
+          while read -r line; do
+            echo "$line" >> ~/combined_failed_spec_ci
+          done <<< "$failed_specs"
+
+      # Upload combined failed CI spec list to a file
+      # This is done for debugging.
+      - name: upload combined failed spec
+        if: needs.ci-test-full.result != 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined_failed_spec_ci
+          path: ~/combined_failed_spec_ci
+          overwrite: true
+
+      - name: Get Latest flaky Tests
+        shell: bash
+        run: |
+          touch ~/knownfailures
+
+      # Verify CI test failures against known failures
+      - name: Verify CI test failures against known failures
+        if: needs.ci-test-full.result != 'success'
+        shell: bash
+        run: |
+          new_failed_spec_env="<ol>$(comm -1 -3 <(sort ~/knownfailures) <(sort -u ~/combined_failed_spec_ci) | sed 's/|cypress|cypress/\n/g' | sed 's/^/<li>/')</ol>"
+          echo "$new_failed_spec_env"
+          echo "new_failed_spec_env<<EOF" >> $GITHUB_ENV
+          echo "$new_failed_spec_env" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Add a comment on the PR with new CI failures
+        if: needs.ci-test-full.result != 'success' && needs.file-check.outputs.pr != '0'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{fromJson(needs.file-check.outputs.pr)}}
+          body: |
+            Workflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>.
+            Cypress dashboard: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank"> Click here!</a>
+            The following are new failures, please fix them before merging the PR: ${{env.new_failed_spec_env}}
+            To know the list of identified flaky tests - <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">Refer here</a>
+
+      - name: Add a comment on the PR when ci-test-full is success
+        if: needs.ci-test-full.result == 'success' && needs.file-check.outputs.pr != '0'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{fromJson(needs.file-check.outputs.pr)}}
+          body: |
+            Workflow run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>.
+            Cypress dashboard url: <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=${{ github.run_id }}&attempt=${{ github.run_attempt }}" target="_blank">Click here!</a>
+            All cypress tests have passed 🎉🎉🎉
+
+      - name: Check ci-test-full set status
+        if: needs.ci-test-full.result != 'success'
+        run: exit 1
+
   ci-test-limited-result-existing:
-    needs: [file-check, ci-test-limited-existing-docker-image]
-    # Only run if the file-check.runId !=0
-    if: always() && needs.file-check.outputs.runId != '0'
+    needs: [file-check, cypress-scope, ci-test-limited-existing-docker-image]
+    # Only run if the file-check.runId !=0 and limited path was selected
+    if: always() && needs.file-check.outputs.runId != '0' && needs.cypress-scope.outputs.run_full_cypress != 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -217,6 +217,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
       previous-workflow-run-id: ${{ fromJson(needs.file-check.outputs.runId) }}
 
   ci-test-limited-result:

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -104,15 +104,22 @@ jobs:
 
       - name: Set args
         id: args
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          NAMED_ARGS: ${{ toJSON(github.event.client_payload.slash_command.args.named) }}
         run: |
           echo "pr=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
           echo "is-pg-build=${{ github.event.client_payload.pull_request.base.ref == 'pg' }}" >> $GITHUB_OUTPUT
-          checkArg=`echo '${{toJSON(github.event.client_payload.slash_command.args.named)}}' | jq 'has("runId")'`
-          if [[ $checkArg == 'true' ]]; then
-            echo "runId=${{ github.event.client_payload.slash_command.args.named.runId }}" >> $GITHUB_OUTPUT
-          else
-            echo "runId=0" >> $GITHUB_OUTPUT
+          run_id="$(printf '%s' "$NAMED_ARGS" | jq -r 'if type == "object" and has("runId") then (.runId | tostring) else "0" end')"
+          # runId reuses the Docker image from an earlier run. /approve-ci exists to
+          # test the maintainer-approved merge commit, so an image built from some
+          # other commit would report that commit as validated without ever building
+          # it. Refuse the shortcut here instead of honouring it.
+          if [[ "$EVENT_ACTION" == 'approve-ci-command' && "$run_id" != '0' ]]; then
+            echo "::warning::Ignoring runId=${run_id}: /approve-ci always builds and tests the approved commit."
+            run_id='0'
           fi
+          echo "runId=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Get the diff from base branch
         continue-on-error: true

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -2,7 +2,18 @@ name: Build Client, Server & Run only Cypress
 
 on:
   repository_dispatch:
-    types: [ci-test-limit-command]
+    types: [ci-test-limit-command, approve-ci-command]
+
+concurrency:
+  group: trusted-pr-ci-${{ github.event.client_payload.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  packages: write
+  pull-requests: write
 
 jobs:
   file-check:
@@ -15,9 +26,66 @@ jobs:
       runId: ${{steps.args.outputs.runId}}
       matrix_count: ${{steps.matrix.outputs.matrix_count}}
       is-pg-build: ${{steps.args.outputs.is-pg-build}}
+      merge_sha: ${{ steps.approved.outputs.merge_sha }}
     steps:
-      - name: Checkout the head commit of the branch
+      - name: Checkout the PR merge commit
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
+          fetch-depth: 2
+
+      - name: Verify the commit approved by the maintainer
+        id: approved
+        env:
+          APPROVED_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+        run: |
+          current_head_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha
+          )"
+          checked_out_head_sha="$(git rev-parse HEAD^2)"
+
+          if [[ "$current_head_sha" != "$APPROVED_HEAD_SHA" ]]; then
+            echo "::error::PR head changed after /approve-ci was issued. A maintainer must approve the new commit."
+            exit 1
+          fi
+
+          if [[ "$checked_out_head_sha" != "$APPROVED_HEAD_SHA" ]]; then
+            echo "::error::The checked-out merge commit does not contain the approved PR head."
+            exit 1
+          fi
+
+          echo "merge_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Approved head: $APPROVED_HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pinned merge commit: $(git rev-parse HEAD)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record privileged CI approval
+        if: github.event.action == 'approve-ci-command'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.client_payload.pull_request.number;
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: ["ci-approved"],
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: "awaiting-maintainer",
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
 
       - name: Set matrix jobs
         id: matrix
@@ -41,7 +109,7 @@ jobs:
         id: files
         run: |
           git fetch origin release
-          git diff --name-only --diff-filter=A remotes/origin/release...${{ github.ref_name }} -- 'app/client/cypress/e2e' > diff
+          git diff --name-only --diff-filter=A remotes/origin/release...HEAD -- 'app/client/cypress/e2e' > diff
           echo "files_added=$(cat diff)" >> $GITHUB_OUTPUT
           cat diff
 
@@ -93,6 +161,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
       skip-tests: "true"
       is-pg-build: ${{fromJson(needs.file-check.outputs.is-pg-build)}}
 
@@ -104,6 +173,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
       skip-tests: "true"
 
   rts-build:
@@ -114,6 +184,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
 
   build-docker-image:
     needs: [file-check, client-build, server-build, rts-build]
@@ -124,6 +195,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
 
   ci-test-limited:
     needs: [file-check, build-docker-image]
@@ -134,6 +206,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
 
   ci-test-limited-existing-docker-image:
     needs: [file-check]

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -14,6 +14,11 @@ on:
         description: "This is the PR number in case the workflow is being called in a pull request"
         required: false
         type: number
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-docker:
@@ -31,21 +36,27 @@ jobs:
     steps:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
-        if: inputs.pr != 0
+        if: inputs.checkout-ref == '' && inputs.pr != 0
         uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
-        if: inputs.pr == 0 && inputs.branch == ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch == ''
         uses: actions/checkout@v4
 
       - name: Checkout the specified branch
-        if: inputs.pr == 0 && inputs.branch != ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+
+      - name: Checkout the approved immutable commit
+        if: inputs.checkout-ref != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref }}
 
       - name: Download the client build artifact
         if: steps.run_result.outputs.run_result != 'success'

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   chromatic-deployment:
+    # Internal PRs only: the Storybook/Chromatic project token is not available
+    # to fork PRs, so this job would always fail for external contributors.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -244,18 +244,22 @@ jobs:
 
       - name: Set cypress tags to exclude
         if: steps.run_result.outputs.run_result != 'success'
+        env:
+          INPUT_TAGS: ${{ inputs.tags }}
         run: |
           echo 'tags_to_exclude=airgap' >> "$GITHUB_ENV"
-          if [[ "${{ inputs.tags }}" = "@tag.All" ]]; then
+          if [[ "$INPUT_TAGS" = "@tag.All" ]]; then
             echo "CYPRESS_grepTags=" >> "$GITHUB_ENV"
           else
-            echo "CYPRESS_grepTags=${{ inputs.tags }}" >> "$GITHUB_ENV"
+            # Strip CR/LF so an unexpected value cannot inject extra GITHUB_ENV entries.
+            grep_tags="${INPUT_TAGS//[$'\r\n']/}"
+            printf 'CYPRESS_grepTags=%s\n' "$grep_tags" >> "$GITHUB_ENV"
           fi
 
       - name: Print the tags
         run: |
-          echo "tags_to_exclude: ${{ env.tags_to_exclude }}"
-          echo "_grepTags: ${{ env.CYPRESS_grepTags }}"
+          echo "tags_to_exclude: $tags_to_exclude"
+          echo "_grepTags: $CYPRESS_grepTags"
 
       - name: Setting up the cypress tests
         if: steps.run_result.outputs.run_result != 'success'
@@ -313,6 +317,9 @@ jobs:
 
       - name: Run the cypress test
         env:
+          # Untrusted on approved fork PRs: keep as an env var and reference it
+          # quoted in the shell below — never interpolate ${{ inputs.spec }} into run:.
+          INPUT_SPEC: ${{ inputs.spec }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_USERNAME: ${{ secrets.CYPRESS_USERNAME }}
           CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
@@ -386,9 +393,9 @@ jobs:
         run: |
             cd app/client
             ls -la
-            if [[ -n "${{ inputs.spec }}" ]]; then
+            if [[ -n "$INPUT_SPEC" ]]; then
               npx cypress-repeat-pro run -n 3 --rerun-failed-only \
-                --spec "${{ inputs.spec }}" \
+                --spec "$INPUT_SPEC" \
                 --config-file "cypress_ci_custom.config.ts" \
                 --browser "${{ env.BROWSER_PATH }}"
             else

--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: latest
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   ci-test:
@@ -73,15 +78,21 @@ jobs:
 
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
-        if: inputs.pr != 0
+        if: inputs.checkout-ref == '' && inputs.pr != 0
         uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
-        if: inputs.pr == 0
+        if: inputs.checkout-ref == '' && inputs.pr == 0
         uses: actions/checkout@v4
+
+      - name: Checkout the approved immutable commit
+        if: inputs.checkout-ref != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref }}
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: number
         default: 0
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       pr:
@@ -25,6 +30,11 @@ on:
         required: false
         type: number
         default: 0
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   ci-test-limited:
@@ -62,15 +72,21 @@ jobs:
 
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
-        if: inputs.pr != 0
+        if: inputs.checkout-ref == '' && inputs.pr != 0
         uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ inputs.pr }}/merge"
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
-        if: inputs.pr == 0
+        if: inputs.checkout-ref == '' && inputs.pr == 0
         uses: actions/checkout@v4
+
+      - name: Checkout the approved immutable commit
+        if: inputs.checkout-ref != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref }}
 
       # Timestamp will be used to create cache key
       - id: timestamp

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -16,6 +16,11 @@ on:
         description: "This is the branch to be used for the build."
         required: false
         type: string
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -45,7 +50,7 @@ jobs:
 
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        if: inputs.pr != 0
+        if: inputs.checkout-ref == '' && inputs.pr != 0
         uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -53,7 +58,7 @@ jobs:
 
       # Check out the specified branch in case this workflow is called by another workflow
       - name: Checkout the specified branch
-        if: inputs.pr == 0 && inputs.branch != ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -61,10 +66,17 @@ jobs:
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
-        if: inputs.pr == 0 && inputs.branch == ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch == ''
         uses: actions/checkout@v4
         with:
           fetch-tags: true
+
+      - name: Checkout the approved immutable commit
+        if: inputs.checkout-ref != ''
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          ref: ${{ inputs.checkout-ref }}
 
       - name: Get changed files in the client folder
         id: changed-files-specific

--- a/.github/workflows/external-pr-state.yml
+++ b/.github/workflows/external-pr-state.yml
@@ -1,0 +1,116 @@
+name: External PR state
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+# This workflow deliberately does not check out or execute pull-request code.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  mark-waiting:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure contributor-state labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              {
+                name: "external-contribution",
+                color: "0E8A16",
+                description: "Pull request submitted from outside the Appsmith repository",
+              },
+              {
+                name: "awaiting-maintainer",
+                color: "FBCA04",
+                description: "The next action on this pull request belongs to an Appsmith maintainer",
+              },
+              {
+                name: "awaiting-contributor",
+                color: "1D76DB",
+                description: "The contributor needs to respond to review or CI feedback",
+              },
+              {
+                name: "ci-approved",
+                color: "0E8A16",
+                description: "A maintainer approved privileged CI for the current revision",
+              },
+              {
+                name: "preview-ready",
+                color: "5319E7",
+                description: "A deploy preview is available for review",
+              },
+            ];
+
+            const existing = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            const existingNames = new Set(existing.map((label) => label.name));
+
+            for (const label of labels) {
+              if (!existingNames.has(label.name)) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+              }
+            }
+
+      - name: Mark the PR as waiting for a maintainer
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: ["external-contribution", "awaiting-maintainer"],
+            });
+
+            if (context.payload.action === "synchronize") {
+              for (const name of ["awaiting-contributor", "ci-approved", "preview-ready"]) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number,
+                    name,
+                  });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+            }
+
+      - name: Explain the next action on a newly opened PR
+        if: github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                "Thanks for contributing to Appsmith!",
+                "",
+                "Credential-free formatting, lint, type, and unit checks will run after GitHub's workflow approval. An Appsmith maintainer will start privileged integration tests or a deploy preview when needed.",
+                "",
+                "No action is required from you while this PR has the `awaiting-maintainer` label.",
+              ].join("\n"),
+            });

--- a/.github/workflows/external-pr-validation.yml
+++ b/.github/workflows/external-pr-validation.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       client: ${{ steps.filter.outputs.client }}
+      client-src: ${{ steps.filter.outputs.client-src }}
       server: ${{ steps.filter.outputs.server }}
       rts: ${{ steps.filter.outputs.rts }}
     steps:
@@ -34,6 +35,8 @@ jobs:
             client:
               - 'app/client/**'
               - '!app/client/cypress/manual_TestSuite/**'
+            client-src:
+              - 'app/client/src/**'
             server:
               - 'app/server/**'
             rts:
@@ -172,9 +175,127 @@ jobs:
       - name: Build
         run: yarn build
 
+  client-cyclic-deps:
+    name: ci/cyclic-deps-client
+    needs: changes
+    if: needs.changes.outputs.client-src == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/client
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+      - uses: actions/cache/restore@v4
+        with:
+          path: app/client/.yarn/cache
+          key: external-v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+          restore-keys: external-v1-yarn3-
+      - name: Install dpdm globally
+        run: npm install -g dpdm@3.14
+      - name: Install dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+      - name: Count circular dependencies on PR branch
+        id: pr-count
+        run: |
+          dpdm "./src/**/*.{js,jsx,ts,tsx}" --circular --warning=false --tree=false \
+            | sed '1d; s/^[[:space:]]*[0-9]\{4\})[[:space:]]*/• /; /^[[:space:]]*$/d' \
+            | sort | sed '/^[[:space:]]*$/d' > /tmp/pr_circular_deps.txt
+          echo "count=$(awk 'NF' /tmp/pr_circular_deps.txt | wc -l)" >> "$GITHUB_OUTPUT"
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          clean: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+      - name: Install dependencies (base branch)
+        run: |
+          corepack enable
+          yarn install --immutable
+      - name: Count circular dependencies on base branch
+        id: base-count
+        run: |
+          dpdm "./src/**/*.{js,jsx,ts,tsx}" --circular --warning=false --tree=false \
+            | sed '1d; s/^[[:space:]]*[0-9]\{4\})[[:space:]]*/• /; /^[[:space:]]*$/d' \
+            | sort | sed '/^[[:space:]]*$/d' > /tmp/base_circular_deps.txt
+          echo "count=$(awk 'NF' /tmp/base_circular_deps.txt | wc -l)" >> "$GITHUB_OUTPUT"
+      # No PR comment here: fork tokens are read-only, so the result is
+      # reported through the job summary and exit code instead.
+      - name: Compare circular dependencies
+        env:
+          PR_COUNT: ${{ steps.pr-count.outputs.count }}
+          BASE_COUNT: ${{ steps.base-count.outputs.count }}
+        run: |
+          diff_count="$((PR_COUNT - BASE_COUNT))"
+          if [[ "$diff_count" -gt 0 ]]; then
+            {
+              echo "## Cyclic dependency check failed"
+              echo "This PR adds $diff_count circular import(s) compared to the base branch."
+              echo '```diff'
+              diff -u /tmp/base_circular_deps.txt /tmp/pr_circular_deps.txt || true
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::This PR increases circular dependencies by $diff_count. See the job summary for the diff."
+            exit 1
+          fi
+          echo "No new circular dependencies ($PR_COUNT on PR, $BASE_COUNT on base)." >> "$GITHUB_STEP_SUMMARY"
+
+  client-compile:
+    name: ci/compile-client
+    needs: changes
+    if: needs.changes.outputs.client == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: app/client
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+      - uses: actions/cache/restore@v4
+        with:
+          path: app/client/.yarn/cache
+          key: external-v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+          restore-keys: external-v1-yarn3-
+      - name: Install dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+      # Compile-only build: telemetry/analytics keys are intentionally absent.
+      # They only matter for published bundles, not for proving the code builds.
+      - name: Build client bundle with placeholder env
+        env:
+          REACT_APP_ENVIRONMENT: DEVELOPMENT
+          REACT_APP_VERSION_EDITION: Community
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: yarn build
+
   result:
     name: external-ci-result
-    needs: [changes, client-static, client-unit, server, rts]
+    needs:
+      [
+        changes,
+        client-static,
+        client-unit,
+        client-cyclic-deps,
+        client-compile,
+        server,
+        rts,
+      ]
     if: always() && needs.changes.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
@@ -183,10 +304,12 @@ jobs:
           CHANGES: ${{ needs.changes.result }}
           CLIENT_STATIC: ${{ needs.client-static.result }}
           CLIENT_UNIT: ${{ needs.client-unit.result }}
+          CLIENT_CYCLIC: ${{ needs.client-cyclic-deps.result }}
+          CLIENT_COMPILE: ${{ needs.client-compile.result }}
           SERVER: ${{ needs.server.result }}
           RTS: ${{ needs.rts.result }}
         run: |
-          for result in "$CHANGES" "$CLIENT_STATIC" "$CLIENT_UNIT" "$SERVER" "$RTS"; do
+          for result in "$CHANGES" "$CLIENT_STATIC" "$CLIENT_UNIT" "$CLIENT_CYCLIC" "$CLIENT_COMPILE" "$SERVER" "$RTS"; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
               echo "Credential-free validation failed."
               exit 1

--- a/.github/workflows/external-pr-validation.yml
+++ b/.github/workflows/external-pr-validation.yml
@@ -1,0 +1,195 @@
+name: External PR credential-free validation
+
+on:
+  pull_request:
+    branches: [release, master, pg]
+
+# Fork code in this workflow must never receive repository secrets or write
+# access. Keep publishing, commenting, cloud integration, and deploy steps out.
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: external-pr-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      client: ${{ steps.filter.outputs.client }}
+      server: ${{ steps.filter.outputs.server }}
+      rts: ${{ steps.filter.outputs.rts }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            client:
+              - 'app/client/**'
+              - '!app/client/cypress/manual_TestSuite/**'
+            server:
+              - 'app/server/**'
+            rts:
+              - 'app/client/packages/rts/**'
+
+  client-static:
+    name: ci/static-client
+    needs: changes
+    if: needs.changes.outputs.client == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/client
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+      - uses: actions/cache/restore@v4
+        with:
+          path: app/client/.yarn/cache
+          key: external-v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+          restore-keys: external-v1-yarn3-
+      - name: Install dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+      - name: Check formatting
+        run: yarn prettier:ci
+      - name: Lint
+        run: yarn lint:ci
+      - name: Check types
+        run: yarn check-types
+
+  client-unit:
+    name: ci/unit-client
+    needs: changes
+    if: needs.changes.outputs.client == 'true'
+    # Keep untrusted fork code on GitHub-hosted runners.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/client
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+      - uses: actions/cache/restore@v4
+        with:
+          path: app/client/.yarn/cache
+          key: external-v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+          restore-keys: external-v1-yarn3-
+      - name: Install dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+      - name: Run unit tests
+        run: yarn test:unit:ci
+
+  server:
+    name: ci/unit-server
+    needs: changes
+    if: needs.changes.outputs.server == 'true'
+    # Keep untrusted fork code on GitHub-hosted runners.
+    runs-on: ubuntu-22.04
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
+    defaults:
+      run:
+        working-directory: app/server
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: ./.github/actions/setup-server-java
+      - name: Check formatting
+        run: mvn spotless:check
+      - name: Build
+        run: ./build.sh -DskipTests
+      - name: Run unit tests with local services
+        env:
+          ACTIVE_PROFILE: test
+          APPSMITH_CLOUD_SERVICES_BASE_URL: http://127.0.0.1:8090
+          APPSMITH_CLOUD_SERVICES_TEMPLATE_UPLOAD_AUTH: external-ci-dummy
+          APPSMITH_REDIS_URL: redis://127.0.0.1:6379
+          APPSMITH_DB_URL: mongodb://127.0.0.1:27017/appsmith_external_ci
+          APPSMITH_ENCRYPTION_PASSWORD: password
+          APPSMITH_ENCRYPTION_SALT: salt
+          APPSMITH_ENVFILE_PATH: /tmp/dummy.env
+          APPSMITH_VERBOSE_LOGGING_ENABLED: false
+        run: mvn test
+
+  rts:
+    name: ci/unit-rts
+    needs: changes
+    if: needs.changes.outputs.rts == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/client/packages/rts
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: app/client/package.json
+      - uses: actions/cache/restore@v4
+        with:
+          path: app/client/.yarn/cache
+          key: external-v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
+          restore-keys: external-v1-yarn3-
+      - name: Install dependencies
+        working-directory: app/client
+        run: |
+          corepack enable
+          yarn install --immutable
+      - name: Run unit tests
+        run: yarn test:unit
+      - name: Build
+        run: yarn build
+
+  result:
+    name: external-ci-result
+    needs: [changes, client-static, client-unit, server, rts]
+    if: always() && needs.changes.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize credential-free validation
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          CLIENT_STATIC: ${{ needs.client-static.result }}
+          CLIENT_UNIT: ${{ needs.client-unit.result }}
+          SERVER: ${{ needs.server.result }}
+          RTS: ${{ needs.rts.result }}
+        run: |
+          for result in "$CHANGES" "$CLIENT_STATIC" "$CLIENT_UNIT" "$SERVER" "$RTS"; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "Credential-free validation failed."
+              exit 1
+            fi
+          done
+          echo "All applicable credential-free checks passed."

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,4 +1,5 @@
-# If someone with write access comments "/ok-to-test" on a pull request, emit a repository_dispatch event
+# If someone with write access uses an approved slash command on a pull request,
+# emit a repository_dispatch event from the trusted GitHub App.
 name: Ok To Test
 
 on:
@@ -28,6 +29,7 @@ jobs:
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: |
+            approve-ci
             ok-to-test
             ci-test-limit
             build-deploy-preview

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -14,6 +14,10 @@ on:
 
 jobs:
   checkTestLabel:
+    # Fork PRs get a read-only token, so the PR-body writes downstream would
+    # fail with 403. External PRs are handled by external-pr-validation.yml
+    # and the /approve-ci trusted dispatch instead.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       ok_to_test: ${{ steps.checkLabel.outputs.ok_to_test }}

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   path-filter:
+    # Internal PRs only: several downstream jobs need larger runners and
+    # secrets that GitHub does not provide to fork PRs, so they would queue
+    # forever or fail. Fork PRs run external-pr-validation.yml instead.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       server: ${{ steps.filter.outputs.server }}
@@ -104,7 +108,10 @@ jobs:
         client-lint,
         client-check-cyclic-deps,
       ]
-    if: always()
+    # Skip (rather than pass) on fork PRs so the required check reflects that
+    # these jobs did not run; external PRs are validated by
+    # external-pr-validation.yml until a maintainer runs /approve-ci.
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -19,6 +19,11 @@ on:
         description: "This is the branch to be used for the build."
         required: false
         type: string
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
 
   pull_request:
     branches: [release, master]
@@ -48,7 +53,7 @@ jobs:
 
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        if: inputs.pr != 0
+        if: inputs.checkout-ref == '' && inputs.pr != 0
         uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -56,7 +61,7 @@ jobs:
 
       # Check out the specified branch in case this workflow is called by another workflow
       - name: Checkout the specified branch
-        if: inputs.pr == 0 && inputs.branch != ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -64,10 +69,17 @@ jobs:
 
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
-        if: inputs.pr == 0 && inputs.branch == ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch == ''
         uses: actions/checkout@v4
         with:
           fetch-tags: true
+
+      - name: Checkout the approved immutable commit
+        if: inputs.checkout-ref != ''
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          ref: ${{ inputs.checkout-ref }}
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: "false"
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
 
   workflow_dispatch:
     inputs:
@@ -71,14 +76,14 @@ jobs:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Check out merged commit from PR and base branch
         uses: actions/checkout@v4
-        if: inputs.pr != 0
+        if: inputs.checkout-ref == '' && inputs.pr != 0
         with:
           fetch-tags: true
           ref: refs/pull/${{ inputs.pr }}/merge
 
       # Check out the specified branch in case this workflow is called by another workflow
       - name: Checkout the specified branch
-        if: inputs.pr == 0 && inputs.branch != ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -87,9 +92,16 @@ jobs:
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Check out the head commit of the branch
         uses: actions/checkout@v4
-        if: inputs.pr == 0 && inputs.branch == ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch == ''
         with:
           fetch-tags: true
+
+      - name: Check out the approved immutable commit
+        if: inputs.checkout-ref != ''
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          ref: ${{ inputs.checkout-ref }}
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,11 +17,11 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-pr-stale: 30
-        days-before-pr-close: 7
+        days-before-pr-stale: 14
+        days-before-pr-close: 14
         days-before-issue-stale: 7
         stale-issue-message: 'This **critical** issue has not seen activity for a while. It will be closed in 7 days unless further activity is detected or the Critical tag is removed.'
-        stale-pr-message: 'This PR has not seen activitiy for a while. It will be closed in 7 days unless further activity is detected.'
+        stale-pr-message: 'This PR has not seen activity for 14 days. It will be closed in 14 days unless further activity is detected.'
         close-issue-message: 'This issue has been closed because of inactivity.'
         close-pr-message: 'This PR has been closed because of inactivity.'
         only-issue-labels: 'Critical'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,16 +14,17 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-pr-stale: 7
+        days-before-pr-stale: 30
+        days-before-pr-close: 7
         days-before-issue-stale: 7
         stale-issue-message: 'This **critical** issue has not seen activity for a while. It will be closed in 7 days unless further activity is detected or the Critical tag is removed.'
         stale-pr-message: 'This PR has not seen activitiy for a while. It will be closed in 7 days unless further activity is detected.'
         close-issue-message: 'This issue has been closed because of inactivity.'
         close-pr-message: 'This PR has been closed because of inactivity.'
         only-issue-labels: 'Critical'
-        exempt-pr-labels: 'Dont merge,WIP,User Testing'
+        exempt-pr-labels: 'Dont merge,WIP,User Testing,awaiting-maintainer,ci-approved,preview-ready'
         
         

--- a/contributions/CodeContributionsGuidelines.md
+++ b/contributions/CodeContributionsGuidelines.md
@@ -50,6 +50,29 @@ We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so
 - **Waiting for a deploy preview:** A maintainer may use
   `/build-deploy-preview` when the change needs hands-on product testing.
 
+#### Cypress on fork PRs (maintainer-triggered)
+
+On pull requests from forks, Cypress does **not** run when the contributor
+opens the PR or pushes new commits. The `ok-to-test` label alone also does
+nothing on a fork PR — `/approve-ci` is the trigger that starts privileged
+CI for the current commit. The label and optional `tags=` only set the
+**scope** of Cypress once that approval runs.
+
+| Maintainer action | `ok-to-test` label | What runs |
+| --- | --- | --- |
+| `/approve-ci` | absent | Build + Docker + `limited-tests.txt` |
+| `/approve-ci` | present | Sharded Cypress, default `@tag.All` (60 shards) |
+| `/approve-ci tags="@tag.Sanity"` | either | Sanity only (20 shards) |
+| `/approve-ci tags="@tag.Git, @tag.Table"` | either | Those tags (20 shards) |
+| `/approve-ci` | present, tags also in PR body | Body tags used when the command has no `tags=` |
+
+Tag resolution precedence: **command `tags=` → PR body → label default (`@tag.All`) → limited suite**.
+
+The `ok-to-test` label persists across contributor pushes (so maintainers do
+not have to re-add it). `/approve-ci` approval does **not** — after a new
+push, a maintainer must run `/approve-ci` again. If the label is still
+present on that re-approval, Cypress runs again for the new commit.
+
 When a PR is labelled `awaiting-maintainer`, the next action belongs to
 Appsmith. When it is labelled `awaiting-contributor`, the contributor should
 respond to the latest review or CI feedback.

--- a/contributions/CodeContributionsGuidelines.md
+++ b/contributions/CodeContributionsGuidelines.md
@@ -28,9 +28,29 @@ We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so
 5. Once you are confident in your code changes, create a pull request in your fork to the release branch in the appsmithorg/appsmith base repository.
 6. If you've changed any APIs, please call this out in the pull request and ensure backward compatibility.
 7. Link the issue of the base repository in your Pull request description. [Guide](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-8. When you raise a pull request, tag the maintainer you are collaborating with to start the build process.
+8. Pull requests from forks run credential-free formatting, lint, type, and unit
+   checks after GitHub's workflow approval. A maintainer will start integration
+   tests or a deploy preview when needed. External contributors do not need to
+   add an `ok-to-test` label or run a slash command.
 9. If changes are requested, work on them, commit them back, and tag the reviewer again. 
 10. Once all changes have been approved by the reviewer and the CI has run successfully, your PR will be merged into the base branch. Congratulations! 
+
+### Pull request check states
+
+- **Waiting for workflow approval:** An Appsmith maintainer must approve the
+  initial GitHub Actions run. No contributor action is required.
+- **Credential-free checks:** These checks run fork code without repository
+  secrets or write access. Their logs are safe for contributors to use when
+  fixing formatting, lint, type, or unit-test failures.
+- **Waiting for integration approval:** A maintainer must review the current
+  commit and use `/approve-ci`. Approval applies only to that exact commit; a
+  later push requires fresh approval.
+- **Waiting for a deploy preview:** A maintainer may use
+  `/build-deploy-preview` when the change needs hands-on product testing.
+
+When a PR is labelled `awaiting-maintainer`, the next action belongs to
+Appsmith. When it is labelled `awaiting-contributor`, the contributor should
+respond to the latest review or CI feedback.
 
 ### 🏡 Setup for local development
 

--- a/contributions/CodeContributionsGuidelines.md
+++ b/contributions/CodeContributionsGuidelines.md
@@ -30,10 +30,11 @@ We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so
 5. Once you are confident in your code changes, create a pull request in your fork to the release branch in the appsmithorg/appsmith base repository.
 6. If you've changed any APIs, please call this out in the pull request and ensure backward compatibility.
 7. Link the issue of the base repository in your Pull request description. [Guide](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-8. Pull requests from forks run credential-free formatting, lint, type, and unit
-   checks after GitHub's workflow approval. A maintainer will start integration
-   tests or a deploy preview when needed. External contributors do not need to
-   add an `ok-to-test` label or run a slash command.
+8. Pull requests from forks run credential-free checks after GitHub's workflow
+   approval, scoped to the parts of the codebase you touched. A maintainer will
+   start integration tests or a deploy preview when needed. External contributors
+   do not need to add an `ok-to-test` label or run a slash command. See
+   [Pull request check states](#pull-request-check-states) for the full list.
 9. If changes are requested, work on them, commit them back, and tag the reviewer again. 
 10. Once all changes have been approved by the reviewer and the CI has run successfully, your PR will be merged into the base branch. Congratulations! 
 
@@ -42,8 +43,19 @@ We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so
 - **Waiting for workflow approval:** An Appsmith maintainer must approve the
   initial GitHub Actions run. No contributor action is required.
 - **Credential-free checks:** These checks run fork code without repository
-  secrets or write access. Their logs are safe for contributors to use when
-  fixing formatting, lint, type, or unit-test failures.
+  secrets or write access, so their logs are safe for contributors to debug
+  against. Only the checks matching the paths you changed will run; the rest are
+  reported as skipped.
+
+  | Check | Runs when you change | Covers |
+  | --- | --- | --- |
+  | `ci/static-client` | `app/client/**` | Prettier formatting, lint, TypeScript types |
+  | `ci/unit-client` | `app/client/**` | Client unit tests |
+  | `ci/compile-client` | `app/client/**` | Client bundle compiles, using placeholder env values |
+  | `ci/cyclic-deps-client` | `app/client/src/**` | Circular-dependency count, compared against the base branch |
+  | `ci/unit-server` | `app/server/**` | Spotless formatting, server build, server unit tests |
+  | `ci/unit-rts` | `app/client/packages/rts/**` | RTS unit tests and build |
+  | `external-ci-result` | any of the above | Aggregate result of the checks above |
 - **Waiting for integration approval:** A maintainer must review the current
   commit and use `/approve-ci`. Approval applies only to that exact commit; a
   later push requires fresh approval.

--- a/contributions/CodeContributionsGuidelines.md
+++ b/contributions/CodeContributionsGuidelines.md
@@ -9,8 +9,10 @@ Before raising a pull request, ensure you have raised a corresponding issue and 
 
 Looking for issues to contribute to? Check out our [Inviting Contribution Issues](https://github.com/appsmithorg/appsmith/issues?q=is:open+is:issue+label:%22Inviting+Contribution%22+) – a great starting point for your contribution journey with Appsmith! Tag @contributor-support to have an issue assigned to you. If you choose to work on issues outside this list, please collaborate closely with us. Failure to inform and get the issue assigned beforehand may result in your contribution being rejected, leading to wasted effort for both parties.
 
+When you comment to express interest in an issue, briefly share how you plan to approach the fix — for example, where you expect the change to live and the high-level steps you would take. A short proposed approach helps maintainers confirm the direction (or steer you earlier), so the issue can be assigned with less back-and-forth and less wasted effort on either side.
+
 #### What not to do:
-1. Work on issues without informing the maintainer. Please get them assigned to yourself first. Comment on the issue if you are interested. 
+1. Work on issues without informing the maintainer. Please get them assigned to yourself first. Comment on the issue if you are interested, and include a brief proposed approach — not only that you want to take it.
 2. Naming lengthy branches. 
 3. Create PR(s) without proper description. 
 4. Requesting for review without latest release pull on PR. 


### PR DESCRIPTION
## Description

Improves the external-contributor pull request experience while preserving the security boundary around secret-bearing CI and deploy-preview workflows.

This change:

- replaces the broken contributor-facing `/ok-to-test` instructions with a clear Testing section and documented check states;
- adds credential-free fork validation for formatting, lint, type checks, and client, server, and RTS unit tests;
- adds external-contribution state labels and explains when the next action belongs to an Appsmith maintainer;
- adds the maintainer-only `/approve-ci` command;
- validates the approved PR head and pins client, server, RTS, Docker, and Cypress jobs to one immutable merge commit;
- preserves the existing `/ci-test-limit`, `/test-pw`, and `/build-deploy-preview` commands;
- changes the PR stale policy to 14 days before stale and 14 days before close, while exempting maintainer-blocked and actively tested PRs;
- upgrades `actions/stale` from v3 to v9.

Internal Appsmith PRs keep using the existing quality-check workflow. The new credential-free validation and external state jobs explicitly skip same-repository PRs.


<h1><a href="https://app.notion.com/p/appsmith/SOP-for-external-contributors-PR-3c7fe271b0e2801cba16f453841b9a85">SOP</a></h1>


## Security model

The external validation workflow has only:

```yaml
permissions:
  contents: read
  pull-requests: read
```

It does not reference repository secrets, write to pull requests, publish images, or access deployment infrastructure. Privileged CI remains maintainer-triggered through the existing GitHub App dispatcher.

`/approve-ci` records the current PR head, verifies that the checked-out merge commit contains that exact head, and passes the immutable merge SHA to every secret-bearing downstream workflow. A later contributor push requires a new approval.

## Testing

/ok-to-test tags="@tag.All"

- [x] Parsed all changed workflow YAML.
- [x] Ran `git diff --check`.
- [x] Ran Actionlint against the new and modified workflows.
- [x] Confirmed the credential-free workflow contains no secret references or write permissions.
- [x] Confirmed every `checkout-ref` caller has a matching reusable-workflow input.
- [x] Compared Actionlint output with the base branch; remaining findings are pre-existing.
- [ ] Run a live trial using a PR from a fork before merging.

## Notes for reviewers

- The PR template no longer seeds `/ok-to-test tags=""`. Internal maintainers can continue using the existing label-based path, but may want to add a maintainer-only syntax hint to the template.
- The new external Yarn cache currently restores only; the first live trial should measure whether adding a safe cache-save job is worthwhile.
- A second trusted slash command on the same PR cancels the earlier run through the new concurrency group.

## Communication

Should the DevRel and Marketing teams inform users about this change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/33061207893>
> Commit: d5532b8176ebff3098e01ee49366a24c88bb7a21
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=33061207893&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 27 Aug 2026 12:05:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added credential-free validation for pull requests from forks.
- Added approval states, labels, and guidance for external contributions.
- Added immutable commit validation for approved checks.
- Added targeted Cypress testing with configurable tags and scopes.

## Bug Fixes
- Prevented deploy previews and visual checks from running on fork pull requests.
- Improved test selection, cancellation, and validation result reporting.
- Updated stale pull request handling and exempted active workflow states.

## Documentation
- Clarified testing requirements, approval workflows, and available checks.
- Added guidance for proposing implementation approaches in contributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
