### PR TITLE
fix: bump npm to 11.18.0 to patch critical CVE-2026-59873 (node-tar DoS)

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -108,6 +108,13 @@ RUN <<END
   tar -xzf "$filename" -C /opt/node --strip-components 1
 
   rm "$filename" SHASUMS256.txt
+
+  # Node 24.x bundles npm 11.16/11.17, whose bundled tar (<=7.5.16) is vulnerable
+  # to CVE-2026-59873 (node-tar gzip-bomb DoS). npm 11.18.0 is the first release
+  # bundling the patched tar 7.5.19; pin it since no Node 24.x ships a fixed npm yet.
+  export PATH="/opt/node/bin:$PATH"
+  npm install -g npm@11.18.0
+  npm cache clean --force
 END
 
 # Install Caddy (built with rate-limit module via xcaddy; the module is inert unless configured)


### PR DESCRIPTION
## Summary
- npm's **bundled** `tar` in the Docker base image (`/opt/node/lib/node_modules/npm/node_modules/tar`) was `<= 7.5.16`, flagged by **CVE-2026-59873** (critical, node-tar gzip-bomb DoS; fixed in `tar@7.5.19`).
- Node 24.x ships npm 11.16/11.17 (tar `<= 7.5.16`), so a plain rebuild stays vulnerable. This pins **`npm@11.18.0`** — the first npm release bundling patched **`tar@7.5.19`** — in `deploy/docker/base.dockerfile`.

Linear: https://linear.app/appsmith/issue/APP-15736

## Notes
- Canonical CE change; syncs to EE. EE validation PR: https://github.com/appsmithorg/appsmith-ee/pull/9391
- Base-image change verified on the (identical) EE base image: `npm -v` = `11.18.0`, bundled `tar` = `7.5.19`, CVE-2026-59873 no longer reported.
- Base-image-only change: the `ok-to-test` Cypress matrix builds on `base-ce:release`, so it does not exercise this change directly.

## Test plan
- [x] Base image rebuilt from branch; `npm -v` = `11.18.0` and bundled `tar` = `7.5.19`
- [x] Image scan: CVE-2026-59873 no longer reported at the npm tar path
- [ ] App image builds on the new base (RTS `npm install` succeeds)

## Automation
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/30451625675>
> Commit: 23e0957b37dc12c1193b14f9bb99e208c57c4104
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=30451625675&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 29 Jul 2026 14:24:20 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Node.js environment to use a newer npm version, addressing a security vulnerability in bundled tooling.
  * Improved command resolution and refreshed the npm cache during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->