### PR TITLE
build: raise client build Node heap cap to 16 GB

### DIFF
--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -16,6 +16,6 @@ fi
 # build cra app
 export REACT_APP_SENTRY_RELEASE=$GIT_SHA
 export REACT_APP_CLIENT_LOG_LEVEL=ERROR
-node --max-old-space-size=8192 scripts/build.js
+node --max-old-space-size=16384 scripts/build.js
 
 echo "build finished"


### PR DESCRIPTION
## Description

Production client builds intermittently die with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` (exit code 134), most recently on the EE Github Release workflow for v2.2 and v2.3. Retries sometimes pass because peak live memory varies slightly run to run — the build is sitting right at the cap.

`app/client/build.sh` hardcodes `node --max-old-space-size=8192 scripts/build.js`. Crash logs show full mark-compacts reclaiming essentially nothing at ~7.4 GB committed heap, so this is genuine live-set growth (production builds use the full `source-map` devtool, the most memory-expensive path), not GC timing. The CI runner (`ubuntu-latest-8-cores`) has 32 GB RAM, so the hardcoded cap — set in #38768 when the build fit comfortably — is the binding constraint, not the machine.

This raises the cap to 16 GB. `--max-old-space-size` is a limit, not an allocation: builds that fit in less memory are unchanged, including local dev builds on smaller machines.

## Impact on existing instances

None. This changes only the build-time Node heap limit; the produced bundle is identical. No runtime behavior, defaults, or configuration change.

Fixes https://linear.app/appsmith/issue/APP-15795

## Automation

/ok-to-test tags="@tag.All"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Increased the client build memory limit to improve reliability when processing larger builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->