### PR TITLE
fix(actionCollections): propagate archiveGivenNewAction errors instead of swallowing them with Mono.empty()

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -443,16 +443,7 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
         return unpublishedJsActionsFlux
                 .mergeWith(publishedJsActionsFlux)
                 .flatMap(toArchive -> newActionService
-                        .archiveGivenNewAction(toArchive)
-                        // return an empty action so that the filter can remove it from the list
-                        .onErrorResume(throwable -> {
-                            log.debug(
-                                    "Failed to delete action with id {} for collection with id: {}",
-                                    toArchive.getId(),
-                                    actionCollection.getId());
-                            log.error(throwable.getMessage());
-                            return Mono.empty();
-                        }))
+                        .archiveGivenNewAction(toArchive))
                 .collectList()
                 .flatMap(newActions -> {
                     List<ActionDTO> actionDTOs = newActions.stream()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/actioncollections/base/ActionCollectionServiceCEImpl.java
@@ -433,6 +433,17 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
         return actionCollectionMono.flatMap(this::archiveGivenActionCollection);
     }
 
+    /**
+     * Archives the given {@link ActionCollection} and all of its child {@link NewAction} documents.
+     *
+     * <p>Each child action is archived via {@link com.appsmith.server.newactions.base.NewActionService#archiveGivenNewAction}.
+     * If any child archive fails the error propagates and the parent collection is <em>not</em> archived,
+     * preventing orphaned {@link NewAction} documents in MongoDB.
+     *
+     * @param actionCollection the collection to archive; must not be {@code null}
+     * @return a {@link Mono} that emits the archived collection, or terminates with an error if any
+     *         child action could not be archived
+     */
     protected Mono<ActionCollection> archiveGivenActionCollection(ActionCollection actionCollection) {
         Mono<AclPermission> deleteActionPermissionMono =
                 actionPermission.getDeletePermission().cache();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -669,6 +670,12 @@ public class ActionCollectionServiceImplTest {
         NewAction newAction = new NewAction();
         newAction.setId("testActionId");
 
+        // archiveGivenActionCollection builds the reactive chain eagerly, so
+        // repository.archive() is invoked at chain-assembly time (not subscription time).
+        // We stub it with Mono.defer so the call returns a valid Mono (preventing NPE),
+        // then track subscription separately with an AtomicBoolean.
+        AtomicBoolean archiveSubscribed = new AtomicBoolean(false);
+
         Mockito.when(actionCollectionRepository.findById("testCollectionId"))
                 .thenReturn(Mono.just(actionCollection));
         Mockito.when(newActionService.findByCollectionIdAndViewMode(
@@ -679,6 +686,11 @@ public class ActionCollectionServiceImplTest {
                 .thenReturn(Flux.empty());
         Mockito.when(newActionService.archiveGivenNewAction(Mockito.eq(newAction)))
                 .thenReturn(Mono.error(new RuntimeException("Archive failed")));
+        Mockito.when(actionCollectionRepository.archive(Mockito.any()))
+                .thenReturn(Mono.defer(() -> {
+                    archiveSubscribed.set(true);
+                    return Mono.just(actionCollection);
+                }));
 
         StepVerifier.create(actionCollectionService.archiveById("testCollectionId"))
                 .expectErrorMatches(t -> t instanceof RuntimeException
@@ -686,7 +698,8 @@ public class ActionCollectionServiceImplTest {
                 .verify();
 
         Mockito.verify(newActionService).archiveGivenNewAction(newAction);
-        Mockito.verify(actionCollectionRepository, Mockito.never()).archive(Mockito.any());
+        // archive() was called during chain assembly but must never be subscribed to
+        assertThat(archiveSubscribed.get()).isFalse();
         Mockito.verify(analyticsService, Mockito.never()).sendDeleteEvent(Mockito.any(), Mockito.any());
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -648,6 +648,16 @@ public class ActionCollectionServiceImplTest {
                 .verifyComplete();
     }
 
+    /**
+     * Regression test for appsmithorg/appsmith#42116.
+     * <p>
+     * Before the fix, {@code archiveGivenActionCollection} swallowed errors from
+     * {@code archiveGivenNewAction} via {@code onErrorResume}, so a child-action failure
+     * would silently be ignored while the parent collection was still deleted.
+     * <p>
+     * After the fix the error must propagate: neither {@code repository.archive} nor
+     * {@code analyticsService.sendDeleteEvent} should be invoked.
+     */
     @Test
     public void testArchiveById_whenChildActionArchiveFails_propagatesError() {
         ActionCollection actionCollection = new ActionCollection();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -647,4 +647,34 @@ public class ActionCollectionServiceImplTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    public void testArchiveById_whenChildActionArchiveFails_propagatesError() {
+        ActionCollection actionCollection = new ActionCollection();
+        actionCollection.setId("testCollectionId");
+        ActionCollectionDTO collectionDTO = new ActionCollectionDTO();
+        actionCollection.setUnpublishedCollection(collectionDTO);
+        actionCollection.setPublishedCollection(collectionDTO);
+
+        NewAction newAction = new NewAction();
+        newAction.setId("testActionId");
+
+        Mockito.when(actionCollectionRepository.findById("testCollectionId"))
+                .thenReturn(Mono.just(actionCollection));
+        Mockito.when(newActionService.findByCollectionIdAndViewMode(
+                        Mockito.eq("testCollectionId"), Mockito.eq(false), Mockito.any()))
+                .thenReturn(Flux.just(newAction));
+        Mockito.when(newActionService.findByCollectionIdAndViewMode(
+                        Mockito.eq("testCollectionId"), Mockito.eq(true), Mockito.any()))
+                .thenReturn(Flux.empty());
+        Mockito.when(newActionService.archiveGivenNewAction(Mockito.any()))
+                .thenReturn(Mono.error(new RuntimeException("Archive failed")));
+
+        StepVerifier.create(actionCollectionService.archiveById("testCollectionId"))
+                .expectError(RuntimeException.class)
+                .verify();
+
+        Mockito.verify(actionCollectionRepository, Mockito.never()).archive(Mockito.any());
+        Mockito.verify(analyticsService, Mockito.never()).sendDeleteEvent(Mockito.any(), Mockito.any());
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -677,13 +677,15 @@ public class ActionCollectionServiceImplTest {
         Mockito.when(newActionService.findByCollectionIdAndViewMode(
                         Mockito.eq("testCollectionId"), Mockito.eq(true), Mockito.any()))
                 .thenReturn(Flux.empty());
-        Mockito.when(newActionService.archiveGivenNewAction(Mockito.any()))
+        Mockito.when(newActionService.archiveGivenNewAction(Mockito.eq(newAction)))
                 .thenReturn(Mono.error(new RuntimeException("Archive failed")));
 
         StepVerifier.create(actionCollectionService.archiveById("testCollectionId"))
-                .expectError(RuntimeException.class)
+                .expectErrorMatches(t -> t instanceof RuntimeException
+                        && "Archive failed".equals(t.getMessage()))
                 .verify();
 
+        Mockito.verify(newActionService).archiveGivenNewAction(newAction);
         Mockito.verify(actionCollectionRepository, Mockito.never()).archive(Mockito.any());
         Mockito.verify(analyticsService, Mockito.never()).sendDeleteEvent(Mockito.any(), Mockito.any());
     }


### PR DESCRIPTION
## What

Remove the onErrorResume(Mono.empty()) handler in archiveGivenActionCollection so that failures in archiveGivenNewAction propagate up instead of being silently discarded.

## Why

archiveGivenActionCollection iterates over all JS actions in a collection and calls newActionService.archiveGivenNewAction for each. If archiveGivenNewAction fails for any action, the current code catches the error and returns Mono.empty() so the action is simply omitted from the results list:

  .onErrorResume(throwable -> {
      log.debug(...);
      log.error(throwable.getMessage());
      return Mono.empty();  // error discarded
  })

As a result, the collection proceeds to archive itself (repository.archive(actionCollection)) even when some of its actions were not deleted. This creates orphaned NewAction documents in MongoDB that are invisible in the UI but permanently consume storage and can interfere with future imports or conflict during workspace exports.

## How

Remove the onErrorResume block entirely. Any error from archiveGivenNewAction now propagates through the reactive chain and causes the entire archiveGivenActionCollection call to fail, which is the correct behavior: if an action cannot be archived, the collection should not be marked as archived either.

Closes #42116

harsh4vardhan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archiving an action collection now reports failures when an individual action cannot be archived.
  * Prevented incomplete archiving and related deletion events when an individual action fails to archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->