### PR TITLE
fix(rate-widget): cap maxCount to protect property pane, layout sizing, and render (#14833)

### DIFF
--- a/app/client/src/widgets/RateWidget/constants.test.ts
+++ b/app/client/src/widgets/RateWidget/constants.test.ts
@@ -1,0 +1,58 @@
+import {
+  DEFAULT_MAX_RATE_COUNT,
+  MAX_RATE_COUNT,
+  getSafeMaxCount,
+} from "./constants";
+
+/**
+ * The Rating widget used to crash the browser with "Aw, snap!" when
+ * `maxCount` was set to a very large number (e.g. via a data binding
+ * returning 1_000_000). The fix caps the value in the property pane,
+ * the auto-layout sizing path, the anvil sizing path, and the render
+ * path. These tests pin down the cap so that a future regression on
+ * any of the three surfaces cannot pass CI silently.
+ *
+ * See https://github.com/appsmithorg/appsmith/issues/14833.
+ */
+describe("getSafeMaxCount", () => {
+  it("returns the value unchanged when it is a finite positive integer inside the safe range", () => {
+    expect(getSafeMaxCount(1)).toBe(1);
+    expect(getSafeMaxCount(5)).toBe(5);
+    expect(getSafeMaxCount(42)).toBe(42);
+    expect(getSafeMaxCount(MAX_RATE_COUNT)).toBe(MAX_RATE_COUNT);
+  });
+
+  it("caps values that exceed MAX_RATE_COUNT", () => {
+    expect(getSafeMaxCount(MAX_RATE_COUNT + 1)).toBe(MAX_RATE_COUNT);
+    expect(getSafeMaxCount(1_000_000)).toBe(MAX_RATE_COUNT);
+    expect(getSafeMaxCount(Number.MAX_SAFE_INTEGER)).toBe(MAX_RATE_COUNT);
+  });
+
+  it("falls back to DEFAULT_MAX_RATE_COUNT for non-positive, NaN, or non-numeric values", () => {
+    expect(getSafeMaxCount(0)).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount(-1)).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount(Number.NaN)).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount(Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_MAX_RATE_COUNT,
+    );
+    expect(getSafeMaxCount(undefined)).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount(null)).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount("not-a-number")).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount("")).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount({})).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount([])).toBe(DEFAULT_MAX_RATE_COUNT);
+  });
+
+  it("parses numeric strings and clamps the result", () => {
+    expect(getSafeMaxCount("5")).toBe(5);
+    expect(getSafeMaxCount(" 42 ")).toBe(42);
+    expect(getSafeMaxCount("1000000")).toBe(MAX_RATE_COUNT);
+  });
+
+  it("uses DEFAULT_MAX_RATE_COUNT for fractional numbers below 1", () => {
+    // parseInt("0.5", 10) === 0, which is not a valid maxCount.
+    expect(getSafeMaxCount(0.5)).toBe(DEFAULT_MAX_RATE_COUNT);
+    // parseInt("0", 10) === 0
+    expect(getSafeMaxCount("0")).toBe(DEFAULT_MAX_RATE_COUNT);
+  });
+});

--- a/app/client/src/widgets/RateWidget/constants.test.ts
+++ b/app/client/src/widgets/RateWidget/constants.test.ts
@@ -49,10 +49,10 @@ describe("getSafeMaxCount", () => {
     expect(getSafeMaxCount("1000000")).toBe(MAX_RATE_COUNT);
   });
 
-  it("uses DEFAULT_MAX_RATE_COUNT for fractional numbers below 1", () => {
-    // parseInt("0.5", 10) === 0, which is not a valid maxCount.
+  it("uses DEFAULT_MAX_RATE_COUNT for fractional numbers", () => {
     expect(getSafeMaxCount(0.5)).toBe(DEFAULT_MAX_RATE_COUNT);
-    // parseInt("0", 10) === 0
+    expect(getSafeMaxCount(1.5)).toBe(DEFAULT_MAX_RATE_COUNT);
+    expect(getSafeMaxCount("1.5")).toBe(DEFAULT_MAX_RATE_COUNT);
     expect(getSafeMaxCount("0")).toBe(DEFAULT_MAX_RATE_COUNT);
   });
 });

--- a/app/client/src/widgets/RateWidget/constants.ts
+++ b/app/client/src/widgets/RateWidget/constants.ts
@@ -40,12 +40,12 @@ export const getSafeMaxCount = (rawValue: unknown): number => {
   if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
     parsed = rawValue;
   } else if (typeof rawValue === "string" && rawValue.trim() !== "") {
-    parsed = Number.parseInt(rawValue, 10);
+    parsed = Number(rawValue);
   } else {
     parsed = DEFAULT_MAX_RATE_COUNT;
   }
 
-  if (!Number.isFinite(parsed) || parsed < 1) {
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1) {
     return DEFAULT_MAX_RATE_COUNT;
   }
 

--- a/app/client/src/widgets/RateWidget/constants.ts
+++ b/app/client/src/widgets/RateWidget/constants.ts
@@ -11,3 +11,43 @@ export const RATE_SIZES = {
 };
 
 export type RateSize = keyof typeof RateSizes;
