### PR TITLE
fix(client): skip null values when scanning a config object for functions

### DIFF
--- a/app/client/src/workers/Evaluation/__tests__/validations.test.ts
+++ b/app/client/src/workers/Evaluation/__tests__/validations.test.ts
@@ -1761,6 +1761,35 @@ describe("Validate Validators", () => {
       expect(result).toStrictEqual(expected[i]);
     });
   });
+
+  it("correctly validates OBJECT_WITH_FUNCTION containing null values", () => {
+    const config = {
+      type: ValidationTypes.OBJECT_WITH_FUNCTION,
+      params: { default: {} },
+    };
+    // A query row with a null column reaches this validator through any chart
+    // config bound to query data.
+    const input = {
+      series: [{ data: [[1, null]], label: { formatter: () => "z" } }],
+      updated_by: null,
+    };
+
+    const response = validate(
+      config,
+      input,
+      DUMMY_WIDGET,
+      "customEChartConfig",
+    );
+
+    expect(response.isValid).toBe(true);
+    // Nulls are preserved, functions are stringified, and the config is not
+    // discarded in favour of the default.
+    expect(response.parsed).toMatchObject({
+      series: [{ data: [[1, null]], label: { formatter: '() => "z"' } }],
+      updated_by: null,
+      __fn_keys__: ["series.[0].label.formatter"],
+    });
+  });
 });
 
 // describe("Color Picker Text validator", () => {

--- a/app/client/src/workers/Evaluation/helpers.test.ts
+++ b/app/client/src/workers/Evaluation/helpers.test.ts
@@ -94,6 +94,43 @@ describe("stringifyFnsInObject", () => {
       },
     });
   });
