### PR TITLE
fix: remediate server and plugin jar CVEs from docker scout scan

### DIFF
--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.16</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -26,20 +26,27 @@
     </modules>
 
     <properties>
+        <!-- Pinned above the Spring Boot BOM default (3.17.0) for CVE-2025-48924. appsmith-interfaces
+             already asks for 3.18.0 directly, but the BOM-managed version is what lands in server.jar. -->
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <deploy.disabled>true</deploy.disabled>
-        <!-- Pinned to 2.18.8 for CVE-2026-54512 / CVE-2026-54513 -->
-        <jackson-bom.version>2.18.8</jackson-bom.version>
-        <jackson.version>2.18.8</jackson.version>
+        <!-- Held on the 2.18.x line for CVE-2026-54512 / CVE-2026-54513; 2.18.9 adds
+             CVE-2026-59889 / CVE-2026-54515 / GHSA-mhm7-754m-9p8w -->
+        <jackson-bom.version>2.18.9</jackson-bom.version>
+        <jackson.version>2.18.9</jackson.version>
         <java.version>25</java.version>
         <javadoc.disabled>true</javadoc.disabled>
+        <!-- Pinned above the Spring Boot BOM default (1.5.34) for CVE-2026-10532 / CVE-2026-9828 -->
+        <logback.version>1.5.35</logback.version>
         <!-- Pin Lombok to 1.18.42 to avoid breaking @FieldNameConstants inner class constructor change in 1.18.44 -->
         <lombok.version>1.18.42</lombok.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <mockito.version>4.4.0</mockito.version>
         <mockwebserver.version>5.0.0-alpha.2</mockwebserver.version>
-        <!-- Pinned above the Spring Boot BOM default for CVE-2026-42583/42579/42584/42587/33870/33871/44249/45416/50010/45674/47691 -->
-        <netty.version>4.1.135.Final</netty.version>
+        <!-- Pinned above the Spring Boot BOM default for CVE-2026-42583/42579/42584/42587/33870/33871/44249/45416/50010/45674/47691
+             and CVE-2026-55831/55833/55851/56745/56746/59898/59899/59900/59901/59919/59921 -->
+        <netty.version>4.1.136.Final</netty.version>
         <okhttp3.version>4.12.0</okhttp3.version>
         <org.pf4j.version>3.15.0</org.pf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -72,6 +79,12 @@
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>3.6.1</version>
+            </dependency>
+            <dependency>
+                <!-- CVE-2020-13956: awssdk apache-client 2.15.3 pulls 4.5.9 into the AWS plugin jars -->
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.14</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -33,11 +33,8 @@
         <!-- Held on the 2.18.x line for CVE-2026-54512 / CVE-2026-54513; 2.18.9 adds
              CVE-2026-59889 / CVE-2026-54515 / GHSA-mhm7-754m-9p8w -->
         <jackson-bom.version>2.18.9</jackson-bom.version>
-        <jackson.version>2.18.9</jackson.version>
         <java.version>25</java.version>
         <javadoc.disabled>true</javadoc.disabled>
-        <!-- Pinned above the Spring Boot BOM default (1.5.34) for CVE-2026-10532 / CVE-2026-9828 -->
-        <logback.version>1.5.35</logback.version>
         <!-- Pin Lombok to 1.18.42 to avoid breaking @FieldNameConstants inner class constructor change in 1.18.44 -->
         <lombok.version>1.18.42</lombok.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
/ok-to-test tags="@tag.All"

Linear: https://linear.app/appsmith/issue/APP-15743

## Why

`docker scout cves --only-fixed` on the shipped release image reports 176 fixable vulnerabilities across 70 packages. **52 of them live in `server.jar` and the plugin jars**, and are controlled from `app/server/pom.xml`. This clears **40** of those (9 high, 26 medium, 5 low).

This is the direct successor to #41928 (`bump Spring Boot to 3.5.14 and Netty to 4.1.135`) and #41947 (`batch security update — 17 CVEs from release image scan`).

