### PR TITLE
chore: remove legacy Intercom env fallbacks after Pylon migration

### DIFF
--- a/.github/workflows/ci-test-playwright.yml
+++ b/.github/workflows/ci-test-playwright.yml
@@ -171,7 +171,7 @@ jobs:
             -v "$PWD/stacks:/appsmith-stacks" \
             -e APPSMITH_LICENSE_KEY="$APPSMITH_LICENSE_KEY" \
             -e APPSMITH_DISABLE_TELEMETRY=true \
-            -e APPSMITH_INTERCOM_APP_ID=DUMMY_VALUE \
+            -e APPSMITH_PYLON_APP_ID=DUMMY_VALUE \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
             -e APPSMITH_CLOUD_SERVICES_SIGNATURE_BASE_URL=http://host.docker.internal:8090 \
             -e APPSMITH_RATE_LIMIT=1000 \

--- a/app/client/.env.example
+++ b/app/client/.env.example
@@ -4,6 +4,3 @@
 # Pylon in-app chat — APP_ID from https://app.usepylon.com/settings/in-app-chat
 # Docs: https://docs.usepylon.com/pylon-docs/chat-widget/chat-setup
 REACT_APP_PYLON_APP_ID=
-
-# Legacy: Intercom app id (only if you have not migrated env vars yet)
-# REACT_APP_INTERCOM_APP_ID=

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -180,13 +180,9 @@
 
       const PYLON_APP_ID_RAW =
         parseConfig("%REACT_APP_PYLON_APP_ID%") ||
-        parseConfig("%REACT_APP_INTERCOM_APP_ID%") ||
-        parseConfig('{{env "APPSMITH_PYLON_APP_ID"}}') ||
-        parseConfig('{{env "APPSMITH_INTERCOM_APP_ID"}}');
-      const DISABLE_PYLON =
-        parseConfig('{{env "APPSMITH_DISABLE_PYLON"}}') ||
-        parseConfig('{{env "APPSMITH_DISABLE_INTERCOM"}}');
-      // No third-party chat widget on airgapped deployments (same as BetterBugs / legacy Intercom)
+        parseConfig('{{env "APPSMITH_PYLON_APP_ID"}}');
+      const DISABLE_PYLON = parseConfig('{{env "APPSMITH_DISABLE_PYLON"}}');
+      // No third-party chat widget on airgapped deployments (same as BetterBugs)
       const PYLON_APP_ID =
         AIRGAPPED || typeof PYLON_APP_ID_RAW !== "string"
           ? ""

--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -118,10 +118,7 @@ export const getConfigsFromEnvVars = (): INJECTED_CONFIGS => {
       releaseDate: "",
       edition: process.env.REACT_APP_VERSION_EDITION || "",
     },
-    pylonAppID:
-      process.env.REACT_APP_PYLON_APP_ID ||
-      process.env.REACT_APP_INTERCOM_APP_ID ||
-      "",
+    pylonAppID: process.env.REACT_APP_PYLON_APP_ID || "",
     mailEnabled: process.env.REACT_APP_MAIL_ENABLED
       ? process.env.REACT_APP_MAIL_ENABLED.length > 0
       : false,


### PR DESCRIPTION
## Description

The Intercom chat widget (`widget.intercom.io`) was already replaced by Pylon in #41722. This PR removes leftover **Intercom environment variable fallbacks** that could still treat an old `APPSMITH_INTERCOM_APP_ID` / `REACT_APP_INTERCOM_APP_ID` as a Pylon app id.

Changes:
- Drop Intercom app-id / disable-env fallbacks from `index.html` and client configs
- Remove legacy Intercom note from `app/client/.env.example`
- Align Playwright CI dummy env with `APPSMITH_PYLON_APP_ID` (matching other CI workflows)

Out of scope: renaming `IntercomConsent` / `isIntercomConsentGiven` (those still gate Pylon consent UX/API).

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

## Test plan
- [ ] Confirm grep finds no `APPSMITH_INTERCOM` / `REACT_APP_INTERCOM` / `DISABLE_INTERCOM` / `widget.intercom`
- [ ] With only `APPSMITH_PYLON_APP_ID` set, Pylon stub/boot still works
- [ ] With only legacy Intercom env vars set (and no Pylon vars), chat widget no longer activates


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated customer support chat configuration to use the Pylon application ID exclusively.
  * Removed legacy Intercom configuration fallbacks and environment variable guidance.
  * Improved air-gapped deployment messaging to reference third-party chat restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->