### PR TITLE
fix(git): preserve origin segments in autocommit branches

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImpl.java
@@ -142,7 +142,9 @@ public class GitAutoCommitHelperImpl implements GitAutoCommitHelper {
             return Mono.just(Boolean.FALSE);
         }
 
-        final String finalBranchName = branchName.replaceFirst("origin/", "");
+        final String finalBranchName = branchName.startsWith("origin/")
+                ? branchName.substring("origin/".length())
+                : branchName;
 
         Mono<Application> applicationMono = applicationService
                 .findById(defaultApplicationId, applicationPermission.getEditPermission())

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/autocommit/helpers/GitAutoCommitHelperImplTest.java
@@ -210,6 +210,56 @@ public class GitAutoCommitHelperImplTest {
     }
 
     @Test
+    public void autoCommitApplication_WhenBranchContainsOriginSegment_PreservesBranchName() {
+        String branchNameWithOriginSegment = "feature/origin/main";
+        Application application = new Application();
+        application.setWorkspaceId("sample-workspace-id");
+        GitArtifactMetadata metaData = new GitArtifactMetadata();
+        metaData.setRepoName("test-repo-name");
+
+        GitAuth gitAuth = new GitAuth();
+        gitAuth.setPrivateKey("private-key");
+        gitAuth.setPublicKey("public-key");
+        metaData.setGitAuth(gitAuth);
+        application.setGitApplicationMetadata(metaData);
+
+        Mockito.doReturn(Mono.just(application))
+                .when(applicationService)
+                .findById(defaultApplicationId, applicationPermission.getEditPermission());
+        Mockito.doReturn(Mono.just(application))
+                .when(applicationService)
+                .findByBranchNameAndBaseApplicationId(
+                        eq(branchNameWithOriginSegment), eq(defaultApplicationId), any(AclPermission.class));
+        Mockito.when(gitPrivateRepoHelper.isBranchProtected(
+                        any(GitArtifactMetadata.class), eq(branchNameWithOriginSegment)))
+                .thenReturn(Mono.just(Boolean.FALSE));
+        Mockito.when(centralGitService.fetchRemoteChanges(
+                        any(Application.class),
+                        any(Application.class),
+                        anyBoolean(),
+                        any(GitType.class),
+                        any(RefType.class)))
+                .thenReturn(Mono.just(branchTrackingStatus));
+        Mockito.when(branchTrackingStatus.getBehindCount()).thenReturn(0);
+
+        GitProfile gitProfile = new GitProfile();
+        gitProfile.setAuthorEmail("user@example.com");
+        gitProfile.setAuthorName("test user name");
+        Mockito.when(userDataService.getGitProfileForCurrentUser(defaultApplicationId))
+                .thenReturn(Mono.just(gitProfile));
+
+        StepVerifier.create(
+                        gitAutoCommitHelper.autoCommitClientMigration(
+                                defaultApplicationId, branchNameWithOriginSegment))
+                .assertNext(aBoolean -> assertThat(aBoolean).isTrue())
+                .verifyComplete();
+
+        Mockito.verify(applicationService)
+                .findByBranchNameAndBaseApplicationId(
+                        eq(branchNameWithOriginSegment), eq(defaultApplicationId), any(AclPermission.class));
+    }
+
+    @Test
     public void getAutoCommitProgress_WhenNoAutoCommitFinished_ReturnsValidResponse() {
         Mono<AutoCommitResponseDTO> progressDTOMono = redisUtils
                 .startAutoCommit(defaultApplicationId, branchName)


### PR DESCRIPTION
## Summary

- Preserve branch names such as `feature/origin/main` when autocommit resolves the branched application.
- Normalize only a leading `origin/` prefix, matching the existing Central/Common Git branch contract.
- Add a regression test covering an internal `origin/` segment.

## Context

This is the autocommit follow-up to commit `2fe167c7f901` and closed PR #41793. That change corrected the Central/Common branch-listing paths, but `GitAutoCommitHelperImpl` still used `replaceFirst("origin/", "")`, which changes `feature/origin/main` into `feature/main`. This PR scopes the fix to that missed production site and its focused unit test.

## Validation

- `git diff --check` passed.
- Source assertions confirm the old broad replacement is gone and the regression test asserts the exact branch lookup.
- Focused Maven test was attempted with `mvn -pl appsmith-server -Dtest=GitAutoCommitHelperImplTest -DskipITs test`, but this environment has no `mvn`; the repository build also requires Java 17 or 25 while only Java 8/10 are installed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git branch handling so names containing `origin` as part of the branch path are preserved correctly.
  * Client auto-commit now succeeds reliably for these branch names while maintaining accurate branch protection checks.

* **Tests**
  * Added coverage to verify branch lookup, synchronization, and auto-commit behavior for branches containing an `origin` segment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->