### PR TITLE
fix(test): stop cy.log in the Cypress fail listener masking real errors

### DIFF
--- a/app/client/cypress/support/e2e.js
+++ b/app/client/cypress/support/e2e.js
@@ -59,7 +59,11 @@ Cypress.on("uncaught:exception", (error) => {
 });
 
 Cypress.on("fail", (error) => {
-  cy.log(error.message);
+  // This listener runs outside the Cypress command queue. Enqueuing a cy.*
+  // command here makes Cypress raise "returned a promise from a command while
+  // also invoking one or more cy commands", and that second error replaces the
+  // real failure in the log and the report. Log outside the queue instead.
+  console.log(error.message);
   throw error; // throw error to have test fail
 });
 


### PR DESCRIPTION
## Description

`app/client/cypress/support/e2e.js` registers a `Cypress.on("fail")` listener that calls `cy.log(error.message)`.

Event listeners run outside the Cypress command queue, so enqueuing a `cy.*` command there makes Cypress raise a second error:

```text
CypressError: Cypress detected that you returned a promise from a command
while also invoking one or more cy commands in that promise.
  The command that returned the promise was:   > `cy.reload()`
  The cy command you invoked inside the promise was:   > `cy.log()`
```

That second error is what lands in the job log and the mochawesome report, so the real assertion failure is replaced by a message about promises. This is the same bug class as #42069 (`cy.log` inside a `cy.intercept` response handler); that PR fixed the intercept instance and this is the remaining one — the completeness check missed it because the call site is an event listener rather than an intercept handler.

The fix logs outside the command queue and keeps the rethrow, matching the pattern #42069 established.

This does not make any failing spec pass. It stops failing specs from being misreported, which is what makes them hard to triage.

## Evidence

Mined from the 12 most recent `test-build-docker-image.yml` scheduled runs on `appsmithorg/appsmith-ee`, 2026-08-06 through 2026-08-11 (all post-#42069, so the intercept instance is already fixed):

- 8 occurrences across 7 of 12 runs, in 5 distinct specs:
  `EE/Enterprise/MultipleEnv/ME_CustomEnv_spec.ts`,
  `EE/Enterprise/SettingsPane/BrandingBuisness_Settings_spec.ts`,
  `EE/Enterprise/AuditLogs/Audit_logs_EEAccess_spec.js`,
  `EE/Enterprise/RBAC/RBACUITests/Users_spec.js`,
  `Regression/ClientSide/Widgets/Input/InputRTL_support.ts`.
- The stack identifies the emitter path rather than an intercept:

```text
at cy.<computed> [as log] (cypress_runner.js)
at listener (cypress_runner.js:140042)
at $Cypress.<anonymous> (cypress_runner.js:140044)
at parent.<computed> [as emitMap]
at $Cypress.action
```

- Worked example, run 31376991838 shard 28, `BrandingBuisness_Settings_spec.ts`: the real failure is a toast assertion (`AggregateHelper.ValidateToastMessage` -> `GetNAssertContains` -> `GetElement`). What the report shows instead is the promise CypressError.
- When the masked failure happens in a `before all` hook, the log reads `Because this error occurred during a 'before all' hook we are skipping the remaining tests in the current suite`, attributing a whole skipped suite to the promise error rather than to the assertion that actually failed (run 31462702539 shard 2, `ME_CustomEnv_spec.ts`).

Completeness check: a brace-scan of every `Cypress.on(...)` block across `app/client/cypress` finds exactly one `cy.*` call in each repo — this one. The same scan was validated against the pre-#42069 tree, where it correctly reports `FeatureFlags.ts:75`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Automation

/ok-to-test tags="@tag.All"

## Related

https://linear.app/appsmith/issue/APP-15705


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/31490627773>
> Commit: caa5d6c203456874327f17f2926dada785237dd1
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=31490627773&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 11 Aug 2026 13:27:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cypress error reporting to avoid command-queue conflicts while preserving failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->