### PR TITLE
fix: harden IP literal handling in RestrictedHostFilter

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
@@ -1,5 +1,6 @@
 package com.appsmith.util;
 
+import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Promise;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.validator.routines.InetAddressValidator;
@@ -12,6 +13,7 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
@@ -694,7 +696,7 @@ public final class RestrictedHostFilter {
             return false;
         }
         try {
-            return matchesBlockedAddressClass(InetAddress.getByName(canonicalHost));
+            return matchesBlockedAddressClass(parseIpLiteral(stripHostDecorators(canonicalHost)));
         } catch (UnknownHostException e) {
             return false;
         }
@@ -708,9 +710,23 @@ public final class RestrictedHostFilter {
             return true;
         }
         if (address instanceof Inet6Address) {
+            final byte[] addressBytes = address.getAddress();
+            // Transition addresses tunnel an IPv4 destination inside an IPv6 wrapper. The wrapper
+            // is itself neither loopback nor link-local, so classify what the address actually
+            // reaches: 64:ff9b::7f00:1 and 2002:7f00:1:: both arrive at 127.0.0.1.
+            for (byte[] embeddedIpv4 : embeddedIpv4Candidates(addressBytes)) {
+                try {
+                    if (matchesBlockedAddressClass(InetAddress.getByAddress(embeddedIpv4))) {
+                        return true;
+                    }
+                } catch (UnknownHostException e) {
+                    // Every candidate is 4 bytes, so this cannot happen; block rather than fall
+                    // through if it ever does.
+                    return true;
+                }
+            }
             // fc00::/7 — IPv6 Unique Local Addresses
-            byte firstByte = address.getAddress()[0];
-            return (firstByte & (byte) 0xFE) == (byte) 0xFC;
+            return (addressBytes[0] & (byte) 0xFE) == (byte) 0xFC;
         }
         return false;
     }
