### PR TITLE
fix(snapshots): wrap createApplicationSnapshot with transactionalOperator to prevent orphaned snapshot loss

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationSnapshotServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationSnapshotServiceImpl.java
@@ -9,6 +9,7 @@ import com.appsmith.server.solutions.ApplicationPermission;
 import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.reactive.TransactionalOperator;
 
 @Slf4j
 @Service
@@ -20,13 +21,15 @@ public class ApplicationSnapshotServiceImpl extends ApplicationSnapshotServiceCE
             ImportService importService,
             ExportService exportService,
             ApplicationPermission applicationPermission,
-            Gson gson) {
+            Gson gson,
+            TransactionalOperator transactionalOperator) {
         super(
                 applicationSnapshotRepository,
                 applicationService,
                 importService,
                 exportService,
                 applicationPermission,
-                gson);
+                gson,
+                transactionalOperator);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationSnapshotServiceCEImpl.java
@@ -16,6 +16,7 @@ import com.appsmith.server.repositories.ApplicationSnapshotRepository;
 import com.appsmith.server.solutions.ApplicationPermission;
 import com.google.gson.Gson;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -33,6 +34,7 @@ public class ApplicationSnapshotServiceCEImpl implements ApplicationSnapshotServ
     private final ExportService exportService;
     private final ApplicationPermission applicationPermission;
     private final Gson gson;
+    private final TransactionalOperator transactionalOperator;
 
     private static final int MAX_SNAPSHOT_SIZE = 15 * 1024 * 1024; // 15 MB
 
@@ -47,7 +49,8 @@ public class ApplicationSnapshotServiceCEImpl implements ApplicationSnapshotServ
                             .deleteAllByApplicationId(branchedApplicationId)
                             .thenMany(createSnapshots(branchedApplicationId, applicationJson));
                 })
-                .then(Mono.just(Boolean.TRUE));
+                .then(Mono.just(Boolean.TRUE))
+                .as(transactionalOperator::transactional);
     }
 
     private Flux<ApplicationSnapshot> createSnapshots(String applicationId, ApplicationJson applicationJson) {


### PR DESCRIPTION
## What

Add a TransactionalOperator field to ApplicationSnapshotServiceCEImpl and apply .as(transactionalOperator::transactional) to the createApplicationSnapshot reactive pipeline so the delete-then-insert is atomic.

## Why

createApplicationSnapshot performs two sequential database operations:
1. applicationSnapshotRepository.deleteAllByApplicationId(branchedApplicationId) -- deletes all existing snapshot chunks
2. createSnapshots(branchedApplicationId, applicationJson) -- inserts new snapshot chunks

The two operations execute in separate database transactions. If the process crashes, the network drops, or any runtime error occurs after step 1 commits but before step 2 completes, the application has no snapshot at all. The previously saved snapshot is gone and cannot be recovered, leaving the application without version control history.

## How

Add TransactionalOperator as a final field (injected via Lombok @RequiredArgsConstructor) and wrap the entire pipeline:

  .then(Mono.just(Boolean.TRUE))
  .as(transactionalOperator::transactional);

This causes MongoDB to treat the delete and the subsequent inserts as a single multi-document transaction, rolling back the delete if the inserts fail.

Closes #42115

harsh4vardhan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Application snapshots are now created within a transaction, improving consistency and reliability during snapshot creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->