### PR TITLE
fix: clear leftover widget event lint after removing an action

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/utils.test.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/utils.test.ts
@@ -16,6 +16,7 @@ import {
   stringToJS,
   textGetter,
   textSetter,
+  isEmptyBlock,
   isValueValidURL,
   objectSetter,
   sortSubMenuOptions,
@@ -1069,4 +1070,19 @@ describe("sortSubMenuOptions", () => {
       expect(result).toStrictEqual(expected);
     },
   );
+});
+
+describe("isEmptyBlock", () => {
+  it.each([
+    ["", true],
+    ["{{}}", true],
+    ["{{ }}", true],
+    ["{{;}}", true],
+    ["{{ ; }}", true],
+    [";", true],
+    ["undefined;", true],
+    ["{{showAlert('hi');}}", false],
+  ])("returns %s → %s", (value, expected) => {
+    expect(isEmptyBlock(value)).toBe(expected);
+  });
 });

--- a/app/client/src/components/editorComponents/ActionCreator/utils.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/utils.ts
@@ -1,5 +1,8 @@
 import { FUNC_ARGS_REGEX } from "./regex";
-import { getDynamicBindings } from "utils/DynamicBindingUtils";
+import {
+  getDynamicBindings,
+  isEmptyTriggerValue,
+} from "utils/DynamicBindingUtils";
 import { isValidURL, matchesURLPattern } from "utils/URLUtils";
 import {
   getTextArgumentAtPosition,
@@ -603,7 +606,7 @@ export function actionToCode(
 }
 
 export function isEmptyBlock(block: string) {
-  return [";", "undefined;", ""].includes(getCodeFromMoustache(block));
+  return isEmptyTriggerValue(block);
 }
 
 /** {{Hello {{Input.text}}}} -> Hello {{Input.text}} */

--- a/app/client/src/plugins/Linting/utils/lintTriggerPath.test.ts
+++ b/app/client/src/plugins/Linting/utils/lintTriggerPath.test.ts
@@ -1,0 +1,40 @@
+import { ENTITY_TYPE } from "ee/entities/DataTree/types";
+import type { DataTreeEntity } from "entities/DataTree/dataTreeTypes";
+import lintTriggerPath from "./lintTriggerPath";
+
+jest.mock("ee/utils/lintRulesHelpers", () => ({
+  getLintRulesBasedOnContext: jest.fn(() => ({})),
+}));
+
+const widgetEntity = {
+  ENTITY_TYPE: ENTITY_TYPE.WIDGET,
+} as DataTreeEntity;
+
+const webworkerTelemetry = {};
+
+describe("lintTriggerPath", () => {
+  it.each(["", "{{}}", "{{;}}", ";", "{{undefined;}}"])(
+    "returns no errors for empty leftover trigger value %j",
+    (userScript) => {
+      const lintErrors = lintTriggerPath({
+        userScript,
+        entity: widgetEntity,
+        globalData: {},
+        webworkerTelemetry,
+      });
+
+      expect(lintErrors).toEqual([]);
+    },
+  );
+
+  it("still reports syntax errors in a real trigger script", () => {
+    const lintErrors = lintTriggerPath({
+      userScript: "{{showAlert(}}",
+      entity: widgetEntity,
+      globalData: {},
+      webworkerTelemetry,
+    });
+
+    expect(lintErrors.length).toBeGreaterThan(0);
+  });
+});

--- a/app/client/src/plugins/Linting/utils/lintTriggerPath.ts
+++ b/app/client/src/plugins/Linting/utils/lintTriggerPath.ts
@@ -1,4 +1,7 @@
-import { getDynamicBindings } from "utils/DynamicBindingUtils";
+import {
+  getDynamicBindings,
+  isEmptyTriggerValue,
+} from "utils/DynamicBindingUtils";
 import {
   EvaluationScriptType,
   getScriptToEval,
@@ -13,12 +16,19 @@ export default function lintTriggerPath({
   webworkerTelemetry,
 }: lintTriggerPathProps) {
   const { jsSnippets } = getDynamicBindings(userScript, entity);
-  const script = getScriptToEval(jsSnippets[0], EvaluationScriptType.TRIGGERS);
+  const snippet = jsSnippets[0];
+
+  // Empty leftover events must not be wrapped as `const $$result = ;`.
+  if (isEmptyTriggerValue(snippet)) {
+    return [];
+  }
+
+  const script = getScriptToEval(snippet, EvaluationScriptType.TRIGGERS);
 
   return getLintingErrors({
     script,
     data: globalData,
-    originalBinding: jsSnippets[0],
+    originalBinding: snippet,
     scriptType: EvaluationScriptType.TRIGGERS,
     webworkerTelemetry,
   });

--- a/app/client/src/sagas/WidgetOperationSaga.test.tsx
+++ b/app/client/src/sagas/WidgetOperationSaga.test.tsx
@@ -5,7 +5,9 @@ import {
   removeDynamicBindingProperties,
   handleUpdateWidgetDynamicProperty,
   batchUpdateWidgetDynamicPropertySaga,
+  getPropertiesToUpdate,
 } from "./WidgetOperationSagas";
+import type { WidgetProps } from "widgets/BaseWidget";
 
 const widget = {
   isVisible: "true",
@@ -329,5 +331,72 @@ describe("test removeDynamicBindingList", () => {
         }),
       ]),
     );
+  });
+});
+
+describe("getPropertiesToUpdate — dynamicTriggerPathList", () => {
+  const buttonWithOnClickTrigger = {
+    widgetId: "buttonId",
+    widgetName: "Button1",
+    type: "BUTTON_WIDGET",
+    onClick: "{{showAlert('hi');}}",
+    dynamicTriggerPathList: [{ key: "onClick" }],
+    dynamicBindingPathList: [],
+  } as unknown as WidgetProps;
+
+  const buttonWithoutOnClickTrigger = {
+    ...buttonWithOnClickTrigger,
+    onClick: undefined,
+    dynamicTriggerPathList: [],
+  } as unknown as WidgetProps;
+
+  it("removes onClick from dynamicTriggerPathList when the event is cleared", () => {
+    const result = getPropertiesToUpdate(
+      buttonWithOnClickTrigger,
+      { onClick: "" },
+      ["onClick"],
+    );
+
+    expect(result.dynamicTriggerPathList).toEqual([]);
+  });
+
+  it("removes onClick from dynamicTriggerPathList when the leftover value is an empty binding", () => {
+    const result = getPropertiesToUpdate(
+      buttonWithOnClickTrigger,
+      { onClick: "{{}}" },
+      ["onClick"],
+    );
+
+    expect(result.dynamicTriggerPathList).toEqual([]);
+  });
+
+  it("removes onClick from dynamicTriggerPathList when the leftover value is a stray semicolon", () => {
+    const result = getPropertiesToUpdate(
+      buttonWithOnClickTrigger,
+      { onClick: "{{;}}" },
+      ["onClick"],
+    );
+
+    expect(result.dynamicTriggerPathList).toEqual([]);
+  });
+
+  it("adds onClick to dynamicTriggerPathList when an action is set", () => {
+    const result = getPropertiesToUpdate(
+      buttonWithoutOnClickTrigger,
+      { onClick: "{{showAlert('hi');}}" },
+      ["onClick"],
+    );
+
+    expect(result.dynamicTriggerPathList).toEqual([{ key: "onClick" }]);
+  });
+
+  it("does not add an empty onClick to dynamicTriggerPathList", () => {
+    const result = getPropertiesToUpdate(
+      buttonWithoutOnClickTrigger,
+      { onClick: "" },
+      ["onClick"],
+    );
+
+    expect(result.dynamicTriggerPathList).toEqual([]);
   });
 });

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -62,6 +62,7 @@ import {
   getWidgetDynamicTriggerPathList,
   isChildPropertyPath,
   isDynamicValue,
+  isEmptyTriggerValue,
   isPathADynamicBinding,
   isPathDynamicTrigger,
 } from "utils/DynamicBindingUtils";
