### PR TITLE
ci: migrate CE build cache from cibuildcache (Git LFS) to GitHub Actions Cache

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -136,7 +136,12 @@ jobs:
       - name: Get the previous run result
         if: steps.client-build-decision.outputs.need_build == 'true'
         id: run_result
-        run: cat ~/run_result 2>/dev/null || echo 'default'
+        run: |
+          if [[ -f "$HOME/run_result" ]]; then
+            cat "$HOME/run_result" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_result=default" >> "$GITHUB_OUTPUT"
+          fi
 
       # In case of prior failure run the job
       - if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
@@ -189,7 +194,7 @@ jobs:
       # This is to ensure that we don't need to configure it in each installation.
       # Client build fails only on errors (EXIT_CODE > 1); warnings (EXIT_CODE <= 1) don’t affect it.
       - name: Create the bundle
-        if: steps.client-build-decision.outputs.need_build == 'true'
+        if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
             export REACT_APP_SEGMENT_CE_KEY="${{ secrets.APPSMITH_SEGMENT_CE_KEY }}"
@@ -215,7 +220,7 @@ jobs:
       # Saving the cache to use it in subsequent runs
       - name: Save Yarn cache
         uses: actions/cache/save@v4
-        if: steps.cache-dependencies.outputs.cache-hit != 'true' && steps.client-build-decision.outputs.need_build == 'true'
+        if: steps.cache-dependencies.outputs.cache-hit != 'true' && steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         with:
           path: |
             app/client/.yarn/cache
@@ -253,4 +258,4 @@ jobs:
 
       # Set status = success
       - name: Save the status of the run
-        run: echo "run_result=success" >> $GITHUB_OUTPUT > ~/run_result
+        run: echo "run_result=success" > "$HOME/run_result"

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -66,6 +66,10 @@ jobs:
         with:
           fetch-tags: true
 
+      - name: Compute client source tree fingerprint
+        id: client-source-tree
+        run: echo "sha=$(git rev-parse HEAD:app/client)" >> "$GITHUB_OUTPUT"
+
       - name: Get changed files in the client folder
         id: changed-files-specific
         uses: tj-actions/changed-files@v46
@@ -100,24 +104,22 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: app/client/build.tar
-          key: release-client-v1-${{ github.run_id }}
-          restore-keys: release-client-v1-
+          key: release-client-v2-${{ steps.client-source-tree.outputs.sha }}
 
       - name: Determine whether the client build is needed
         id: client-build-decision
         env:
           CACHE_HIT: ${{ steps.restore-release-client-build.outputs.cache-hit }}
-          CACHE_MATCHED_KEY: ${{ steps.restore-release-client-build.outputs.cache-matched-key }}
           EVENT_NAME: ${{ github.event_name }}
           SIDE_CHANGED: ${{ steps.changed-files-specific.outputs.any_changed }}
         run: |
-          # cache-hit is false for restore-keys matches, so cache-matched-key
-          # distinguishes a warm prefix restore from an actual cache miss.
+          # Release caches use exact source-tree keys, so only cache-hit=true
+          # is safe to reuse. Skipped restores and misses both rebuild.
           if [[ "$SIDE_CHANGED" == "true" ||
                 "$EVENT_NAME" == "push" ||
                 "$EVENT_NAME" == "workflow_dispatch" ||
                 "$EVENT_NAME" == "schedule" ||
-                ( "$CACHE_HIT" != "true" && -z "$CACHE_MATCHED_KEY" ) ]]; then
+                "$CACHE_HIT" != "true" ]]; then
             echo "need_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "need_build=false" >> "$GITHUB_OUTPUT"
@@ -138,7 +140,7 @@ jobs:
         id: run_result
         run: |
           if [[ -f "$HOME/run_result" ]]; then
-            cat "$HOME/run_result" >> "$GITHUB_OUTPUT"
+            echo "run_result=$(cat "$HOME/run_result")" >> "$GITHUB_OUTPUT"
           else
             echo "run_result=default" >> "$GITHUB_OUTPUT"
           fi
