### PR TITLE
ci: fix Caddy route tests and run them on Caddy config changes

### DIFF
--- a/.github/workflows/caddy-routes-test.yml
+++ b/.github/workflows/caddy-routes-test.yml
@@ -2,8 +2,24 @@ name: Caddy route tests
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * MON"
+  push:
+    branches:
+      - release
+    paths:
+      - .github/workflows/caddy-routes-test.yml
+      - deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+      - deploy/docker/fs/opt/appsmith/templates/docker.env.sh
+      - deploy/docker/route-tests/**
+      - deploy/docker/tests/**
+  pull_request:
+    branches:
+      - release
+    paths:
+      - .github/workflows/caddy-routes-test.yml
+      - deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
+      - deploy/docker/fs/opt/appsmith/templates/docker.env.sh
+      - deploy/docker/route-tests/**
+      - deploy/docker/tests/**
 
 jobs:
   build:

--- a/deploy/docker/route-tests/entrypoint.sh
+++ b/deploy/docker/route-tests/entrypoint.sh
@@ -23,7 +23,10 @@ reload-caddy() {
 }
 
 run-hurl() {
+  # Default value for the frame_ancestors variable; specs override it by
+  # passing their own --variable frame_ancestors=... (the last definition wins).
   hurl --test \
+    --variable "frame_ancestors=$default_frame_ancestors" \
     --resolve local.com:80:127.0.0.1 \
     --resolve custom-domain.com:80:127.0.0.1 \
     --resolve custom-domain.com:443:127.0.0.1 \
@@ -43,15 +46,17 @@ echo
 
 export TMP=/tmp/appsmith
 export WWW_PATH="$TMP/www"
+export _APPSMITH_CADDY=caddy
 
 # Fake files needed by the caddy-reconfigure script
 mkdir -p "$WWW_PATH" /opt/appsmith/editor
 echo -n 'index.html body, this will be replaced' > "$WWW_PATH/index.html"
 echo '{}' > /opt/appsmith/info.json
 echo -n 'actual index.html body' > /opt/appsmith/editor/index.html
-# A file large enough (>256 bytes) for Caddy's encode directive to compress.
+echo -n 'actual 404.html body' > /opt/appsmith/editor/404.html
+# A file large enough to exceed the encode directive's minimum length, so Caddy compresses it.
 mkdir -p /opt/appsmith/editor/static
-printf 'a%.0s' {1..512} > /opt/appsmith/editor/static/test-encoding.txt
+printf 'a%.0s' {1..4096} > /opt/appsmith/editor/static/test-encoding.txt
 mkcert -install
 
 # Start echo server
@@ -60,13 +65,16 @@ XDG_DATA_HOME="$TMP/echo-data" \
   caddy start --config echo.caddyfile --adapter caddyfile \
   >> "$TMP/echo-caddy.log" 2>&1
 
-# Start Caddy for use with our config to test
-caddy start >> "$TMP/caddy.log" 2>&1
+# Start Caddy for use with our config to test. The admin endpoint must be the
+# same unix socket that the generated Caddyfile declares, so that reloads can
+# reach this instance.
+printf '{\n\tadmin unix/%s/caddy.sock\n}\n' "$TMP" > "$TMP/bootstrap.caddyfile"
+caddy start --config "$TMP/bootstrap.caddyfile" --adapter caddyfile >> "$TMP/caddy.log" 2>&1
 
 sleep 1
 
 # Default values for Hurl variables
-export HURL_frame_ancestors="'self'"
+default_frame_ancestors="'self'"
 
 
 # Run tests, scenario by scenario
@@ -126,7 +134,7 @@ reload-caddy
 run-hurl common/*.hurl
 
 
-new-spec "Spec 7: Frame ancestors value with extra CSP directives"
+new-spec "Spec 8: Frame ancestors value with extra CSP directives"
 export APPSMITH_ALLOWED_FRAME_ANCESTORS="something.com; script-src something more not allowed"
 node /caddy-reconfigure.mjs
 reload-caddy


### PR DESCRIPTION
## Description

The "Caddy route tests" workflow has failed on every weekly scheduled run since late 2024. The test harness fell behind three changes to the code it exercises, and the weekly cron meant nobody was looking when each one landed:

1. #37672 made `caddy-reconfigure.mjs` template `404.html` alongside `index.html`, but the harness only created a fake `index.html` — every spec died with ENOENT before any route assertion ran.
2. `caddy-reconfigure.mjs` invokes the Caddy binary via `_APPSMITH_CADDY`, which only the production entrypoint exports.
3. #41847 bound Caddy's admin API to a unix socket in the generated Caddyfile, but the harness started Caddy with no config (admin on default TCP port), so config reloads could not reach the running instance. The harness now bootstraps Caddy with the same admin socket, matching how the production entrypoint starts it.

Two further breakages came from unpinned tooling in the test image (it always installs the latest Caddy and hurl):

4. Current Caddy no longer compresses the 512-byte test file; it is now 4096 bytes.
5. hurl 8 no longer honors `HURL_*` environment variables, so the `frame_ancestors` default is now passed with an explicit `--variable` flag, which spec-specific definitions still override (last definition wins).

With these fixes the full suite passes locally: all 8 specs, every hurl file green.

The workflow trigger changes from a weekly cron (which let it stay quietly red for years) to `push`/`pull_request` triggers path-filtered to the files the workflow actually tests: the workflow itself, `caddy-reconfigure.mjs`, the `docker.env.sh` template, the route-tests harness, and `deploy/docker/tests/`. `workflow_dispatch` remains for manual runs.

Since this PR touches those paths, the workflow runs on this PR itself and demonstrates the fix. Cypress is not run: this PR only changes a CI workflow and its test harness, no runtime behavior.

Linear: https://linear.app/appsmith/issue/APP-15740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route test setup and execution for more reliable Caddy configuration validation.
  * Added default and per-test overrides for frame-ancestor security directives.
  * Expanded coverage for additional Content Security Policy scenarios.
  * Corrected static test content sizing to validate response encoding behavior.

* **Chores**
  * Updated automated route tests to run for relevant changes on the release branch.
  * Removed scheduled route test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->