### PR TITLE
fix: document SCP vs ssh:// port handling for private repo check

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -34,16 +34,15 @@ public class GitUtils {
             Pattern.compile("^ssh://([a-z_][\\w-]+@)?(?<host>[\\w-.]+)(:(?<port>\\d*))?/+(?<path>.+?)(\\.git)?$");
 
     /**
-     * Pattern for validating the ssh address if it strictly doesn't start with a scheme
+     * Pattern for validating the ssh address if it strictly doesn't start with a scheme (SCP-like).
      * username can start with any small alphabet or a _ underscore
      * hostname can have all alphanumerics, -, and .  e.g. _ab-xy@ab-12.ab:v3/newJet/ai/zilla.git
-     * Optional custom port is supported as user@host:port/path (e.g. git@host:2222/user/repo.git).
-     * A leading numeric path segment followed by '/' is treated as a port, matching common
-     * non-standard SCP-style URLs; such numeric namespaces are extremely rare in practice.
-     * The captured port is not included in the HTTPS conversion (same as URL_PATTERN_WITH_SCHEME).
+     * Per Git, SCP-like syntax is user@host:path and does not support a custom port; a leading
+     * numeric segment (e.g. git@host:2222/user/repo.git) is part of the path. Custom SSH ports
+     * require the ssh:// form matched by {@link #URL_PATTERN_WITH_SCHEME}.
      */
     public static final Pattern URL_PATTERN_WITHOUT_SCHEME =
-            Pattern.compile("^[a-z_][\\w-]+@(?<host>[\\w-.]+):(?:(?<port>\\d+)/)?/*(?<path>.+?)(\\.git)?$");
+            Pattern.compile("^[a-z_][\\w-]+@(?<host>[\\w-.]+):/*(?<path>.+?)(\\.git)?$");
 
     /**
      * Sample repo urls :

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -36,11 +36,14 @@ public class GitUtils {
     /**
      * Pattern for validating the ssh address if it strictly doesn't start with a scheme
      * username can start with any small alphabet or a _ underscore
-     * hostname can have all alphanumerics, -, and .  e.g. ssh://_ab-xy@ab-12.ab:/v3/newJet/ai/zilla.git
-     * the port number could be not present as well. e.g. ssh://_ab-xy@domain.com:/v3/newJet/ai/zilla
+     * hostname can have all alphanumerics, -, and .  e.g. _ab-xy@ab-12.ab:v3/newJet/ai/zilla.git
+     * Optional custom port is supported as user@host:port/path (e.g. git@host:2222/user/repo.git).
+     * A leading numeric path segment followed by '/' is treated as a port, matching common
+     * non-standard SCP-style URLs; such numeric namespaces are extremely rare in practice.
+     * The captured port is not included in the HTTPS conversion (same as URL_PATTERN_WITH_SCHEME).
      */
     public static final Pattern URL_PATTERN_WITHOUT_SCHEME =
-            Pattern.compile("^[a-z_][\\w-]+@(?<host>[\\w-.]+):/*(?<path>.+?)(\\.git)?$");
+            Pattern.compile("^[a-z_][\\w-]+@(?<host>[\\w-.]+):(?:(?<port>\\d+)/)?/*(?<path>.+?)(\\.git)?$");
 
     /**
      * Sample repo urls :

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -57,7 +57,7 @@ public class GitUtilsTest {
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@absolute.path.com:/test/newRepo.git"))
                 .isEqualTo("https://absolute.path.com/test/newRepo");
 
-        // Custom SSH port (ssh:// scheme — port must not become part of the HTTPS path):
+        // Custom SSH port (ssh:// only — port must not become part of the HTTPS path):
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
                         "ssh://git@example.test.net:1234/user/test/tests/testRepo.git"))
                 .isEqualTo("https://example.test.net/user/test/tests/testRepo");
@@ -68,15 +68,16 @@ public class GitUtilsTest {
                         "ssh://git@tim.tam.example.com:9876/v3/sladeping/pyhe/SpaceJunk"))
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
 
-        // Custom SSH port (SCP-like form user@host:port/path — same HTTPS result as ssh://):
+        // SCP-like syntax has no port: a leading numeric segment is a path namespace, not a port.
+        // Custom ports require ssh://user@host:port/path (covered above).
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
                         "git@example.test.net:2222/user/test/tests/testRepo.git"))
-                .isEqualTo("https://example.test.net/user/test/tests/testRepo");
+                .isEqualTo("https://example.test.net/2222/user/test/tests/testRepo");
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@example.com:443/test/testRepo.git"))
-                .isEqualTo("https://example.com/test/testRepo");
+                .isEqualTo("https://example.com/443/test/testRepo");
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
                         "git@tim.tam.example.com:5678/v3/sladeping/pyhe/SpaceJunk"))
-                .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
+                .isEqualTo("https://tim.tam.example.com/5678/v3/sladeping/pyhe/SpaceJunk");
 
         // custom ssh username:
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("abc-xy@vs-ssh.visualstudio.com:v3/newJet/ai/zilla"))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -57,7 +57,7 @@ public class GitUtilsTest {
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@absolute.path.com:/test/newRepo.git"))
                 .isEqualTo("https://absolute.path.com/test/newRepo");
 
-        // Custom SSH port:
+        // Custom SSH port (ssh:// scheme — port must not become part of the HTTPS path):
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
                         "ssh://git@example.test.net:1234/user/test/tests/testRepo.git"))
                 .isEqualTo("https://example.test.net/user/test/tests/testRepo");
@@ -66,6 +66,16 @@ public class GitUtilsTest {
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
                         "ssh://git@tim.tam.example.com:9876/v3/sladeping/pyhe/SpaceJunk"))
+                .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
+
+        // Custom SSH port (SCP-like form user@host:port/path — same HTTPS result as ssh://):
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
+                        "git@example.test.net:2222/user/test/tests/testRepo.git"))
+                .isEqualTo("https://example.test.net/user/test/tests/testRepo");
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@example.com:443/test/testRepo.git"))
+                .isEqualTo("https://example.com/test/testRepo");
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl(
+                        "git@tim.tam.example.com:5678/v3/sladeping/pyhe/SpaceJunk"))
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
 
         // custom ssh username:


### PR DESCRIPTION
## Description
CodeRabbit correctly flagged that Git SCP-like remotes (`user@host:path`) do **not** support a custom port. A leading numeric segment such as `git@host:2222/user/repo.git` is a path namespace, not a port.

Treating it as a port would convert to `https://host/user/repo` and make `isRepoPrivate` / `browserSupportedRemoteUrl` hit the wrong repository.

Custom SSH ports already work via the `ssh://` form (`ssh://git@host:2222/user/repo.git`), which `URL_PATTERN_WITH_SCHEME` parses while omitting the port from the HTTPS URL.

## Changes
- Clarify `URL_PATTERN_WITHOUT_SCHEME` javadoc: SCP-like has no port; use `ssh://` for custom ports
- Add regression tests that SCP-like numeric first segments stay in the HTTPS path
- Keep existing `ssh://…:port/…` coverage (port excluded from HTTPS path)

## Test plan
- [x] `GitUtilsTest#convertSshUrlToBrowserSupportedUrl` covers both forms
- [ ] CI `GitUtilsTest` on this PR

Fixes #32862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of Git SSH-style repository URLs with numeric path segments.
  * Custom SSH ports continue to work with `ssh://` URLs, while SCP-style URLs now preserve numeric path components correctly.
  * Improved conversion of SSH repository URLs to browser-compatible links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->