### PR TITLE
fix(app): wrap deleteApplicationResources reactive chain with transactionalOperator to prevent partial deletion

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -590,7 +590,8 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                         newPageService.archivePagesByApplicationId(application.getId(), pageDeletePermission)))
                 .then(themeService.archiveApplicationThemes(application))
                 .then(userDataService.removeApplicationFromAllFavorites(favoriteId))
-                .then(applicationService.archive(application));
+                .then(applicationService.archive(application))
+                .as(transactionalOperator::transactional);
     }
 
     protected Mono<Application> sendAppDeleteAnalytics(Application deletedApplication) {


### PR DESCRIPTION
## What

Append .as(transactionalOperator::transactional) to the reactive chain in deleteApplicationResources so all archive operations participate in a single reactive transaction.

## Why

ApplicationPageServiceCEImpl declares a TransactionalOperator field (injected at construction) but never applies it to deleteApplicationResources. The method archives action collections, actions, pages, themes, and favorites in sequence. If any step succeeds but a later step fails, the earlier writes are already committed and cannot be rolled back, leaving the application in a partially deleted state. An admin may then see orphaned actions or pages pointing to a non-existent application.

## How

  before:
    .then(applicationService.archive(application));

  after:
    .then(applicationService.archive(application))
    .as(transactionalOperator::transactional);

The TransactionalOperator field was already declared and injected -- it just was never used.

Closes #42117

harsh4vardhan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when archiving an application and its related resources by ensuring the operation completes as a single transaction.
  * Prevented partially archived applications if an error occurs during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->