### PR TITLE
fix: add INFO-level logging to critical code paths for RCA diagnosability

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -1304,8 +1304,21 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                                 .setStrategy(MergeStrategy.RECURSIVE)
                                                 .call();
                                         processStopwatch.stopAndLogTimeInMillis();
+                                        log.info(
+                                                "Git merge completed: repo={}, source={}, dest={}, status={}, durationMs={}",
+                                                repoSuffix,
+                                                sourceBranch,
+                                                destinationBranch,
+                                                mergeResult.getMergeStatus().name(),
+                                                processStopwatch.getExecutionTime());
                                         return mergeResult.getMergeStatus().name();
                                     } catch (GitAPIException e) {
+                                        log.warn(
+                                                "Git merge failed: repo={}, source={}, dest={}",
+                                                repoSuffix,
+                                                sourceBranch,
+                                                destinationBranch,
+                                                e);
                                         // On merge conflicts abort the merge => git merge --abort
                                         git.getRepository().writeMergeCommitMsg(null);
                                         git.getRepository().writeMergeHeads(null);
@@ -1374,7 +1387,7 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                     return fetchMessages;
                                 })
                                 .onErrorResume(error -> {
-                                    log.error(error.getMessage());
+                                    log.error("Git fetch failed: repo={}", repoSuffix, error);
                                     return Mono.error(error);
                                 })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
@@ -1448,7 +1461,7 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                     return fetchMessages;
                                 })
                                 .onErrorResume(error -> {
-                                    log.error(error.getMessage());
+                                    log.error("Git fetch failed: repo={}", repoSuffix, error);
                                     return Mono.error(error);
                                 })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/handler/ce/FSGitHandlerCEImpl.java
@@ -1333,6 +1333,13 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                         return Mono.error(error);
                                     }
 
+                                    log.warn(
+                                            "Git merge failed, resetting to last commit: repo={}, source={}, dest={}",
+                                            repoSuffix,
+                                            sourceBranch,
+                                            destinationBranch,
+                                            error);
+
                                     try {
                                         return resetToLastCommit(repoSuffix, destinationBranch, keepWorkingDirChanges)
                                                 .thenReturn(error.getMessage());
@@ -1387,10 +1394,15 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                     return fetchMessages;
                                 })
                                 .onErrorResume(error -> {
-                                    log.error("Git fetch failed: repo={}", repoSuffix, error);
                                     return Mono.error(error);
                                 })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
+                                .doOnError(error -> log.error(
+                                        "Git fetch failed: repo={}, branch={}, fetchAll={}",
+                                        repoSuffix,
+                                        branchName,
+                                        isFetchAll,
+                                        error))
                                 .name(GitSpan.FS_FETCH_REMOTE)
                                 .tap(Micrometer.observation(observationRegistry)),
                         Git::close)
@@ -1461,10 +1473,15 @@ public class FSGitHandlerCEImpl implements FSGitHandler {
                                     return fetchMessages;
                                 })
                                 .onErrorResume(error -> {
-                                    log.error("Git fetch failed: repo={}", repoSuffix, error);
                                     return Mono.error(error);
                                 })
                                 .timeout(Duration.ofMillis(Constraint.TIMEOUT_MILLIS))
+                                .doOnError(error -> log.error(
+                                        "Git fetch failed: repo={}, refType={}, fetchAll={}",
+                                        repoSuffix,
+                                        fetchRemoteDTO.getRefType(),
+                                        fetchRemoteDTO.getIsFetchAll(),
+                                        error))
                                 .name(GitSpan.FS_FETCH_REMOTE)
                                 .tap(Micrometer.observation(observationRegistry)),
                         Git::close)

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Stopwatch.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Stopwatch.java
@@ -25,6 +25,13 @@ public class Stopwatch {
         log.debug("Execute time: {}, Time elapsed: {}ms", this.flow, this.watch.getTime(TimeUnit.MILLISECONDS));
     }
 