@@ -254,8 +256,8 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: app/client/build.tar
-          key: release-client-v1-${{ github.run_id }}
+          key: release-client-v2-${{ steps.client-source-tree.outputs.sha }}
 
       # Set status = success
       - name: Save the status of the run
-        run: echo "run_result=success" > "$HOME/run_result"
+        run: echo "success" > "$HOME/run_result"

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -94,9 +94,37 @@ jobs:
           script: |
             await require("client-build-compliance.js")({core, github, context})
 
+      - name: Restore the release client build
+        id: restore-release-client-build
+        uses: actions/cache/restore@v4
+        with:
+          path: app/client/build.tar
+          key: release-client-v1-${{ github.run_id }}
+          restore-keys: release-client-v1-
+
+      - name: Determine whether the client build is needed
+        id: client-build-decision
+        env:
+          CACHE_HIT: ${{ steps.restore-release-client-build.outputs.cache-hit }}
+          CACHE_MATCHED_KEY: ${{ steps.restore-release-client-build.outputs.cache-matched-key }}
+          EVENT_NAME: ${{ github.event_name }}
+          SIDE_CHANGED: ${{ steps.changed-files-specific.outputs.any_changed }}
+        run: |
+          # cache-hit is false for restore-keys matches, so cache-matched-key
+          # distinguishes a warm prefix restore from an actual cache miss.
+          if [[ "$SIDE_CHANGED" == "true" ||
+                "$EVENT_NAME" == "push" ||
+                "$EVENT_NAME" == "workflow_dispatch" ||
+                "$EVENT_NAME" == "schedule" ||
+                ( "$CACHE_HIT" != "true" && -z "$CACHE_MATCHED_KEY" ) ]]; then
+            echo "need_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "need_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        if: steps.client-build-decision.outputs.need_build == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -105,16 +133,16 @@ jobs:
 
       # Fetch prior run result
       - name: Get the previous run result
-        if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        if: steps.client-build-decision.outputs.need_build == 'true'
         id: run_result
         run: cat ~/run_result 2>/dev/null || echo 'default'
 
       # In case of prior failure run the job
-      - if: steps.run_result.outputs.run_result != 'success' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+      - if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         run: echo "I'm alive!" && exit 0
 
       - name: Use Node.js
-        if: steps.run_result.outputs.run_result != 'success' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: app/client/package.json
@@ -123,7 +151,7 @@ jobs:
       # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
       # Restoring the cache manually instead
       - name: Restore Yarn cache
-        if: steps.run_result.outputs.run_result != 'success' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         uses: actions/cache@v4
         id: cache-dependencies
         with:
@@ -134,16 +162,16 @@ jobs:
 
       # Install all the dependencies
       - name: Install dependencies
-        if: steps.run_result.outputs.run_result != 'success' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         run: yarn install --immutable
 
       # Type checking before starting the build
       - name: Run type check
-        if: steps.run_result.outputs.run_result != 'success' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         run: yarn run check-types
 
       - name: Set the build environment based on the branch
-        if: steps.run_result.outputs.run_result != 'success' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success' && steps.client-build-decision.outputs.need_build == 'true'
         id: vars
         run: |
           set +o pipefail
@@ -160,7 +188,7 @@ jobs:
       # This is to ensure that we don't need to configure it in each installation.
       # Client build fails only on errors (EXIT_CODE > 1); warnings (EXIT_CODE <= 1) don’t affect it.
       - name: Create the bundle
-        if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        if: steps.client-build-decision.outputs.need_build == 'true'
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
             export REACT_APP_SEGMENT_CE_KEY="${{ secrets.APPSMITH_SEGMENT_CE_KEY }}"
@@ -186,7 +214,7 @@ jobs:
       # Saving the cache to use it in subsequent runs
       - name: Save Yarn cache
         uses: actions/cache/save@v4
