### PR TITLE
fix(test): use atLeastOnce() for ACL-scoped findById verify in GHSA-fhgw test

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceUnitTest.java
@@ -244,7 +244,13 @@ public class NewActionServiceUnitTest {
         StepVerifier.create(result).expectError(AppsmithException.class).verify();
 
         // Post-fix assertions: the ACL-scoped overload was called; the unchecked overload was not.
-        Mockito.verify(datasourceService).findById(eq(foreignDatasourceId), eq(actionCreatePermission));
+        // atLeastOnce() because the cold datasourceMono is subscribed more than once in the
+        // pluginMono.zipWith(datasourceMono) pipeline inside validateAction; each subscription
+        // triggers a separate findById call.  The security invariant is that every call uses
+        // the ACL-scoped overload (asserted here) and the unchecked overload is never used
+        // (asserted below).
+        Mockito.verify(datasourceService, Mockito.atLeastOnce())
+                .findById(eq(foreignDatasourceId), eq(actionCreatePermission));
         Mockito.verify(datasourceService, Mockito.never()).findById(eq(foreignDatasourceId));
     }
 }


### PR DESCRIPTION
## Description
Fixes `TooManyActualInvocations` in `NewActionServiceUnitTest#testValidateAction_withForeignDatasourceId_shouldUseScopedFindById_GHSA_fhgw_q2jf_8fq7`.

## Root cause
Inside `validateAction()`, the cold `datasourceMono` is subscribed **twice** in the reactive pipeline:

1. Through `pluginMono = datasourceMono.flatMap(...)` (line 654)
2. Directly via `pluginMono.zipWith(datasourceMono)` (line 667)

Each subscription triggers a separate `datasourceService.findById(id, permission)` call. The test's `verify(datasourceService).findById(...)` asserts `times(1)` (default), but 2 calls actually happen.

## Fix
Change the verification from the implicit `times(1)` to `atLeastOnce()`. The security invariant remains intact:
- `atLeastOnce()`: every call to `findById` uses the ACL-scoped overload
- `never()` (unchanged): the unchecked `findById(String)` overload is never called

## Impact on existing instances
None — test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated security coverage to verify that datasource lookups respect access controls.
  * Confirmed unrestricted datasource lookups are not used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->