### PR TITLE
fix: extend AI assistant provider timeout

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AIAssistantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AIAssistantServiceCEImpl.java
@@ -64,6 +64,12 @@ public class AIAssistantServiceCEImpl implements AIAssistantServiceCE {
 
     private static final int AI_SCHEMA_CONTEXT_MAX = 15000;
 
+    /**
+     * Full-file code generation (e.g. the custom widget copilot) routinely takes
+     * longer than a minute; the client waits up to 180s, so match that here.
+     */
+    private static final Duration AI_PROVIDER_RESPONSE_TIMEOUT = Duration.ofSeconds(180);
+
     private final OrganizationService organizationService;
     private final AIReferenceService aiReferenceService;
     private final NewActionService newActionService;
@@ -101,12 +107,12 @@ public class AIAssistantServiceCEImpl implements AIAssistantServiceCE {
     }
 
     private static final WebClient claudeWebClient = WebClientUtils.builder(
-                    HttpClient.create().responseTimeout(Duration.ofSeconds(60)))
+                    HttpClient.create().responseTimeout(AI_PROVIDER_RESPONSE_TIMEOUT))
             .baseUrl(DEFAULT_CLAUDE_BASE_URL)
             .build();
 
     private static final WebClient openaiWebClient = WebClientUtils.builder(
-                    HttpClient.create().responseTimeout(Duration.ofSeconds(60)))
+                    HttpClient.create().responseTimeout(AI_PROVIDER_RESPONSE_TIMEOUT))
             .baseUrl(DEFAULT_OPENAI_BASE_URL)
             .build();
 
@@ -114,7 +120,7 @@ public class AIAssistantServiceCEImpl implements AIAssistantServiceCE {
         if (baseUrl == null || baseUrl.isEmpty() || defaultBaseUrl.equals(baseUrl)) {
             return cachedClient;
         }
-        return WebClientUtils.builder(HttpClient.create().responseTimeout(Duration.ofSeconds(60)))
+        return WebClientUtils.builder(HttpClient.create().responseTimeout(AI_PROVIDER_RESPONSE_TIMEOUT))
                 .baseUrl(baseUrl)
                 .build();
     }
@@ -830,7 +836,7 @@ public class AIAssistantServiceCEImpl implements AIAssistantServiceCE {
         // replaces the connector WebClientUtils installs, which is what carries the DNS-aware
         // resolver — leaving only the literal host check and letting a hostname that resolves to
         // loopback or a metadata endpoint through.
-        WebClient webClient = WebClientUtils.builder(HttpClient.create().responseTimeout(Duration.ofSeconds(60)))
+        WebClient webClient = WebClientUtils.builder(HttpClient.create().responseTimeout(AI_PROVIDER_RESPONSE_TIMEOUT))
                 .build();
 
         return webClient


### PR DESCRIPTION
## Summary

- raise the remote AI provider response timeout from 60 seconds to 180 seconds
- use one shared timeout for Claude, OpenAI, custom provider URLs, and Azure OpenAI
- allow larger AI Assistant generations to finish instead of failing at the one-minute mark

The Local LLM client keeps its existing 120-second timeout.

## Testing

- server Spotless/pre-commit checks passed across all modules
- CI server tests

## Linear

https://linear.app/appsmith/issue/APP-15735/replace-internal-appsmith-app-with-native-co-pilot-component

## Automation

/ok-to-test tags="@tag.Widget, @tag.IDE"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/31090811946>
> Commit: cbbb64036307c34048ed02f4f1dd0b967c9aedd0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=31090811946&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Widget, @tag.IDE`
> Spec:
> <hr>Thu, 06 Aug 2026 11:03:38 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the AI provider response timeout to 180 seconds.
  * Improved reliability for Claude, OpenAI, custom endpoint, and Azure OpenAI requests that require additional processing time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->