@@ -719,8 +735,13 @@ public final class RestrictedHostFilter {
         if (!StringUtils.hasText(host)) {
             return false;
         }
-        host = stripHostDecorators(host);
-        return inetAddressValidator.isValid(host);
+        final String sanitizedHost = stripHostDecorators(host);
+        // Apache Commons rejects non-canonical octet forms such as leading zeros, while Netty's
+        // parser — the one reactor-netty uses to build the remote address — accepts them and dials
+        // the canonical address. Recognizing the union of both keeps the set of literals this
+        // filter classifies a superset of the ones the HTTP client is willing to connect to.
+        return inetAddressValidator.isValid(sanitizedHost)
+                || NetUtil.createByteArrayFromIpAddressString(sanitizedHost) != null;
     }
 
     static String normalizeHostForComparison(String host) throws UnknownHostException {
@@ -752,20 +773,121 @@ public final class RestrictedHostFilter {
     }
 
     private static String normalizeIpAddress(String host) throws UnknownHostException {
-        final InetAddress address = InetAddress.getByName(host);
+        final InetAddress address = parseIpLiteral(host);
 
         if (address instanceof Inet6Address) {
-            final byte[] addressBytes = address.getAddress();
-            // Normalize IPv4-compatible and IPv4-mapped IPv6 literals back to the embedded IPv4 address so a single
-            // denylist entry blocks equivalent literal representations such as `100.100.100.200` and
-            // `[::100.100.100.200]`.
-            if (isIpv4CompatibleOrMapped(addressBytes)) {
-                return InetAddress.getByAddress(Arrays.copyOfRange(addressBytes, 12, 16))
-                        .getHostAddress();
+            // Collapse every IPv4-in-IPv6 embedding to the address it actually reaches, so one
+            // denylist entry covers all of its literal spellings — `100.100.100.200`,
+            // `[::100.100.100.200]`, and the NAT64 / 6to4 encodings alike.
+            final byte[] embeddedIpv4 = extractEmbeddedIpv4(address.getAddress());
+            if (embeddedIpv4 != null) {
+                return InetAddress.getByAddress(embeddedIpv4).getHostAddress();
             }
         }
 
         return address.getHostAddress();
+    }
+
+    /**
+     * Parses an IP literal with Netty's parser first, so the canonical form this filter compares
+     * against is the one reactor-netty would hand the HTTP client. Falls back to the JDK for
+     * literals Netty declines but {@link #isValidIpAddress(String)} accepted.
+     */
+    private static InetAddress parseIpLiteral(String host) throws UnknownHostException {
+        final byte[] addressBytes = NetUtil.createByteArrayFromIpAddressString(host);
+        return addressBytes != null ? InetAddress.getByAddress(addressBytes) : InetAddress.getByName(host);
+    }
+
+    /**
+     * The IPv4 address an IPv6 literal canonically represents, or {@code null} if it represents
+     * none. Covers the embeddings where the IPv6 address is purely an encoding of an IPv4 one, so
+     * collapsing to that IPv4 is a faithful canonical form: IPv4-compatible ({@code ::d.d.d.d}),
+     * IPv4-mapped ({@code ::ffff:d.d.d.d}), IPv4-translated ({@code ::ffff:0:d.d.d.d}, RFC 2765),
+     * NAT64 (RFC 6052 well-known {@code 64:ff9b::/96} and RFC 8215 local-use {@code 64:ff9b:1::/48}),
+     * and 6to4 (RFC 3056 {@code 2002::/16}).
+     */
+    private static byte[] extractEmbeddedIpv4(byte[] addressBytes) {
+        if (addressBytes.length != 16) {
+            return null;
+        }
+        if (isIpv4CompatibleOrMapped(addressBytes) || isIpv4Translated(addressBytes) || isNat64(addressBytes)) {
+            return Arrays.copyOfRange(addressBytes, 12, 16);
+        }
+        if (isSixToFour(addressBytes)) {
+            return Arrays.copyOfRange(addressBytes, 2, 6);
+        }
+        return null;
+    }
+
+    /**
+     * Every IPv4 destination an IPv6 literal could deliver to, for classification only. Wider than
+     * {@link #extractEmbeddedIpv4(byte[])}: Teredo carries two addresses (its relay server, and a
+     * client address obfuscated by ones-complement) and ISATAP's is an interface identifier, so
+     * none of them is a canonical form of the address and none may be used to normalize it — but
+     * each is somewhere the packet can end up, so each is classified.
+     *
+     * <p>Together with {@link #extractEmbeddedIpv4(byte[])} this covers the standardized set of
+     * IPv4-in-IPv6 embeddings. 6rd (RFC 5969) is deliberately absent: it uses an operator-chosen
+     * prefix that cannot be recognized from the address alone.
+     */
+    private static List<byte[]> embeddedIpv4Candidates(byte[] addressBytes) {
+        if (addressBytes.length != 16) {
+            return List.of();
+        }
+        final byte[] canonical = extractEmbeddedIpv4(addressBytes);
+        if (canonical != null) {
+            return List.of(canonical);
+        }
+        if (isIsatap(addressBytes)) {
+            return List.of(Arrays.copyOfRange(addressBytes, 12, 16));
+        }
+        if (isTeredo(addressBytes)) {
+            final byte[] client = Arrays.copyOfRange(addressBytes, 12, 16);
+            for (int i = 0; i < client.length; i++) {
+                client[i] ^= (byte) 0xff;
+            }
+            return List.of(Arrays.copyOfRange(addressBytes, 4, 8), client);
+        }
+        return List.of();
+    }
+
+    /** {@code 64:ff9b::/32} — spans the RFC 6052 well-known and RFC 8215 local-use NAT64 prefixes. */
+    private static boolean isNat64(byte[] addressBytes) {
+        return addressBytes[0] == 0x00
+                && addressBytes[1] == 0x64
+                && addressBytes[2] == (byte) 0xff
+                && addressBytes[3] == (byte) 0x9b;
+    }
+
+    /** {@code 2002::/16} — 6to4 carries its IPv4 in bytes 2-5 rather than the low 32 bits. */
+    private static boolean isSixToFour(byte[] addressBytes) {
+        return addressBytes[0] == 0x20 && addressBytes[1] == 0x02;
+    }
+
+    /** {@code ::ffff:0:0:0/96} — the RFC 2765 IPv4-translated form, distinct from IPv4-mapped. */
+    private static boolean isIpv4Translated(byte[] addressBytes) {
+        for (int i = 0; i < 8; i++) {
+            if (addressBytes[i] != 0) {
+                return false;
+            }
+        }
+        return addressBytes[8] == (byte) 0xff
+                && addressBytes[9] == (byte) 0xff
+                && addressBytes[10] == 0
+                && addressBytes[11] == 0;
+    }
+
+    /** {@code 2001:0::/32} — Teredo (RFC 4380). */
+    private static boolean isTeredo(byte[] addressBytes) {
+        return addressBytes[0] == 0x20 && addressBytes[1] == 0x01 && addressBytes[2] == 0 && addressBytes[3] == 0;
+    }
+
+    /** ISATAP (RFC 5214) — the {@code 0000:5efe} / {@code 0200:5efe} interface identifier. */
+    private static boolean isIsatap(byte[] addressBytes) {
+        return (addressBytes[8] == 0x00 || addressBytes[8] == 0x02)
+                && addressBytes[9] == 0x00
+                && addressBytes[10] == 0x5e
+                && addressBytes[11] == (byte) 0xfe;
     }
 
     private static boolean isIpv4CompatibleOrMapped(byte[] addressBytes) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
@@ -711,6 +711,14 @@ public final class RestrictedHostFilter {
         }
         if (address instanceof Inet6Address) {
             final byte[] addressBytes = address.getAddress();
+            // The RFC 8215 local-use NAT64 prefix (64:ff9b:1::/48) is registered Globally Reachable
+            // = False, and RFC 8215 §5 forbids assuming where the IPv4 is embedded within it (a
+            // §6 checksum-neutral encoding can place it in the low 32 bits while the /48-position
+            // bytes hold an unrelated routable-looking value). There is no legitimate external
+            // target under it, so block the whole prefix rather than trust any single position.
+            if (isNat64LocalUse(addressBytes)) {
+                return true;
+            }
             // Transition addresses tunnel an IPv4 destination inside an IPv6 wrapper. The wrapper
             // is itself neither loopback nor link-local, so classify what the address actually
             // reaches: 64:ff9b::7f00:1 and 2002:7f00:1:: both arrive at 127.0.0.1.
@@ -803,9 +811,10 @@ public final class RestrictedHostFilter {
      * none. Covers the embeddings where the IPv6 address is purely an encoding of an IPv4 one, so
      * collapsing to that IPv4 is a faithful canonical form: IPv4-compatible ({@code ::d.d.d.d}),
      * IPv4-mapped ({@code ::ffff:d.d.d.d}), IPv4-translated ({@code ::ffff:0:d.d.d.d}, RFC 2765),
-     * NAT64 — the RFC 6052 well-known {@code 64:ff9b::/96} (low 32 bits) and the RFC 8215 local-use
-     * {@code 64:ff9b:1::/48} (RFC 6052 /48 layout: bytes 6-7 and 9-10) — and 6to4 (RFC 3056
-     * {@code 2002::/16}).
+     * the RFC 6052 well-known NAT64 prefix {@code 64:ff9b::/96} (low 32 bits), and 6to4 (RFC 3056
+     * {@code 2002::/16}). The RFC 8215 local-use NAT64 prefix {@code 64:ff9b:1::/48} is not here:
+     * it has no fixed embedded-IPv4 position to canonicalize to and is blocked wholesale in
+     * {@link #matchesBlockedAddressClass(InetAddress)}.
      */
     private static byte[] extractEmbeddedIpv4(byte[] addressBytes) {
         if (addressBytes.length != 16) {
@@ -816,16 +825,12 @@ public final class RestrictedHostFilter {
                 || isNat64WellKnown(addressBytes)) {
             return Arrays.copyOfRange(addressBytes, 12, 16);
         }
-        if (isNat64LocalUse(addressBytes)) {
-            // RFC 6052 /48 layout: the 32-bit IPv4 is split across bytes 6-7 and 9-10; byte 8 is
-            // the reserved u-octet and is skipped. Reading the low 32 bits here (bytes 12-15) would
-            // misread the address — letting a /48-embedded internal destination through when its
-            // suffix looks routable, and over-blocking a /48-embedded routable one whose suffix is 0.
-            return new byte[] {addressBytes[6], addressBytes[7], addressBytes[9], addressBytes[10]};
-        }
         if (isSixToFour(addressBytes)) {
             return Arrays.copyOfRange(addressBytes, 2, 6);
         }
+        // The RFC 8215 local-use prefix (64:ff9b:1::/48) is deliberately absent: it has no fixed
+        // embedded-IPv4 position to canonicalize to (RFC 8215 §5), so it is not normalized here.
+        // matchesBlockedAddressClass blocks the whole prefix instead.
         return null;
     }
 
@@ -882,11 +887,11 @@ public final class RestrictedHostFilter {
     }
 
     /**
-     * {@code 64:ff9b:1::/48} — the RFC 8215 local-use NAT64 prefix. Per RFC 6052 the /48 layout
-     * embeds the IPv4 across bytes 6-7 and 9-10 (byte 8 is the reserved u-octet), which
-     * {@link #extractEmbeddedIpv4(byte[])} reassembles. Other RFC 6052 prefix lengths use a
-     * Network-Specific Prefix that cannot be recognized from the address alone, so — like 6rd —
-     * they are out of scope.
+     * {@code 64:ff9b:1::/48} — the RFC 8215 local-use NAT64 prefix (registered Globally Reachable
+     * = False). RFC 8215 §5 forbids assuming where the IPv4 is embedded within it, so the filter
+     * blocks the whole prefix in {@link #matchesBlockedAddressClass(InetAddress)} rather than
+     * extract a single position. Other NAT64 prefix lengths use a Network-Specific Prefix that
+     * cannot be recognized from the address alone, so — like 6rd — they are out of scope.
      */
     private static boolean isNat64LocalUse(byte[] addressBytes) {
         return addressBytes[0] == 0x00

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/RestrictedHostFilter.java
@@ -803,15 +803,25 @@ public final class RestrictedHostFilter {
      * none. Covers the embeddings where the IPv6 address is purely an encoding of an IPv4 one, so
      * collapsing to that IPv4 is a faithful canonical form: IPv4-compatible ({@code ::d.d.d.d}),
      * IPv4-mapped ({@code ::ffff:d.d.d.d}), IPv4-translated ({@code ::ffff:0:d.d.d.d}, RFC 2765),
-     * NAT64 (RFC 6052 well-known {@code 64:ff9b::/96} and RFC 8215 local-use {@code 64:ff9b:1::/48}),
-     * and 6to4 (RFC 3056 {@code 2002::/16}).
+     * NAT64 — the RFC 6052 well-known {@code 64:ff9b::/96} (low 32 bits) and the RFC 8215 local-use
+     * {@code 64:ff9b:1::/48} (RFC 6052 /48 layout: bytes 6-7 and 9-10) — and 6to4 (RFC 3056
+     * {@code 2002::/16}).
      */
     private static byte[] extractEmbeddedIpv4(byte[] addressBytes) {
         if (addressBytes.length != 16) {
             return null;
         }
-        if (isIpv4CompatibleOrMapped(addressBytes) || isIpv4Translated(addressBytes) || isNat64(addressBytes)) {
+        if (isIpv4CompatibleOrMapped(addressBytes)
+                || isIpv4Translated(addressBytes)
+                || isNat64WellKnown(addressBytes)) {
             return Arrays.copyOfRange(addressBytes, 12, 16);
+        }
+        if (isNat64LocalUse(addressBytes)) {
+            // RFC 6052 /48 layout: the 32-bit IPv4 is split across bytes 6-7 and 9-10; byte 8 is
+            // the reserved u-octet and is skipped. Reading the low 32 bits here (bytes 12-15) would
+            // misread the address — letting a /48-embedded internal destination through when its
+            // suffix looks routable, and over-blocking a /48-embedded routable one whose suffix is 0.
+            return new byte[] {addressBytes[6], addressBytes[7], addressBytes[9], addressBytes[10]};
         }
         if (isSixToFour(addressBytes)) {
             return Arrays.copyOfRange(addressBytes, 2, 6);
@@ -851,12 +861,40 @@ public final class RestrictedHostFilter {
         return List.of();
     }
 
-    /** {@code 64:ff9b::/32} — spans the RFC 6052 well-known and RFC 8215 local-use NAT64 prefixes. */
-    private static boolean isNat64(byte[] addressBytes) {
+    /**
+     * {@code 64:ff9b::/96} — the RFC 6052 well-known NAT64 prefix. Mandated to use the /96 layout,
+     * so the embedded IPv4 is the low 32 bits (bytes 12-15). Requires bytes 4-11 to be zero;
+     * without that, a {@code 64:ff9b:1::/48} local-use address would also match and be misread.
+     */
+    private static boolean isNat64WellKnown(byte[] addressBytes) {
+        if (addressBytes[0] != 0x00
+                || addressBytes[1] != 0x64
+                || addressBytes[2] != (byte) 0xff
+                || addressBytes[3] != (byte) 0x9b) {
+            return false;
+        }
+        for (int i = 4; i < 12; i++) {
+            if (addressBytes[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * {@code 64:ff9b:1::/48} — the RFC 8215 local-use NAT64 prefix. Per RFC 6052 the /48 layout
+     * embeds the IPv4 across bytes 6-7 and 9-10 (byte 8 is the reserved u-octet), which
+     * {@link #extractEmbeddedIpv4(byte[])} reassembles. Other RFC 6052 prefix lengths use a
+     * Network-Specific Prefix that cannot be recognized from the address alone, so — like 6rd —
+     * they are out of scope.
+     */
+    private static boolean isNat64LocalUse(byte[] addressBytes) {
         return addressBytes[0] == 0x00
                 && addressBytes[1] == 0x64
                 && addressBytes[2] == (byte) 0xff
-                && addressBytes[3] == (byte) 0x9b;
+                && addressBytes[3] == (byte) 0x9b
+                && addressBytes[4] == 0x00
+                && addressBytes[5] == 0x01;
     }
 
     /** {@code 2002::/16} — 6to4 carries its IPv4 in bytes 2-5 rather than the low 32 bits. */

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
@@ -215,9 +215,16 @@ public class RestrictedHostFilterTest {
                 "64:ff9b::7f00:1", // 127.0.0.1
                 "64:ff9b::a9fe:a9fe", // 169.254.169.254
                 "64:ff9b::e000:1", // 224.0.0.1
-                // NAT64 local-use prefix (RFC 8215)
-                "64:ff9b:1::7f00:1", // 127.0.0.1
-                "64:ff9b:1::a9fe:a9fe", // 169.254.169.254
+                // NAT64 local-use prefix (RFC 8215, 64:ff9b:1::/48). Per RFC 6052 the embedded
+                // IPv4 lives in bytes 6-7 and 9-10 (byte 8 is the reserved u-octet), NOT the low
+                // 32 bits. The first two have zero in those positions, so they embed 0.0.0.0
+                // (any-local) and block on that; the next two embed a non-routable address in the
+                // correct /48 position while carrying a *routable* suffix in the low 32 bits —
+                // reading the low bits (the old behavior) would let these through.
+                "64:ff9b:1::7f00:1", // /48 positions zero -> 0.0.0.0
+                "64:ff9b:1::a9fe:a9fe", // /48 positions zero -> 0.0.0.0
+                "64:ff9b:1:7f00:0:100:808:808", // /48 embeds 127.0.0.1; low bits 8.8.8.8
+                "64:ff9b:1:a9fe:a9:fe00:808:808", // /48 embeds 169.254.169.254; low bits 8.8.8.8
                 // 6to4 (RFC 3056) — embedded IPv4 sits in bytes 2-5
                 "2002:7f00:1::", // 127.0.0.1
                 "2002:a9fe:a9fe::", // 169.254.169.254
@@ -257,6 +264,10 @@ public class RestrictedHostFilterTest {
                 // IPv6-only network this is how legitimate IPv4 destinations are addressed.
                 "2002:0808:0808::",
                 "64:ff9b::808:808",
+                // NAT64 /48 local-use embedding a routable public IPv4 (8.8.8.8) in the correct
+                // RFC 6052 /48 position. Reading the low 32 bits (the old behavior) saw 0.0.0.0
+                // and over-blocked this legitimate destination.
+                "64:ff9b:1:808:8:800::",
             })
     public void isBlockedIpAddressClass_stillAllowsRoutableNonCanonicalLiterals(String host) {
         assertFalse(

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
@@ -275,6 +275,38 @@ public class RestrictedHostFilterTest {
                 "Did not expect routable literal " + host + " to be blocked");
     }
 
+    // Regression test for a residual SSRF bypass in the 64:ff9b:1::/48 (RFC 8215 local-use)
+    // handling. It fails against the current code and should pass once the fix lands.
+    //
+    // extractEmbeddedIpv4 reads the embedded IPv4 for this prefix from one fixed position
+    // (bytes 6-7 and 9-10), and embeddedIpv4Candidates then yields only that single candidate.
+    // RFC 8215 section 5 forbids assuming the location of the embedded IPv4 in this prefix, so an
+    // internal destination placed in another valid position is never classified.
+    //
+    // 64:ff9b:1:fffe::/96 is RFC 8215 section 6's own checksum-neutral example prefix; the low 32
+    // bits below encode 127.0.0.1 and 169.254.169.254, yet the filter reads the /48 position
+    // (0xff,0xfe,0x00,0x00 = 255.254.0.0, routable) and lets them through.
+    //
+    // Fix so this passes: have the /48 handling consider every candidate position — e.g. add both
+    // the /48 bytes and the low 32 bits in embeddedIpv4Candidates and block if any is non-routable,
+    // the way Teredo already contributes two candidates — or block 64:ff9b:1::/48 wholesale
+    // (RFC 8215 marks it Globally Reachable = False).
+    @Test
+    public void rfc8215LocalUsePrefix_blocksEmbeddedNonRoutableRegardlessOfPosition() {
+        final String[] mustBlock = {
+            "64:ff9b:1:fffe:0:0:7f00:1", // low 32 bits -> 127.0.0.1
+            "64:ff9b:1:fffe:0:0:a9fe:a9fe", // low 32 bits -> 169.254.169.254 (cloud metadata)
+        };
+        for (String host : mustBlock) {
+            assertTrue(
+                    RestrictedHostFilter.isBlockedIpAddressClass(host)
+                            && RestrictedHostFilter.isLiteralBlocked(host)
+                            && RestrictedHostFilter.isDisallowedAndFail(host, null),
+                    "Expected RFC 8215 local-use encoding " + host
+                            + " to be blocked at every entry point (address-class, literal fast path, resolver hook)");
+        }
+    }
+
     // The WebClient/HTTP path is the one the advisories exercise: isLiteralBlocked is the
     // pre-resolver fast path and isDisallowedAndFail is the resolver hook. Drive both, not just
     // the address-class helper they delegate to.

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
@@ -225,6 +225,9 @@ public class RestrictedHostFilterTest {
                 "64:ff9b:1::a9fe:a9fe", // /48 positions zero -> 0.0.0.0
                 "64:ff9b:1:7f00:0:100:808:808", // /48 embeds 127.0.0.1; low bits 8.8.8.8
                 "64:ff9b:1:a9fe:a9:fe00:808:808", // /48 embeds 169.254.169.254; low bits 8.8.8.8
+                // The whole 64:ff9b:1::/48 prefix is blocked (Globally Reachable = False), so even a
+                // routable IPv4 in the /48 position does not make it reachable.
+                "64:ff9b:1:808:8:800::",
                 // 6to4 (RFC 3056) — embedded IPv4 sits in bytes 2-5
                 "2002:7f00:1::", // 127.0.0.1
                 "2002:a9fe:a9fe::", // 169.254.169.254
@@ -264,10 +267,10 @@ public class RestrictedHostFilterTest {
                 // IPv6-only network this is how legitimate IPv4 destinations are addressed.
                 "2002:0808:0808::",
                 "64:ff9b::808:808",
-                // NAT64 /48 local-use embedding a routable public IPv4 (8.8.8.8) in the correct
-                // RFC 6052 /48 position. Reading the low 32 bits (the old behavior) saw 0.0.0.0
-                // and over-blocked this legitimate destination.
-                "64:ff9b:1:808:8:800::",
+                // NOTE: 64:ff9b:1::/48 (RFC 8215 local-use) is NOT in this allow list, even when its
+                // /48 position holds a routable IPv4 — that prefix is registered Globally Reachable =
+                // False and is blocked wholesale (see the block test below and
+                // rfc8215LocalUsePrefix_blocksEmbeddedNonRoutableRegardlessOfPosition).
             })
     public void isBlockedIpAddressClass_stillAllowsRoutableNonCanonicalLiterals(String host) {
         assertFalse(

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/util/RestrictedHostFilterTest.java
@@ -170,6 +170,208 @@ public class RestrictedHostFilterTest {
                 "Did not expect " + host + " to be recognized as a blocked address class");
     }
 
+    // ---------- Non-canonical IP literals (GHSA-x3j2-rfj9-cc32, GHSA-342c-q2qr-jxrj) ----------
+    //
+    // Two ways an internal destination hides from the filter while the HTTP client still
+    // connects to it:
+    //
+    //   1. Leading-zero octets ("127.0.0.01"). Apache Commons InetAddressValidator rejects
+    //      these, so the host was never canonicalized and was compared as an opaque string.
+    //      Netty's NetUtil parses them as decimal, and reactor-netty hands the client an
+    //      already-resolved address, so the resolver hook never runs either.
+    //   2. IPv6 transition addresses (NAT64 64:ff9b::/96 and 64:ff9b:1::/48, 6to4 2002::/16).
+    //      Every parser agrees these are valid IPv6; the filter simply never unwrapped the
+    //      embedded IPv4, so it classified the outer wrapper instead of the destination.
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                // Loopback
+                "127.0.0.01",
+                "127.000.000.001",
+                "127.0.0.001",
+                // Link-local
+                "169.254.001.001",
+                "169.254.0.01",
+                // Any-local
+                "0.0.0.00",
+                "00.0.0.0",
+                // Multicast
+                "224.0.0.01",
+                // IPv4-mapped IPv6 carrying a zero-padded embedded octet
+                "::ffff:127.0.0.01",
+                "::ffff:169.254.001.001",
+            })
+    public void isBlockedIpAddressClass_recognizesZeroPaddedNonRoutableLiterals(String host) {
+        assertTrue(
+                RestrictedHostFilter.isBlockedIpAddressClass(host),
+                "Expected zero-padded literal " + host + " to be recognized as a blocked address class");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                // NAT64 well-known prefix (RFC 6052) embedding a non-routable IPv4
+                "64:ff9b::7f00:1", // 127.0.0.1
+                "64:ff9b::a9fe:a9fe", // 169.254.169.254
+                "64:ff9b::e000:1", // 224.0.0.1
+                // NAT64 local-use prefix (RFC 8215)
+                "64:ff9b:1::7f00:1", // 127.0.0.1
+                "64:ff9b:1::a9fe:a9fe", // 169.254.169.254
+                // 6to4 (RFC 3056) — embedded IPv4 sits in bytes 2-5
+                "2002:7f00:1::", // 127.0.0.1
+                "2002:a9fe:a9fe::", // 169.254.169.254
+                // IPv4-translated (RFC 2765) — 0xffff sits in bytes 8-9, not 10-11 as in mapped
+                "::ffff:0:127.0.0.1",
+                "::ffff:0:7f00:1",
+                "::ffff:0:a9fe:a9fe",
+                // ISATAP (RFC 5214) — IPv4 in the interface identifier after the 5efe marker
+                "::5efe:127.0.0.1",
+                "::0:5efe:7f00:1",
+                "2001:db8::5efe:7f00:1",
+                "2001:db8::200:5efe:a9fe:a9fe",
+                // Teredo (RFC 4380) — relay server IPv4 in bytes 4-7, client IPv4 in bytes 12-15
+                // stored as its ones-complement
+                "2001:0:7f00:1::", // server 127.0.0.1
+                "2001:0:a9fe:a9fe::", // server 169.254.169.254
+                "2001:0:0:0:0:0:80ff:fffe", // client ones-complement of 127.0.0.1
+            })
+    public void isBlockedIpAddressClass_recognizesIpv6TransitionEmbeddedNonRoutable(String host) {
+        assertTrue(
+                RestrictedHostFilter.isBlockedIpAddressClass(host),
+                "Expected transition address " + host + " to be classified by its embedded IPv4");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                // RFC 1918 is intentionally ALLOWED (see resolveIfAllowed). Canonicalizing a
+                // zero-padded literal must not start blocking a range the filter permits — the
+                // fix normalizes these, it does not reject them.
+                "010.0.0.1",
+                "192.168.001.001",
+                "172.016.0.1",
+                // Ordinary public addresses in zero-padded form stay allowed too.
+                "008.008.008.008",
+                // A 6to4 address embedding a routable public IPv4 must remain reachable: on an
+                // IPv6-only network this is how legitimate IPv4 destinations are addressed.
+                "2002:0808:0808::",
+                "64:ff9b::808:808",
+            })
+    public void isBlockedIpAddressClass_stillAllowsRoutableNonCanonicalLiterals(String host) {
+        assertFalse(
+                RestrictedHostFilter.isBlockedIpAddressClass(host),
+                "Did not expect routable literal " + host + " to be blocked");
+    }
+
+    // The WebClient/HTTP path is the one the advisories exercise: isLiteralBlocked is the
+    // pre-resolver fast path and isDisallowedAndFail is the resolver hook. Drive both, not just
+    // the address-class helper they delegate to.
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "127.0.0.01",
+                "127.000.000.001",
+                "169.254.001.001",
+                "0.0.0.00",
+                // Denylist entry reachable by zero-padding its final octet
+                "168.63.129.016",
+                "::ffff:127.0.0.01",
+                "64:ff9b::7f00:1",
+                "64:ff9b::a9fe:a9fe",
+                "2002:7f00:1::",
+            })
+    public void isLiteralBlocked_blocksNonCanonicalAndTransitionLiterals(String host) {
+        assertTrue(
+                RestrictedHostFilter.isLiteralBlocked(host),
+                "Expected " + host + " to be blocked on the WebClient pre-resolver fast path");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "127.0.0.01",
+                "127.000.000.001",
+                "169.254.001.001",
+                "0.0.0.00",
+                "168.63.129.016",
+                "::ffff:127.0.0.01",
+                "64:ff9b::7f00:1",
+                "64:ff9b::a9fe:a9fe",
+                "2002:7f00:1::",
+            })
+    public void isDisallowedAndFail_blocksNonCanonicalAndTransitionLiterals(String host) {
+        assertTrue(
+                RestrictedHostFilter.isDisallowedAndFail(host, null),
+                "Expected " + host + " to be blocked by the Netty resolver hook");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "1.1.1.1",
+                "8.8.8.8",
+                "010.0.0.1",
+                "192.168.001.001",
+                "smtp.gmail.com",
+                // Octal-looking literals are read as decimal by both Netty and the JVM, so these dial
+                // 177.0.0.1 rather than 127.0.0.1 and are not loopback in disguise. Should any runtime
+                // ever read them as octal, the resolver hook catches the loopback address post-DNS.
+                "0177.0.0.1",
+                "0177.0.0.01",
+            })
+    public void isLiteralBlocked_stillAllowsPublicAndPrivateHosts(String host) {
+        assertFalse(RestrictedHostFilter.isLiteralBlocked(host), "Did not expect " + host + " to be blocked");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "127.0.0.01",
+                "169.254.001.001",
+                "::ffff:127.0.0.01",
+                "64:ff9b::7f00:1",
+                "2002:7f00:1::",
+            })
+    public void isHostBlocked_blocksNonCanonicalAndTransitionLiterals(String host) {
+        assertTrue(RestrictedHostFilter.isHostBlocked(host), "Expected " + host + " to be blocked");
+    }
+
+    /**
+     * The invariant behind both advisories: whatever address the runtime would actually dial, if it
+     * is non-routable the request must not get through. Two different stages enforce that — literals
+     * Netty pre-parses are caught on the fast path, and the ones it declines (dotted-decimal
+     * shorthand, 32-bit integers) are caught after the resolver runs. Asserting the end-to-end
+     * verdict rather than the stage means dropping either half fails this test.
+     */
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                // Netty pre-parses these, so the resolver hook never sees them
+                "127.0.0.01",
+                "127.000.000.001",
+                "169.254.001.001",
+                "0.0.0.00",
+                "224.0.0.01",
+                // Netty declines these; the JVM resolver still lands on loopback
+                "2130706433",
+                "127.1",
+                "127.0.1",
+            })
+    public void blocksEveryLiteralSpellingThatResolvesToANonRoutableAddress(String literal) throws Exception {
+        final InetAddress effective = InetAddress.getByName(literal);
+        assertTrue(
+                RestrictedHostFilter.matchesBlockedAddressClass(effective),
+                "precondition: " + literal + " must resolve to a non-routable address, got "
+                        + effective.getHostAddress());
+        assertTrue(
+                RestrictedHostFilter.isLiteralBlocked(literal)
+                        || RestrictedHostFilter.isDisallowedAndFail(literal, null)
+                        || RestrictedHostFilter.isDisallowedAndFail(effective.getHostAddress(), null),
+                literal + " resolves to " + effective.getHostAddress() + " but the filter allows it");
+    }
+
     // ---------- isHostBlocked: used by the Redis plugin (GHSA-qhfj-g87x-m39w) ----------
 
     @Test


### PR DESCRIPTION
Hardens `RestrictedHostFilter` so the address it evaluates is the address the HTTP
client will actually connect to, across IP literal forms where the two could differ.

- Canonicalizes IP literals using the same parser the HTTP client uses, so equivalent
  spellings are evaluated consistently rather than one being recognized and another
  slipping through.
- Extends the existing IPv4-in-IPv6 handling to the remaining standardized embeddings.

Routable public and private-network (RFC 1918) destinations are unaffected. The
operator opt-out `APPSMITH_DISABLE_SSRF_FILTER` is unchanged.

https://linear.app/appsmith/issue/APP-15786

## Impact on existing instances

A datasource that reached an internal address by a non-canonical spelling of that
address is now blocked, matching how the canonical spelling was already treated.
Routable destinations, public or private, are unaffected. No configuration change or
migration; rollback restores prior behavior.

Security advisories:
- https://github.com/appsmithorg/appsmith/security/advisories/GHSA-x3j2-rfj9-cc32
- https://github.com/appsmithorg/appsmith/security/advisories/GHSA-342c-q2qr-jxrj

## Automation

/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/32870304950>
> Commit: 46d1a7595925c4ee7f526c86798737e23269b3eb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=32870304950&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 25 Aug 2026 17:08:56 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against restricted destinations represented using alternate IPv4 and IPv6 address formats.
  * Correctly identifies private and non-routable IPv4 addresses embedded in supported IPv6 transition formats.
  * Blocks local-use NAT64 addresses consistently, while preserving access to valid routable destinations.

* **Tests**
  * Added coverage for alternate literal spellings and IPv6 transition addresses, including NAT64 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->