### PR TITLE
fix(test): re-read the active editor tab in GlobalSearch test 7

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/GlobalSearch_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/GlobalSearch_spec.js
@@ -161,7 +161,12 @@ describe("GlobalSearch", { tags: ["@tag.Sanity"] }, function () {
       .first()
       .click();
     cy.wait("@createNewApi");
-    _.agHelper.GetObjectName().then((title) => expect(title).includes("Api"));
+    // The "New Query" add-tab stays active for a beat after the action is created, so
+    // the active tab has to be re-read until it settles on the new API. A tab that is
+    // still in rename mode carries its name in data-value instead of a text node.
+    _.agHelper.GetElement(_.locators._activeEntityTab).should(($tab) => {
+      expect($tab.attr("data-value") ?? $tab.text()).to.include("Api");
+    });
   });
 
   // since now datasource will only be saved once user clicks on save button explicitly,


### PR DESCRIPTION
## Description

`GlobalSearch_spec.js` test 7 ("Api actions should have API as prefix") creates an API
from a datasource and then reads the active editor tab exactly once:

```js
_.agHelper.GetObjectName().then((title) => expect(title).includes("Api"));
```

`GetObjectName()` is `cy.get(".editor-tab.active .ads-v2-text").invoke("text")`. Because
the value is consumed in a `.then()`, the read is never retried — the assertion sees
whatever the tab bar happened to render at that instant.

The tab swap after `POST /api/v1/actions` is not atomic:

1. `handleActionCreatedSaga` (`app/client/src/sagas/ApiPaneSagas.ts`) pushes the new API
   route with `editName=true`.
2. `segmentMode` only flips `Add` -> `Edit` on the next commit of `useCurrentEditorState`,
   so on the render right after the push, `AddTab` is still the active tab.
3. The tab list itself is rewritten later still, by `updateIDETabsOnRouteChangeSaga`
   (`app/client/src/sagas/IDESaga.tsx`) via `SET_IDE_QUERIES_TABS`.

`AddTab` (`app/client/src/pages/AppIDE/layouts/components/EditorTabs/AddTab.tsx`) labels
itself `New ${segmentName}`, so inside that window the active tab reads **"New Query"** —
which is exactly the value the failures report.

This PR re-reads the active tab until it settles on the new API. The route carries
`editName=true`, which mounts the tab in rename mode, and in that state ADS `Text` renders
an input rather than a text node (`app/client/packages/design-system/ads/src/Text/Text.tsx`)
— so the name is taken from `data-value` when present and from the text node otherwise.
Both states are covered, and the assertion retries through the whole transition.

## Evidence

Mined from the last 12 `test-build-docker-image` runs on `appsmithorg/appsmith-ee`
(10 parsed, 600 shard logs) with `.cursor/skills/cypress-flake-report`:

`Regression/ClientSide/OtherUIFeatures/GlobalSearch_spec.js` — 4 retry events in 4 of 10
runs, all recovered on retry, i.e. invisible in the run status.

Two distinct signatures, both in test 7. This PR fixes the tab-name one:

| run | date | failing command |
|---|---|---|
| 31451657906 | 2026-08-11 | `assert expected New Query to include Api` |
| 31789468105 | 2026-08-14 | `assert expected New Query to include Api` |

Shard 47 in both, position 4 in the lineup, spec passed on the automatic retry. The
2026-08-14 command log shows the ordering directly — the failed assertion is logged
*before* `new url .../edit/api/<id>?a=b&editName=true&from=datasources`, so the read
happened while the editor was still routed to the add-new tab.

The other signature in that spec (`data-selected` on the sidebar Editor button, runs
31568260858 / 31625953107 / 31688250922) is a separate race in `Sidebar.navigate` and is
deliberately **not** touched here — that helper is called by hundreds of specs and the
mechanism is not yet proven.

## Impact on existing instances

None. Test-only change, one spec file, no product code and no CI configuration.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

Full Cypress suite via the automation command below. The change makes an existing
assertion auto-retrying; it does not weaken it — a tab that never reaches a name
containing `Api` still fails.

## Automation

/ok-to-test tags="@tag.All"

Tracking: https://linear.app/appsmith/issue/APP-15705


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/31799791927>
> Commit: ad47fe771df95234984ff608dee9214f80e8038d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=31799791927&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 14 Aug 2026 13:33:37 UTC
<!-- end of auto-generated comment: Cypress test results  -->
