### PR TITLE
fix: move OAuth2 "expires in" field just after "Scope(s)" in REST API datasource form

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -683,6 +683,21 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        {_.get(formData.authentication, "grantType") ===
+          GrantType.AuthorizationCode && (
+          <FormInputContainer
+            data-location-id={btoa("authentication.expiresIn")}
+          >
+            {this.renderInputTextControlViaFormControl({
+              configProperty: "authentication.expiresIn",
+              label: "Authorization expires in (seconds)",
+              placeholderText: "3600",
+              dataType: "NUMBER",
+              encrypted: false,
+              isRequired: false,
+            })}
+          </FormInputContainer>
+        )}
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -870,17 +885,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             false,
           )}
         </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
-        </FormInputContainer>
-
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&
           this.renderOauth2CommonAdvanced()}
       </>


### PR DESCRIPTION
## Description
> **Fixes #31059**
 
When configuring an OAuth2 authenticated API datasource, the "Authorization expires in (seconds)" input field now renders immediately after the "Scope(s)" field, so that all authentication fields are adjacent to each other and users can discover the expires_in setting quickly.
 
### Changes
- Moved the `authentication.expiresIn` input from the end of the OAuth 2.0 **Authorization Code** form to directly after the `Scope(s)` field
- Guarded the field so it only renders for the **Authorization Code** grant type, matching the data model (`expiresIn` exists only on `AuthorizationCode`, not `ClientCredentials`)
- The **Client Credentials** flow is unchanged
 
### New field order (Authorization Code)
`Client secret → Scope(s) → Expires In → Client Authentication → Authorization URL → Redirect URL → Custom Authentication Parameters`
 
## Type of change
- Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?
- [x] Manual: create an OAuth 2.0 datasource with Authorization Code grant and verify field order
- [x] Manual: verify Client Credentials flow is unaffected
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth2 authorization-code settings now display the expiration field in the correct location.
  - Removed the duplicate expiration field from authorization-code configuration forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->