### PR TITLE
fix(deps): bump ip-address to >=10.3.1 (SSRF bypass — Dependabot #711)

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -497,6 +497,7 @@
     "svgo@^2.7.0": "2.8.3",
     "svgo@^3.3.3": "3.3.4",
     "svgo": "^2.8.3",
-    "@opentelemetry/core": "^2.8.0"
+    "@opentelemetry/core": "^2.8.0",
+    "ip-address": "^10.3.1"
   }
 }

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -22013,13 +22013,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: 1.1.0
-    sprintf-js: ^1.1.3
-  checksum: aa15f12cfd0ef5e38349744e3654bae649a34c3b10c77a674a167e99925d1549486c5b14730eebce9fea26f6db9d5e42097b00aa4f9f612e68c79121c71652dc
+"ip-address@npm:^10.3.1":
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: ffb64aea3ab0bf975b237954f89bf3c37cb5fc9d078cf5868408e54d29636d14618ed67dafcde664b3cdfc778ee78c811286cf67e59d1243a0c198d05aa47683
   languageName: node
   linkType: hard
 
@@ -23715,13 +23712,6 @@ __metadata:
   version: 4.3.0
   resolution: "jsbi@npm:4.3.0"
   checksum: 27c4f178eb7fd9d1756144066fdebc62f4a0176e877f55e646e8ce84075c13551bd575a316b9959ccdcca9d5dc05a81c9907cfa09f0cfeb43c9777797e36b0e9
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 944f924f2bd67ad533b3850eee47603eed0f6ae425fd1ee8c760f477e8c34a05f144c1bd4f5a5dd1963141dc79a2c55f89ccc5ab77d039e7077f3ad196b64965
   languageName: node
   linkType: hard
 
@@ -32479,13 +32469,6 @@ __metadata:
   version: 4.2.0
   resolution: "split2@npm:4.2.0"
   checksum: 05d54102546549fe4d2455900699056580cca006c0275c334611420f854da30ac999230857a85fdd9914dc2109ae50f80fda43d2a445f2aa86eccdc1dfce779d
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: a3fdac7b49643875b70864a9d9b469d87a40dfeaf5d34d9d0c5b1cda5fd7d065531fcb43c76357d62254c57184a7b151954156563a4d6a747015cfb41021cad0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves Dependabot [#711](https://github.com/appsmithorg/appsmith/security/dependabot/711) — **ip-address ≤10.3.0** decodes leading-zero octets as decimal while OS/DNS resolvers decode them as octal, enabling SSRF and trust-boundary bypass (High severity).

Supersedes [#42102](https://github.com/appsmithorg/appsmith/pull/42102) which went stale after CE#42103 (OTel v2 migration) merged and created lockfile conflicts. The propagator-jaeger half of #42102 is already fixed.

### Change

Resolution pin `"ip-address": "^10.3.1"` in `app/client/package.json`. Resolves to `10.5.0` (latest). The package is a transitive dep (via `socks`); v10 drops `jsbn` and `sprintf-js` transitive deps.

Identical fix is already on EE release via [EE#9466](https://github.com/appsmithorg/appsmith-ee/pull/9466) (merged Aug 11). CE→EE hourly sync will reconcile.

### Impact on existing instances

- **Fresh install / upgrade-from-default / upgrade-from-customized**: no impact — `ip-address` is a transitive lockfile-only dep, no API surface change.
- **Rollback**: reverts to 9.0.5, re-exposes the vulnerability.

/ok-to-test tags="@tag.All"

## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]
> 🔴 🔴 🔴 Some tests have failed.
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/31465613333>
> Commit: 6268596ed8b842fe2c682761c902d2e509954590
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=31465613333&attempt=1&selectiontype=test&testsstatus=failed&specsstatus=fail" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> The following are new failures, please fix them before merging the PR: <ol>
> <li>cypress/e2e/Regression/ClientSide/Widgets/ListV2/Listv2_BasicClientSideData_spec.js</ol>
> <a href="https://internal.appsmith.com/app/cypress-dashboard/identified-flaky-tests-65890b3c81d7400d08fa9ee3?branch=master" target="_blank">List of identified flaky tests</a>.
> <hr>Tue, 11 Aug 2026 07:41:12 UTC
<!-- end of auto-generated comment: Cypress test results  -->
