### PR TITLE
fix: resolve datasource once in validateAction instead of double-subscribing

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -651,6 +651,11 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 }
             }
 
+            // datasourceMono is subscribed twice below (pluginMono and the zipWith), so cache it
+            // to avoid re-running the ACL-scoped findById, datasource validation, and the
+            // public-action policy update on the second subscription.
+            datasourceMono = datasourceMono.cache();
+
             Mono<Plugin> pluginMono = datasourceMono.flatMap(datasource -> {
                 if (datasource.getPluginId() == null) {
                     return Mono.error(new AppsmithException(AppsmithError.PLUGIN_ID_NOT_GIVEN));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -651,33 +651,28 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 }
             }
 
-            // datasourceMono is subscribed twice below (pluginMono and the zipWith), so cache it
-            // to avoid re-running the ACL-scoped findById, datasource validation, and the
-            // public-action policy update on the second subscription.
-            datasourceMono = datasourceMono.cache();
-
-            Mono<Plugin> pluginMono = datasourceMono.flatMap(datasource -> {
+            // Resolve the datasource once and keep it in scope for the final mapping, rather than
+            // subscribing the chain a second time (e.g. via zipWith), which would re-run the
+            // ACL-scoped findById, datasource validation, and the public-action policy update.
+            validatedActionMono = datasourceMono.flatMap(datasource -> {
                 if (datasource.getPluginId() == null) {
                     return Mono.error(new AppsmithException(AppsmithError.PLUGIN_ID_NOT_GIVEN));
                 }
-                return pluginService.findById(datasource.getPluginId()).switchIfEmpty(Mono.defer(() -> {
-                    editActionDTO.setIsValid(false);
-                    invalids.add(
-                            AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.PLUGIN, datasource.getPluginId()));
-                    return Mono.just(new Plugin());
-                }));
+                return pluginService
+                        .findById(datasource.getPluginId())
+                        .switchIfEmpty(Mono.defer(() -> {
+                            editActionDTO.setIsValid(false);
+                            invalids.add(AppsmithError.NO_RESOURCE_FOUND.getMessage(
+                                    FieldName.PLUGIN, datasource.getPluginId()));
+                            return Mono.just(new Plugin());
+                        }))
+                        // Set plugin in the action before saving.
+                        .map(plugin -> {
+                            editActionDTO.setDatasource(datasource);
+                            editActionDTO.setPluginName(plugin.getName());
+                            return newAction;
+                        });
             });
-
-            validatedActionMono = pluginMono
-                    .zipWith(datasourceMono)
-                    // Set plugin in the action before saving.
-                    .map(tuple -> {
-                        Plugin plugin = tuple.getT1();
-                        Datasource datasource = tuple.getT2();
-                        editActionDTO.setDatasource(datasource);
-                        editActionDTO.setPluginName(plugin.getName());
-                        return newAction;
-                    });
         }
 
         return validatedActionMono


### PR DESCRIPTION
## Description

The `server-unit-tests / server-unit-tests` check fails on every server-touching PR (e.g. #42131, #42132) because `NewActionServiceUnitTest.testValidateAction_withForeignDatasourceId_shouldUseScopedFindById_GHSA_fhgw_q2jf_8fq7` fails deterministically on `release` HEAD:

```text
org.mockito.exceptions.verification.TooManyActualInvocations:
datasourceService.findById("foreign-workspace-datasource-id", CREATE_DATASOURCE_ACTIONS)
Wanted 1 time — but was 2 times
```

**Root cause:** in `NewActionServiceCEImpl.validateAction(NewAction, boolean)`, `datasourceMono` was subscribed twice — once via `pluginMono = datasourceMono.flatMap(...)` and again in `pluginMono.zipWith(datasourceMono)`. The `zipWith` (dating to 2019) existed only to bring the datasource back into scope for the final mapping. Since the GHSA-h5qf-426x-5mv5 fix moved the ACL-scoped `findById` inside the reactive chain, the lookup (plus `validateDatasource` on the no-ID branch and `updateDatasourcePolicyForPublicAction`) re-ran on the second subscription. The GHSA-fhgw-q2jf-8fq7 regression test asserts exactly one scoped `findById` call, so it fails. Functionality and security enforcement are unaffected — the redundant second execution produced identical results; the defect is duplicated work made newly observable.

**Fix:** remove the second subscription. The final mapping is nested inside a single `flatMap` on `datasourceMono`, keeping the datasource in scope via closure — so the resolution chain executes exactly once by construction. No `zipWith`, no memoization. No security behavior changes: the ACL-scoped lookup and its `switchIfEmpty` error path are unchanged.

**Verification:** on `release` HEAD locally, the test fails 5/5 before this change and passes 3/3 after (plus spotless clean). Call sites checked: both `datasourceMono` fan-out sites in `NewActionServiceCEImpl` — the bulk-import variant compensates with `.cache()` and keeps working; this method's fan-out is removed outright.

Linear: https://linear.app/appsmith/issue/APP-15804

## Impact on existing instances

Behavior fix only: removes a redundant second ACL-scoped datasource read and a duplicate public-action policy update per action create/update. No config, schema, env var, or persisted data change. Fresh install, upgrade, and rollback are all unaffected.

## Automation

/ok-to-test tags="@tag.All"

<!-- Cypress test suite will run when the ok-to-test label is applied -->


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/31838945397>
> Commit: d6902d578e57d33b7420a5fd45cc8ab7bb2ab667
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=31838945397&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 14 Aug 2026 22:47:57 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action validation to process datasource and plugin checks more reliably.
  * Prevented duplicate datasource validation and lookup operations during action configuration.
  * Ensured access controls and public-policy updates are applied consistently while validating actions.
  * Preserved automatic population of supported action fields during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->