### PR TITLE
chore(mongo): upgrade embedded MongoDB from 7.0 to 8.0

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -62,10 +62,9 @@ RUN set -o xtrace \
     software-properties-common \
     git \
   && add-apt-repository -y ppa:git-core/ppa \
-  # Install MongoDB v7, PostgreSQL v14
-  # Note: MongoDB 7.0 does not publish apt packages for Ubuntu 24.04 (noble) yet, so we use the jammy (22.04) packages — same pattern used for the previous 6.0 install.
-  && curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg \
-  && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
+  # Install MongoDB v8, PostgreSQL v14
+  && curl -fsSL https://pgp.mongodb.com/server-8.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg \
+  && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list \
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -324,24 +324,25 @@ init_replica_set() {
   fi
 }
 
-# Pre-flight check for embedded MongoDB 7.0 upgrades on existing data.
+# Pre-flight check for embedded MongoDB 8.0 upgrades on existing data.
 #
-# MongoDB 7.0 refuses to start on data whose featureCompatibilityVersion (FCV)
-# is below 6.0. Without a check up front, supervisord would retry mongod a few
+# MongoDB 8.0 refuses to start on data whose featureCompatibilityVersion (FCV)
+# is below 7.0. Without a check up front, supervisord would retry mongod a few
 # times and give up, leaving the container in a confusing degraded state with
 # no clear error for the administrator.
 #
 # Fast path: marker file ($MONGO_DB_PATH/.appsmith-mongo-fcv-min) is written by
-# mongodb-fixer.sh only after mongod is confirmed running under this Appsmith
-# release. Its presence proves this release has already booted successfully on
-# this data, so the probe can be skipped with zero overhead. Contents record
-# the FCV floor this release commits to, for future upgrade decisions; they
-# aren't consulted here.
+# mongodb-fixer.sh only after mongod is confirmed running under an Appsmith
+# release, and records the FCV floor that release commits to preserve. A marker
+# at or above the floor mongod 8.x needs (7.0) proves the data is loadable, so
+# the probe can be skipped with zero overhead. Markers below 7.0 (written by
+# releases 2.0 and 2.1, whose floor was 6.0) prove nothing about mongod 8.x
+# compatibility, so they fall through to the probe.
 #