-        if: steps.cache-dependencies.outputs.cache-hit != 'true' && (steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.cache-dependencies.outputs.cache-hit != 'true' && steps.client-build-decision.outputs.need_build == 'true'
         with:
           path: |
             app/client/.yarn/cache
@@ -195,7 +223,7 @@ jobs:
 
       # Restore the previous built bundle if present. If not push the newly built into the cache
       - name: Restore the previous bundle
-        if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        if: steps.client-build-decision.outputs.need_build == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -203,31 +231,9 @@ jobs:
           key: ${{ github.run_id }}-${{ github.job }}-client
 
       - name: Pack the client build directory
-        if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        if: steps.client-build-decision.outputs.need_build == 'true'
         run: |
           tar -cvf ./build.tar -C build .
-
-      - name: Fetch client build from cache
-        if: steps.changed-files-specific.outputs.any_changed == 'false' && success()  && github.event_name != 'push' && github.event_name != 'workflow_dispatch'  && github.event_name != 'schedule'
-        env:
-          cachetoken: ${{ secrets.CACHETOKEN }}
-          reponame: ${{ github.event.repository.name }}
-          gituser: ${{ secrets.CACHE_GIT_USER }}
-          gituseremail: ${{ secrets.CACHE_GIT_EMAIL }}
-        run: |
-          mkdir cacherepo
-          cd ./cacherepo
-          git lfs install
-          git config --global user.email "$gituseremail"
-          git config --global user.name "$gituser"
-          git clone https://$cachetoken@github.com/appsmithorg/cibuildcache.git
-          if [ "$reponame" = "appsmith" ]; then export repodir="CE"; fi
-          if [ "$reponame" = "appsmith-ee" ]; then export repodir="EE"; fi
-          cd cibuildcache/$repodir/release/client
-          git lfs install
-          git lfs migrate import --everything --yes
-          git lfs pull ./build.tar
-          mv ./build.tar ../../../../../build.tar
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload react build bundle
@@ -239,30 +245,10 @@ jobs:
 
       - name: Put release build in cache
         if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-        env:
-          cachetoken: ${{ secrets.CACHETOKEN }}
-          reponame: ${{ github.event.repository.name }}
-          gituser: ${{ secrets.CACHE_GIT_USER }}
-          gituseremail: ${{ secrets.CACHE_GIT_EMAIL }}
-        # git lfs update --force in the script below overrides appsmith git hooks with git lfs hooks since appsmith hooks are not required during workflow runs
-        run: |
-          pwd
-          mkdir cacherepo
-          cd ./cacherepo
-          git config --global user.email "$gituseremail"
-          git config --global user.name "$gituser"
-          git clone https://$cachetoken@github.com/appsmithorg/cibuildcache.git
-          git lfs update --force
-          git lfs install
-          cd cibuildcache/
-          if [ "$reponame" = "appsmith" ]; then export repodir="CE"; fi
-          if [ "$reponame" = "appsmith-ee" ]; then export repodir="EE"; fi
-          cd $repodir/release/client
-          cp ../../../../../build.tar ./
-          git lfs track "build.tar"
-          git add  build.tar
-          git commit --allow-empty -m "Update Latest build.tar"
-          git push
+        uses: actions/cache/save@v4
+        with:
+          path: app/client/build.tar
+          key: release-client-v1-${{ github.run_id }}
 
       # Set status = success
       - name: Save the status of the run

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -95,6 +95,7 @@ jobs:
             await require("client-build-compliance.js")({core, github, context})
 
       - name: Restore the release client build
+        if: steps.changed-files-specific.outputs.any_changed == 'false' && github.event_name != 'push' && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
         id: restore-release-client-build
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -118,9 +118,37 @@ jobs:
           echo "List all the files that have changed:"
           cat "${{ github.workspace }}/.github/outputs/all_modified_files.txt"
 
+      - name: Restore the release server build
+        id: restore-release-server-build
+        uses: actions/cache/restore@v4
+        with:
+          path: app/server/server.jar
+          key: release-server-v1-${{ github.run_id }}
+          restore-keys: release-server-v1-
+
+      - name: Determine whether the server build is needed
+        id: server-build-decision
+        env:
+          CACHE_HIT: ${{ steps.restore-release-server-build.outputs.cache-hit }}
+          CACHE_MATCHED_KEY: ${{ steps.restore-release-server-build.outputs.cache-matched-key }}
+          EVENT_NAME: ${{ github.event_name }}
+          SIDE_CHANGED: ${{ steps.changed-files-specific.outputs.any_modified }}
+        run: |
+          # cache-hit is false for restore-keys matches, so cache-matched-key
+          # distinguishes a warm prefix restore from an actual cache miss.
+          if [[ "$SIDE_CHANGED" == "true" ||
+                "$EVENT_NAME" == "push" ||
+                "$EVENT_NAME" == "workflow_dispatch" ||
+                "$EVENT_NAME" == "schedule" ||
+                ( "$CACHE_HIT" != "true" && -z "$CACHE_MATCHED_KEY" ) ]]; then
+            echo "need_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "need_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        if: inputs.skip-tests != 'true' && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: inputs.skip-tests != 'true' && steps.server-build-decision.outputs.need_build == 'true'
         id: cache-appsmith
         uses: actions/cache@v4
         with:
@@ -130,7 +158,7 @@ jobs:
 
       # Fetch prior run result
       - name: Get the previous run result
-        if: inputs.skip-tests != 'true' && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: inputs.skip-tests != 'true' && steps.server-build-decision.outputs.need_build == 'true'
         id: run_result
         run: |
           if [ -f ~/run_result ]; then
@@ -155,7 +183,7 @@ jobs:
           echo "tests=$failed_tests" >> $GITHUB_OUTPUT
 
       # In case of prior failure run the job
-      - if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+      - if: steps.run_result.outputs.run_result != 'success' && steps.server-build-decision.outputs.need_build == 'true'
         run: echo "I'm alive!" && exit 0
 
       # Setup Java
@@ -170,7 +198,7 @@ jobs:
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies
-        if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success' && steps.server-build-decision.outputs.need_build == 'true'
         uses: actions/cache@v4
         env:
           cache-name: cache-maven-dependencies
@@ -182,7 +210,7 @@ jobs:
 
       # Build the code
       - name: Build
-        if: steps.run_result.outputs.run_result != 'success'  && (steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+        if: steps.run_result.outputs.run_result != 'success' && steps.server-build-decision.outputs.need_build == 'true'
         run: |
           ./build.sh -DskipTests
 
@@ -313,38 +341,22 @@ jobs:
           if-no-files-found: ignore
           overwrite: true
 
-      - name: Fetch server build from cache
-        if: steps.changed-files-specific.outputs.any_modified == 'false' && success()  && github.event_name != 'push' && github.event_name != 'workflow_dispatch'  && github.event_name != 'schedule'
-        env:
-          cachetoken: ${{ secrets.CACHETOKEN }}
-          reponame: ${{ github.event.repository.name }}
-          gituser: ${{ secrets.CACHE_GIT_USER }}
-          gituseremail: ${{ secrets.CACHE_GIT_EMAIL }}
-        run: |
-          mkdir cacherepo
-          cd ./cacherepo
-          git lfs install
-          git config --global user.email "$gituseremail"
-          git config --global user.name "$gituser"
-          git clone https://$cachetoken@github.com/appsmithorg/cibuildcache.git
-          if [ "$reponame" = "appsmith" ]; then export repodir="CE"; fi
-          if [ "$reponame" = "appsmith-ee" ]; then export repodir="EE"; fi
-          cd cibuildcache/$repodir/release/server
-          git lfs install
-          git lfs migrate import --everything --yes
-          git lfs pull ./server.jar
-          mv ./server.jar ../../../../../server.jar
-          cd ../../../../../
-          tar -xzvf ./server.jar
-
       # Restore the previous built bundle if present. If not push the newly built into the cache
       - name: Restore the previous bundle
-        if: steps.changed-files-specific.outputs.any_modified == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: steps.server-build-decision.outputs.need_build == 'true'
         uses: actions/cache@v4
         with:
           path: |
             app/server/dist/
           key: ${{ github.run_id }}-${{ github.job }}-server
+
+      - name: Pack the server build directory
+        if: steps.server-build-decision.outputs.need_build == 'true'
+        run: tar -czvf server.jar dist/
+
+      - name: Extract the cached server build
+        if: steps.server-build-decision.outputs.need_build == 'false'
+        run: tar -xzvf server.jar
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle
@@ -356,29 +368,10 @@ jobs:
 
       - name: Put release build in cache
         if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-        env:
-          cachetoken: ${{ secrets.CACHETOKEN }}
-          reponame: ${{ github.event.repository.name }}
-          gituser: ${{ secrets.CACHE_GIT_USER }}
-          gituseremail: ${{ secrets.CACHE_GIT_EMAIL }}
-        run: |
-          pwd
-          tar -czvf server.jar dist/
-          mkdir cacherepo
-          cd ./cacherepo
-          git config --global user.email "$gituseremail"
-          git config --global user.name "$gituser"
-          git clone https://$cachetoken@github.com/appsmithorg/cibuildcache.git
-          git lfs install
-          cd cibuildcache/
-          if [ "$reponame" = "appsmith" ]; then export repodir="CE"; fi
-          if [ "$reponame" = "appsmith-ee" ]; then export repodir="EE"; fi
-          cd $repodir/release/server
-          cp ../../../../../server.jar ./
-          git lfs track "server.jar"
-          git add  server.jar
-          git commit --allow-empty -m "Update Latest Server.jar"
-          git push
+        uses: actions/cache/save@v4
+        with:
+          path: app/server/server.jar
+          key: release-server-v1-${{ github.run_id }}
 
       - name: Save the status of the run
         run: echo "run_result=success" >> $GITHUB_OUTPUT > ~/run_result

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -91,6 +91,10 @@ jobs:
         with:
           fetch-tags: true
 
+      - name: Compute server source tree fingerprint
+        id: server-source-tree
+        run: echo "sha=$(git rev-parse HEAD:app/server)" >> "$GITHUB_OUTPUT"
+
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}
 
@@ -124,24 +128,22 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: app/server/server.jar
-          key: release-server-v1-${{ github.run_id }}
-          restore-keys: release-server-v1-
+          key: release-server-v2-${{ steps.server-source-tree.outputs.sha }}
 
       - name: Determine whether the server build is needed
         id: server-build-decision
         env:
           CACHE_HIT: ${{ steps.restore-release-server-build.outputs.cache-hit }}
-          CACHE_MATCHED_KEY: ${{ steps.restore-release-server-build.outputs.cache-matched-key }}
           EVENT_NAME: ${{ github.event_name }}
           SIDE_CHANGED: ${{ steps.changed-files-specific.outputs.any_modified }}
         run: |
-          # cache-hit is false for restore-keys matches, so cache-matched-key
-          # distinguishes a warm prefix restore from an actual cache miss.
+          # Release caches use exact source-tree keys, so only cache-hit=true
+          # is safe to reuse. Skipped restores and misses both rebuild.
           if [[ "$SIDE_CHANGED" == "true" ||
                 "$EVENT_NAME" == "push" ||
                 "$EVENT_NAME" == "workflow_dispatch" ||
                 "$EVENT_NAME" == "schedule" ||
-                ( "$CACHE_HIT" != "true" && -z "$CACHE_MATCHED_KEY" ) ]]; then
+                "$CACHE_HIT" != "true" ]]; then
             echo "need_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "need_build=false" >> "$GITHUB_OUTPUT"
