### PR TITLE
ci: retry docker pull of citest image with backoff in test workflows

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -130,8 +130,24 @@ jobs:
         env:
           GHCR_IMAGE: ghcr.io/${{ github.repository }}-citest:run-${{ github.run_id }}
         run: |
+          # A freshly pushed tag can briefly 404 on GHCR, and ~60 shards pulling
+          # it at once can get throttled; retry before failing the shard.
+          pull_with_retry() {
+            local image="$1" attempt
+            for attempt in 1 2 3 4 5; do
+              if timeout 600 docker pull "$image"; then
+                return 0
+              fi
+              if [[ "$attempt" -lt 5 ]]; then
+                echo "docker pull $image failed (attempt $attempt of 5); retrying in 20s" >&2
+                sleep 20
+              fi
+            done
+            echo "docker pull $image failed after 5 attempts; giving up" >&2
+            return 1
+          }
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
-          docker pull "$GHCR_IMAGE"
+          pull_with_retry "$GHCR_IMAGE"
           docker tag "$GHCR_IMAGE" cicontainer
 
       - name: Create folder

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -214,8 +214,24 @@ jobs:
             image_run_id='${{ github.run_id }}'
           fi
           ghcr_image="ghcr.io/${{ github.repository }}-citest:run-$image_run_id"
+          # A freshly pushed tag can briefly 404 on GHCR, and many shards pulling
+          # it at once can get throttled; retry before failing the shard.
+          pull_with_retry() {
+            local image="$1" attempt
+            for attempt in 1 2 3 4 5; do
+              if timeout 600 docker pull "$image"; then
+                return 0
+              fi
+              if [[ "$attempt" -lt 5 ]]; then
+                echo "docker pull $image failed (attempt $attempt of 5); retrying in 20s" >&2
+                sleep 20
+              fi
+            done
+            echo "docker pull $image failed after 5 attempts; giving up" >&2
+            return 1
+          }
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
-          docker pull "$ghcr_image"
+          pull_with_retry "$ghcr_image"
           docker tag "$ghcr_image" cicontainer
 
       - name: Create folder

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -125,8 +125,24 @@ jobs:
             image_run_id='${{ github.run_id }}'
           fi
           ghcr_image="ghcr.io/${{ github.repository }}-citest:run-$image_run_id"
+          # A freshly pushed tag can briefly 404 on GHCR, and many shards pulling
+          # it at once can get throttled; retry before failing the shard.
+          pull_with_retry() {
+            local image="$1" attempt
+            for attempt in 1 2 3 4 5; do
+              if timeout 600 docker pull "$image"; then
+                return 0
+              fi
+              if [[ "$attempt" -lt 5 ]]; then
+                echo "docker pull $image failed (attempt $attempt of 5); retrying in 20s" >&2
+                sleep 20
+              fi
+            done
+            echo "docker pull $image failed after 5 attempts; giving up" >&2
+            return 1
+          }
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
-          docker pull "$ghcr_image"
+          pull_with_retry "$ghcr_image"
           docker tag "$ghcr_image" cicontainer
 
       - name: Create folder

--- a/.github/workflows/ci-test-playwright.yml
+++ b/.github/workflows/ci-test-playwright.yml
@@ -107,12 +107,28 @@ jobs:
           GHCR_IMAGE: ghcr.io/${{ github.repository }}-citest:run-${{ github.run_id }}
           DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
         run: |
+          # A freshly pushed tag can briefly 404 on GHCR, and many shards pulling
+          # it at once can get throttled; retry before failing the shard.
+          pull_with_retry() {
+            local image="$1" attempt
+            for attempt in 1 2 3 4 5; do
+              if timeout 600 docker pull "$image"; then
+                return 0
+              fi
+              if [[ "$attempt" -lt 5 ]]; then
+                echo "docker pull $image failed (attempt $attempt of 5); retrying in 20s" >&2
+                sleep 20
+              fi
+            done
+            echo "docker pull $image failed after 5 attempts; giving up" >&2
+            return 1
+          }
           if [[ -z "$DOCKER_IMAGE_NAME" ]]; then
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
-            docker pull "$GHCR_IMAGE"
+            pull_with_retry "$GHCR_IMAGE"
             docker tag "$GHCR_IMAGE" cicontainer
           else
-            docker pull "$DOCKER_IMAGE_NAME"
+            pull_with_retry "$DOCKER_IMAGE_NAME"
           fi
 
       - name: Create Appsmith stacks folder


### PR DESCRIPTION
## Description

On run [31109763700](https://github.com/appsmithorg/appsmith/actions/runs/31109763700) (PR #42094), 8 of ~60 Cypress shards failed at the "Load Docker image" step doing a bare `docker pull` of `ghcr.io/<repo>-citest:run-<run_id>` immediately after build-docker successfully pushed that tag — consistent with GHCR read-after-write lag or throttling under ~60 simultaneous pulls of a fresh tag. Each failed shard wastes a full rerun cycle (~45-60 min of wall time) because reruns can only start after the whole attempt completes.

This wraps every citest-image `docker pull` in a bounded retry: 5 attempts, 20s sleep between attempts, a 10-minute `timeout` per attempt (explicit timeout on the network call), and a loud failure message after exhaustion. Plain shell inside the existing `run:` blocks; no new `${{ }}` interpolation added.

Call sites covered (all `docker pull` occurrences under `.github/workflows/`):

- `ci-test-custom-script.yml` — GHCR pull
- `ci-test-limited.yml` — GHCR pull
- `ci-test-limited-with-count.yml` — GHCR pull
- `ci-test-playwright.yml` — both branches: the GHCR pull and the `docker_image_name` pull

The only other match is a description string in `playwright-e2e.yml` (no pull command). `docker login` is not retried — the failures observed were on the pull, and login goes to the same registry a successful push just used.

Skipping the Cypress run per the CI-workflow-only exception; this change cannot affect runtime behavior of the product, and the retry path only engages when the pull fails (which today fails the shard outright).

**CE-EE sync note:** EE's Load Docker image steps in `ci-test-custom-script.yml`, `ci-test-limited.yml`, and `ci-test-limited-with-count.yml` carry airgap docker-load branches, so this change will conflict in the hourly sync. The prepared EE-side end state is branch [`app-15766-docker-pull-retry-ee`](https://github.com/appsmithorg/appsmith-ee/tree/app-15766-docker-pull-retry-ee) — use it as the source of truth when resolving the bot's sync PR.

Fixes https://linear.app/appsmith/issue/APP-15766

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated test runs by retrying container image downloads when temporary network or registry errors occur.
  * Each download now retries up to five times with a delay between attempts and reports a clear failure if all attempts are unsuccessful.
  * Applies across standard, limited, counted, and Playwright test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->