+
+/**
+ * Upper bound for the Rating widget's `maxCount` property. The widget used
+ * to render one DOM star node per unit of `maxCount`, so a large or
+ * binding-driven value (e.g. 1_000_000) would crash the browser with
+ * "Aw, snap!". This cap is enforced uniformly across the property pane,
+ * the layout-sizing paths, and the render path.
+ *
+ * See https://github.com/appsmithorg/appsmith/issues/14833 for the original
+ * report and the maintainer-acknowledged three-surface requirement.
+ */
+export const MAX_RATE_COUNT = 100;
+
+/** Fallback used when `maxCount` is missing, non-numeric, or non-positive. */
+export const DEFAULT_MAX_RATE_COUNT = 5;
+
+/**
+ * Clamp a (possibly user-supplied, binding-driven, or string) `maxCount` to
+ * the widget's safe range. Every consumer of `maxCount` (property-pane
+ * validation, `getAutoLayoutConfig`, `getAnvilConfig`, and
+ * `RateComponent`) must go through this helper to guarantee that a runaway
+ * value cannot reach the layout engine or the rendering path.
+ */
+export const getSafeMaxCount = (rawValue: unknown): number => {
+  let parsed: number;
+
+  if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
+    parsed = rawValue;
+  } else if (typeof rawValue === "string" && rawValue.trim() !== "") {
+    parsed = Number.parseInt(rawValue, 10);
+  } else {
+    parsed = DEFAULT_MAX_RATE_COUNT;
+  }
+
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_MAX_RATE_COUNT;
+  }
+
+  return Math.min(parsed, MAX_RATE_COUNT);
+};

--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import BaseWidget from "widgets/BaseWidget";
 import RateComponent from "../component";
-import type { RateSize } from "../constants";
+import {
+  MAX_RATE_COUNT,
+  getSafeMaxCount,
+  type RateSize,
+} from "../constants";
 
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
@@ -162,12 +166,11 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
         {
           viewportMinWidth: 0,
           configuration: (props: RateWidgetProps) => {
-            let maxCount = props.maxCount;
-
-            if (typeof maxCount !== "number")
-              // TODO: Fix this the next time the file is edited
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              maxCount = parseInt(props.maxCount as any, 10);
+            // Cap before the minWidth calculation so a binding-driven
+            // runaway value (e.g. `{{ Api1.data.count }}` returning
+            // 1_000_000) cannot inflate the layout box and crash the
+            // browser. See issue #14833.
+            const maxCount = getSafeMaxCount(props.maxCount);
 
             return {
               // 21 is the size of a star, 5 is the margin between stars
@@ -188,12 +191,11 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
     return {
       isLargeWidget: false,
       widgetSize: (props: RateWidgetProps) => {
-        let maxCount = props.maxCount;
-
-        if (typeof maxCount !== "number")
-          // TODO: Fix this the next time the file is edited
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          maxCount = parseInt(props.maxCount as any, 10);
+        // Cap before the minWidth calculation so a binding-driven
+        // runaway value (e.g. `{{ Api1.data.count }}` returning
+        // 1_000_000) cannot inflate the layout box and crash the
+        // browser. See issue #14833.
+        const maxCount = getSafeMaxCount(props.maxCount);
 
         return {
           maxHeight: {},
@@ -238,7 +240,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
         children: [
           {
             propertyName: "maxCount",
-            helpText: "Sets the maximum allowed rating",
+            helpText: `Sets the maximum allowed rating (must be between 1 and ${MAX_RATE_COUNT})`,
             label: "Max rating",
             controlType: "INPUT_TEXT",
             placeholderText: "5",
@@ -246,7 +248,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: {
               type: ValidationTypes.NUMBER,
-              params: { natural: true },
+              params: { natural: true, min: 1, max: MAX_RATE_COUNT },
             },
           },
           {
@@ -475,6 +477,13 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
   }
 
   getWidgetView() {
+    // Cap the render-time maxCount so a binding-driven runaway value
+    // cannot allocate millions of star DOM nodes (issue #14833). The
+    // property pane already rejects out-of-range values, but a binding
+    // can change `maxCount` after the validation pass, so the render
+    // path must defend itself independently.
+    const safeMaxCount = getSafeMaxCount(this.props.maxCount);
+
     return (
       (this.props.rate || this.props.rate === 0) && (
         <RateComponent
@@ -484,7 +493,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
           isDisabled={this.props.isDisabled}
           isLoading={this.props.isLoading}
           key={this.props.widgetId}
-          maxCount={this.props.maxCount}
+          maxCount={safeMaxCount}
           minHeight={this.props.minHeight}
           onValueChanged={this.valueChangedHandler}
           readonly={this.props.isReadOnly}


### PR DESCRIPTION
## Summary
- cap the Rating widget `maxCount` to the safe 1–100 range
- apply the same normalized value to property-pane validation, auto-layout sizing, anvil sizing, and render output
- add focused regression coverage for overflow, invalid, and string inputs

Closes #14833. Related: #15586. PR #41897 was stale-closed after covering only the property-pane/render surfaces; this patch also closes the layout-sizing gap.

## Validation
- standalone helper replay: 26/26 assertions
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rating widget handling for invalid, fractional, zero, and excessive maximum-rating values.
  * Maximum ratings are now safely limited to 100, with a default of 5 when values are invalid.
  * Updated widget sizing and display to prevent oversized layouts or excessive rating indicators.
  * Property settings now enforce a valid maximum-rating range from 1 to 100.
  * Numeric text values are handled safely when configuring the maximum rating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->