@@ -372,7 +374,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: app/server/server.jar
-          key: release-server-v1-${{ github.run_id }}
+          key: release-server-v2-${{ steps.server-source-tree.outputs.sha }}
 
       - name: Save the status of the run
-        run: echo "run_result=success" >> $GITHUB_OUTPUT > ~/run_result
+        run: echo "success" > "$HOME/run_result"

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -119,6 +119,7 @@ jobs:
           cat "${{ github.workspace }}/.github/outputs/all_modified_files.txt"
 
       - name: Restore the release server build
+        if: steps.changed-files-specific.outputs.any_modified == 'false' && github.event_name != 'push' && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
         id: restore-release-server-build
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
## Summary

- Replace the CE client and server Git-LFS `cibuildcache` reads/writes with GitHub Actions Cache restore/save actions.
- Keep `build.tar` and `server.jar` as the cache payloads; preserve the existing uploaded artifact contracts consumed by Cypress, deploy previews, `/ok-to-test`, releases, and airgap packaging.
- Fall back to a source build whenever the relevant side changed, the event writes the release cache, or no cache key was restored.

## Why

The one-time Git LFS purge is already complete, but continued workflow writes would regrow `cibuildcache` and restore the approximately **$430/month** Git LFS cost. Moving the release build cache to GitHub Actions Cache removes that regrowth path.

