### PR TITLE
fix(test): stop cy.log inside the consolidated-api intercept failing hooks

### DIFF
--- a/app/client/cypress/support/Objects/FeatureFlags.ts
+++ b/app/client/cypress/support/Objects/FeatureFlags.ts
@@ -72,7 +72,12 @@ export const getConsolidatedDataApi = (
             : { ...flags };
           return res.send(updatedResponse);
         } catch (e) {
-          cy.log(`Featureflags.ts error `, e);
+          // This runs inside a cy.intercept response handler, which is outside
+          // the Cypress command queue. Enqueuing a cy.* command here makes
+          // Cypress throw "returned a promise from a command while also invoking
+          // one or more cy commands", failing whichever hook or test the
+          // intercept fired under. Log outside the queue instead.
+          console.log("FeatureFlags.ts: consolidated-api rewrite failed", e);
         }
       }
     });


### PR DESCRIPTION
## Description

`getConsolidatedDataApi` in `cypress/support/Objects/FeatureFlags.ts` rewrites the `/api/v1/consolidated-api/*` response to inject feature flags. Its `catch` calls `cy.log`:

```ts
req.reply((res: any) => {
  if (res.statusCode === 200 || res.statusCode === 401 || res.statusCode === 500) {
    try {
      const updatedResponse = JSON.parse(JSON.stringify(res?.body));
      updatedResponse.data.featureFlags.data = ...;
      return res.send(updatedResponse);
    } catch (e) {
      cy.log(`Featureflags.ts error `, e);   // <- inside the intercept handler
    }
  }
});
```

A `cy.intercept` response handler runs outside the Cypress command queue. Enqueuing a command from there produces:

```
CypressError: The following error originated from your test code, not from Cypress.
It was caused by an unhandled promise rejection.

  > Cypress detected that you returned a promise from a command while also invoking
    one or more cy commands in that promise.

The command that returned the promise was:   > `cy.reload()`
The cy command you invoked inside the promise was:   > `cy.log()`
```

Cypress fails the current test on an uncaught error, so a logging line in an error path takes down whatever command was in flight when the intercept resolved.

The `catch` fires when the response body is not the expected shape — the handler admits `401` and `500` as well as `200`, and those bodies have no `data.featureFlags`, so `updatedResponse.data.featureFlags.data = ...` throws `TypeError`. That is why this is intermittent: an occasional non-200 on `consolidated-api` turns into a suite-killing `CypressError` instead of a log line.

## Evidence

Mined the last 12 scheduled `test-build-docker-image` runs on the EE mirror (11 had ci-test logs). The signature appears in **7 of 11 runs**, 18 occurrences, across 6 distinct shards.

The inner command is `cy.log()` in **every** occurrence, and `FeatureFlags.ts:75` is the only `cy.log` inside a `cy.intercept` route handler anywhere under `cypress/support/` — the other matches are all inside `.then()` callbacks, where `cy.*` is legal. The outer command varies with whatever was in flight (`cy.reload()`, `cy.visit()`, `cy.get()`), which is consistent with the intercept firing during navigation.

Three of the occurrences landed in a `before all` hook and skipped an entire suite:

```
Because this error occurred during a `before all` hook we are skipping the
remaining tests in the current suite: `Tests general functionality...`
```

That is `EE/Enterprise/MultipleEnv/ME_CustomEnv_spec.ts` (`describe("Tests general functionality of custom environment")`), which is currently the joint-worst repeat offender in the mining table — 3 retry events across 3 runs, on runs 30259133481, 30350063215 and 30507869945, all on shard 2. The remaining occurrences failed a single test rather than a whole suite.

## Change

One line: log outside the command queue instead of inside it. No behavior change on the success path, and the `catch` still swallows the error exactly as before — the response falls through unmodified, as it does today.

Test support code only. No product code, no spec files, no CI config.

## Verification note

There is no red-before/green-after repro for this. Triggering the `catch` requires `consolidated-api` to return a body without `data.featureFlags` — an intermittent backend condition the test cannot summon on demand. A green Cypress run demonstrates the change does not break anything; the argument that it removes the failure is the source above, plus the fact that a `console.log` cannot raise `CypressError`.

Running with `@tag.All` because this file is shared support code loaded by every spec that intercepts feature flags.

## Automation

/ok-to-test tags="@tag.All"

Tracking: https://linear.app/appsmith/issue/APP-15705


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/30549711772>
> Commit: a7bd55889c0042860d68170254f03cfdb7b871b6
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=30549711772&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 30 Jul 2026 15:17:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling for API response interception in automated tests.
  * Added diagnostic logging when response processing cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->