### PR TITLE
fix(anvil): re-bind canvas click handler so it reads current drag state

### DIFF
--- a/app/client/src/layoutSystems/anvil/editor/canvas/AnvilEditorCanvas.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/canvas/AnvilEditorCanvas.tsx
@@ -44,17 +44,29 @@ export const AnvilEditorCanvas = (props: BaseWidgetProps) => {
     [clickToClearSelections],
   );
 
+  // Keep the latest handler in a ref so the click listener is registered once
+  // with a stable identity while still reading current drag/resize state.
+  // useClickToClearSelections returns a new function each render, so depending
+  // the effect on handleOnClickCapture would re-bind the listener on every
+  // render (constant add/remove churn during a drag, with a brief window where
+  // no listener is attached). The ref keeps the fix for the stale closure an
+  // empty dependency array caused, without that re-registration.
+  const handleOnClickCaptureRef = useRef(handleOnClickCapture);
   useEffect(() => {
-    canvasRef.current?.addEventListener("click", handleOnClickCapture);
+    handleOnClickCaptureRef.current = handleOnClickCapture;
+  });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const handleClick = (event: MouseEvent) =>
+      handleOnClickCaptureRef.current(event);
+
+    canvas?.addEventListener("click", handleClick);
 
     return () => {
-      canvasRef.current?.removeEventListener("click", handleOnClickCapture);
+      canvas?.removeEventListener("click", handleClick);
     };
-    // Depend on handleOnClickCapture so the listener is re-bound when it
-    // changes. With an empty array the effect kept the handler captured at
-    // mount, which read stale drag/resize state and cleared selections during
-    // an active drag.
-  }, [handleOnClickCapture]);
+  }, []);
   /* End of click event listener */
 
   useSelectWidgetListener();

--- a/app/client/src/layoutSystems/anvil/editor/canvas/AnvilEditorCanvas.tsx
+++ b/app/client/src/layoutSystems/anvil/editor/canvas/AnvilEditorCanvas.tsx
@@ -50,7 +50,11 @@ export const AnvilEditorCanvas = (props: BaseWidgetProps) => {
     return () => {
       canvasRef.current?.removeEventListener("click", handleOnClickCapture);
     };
-  }, []);
+    // Depend on handleOnClickCapture so the listener is re-bound when it
+    // changes. With an empty array the effect kept the handler captured at
+    // mount, which read stale drag/resize state and cleared selections during
+    // an active drag.
+  }, [handleOnClickCapture]);
   /* End of click event listener */
 
   useSelectWidgetListener();


### PR DESCRIPTION
Fixes #42118.

`AnvilEditorCanvas` binds a capture-phase click handler in a `useEffect` with an empty dependency array:

```tsx
const handleOnClickCapture = useCallback((event) => { ... }, [clickToClearSelections]);

useEffect(() => {
  canvasRef.current?.addEventListener("click", handleOnClickCapture);
  return () => {
    canvasRef.current?.removeEventListener("click", handleOnClickCapture);
  };
}, []); // never re-runs
```

`handleOnClickCapture` closes over `clickToClearSelections`, and that hook reads `isDragging`, `isAutoCanvasResizing`, and the space-distribution status from Redux and only clears selections when none of them are active:

```ts
if (!(isDragging || isCanvasResizing || isDistributingSpace)) { ... }
```

Because the effect runs only at mount, the listener keeps the very first `handleOnClickCapture`, which captured `isDragging === false`. When a drag starts, the bound handler still sees the mount-time state, so the guard passes and canvas clicks clear the selection mid-drag instead of being suppressed.

Adding `handleOnClickCapture` to the dependency array re-binds the listener whenever it changes, so it always reads current drag/resize state. This is also what `react-hooks/exhaustive-deps` expects here.

One note for reviewers: `useClickToClearSelections` returns a new function each render, so with this change the listener re-binds fairly often. That is correct, but if you would prefer to also cut down the re-binding I can wrap that hook's return in `useCallback` in a follow-up. I kept this PR to the one-line correctness fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas click handling so drag and resize interactions consistently use the latest state.
  * Prevented outdated interaction behavior after callback updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->