@@ -367,12 +368,15 @@ function getDynamicTriggerPathListUpdate(
   propertyPath: string,
   propertyValue: string,
 ): DynamicPathUpdate {
-  if (propertyValue && !isPathDynamicTrigger(widget, propertyPath)) {
+  const isEmpty = isEmptyTriggerValue(propertyValue);
+  const isTriggerPath = isPathDynamicTrigger(widget, propertyPath);
+
+  if (!isEmpty && !isTriggerPath) {
     return {
       propertyPath,
       effect: DynamicPathUpdateEffectEnum.ADD,
     };
-  } else if (!propertyValue && !isPathDynamicTrigger(widget, propertyPath)) {
+  } else if (isEmpty && isTriggerPath) {
     return {
       propertyPath,
       effect: DynamicPathUpdateEffectEnum.REMOVE,

--- a/app/client/src/utils/DynamicBindingUtils.test.ts
+++ b/app/client/src/utils/DynamicBindingUtils.test.ts
@@ -303,6 +303,10 @@ describe("isEmptyTriggerValue", () => {
     ["undefined;", true],
     ["{{showAlert('hi');}}", false],
     ["showAlert('hi');", false],
+    // Incomplete mustache pairs must stay non-empty so they still lint.
+    ["{{;", false],
+    ["{{", false],
+    ["undefined;}}", false],
   ])("returns %s → %s", (value, expected) => {
     expect(isEmptyTriggerValue(value)).toBe(expected);
   });

--- a/app/client/src/utils/DynamicBindingUtils.test.ts
+++ b/app/client/src/utils/DynamicBindingUtils.test.ts
@@ -5,6 +5,7 @@ import {
   combineDynamicBindings,
   getDynamicBindings,
   getPropertyPath,
+  isEmptyTriggerValue,
 } from "./DynamicBindingUtils";
 import {
   EVAL_VALUE_PATH,
@@ -285,5 +286,24 @@ describe("getDynamicBindings and combineDynamicBindings  function", () => {
       });
       expect(combineDynamicBindings(jsSnippets, stringSegments)).toEqual(js);
     });
+  });
+});
+
+describe("isEmptyTriggerValue", () => {
+  it.each([
+    [undefined, true],
+    ["", true],
+    ["   ", true],
+    ["{{}}", true],
+    ["{{ }}", true],
+    ["{{;}}", true],
+    ["{{ ; }}", true],
+    ["{{undefined;}}", true],
+    [";", true],
+    ["undefined;", true],
+    ["{{showAlert('hi');}}", false],
+    ["showAlert('hi');", false],
+  ])("returns %s → %s", (value, expected) => {
+    expect(isEmptyTriggerValue(value)).toBe(expected);
   });
 });

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -265,10 +265,13 @@ export const isEmptyTriggerValue = (value?: string): boolean => {
     return true;
   }
 