## What changed

| Property | From | To |
|---|---|---|
| `spring-boot-starter-parent` | `3.5.14` | `3.5.16` |
| `netty.version` | `4.1.135.Final` | `4.1.136.Final` |
| `jackson-bom.version` | `2.18.8` | `2.18.9` |
| `commons-lang3.version` | *(BOM default 3.17.0)* | `3.18.0` |
| `httpclient` (dependencyManagement) | *(transitive 4.5.9)* | `4.5.14` |

Two worth explaining:

- **jackson stays on the 2.18.x line.** Spring Boot 3.5.x manages jackson at 2.21.x; the existing `2.18.8` entry is a deliberate pin *downward* for CVE-2026-54512 / CVE-2026-54513. Moving to 2.18.9 respects that intent while picking up CVE-2026-59889, CVE-2026-54515 and GHSA-mhm7-754m-9p8w. It also drags the plugin jars up from 2.16.0.
- **`commons-lang3` needed a property, not a dependency.** `appsmith-interfaces` already declares 3.18.0 directly, but the Spring Boot BOM manages it to 3.17.0 and that is what was landing in `server.jar`.

The unreferenced `jackson.version` property is removed — Spring Boot imports `jackson-bom.version` only, and `${jackson.version}` is not expanded anywhere in the repo. Removing it moves no resolved version.

## Verification

`mvn dependency:tree` across `appsmith-server` and the plugin modules confirms every pin resolves as intended:

```
com.fasterxml.jackson.core:jackson-databind    2.18.9
io.netty:netty-codec-http                      4.1.136.Final
io.netty:netty-common                          4.1.136.Final
org.apache.commons:commons-lang3               3.18.0
org.apache.httpcomponents:httpclient           4.5.14
ch.qos.logback:logback-core                    1.5.34
org.springframework:spring-webflux             6.2.19
org.springframework.security:spring-security-web  6.5.11
com.google.guava:guava                         32.0.1-jre
```

Full reactor compiles clean; `mvn spotless:check` passes. Validated on the EE side first in appsmith-ee#9405, where the full Cypress suite is green.

## What is deliberately NOT here

| Finding | Why not |
|---|---|
| `vertx-core` 4.5.21 (2 medium) | Part of a 4.5.21 family; pinning one artifact risks version skew. Needs the family moved together. |
| `log4j-core` 2.20.0 (3 medium), `nimbus-jose-jwt` 9.37.2 (1 medium) | Shaded inside a vendor uber-jar — absent from the resolved tree, so no `dependencyManagement` pin reaches them. Needs a `databricks-sdk-java` upgrade. |
| `bcpkix-jdk15on` 1.70 (2 medium) | Transitive from `sshj 0.35.0`; the `jdk15on` line ended at 1.70 and sshj 0.37+ moves to `bcpkix-jdk18on`. That is the SSH library behind git deploy keys — deserves its own PR. |
| `logback` | Boot 3.5.16 brings 1.5.34, which is already outside the affected range (`<1.5.34`) for both logback advisories. No pin needed. |

## Known false positives

- **`com.appsmith/server` and `com.appsmith/interfaces`** (3 high) — the jars are versioned `1.0-SNAPSHOT`, which sorts below the advisories' `1.99`/`2.0` fixed versions, so they are flagged permanently. GHSA-j9gf-vw2f-9hrw is already fixed (#41766).
- **`mssql-jdbc` CVE-2025-59250** (1 high) — affected range is `>=11.2.0.jre11, <11.2.4.jre11` and `mssqlPlugin` declares exactly `11.2.4.jre11`. Scout normalises the classifier away and compares `11.2.4 < 11.2.4.jre11`.

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/30653707840>
> Commit: 68f0af9979dd298b919ec1681817a64037b1667e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=30653707840&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 31 Jul 2026 21:13:48 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated underlying application components and libraries to newer versions.
  * Added dependency management improvements for improved compatibility and security.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->