+
+  it("skips null values instead of recursing into them", () => {
+    expect(stringifyFnsInObject({ updated_by: null })).toEqual({
+      __fn_keys__: [],
+      updated_by: null,
+    });
+  });
+
+  it("skips nulls nested inside an array of rows", () => {
+    const rows = [
+      { id: 22, updated_by: null, qdis_score1: 42 },
+      { id: 23, updated_by: null, qdis_score1: null },
+    ];
+
+    expect(stringifyFnsInObject({ series: rows })).toEqual({
+      __fn_keys__: [],
+      series: rows,
+    });
+  });
+
+  it("collects nested function paths when null siblings are present", () => {
+    const result = stringifyFnsInObject({
+      tooltip: { formatter: () => "y", nothing: null },
+      series: [{ data: [[1, null]], label: { formatter: () => "z" } }],
+    });
+
+    expect(result[fn_keys]).toEqual([
+      "tooltip.formatter",
+      "series.[0].label.formatter",
+    ]);
+  });
+
+  it("keeps array indices correct when a null precedes a function", () => {
+    const result = stringifyFnsInObject({ arr: [null, () => "q"] });
+
+    expect(result[fn_keys]).toEqual(["arr.[1]"]);
+  });
 });
 
 describe("updatePrevState", () => {

--- a/app/client/src/workers/Evaluation/helpers.ts
+++ b/app/client/src/workers/Evaluation/helpers.ts
@@ -135,13 +135,20 @@ const parseFunctionsInObject = (
   paths: string[] = [],
   path: string = "",
 ): string[] => {
+  // typeof null is "object", and primitives cannot hold functions. Both must be
+  // rejected here, otherwise Object.keys below throws on them.
+  if (userObject === null || typeof userObject !== "object") {
+    return paths;
+  }
+
   if (Array.isArray(userObject)) {
     for (let i = 0; i < userObject.length; i++) {
       const arrayValue = userObject[i];
 
+      // typeof null is "object", so null is excluded from the recursion below
       if (typeof arrayValue == "function") {
         paths.push(constructPath(path, `[${i}]`));
-      } else if (typeof arrayValue == "object") {
+      } else if (arrayValue !== null && typeof arrayValue == "object") {
         parseFunctionsInObject(
           arrayValue,
           paths,
@@ -155,9 +162,10 @@ const parseFunctionsInObject = (
     for (const key of keys) {
       const value = userObject[key];
 
+      // typeof null is "object", so null is excluded from the recursion below
       if (typeof value == "function") {
         paths.push(constructPath(path, key));
-      } else if (typeof value == "object") {
+      } else if (value !== null && typeof value == "object") {
         parseFunctionsInObject(
           value as Record<string, unknown>,
           paths,


### PR DESCRIPTION
## Description

`typeof null === "object"`, so `parseFunctionsInObject` recursed into `null` values and called `Object.keys(null)`, throwing `TypeError: Cannot convert undefined or null to object`.

That throw escaped the per-property `try/catch` in `DataTreeEvaluator.evaluateTree` — `validateAndParseWidgetProperty` is called outside it — so the whole evaluation pass aborted and returned the un-evaluated tree. **Every widget on the page** then rendered its raw `{{ }}` template behind a generic *"Unexpected error occurred while evaluating the application"* toast.

The Chart widget's **Custom ECharts Configuration** is the only property using `OBJECT_WITH_FUNCTION` validation, so any chart config bound to query data containing a null column bricked the entire page. Setting the widget to invisible did not help, because validation runs regardless of `isVisible`.

Reported by a customer whose console log named the error verbatim:

```text
{type: 'EVAL_TREE_ERROR', message: 'Cannot convert undefined or null to object', ...}
```

Fixes https://linear.app/appsmith/issue/APP-15811

### Reproduction

No query needed:

1. Drop a Chart widget, set **Chart type** to **Custom EChart**.
2. Set **Custom ECharts Configuration** to `{{ { series: null } }}`.
3. The whole page breaks, not just the chart.

Verified through the real validator:

| Value | Before | After |
|---|---|---|
| `{{ { series: null } }}` | crashes page | renders |
| `{{ { series: [null] } }}` | crashes page | renders |
| `{{ { series: [1, null, 3] } }}` | crashes page | renders |
| `{{ { series: [{ name: null }] } }}` | crashes page | renders |
| `{{ { series: [] } }}` | ok | ok |

### Regression window

Introduced in d9657b2a02 (2023-11-08, #28513), which added `stringifyFnsInObject` / `parseFunctionsInObject`. Present in every release since. **Not a recent regression.**

## Impact on existing instances

No migration, no config, no persisted data, no API surface. Client-only.

- **Fresh install / upgrade / rollback:** no action. The guard is a no-op on null-free input — `parseFunctionsInObject` only *collects paths*, it never writes output, so for any previously-working config the behaviour is bit-identical.
- **Behaviour change:** configs containing nulls now render instead of aborting evaluation. Nulls are preserved in the parsed output (not stripped), and `__fn_keys__` indices remain correct across skipped nulls — both asserted in tests. ECharts handles null data points natively.
- **Note:** previously the walk threw on the *first* null; it now runs to completion. On very large null-bearing datasets this trades an evaluation error for evaluation latency. Not a speedup.

## Tests

Added to existing homes rather than a new file:

- `workers/Evaluation/helpers.test.ts` → 4 cases in the existing `describe("stringifyFnsInObject")`: a null property, nulls in an array of query rows, nested function paths collected alongside null siblings, and array-index correctness when a null precedes a function.
- `workers/Evaluation/__tests__/validations.test.ts` → first `OBJECT_WITH_FUNCTION` coverage in that file, driving the real validator and asserting the parsed output (nulls preserved, functions stringified, config not silently replaced by the default).

Verified red without the source change and green with it (stashing `helpers.ts` only): exactly the 5 new tests fail, no others.

```text
npx jest src/workers/Evaluation/ src/workers/common/ src/widgets/ChartWidget/
  46 suites, 423 tests, all passing
eslint    0 errors (4 pre-existing Object.keys warnings, none on touched lines)
prettier  clean
tsc       no new errors
```

## Follow-ups (filed separately, not bundled)

1. **Blast radius** — move `validateAndParseWidgetProperty` inside the per-path `try/catch` so a single bad property can never abort the whole pass. High blast radius; needs its own PR and full Cypress.
2. **Sibling triggers** — BigInt, circular references, throwing getters, and pathological nesting still reach the same unguarded catch and reproduce the identical page-wide failure. Verified reproducible; best closed with a `try/catch` at the `OBJECT_WITH_FUNCTION` validator boundary.
3. **Observability** — `EVAL_TREE_ERROR` carries no property path, so a page-wide failure gives no clue which property caused it. Diagnosing this bug required a full customer console log.
4. **E2E gap** — the only Custom EChart Cypress spec is `describe.skip`ped.
5. **Perf** — `stringifyFnsInObject` deep-clones the whole evaluated value via `JSON.parse(JSON.stringify(...))` on every validation pass, uncached. Measurement-gated.

## Automation

/ok-to-test tags="@tag.All"

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/32091971531>
> Commit: 08eabeee4b13478c7e111c6ecaf1d01bbb31dfcd
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=32091971531&attempt=3" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 18 Aug 2026 13:14:27 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for configurations containing `null` values.
  * Preserved `null` values while correctly processing nested functions.
  * Maintained accurate function paths and array indices during configuration processing.

* **Tests**
  * Added coverage for top-level, nested, and array-based `null` values.
  * Added validation tests confirming defaults are not incorrectly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->