-# First boot after upgrade: no marker yet. Do a one-time mongod --fork probe
-# to verify the data is compatible. If it starts, proceed; the fixer will
-# write the marker after supervisord brings mongod up for real. If it fails,
-# print an actionable error and exit.
+# No marker, or a marker below the floor: do a one-time mongod --fork probe to
+# verify the data is compatible. If it starts, proceed; the fixer will write
+# the current floor's marker after supervisord brings mongod up for real. If
+# it fails, print an actionable error and exit.
 ensure_mongodb_fcv_compatible() {
   # Only applies to existing local-Mongo data — fresh installs have nothing to
   # check, and external Mongo is out of our control.
@@ -349,13 +350,22 @@ ensure_mongodb_fcv_compatible() {
     return
   fi
 
+  # Minimum FCV the embedded MongoDB 8.x binary can load.
+  local mongod_fcv_floor=7
+
   local marker="$MONGO_DB_PATH/.appsmith-mongo-fcv-min"
   if [[ -f "$marker" ]]; then
-    tlog "MongoDB FCV marker present; skipping pre-flight check"
-    return
+    local marker_value marker_major
+    marker_value="$(head -n 1 "$marker" 2>/dev/null | tr -d '[:space:]' || true)"
+    marker_major="${marker_value%%.*}"
+    if [[ "$marker_major" =~ ^[0-9]+$ ]] && (( marker_major >= mongod_fcv_floor )); then
+      tlog "MongoDB FCV marker ($marker_value) meets the $mongod_fcv_floor.0 floor; skipping pre-flight check"
+      return
+    fi
+    tlog "MongoDB FCV marker ($marker_value) is below the $mongod_fcv_floor.0 floor required by MongoDB 8.x; running one-time compatibility probe"
+  else
+    tlog "No MongoDB FCV marker found on existing data; running one-time compatibility probe"
   fi
-
-  tlog "No MongoDB FCV marker found on existing data; running one-time compatibility probe"
   # Persist the probe log inside the Mongo data directory so it survives container
   # restarts. $TMP would be wiped, leaving no forensic trail when an admin comes
   # back to investigate why their container exited. Append rather than truncate so
@@ -375,21 +385,21 @@ ensure_mongodb_fcv_compatible() {
   probe_err="$(grep -Ei 'featurecompatibilityversion|upgrade|downgrade' "$probe_log" 2>/dev/null | tail -n 1 || true)"
   tlog "====================================================================================================" >&2
   tlog "==" >&2
-  tlog "== ERROR: Embedded MongoDB 7.0 failed to start on the existing data. The most common cause is that the data is at featureCompatibilityVersion below the required 6.0 minimum." >&2
+  tlog "== ERROR: Embedded MongoDB 8.0 failed to start on the existing data. The most common cause is that the data is at featureCompatibilityVersion below the required 7.0 minimum." >&2
   if [[ -n "$probe_err" ]]; then
     tlog "== mongod log: $probe_err" >&2
   fi
   tlog "==" >&2
   tlog "== About this error:" >&2
-  tlog "==   Appsmith 2.x ships with MongoDB 7.x, which requires the database to be at featureCompatibilityVersion (FCV) 6.0 or higher. Appsmith releases 1.96 to 1.99 automatically raise FCV to 6.0 on boot, so any instance that has run one of those releases is fine. Instances that have only ever run Appsmith older than 1.70 may still be at FCV 5.0, which MongoDB 7.x refuses to load." >&2
+  tlog "==   This Appsmith release ships with MongoDB 8.x, which requires the database to be at featureCompatibilityVersion (FCV) 7.0 or higher. Appsmith releases 2.2 and 2.3 automatically raise FCV to 7.0 on boot, so any instance that has run one of those releases is fine. Instances upgrading directly from Appsmith 2.1 or older may still be at a lower FCV, which MongoDB 8.x refuses to load." >&2
   tlog "==" >&2
   tlog "==   This check only runs for instances using the embedded MongoDB. Instances configured with an external MongoDB are not affected." >&2
   tlog "==" >&2
-  tlog "==   The failure happens during MongoDB pre-flight, before any Appsmith service comes online. No Appsmith database migrations have been attempted, so rolling back to a 1.x release is simply a matter of changing the image version on your deployment." >&2
+  tlog "==   The failure happens during MongoDB pre-flight, before any Appsmith service comes online. No Appsmith database migrations have been attempted, so rolling back to your previous release is simply a matter of changing the image version on your deployment." >&2
   tlog "==" >&2
   tlog "== To recover:" >&2
   tlog "==" >&2
-  tlog "==   1. Alter your Appsmith deployment to use a release in the 1.96 to 1.99 range (we recommend the latest, 1.99). These ship with MongoDB 6.x and will raise the compatibility version automatically." >&2
+  tlog "==   1. Alter your Appsmith deployment to use release v2.2 or v2.3 (we recommend the latest, v2.3). These ship with MongoDB 7.x and will raise the compatibility version to 7.0 automatically. If that release also refuses to start, follow the instructions it prints — data from very old releases may need an additional hop." >&2
   tlog "==   2. Let the container start fully so the MongoDB FCV upgrade completes." >&2
   tlog "==   3. Shut down, then alter your Appsmith deployment to use this version again." >&2
   tlog "==" >&2

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -358,11 +358,13 @@ ensure_mongodb_fcv_compatible() {
     local marker_value marker_major
     marker_value="$(head -n 1 "$marker" 2>/dev/null | tr -d '[:space:]' || true)"
     marker_major="${marker_value%%.*}"
-    if [[ "$marker_major" =~ ^[0-9]+$ ]] && (( marker_major >= mongod_fcv_floor )); then
+    # The full value must be a well-formed major.minor FCV before the major is
+    # trusted — anything malformed falls through to the probe.
+    if [[ "$marker_value" =~ ^[0-9]+\.[0-9]+$ ]] && (( marker_major >= mongod_fcv_floor )); then
       tlog "MongoDB FCV marker ($marker_value) meets the $mongod_fcv_floor.0 floor; skipping pre-flight check"
       return
     fi
-    tlog "MongoDB FCV marker ($marker_value) is below the $mongod_fcv_floor.0 floor required by MongoDB 8.x; running one-time compatibility probe"
+    tlog "MongoDB FCV marker ($marker_value) does not meet the $mongod_fcv_floor.0 floor required by MongoDB 8.x; running one-time compatibility probe"
   else
     tlog "No MongoDB FCV marker found on existing data; running one-time compatibility probe"
   fi

--- a/deploy/docker/fs/opt/appsmith/mongodb-fixer.sh
+++ b/deploy/docker/fs/opt/appsmith/mongodb-fixer.sh
@@ -13,21 +13,21 @@ set -o nounset
 # current FCV. Use `mongosh` if you want the live value.
 MONGO_FCV_MIN_MARKER="/appsmith-stacks/data/mongodb/.appsmith-mongo-fcv-min"
 
-# Minimum FCV this Appsmith release commits to preserve. We raise this to 7.0
-# (up from 6.0) as groundwork for the upcoming MongoDB 8.x upgrade: MongoDB 8.x
-# refuses to start on data below FCV 7.0, so we bump the data to 7.0 now, while
-# this release still runs MongoDB 7.x. A later release can then ship MongoDB 8.x
-# and boot cleanly on data that is already at FCV 7.0.
+# Minimum FCV this Appsmith release commits to preserve. This release ships
+# MongoDB 8.x, whose binary requires FCV >= 7.0 to start — the same value as
+# this floor, so the pre-flight check in
+# entrypoint.sh::ensure_mongodb_fcv_compatible enforces it before supervisord
+# ever launches mongod.
 #
-# This release still ships MongoDB 7.x, whose binary only requires FCV >= 6.0 to
-# start (see entrypoint.sh::ensure_mongodb_fcv_compatible). The 7.0 floor here is
-# forward-prep applied by the block below, not a startup requirement yet — the
-# pre-flight check in entrypoint.sh is intentionally left at the 6.0 mongod floor.
+# The floor deliberately stays at 7.0 rather than 8.0: data left at FCV 7.0 can
+# still be loaded by MongoDB 7.x, so rolling back to an Appsmith release that
+# bundles MongoDB 7.x (2.0 through 2.3) keeps working. A later release will
+# raise this to 8.0 as groundwork for a future MongoDB 9.x upgrade, and only
+# then is that rollback line crossed.
 #
-# Tradeoff: raising FCV to 7.0 forfeits the ability to roll back to an Appsmith
-# release that bundles MongoDB 6.x (1.99 and earlier) without first deleting the
-# Mongo data files. Instances on this release are well past that line, so this is
-# an accepted one-way step.
+# Note: fresh installs of this release get FCV 8.0 (mongod 8.x's default for
+# new data), not this floor — the block below only ever raises FCV, it never
+# lowers it.
 FCV_MIN="7.0"
 
 write_fcv_marker() {


### PR DESCRIPTION
## Description

Upgrades the embedded MongoDB in the Docker image from 7.0.x to 8.0.x (latest patch of the 8.0 LTS line via the apt series pin; currently 8.0.29). The 8.0 series publishes Ubuntu 24.04 (noble) packages, so the jammy-packages-on-noble workaround is gone too.

MongoDB 8.x refuses to start on data below featureCompatibilityVersion (FCV) 7.0. Releases v2.2/v2.3 already raise FCV to 7.0 on boot (#41922), so instances that have run either upgrade cleanly. The startup pre-flight is adapted for the cases that haven't:

- The FCV marker fast-path now checks the marker's **value**, not just its presence. Markers written by v2.0/v2.1 contain `6.0` (their committed floor) and prove nothing about mongod 8.x compatibility — they fall through to the one-time `mongod` probe. Under the old presence-only check, that data would have skipped straight into a supervisord crash-loop.
- The probe failure message now points operators at the v2.2/v2.3 hop.
- `mongodb-fixer.sh`'s committed floor stays at **7.0** — same two-step pattern as the 6→7 upgrade — so rollback to the MongoDB-7-based releases (v2.0–v2.3) keeps working. Raising the floor to 8.0 is a later release's groundwork for MongoDB 9.

External MongoDB instances are unaffected: the pre-flight and fixer only run for the embedded database (`isUriLocal`), unchanged.

Linear: https://linear.app/appsmith/issue/APP-14888

## Impact on existing instances

- **Fresh install**: mongod 8.0.x, new data at FCV 8.0 (mongod default), marker `7.0`. No probe runs.
- **Upgrade from default v2.2/v2.3**: marker `7.0` fast-path, no probe, FCV stays 7.0.
- **Upgrade from v2.0/v2.1**: marker `6.0` → probe runs once. Data actually at FCV 7.0 (fresh 2.x installs): probe passes, marker rewritten. Data at FCV 6.0 (upgraded from 1.x): container exits 1 pre-flight with instructions to hop through v2.2/v2.3. No migrations have run at that point, so rollback is just an image-tag change.
- **Upgrade from ≤ v1.99**: no marker, FCV ≤ 6.0 → probe fails fast with the same guidance (possibly two hops for pre-1.96 data — the v2.3 pre-flight's own message covers that leg).
- **Rollback**: v2.4 → v2.2/v2.3 works for upgraded data (FCV stays 7.0). A *fresh* v2.4 install rolled back to v2.3 will not start (FCV 8.0 data; same one-way property fresh v2.0 installs had toward 1.x).
- **External MongoDB**: no behavior change.

## Call sites checked

- `ensure_mongodb_fcv_compatible` (entrypoint.sh) — only consumer of the marker file; updated.
- `mongodb-fixer.sh` — only writer of the marker file; floor unchanged at 7.0, comments updated.
- `base.dockerfile` — only place the embedded mongod version is installed. mongosh comes from the same 8.0 repo; mongo database tools are built from source at 100.17.0, which supports server 8.0.
- Server: Spring Boot 3.5.16 → mongodb-driver 5.5.x, supports MongoDB 8.0.
- RTS/appsmithctl: node `mongodb@^5.8.0` — officially supports ≤7.0, but its usage (hello/admin commands; backup shells out to mongodump) verified working against 8.0 in the validation runs below. Driver bump tracked separately.
- Helm: the MongoDBCommunity operator preview already deploys 8.0.20; the Bitnami subchart is a separate (pre-existing) concern not touched here.

## Validation

Local Docker upgrade-path matrix, run against this PR's DP image (`appsmith/appsmith-dp:ce-42153`, mongod 8.0.29) — all passed:

- [x] fresh install → mongod 8.0.x, FCV 8.0, marker 7.0, no probe
- [x] v2.3 → this (marker fast path, no probe, FCV stays 7.0)
- [x] fresh v2.1 → this (marker 6.0 + FCV 7.0 → probe runs, passes, marker rewritten to 7.0)
- [x] v1.99 → this (container exits 1 pre-flight with recovery guidance)
- [x] v1.99 → v2.1 → this (marker 6.0 + FCV 6.0 → fails fast, **not** a crash-loop) → v2.3 (FCV raised to 7.0) → this (boots via fast path)
- [x] v2.3 → this as UID 1000:1000 (non-root)
- [x] external MongoDB 8 replica set (no probe, no marker activity, full server boot)
- [x] appsmithctl backup against mongo 8 (archive created; node driver 5.8 + mongodump 100.17.0 both fine)

## Automation

/ok-to-test tags="@tag.All"

<!-- Cypress will be triggered via the ok-to-test label once the DP build is green -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34354025984>
> Commit: 45d1f724ac83aef342c12ddc69dbb626d8973bfe
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34354025984&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: @tag.All
> Spec: 
> It seems like **no tests ran** 😔. We are not able to recognize it, please check <a href="https://github.com/appsmithorg/appsmith/actions/runs/34354025984" target="_blank">workflow here</a>.
> <hr>Wed, 09 Sep 2026 19:04:31 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Deployments now use MongoDB 8.0 on Ubuntu Noble.
  * MongoDB 8.x compatibility checks require a minimum feature compatibility version of 7.0.
  * Fresh installations default to feature compatibility version 8.0.

* **Bug Fixes**
  * Improved detection and recovery messaging for existing MongoDB installations.
  * Preserved MongoDB 7.x compatibility during rollback scenarios.

* **Documentation**
  * Updated MongoDB upgrade guidance and future compatibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->