### PR TITLE
fix: cache validateAction datasource fetch; silence dev-server warnings

### DIFF
--- a/app/client/config/webpack.config.js
+++ b/app/client/config/webpack.config.js
@@ -369,6 +369,9 @@ module.exports = function (webpackEnv) {
         fs: false,
         os: false,
         path: false,
+        // Referenced by a Node-only code path in @betterbugs/web-sdk; never
+        // executed in the browser.
+        worker_threads: false,
         "react/jsx-runtime": require.resolve("react/jsx-runtime"),
       },
       plugins: [
@@ -609,6 +612,17 @@ module.exports = function (webpackEnv) {
           warning.module?.resource.includes("/node_modules/sass/sass.dart.js")
         );
       },
+      // The eval/lint/Tern workers lazily import() the same widget-config and
+      // vendor modules as the main graph, so webpack attaches those chunks to
+      // both runtimes (deliberate: the browser downloads each chunk once).
+      // Since main also references the worker entry chunks, webpack cannot
+      // compute independent per-runtime content hashes and warns "Circular
+      // dependency between chunks with runtime (evalWorker, main)". The only
+      // effect is a fallback hashing strategy for those chunks (a long-term
+      // caching micro-optimization); output correctness is unaffected.
+      // "Fixing" it would require isolating the worker bundles and duplicating
+      // several MB of shared vendors into each worker, which is strictly worse.
+      { message: /Circular dependency between chunks with runtime/ },
     ],
     plugins: [
       // Replace BlueprintJS’s icon component with our own implementation

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/newactions/base/NewActionServiceCEImpl.java
@@ -651,6 +651,10 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                 }
             }
 
+            // Both pluginMono and the zipWith below subscribe this Mono; without cache() the
+            // ACL-scoped datasource fetch and the public-action policy update above run twice.
+            datasourceMono = datasourceMono.cache();
+
             Mono<Plugin> pluginMono = datasourceMono.flatMap(datasource -> {
                 if (datasource.getPluginId() == null) {
                     return Mono.error(new AppsmithException(AppsmithError.PLUGIN_ID_NOT_GIVEN));


### PR DESCRIPTION
## Description

Two small shared-infrastructure fixes, both already verified in EE:

**1. `validateAction` double ACL datasource fetch (server).** The `isDryOps` refactor left `NewActionServiceCEImpl.validateAction` subscribing `datasourceMono` twice — once through `pluginMono`'s flatMap chain and once through `pluginMono.zipWith(datasourceMono)`. As a result the GHSA-fhgw-q2jf-8fq7 ACL-scoped datasource fetch and `updateDatasourcePolicyForPublicAction` execute **twice per action validation** (redundant DB fetch plus a racy duplicate policy save), and the strict-count GHSA regression test `NewActionServiceUnitTest.testValidateAction_withForeignDatasourceId_shouldUseScopedFindById_GHSA_fhgw_q2jf_8fq7` fails ("Wanted 1 time, but was 2 times") on any PR that runs server unit tests. The fix adds `datasourceMono = datasourceMono.cache();` before `pluginMono` — the identical pattern `validateActionBeforeImport` already uses in the same file. The Mono is method-local, so `cache()` cannot share data across requests or users; error signals (`NO_RESOURCE_FOUND` sits upstream of `cache()`) replay identically to both subscribers.

**2. Dev-server compile warnings (client webpack).**
- `worker_threads: false` added to the existing Node-builtin stubs in `resolve.fallback`: `@betterbugs/web-sdk` (#41532) references the Node-only module in a code path never executed in the browser.
- An `ignoreWarnings` entry for "Circular dependency between chunks with runtime (evalWorker, main)": the eval/lint/Tern workers lazily import the same widget-config and vendor chunks as the main graph (deliberate — the browser downloads each chunk once), which structurally prevents independent per-runtime content hashes. The only effect is a fallback hashing strategy for those chunks; a "real" fix would duplicate several MB of shared vendors into each worker bundle. Rationale is documented in a comment in the config.

**Call sites checked:** both subscription points of `datasourceMono` in `validateAction`; the `validateActionBeforeImport` precedent; the config's pre-existing `ignoreWarnings` list (merged into, not duplicated — note the file has an existing `ignoreWarnings` key, which silently wins over a duplicate key).

**Impact on existing instances:** none. No defaults, env vars, persisted data, or APIs change. Fresh install / upgrade / rollback all unaffected; the server change only removes a redundant duplicate fetch+save within a single request.

Linear: https://linear.app/appsmith/issue/APP-15808

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012V9eJJ4xgmcvWvvHiy4Dpg


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/32036647064>
> Commit: b08ba591101024ddfc3f584e2b4ebac115e1da86
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=32036647064&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 17 Aug 2026 15:57:21 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser build compatibility for integrations that rely on Node-only functionality.
  - Reduced unnecessary build warnings related to circular runtime dependencies.
  - Prevented repeated datasource validation and policy updates during action validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->