+    public void stopAndLogTimeAtInfoLevel() {
+        if (!this.watch.isStopped()) {
+            this.watch.stop();
+        }
+        log.info("{}: durationMs={}", this.flow, this.watch.getTime(TimeUnit.MILLISECONDS));
+    }
+
     public void stopTimer() {
         if (!this.watch.isStopped()) {
             this.watch.stop();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AccessDeniedHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AccessDeniedHandlerCE.java
@@ -13,7 +13,7 @@ public class AccessDeniedHandlerCE implements ServerAccessDeniedHandler {
     @Override
     public Mono<Void> handle(ServerWebExchange exchange, AccessDeniedException denied) {
         return Mono.fromRunnable(() -> {
-            log.warn("Access denied: path={}, reason={}", exchange.getRequest().getPath(), denied.getMessage());
+            log.warn("Access denied: path={}", exchange.getRequest().getPath());
             ServerHttpResponse response = exchange.getResponse();
             response.setStatusCode(HttpStatus.UNAUTHORIZED);
         });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AccessDeniedHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AccessDeniedHandlerCE.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.authentication.handlers.ce;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.access.AccessDeniedException;
@@ -7,10 +8,12 @@ import org.springframework.security.web.server.authorization.ServerAccessDeniedH
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 public class AccessDeniedHandlerCE implements ServerAccessDeniedHandler {
     @Override
     public Mono<Void> handle(ServerWebExchange exchange, AccessDeniedException denied) {
         return Mono.fromRunnable(() -> {
+            log.warn("Access denied: path={}, reason={}", exchange.getRequest().getPath(), denied.getMessage());
             ServerHttpResponse response = exchange.getResponse();
             response.setStatusCode(HttpStatus.UNAUTHORIZED);
         });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCE.java
@@ -24,7 +24,8 @@ public class AuthenticationFailureHandlerCE implements ServerAuthenticationFailu
     @Override
     public Mono<Void> onAuthenticationFailure(WebFilterExchange webFilterExchange, AuthenticationException exception) {
         String source = exception instanceof OAuth2AuthenticationException
-                ? ((OAuth2AuthenticationException) exception).getError().getErrorCode()
+                ? sanitizeLogInput(
+                        ((OAuth2AuthenticationException) exception).getError().getErrorCode())
                 : SOURCE_FORM;
 
         String errorMessage = exception.getMessage();
@@ -38,6 +39,13 @@ public class AuthenticationFailureHandlerCE implements ServerAuthenticationFailu
                 .counter(LOGIN_FAILURE, "source", source, "message", errorMessage)
                 .increment();
         return authenticationFailureRetryHandler.retryAndRedirectOnAuthenticationFailure(webFilterExchange, exception);
+    }
+
+    private static String sanitizeLogInput(String input) {
+        if (input == null) {
+            return null;
+        }
+        return input.replaceAll("[\\r\\n]", "_");
     }
 
     public Mono<Void> handleErrorRedirect(WebFilterExchange webFilterExchange) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCE.java
@@ -29,6 +29,8 @@ public class AuthenticationFailureHandlerCE implements ServerAuthenticationFailu
 
         String errorMessage = exception.getMessage();
 
+        log.warn("Authentication failed: source={}, message={}", source, errorMessage);
+
         meterRegistry
                 .counter(LOGIN_FAILURE, "source", source, "message", errorMessage)
                 .increment();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCE.java
@@ -29,7 +29,10 @@ public class AuthenticationFailureHandlerCE implements ServerAuthenticationFailu
 
         String errorMessage = exception.getMessage();
 
-        log.warn("Authentication failed: source={}, message={}", source, errorMessage);
+        log.warn(
+                "Authentication failed: source={}, errorCode={}",
+                source,
+                exception.getClass().getSimpleName());
 
         meterRegistry
                 .counter(LOGIN_FAILURE, "source", source, "message", errorMessage)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
@@ -48,7 +48,7 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
                 .filter(config -> TRUE.equals(config.getConfig().get("value")))
                 .switchIfEmpty(Mono.defer(instanceConfigHelper::registerInstance))
                 .onErrorResume(errorSignal -> {
-                    log.debug("Instance registration failed with error: \n{}", errorSignal.getMessage());
+                    log.warn("Instance registration failed: error={}", errorSignal.getMessage());
                     return Mono.empty();
                 })
                 .then(instanceConfigHelper.performRtsHealthCheck());
@@ -69,7 +69,7 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
         try {
             startupProcess.block();
         } catch (Exception e) {
-            log.debug("Application start up encountered an error: {}", e.getMessage());
+            log.error("Application startup failed: error={}", e.getMessage(), e);
         }
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
@@ -121,6 +121,12 @@ public class RedisConfig {
         final URI redisUri = URI.create(redisURL);
         final String scheme = redisUri.getScheme();
 
+        log.info(
+                "Initializing Redis connection: scheme={}, host={}, port={}",
+                scheme,
+                redisUri.getHost(),
+                redisUri.getPort());
+
         switch (scheme) {
             case "redis" -> {
                 final RedisStandaloneConfiguration config =

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportServiceCEImpl.java
@@ -93,7 +93,7 @@ public class ExportServiceCEImpl implements ExportServiceCE {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, ARTIFACT_CONTEXT));
         }
 
-        log.info("Export started: artifactId={}, branchName={}, artifactType={}", artifactId, branchName, artifactType);
+        log.info("Export started: artifactId={}, artifactType={}", artifactId, artifactType);
 
         ArtifactBasedExportService<?, ?> artifactBasedExportService = getContextBasedExportService(artifactType);
         Map<String, String> artifactContextConstantMap = artifactBasedExportService.getConstantsMap();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exports/internal/ExportServiceCEImpl.java
@@ -93,6 +93,8 @@ public class ExportServiceCEImpl implements ExportServiceCE {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, ARTIFACT_CONTEXT));
         }
 
+        log.info("Export started: artifactId={}, branchName={}, artifactType={}", artifactId, branchName, artifactType);
+
         ArtifactBasedExportService<?, ?> artifactBasedExportService = getContextBasedExportService(artifactType);
         Map<String, String> artifactContextConstantMap = artifactBasedExportService.getConstantsMap();
         String idConstant = artifactContextConstantMap.get(FieldName.ID);
@@ -177,6 +179,10 @@ public class ExportServiceCEImpl implements ExportServiceCE {
                 .flatMap(user -> {
                     Map<String, String> contextConstants = artifactBasedExportService.getConstantsMap();
                     stopwatch.stopTimer();
+                    log.info(
+                            "Export completed: artifactId={}, durationMs={}",
+                            exportingMetaDTO.getArtifactId(),
+                            stopwatch.getExecutionTime());
                     final Map<String, Object> data = new HashMap<>();
                     data.put(FieldName.FLOW_NAME, stopwatch.getFlow());
                     data.put("executionTime", stopwatch.getExecutionTime());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -2026,11 +2026,11 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                         branchName,
                         System.currentTimeMillis() - pullStartTime))
                 .doOnError(error -> log.warn(
-                        "Git pull failed: artifactId={}, branch={}, durationMs={}, error={}",
+                        "Git pull failed: artifactId={}, branch={}, durationMs={}",
                         baseArtifactId,
                         branchName,
                         System.currentTimeMillis() - pullStartTime,
-                        error.getMessage()))
+                        error))
                 .subscribe(sink::success, sink::error, null, sink.currentContext()));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/central/CentralGitServiceCEImpl.java
@@ -1982,6 +1982,10 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
         GitArtifactMetadata branchedGitMetadata = branchedArtifact.getGitArtifactMetadata();
         ArtifactType artifactType = baseArtifact.getArtifactType();
         String baseArtifactId = branchedGitMetadata.getDefaultArtifactId();
+        String branchName = branchedGitMetadata.getRefName();
+
+        log.info("Git pull started: artifactId={}, branch={}", baseArtifactId, branchName);
+        long pullStartTime = System.currentTimeMillis();
 
         Mono<GitPullDTO> lockHandledpullDTOMono = Mono.usingWhen(
                         gitRedisUtils.acquireGitLock(artifactType, baseArtifactId, GitCommandConstants.PULL, TRUE),
@@ -2015,8 +2019,19 @@ public class CentralGitServiceCEImpl implements CentralGitServiceCE {
                 .name(GitSpan.OPS_PULL)
                 .tap(Micrometer.observation(observationRegistry));
 
-        return Mono.create(
-                sink -> lockHandledpullDTOMono.subscribe(sink::success, sink::error, null, sink.currentContext()));
+        return Mono.create(sink -> lockHandledpullDTOMono
+                .doOnSuccess(result -> log.info(
+                        "Git pull completed: artifactId={}, branch={}, durationMs={}",
+                        baseArtifactId,
+                        branchName,
+                        System.currentTimeMillis() - pullStartTime))
+                .doOnError(error -> log.warn(
+                        "Git pull failed: artifactId={}, branch={}, durationMs={}, error={}",
+                        baseArtifactId,
+                        branchName,
+                        System.currentTimeMillis() - pullStartTime,
+                        error.getMessage()))
+                .subscribe(sink::success, sink::error, null, sink.currentContext()));
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/imports/internal/ImportServiceCEImpl.java
@@ -412,6 +412,13 @@ public class ImportServiceCEImpl implements ImportServiceCE {
             ImportArtifactPermissionProvider permissionProvider,
             Set<String> permissionGroups) {
 
+        log.info(
+                "Import started: workspaceId={}, artifactId={}, appendToArtifact={}, artifactType={}",
+                workspaceId,
+                branchedArtifactId,
+                appendToArtifact,
+                artifactExchangeJson.getArtifactJsonType());
+
         ArtifactBasedImportService<?, ?, ?> artifactBasedImportService =
                 getArtifactBasedImportService(artifactExchangeJson);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -235,6 +235,11 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                                                 datasourceStorage.getDatasourceConfiguration());
                                     }
                                 })
+                                .doOnError(e -> log.error(
+                                        "Datasource connection creation failed: datasourceId={}, pluginId={}, error={}",
+                                        datasourceStorage.getDatasourceId(),
+                                        datasourceStorage.getPluginId(),
+                                        e.getMessage()))
                                 .cache();
 
                         Mono<DatasourceContext<Object>> datasourceContextMonoCache = connectionMonoCache

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -236,10 +236,11 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                                     }
                                 })
                                 .doOnError(e -> log.error(
-                                        "Datasource connection creation failed: datasourceId={}, pluginId={}, error={}",
+                                        "Datasource connection creation failed: datasourceId={}, pluginId={}, errorType={}",
                                         datasourceStorage.getDatasourceId(),
                                         datasourceStorage.getPluginId(),
-                                        e.getMessage()))
+                                        e.getClass().getSimpleName(),
+                                        e))
                                 .cache();
 
                         Mono<DatasourceContext<Object>> datasourceContextMonoCache = connectionMonoCache

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/authentication/handlers/ce/AuthenticationFailureHandlerCETest.java
@@ -1,0 +1,45 @@
+package com.appsmith.server.authentication.handlers.ce;
+
+import com.appsmith.server.authentication.helpers.AuthenticationFailureRetryHandler;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthenticationFailureHandlerCETest {
+
+    private AuthenticationFailureHandlerCE handler;
+    private MeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        AuthenticationFailureRetryHandler retryHandler = mock(AuthenticationFailureRetryHandler.class);
+        when(retryHandler.retryAndRedirectOnAuthenticationFailure(any(), any())).thenReturn(Mono.empty());
+        meterRegistry = new SimpleMeterRegistry();
+        handler = new AuthenticationFailureHandlerCE(retryHandler, meterRegistry);
+    }
+
+    @Test
+    void onAuthenticationFailure_sanitizesCrlfInOAuth2ErrorCode() {
+        String maliciousErrorCode = "invalid_grant\r\nINFO: Forged log entry";
+        OAuth2Error error = new OAuth2Error(maliciousErrorCode, "some description", null);
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(error, "auth failed");
+
+        // The handler should not throw — it sanitizes and logs safely
+        handler.onAuthenticationFailure(null, exception).block();
+
+        // Verify the metric tag was recorded with sanitized source (no CRLF)
+        String recordedSource =
+                meterRegistry.get("appsmith.login_failure").counter().getId().getTag("source");
+        assertThat(recordedSource).doesNotContain("\r").doesNotContain("\n");
+        assertThat(recordedSource).isEqualTo("invalid_grant__INFO: Forged log entry");
+    }
+}