- Slack context: https://theappsmith.slack.com/archives/C09NG5BJ18S/p1787051964051609
- Cost analysis: https://app.notion.com/p/appsmith/GH-Cost-Optimization-WIP-3c0fe271b0e280569709cc12ada7af01

## Design

- Compute tracked Git tree fingerprints for `app/client` and `app/server` immediately after checkout.
- Restore client `app/client/build.tar` with exact key `release-client-v2-<client-tree-sha>`.
- Restore server `app/server/server.jar` with exact key `release-server-v2-<server-tree-sha>`.
- Compute `need_build` from side changes, `push`/`workflow_dispatch`/`schedule`, or a true cache miss.
- Reuse a release bundle only on an exact `cache-hit=true`; misses and skipped restores rebuild from source.
- Build and pack only when `need_build=true`; otherwise use the restored tarball.
- Save only successful release writing events under the same content-addressed tree key, so unchanged schedules deduplicate and concurrent source versions cannot overwrite each other.
- Keep the client artifact as `build.tar`. For the server, extract cached `server.jar` back to `dist/` before the existing `server-build` artifact upload, preserving every downstream consumer's current layout.

## Impact on existing instances

- **CI-only change:** no product, runtime, installation, or deploy-artifact format impact.
- **Fresh run / cold cache:** builds from source, packages the same payload, and continues.
- **Warm cache:** unchanged PR sides reuse the newest release cache through the restore prefix.
- **Upgrade from default or customized instances:** no instance configuration or persisted state changes.
- **Rollback:** revert this commit to restore the prior Git-LFS workflow; no data migration is required.

