### PR TITLE
fix: fetch current AI model lists for OpenAI, Anthropic and Google AI datasources

### DIFF
--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/AnthropicPlugin.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/AnthropicPlugin.java
@@ -22,6 +22,7 @@ import com.external.plugins.models.AnthropicRequestDTO;
 import com.external.plugins.models.CompletionDTO;
 import com.external.plugins.models.MessageDTO;
 import com.external.plugins.utils.AnthropicMethodStrategy;
+import com.external.plugins.utils.CommandUtils;
 import com.external.plugins.utils.RequestUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.cache.Cache;
@@ -39,6 +40,8 @@ import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -48,10 +51,9 @@ import java.util.stream.Collectors;
 
 import static com.external.plugins.constants.AnthropicConstants.ANTHROPIC_MODELS;
 import static com.external.plugins.constants.AnthropicConstants.BODY;
-import static com.external.plugins.constants.AnthropicConstants.CLAUDE3_PREFIX;
+import static com.external.plugins.constants.AnthropicConstants.DATA;
+import static com.external.plugins.constants.AnthropicConstants.ID;
 import static com.external.plugins.constants.AnthropicConstants.LABEL;
-import static com.external.plugins.constants.AnthropicConstants.TEST_MODEL;
-import static com.external.plugins.constants.AnthropicConstants.TEST_PROMPT;
 import static com.external.plugins.constants.AnthropicConstants.VALUE;
 import static com.external.plugins.constants.AnthropicErrorMessages.EMPTY_API_KEY;
 import static com.external.plugins.constants.AnthropicErrorMessages.INVALID_API_KEY;
@@ -65,8 +67,10 @@ public class AnthropicPlugin extends BasePlugin {
 
     public static class AnthropicPluginExecutor extends BaseRestApiPluginExecutor {
         private static final Gson gson = new Gson();
-        private static final Cache<String, TriggerResultDTO> triggerResponseCache =
-                CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.DAYS).build();
+        private static final Cache<String, TriggerResultDTO> triggerResponseCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(1, TimeUnit.DAYS)
+                .maximumSize(500)
+                .build();
 
         protected AnthropicPluginExecutor(SharedConfig sharedConfig) {
             super(sharedConfig);
@@ -81,17 +85,10 @@ public class AnthropicPlugin extends BasePlugin {
                         AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, EMPTY_API_KEY));
             }
 
-            AnthropicCommand anthropicCommand = AnthropicMethodStrategy.selectExecutionMethod(AnthropicConstants.CHAT);
-            URI uri = anthropicCommand.createExecutionUri();
-            HttpMethod httpMethod = anthropicCommand.getExecutionMethod();
+            // Listing models validates the API key without depending on any particular model being available
+            URI uri = URI.create(AnthropicConstants.ANTHROPIC_API_ENDPOINT + AnthropicConstants.MODELS_API);
 