### PR DESCRIPTION
## Summary

Critical code paths (authentication, datasource connections, Git operations, import/export, startup) either had **no logging at all** or logged failures at DEBUG level — invisible in production where INFO is the floor. An RCA agent working from customer-shared Grafana logs had zero signal for the most common failure scenarios.

Slack thread that prompted this: https://theappsmith.slack.com/archives/C09NG5BJ18S/p1785766042770509

Builds on the foundation of #42053 (which fixed Git error messages and stack traces) by adding the **timing and entry/exit breadcrumbs** that are still missing.

## Changes

| Area | File | What was added |
|------|------|---------------|
| Auth | `AuthenticationFailureHandlerCE` | WARN log with source + error (was: only metric, no log) |
| Auth | `AccessDeniedHandlerCE` | WARN log with path + reason (was: silent 401) |
| Startup | `InstanceConfig` | Elevated registration failure from DEBUG→WARN, startup error from DEBUG→ERROR |
| Startup | `RedisConfig` | INFO log of scheme/host/port at connection init |
| Git | `FSGitHandlerCEImpl.fetchRemote` | Fixed 2 sites still using `log.error(e.getMessage())` — now logs full stack trace with repo context |
| Git | `FSGitHandlerCEImpl.mergeBranch` | WARN on failure with repo/source/dest; INFO on success with duration |
| Git | `CentralGitServiceCEImpl.pullArtifact` | INFO entry/exit logs with artifactId, branch, and durationMs |
| Datasource | `DatasourceContextServiceCEImpl` | ERROR log on connection creation failure with datasourceId + pluginId |
| Export | `ExportServiceCEImpl` | INFO entry/exit logs with artifactId + duration (was: 0 log statements in 346 lines) |
| Import | `ImportServiceCEImpl` | INFO entry log with workspaceId, artifactId, artifactType |
| Utility | `Stopwatch` | Added `stopAndLogTimeAtInfoLevel()` for callers that need production-visible duration |

