### PR TITLE
fix(security): remediate base image CVEs from docker scout scan

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -12,20 +12,25 @@ FROM caddy:builder-alpine AS caddybuilder
 # coordinated Go security disclosure. None are reachable in Caddy's HTTP
 # path (the x/crypto CVEs are all in the SSH subsystem), but scanners
 # flag the embedded library version regardless.
+#
+# Note: a --replace only binds for a module Caddy actually requires. x/text is
+# reached indirectly, so replacing it is a no-op — a pin here silently does
+# nothing. It currently resolves to 0.38.0 via x/net; 0.39.0 would need an
+# explicit require, which xcaddy does not expose.
 RUN XCADDY_SETCAP=0 xcaddy build \
   --with github.com/mholt/caddy-ratelimit \
   --replace golang.org/x/crypto=golang.org/x/crypto@v0.52.0 \
-  --replace golang.org/x/net=golang.org/x/net@v0.55.0
+  --replace golang.org/x/net=golang.org/x/net@v0.56.0
 
 # Build MongoDB database tools from source with pinned x/crypto and x/net
 # Apt-installed mongodb-database-tools ships x/crypto@0.45.0 with no upstream fix available.
-FROM golang:1.26.4-alpine AS mongotoolsbuilder
+FROM golang:1.26.5-alpine AS mongotoolsbuilder
 
 RUN apk add --no-cache git make bash
 WORKDIR /tmp/mongo-tools
 RUN git clone --depth 1 --branch 100.17.0 https://github.com/mongodb/mongo-tools.git .
 RUN go mod edit -require=golang.org/x/crypto@v0.52.0 \
-               -require=golang.org/x/net@v0.55.0 && \
+               -require=golang.org/x/net@v0.56.0 && \
     go mod tidy && \
     go mod vendor
 ENV GOROOT=/usr/local/go
@@ -67,6 +72,12 @@ RUN set -o xtrace \
     mongodb-org-server mongodb-org-mongos mongodb-mongosh \
     postgresql-14 \
     git tar zstd openssh-client \
+  # software-properties-common is only needed for the add-apt-repository call above, but it
+  # pulls in python3-launchpadlib, which drags python3-cryptography, python3-jwt and
+  # python3-httplib2 into the runtime image and accounts for 12 scanner findings. Purge it
+  # once the PPA is registered — the sources.list entry and its signing key persist
+  # independently of the tool that wrote them.
+  && DEBIAN_FRONTEND=noninteractive apt-get purge --yes --auto-remove software-properties-common \
   && apt-get clean \
   && rm -rf \
     /root/.cache \

--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -8,19 +8,19 @@ FROM caddy:builder-alpine AS caddybuilder
 # restricted profile with cap-drop ALL). The image binds low ports via
 # net.ipv4.ip_unprivileged_port_start, so the setcap is unnecessary.
 #
-# --replace pins mitigate x/crypto and x/net CVEs from the May 22, 2026
+# --replace pins mitigate x/crypto, x/net and x/text CVEs from the May 22, 2026
 # coordinated Go security disclosure. None are reachable in Caddy's HTTP
 # path (the x/crypto CVEs are all in the SSH subsystem), but scanners
 # flag the embedded library version regardless.
 #
-# Note: a --replace only binds for a module Caddy actually requires. x/text is
-# reached indirectly, so replacing it is a no-op — a pin here silently does
-# nothing. It currently resolves to 0.38.0 via x/net; 0.39.0 would need an
-# explicit require, which xcaddy does not expose.
+# Verify these with `go version -m /opt/caddy/caddy`, which prints the effective
+# "dep X => Y" pairs. Grepping the binary for module@version strings reports the
+# pre-replace version and will make a working pin look inert.
 RUN XCADDY_SETCAP=0 xcaddy build \
   --with github.com/mholt/caddy-ratelimit \
   --replace golang.org/x/crypto=golang.org/x/crypto@v0.52.0 \
-  --replace golang.org/x/net=golang.org/x/net@v0.56.0
+  --replace golang.org/x/net=golang.org/x/net@v0.56.0 \
+  --replace golang.org/x/text=golang.org/x/text@v0.39.0
 
 # Build MongoDB database tools from source with pinned x/crypto and x/net
 # Apt-installed mongodb-database-tools ships x/crypto@0.45.0 with no upstream fix available.
@@ -30,7 +30,8 @@ RUN apk add --no-cache git make bash
 WORKDIR /tmp/mongo-tools
 RUN git clone --depth 1 --branch 100.17.0 https://github.com/mongodb/mongo-tools.git .
 RUN go mod edit -require=golang.org/x/crypto@v0.52.0 \
-               -require=golang.org/x/net@v0.56.0 && \
+               -require=golang.org/x/net@v0.56.0 \
+               -require=golang.org/x/text@v0.39.0 && \
     go mod tidy && \
     go mod vendor
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
Linear: https://linear.app/appsmith/issue/APP-15742

## Why

`docker scout cves --only-fixed` on the shipped release image reports 176 fixable vulnerabilities. This is the **CE-owned share of the base image fixes** — the regions of `deploy/docker/base.dockerfile` that CE and EE hold in common.

Follows the same ownership split as #41873 (golang bump for the mongo-tools builder), #41808 (Caddy/xcaddy) and #41850 (mongo-tools from source).

## What changed

| Change | Effect |
|---|---|
| Purge `software-properties-common` after `add-apt-repository` | clears **12** findings (7 high) |
| mongo-tools Go toolchain `1.26.4` → `1.26.5` | clears the `stdlib` findings |
| `x/net` pin `0.55.0` → `0.56.0` (Caddy + mongo-tools) | clears CVE-2026-46600 |
| New `x/text` → `0.39.0` pin (Caddy + mongo-tools) | clears CVE-2026-56852 |

### Why `software-properties-common` can go

It exists solely for the `add-apt-repository -y ppa:git-core/ppa` call, but drags in `python3-launchpadlib` and with it `python3-cryptography`, `python3-jwt` and `python3-httplib2`. The PPA's sources entry and signing key persist independently of the tool that wrote them, so purging after registration is safe.

Verified by building the dependency-package block in isolation:

- `python3-cryptography`, `python3-jwt`, `python3-httplib2`, `python3-launchpadlib`, `software-properties-common` — all removed, no `.dist-info` left behind.
- `git 2.54.0` (Ubuntu 24.04 ships 2.43, so the PPA is still active), `supervisord 4.2.5`, `mongod 7.0.39`, `mongosh 2.9.2`, `psql 14.23` — all working.
- `/etc/apt/sources.list.d/git-core-ubuntu-ppa-noble.sources` still present.

### On the Go pins

Verify these with `go version -m <binary>`, not by grepping for `module@version` strings — the grep reports the *pre-replace* version and makes a working pin look inert. Confirmed on the built binaries:

```
caddy      dep golang.org/x/text v0.38.0 => v0.39.0
mongodump  dep golang.org/x/text v0.39.0
```

## Scope

EE-only parts of this file — the Keycloak upgrade and the Temporal builder — are handled separately in appsmith-ee#9404, matching the existing split (#9060 for Keycloak, #9155 / #9052 for Temporal). Nothing in this PR touches a region that does not exist in EE, so it should sync cleanly.

A full base-image rebuild and rescan was done on the EE side with both halves applied: **123 → 52 findings (−58%)**, high 42 → 20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling and platform components to newer versions for improved compatibility and maintenance.
  * Refined MongoDB tooling builds with more consistent dependency versions.
  * Reduced unnecessary packages from runtime images after setup, helping keep deployments leaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->