### PR TITLE
ci: run server build and tests on deletion-only server PRs

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -109,18 +109,18 @@ jobs:
 
       # - name: Updating the server changed file variable
       #   id: changed-files-specific
-      #   run: echo "any_changed=true" >> "$GITHUB_OUTPUT"
+      #   run: echo "any_modified=true" >> "$GITHUB_OUTPUT"
 
       - name: Run step if any file(s) in the server folder change
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        if: steps.changed-files-specific.outputs.any_modified == 'true'
         run: |
           echo "One or more files in the server folder has changed."
           echo "List all the files that have changed:"
-          cat "${{ github.workspace }}/.github/outputs/all_changed_files.txt"
+          cat "${{ github.workspace }}/.github/outputs/all_modified_files.txt"
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        if: inputs.skip-tests != 'true' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: inputs.skip-tests != 'true' && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         id: cache-appsmith
         uses: actions/cache@v4
         with:
@@ -130,7 +130,7 @@ jobs:
 
       # Fetch prior run result
       - name: Get the previous run result
-        if: inputs.skip-tests != 'true' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: inputs.skip-tests != 'true' && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         id: run_result
         run: |
           if [ -f ~/run_result ]; then
@@ -140,7 +140,7 @@ jobs:
           fi
 
       - name: Download the failed test artifact in case of rerun
-        if: steps.run_result.outputs.run_result == 'failedtest' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result == 'failedtest' && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         uses: actions/download-artifact@v4
         with:
           name: failed-server-tests
@@ -155,7 +155,7 @@ jobs:
           echo "tests=$failed_tests" >> $GITHUB_OUTPUT
 
       # In case of prior failure run the job
-      - if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+      - if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         run: echo "I'm alive!" && exit 0
 
       # Setup Java
@@ -170,7 +170,7 @@ jobs:
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies
-        if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         uses: actions/cache@v4
         env:
           cache-name: cache-maven-dependencies
@@ -182,13 +182,13 @@ jobs:
 
       # Build the code
       - name: Build
-        if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         run: |
           ./build.sh -DskipTests
 
       # Test the code
       - name: Run only tests
-        if: (inputs.skip-tests != 'true' || steps.run_result.outputs.run_result == 'failedtest')  && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: (inputs.skip-tests != 'true' || steps.run_result.outputs.run_result == 'failedtest')  && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         env:
           ACTIVE_PROFILE: test
           APPSMITH_CLOUD_SERVICES_BASE_URL: "https://release-cs.appsmith.com"
@@ -314,7 +314,7 @@ jobs:
           overwrite: true
 
       - name: Fetch server build from cache
-        if: steps.changed-files-specific.outputs.any_changed == 'false' && success()  && github.event_name != 'push' && github.event_name != 'workflow_dispatch'  && github.event_name != 'schedule'
+        if: steps.changed-files-specific.outputs.any_modified == 'false' && success()  && github.event_name != 'push' && github.event_name != 'workflow_dispatch'  && github.event_name != 'schedule'
         env:
           cachetoken: ${{ secrets.CACHETOKEN }}
           reponame: ${{ github.event.repository.name }}
@@ -339,7 +339,7 @@ jobs:
 
       # Restore the previous built bundle if present. If not push the newly built into the cache
       - name: Restore the previous bundle
-        if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
## Description

`server-build.yml` gates its build and test steps on the `any_changed` output of `tj-actions/changed-files`, which counts added/copied/modified/renamed files but excludes deletions. A PR that only deletes files under `app/server/` therefore skips compilation and tests entirely and takes the fetch-prebuilt-bundle-from-cache path instead — a deletion that breaks the build (e.g. removing a class another file imports) goes green without ever compiling.

This switches every gate to `any_modified`, which includes deletions:

- All build/test/cache step conditions now use `steps.changed-files-specific.outputs.any_modified`.
- The debug listing step reads `all_modified_files.txt` to match.
- The "Fetch server build from cache" step keeps the inverted condition (`== 'false'`) on the same signal, so the fetch-prebuilt and build-fresh paths stay complementary.

The EE repo hit the failing side of this in practice (its bundle-upload step uses `if-no-files-found: error`) and carries the equivalent fix in appsmithorg/appsmith-ee#9420.

## Impact

CI-only; no runtime behavior changes. Deletion-only server PRs now run the full server build and test suite instead of skipping it. PRs with no server changes at all are unaffected (`any_modified` is false for them, same as before).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server build workflow change detection to reliably identify modified files.
  * Aligned testing, caching, build, and artifact steps with the updated detection result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->