-  const code = value
-    .trim()
-    .replace(/^{{|}}$/g, "")
-    .trim();
+  let code = value.trim();
+
+  // Only strip a complete {{ ... }} pair. A lone "{{" or "}}" is malformed
+  // input and must not be treated as an empty leftover event.
+  if (code.startsWith("{{") && code.endsWith("}}")) {
+    code = code.slice(2, -2).trim();
+  }
 
   return code === "" || code === ";" || code === "undefined;";
 };

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -255,6 +255,24 @@ export const isPathDynamicTrigger = (
   return false;
 };
 
+/**
+ * True when a trigger property has no executable JS: empty string, empty
+ * mustache `{{}}`, a leftover semicolon, or `undefined;`.
+ * Used when dropping a path from dynamicTriggerPathList and when skipping lint.
+ */
+export const isEmptyTriggerValue = (value?: string): boolean => {
+  if (!value || !value.trim()) {
+    return true;
+  }
+
+  const code = value
+    .trim()
+    .replace(/^{{|}}$/g, "")
+    .trim();
+
+  return code === "" || code === ";" || code === "undefined;";
+};
+
 export const getWidgetDynamicPropertyPathList = (
   widget: WidgetProps,
 ): DynamicPath[] => {


### PR DESCRIPTION
## Description
Adding then removing a widget event (for example a button onClick) left a stuck linter error: `Expected an identifier and instead saw ';'`. The field looked empty, so the error could not be cleared.

Clearing the event never dropped it from `dynamicTriggerPathList` (wrong membership check on `REMOVE`). The linter still treated the blank value as code and wrapped it as `const $$result = ;`.

This restores `REMOVE` when the event is empty, skips linting empty leftover snippets, and uses one shared “empty event” check.

Fixes https://github.com/appsmithorg/appsmith-ee/issues/8529

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/32114437392>
> Commit: a8991d24b10668e95fe4483a649e9599896762ef
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=32114437392&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 18 Aug 2026 12:05:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty, whitespace-only, and placeholder trigger values.
  - Prevented false linting errors for empty trigger expressions.
  - Correctly updates dynamic event paths when actions are cleared or added.
  - Preserved syntax errors for malformed, non-empty trigger code.

- **Tests**
  - Added coverage for empty expressions, semicolons, undefined values, valid actions, and malformed trigger code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->