### PR TITLE
ci: add concurrency guard to test-build-docker-image workflow

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -32,6 +32,10 @@ on:
       - "Dockerfile"
       - "deploy/docker/base.dockerfile"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -134,13 +138,13 @@ jobs:
 
   ci-test-result:
     needs: [ci-test, client-unit-tests, server-unit-tests]
-    if: always() &&
+    if: "!cancelled() &&
       (github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
       ( github.event_name != 'push' || github.ref == 'refs/heads/master' ) ||
       (github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
-      github.event.pull_request.head.repo.full_name == github.repository))
+      github.event.pull_request.head.repo.full_name == github.repository))"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -301,7 +305,7 @@ jobs:
       id-token: write
 
     # Run this job as soon as the docker image is ready, if this is the release branch
-    if: ( always() && github.ref == 'refs/heads/release' )
+    if: ( !cancelled() && github.ref == 'refs/heads/release' )
 
     steps:
       - name: Checkout the head commit of the branch


### PR DESCRIPTION
## Summary

`test-build-docker-image.yml` has no concurrency guard. When two commits land
on the same branch in quick succession (back-to-back PR merges, or a push
overlapping a scheduled run), two full workflow runs execute in parallel:

- Both build client, server, and RTS independently — wasting CI minutes
- Both push the same Docker Hub tag (e.g. `:release`) — the slower (older SHA)
  run can overwrite the newer image
- `always()` on `ci-test-result` and `package-release` means a cancelled run
  still attempts downstream work with missing artifacts

### Changes

1. **Add `concurrency:` block** keyed on `workflow + ref` with
   `cancel-in-progress: true` — second push cancels the first, only the latest
   SHA is built and published.
2. **Replace `always()` with `!cancelled()`** on `ci-test-result` and
   `package-release` — these jobs still run on success *or* failure, but no
   longer fire on cancellation (where artifacts are missing and work is wasted).

### Impact on existing instances

None. This is a CI-only change — no product code, no deployment artifact, no
config change.

## Test plan

- [x] YAML syntax validated (`yaml.safe_load`)
- [ ] Verify next scheduled run on `master` completes normally
- [ ] Simulate: merge two PRs back-to-back → confirm first run is cancelled

https://linear.app/appsmith/issue/APP-15832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build workflow management by canceling outdated in-progress runs.
  * Prevented follow-up testing and packaging steps from running after a workflow is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->