## Design decisions

- **All at INFO or WARN** — visible on Grafana without config changes
- **Minimal footprint** — +70 lines across 10 files; no new dependencies
- **Structured key=value format** — machine-parseable by an RCA agent
- **No sensitive data** — logs identifiers (IDs, paths, types), never credentials or PII

## Test plan

- [x] Full Maven compile passes (`mvn compile -q -DskipTests` — zero errors)
- [x] Spotless formatting passes (pre-commit hook)
- [ ] CI green on this PR
- [ ] Manual verification: deploy preview → trigger each path → confirm log lines appear in Grafana

## Automation
/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/30845659889>
> Commit: d42a276e6f2370fda9070f912c25bdaf6d81010a
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=30845659889&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Sanity`
> Spec:
> <hr>Mon, 03 Aug 2026 19:57:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

* **Diagnostics**
  * Enhanced operational logging across authentication, authorization, startup, data connections, imports, exports, and Git operations.
  * Added clearer status, duration, repository, branch, and artifact details for completed and failed operations.
* **Security & Reliability**
  * Improved error reporting while preserving existing workflows, responses, and authorization behavior.
  * Sanitized authentication error details before recording diagnostic metrics, reducing the risk of unsafe log data.
* **Testing**
  * Added coverage to verify authentication error details are safely sanitized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->