## CE / EE sync

- `client-build.yml`: CE and EE share the legacy client cache mechanism. The cache migration is intended to sync into EE; however, EE has airgap-specific surrounding build logic, so the hourly sync must still be observed rather than assumed conflict-free.
- `server-build.yml`: **divergent by design.** EE has no `cibuildcache` server steps and builds fresh. This CE server change will not map cleanly through hourly sync and requires a planned EE-specific companion change or careful sync-conflict resolution. This PR does not edit EE.

## Pending before Ready

- [ ] @Wyatt approves the approach.
- [ ] Add the Linear issue link.
- [ ] Run Cypress by adding `/ok-to-test tags="@tag.All"` to Automation and applying the `ok-to-test` label.
- [ ] Plan the EE `server-build.yml` sync/companion work.

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/32515003182>
> Commit: 1972a0f3157f81f62b3d287f4aca6e9403ddf6c0
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=32515003182&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Sat, 22 Aug 2026 02:09:54 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication

Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Build and Release Improvements

- Release builds now more reliably reuse unchanged client and server bundles.
- Builds automatically rerun when source changes or cached results are unavailable.
- Client and server release artifacts are packaged consistently for restoration.
- Build status reporting is more consistent across release workflows.
- Improved cache handling reduces unnecessary rebuilds and supports more predictable release results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