-            AnthropicRequestDTO anthropicRequestDTO = new AnthropicRequestDTO();
-            anthropicRequestDTO.setPrompt(TEST_PROMPT);
-            anthropicRequestDTO.setModel(TEST_MODEL);
-            anthropicRequestDTO.setMaxTokensToSample(1);
-            anthropicRequestDTO.setTemperature(0f);
-
-            return RequestUtils.makeRequest(httpMethod, uri, apiKeyAuth, BodyInserters.fromValue(anthropicRequestDTO))
+            return RequestUtils.makeRequest(HttpMethod.GET, uri, apiKeyAuth, BodyInserters.empty())
                     .map(responseEntity -> {
                         HttpStatusCode statusCode = responseEntity.getStatusCode();
                         if (HttpStatusCode.valueOf(401).isSameCodeAs(statusCode)) {
@@ -192,11 +189,11 @@ public class AnthropicPlugin extends BasePlugin {
                         Object body;
                         try {
                             body = objectMapper.readValue(responseEntity.getBody(), Object.class);
-                            if (model.contains(CLAUDE3_PREFIX)) {
-                                actionExecutionResult.setBody(body);
-                            } else {
+                            if (CommandUtils.isLegacyCompletionModel(model)) {
                                 actionExecutionResult.setBody(
                                         formatResponseBodyAsCompletionAPI(model, responseEntity.getBody()));
+                            } else {
+                                actionExecutionResult.setBody(body);
                             }
                         } catch (IOException ex) {
                             actionExecutionResult.setIsExecutionSuccess(false);
@@ -267,7 +264,9 @@ public class AnthropicPlugin extends BasePlugin {
             HttpMethod httpMethod = anthropicCommand.getTriggerHTTPMethod();
             URI uri = anthropicCommand.createTriggerUri();
 
-            TriggerResultDTO triggerResultDTO = triggerResponseCache.getIfPresent(requestType);
+            // model availability can differ per API key, so scope the cache to the key as well
+            String cacheKey = requestType + ":" + sha256(apiKeyAuth.getValue());
+            TriggerResultDTO triggerResultDTO = triggerResponseCache.getIfPresent(cacheKey);
             if (triggerResultDTO != null) {
                 return Mono.just(triggerResultDTO);
             }
@@ -283,18 +282,10 @@ public class AnthropicPlugin extends BasePlugin {
                                     new AppsmithPluginException(AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR));
                         }
 
-                        // link to get response data https://platform.openai.com/docs/api-reference/models/list
+                        // response format: https://docs.anthropic.com/en/api/models-list
                         return Mono.just(new JSONObject(new String(responseEntity.getBody())));
                     })
-                    .map(jsonObject -> {
-                        JSONArray jsonArray = jsonObject.getJSONArray("data");
-                        int len = jsonArray.length();
-                        List<String> models = new ArrayList<>();
-                        for (int i = 0; i < len; i++) {
-                            models.add(jsonArray.getString(i));
-                        }
-                        return getDataToMap(models);
-                    })
+                    .map(jsonObject -> getDataToMap(extractModelIds(jsonObject)))
                     .onErrorResume(error -> {
                         log.debug("Error while fetching Anthropic models list", error);
                         if (ANTHROPIC_MODELS.containsKey(requestType)) {
@@ -305,10 +296,40 @@ public class AnthropicPlugin extends BasePlugin {
                     })
                     .map(trigger -> {
                         TriggerResultDTO triggerResult = new TriggerResultDTO(trigger);
-                        // saving response on request type
-                        triggerResponseCache.put(requestType, triggerResult);
+                        triggerResponseCache.put(cacheKey, triggerResult);
                         return triggerResult;
                     });
+        }
+
+        /**
+         * Extracts model ids from the GET /v1/models response
+         * (https://docs.anthropic.com/en/api/models-list). Package-visible for tests.
+         */
+        static List<String> extractModelIds(JSONObject modelsResponse) {
+            JSONArray jsonArray = modelsResponse.getJSONArray(DATA);
+            List<String> models = new ArrayList<>();
+            for (int i = 0; i < jsonArray.length(); i++) {
+                models.add(jsonArray.getJSONObject(i).getString(ID));
+            }
+            return models;
+        }
+
+        private static String sha256(String base) {
+            try {
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                byte[] hash = digest.digest(base.getBytes(StandardCharsets.UTF_8));
+                StringBuilder hexString = new StringBuilder();
+                for (byte b : hash) {
+                    String hex = Integer.toHexString(0xff & b);
+                    if (hex.length() == 1) {
+                        hexString.append('0');
+                    }
+                    hexString.append(hex);
+                }
+                return hexString.toString();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
         }
 
         @Override

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/AnthropicPlugin.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/AnthropicPlugin.java
@@ -91,12 +91,15 @@ public class AnthropicPlugin extends BasePlugin {
             return RequestUtils.makeRequest(HttpMethod.GET, uri, apiKeyAuth, BodyInserters.empty())
                     .map(responseEntity -> {
                         HttpStatusCode statusCode = responseEntity.getStatusCode();
+                        if (statusCode.is2xxSuccessful()) {
+                            return new DatasourceTestResult();
+                        }
                         if (HttpStatusCode.valueOf(401).isSameCodeAs(statusCode)) {
                             // invalid credentials
                             return new DatasourceTestResult(INVALID_API_KEY);
                         }
-
-                        return new DatasourceTestResult();
+                        return new DatasourceTestResult(
+                                "Anthropic API returned status " + statusCode.value() + " while listing models");
                     })
                     .onErrorResume(error -> Mono.just(new DatasourceTestResult(
                             "Error while trying to test the datasource configurations" + error.getMessage())));

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
@@ -19,15 +19,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static com.external.plugins.constants.AnthropicConstants.ANTHROPIC;
+import static com.external.plugins.constants.AnthropicConstants.ANTHROPIC_API_ENDPOINT;
 import static com.external.plugins.constants.AnthropicConstants.CHAT_MODEL_SELECTOR;
-import static com.external.plugins.constants.AnthropicConstants.CHAT_V2;
-import static com.external.plugins.constants.AnthropicConstants.CLOUD_SERVICES;
-import static com.external.plugins.constants.AnthropicConstants.COMMAND;
 import static com.external.plugins.constants.AnthropicConstants.CONTENT;
 import static com.external.plugins.constants.AnthropicConstants.MESSAGES;
 import static com.external.plugins.constants.AnthropicConstants.MODELS_API;
-import static com.external.plugins.constants.AnthropicConstants.PROVIDER;
+import static com.external.plugins.constants.AnthropicConstants.MODELS_PAGE_LIMIT;
 import static com.external.plugins.constants.AnthropicConstants.ROLE;
 import static com.external.plugins.constants.AnthropicConstants.SYSTEM_PROMPT;
 import static com.external.plugins.constants.AnthropicErrorMessages.EXECUTION_FAILURE;
@@ -53,9 +50,8 @@ public class ChatCommand implements AnthropicCommand {
 
     @Override
     public URI createTriggerUri() {
-        return UriComponentsBuilder.fromUriString(CLOUD_SERVICES + MODELS_API)
-                .queryParam(PROVIDER, ANTHROPIC)
-                .queryParam(COMMAND, CHAT_V2)
+        return UriComponentsBuilder.fromUriString(ANTHROPIC_API_ENDPOINT + MODELS_API)
+                .queryParam("limit", MODELS_PAGE_LIMIT)
                 .build()
                 .toUri();
     }

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -18,15 +18,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static com.external.plugins.constants.AnthropicConstants.ANTHROPIC;
+import static com.external.plugins.constants.AnthropicConstants.ANTHROPIC_API_ENDPOINT;
 import static com.external.plugins.constants.AnthropicConstants.BASE64;
-import static com.external.plugins.constants.AnthropicConstants.CLOUD_SERVICES;
-import static com.external.plugins.constants.AnthropicConstants.COMMAND;
 import static com.external.plugins.constants.AnthropicConstants.CONTENT;
 import static com.external.plugins.constants.AnthropicConstants.IMAGE;
 import static com.external.plugins.constants.AnthropicConstants.MESSAGES;
 import static com.external.plugins.constants.AnthropicConstants.MODELS_API;
-import static com.external.plugins.constants.AnthropicConstants.PROVIDER;
+import static com.external.plugins.constants.AnthropicConstants.MODELS_PAGE_LIMIT;
 import static com.external.plugins.constants.AnthropicConstants.ROLE;
 import static com.external.plugins.constants.AnthropicConstants.SYSTEM_PROMPT;
 import static com.external.plugins.constants.AnthropicConstants.TEXT;
@@ -56,9 +54,8 @@ public class VisionCommand implements AnthropicCommand {
 
     @Override
     public URI createTriggerUri() {
-        return UriComponentsBuilder.fromUriString(CLOUD_SERVICES + MODELS_API)
-                .queryParam(PROVIDER, ANTHROPIC)
-                .queryParam(COMMAND, VISION)
+        return UriComponentsBuilder.fromUriString(ANTHROPIC_API_ENDPOINT + MODELS_API)
+                .queryParam("limit", MODELS_PAGE_LIMIT)
                 .build()
                 .toUri();
     }

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/constants/AnthropicConstants.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/constants/AnthropicConstants.java
@@ -12,8 +12,6 @@ public class AnthropicConstants {
     public static final String CHAT_MODELS = "CHAT_MODELS";
     public static final String VISION_MODELS = "VISION_MODELS";
     public static final String CHAT = "CHAT";
-    // chat v2 includes claude-3 models
-    public static final String CHAT_V2 = "CHAT_V2";
     public static final String VISION = "VISION";
     public static final String COMMAND = "command";
     public static final String DATA = "data";
@@ -27,8 +25,8 @@ public class AnthropicConstants {
     public static final String ROLE = "role";
     public static final String TYPE = "type";
     public static final String CONTENT = "content";
-    public static final String CLAUDE3_PREFIX = "claude-3";
     public static final String MODEL = "model";
+    public static final String ID = "id";
     public static final String CHAT_MODEL_SELECTOR = "chatModel";
     public static final String VISION_MODEL_SELECTOR = "visionModel";
     public static final String MESSAGES = "messages";
@@ -41,21 +39,20 @@ public class AnthropicConstants {
     public static final String API_KEY_HEADER = "x-api-key";
     public static final String ANTHROPIC_VERSION_HEADER = "anthropic-version";
     public static final String ANTHROPIC_VERSION = "2023-06-01";
-    public static final Map<String, List<String>> ANTHROPIC_MODELS = Map.of(
-            CHAT,
-                    List.of(
-                            "claude-instant-1.2",
-                            "claude-2.1",
-                            "claude-3-opus-20240229",
-                            "claude-3-sonnet-20240229",
-                            "claude-3-haiku-20240307"),
-            VISION, List.of("claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307"));
-    public static final String CLOUD_SERVICES = "https://cs.appsmith.com";
-    public static final String MODELS_API = "/api/v1/ai/models";
-    public static final String PROVIDER = "provider";
-    public static final String ANTHROPIC = "anthropic";
-    public static final String TEST_MODEL = "claude-instant-1.2";
-    public static final String TEST_PROMPT = "Human:Hey Assistant:";
+    // Fallback lists used when the live GET /v1/models call fails, keyed by trigger request type.
+    // All current Claude models accept both text and image input, so chat and vision share one list.
+    private static final List<String> FALLBACK_MODELS = List.of(
+            "claude-fable-5",
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-haiku-4-5",
+            "claude-opus-4-8",
+            "claude-sonnet-4-6");
+    public static final Map<String, List<String>> ANTHROPIC_MODELS =
+            Map.of(CHAT_MODELS, FALLBACK_MODELS, VISION_MODELS, FALLBACK_MODELS);
+    public static final String MODELS_API = "/models";
+    // single page; Anthropic caps limit at 1000, no pagination follow-up on purpose
+    public static final int MODELS_PAGE_LIMIT = 100;
     public static final ExchangeStrategies EXCHANGE_STRATEGIES = ExchangeStrategies.builder()
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(/* 10MB */ 10 * 1024 * 1024))
             .build();

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/constants/AnthropicConstants.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/constants/AnthropicConstants.java
@@ -51,8 +51,8 @@ public class AnthropicConstants {
     public static final Map<String, List<String>> ANTHROPIC_MODELS =
             Map.of(CHAT_MODELS, FALLBACK_MODELS, VISION_MODELS, FALLBACK_MODELS);
     public static final String MODELS_API = "/models";
-    // single page; Anthropic caps limit at 1000, no pagination follow-up on purpose
-    public static final int MODELS_PAGE_LIMIT = 100;
+    // single page at the API's maximum page size; pagination deliberately skipped
+    public static final int MODELS_PAGE_LIMIT = 1000;
     public static final ExchangeStrategies EXCHANGE_STRATEGIES = ExchangeStrategies.builder()
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(/* 10MB */ 10 * 1024 * 1024))
             .build();

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/utils/CommandUtils.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/utils/CommandUtils.java
@@ -75,6 +75,18 @@ public class CommandUtils {
     }
 
     /**
+     * Responses for models that predate the messages API (claude-1, claude-2, claude-instant) are
+     * reshaped into the legacy completion-API format for backward compatibility. Every other model,
+     * current or future, returns the messages API response as-is.
+     */
+    public static boolean isLegacyCompletionModel(String model) {
+        if (!StringUtils.hasText(model)) {
+            return false;
+        }
+        return model.startsWith("claude-1") || model.startsWith("claude-2") || model.startsWith("claude-instant");
+    }
+
+    /**
      * Anthropic message API expect role to be one of user or assistant. This method converts Human to user and Assistant to assistant
      * @param role - Appsmith understood role
      * @return - Actual role value expected by Anthropic message API

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/utils/CommandUtils.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/utils/CommandUtils.java
@@ -83,7 +83,8 @@ public class CommandUtils {
         if (!StringUtils.hasText(model)) {
             return false;
         }
-        return model.startsWith("claude-1") || model.startsWith("claude-2") || model.startsWith("claude-instant");
+        // family token must end at the prefix (claude-2, claude-2.1) — claude-10/claude-20 are not legacy
+        return model.matches("^claude-(1|2|instant)([.-].*)?$");
     }
 
     /**

--- a/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/AnthropicPluginTest.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/AnthropicPluginTest.java
@@ -4,9 +4,11 @@ import com.appsmith.external.models.ApiKeyAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.services.SharedConfig;
+import com.external.plugins.constants.AnthropicConstants;
 import com.external.plugins.constants.AnthropicErrorMessages;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -15,6 +17,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -99,15 +102,37 @@ public class AnthropicPluginTest {
     }
 
     @Test
+    public void testFallbackModelsAreKeyedByTriggerRequestType() {
+        // trigger() looks up the fallback map by the request type sent from the editor forms
+        assertTrue(AnthropicConstants.ANTHROPIC_MODELS.containsKey(AnthropicConstants.CHAT_MODELS));
+        assertTrue(AnthropicConstants.ANTHROPIC_MODELS.containsKey(AnthropicConstants.VISION_MODELS));
+        assertFalse(AnthropicConstants.ANTHROPIC_MODELS
+                .get(AnthropicConstants.CHAT_MODELS)
+                .isEmpty());
+        assertFalse(AnthropicConstants.ANTHROPIC_MODELS
+                .get(AnthropicConstants.VISION_MODELS)
+                .isEmpty());
+    }
+
+    @Test
+    public void testExtractModelIdsFromModelsListResponse() {
+        JSONObject modelsResponse = new JSONObject(
+                "{\"data\":[{\"type\":\"model\",\"id\":\"claude-opus-5\",\"display_name\":\"Claude Opus 5\"},"
+                        + "{\"type\":\"model\",\"id\":\"claude-sonnet-5\",\"display_name\":\"Claude Sonnet 5\"}],"
+                        + "\"has_more\":false}");
+
+        assertEquals(
+                List.of("claude-opus-5", "claude-sonnet-5"),
+                AnthropicPlugin.AnthropicPluginExecutor.extractModelIds(modelsResponse));
+    }
+
+    // hits the real Anthropic API; the invalid key must produce a 401 -> invalid result
+    @Test
     public void verifyTestDatasourceReturnsFalse() {
         ApiKeyAuth apiKeyAuth = new ApiKeyAuth();
         apiKeyAuth.setValue("apiKey");
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
         datasourceConfiguration.setAuthentication(apiKeyAuth);
-
-        MockResponse mockResponse = new MockResponse();
-        mockResponse.setResponseCode(401);
-        mockEndpoint.enqueue(mockResponse);
 
         Mono<DatasourceTestResult> datasourceTestResultMono = pluginExecutor.testDatasource(datasourceConfiguration);
 

--- a/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
@@ -15,7 +15,6 @@ import static com.external.plugins.constants.AnthropicConstants.CHAT_MODEL_SELEC
 import static com.external.plugins.constants.AnthropicConstants.DATA;
 import static com.external.plugins.constants.AnthropicConstants.DEFAULT_MAX_TOKEN;
 import static com.external.plugins.constants.AnthropicConstants.DEFAULT_TEMPERATURE;
-import static com.external.plugins.constants.AnthropicConstants.TEST_MODEL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -25,7 +24,8 @@ public class ChatCommandTest {
     public void testCreateTriggerUri() {
         ChatCommand command = new ChatCommand();
         URI uri = command.createTriggerUri();
-        assertEquals("/api/v1/ai/models", uri.getPath());
+        assertEquals("api.anthropic.com", uri.getHost());
+        assertEquals("/v1/models", uri.getPath());
     }
 
     @Test
@@ -44,7 +44,7 @@ public class ChatCommandTest {
         ChatCommand command = new ChatCommand();
 
         Map<String, Object> formData = new HashMap<>();
-        formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, TEST_MODEL));
+        formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, "claude-sonnet-5"));
 
         Object messages =
                 List.of(Map.of("role", "Human", "content", "Hey"), Map.of("role", "Assistant", "content", "Hi there!"));
@@ -54,7 +54,7 @@ public class ChatCommandTest {
 
         AnthropicRequestDTO request = command.makeRequestBody(actionConfiguration);
 
-        assertEquals(TEST_MODEL, request.getModel());
+        assertEquals("claude-sonnet-5", request.getModel());
         assertNotNull(request.getPrompt());
         assertEquals(DEFAULT_TEMPERATURE, request.getTemperature());
         assertEquals(DEFAULT_MAX_TOKEN, request.getMaxTokensToSample());

--- a/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/CommandUtilsTest.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/CommandUtilsTest.java
@@ -14,6 +14,8 @@ public class CommandUtilsTest {
         assertTrue(CommandUtils.isLegacyCompletionModel("claude-2.1"));
         assertTrue(CommandUtils.isLegacyCompletionModel("claude-2.0"));
 
+        assertFalse(CommandUtils.isLegacyCompletionModel("claude-10"));
+        assertFalse(CommandUtils.isLegacyCompletionModel("claude-20"));
         assertFalse(CommandUtils.isLegacyCompletionModel("claude-3-opus-20240229"));
         assertFalse(CommandUtils.isLegacyCompletionModel("claude-3-5-sonnet-20240620"));
         assertFalse(CommandUtils.isLegacyCompletionModel("claude-sonnet-4-6"));

--- a/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/CommandUtilsTest.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/CommandUtilsTest.java
@@ -1,0 +1,24 @@
+package com.external.plugins;
+
+import com.external.plugins.utils.CommandUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CommandUtilsTest {
+
+    @Test
+    public void testIsLegacyCompletionModel() {
+        assertTrue(CommandUtils.isLegacyCompletionModel("claude-instant-1.2"));
+        assertTrue(CommandUtils.isLegacyCompletionModel("claude-2.1"));
+        assertTrue(CommandUtils.isLegacyCompletionModel("claude-2.0"));
+
+        assertFalse(CommandUtils.isLegacyCompletionModel("claude-3-opus-20240229"));
+        assertFalse(CommandUtils.isLegacyCompletionModel("claude-3-5-sonnet-20240620"));
+        assertFalse(CommandUtils.isLegacyCompletionModel("claude-sonnet-4-6"));
+        assertFalse(CommandUtils.isLegacyCompletionModel("claude-opus-5"));
+        assertFalse(CommandUtils.isLegacyCompletionModel("claude-fable-5"));
+        assertFalse(CommandUtils.isLegacyCompletionModel(null));
+    }
+}

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/GoogleAiPlugin.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/GoogleAiPlugin.java
@@ -249,20 +249,31 @@ public class GoogleAiPlugin extends BasePlugin {
                 return models;
             }
             for (JsonElement modelElement : response.getAsJsonArray(GoogleAIConstants.MODELS_RESPONSE_KEY)) {
-                JsonObject model = modelElement.getAsJsonObject();
-                if (!model.has(GoogleAIConstants.NAME) || !model.has(GoogleAIConstants.SUPPORTED_GENERATION_METHODS)) {
+                // a malformed entry must not discard the rest of the list
+                if (!modelElement.isJsonObject()) {
                     continue;
                 }
-                String name = model.get(GoogleAIConstants.NAME)
-                        .getAsString()
-                        .replaceFirst("^" + GoogleAIConstants.MODELS_NAME_PREFIX, "");
+                JsonObject model = modelElement.getAsJsonObject();
+                JsonElement nameElement = model.get(GoogleAIConstants.NAME);
+                JsonElement methodsElement = model.get(GoogleAIConstants.SUPPORTED_GENERATION_METHODS);
+                if (nameElement == null
+                        || !nameElement.isJsonPrimitive()
+                        || methodsElement == null
+                        || !methodsElement.isJsonArray()) {
+                    continue;
+                }
+                String name = nameElement.getAsString();
+                if (name.startsWith(GoogleAIConstants.MODELS_NAME_PREFIX)) {
+                    name = name.substring(GoogleAIConstants.MODELS_NAME_PREFIX.length());
+                }
                 if (!name.startsWith("gemini")
                         || NON_CHAT_MODEL_PATTERN.matcher(name).find()) {
                     continue;
                 }
                 boolean supportsGenerateContent = false;
-                for (JsonElement method : model.getAsJsonArray(GoogleAIConstants.SUPPORTED_GENERATION_METHODS)) {
-                    if (GoogleAIConstants.GENERATE_CONTENT_METHOD.equals(method.getAsString())) {
+                for (JsonElement method : methodsElement.getAsJsonArray()) {
+                    if (method.isJsonPrimitive()
+                            && GoogleAIConstants.GENERATE_CONTENT_METHOD.equals(method.getAsString())) {
                         supportsGenerateContent = true;
                         break;
                     }

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/GoogleAiPlugin.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/GoogleAiPlugin.java
@@ -22,6 +22,9 @@ import com.external.plugins.models.GoogleAIRequestDTO;
 import com.external.plugins.utils.GoogleAIMethodStrategy;
 import com.external.plugins.utils.RequestUtils;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.PluginWrapper;
 import org.springframework.http.HttpMethod;
@@ -37,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.external.plugins.constants.GoogleAIConstants.BODY;
@@ -56,6 +60,11 @@ public class GoogleAiPlugin extends BasePlugin {
 
     public static class GoogleAiPluginExecutor extends BaseRestApiPluginExecutor {
         private static final Gson gson = new Gson();
+
+        // TTS, live/realtime, image/video generation and embedding variants also expose
+        // generateContent but are not usable as chat models
+        private static final Pattern NON_CHAT_MODEL_PATTERN =
+                Pattern.compile("tts|live|image|audio|embed|aqa|computer-use");
 
         protected GoogleAiPluginExecutor(SharedConfig sharedConfig) {
             super(sharedConfig);
@@ -197,7 +206,72 @@ public class GoogleAiPlugin extends BasePlugin {
         public Mono<TriggerResultDTO> trigger(
                 APIConnection connection, DatasourceConfiguration datasourceConfiguration, TriggerRequestDTO request) {
             log.debug(Thread.currentThread().getName() + ": trigger() called for GoogleAI plugin.");
-            return Mono.just(new TriggerResultDTO(getDataToMap(GoogleAIConstants.GOOGLE_AI_MODELS)));
+            final ApiKeyAuth apiKeyAuth = (ApiKeyAuth) datasourceConfiguration.getAuthentication();
+
+            // Without a usable key the live fetch cannot succeed; return the fallback list directly
+            if (apiKeyAuth == null || !StringUtils.hasText(apiKeyAuth.getValue())) {
+                return Mono.just(new TriggerResultDTO(getDataToMap(GoogleAIConstants.GOOGLE_AI_MODELS)));
+            }
+
+            URI uri = UriComponentsBuilder.fromUriString(GOOGLE_AI_API_ENDPOINT)
+                    .path(MODELS)
+                    // single page; Google caps pageSize at 1000, no pagination follow-up on purpose
+                    .queryParam("pageSize", 1000)
+                    .build()
+                    .toUri();
+
+            return Mono.defer(() -> RequestUtils.makeRequest(HttpMethod.GET, uri, apiKeyAuth, BodyInserters.empty()))
+                    .map(responseEntity -> {
+                        if (!responseEntity.getStatusCode().is2xxSuccessful() || responseEntity.getBody() == null) {
+                            throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR);
+                        }
+                        List<String> models = extractGenerateContentModels(new String(responseEntity.getBody()));
+                        if (models.isEmpty()) {
+                            throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR);
+                        }
+                        return models;
+                    })
+                    .onErrorResume(error -> {
+                        log.debug("Error while fetching Google AI models list, using the fallback list", error);
+                        return Mono.just(GoogleAIConstants.GOOGLE_AI_MODELS);
+                    })
+                    .map(models -> new TriggerResultDTO(getDataToMap(models)));
+        }
+
+        /**
+         * Parses the models.list response (https://ai.google.dev/api/models#method:-models.list) down to
+         * gemini chat models usable with the generateContent command. Package-visible for tests.
+         */
+        static List<String> extractGenerateContentModels(String responseBody) {
+            JsonObject response = JsonParser.parseString(responseBody).getAsJsonObject();
+            List<String> models = new ArrayList<>();
+            if (!response.has(GoogleAIConstants.MODELS_RESPONSE_KEY)) {
+                return models;
+            }
+            for (JsonElement modelElement : response.getAsJsonArray(GoogleAIConstants.MODELS_RESPONSE_KEY)) {
+                JsonObject model = modelElement.getAsJsonObject();
+                if (!model.has(GoogleAIConstants.NAME) || !model.has(GoogleAIConstants.SUPPORTED_GENERATION_METHODS)) {
+                    continue;
+                }
+                String name = model.get(GoogleAIConstants.NAME)
+                        .getAsString()
+                        .replaceFirst("^" + GoogleAIConstants.MODELS_NAME_PREFIX, "");
+                if (!name.startsWith("gemini")
+                        || NON_CHAT_MODEL_PATTERN.matcher(name).find()) {
+                    continue;
+                }
+                boolean supportsGenerateContent = false;
+                for (JsonElement method : model.getAsJsonArray(GoogleAIConstants.SUPPORTED_GENERATION_METHODS)) {
+                    if (GoogleAIConstants.GENERATE_CONTENT_METHOD.equals(method.getAsString())) {
+                        supportsGenerateContent = true;
+                        break;
+                    }
+                }
+                if (supportsGenerateContent) {
+                    models.add(name);
+                }
+            }
+            return models;
         }
 
         @Override

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/constants/GoogleAIConstants.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/constants/GoogleAIConstants.java
@@ -23,10 +23,20 @@ public class GoogleAIConstants {
     public static final String MESSAGES = "messages";
     public static final String LABEL = "label";
     public static final String VALUE = "value";
+    public static final String NAME = "name";
+    public static final String MODELS_RESPONSE_KEY = "models";
+    public static final String MODELS_NAME_PREFIX = "models/";
+    public static final String SUPPORTED_GENERATION_METHODS = "supportedGenerationMethods";
+    public static final String GENERATE_CONTENT_METHOD = "generateContent";
+    // Fallback list used when the live GET /models call fails
     public static final List<String> GOOGLE_AI_MODELS = List.of(
+            "gemini-3.6-flash",
+            "gemini-3.5-flash",
+            "gemini-3.5-flash-lite",
+            "gemini-3.1-flash-lite",
             "gemini-2.5-pro",
             "gemini-2.5-flash",
-            "gemini-2.0-flash",
+            "gemini-2.5-flash-lite",
             "gemini-flash-latest",
             "gemini-flash-lite-latest");
     public static final ExchangeStrategies EXCHANGE_STRATEGIES = ExchangeStrategies.builder()

--- a/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GoogleAiPluginTest.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GoogleAiPluginTest.java
@@ -157,6 +157,22 @@ public class GoogleAiPluginTest {
         assertEquals(List.of("gemini-3.6-flash", "gemini-3.1-pro-preview"), models);
     }
 
+    @Test
+    public void testExtractGenerateContentModels_skipsMalformedEntries() {
+        String responseBody = "{\"models\":["
+                + "\"not-an-object\","
+                + "{\"name\":123,\"supportedGenerationMethods\":[\"generateContent\"]},"
+                + "{\"name\":\"models/gemini-3.6-flash\",\"supportedGenerationMethods\":\"generateContent\"},"
+                + "{\"name\":\"models/gemini-3.6-flash\"},"
+                + model("models/gemini-3.5-flash", "generateContent")
+                + "]}";
+
+        // malformed entries are skipped without discarding the valid ones after them
+        assertEquals(
+                List.of("gemini-3.5-flash"),
+                GoogleAiPlugin.GoogleAiPluginExecutor.extractGenerateContentModels(responseBody));
+    }
+
     private static String model(String name, String... methods) {
         String methodList =
                 java.util.Arrays.stream(methods).map(m -> "\"" + m + "\"").collect(Collectors.joining(","));

--- a/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GoogleAiPluginTest.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/GoogleAiPluginTest.java
@@ -103,16 +103,13 @@ public class GoogleAiPluginTest {
                 .verifyComplete();
     }
 
+    // hits the real Google AI API; the fake key makes the live fetch fail, exercising the fallback path
     @Test
     public void verifyDatasourceTriggerResultsForChatModels() {
         ApiKeyAuth apiKeyAuth = new ApiKeyAuth();
         apiKeyAuth.setValue("apiKey");
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
         datasourceConfiguration.setAuthentication(apiKeyAuth);
-        String responseBody = "[\"gemini-2.5-pro\"]";
-        MockResponse mockResponse = new MockResponse().setBody(responseBody);
-        mockResponse.setResponseCode(200);
-        mockEndpoint.enqueue(mockResponse);
 
         TriggerRequestDTO request = new TriggerRequestDTO();
         request.setRequestType(GoogleAIConstants.GENERATE_CONTENT_MODEL);
@@ -122,17 +119,48 @@ public class GoogleAiPluginTest {
         StepVerifier.create(datasourceTriggerResultMono)
                 .assertNext(result -> {
                     assertTrue(result.getTrigger() instanceof List<?>);
-                    assertEquals(((List) result.getTrigger()).size(), 5);
-                    assertEquals(
-                            result.getTrigger(),
-                            getDataToMap(List.of(
-                                    "gemini-2.5-pro",
-                                    "gemini-2.5-flash",
-                                    "gemini-2.0-flash",
-                                    "gemini-flash-latest",
-                                    "gemini-flash-lite-latest")));
+                    assertEquals(((List) result.getTrigger()).size(), GoogleAIConstants.GOOGLE_AI_MODELS.size());
+                    assertEquals(result.getTrigger(), getDataToMap(GoogleAIConstants.GOOGLE_AI_MODELS));
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    public void verifyDatasourceTriggerReturnsFallbackWhenApiKeyIsMissing() {
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(new ApiKeyAuth());
+
+        TriggerRequestDTO request = new TriggerRequestDTO();
+        request.setRequestType(GoogleAIConstants.GENERATE_CONTENT_MODEL);
+
+        StepVerifier.create(pluginExecutor.trigger(null, datasourceConfiguration, request))
+                .assertNext(
+                        result -> assertEquals(result.getTrigger(), getDataToMap(GoogleAIConstants.GOOGLE_AI_MODELS)))
+                .verifyComplete();
+    }
+
+    @Test
+    public void testExtractGenerateContentModels() {
+        String responseBody = "{\"models\":["
+                + model("models/gemini-3.6-flash", "generateContent", "countTokens")
+                + "," + model("models/gemini-2.5-flash-preview-tts", "generateContent")
+                + "," + model("models/gemini-3.1-flash-live-preview", "generateContent")
+                + "," + model("models/embedding-001", "embedContent")
+                + "," + model("models/imagen-3.0-generate-002", "predict")
+                + "," + model("models/gemini-3.1-pro-preview", "generateContent")
+                + "," + model("models/gemini-embedding-001", "generateContent")
+                + "]}";
+
+        List<String> models = GoogleAiPlugin.GoogleAiPluginExecutor.extractGenerateContentModels(responseBody);
+
+        // tts/live/embedding variants and non-gemini/non-generateContent models are filtered out
+        assertEquals(List.of("gemini-3.6-flash", "gemini-3.1-pro-preview"), models);
+    }
+
+    private static String model(String name, String... methods) {
+        String methodList =
+                java.util.Arrays.stream(methods).map(m -> "\"" + m + "\"").collect(Collectors.joining(","));
+        return "{\"name\":\"" + name + "\",\"supportedGenerationMethods\":[" + methodList + "]}";
     }
 
     private List<Map<String, String>> getDataToMap(List<String> data) {

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
@@ -44,7 +44,9 @@ public class ChatCommand implements OpenAICommand {
 
     private final Gson gson;
 
-    private final String regex = "^(?!.*vision)(ft:)?gpt.*";
+    // Chat-completions families: gpt-*, chatgpt-* and o-series reasoning models (o1, o3, o4-mini, ...).
+    // Vision-suffixed models are listed by the vision command instead.
+    private final String regex = "^(?!.*vision)(ft:)?(gpt|chatgpt|o\\d).*";
     private final Pattern pattern = Pattern.compile(regex);
 
     public ChatCommand(Gson gson) {
@@ -130,17 +132,18 @@ public class ChatCommand implements OpenAICommand {
     }
 
     private Float getTemperatureFromFormData(Map<String, Object> formData) {
-        float defaultFloatValue = 1.0f;
         String temperatureString = RequestUtils.extractValueFromFormData(formData, TEMPERATURE);
 
+        // Leave temperature unset unless the user provided one: reasoning models (o-series, gpt-5.*)
+        // reject any non-default temperature, and OpenAI applies its own default when it is omitted.
         if (!StringUtils.hasText(temperatureString)) {
-            return defaultFloatValue;
+            return null;
         }
 
         try {
             return Float.parseFloat(temperatureString);
         } catch (IllegalArgumentException illegalArgumentException) {
-            return defaultFloatValue;
+            return null;
         } catch (Exception exception) {
             throw new AppsmithPluginException(
                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
@@ -44,12 +44,14 @@ public class ChatCommand implements OpenAICommand {
 
     private final Gson gson;
 
-    // Chat-completions families: gpt-*, chatgpt-* and o-series reasoning models (o1, o3, o4-mini, ...).
-    // Excluded: vision-suffixed models (listed by the vision command), variants served by other
-    // endpoints (image, realtime, tts, transcribe, legacy instruct completions) and models that
-    // are only available on the Responses API (-pro, deep-research, codex).
+    // Chat-completions families: gpt-*, chat* aliases (chatgpt-4o-latest, chat-latest) and o-series
+    // reasoning models (o1, o3, o4-mini, ...). Excluded: vision-suffixed models (listed by the vision
+    // command), variants served by other endpoints (image, realtime, tts, transcribe, legacy instruct
+    // completions) and models only available on the Responses API (-pro, deep-research, codex).
+    // Matched against the base model (fine-tune wrapper stripped) so customer-chosen ft: suffixes
+    // cannot trip the exclusions.
     private final String regex =
-            "^(?!.*(vision|instruct|realtime|transcribe|tts|image|deep-research|codex|-pro))(ft:)?(gpt|chatgpt|o\\d).*";
+            "^(?!.*(vision|instruct|realtime|transcribe|tts|image|deep-research|codex|-pro))(gpt|chat|o\\d).*";
     private final Pattern pattern = Pattern.compile(regex);
 
     public ChatCommand(Gson gson) {
@@ -164,7 +166,8 @@ public class ChatCommand implements OpenAICommand {
             return false;
         }
 
-        return pattern.matcher(modelJsonObject.getString(ID)).matches();
+        return pattern.matcher(RequestUtils.baseModel(modelJsonObject.getString(ID)))
+                .matches();
     }
 
     @Override

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
@@ -45,8 +45,11 @@ public class ChatCommand implements OpenAICommand {
     private final Gson gson;
 
     // Chat-completions families: gpt-*, chatgpt-* and o-series reasoning models (o1, o3, o4-mini, ...).
-    // Vision-suffixed models are listed by the vision command instead.
-    private final String regex = "^(?!.*vision)(ft:)?(gpt|chatgpt|o\\d).*";
+    // Excluded: vision-suffixed models (listed by the vision command), variants served by other
+    // endpoints (image, realtime, tts, transcribe, legacy instruct completions) and models that
+    // are only available on the Responses API (-pro, deep-research, codex).
+    private final String regex =
+            "^(?!.*(vision|instruct|realtime|transcribe|tts|image|deep-research|codex|-pro))(ft:)?(gpt|chatgpt|o\\d).*";
     private final Pattern pattern = Pattern.compile(regex);
 
     public ChatCommand(Gson gson) {

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
@@ -144,7 +144,9 @@ public class ChatCommand implements OpenAICommand {
         }
 
         try {
-            return Float.parseFloat(temperatureString);
+            float temperature = Float.parseFloat(temperatureString);
+            // parseFloat accepts "NaN" and "Infinity", which serialize to invalid JSON — treat as unset
+            return Float.isFinite(temperature) ? temperature : null;
         } catch (IllegalArgumentException illegalArgumentException) {
             return null;
         } catch (Exception exception) {

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/ChatCommand.java
@@ -100,9 +100,11 @@ public class ChatCommand implements OpenAICommand {
                 transformToMessages(MessageUtils.extractMessages((Map<String, Object>) formData.get(MESSAGES)));
         verifyRoleForChatMessages(chatMessages);
 
-        Float temperature = getTemperatureFromFormData(formData);
         chatRequestDTO.setMessages(chatMessages);
-        chatRequestDTO.setTemperature(temperature);
+        // reasoning models reject any explicit temperature, including the form's default "0"
+        if (!RequestUtils.isReasoningModel(model)) {
+            chatRequestDTO.setTemperature(getTemperatureFromFormData(formData));
+        }
         return chatRequestDTO;
     }
 

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -61,9 +61,12 @@ public class VisionCommand implements OpenAICommand {
     private final Gson gson;
 
     // Image-input capable families: legacy gpt-4 vision previews, gpt-4o, gpt-4.x, gpt-5.x, chatgpt-*
-    // and vision-capable o-series models. o1-mini, o3-mini and o1-preview are text-only.
-    private final String regex =
-            "^(ft:)?(?!o1-mini|o3-mini|o1-preview)(gpt-4-(vision-preview|\\d{4}-vision-preview)|gpt-4o|gpt-4\\.\\d|gpt-5|o\\d|chatgpt).*";
+    // and vision-capable o-series models. o1-mini, o3-mini and o1-preview are text-only, and the
+    // audio/search/realtime/tts/transcribe variants and Responses-API-only models (-pro, codex,
+    // deep-research) do not take image input on chat completions.
+    private final String regex = "^(?!.*(instruct|realtime|transcribe|tts|image|deep-research|codex|-pro|audio|search))"
+            + "(ft:)?(?!o1-mini|o3-mini|o1-preview)"
+            + "(gpt-4-(vision-preview|\\d{4}-vision-preview)|gpt-4o|gpt-4\\.\\d|gpt-5|o\\d|chatgpt).*";
     private final Pattern pattern = Pattern.compile(regex);
 
     @Override

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -60,8 +60,10 @@ public class VisionCommand implements OpenAICommand {
 
     private final Gson gson;
 
+    // Image-input capable families: legacy gpt-4 vision previews, gpt-4o, gpt-4.x, gpt-5.x, chatgpt-*
+    // and vision-capable o-series models. o1-mini, o3-mini and o1-preview are text-only.
     private final String regex =
-            "^(gpt-4-(vision-preview|\\d{4}-vision-preview)|gpt-4o(.*)?|ft:(gpt-4-(vision-preview|\\d{4}-vision-preview)|gpt-4o).*)$";
+            "^(ft:)?(?!o1-mini|o3-mini|o1-preview)(gpt-4-(vision-preview|\\d{4}-vision-preview)|gpt-4o|gpt-4\\.\\d|gpt-5|o\\d|chatgpt).*";
     private final Pattern pattern = Pattern.compile(regex);
 
     @Override
@@ -117,7 +119,7 @@ public class VisionCommand implements OpenAICommand {
         Float temperature = getTemperatureFromFormData(formData);
 
         visionRequestDTO.setMessages(visionMessages);
-        visionRequestDTO.setMaxTokens(getMaxTokenFromFormData(formData));
+        visionRequestDTO.setMaxCompletionTokens(getMaxTokenFromFormData(formData));
         visionRequestDTO.setTemperature(temperature);
         return visionRequestDTO;
     }
@@ -207,17 +209,18 @@ public class VisionCommand implements OpenAICommand {
     }
 
     private Float getTemperatureFromFormData(Map<String, Object> formData) {
-        float defaultFloatValue = 1.0f;
         String temperatureString = RequestUtils.extractValueFromFormData(formData, TEMPERATURE);
 
+        // Leave temperature unset unless the user provided one: reasoning models (o-series, gpt-5.*)
+        // reject any non-default temperature, and OpenAI applies its own default when it is omitted.
         if (!StringUtils.hasText(temperatureString)) {
-            return defaultFloatValue;
+            return null;
         }
 
         try {
             return Float.parseFloat(temperatureString);
         } catch (IllegalArgumentException illegalArgumentException) {
-            return defaultFloatValue;
+            return null;
         } catch (Exception exception) {
             throw new AppsmithPluginException(
                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -60,13 +60,15 @@ public class VisionCommand implements OpenAICommand {
 
     private final Gson gson;
 
-    // Image-input capable families: legacy gpt-4 vision previews, gpt-4o, gpt-4.x, gpt-5.x, chatgpt-*
-    // and vision-capable o-series models. o1-mini, o3-mini and o1-preview are text-only, and the
-    // audio/search/realtime/tts/transcribe variants and Responses-API-only models (-pro, codex,
-    // deep-research) do not take image input on chat completions.
+    // Image-input capable families: legacy gpt-4 vision previews, gpt-4o, gpt-4.x, gpt-5.x, the chat*
+    // aliases (chatgpt-4o-latest, chat-latest) and vision-capable o-series models. o1-mini, o3-mini
+    // and o1-preview are text-only, and the audio/search/realtime/tts/transcribe variants and
+    // Responses-API-only models (-pro, codex, deep-research) do not take image input on chat
+    // completions. Matched against the base model (fine-tune wrapper stripped) so customer-chosen
+    // ft: suffixes cannot trip the exclusions.
     private final String regex = "^(?!.*(instruct|realtime|transcribe|tts|image|deep-research|codex|-pro|audio|search))"
-            + "(ft:)?(?!o1-mini|o3-mini|o1-preview)"
-            + "(gpt-4-(vision-preview|\\d{4}-vision-preview)|gpt-4o|gpt-4\\.\\d|gpt-5|o\\d|chatgpt).*";
+            + "(?!o1-mini|o3-mini|o1-preview)"
+            + "(gpt-4-(vision-preview|\\d{4}-vision-preview)|gpt-4o|gpt-4\\.\\d|gpt-5|o\\d|chat).*";
     private final Pattern pattern = Pattern.compile(regex);
 
     @Override
@@ -241,7 +243,8 @@ public class VisionCommand implements OpenAICommand {
             return false;
         }
 
-        return pattern.matcher(modelJsonObject.getString(ID)).matches();
+        return pattern.matcher(RequestUtils.baseModel(modelJsonObject.getString(ID)))
+                .matches();
     }
 
     @Override

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -119,11 +119,13 @@ public class VisionCommand implements OpenAICommand {
 
         visionMessages.addAll(
                 transformUserMessages(MessageUtils.extractMessages((Map<String, Object>) formData.get(USER_MESSAGES))));
-        Float temperature = getTemperatureFromFormData(formData);
 
         visionRequestDTO.setMessages(visionMessages);
         visionRequestDTO.setMaxCompletionTokens(getMaxTokenFromFormData(formData));
-        visionRequestDTO.setTemperature(temperature);
+        // reasoning models reject any explicit temperature, including the form's default "0"
+        if (!RequestUtils.isReasoningModel(model)) {
+            visionRequestDTO.setTemperature(getTemperatureFromFormData(formData));
+        }
         return visionRequestDTO;
     }
 

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -221,7 +221,9 @@ public class VisionCommand implements OpenAICommand {
         }
 
         try {
-            return Float.parseFloat(temperatureString);
+            float temperature = Float.parseFloat(temperatureString);
+            // parseFloat accepts "NaN" and "Infinity", which serialize to invalid JSON — treat as unset
+            return Float.isFinite(temperature) ? temperature : null;
         } catch (IllegalArgumentException illegalArgumentException) {
             return null;
         } catch (Exception exception) {

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/ChatRequestDTO.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/ChatRequestDTO.java
@@ -1,5 +1,6 @@
 package com.external.plugins.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,10 +8,11 @@ import java.util.List;
 
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChatRequestDTO extends OpenAIRequestDTO {
 
     /**
-     * a decimal number between 0 and 2 inclusive
+     * a decimal number between 0 and 2 inclusive; null means "let OpenAI apply the model's default"
      */
     Float temperature;
 

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/VisionRequestDTO.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/models/VisionRequestDTO.java
@@ -1,5 +1,6 @@
 package com.external.plugins.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
@@ -10,15 +11,17 @@ import java.util.List;
 @Getter
 @Setter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class VisionRequestDTO extends OpenAIRequestDTO {
     /**
      * a decimal number between 0 and 2 inclusive
      */
     Float temperature;
     /**
-     * maximum tokens to use for this request
+     * output token cap for this request, sent as max_completion_tokens; the older max_tokens
+     * field is rejected by reasoning models (o-series, gpt-5.*)
      */
-    Integer maxTokens;
+    Integer maxCompletionTokens;
 
     List<VisionMessage> messages;
 }

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
@@ -45,10 +45,25 @@ public class RequestUtils {
     // Reasoning models (o-series, gpt-5.* except the gpt-5-chat variants) accept only their default
     // temperature; any explicit value — including the editor form's initialValue of "0" — is rejected
     private static final java.util.regex.Pattern REASONING_MODEL_PATTERN =
-            java.util.regex.Pattern.compile("^(ft:)?(o\\d|gpt-5(?!.*chat)).*");
+            java.util.regex.Pattern.compile("^(o\\d|gpt-5(?!.*chat)).*");
 
     public static boolean isReasoningModel(String model) {
-        return model != null && REASONING_MODEL_PATTERN.matcher(model).matches();
+        return model != null
+                && REASONING_MODEL_PATTERN.matcher(baseModel(model)).matches();
+    }
+
+    /**
+     * Strips the fine-tune wrapper from a model id: "ft:gpt-4o:org:suffix:id" -> "gpt-4o".
+     * Compatibility checks must run against the base model only — the org/suffix segments are
+     * customer-chosen text and must not influence filtering.
+     */
+    public static String baseModel(String modelId) {
+        if (modelId == null || !modelId.startsWith("ft:")) {
+            return modelId;
+        }
+        String withoutPrefix = modelId.substring(3);
+        int colonIndex = withoutPrefix.indexOf(':');
+        return colonIndex == -1 ? withoutPrefix : withoutPrefix.substring(0, colonIndex);
     }
 
     public static String extractDataFromFormData(Map<String, Object> formData, String key) {

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
@@ -42,6 +42,15 @@ import static com.external.plugins.constants.OpenAIErrorMessages.EMPTY_BEARER_TO
 public class RequestUtils {
     private static final WebClient webClient = createWebClient();
 
+    // Reasoning models (o-series, gpt-5.* except the gpt-5-chat variants) accept only their default
+    // temperature; any explicit value — including the editor form's initialValue of "0" — is rejected
+    private static final java.util.regex.Pattern REASONING_MODEL_PATTERN =
+            java.util.regex.Pattern.compile("^(ft:)?(o\\d|gpt-5(?!.*chat)).*");
+
+    public static boolean isReasoningModel(String model) {
+        return model != null && REASONING_MODEL_PATTERN.matcher(model).matches();
+    }
+
     public static String extractDataFromFormData(Map<String, Object> formData, String key) {
         return (String) ((Map<String, Object>) formData.get(key)).get(DATA);
     }

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import static com.external.plugins.constants.OpenAIConstants.CHAT_MODEL_SELECTOR;
 import static com.external.plugins.constants.OpenAIConstants.DATA;
 import static com.external.plugins.constants.OpenAIConstants.ID;
+import static com.external.plugins.constants.OpenAIConstants.TEMPERATURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -195,6 +196,36 @@ public class ChatCommandTest {
         ChatRequestDTO request = (ChatRequestDTO) command.makeRequestBody(actionConfiguration);
 
         assertNull(request.getTemperature());
+    }
+
+    @Test
+    public void testMakeRequestBody_nonFiniteTemperature_leavesTemperatureUnset() {
+        ChatCommand command = new ChatCommand(gson);
+
+        for (String badValue : List.of("NaN", "Infinity", "-Infinity")) {
+            Map<String, Object> formData = new HashMap<>();
+            formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, "gpt-4o"));
+            formData.put(TEMPERATURE, badValue);
+            formData.put("messages", Map.of("data", List.of(Map.of("role", "user", "content", "Hello"))));
+            ActionConfiguration actionConfiguration = new ActionConfiguration();
+            actionConfiguration.setFormData(formData);
+
+            ChatRequestDTO request = (ChatRequestDTO) command.makeRequestBody(actionConfiguration);
+
+            assertNull(request.getTemperature(), badValue + " must not be sent as temperature");
+        }
+
+        // out-of-range finite values pass through so OpenAI can report them explicitly
+        Map<String, Object> formData = new HashMap<>();
+        formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, "gpt-4o"));
+        formData.put(TEMPERATURE, "2.5");
+        formData.put("messages", Map.of("data", List.of(Map.of("role", "user", "content", "Hello"))));
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setFormData(formData);
+
+        ChatRequestDTO request = (ChatRequestDTO) command.makeRequestBody(actionConfiguration);
+
+        assertEquals(2.5f, request.getTemperature());
     }
 
     @Test

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
@@ -3,6 +3,7 @@ package com.external.plugins;
 import com.appsmith.external.models.ActionConfiguration;
 import com.external.plugins.commands.ChatCommand;
 import com.external.plugins.models.ChatRequestDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,10 @@ import static com.external.plugins.constants.OpenAIConstants.CHAT_MODEL_SELECTOR
 import static com.external.plugins.constants.OpenAIConstants.DATA;
 import static com.external.plugins.constants.OpenAIConstants.ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ChatCommandTest {
 
@@ -131,5 +135,64 @@ public class ChatCommandTest {
             }
         }
         assertEquals(counter, 10);
+    }
+
+    @Test
+    public void testModelFilter_currentGenerationModels() {
+        ChatCommand chatCommand = new ChatCommand(gson);
+        List<String> compatibleModels = List.of(
+                "gpt-4o",
+                "gpt-4o-mini",
+                "gpt-4.1",
+                "gpt-5",
+                "gpt-5.4-mini",
+                "o1",
+                "o3",
+                "o3-mini",
+                "o4-mini",
+                "o3-pro",
+                "chatgpt-4o-latest",
+                "ft:gpt-4o:acme::abc123");
+        List<String> incompatibleModels = List.of(
+                "gpt-4-vision-preview",
+                "whisper-1",
+                "text-embedding-3-large",
+                "omni-moderation-latest",
+                "dall-e-3",
+                "tts-1");
+        for (String model : compatibleModels) {
+            JSONObject jsonObject = new JSONObject(String.format("{\"%s\": \"%s\" }", ID, model));
+            assertTrue(chatCommand.isModelCompatible(jsonObject), model + " should be listed");
+        }
+        for (String model : incompatibleModels) {
+            JSONObject jsonObject = new JSONObject(String.format("{\"%s\": \"%s\" }", ID, model));
+            assertFalse(chatCommand.isModelCompatible(jsonObject), model + " should not be listed");
+        }
+    }
+
+    @Test
+    public void testMakeRequestBody_withoutTemperature_leavesTemperatureUnset() {
+        ChatCommand command = new ChatCommand(gson);
+
+        Map<String, Object> formData = new HashMap<>();
+        formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, "o3"));
+        Object messages = List.of(Map.of("role", "user", "content", "Hello"));
+        formData.put("messages", Map.of("data", messages));
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setFormData(formData);
+
+        ChatRequestDTO request = (ChatRequestDTO) command.makeRequestBody(actionConfiguration);
+
+        assertNull(request.getTemperature());
+    }
+
+    @Test
+    public void testSerialization_omitsNullTemperature() throws Exception {
+        ChatRequestDTO request = new ChatRequestDTO();
+        request.setModel("o3");
+
+        String body = new ObjectMapper().writeValueAsString(request);
+
+        assertFalse(body.contains("temperature"), "null temperature must be omitted from the request body");
     }
 }

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
@@ -134,7 +134,8 @@ public class ChatCommandTest {
                 counter += 1;
             }
         }
-        assertEquals(counter, 10);
+        // 8 chat-capable gpt models; the two gpt-3.5-turbo-instruct variants are legacy-completions-only
+        assertEquals(counter, 8);
     }
 
     @Test
@@ -150,8 +151,9 @@ public class ChatCommandTest {
                 "o3",
                 "o3-mini",
                 "o4-mini",
-                "o3-pro",
                 "chatgpt-4o-latest",
+                "gpt-4o-audio-preview",
+                "gpt-4o-search-preview",
                 "ft:gpt-4o:acme::abc123");
         List<String> incompatibleModels = List.of(
                 "gpt-4-vision-preview",
@@ -159,7 +161,16 @@ public class ChatCommandTest {
                 "text-embedding-3-large",
                 "omni-moderation-latest",
                 "dall-e-3",
-                "tts-1");
+                "tts-1",
+                // wrong endpoint or Responses-API-only: must not appear in the chat dropdown
+                "o3-pro",
+                "o3-deep-research",
+                "gpt-5-codex",
+                "gpt-image-1",
+                "gpt-4o-realtime-preview",
+                "gpt-4o-mini-tts",
+                "gpt-4o-transcribe",
+                "gpt-3.5-turbo-instruct");
         for (String model : compatibleModels) {
             JSONObject jsonObject = new JSONObject(String.format("{\"%s\": \"%s\" }", ID, model));
             assertTrue(chatCommand.isModelCompatible(jsonObject), model + " should be listed");

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
@@ -155,7 +155,10 @@ public class ChatCommandTest {
                 "chatgpt-4o-latest",
                 "gpt-4o-audio-preview",
                 "gpt-4o-search-preview",
-                "ft:gpt-4o:acme::abc123");
+                "chat-latest",
+                "ft:gpt-4o:acme::abc123",
+                // exclusions apply to the base model only, not customer-chosen ft: suffixes
+                "ft:gpt-4o:acme-instruct-team::abc123");
         List<String> incompatibleModels = List.of(
                 "gpt-4-vision-preview",
                 "whisper-1",
@@ -186,8 +189,9 @@ public class ChatCommandTest {
     public void testMakeRequestBody_withoutTemperature_leavesTemperatureUnset() {
         ChatCommand command = new ChatCommand(gson);
 
+        // non-reasoning model, so the blank-value path itself is exercised
         Map<String, Object> formData = new HashMap<>();
-        formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, "o3"));
+        formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, "gpt-4o"));
         Object messages = List.of(Map.of("role", "user", "content", "Hello"));
         formData.put("messages", Map.of("data", messages));
         ActionConfiguration actionConfiguration = new ActionConfiguration();

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/ChatCommandTest.java
@@ -229,6 +229,33 @@ public class ChatCommandTest {
     }
 
     @Test
+    public void testMakeRequestBody_reasoningModels_dropTemperatureEvenWhenFormSendsDefault() {
+        ChatCommand command = new ChatCommand(gson);
+
+        // the editor form's temperature field has initialValue "0", so every new query sends it
+        for (String reasoningModel : List.of("o3", "o4-mini", "gpt-5", "gpt-5.4-mini", "ft:o4-mini:acme::x")) {
+            ChatRequestDTO request = makeRequestWithTemperature(command, reasoningModel, "0");
+            assertNull(request.getTemperature(), reasoningModel + " must not receive a temperature");
+        }
+
+        // non-reasoning models keep the explicit value, including the form default 0
+        assertEquals(0.0f, makeRequestWithTemperature(command, "gpt-4o", "0").getTemperature());
+        assertEquals(
+                0.3f,
+                makeRequestWithTemperature(command, "gpt-5-chat-latest", "0.3").getTemperature());
+    }
+
+    private ChatRequestDTO makeRequestWithTemperature(ChatCommand command, String model, String temperature) {
+        Map<String, Object> formData = new HashMap<>();
+        formData.put(CHAT_MODEL_SELECTOR, Map.of(DATA, model));
+        formData.put(TEMPERATURE, temperature);
+        formData.put("messages", Map.of("data", List.of(Map.of("role", "user", "content", "Hello"))));
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setFormData(formData);
+        return (ChatRequestDTO) command.makeRequestBody(actionConfiguration);
+    }
+
+    @Test
     public void testSerialization_omitsNullTemperature() throws Exception {
         ChatRequestDTO request = new ChatRequestDTO();
         request.setModel("o3");

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
@@ -178,6 +178,27 @@ public class VisionCommandTest {
     }
 
     @Test
+    public void testMakeRequestBody_nonFiniteTemperature_leavesTemperatureUnset() {
+        for (String badValue : List.of("NaN", "Infinity", "-Infinity")) {
+            Map<String, Object> formData = new HashMap<>();
+            formData.put(VISION_MODEL_SELECTOR, Map.of(DATA, "gpt-4o"));
+            formData.put(TEMPERATURE, badValue);
+
+            UserQuery userQuery = new UserQuery();
+            userQuery.setContent("What's in this image?");
+            userQuery.setType(QueryType.TEXT);
+            formData.put(USER_MESSAGES, Map.of("data", List.of(userQuery)));
+
+            ActionConfiguration actionConfiguration = new ActionConfiguration();
+            actionConfiguration.setFormData(formData);
+
+            VisionRequestDTO request = (VisionRequestDTO) visionCommand.makeRequestBody(actionConfiguration);
+
+            assertNull(request.getTemperature(), badValue + " must not be sent as temperature");
+        }
+    }
+
+    @Test
     public void testSerialization_usesMaxCompletionTokensAndOmitsNulls() throws Exception {
         VisionRequestDTO request = new VisionRequestDTO();
         request.setModel("gpt-4o");

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
@@ -206,7 +206,19 @@ public class VisionCommandTest {
                 "chatgpt-4o-latest",
                 "ft:gpt-4o:acme::abc123");
         List<String> incompatibleModels = List.of(
-                "o1-mini", "o3-mini", "o1-preview", "gpt-3.5-turbo", "whisper-1", "text-embedding-3-small", "dall-e-3");
+                "o1-mini",
+                "o3-mini",
+                "o1-preview",
+                "gpt-3.5-turbo",
+                "whisper-1",
+                "text-embedding-3-small",
+                "dall-e-3",
+                // chat-capable but no image input, or Responses-API-only
+                "gpt-4o-audio-preview",
+                "gpt-4o-search-preview",
+                "gpt-4o-realtime-preview",
+                "o3-pro",
+                "gpt-5-codex");
         for (String model : compatibleModels) {
             JSONObject jsonObject = new JSONObject(String.format("{\"%s\": \"%s\" }", ID, model));
             assertTrue(visionCommand.isModelCompatible(jsonObject), model + " should be listed");

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
@@ -5,6 +5,7 @@ import com.external.plugins.commands.VisionCommand;
 import com.external.plugins.models.QueryType;
 import com.external.plugins.models.UserQuery;
 import com.external.plugins.models.VisionRequestDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,10 @@ import static com.external.plugins.constants.OpenAIConstants.TEMPERATURE;
 import static com.external.plugins.constants.OpenAIConstants.USER_MESSAGES;
 import static com.external.plugins.constants.OpenAIConstants.VISION_MODEL_SELECTOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VisionCommandTest {
     private static final Gson gson = new Gson();
@@ -75,7 +79,7 @@ public class VisionCommandTest {
 
         assertEquals("gpt-4-vision-preview", request.getModel());
         assertEquals(0.1f, request.getTemperature());
-        assertEquals(1000, request.getMaxTokens());
+        assertEquals(1000, request.getMaxCompletionTokens());
         assertNotNull(request.getMessages());
         assertEquals(3, request.getMessages().size());
     }
@@ -153,5 +157,63 @@ public class VisionCommandTest {
             }
         }
         assertEquals(counter, 2);
+    }
+
+    @Test
+    public void testMakeRequestBody_withoutTemperature_leavesTemperatureUnset() {
+        Map<String, Object> formData = new HashMap<>();
+        formData.put(VISION_MODEL_SELECTOR, Map.of(DATA, "o3"));
+
+        UserQuery userQuery = new UserQuery();
+        userQuery.setContent("What's in this image?");
+        userQuery.setType(QueryType.TEXT);
+        formData.put(USER_MESSAGES, Map.of("data", List.of(userQuery)));
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setFormData(formData);
+
+        VisionRequestDTO request = (VisionRequestDTO) visionCommand.makeRequestBody(actionConfiguration);
+
+        assertNull(request.getTemperature());
+    }
+
+    @Test
+    public void testSerialization_usesMaxCompletionTokensAndOmitsNulls() throws Exception {
+        VisionRequestDTO request = new VisionRequestDTO();
+        request.setModel("gpt-4o");
+        request.setMaxCompletionTokens(1000);
+
+        String body = new ObjectMapper().writeValueAsString(request);
+
+        assertTrue(body.contains("\"max_completion_tokens\":1000"), "output cap must be sent as max_completion_tokens");
+        assertFalse(body.contains("temperature"), "null temperature must be omitted from the request body");
+    }
+
+    @Test
+    public void testModelFilter_currentGenerationModels() {
+        List<String> compatibleModels = List.of(
+                "gpt-4-vision-preview",
+                "gpt-4-1106-vision-preview",
+                "gpt-4o",
+                "gpt-4o-mini",
+                "gpt-4.1",
+                "gpt-4.1-nano",
+                "gpt-5",
+                "gpt-5.4",
+                "o1",
+                "o3",
+                "o4-mini",
+                "chatgpt-4o-latest",
+                "ft:gpt-4o:acme::abc123");
+        List<String> incompatibleModels = List.of(
+                "o1-mini", "o3-mini", "o1-preview", "gpt-3.5-turbo", "whisper-1", "text-embedding-3-small", "dall-e-3");
+        for (String model : compatibleModels) {
+            JSONObject jsonObject = new JSONObject(String.format("{\"%s\": \"%s\" }", ID, model));
+            assertTrue(visionCommand.isModelCompatible(jsonObject), model + " should be listed");
+        }
+        for (String model : incompatibleModels) {
+            JSONObject jsonObject = new JSONObject(String.format("{\"%s\": \"%s\" }", ID, model));
+            assertFalse(visionCommand.isModelCompatible(jsonObject), model + " should not be listed");
+        }
     }
 }

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
@@ -199,6 +199,32 @@ public class VisionCommandTest {
     }
 
     @Test
+    public void testMakeRequestBody_reasoningModels_dropTemperatureEvenWhenFormSendsDefault() {
+        // the editor form's temperature field has initialValue "0", so every new query sends it
+        assertNull(makeRequestWithTemperature("o3", "0").getTemperature(), "o3 must not receive a temperature");
+        assertNull(
+                makeRequestWithTemperature("gpt-5.4", "0").getTemperature(), "gpt-5.4 must not receive a temperature");
+
+        // non-reasoning models keep the explicit value, including the form default 0
+        assertEquals(0.0f, makeRequestWithTemperature("gpt-4o", "0").getTemperature());
+    }
+
+    private VisionRequestDTO makeRequestWithTemperature(String model, String temperature) {
+        Map<String, Object> formData = new HashMap<>();
+        formData.put(VISION_MODEL_SELECTOR, Map.of(DATA, model));
+        formData.put(TEMPERATURE, temperature);
+
+        UserQuery userQuery = new UserQuery();
+        userQuery.setContent("What's in this image?");
+        userQuery.setType(QueryType.TEXT);
+        formData.put(USER_MESSAGES, Map.of("data", List.of(userQuery)));
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setFormData(formData);
+        return (VisionRequestDTO) visionCommand.makeRequestBody(actionConfiguration);
+    }
+
+    @Test
     public void testSerialization_usesMaxCompletionTokensAndOmitsNulls() throws Exception {
         VisionRequestDTO request = new VisionRequestDTO();
         request.setModel("gpt-4o");

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/VisionCommandTest.java
@@ -161,8 +161,9 @@ public class VisionCommandTest {
 
     @Test
     public void testMakeRequestBody_withoutTemperature_leavesTemperatureUnset() {
+        // non-reasoning model, so the blank-value path itself is exercised
         Map<String, Object> formData = new HashMap<>();
-        formData.put(VISION_MODEL_SELECTOR, Map.of(DATA, "o3"));
+        formData.put(VISION_MODEL_SELECTOR, Map.of(DATA, "gpt-4o"));
 
         UserQuery userQuery = new UserQuery();
         userQuery.setContent("What's in this image?");
@@ -251,7 +252,10 @@ public class VisionCommandTest {
                 "o3",
                 "o4-mini",
                 "chatgpt-4o-latest",
-                "ft:gpt-4o:acme::abc123");
+                "chat-latest",
+                "ft:gpt-4o:acme::abc123",
+                // exclusions apply to the base model only, not customer-chosen ft: suffixes
+                "ft:gpt-4o:acme-instruct-team::abc123");
         List<String> incompatibleModels = List.of(
                 "o1-mini",
                 "o3-mini",


### PR DESCRIPTION
## Description

**TL;DR:** The OpenAI, Anthropic and Google AI datasources showed stale model lists. OpenAI's live fetch was filtered by gpt-3/4-era regexes (no o-series, no `chatgpt-4o-latest`; vision frozen at gpt-4o), Anthropic's dropdown came from a cloud-services endpoint still serving the retired claude-2/claude-3-2024 lineup, and Google AI's list was hardcoded (including the shut-down `gemini-2.0-flash`). This PR makes all three list current models and keeps them current.

Fixes https://linear.app/appsmith/issue/APP-15788

**OpenAI**
- Chat filter now admits `gpt-*`, `chatgpt-*` and o-series reasoning models; vision filter extended to gpt-4.1/gpt-5.x/chatgpt/vision-capable o-series (text-only `o1-mini`/`o3-mini`/`o1-preview` excluded).
- So the newly listed models actually execute: `temperature` is never sent to reasoning models (they accept only their default, and the editor form defaults the field to "0"), and is omitted for other models when the field is blank or non-finite, and vision requests send `max_completion_tokens` instead of the deprecated `max_tokens`.

**Anthropic**
- Model dropdown now calls Anthropic's `GET /v1/models` with the datasource's own key, instead of the stale cs.appsmith.com list. This also stops sending the user's `x-api-key` header to cloud-services.
- Fixed three latent bugs: the fallback map was keyed so it could never match the trigger requestType (dead code); responses from every non-`claude-3` model were reshaped into legacy completion format (would mangle claude-4/5 output); the datasource Test button POSTed with retired `claude-instant-1.2` (now `GET /v1/models`).
- Fallback list refreshed; trigger cache bounded (500 entries) and keyed per requestType + SHA-256(api key).

**Google AI**
- Trigger now live-fetches `GET /v1beta/models?pageSize=1000` filtered to generateContent-capable gemini chat models (tts/live/image/audio/embedding variants excluded); refreshed fallback list used when the fetch fails or no key is configured.

**Call sites checked:** all consumers of the removed Anthropic constants (`CHAT_V2`, `CLOUD_SERVICES`, `TEST_MODEL`, `CLAUDE3_PREFIX`, …), `VisionRequestDTO.maxTokens`, and the model-filter regexes were grepped across CE and EE — no references outside these three plugin modules. `Migration050MoveAnthropicLegacyModelsInQueries` uses its own literals and is unaffected.

## Impact on existing instances

- **Fresh install:** current models listed for all three providers; no config needed.
- **Upgrade (defaults):** dropdowns start showing current models (up to 24h cache delay for OpenAI/Anthropic). Saved queries keep their stored model string and execute unchanged — except saved **Anthropic** queries on hand-typed modern models (e.g. `claude-sonnet-4-*`), which previously got a completion-shaped body (`{completion: ...}`) and now get the raw messages-API body. That reshaping was itself a bug; bindings on `completion` need updating. **Release note required.** Saved **OpenAI vision** queries now send `max_completion_tokens`; accepted by all current models (the only rejecting family, `gpt-4-*-vision-preview`, is retired upstream).
- **Upgrade (customized):** no server config touches these paths; same as above.
- **Rollback:** stored queries are unchanged in shape; rolling back restores old lists/filters with no data migration in either direction.
- Instances with restricted egress to `api.anthropic.com` / `generativelanguage.googleapis.com` degrade to the refreshed built-in fallback lists.

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/31743718048>
> Commit: ea44ed4fb9c8928bc65629ffe515094b56040f1d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=31743718048&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 13 Aug 2026 22:01:22 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Anthropic and Google AI model lists now load dynamically from their APIs, with fallback options when unavailable.
  - Added support for newer Gemini, GPT, reasoning, and vision-capable models.
- **Bug Fixes**
  - Improved Anthropic credential validation and model compatibility filtering.
  - OpenAI requests now use the correct token settings and omit invalid or unsupported temperature values.
- **Improvements**
  - Updated default model lists and excluded unsupported variants.
  - Improved compatibility with current OpenAI vision models and reasoning models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
