### PR TITLE
fix(plugins): run blocking plugin I/O on the bounded-elastic scheduler and bound socket timeouts

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/SSHUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/SSHUtils.java
@@ -43,6 +43,16 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 @NoArgsConstructor
 public class SSHUtils {
     public static final Long DEFAULT_SSH_PORT = 22L;
+
+    /**
+     * Socket bounds for the SSH tunnel; sshj's defaults are infinite. SSH_SOCKET_TIMEOUT_MS is the socket
+     * SO_TIMEOUT for the life of the tunnel: it bounds the initial banner/kex/auth reads, and on an idle tunnel
+     * sshj's transport Reader catches the resulting SocketTimeoutException and keeps reading (sshj >= 0.35).
+     * Do not lower the sshj version below that without revisiting this value.
+     */
+    public static final int SSH_CONNECT_TIMEOUT_MS = 10_000;
+
+    public static final int SSH_SOCKET_TIMEOUT_MS = 30_000;
     static Object monitor = new Object(); // monitor object to be used for synchronization lock
     public static final int RANDOM_FREE_PORT_NUM = 0; // using port 0 indicates `bind` method to acquire random free
     // port
@@ -65,6 +75,21 @@ public class SSHUtils {
     public static SSHTunnelContext createSSHTunnel(
             String sshHost, int sshPort, String sshUsername, UploadedFile key, String dbHost, int dbPort)
             throws IOException {
+        return createSSHTunnel(
+                sshHost, sshPort, sshUsername, key, dbHost, dbPort, SSH_CONNECT_TIMEOUT_MS, SSH_SOCKET_TIMEOUT_MS);
+    }
+
+    /** Visible for tests, which shrink the timeouts so the unresponsive-server case costs seconds, not minutes. */
+    static SSHTunnelContext createSSHTunnel(
+            String sshHost,
+            int sshPort,
+            String sshUsername,
+            UploadedFile key,
+            String dbHost,
+            int dbPort,
+            int connectTimeoutMs,
+            int socketTimeoutMs)
+            throws IOException {
 
         final SSHClient client = new SSHClient();
 
@@ -74,6 +99,8 @@ public class SSHUtils {
          * folder for cloud hosted instances I am turning this check off.
          */
         client.addHostKeyVerifier(new PromiscuousVerifier());
+        client.setConnectTimeout(connectTimeoutMs);
+        client.setTimeout(socketTimeoutMs);
 
         client.connect(sshHost, sshPort);
         Reader targetReader = new InputStreamReader(new ByteArrayInputStream(key.getDecodedContent()));

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/SSHUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/SSHUtilsTest.java
@@ -5,6 +5,7 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.SSHConnection;
+import com.appsmith.external.models.UploadedFile;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile;
 import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile;
@@ -12,11 +13,21 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.appsmith.external.helpers.SSHUtils.getConnectionContext;
 import static com.appsmith.external.helpers.SSHUtils.getDBPortFromConfigOrDefault;
@@ -167,5 +178,74 @@ public class SSHUtilsTest {
         datasourceConfiguration.setEndpoints(List.of(new Endpoint()));
 
         assertEquals(getDBPortFromConfigOrDefault(datasourceConfiguration, 1234L), 1234L);
+    }
+
+    /**
+     * An SSH endpoint that accepts the TCP connection but never sends its identification banner. Without socket
+     * timeouts sshj blocks the calling thread indefinitely; with them createSSHTunnel must fail within the bound.
+     * The call runs on a daemon thread so a regression shows up as a failed assertion, not a hung JVM.
+     */
+    @Test
+    public void createSSHTunnel_againstUnresponsiveServer_failsWithinTimeout() throws Exception {
+        Queue<Socket> heldConnections = new ConcurrentLinkedQueue<>();
+        try (ServerSocket silentServer = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            Thread acceptor = new Thread(() -> {
+                try {
+                    while (!silentServer.isClosed()) {
+                        heldConnections.add(silentServer.accept());
+                    }
+                } catch (IOException ignored) {
+                    // server closed
+                }
+            });
+            acceptor.setDaemon(true);
+            acceptor.start();
+
+            UploadedFile key = new UploadedFile();
+            key.setName("unused.pem");
+            key.setBase64Content("");
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+            CountDownLatch finished = new CountDownLatch(1);
+            Thread caller = new Thread(() -> {
+                try {
+                    SSHUtils.createSSHTunnel(
+                            silentServer.getInetAddress().getHostAddress(),
+                            silentServer.getLocalPort(),
+                            "user",
+                            key,
+                            "db.internal",
+                            3306,
+                            2_000,
+                            2_000);
+                } catch (Throwable t) {
+                    failure.set(t);
+                } finally {
+                    finished.countDown();
+                }
+            });
+            caller.setDaemon(true);
+            caller.start();
+
+            long bound = 2_000 + 2_000 + 8_000;
+            assertTrue(
+                    finished.await(bound, TimeUnit.MILLISECONDS),
+                    "createSSHTunnel did not return within " + bound + " ms against an unresponsive SSH server");
+            assertNotNull(failure.get(), "createSSHTunnel must fail, not succeed, against an unresponsive server");
+            assertTrue(
+                    failure.get() instanceof IOException,
+                    "expected the connection-level IOException from sshj, got: " + failure.get());
+            boolean timedOut = false;
+            for (Throwable cause = failure.get(); cause != null; cause = cause.getCause()) {
+                if (cause instanceof SocketTimeoutException) {
+                    timedOut = true;
+                    break;
+                }
+            }
+            assertTrue(timedOut, "expected a SocketTimeoutException in the cause chain, got: " + failure.get());
+        } finally {
+            for (Socket socket : heldConnections) {
+                socket.close();
+            }
+        }
     }
 }

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -22,7 +22,6 @@ import com.arangodb.ArangoDBException;
 import com.arangodb.ArangoDatabase;
 import com.arangodb.ContentType;
 import com.arangodb.Protocol;
-import com.arangodb.entity.CollectionEntity;
 import com.arangodb.model.CollectionsReadOptions;
 import com.arangodb.serde.jackson.JacksonSerde;
 import com.external.plugins.exceptions.ArangoDBErrorMessages;
@@ -43,7 +42,6 @@ import reactor.core.scheduler.Schedulers;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -313,7 +311,10 @@ public class ArangoDBPlugin extends BasePlugin {
         @Override
         public void datasourceDestroy(ArangoDatabase db) {
             log.debug(Thread.currentThread().getName() + ": datasourceDestroy() called for ArangoDB plugin.");
-            db.arango().shutdown();
+            // Closing the HTTP client is I/O; keep it off the caller thread like the other plugins do.
+            Mono.fromRunnable(() -> db.arango().shutdown())
+                    .subscribeOn(scheduler)
+                    .subscribe(ignored -> {}, error -> log.error("Error shutting down ArangoDB client", error));
         }
 
         @Override
@@ -368,6 +369,7 @@ public class ArangoDBPlugin extends BasePlugin {
                         connection.getVersion();
                         return new DatasourceTestResult();
                     })
+                    .subscribeOn(scheduler)
                     .onErrorResume(error -> {
                         log.error("Error when testing ArangoDB datasource.");
                         error.printStackTrace();
@@ -388,17 +390,17 @@ public class ArangoDBPlugin extends BasePlugin {
 
             CollectionsReadOptions options = new CollectionsReadOptions();
             options.excludeSystem(true);
-            Collection<CollectionEntity> collections;
-            try {
-                collections = db.getCollections(options);
-            } catch (ArangoDBException e) {
-                return Mono.error(new AppsmithPluginException(
-                        AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR,
-                        ArangoDBErrorMessages.GET_STRUCTURE_ERROR_MSG,
-                        e.getErrorMessage()));
-            }
 
-            return Flux.fromIterable(collections)
+            // Listing collections is an HTTP round trip; keep it inside the chain so the trailing subscribeOn covers
+            // it.
+            return Mono.fromCallable(() -> db.getCollections(options))
+                    .onErrorMap(
+                            ArangoDBException.class,
+                            e -> new AppsmithPluginException(
+                                    AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR,
+                                    ArangoDBErrorMessages.GET_STRUCTURE_ERROR_MSG,
+                                    e.getErrorMessage()))
+                    .flatMapMany(Flux::fromIterable)
                     .filter(collectionEntity -> !collectionEntity.getIsSystem())
                     .flatMap(collectionEntity -> {
                         log.debug(Thread.currentThread().getName()

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
@@ -17,6 +17,7 @@ import com.arangodb.entity.CollectionType;
 import com.arangodb.entity.Permissions;
 import com.arangodb.model.CollectionCreateOptions;
 import com.arangodb.model.CollectionSchema;
+import com.arangodb.model.CollectionsReadOptions;
 import com.external.plugins.exceptions.ArangoDBPluginError;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -29,19 +30,24 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.external.plugins.exceptions.ArangoDBErrorMessages.DS_HOSTNAME_MISSING_OR_INVALID_ERROR_MSG;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -416,5 +422,56 @@ public class ArangoDBPluginTest {
                     assertEquals("localhost_8529", endpointIdentifier);
                 })
                 .verifyComplete();
+    }
+
+    /**
+     * getStructure() lists collections over HTTP; the server calls it from the continuation of the
+     * datasource-context lookup, so the driver call must never run on the subscribing thread.
+     */
+    @Test
+    public void getStructure_doesNotRunOnTheSubscribingThread() {
+        ArangoDatabase mockDb = mock(ArangoDatabase.class);
+        AtomicReference<String> driverThread = new AtomicReference<>();
+        when(mockDb.getCollections(any(CollectionsReadOptions.class))).thenAnswer(invocation -> {
+            driverThread.set(Thread.currentThread().getName());
+            return List.of();
+        });
+
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(Mono.defer(() -> pluginExecutor.getStructure(mockDb, createDatasourceConfiguration()))
+                            .subscribeOn(caller))
+                    .assertNext(structure -> assertTrue(structure.getTables().isEmpty()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(driverThread.get(), "getCollections was never called");
+        assertFalse(
+                driverThread.get().startsWith("caller-event-loop"),
+                "getCollections ran on the subscribing thread: " + driverThread.get());
+    }
+
+    @Test
+    public void testDatasource_connection_doesNotRunOnTheSubscribingThread() {
+        ArangoDatabase mockDb = mock(ArangoDatabase.class);
+        AtomicReference<String> driverThread = new AtomicReference<>();
+        when(mockDb.getVersion()).thenAnswer(invocation -> {
+            driverThread.set(Thread.currentThread().getName());
+            return null;
+        });
+
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(pluginExecutor.testDatasource(mockDb).subscribeOn(caller))
+                    .assertNext(result -> assertTrue(result.isSuccess()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(driverThread.get(), "getVersion was never called");
+        assertFalse(
+                driverThread.get().startsWith("caller-event-loop"),
+                "getVersion ran on the subscribing thread: " + driverThread.get());
     }
 }

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/main/java/com/external/plugins/AwsLambdaPlugin.java
@@ -33,6 +33,7 @@ import org.pf4j.PluginWrapper;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import java.nio.ByteBuffer;
@@ -57,6 +58,8 @@ public class AwsLambdaPlugin extends BasePlugin {
     @Slf4j
     @Extension
     public static class AwsLambdaPluginExecutor implements PluginExecutor<AWSLambda> {
+
+        private final Scheduler scheduler = Schedulers.boundedElastic();
 
         @Override
         public Mono<ActionExecutionResult> execute(
@@ -95,13 +98,19 @@ public class AwsLambdaPlugin extends BasePlugin {
                             Exception.class,
                             e -> new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, e.getMessage()))
                     .map(obj -> obj)
-                    .subscribeOn(Schedulers.boundedElastic());
+                    .subscribeOn(scheduler);
         }
 
         @Override
         public Mono<TriggerResultDTO> trigger(
                 AWSLambda connection, DatasourceConfiguration datasourceConfiguration, TriggerRequestDTO request) {
             log.debug(Thread.currentThread().getName() + ": trigger() called for AWS Lambda plugin.");
+            // The list* calls below are blocking SDK calls; keep them off the subscribing thread.
+            return Mono.fromCallable(() -> listTriggerOptions(connection, request))
+                    .subscribeOn(scheduler);
+        }
+
+        private TriggerResultDTO listTriggerOptions(AWSLambda connection, TriggerRequestDTO request) {
             if (!StringUtils.hasText(request.getRequestType())) {
                 throw new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "request type is missing");
@@ -177,7 +186,7 @@ public class AwsLambdaPlugin extends BasePlugin {
             TriggerResultDTO triggerResultDTO = new TriggerResultDTO();
             triggerResultDTO.setTrigger(options);
 
-            return Mono.just(triggerResultDTO);
+            return triggerResultDTO;
         }
 
         ActionExecutionResult invokeFunction(ActionConfiguration actionConfiguration, AWSLambda connection) {
@@ -342,6 +351,7 @@ public class AwsLambdaPlugin extends BasePlugin {
                         connection.listFunctions();
                         return new DatasourceTestResult();
                     })
+                    .subscribeOn(scheduler)
                     .onErrorResume(error -> {
                         if (error instanceof AWSLambdaException
                                 && "AccessDenied".equals(((AWSLambdaException) error).getErrorCode())) {

--- a/app/server/appsmith-plugins/awsLambdaPlugin/src/test/java/com/external/plugins/AwsLambdaPluginTest.java
+++ b/app/server/appsmith-plugins/awsLambdaPlugin/src/test/java/com/external/plugins/AwsLambdaPluginTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.nio.ByteBuffer;
@@ -31,9 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.appsmith.external.helpers.PluginUtils.setDataValueSafelyInFormData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -501,5 +506,61 @@ public class AwsLambdaPluginTest {
         assertThrows(AppsmithPluginException.class, () -> {
             pluginExecutor.trigger(mockLambda, datasourceConfiguration, request).block();
         });
+    }
+
+    /**
+     * trigger() lists functions/versions/aliases with the blocking SDK client; the server calls it from the
+     * continuation of the datasource-context lookup, so the SDK call must never run on the subscribing thread.
+     */
+    @Test
+    public void trigger_doesNotRunOnTheSubscribingThread() {
+        AWSLambda mockLambda = mock(AWSLambda.class);
+        AtomicReference<String> sdkThread = new AtomicReference<>();
+        ListFunctionsResult functionsResult = new ListFunctionsResult();
+        functionsResult.setFunctions(List.of(new FunctionConfiguration().withFunctionName("function1")));
+        when(mockLambda.listFunctions()).thenAnswer(invocation -> {
+            sdkThread.set(Thread.currentThread().getName());
+            return functionsResult;
+        });
+        TriggerRequestDTO request = new TriggerRequestDTO();
+        request.setRequestType("FUNCTION_NAMES");
+
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(Mono.defer(
+                                    () -> pluginExecutor.trigger(mockLambda, createDatasourceConfiguration(), request))
+                            .subscribeOn(caller))
+                    .assertNext(result -> assertEquals(1, ((List<?>) result.getTrigger()).size()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(sdkThread.get(), "listFunctions was never called");
+        assertFalse(
+                sdkThread.get().startsWith("caller-event-loop"),
+                "listFunctions ran on the subscribing thread: " + sdkThread.get());
+    }
+
+    @Test
+    public void testDatasource_connection_doesNotRunOnTheSubscribingThread() {
+        AWSLambda mockLambda = mock(AWSLambda.class);
+        AtomicReference<String> sdkThread = new AtomicReference<>();
+        when(mockLambda.listFunctions()).thenAnswer(invocation -> {
+            sdkThread.set(Thread.currentThread().getName());
+            return new ListFunctionsResult();
+        });
+
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(pluginExecutor.testDatasource(mockLambda).subscribeOn(caller))
+                    .assertNext(result -> assertTrue(result.isSuccess()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(sdkThread.get(), "listFunctions was never called");
+        assertFalse(
+                sdkThread.get().startsWith("caller-event-loop"),
+                "listFunctions ran on the subscribing thread: " + sdkThread.get());
     }
 }

--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
@@ -331,9 +331,13 @@ public class DynamoPlugin extends BasePlugin {
 
         @Override
         public void datasourceDestroy(DynamoDbClient client) {
-            if (client != null) {
-                client.close();
+            if (client == null) {
+                return;
             }
+            // Closing the SDK client is socket I/O; keep it off the caller thread like the other plugins.
+            Mono.fromRunnable(client::close)
+                    .subscribeOn(scheduler)
+                    .subscribe(ignored -> {}, error -> log.error("Error closing DynamoDB client.", error));
         }
 
         @Override
@@ -365,13 +369,14 @@ public class DynamoPlugin extends BasePlugin {
         public Mono<DatasourceTestResult> testDatasource(DynamoDbClient connection) {
             log.debug(Thread.currentThread().getName() + ": testDatasource() called for Dynamo plugin.");
             return Mono.fromCallable(() -> {
-                /*
-                 * - Creating a connection with false credentials does not throw an error. Hence,
-                 *   calling listTables() method to check validity.
-                 */
-                connection.listTables();
-                return new DatasourceTestResult();
-            });
+                        /*
+                         * - Creating a connection with false credentials does not throw an error. Hence,
+                         *   calling listTables() method to check validity.
+                         */
+                        connection.listTables();
+                        return new DatasourceTestResult();
+                    })
+                    .subscribeOn(scheduler);
         }
 
         @Override

--- a/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
@@ -16,6 +16,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -27,6 +29,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesResponse;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
@@ -39,14 +42,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_PATH;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Slf4j
 @Testcontainers
@@ -530,5 +540,50 @@ public class DynamoPluginTest {
                         .collect(Collectors.toList())
                         .size()
                 == 0);
+    }
+
+    @Test
+    public void testDatasource_connection_doesNotRunOnTheSubscribingThread() {
+        DynamoDbClient mockClient = mock(DynamoDbClient.class);
+        AtomicReference<String> sdkThread = new AtomicReference<>();
+        when(mockClient.listTables()).thenAnswer(invocation -> {
+            sdkThread.set(Thread.currentThread().getName());
+            return ListTablesResponse.builder().build();
+        });
+
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(pluginExecutor.testDatasource(mockClient).subscribeOn(caller))
+                    .assertNext(result -> assertTrue(result.isSuccess()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(sdkThread.get(), "listTables was never called");
+        assertFalse(
+                sdkThread.get().startsWith("caller-event-loop"),
+                "listTables ran on the subscribing thread: " + sdkThread.get());
+    }
+
+    @Test
+    public void datasourceDestroy_doesNotRunOnTheCallerThread() throws Exception {
+        DynamoDbClient mockClient = mock(DynamoDbClient.class);
+        AtomicReference<String> closeThread = new AtomicReference<>();
+        CountDownLatch closed = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                    closeThread.set(Thread.currentThread().getName());
+                    closed.countDown();
+                    return null;
+                })
+                .when(mockClient)
+                .close();
+
+        Thread caller = new Thread(() -> pluginExecutor.datasourceDestroy(mockClient), "caller-event-loop-destroy");
+        caller.start();
+        caller.join(5_000);
+        assertTrue(closed.await(5, TimeUnit.SECONDS), "close was never called");
+        assertFalse(
+                closeThread.get().startsWith("caller-event-loop-destroy"),
+                "client close ran on the caller thread: " + closeThread.get());
     }
 }

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/main/java/com/external/plugins/ElasticSearchPlugin.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/main/java/com/external/plugins/ElasticSearchPlugin.java
@@ -243,11 +243,16 @@ public class ElasticSearchPlugin extends BasePlugin {
 
         @Override
         public void datasourceDestroy(RestClient client) {
-            try {
-                client.close();
-            } catch (IOException e) {
-                log.warn("Error closing connection to ElasticSearch.", e);
-            }
+            // Closing the low-level REST client is socket I/O; keep it off the caller thread like the other plugins.
+            Mono.fromRunnable(() -> {
+                        try {
+                            client.close();
+                        } catch (IOException e) {
+                            log.warn("Error closing connection to ElasticSearch.", e);
+                        }
+                    })
+                    .subscribeOn(scheduler)
+                    .subscribe(ignored -> {}, error -> log.error("Error closing connection to ElasticSearch.", error));
         }
 
         @Override
@@ -279,50 +284,50 @@ public class ElasticSearchPlugin extends BasePlugin {
         public Mono<DatasourceTestResult> testDatasource(RestClient connection) {
             log.debug(Thread.currentThread().getName() + ": testDatasource() called for ElasticSearch plugin.");
             return Mono.fromCallable(() -> {
-                if (connection == null) {
-                    return new DatasourceTestResult("Null client object to ElasticSearch.");
-                }
-                // This HEAD request is to check if the base of datasource exists. It responds with 200 if the index
-                // exists,
-                // 404 if it doesn't. We just check for either of these two.
-                // Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
-                Request request = new Request("HEAD", "/");
+                        if (connection == null) {
+                            return new DatasourceTestResult("Null client object to ElasticSearch.");
+                        }
+                        // This HEAD request is to check if the base of datasource exists. It responds with 200 if the
+                        // index exists, 404 if it doesn't. We just check for either of these two.
+                        // Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
+                        Request request = new Request("HEAD", "/");
 
-                final Response response;
-                try {
-                    response = connection.performRequest(request);
-                } catch (IOException e) {
-                    final String message = e.getMessage();
+                        final Response response;
+                        try {
+                            response = connection.performRequest(request);
+                        } catch (IOException e) {
+                            final String message = e.getMessage();
 
-                    /* since the 401, and 403 are registered as IOException, but for the given connection it
-                     * in the current rest-client. We will figure out with matching patterns with regexes.
-                     */
+                            /* since the 401, and 403 are registered as IOException, but for the given connection it
+                             * in the current rest-client. We will figure out with matching patterns with regexes.
+                             */
 
-                    if (patternForUnauthorized.matcher(message).find()) {
-                        return new DatasourceTestResult(ElasticSearchErrorMessages.UNAUTHORIZED_ERROR_MSG);
-                    }
+                            if (patternForUnauthorized.matcher(message).find()) {
+                                return new DatasourceTestResult(ElasticSearchErrorMessages.UNAUTHORIZED_ERROR_MSG);
+                            }
 
-                    if (patternForNotFound.matcher(message).find()) {
-                        return new DatasourceTestResult(ElasticSearchErrorMessages.NOT_FOUND_ERROR_MSG);
-                    }
+                            if (patternForNotFound.matcher(message).find()) {
+                                return new DatasourceTestResult(ElasticSearchErrorMessages.NOT_FOUND_ERROR_MSG);
+                            }
 
-                    return new DatasourceTestResult("Error running HEAD request: " + message);
-                }
+                            return new DatasourceTestResult("Error running HEAD request: " + message);
+                        }
 
-                final StatusLine statusLine = response.getStatusLine();
+                        final StatusLine statusLine = response.getStatusLine();
 
-                // earlier it was 404 and 200, now it has been changed to just expect 200 status code
-                // here it checks if it is anything else than 200, even 404 is not allowed!
-                if (statusLine.getStatusCode() == 404) {
-                    return new DatasourceTestResult(ElasticSearchErrorMessages.NOT_FOUND_ERROR_MSG);
-                }
+                        // earlier it was 404 and 200, now it has been changed to just expect 200 status code
+                        // here it checks if it is anything else than 200, even 404 is not allowed!
+                        if (statusLine.getStatusCode() == 404) {
+                            return new DatasourceTestResult(ElasticSearchErrorMessages.NOT_FOUND_ERROR_MSG);
+                        }
 
-                if (statusLine.getStatusCode() != 200) {
-                    return new DatasourceTestResult("Unexpected response from ElasticSearch: " + statusLine);
-                }
+                        if (statusLine.getStatusCode() != 200) {
+                            return new DatasourceTestResult("Unexpected response from ElasticSearch: " + statusLine);
+                        }
 
-                return new DatasourceTestResult();
-            });
+                        return new DatasourceTestResult();
+                    })
+                    .subscribeOn(scheduler);
         }
 
         @Override

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
@@ -13,12 +13,14 @@ import lombok.extern.slf4j.Slf4j;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import org.apache.http.HttpHost;
+import org.apache.http.StatusLine;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,6 +30,8 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
@@ -37,6 +41,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
@@ -45,6 +52,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Slf4j
 @Testcontainers
@@ -728,5 +739,54 @@ public class ElasticSearchPluginTest {
                     assertEquals("localhost_9200", endpointIdentifier);
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    public void testDatasource_connection_doesNotRunOnTheSubscribingThread() throws Exception {
+        RestClient mockClient = mock(RestClient.class);
+        StatusLine okStatus = mock(StatusLine.class);
+        when(okStatus.getStatusCode()).thenReturn(200);
+        Response okResponse = mock(Response.class);
+        when(okResponse.getStatusLine()).thenReturn(okStatus);
+        AtomicReference<String> clientThread = new AtomicReference<>();
+        when(mockClient.performRequest(any(Request.class))).thenAnswer(invocation -> {
+            clientThread.set(Thread.currentThread().getName());
+            return okResponse;
+        });
+
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(pluginExecutor.testDatasource(mockClient).subscribeOn(caller))
+                    .assertNext(result -> assertTrue(result.isSuccess()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(clientThread.get(), "performRequest was never called");
+        assertFalse(
+                clientThread.get().startsWith("caller-event-loop"),
+                "performRequest ran on the subscribing thread: " + clientThread.get());
+    }
+
+    @Test
+    public void datasourceDestroy_doesNotRunOnTheCallerThread() throws Exception {
+        RestClient mockClient = mock(RestClient.class);
+        AtomicReference<String> closeThread = new AtomicReference<>();
+        CountDownLatch closed = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                    closeThread.set(Thread.currentThread().getName());
+                    closed.countDown();
+                    return null;
+                })
+                .when(mockClient)
+                .close();
+
+        Thread caller = new Thread(() -> pluginExecutor.datasourceDestroy(mockClient), "caller-event-loop-destroy");
+        caller.start();
+        caller.join(5_000);
+        assertTrue(closed.await(5, TimeUnit.SECONDS), "close was never called");
+        assertFalse(
+                closeThread.get().startsWith("caller-event-loop-destroy"),
+                "client close ran on the caller thread: " + closeThread.get());
     }
 }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -704,9 +704,16 @@ public class MySqlPlugin extends BasePlugin {
                                         CONNECTION_METHOD_INDEX,
                                         MYSQL_DEFAULT_PORT,
                                         ConnectionPool.class);
-                                ConnectionPool pool =
-                                        getNewConnectionPool(datasourceConfiguration, connectionContext, maxPoolSize);
-                                connectionContext.setConnection(pool);
+                                try {
+                                    ConnectionPool pool = getNewConnectionPool(
+                                            datasourceConfiguration, connectionContext, maxPoolSize);
+                                    connectionContext.setConnection(pool);
+                                } catch (RuntimeException e) {
+                                    // The tunnel is already open but no context has been emitted yet, so the
+                                    // doOnDiscard below cannot see it - close it here before propagating.
+                                    closeSshTunnel(connectionContext);
+                                    throw e;
+                                }
                                 return connectionContext;
                             })
                             .subscribeOn(scheduler))

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -692,21 +692,47 @@ public class MySqlPlugin extends BasePlugin {
         public Mono<ConnectionContext<ConnectionPool>> datasourceCreate(
                 DatasourceConfiguration datasourceConfiguration) {
             log.debug(Thread.currentThread().getName() + ": datasourceCreate() called for MySQL plugin.");
-            return Mono.just(datasourceConfiguration).flatMap(ignore -> {
-                ConnectionContext<ConnectionPool> connectionContext;
-                try {
-                    connectionContext = getConnectionContext(
-                            datasourceConfiguration, CONNECTION_METHOD_INDEX, MYSQL_DEFAULT_PORT, ConnectionPool.class);
-                    return connectionPoolConfig.getMaxConnectionPoolSize().flatMap(maxPoolSize -> {
-                        ConnectionPool pool =
-                                getNewConnectionPool(datasourceConfiguration, connectionContext, maxPoolSize);
-                        connectionContext.setConnection(pool);
-                        return Mono.just(connectionContext);
-                    });
-                } catch (AppsmithPluginException e) {
-                    return Mono.error(e);
-                }
-            });
+            // The config lookup runs first so that getConnectionContext - which opens the SSH tunnel (TCP connect,
+            // key auth, local bind) when the connection method is SSH - is the last, blocking step, on the plugin
+            // scheduler. No reactive step sits between opening the tunnel and delivering it, so a config error can
+            // no longer strand an open tunnel; a cancellation that discards the emitted context closes it.
+            return connectionPoolConfig
+                    .getMaxConnectionPoolSize()
+                    .flatMap(maxPoolSize -> Mono.fromCallable(() -> {
+                                ConnectionContext<ConnectionPool> connectionContext = getConnectionContext(
+                                        datasourceConfiguration,
+                                        CONNECTION_METHOD_INDEX,
+                                        MYSQL_DEFAULT_PORT,
+                                        ConnectionPool.class);
+                                ConnectionPool pool =
+                                        getNewConnectionPool(datasourceConfiguration, connectionContext, maxPoolSize);
+                                connectionContext.setConnection(pool);
+                                return connectionContext;
+                            })
+                            .subscribeOn(scheduler))
+                    .doOnDiscard(ConnectionContext.class, context -> closeSshTunnel(context));
+        }
+
+        /**
+         * Closes the SSH tunnel held by the given context, if any: forwarder socket, SSH client, forwarder thread.
+         */
+        private static void closeSshTunnel(ConnectionContext<?> connectionContext) {
+            SSHTunnelContext sshTunnelContext = connectionContext.getSshTunnelContext();
+            if (sshTunnelContext == null) {
+                return;
+            }
+            try {
+                /**
+                 * IMO, order of these operations is important here (not sure), this particular order
+                 * seems safe. e.g. if the thread is stopped first then there may be some issues with
+                 * closing the server socket or disconnecting client.
+                 */
+                sshTunnelContext.getServerSocket().close();
+                sshTunnelContext.getSshClient().disconnect();
+                sshTunnelContext.getThread().interrupt(); // Gracefully interrupt the thread
+            } catch (IOException e) {
+                log.error("Failed to destroy SSH tunnel context: " + e.getMessage());
+            }
         }
 
         @Override
@@ -714,21 +740,7 @@ public class MySqlPlugin extends BasePlugin {
             log.debug(Thread.currentThread().getName() + ": datasourceDestroy() called for MySQL plugin.");
             Mono.just(connectionContext)
                     .flatMap(ignore -> {
-                        SSHTunnelContext sshTunnelContext = connectionContext.getSshTunnelContext();
-                        if (sshTunnelContext != null) {
-                            try {
-                                /**
-                                 * IMO, order of these operations is important here (not sure), this particular order
-                                 * seems safe. e.g. if the thread is stopped first then there may be some issues with
-                                 * closing the server socket or disconnecting client.
-                                 */
-                                sshTunnelContext.getServerSocket().close();
-                                sshTunnelContext.getSshClient().disconnect();
-                                sshTunnelContext.getThread().interrupt(); // Gracefully interrupt the thread
-                            } catch (IOException e) {
-                                log.error("Failed to destroy SSH tunnel context: " + e.getMessage());
-                            }
-                        }
+                        closeSshTunnel(connectionContext);
                         return Mono.empty();
                     })
                     .subscribeOn(scheduler)

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -45,6 +45,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 
@@ -1787,5 +1789,30 @@ public class MySqlPluginTest {
                     assertEquals("_sshHost_22", endpointIdentifier);
                 })
                 .verifyComplete();
+    }
+
+    /**
+     * datasourceCreate() opens the SSH tunnel (TCP connect, key auth, local ServerSocket bind) when the connection
+     * method is SSH. The server calls it from the continuation of a Redis-backed feature-flag check, so none of that
+     * may run on the subscribing thread.
+     */
+    @Test
+    public void datasourceCreate_doesNotRunOnTheSubscribingThread() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(pluginExecutor.datasourceCreate(dsConfig).subscribeOn(caller))
+                    .assertNext(connectionContext -> {
+                        instanceConnectionContext = connectionContext;
+                        assertNotNull(connectionContext.getConnection());
+                        String thread = Thread.currentThread().getName();
+                        assertFalse(
+                                thread.startsWith("caller-event-loop"),
+                                "datasourceCreate completed on the subscribing thread: " + thread);
+                    })
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
     }
 }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -1792,9 +1792,10 @@ public class MySqlPluginTest {
     }
 
     /**
-     * datasourceCreate() opens the SSH tunnel (TCP connect, key auth, local ServerSocket bind) when the connection
-     * method is SSH. The server calls it from the continuation of a Redis-backed feature-flag check, so none of that
-     * may run on the subscribing thread.
+     * The blocking work in datasourceCreate() (connection-context creation and pool construction) must not run on
+     * the subscribing thread; the server invokes it from the continuation of a Redis-backed feature-flag check.
+     * This test uses a Standard-connection configuration, so it verifies the scheduler hop for the callable as a
+     * whole; the SSH tunnel path inside getConnectionContext is covered by SSHUtilsTest.
      */
     @Test
     public void datasourceCreate_doesNotRunOnTheSubscribingThread() {

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -80,27 +80,39 @@ public class RedisPlugin extends BasePlugin {
             List<RequestParamDTO> requestParams =
                     List.of(new RequestParamDTO(ACTION_CONFIGURATION_BODY, query, null, null, null));
 
-            Jedis jedis;
-            try {
-                jedis = jedisPool.getResource();
-            } catch (Exception e) {
-                return Mono.error(new AppsmithPluginException(
-                        RedisPluginError.QUERY_EXECUTION_FAILED,
-                        RedisErrorMessages.QUERY_EXECUTION_FAILED_ERROR_MSG,
-                        e.getMessage()));
-            }
+            // Borrowing from the pool is network I/O (connect, AUTH/SELECT, and a PING because testOnBorrow is on)
+            // and blocks when the pool is exhausted, so it has to run on the plugin scheduler like the command.
+            // Mono.using returns the Jedis to the pool on complete, error AND cancel, including a cancel that lands
+            // while the borrow itself is still in flight; a plain fromCallable would discard that Jedis unreturned.
+            // eager=false: the result is delivered before the Jedis is returned, so a failed return-to-pool cannot
+            // fail a command that already executed.
+            return Mono.using(
+                            jedisPool::getResource,
+                            jedis -> runCommand(jedis, query, requestParams),
+                            Jedis::close,
+                            false)
+                    .onErrorMap(
+                            e -> !(e instanceof AppsmithPluginException),
+                            e -> new AppsmithPluginException(
+                                    RedisPluginError.QUERY_EXECUTION_FAILED,
+                                    RedisErrorMessages.QUERY_EXECUTION_FAILED_ERROR_MSG,
+                                    e.getMessage()))
+                    .subscribeOn(scheduler);
+        }
+
+        private Mono<ActionExecutionResult> runCommand(Jedis jedis, String query, List<RequestParamDTO> requestParams) {
             return Mono.fromCallable(() -> {
                         if (StringUtils.isNullOrEmpty(query)) {
-                            return Mono.error(new AppsmithPluginException(
+                            throw new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                                    String.format(RedisErrorMessages.BODY_IS_NULL_OR_EMPTY_ERROR_MSG, query)));
+                                    String.format(RedisErrorMessages.BODY_IS_NULL_OR_EMPTY_ERROR_MSG, query));
                         }
 
                         Map cmdAndArgs = getCommandAndArgs(query.trim());
                         if (!cmdAndArgs.containsKey(CMD_KEY)) {
-                            return Mono.error(new AppsmithPluginException(
+                            throw new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                                    RedisErrorMessages.QUERY_PARSING_FAILED_ERROR_MSG));
+                                    RedisErrorMessages.QUERY_PARSING_FAILED_ERROR_MSG);
                         }
 
                         Protocol.Command command;
@@ -108,11 +120,11 @@ public class RedisPlugin extends BasePlugin {
                             // Commands are in upper case
                             command = Protocol.Command.valueOf((String) cmdAndArgs.get(CMD_KEY));
                         } catch (IllegalArgumentException exc) {
-                            return Mono.error(new AppsmithPluginException(
+                            throw new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
                                     String.format(
                                             RedisErrorMessages.INVALID_REDIS_COMMAND_ERROR_MSG,
-                                            cmdAndArgs.get(CMD_KEY))));
+                                            cmdAndArgs.get(CMD_KEY)));
                         }
 
                         Object commandOutput;
@@ -130,10 +142,8 @@ public class RedisPlugin extends BasePlugin {
                         log.debug(
                                 Thread.currentThread().getName() + ": In the RedisPlugin, got action execution result");
 
-                        return Mono.just(actionExecutionResult);
+                        return actionExecutionResult;
                     })
-                    .flatMap(obj -> obj)
-                    .map(obj -> (ActionExecutionResult) obj)
                     .onErrorResume(error -> {
                         error.printStackTrace();
                         ActionExecutionResult result = new ActionExecutionResult();
@@ -155,18 +165,7 @@ public class RedisPlugin extends BasePlugin {
                         ActionExecutionResult result = actionExecutionResult;
                         result.setRequest(request);
                         return result;
-                    })
-                    .doFinally(signalType -> {
-                        /**
-                         * - Return resource back to the pool.
-                         * - https://stackoverflow.com/questions/54902337/is-it-necessary-to-use-jedis-close
-                         * - https://www.baeldung.com/jedis-java-redis-client-library:
-                         */
-                        if (jedis != null) {
-                            jedis.close();
-                        }
-                    })
-                    .subscribeOn(scheduler);
+                    });
         }
 
         /**
@@ -445,20 +444,19 @@ public class RedisPlugin extends BasePlugin {
         }
 
         private Mono<Void> verifyPing(JedisPool connectionPool) {
-            String pingResponse;
-            try {
-                Jedis jedis = connectionPool.getResource();
-                pingResponse = jedis.ping();
-            } catch (Exception exc) {
-                return Mono.error(exc);
-            }
-
-            if (!"PONG".equals(pingResponse)) {
-                return Mono.error(new RuntimeException(
-                        String.format(RedisErrorMessages.NO_PONG_RESPONSE_ERROR_MSG, pingResponse)));
-            }
-
-            return Mono.empty();
+            return Mono.fromCallable(() -> {
+                        try (Jedis jedis = connectionPool.getResource()) {
+                            return jedis.ping();
+                        }
+                    })
+                    .flatMap(pingResponse -> {
+                        if (!"PONG".equals(pingResponse)) {
+                            return Mono.<Void>error(new RuntimeException(
+                                    String.format(RedisErrorMessages.NO_PONG_RESPONSE_ERROR_MSG, pingResponse)));
+                        }
+                        return Mono.<Void>empty();
+                    })
+                    .subscribeOn(scheduler);
         }
 
         @Override

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -25,19 +25,28 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
+import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
@@ -45,6 +54,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 @Slf4j
 @Testcontainers
@@ -555,5 +566,168 @@ public class RedisPluginTest {
                     assertEquals("localhost_6379", endpointIdentifier);
                 })
                 .verifyComplete();
+    }
+
+    /**
+     * Borrowing from the pool is network I/O (connect, and a PING on every borrow because testOnBorrow is on) and can
+     * block when the pool is exhausted. The server calls execute() from the continuation of a Redis-cached lookup,
+     * i.e. on a Lettuce event-loop thread, so the borrow must never happen on the subscribing thread.
+     */
+    @Test
+    public void execute_borrowsPoolConnectionOffTheSubscribingThread() {
+        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
+        JedisPool realPool =
+                pluginExecutor.datasourceCreate(datasourceConfiguration).block();
+        assertNotNull(realPool);
+        JedisPool spyPool = spy(realPool);
+        AtomicReference<String> borrowThread = new AtomicReference<>();
+        doAnswer(invocation -> {
+                    borrowThread.set(Thread.currentThread().getName());
+                    return invocation.callRealMethod();
+                })
+                .when(spyPool)
+                .getResource();
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setBody("PING");
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(Mono.defer(
+                                    () -> pluginExecutor.execute(spyPool, datasourceConfiguration, actionConfiguration))
+                            .subscribeOn(caller))
+                    .assertNext(result -> assertTrue(result.getIsExecutionSuccess()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(borrowThread.get(), "pool borrow never happened");
+        assertFalse(
+                borrowThread.get().startsWith("caller-event-loop"),
+                "Jedis pool borrow ran on the subscribing thread: " + borrowThread.get());
+        realPool.close();
+    }
+
+    @Test
+    public void testDatasource_connection_doesNotRunOnTheSubscribingThread() {
+        JedisPool realPool =
+                pluginExecutor.datasourceCreate(createDatasourceConfiguration()).block();
+        assertNotNull(realPool);
+        JedisPool spyPool = spy(realPool);
+        AtomicReference<String> borrowThread = new AtomicReference<>();
+        doAnswer(invocation -> {
+                    borrowThread.set(Thread.currentThread().getName());
+                    return invocation.callRealMethod();
+                })
+                .when(spyPool)
+                .getResource();
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(pluginExecutor.testDatasource(spyPool).subscribeOn(caller))
+                    .assertNext(result -> assertTrue(result.isSuccess()))
+                    .verifyComplete();
+            assertNotNull(borrowThread.get(), "PING never borrowed from the pool");
+            assertFalse(
+                    borrowThread.get().startsWith("caller-event-loop"),
+                    "PING borrow ran on the subscribing thread: " + borrowThread.get());
+            assertEquals(0, realPool.getNumActive(), "PING must return its Jedis to the pool");
+        } finally {
+            caller.dispose();
+            realPool.close();
+        }
+    }
+
+    /**
+     * The server's action timeout cancels the execution while the pool borrow is still running on the plugin
+     * scheduler. The borrowed Jedis must still be returned to the pool, or five such cancellations wedge the
+     * datasource (maxTotal 5, blockWhenExhausted).
+     */
+    @Test
+    public void execute_cancelledDuringBorrow_returnsJedisToPool() throws Exception {
+        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
+        JedisPool realPool =
+                pluginExecutor.datasourceCreate(datasourceConfiguration).block();
+        assertNotNull(realPool);
+        JedisPool spyPool = spy(realPool);
+        CountDownLatch borrowStarted = new CountDownLatch(1);
+        CountDownLatch releaseBorrow = new CountDownLatch(1);
+        CountDownLatch borrowCompleted = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                    borrowStarted.countDown();
+                    // Disposing the execution interrupts the bounded-elastic worker, but a borrow blocked in socket
+                    // I/O (connect, AUTH, the testOnBorrow PING) is not interruptible: it completes later and hands
+                    // back a real Jedis. Model that by ignoring the interrupt until the test releases the borrow.
+                    long giveUpAt = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                    while (releaseBorrow.getCount() > 0 && System.nanoTime() < giveUpAt) {
+                        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(20));
+                    }
+                    assertEquals(0, releaseBorrow.getCount(), "test did not release the borrow");
+                    Thread.interrupted(); // a completed socket read leaves no pending interrupt for the pool to see
+                    try {
+                        return invocation.callRealMethod();
+                    } finally {
+                        borrowCompleted.countDown();
+                    }
+                })
+                .when(spyPool)
+                .getResource();
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setBody("PING");
+
+        Disposable execution = pluginExecutor
+                .execute(spyPool, datasourceConfiguration, actionConfiguration)
+                .subscribe(result -> {}, error -> {});
+        assertTrue(borrowStarted.await(10, TimeUnit.SECONDS), "borrow never started");
+        execution.dispose(); // the action timeout fires while the borrow is in flight
+        releaseBorrow.countDown(); // the borrow now completes into a cancelled pipeline
+        assertTrue(borrowCompleted.await(10, TimeUnit.SECONDS), "borrow never completed");
+
+        // Returning the Jedis happens asynchronously on the plugin scheduler; give it a moment.
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (realPool.getNumActive() != 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        assertEquals(0, realPool.getNumActive(), "Jedis borrowed into a cancelled execution was never returned");
+        realPool.close();
+    }
+
+    /**
+     * The Jedis is returned to the pool after the command ran; if the pool was destroyed concurrently the return
+     * throws. A command that already executed (and may have had side effects like SET/INCR) must still report
+     * success - the close failure is a cleanup problem, not a command failure.
+     */
+    @Test
+    public void execute_poolReturnFailure_doesNotFailACommandThatExecuted() {
+        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
+        JedisPool realPool =
+                pluginExecutor.datasourceCreate(datasourceConfiguration).block();
+        assertNotNull(realPool);
+        try {
+            JedisPool spyPool = spy(realPool);
+            doAnswer(invocation -> {
+                        Jedis realJedis = (Jedis) invocation.callRealMethod();
+                        Jedis spyJedis = spy(realJedis);
+                        doAnswer(closeInvocation -> {
+                                    realJedis.close(); // actually return it, then fail like a destroyed pool would
+                                    throw new JedisException("pool destroyed concurrently");
+                                })
+                                .when(spyJedis)
+                                .close();
+                        return spyJedis;
+                    })
+                    .when(spyPool)
+                    .getResource();
+
+            ActionConfiguration actionConfiguration = new ActionConfiguration();
+            actionConfiguration.setBody("PING");
+
+            StepVerifier.create(pluginExecutor.execute(spyPool, datasourceConfiguration, actionConfiguration))
+                    .assertNext(result -> assertTrue(
+                            result.getIsExecutionSuccess(),
+                            "a close/return failure must not fail a command that already executed"))
+                    .verifyComplete();
+        } finally {
+            realPool.close();
+        }
     }
 }

--- a/app/server/appsmith-plugins/smtpPlugin/src/main/java/com/external/plugins/SmtpPlugin.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/main/java/com/external/plugins/SmtpPlugin.java
@@ -39,6 +39,8 @@ import org.pf4j.PluginWrapper;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -56,6 +58,15 @@ public class SmtpPlugin extends BasePlugin {
     private static final String BASE64_DELIMITER = ";base64,";
     public static final Long SMTP_DEFAULT_PORT = 25L;
 
+    /**
+     * Socket-level bounds for every SMTP connection. JavaMail's defaults are infinite, which lets a stalled SMTP
+     * server hold the sending thread indefinitely.
+     */
+    public static final int SMTP_CONNECTION_TIMEOUT_MS = 10_000;
+
+    public static final int SMTP_READ_TIMEOUT_MS = 30_000;
+    public static final int SMTP_WRITE_TIMEOUT_MS = 30_000;
+
     public SmtpPlugin(PluginWrapper wrapper) {
         super(wrapper);
     }
@@ -65,6 +76,8 @@ public class SmtpPlugin extends BasePlugin {
 
         private static final String ENCODING = "UTF-8";
 
+        private final Scheduler scheduler = Schedulers.boundedElastic();
+
         @Override
         public Mono<ActionExecutionResult> execute(
                 Session connection,
@@ -72,6 +85,13 @@ public class SmtpPlugin extends BasePlugin {
                 ActionConfiguration actionConfiguration) {
 
             log.debug(Thread.currentThread().getName() + ": execute() called for SMTP plugin.");
+            // Building and sending the message is blocking JavaMail I/O. The server invokes plugins from the
+            // continuation of reactive Redis lookups, so this must never run on the subscribing thread.
+            return Mono.fromCallable(() -> sendEmail(connection, actionConfiguration))
+                    .subscribeOn(scheduler);
+        }
+
+        private ActionExecutionResult sendEmail(Session connection, ActionConfiguration actionConfiguration) {
             MimeMessage message = getMimeMessage(connection);
             ActionExecutionResult result = new ActionExecutionResult();
             try {
@@ -95,14 +115,14 @@ public class SmtpPlugin extends BasePlugin {
                         : null;
 
                 if (!StringUtils.hasText(toAddress)) {
-                    return Mono.error(new AppsmithPluginException(
+                    throw new AppsmithPluginException(
                             AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                            SMTPErrorMessages.RECIPIENT_ADDRESS_NOT_FOUND_ERROR_MSG));
+                            SMTPErrorMessages.RECIPIENT_ADDRESS_NOT_FOUND_ERROR_MSG);
                 }
                 if (!StringUtils.hasText(fromAddress)) {
-                    return Mono.error(new AppsmithPluginException(
+                    throw new AppsmithPluginException(
                             AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                            SMTPErrorMessages.SENDER_ADDRESS_NOT_FOUND_ERROR_MSG));
+                            SMTPErrorMessages.SENDER_ADDRESS_NOT_FOUND_ERROR_MSG);
                 }
                 message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(toAddress, false));
                 message.setFrom(new InternetAddress(fromAddress));
@@ -148,10 +168,10 @@ public class SmtpPlugin extends BasePlugin {
                         Base64.Decoder decoder = Base64.getDecoder();
                         String attachmentStr = String.valueOf(attachment.getData());
                         if (!attachmentStr.contains(BASE64_DELIMITER)) {
-                            return Mono.error(new AppsmithPluginException(
+                            throw new AppsmithPluginException(
                                     SMTPPluginError.MAIL_SENDING_FAILED,
                                     String.format(
-                                            SMTPErrorMessages.INVALID_ATTACHMENT_ERROR_MSG, attachment.getName())));
+                                            SMTPErrorMessages.INVALID_ATTACHMENT_ERROR_MSG, attachment.getName()));
                         }
                         byte[] bytes = decoder.decode(attachmentStr.split(BASE64_DELIMITER)[1]);
                         DataSource emailDatasource = new ByteArrayDataSource(bytes, attachment.getType());
@@ -166,7 +186,7 @@ public class SmtpPlugin extends BasePlugin {
 
                 // Send the email now
                 log.debug("Going to send the email");
-                Transport.send(message);
+                sendMessage(message);
 
                 result.setIsExecutionSuccess(true);
                 Map<String, String> responseBody = new HashMap<>();
@@ -175,18 +195,27 @@ public class SmtpPlugin extends BasePlugin {
 
                 log.debug("Sent the email successfully");
             } catch (MessagingException e) {
-                return Mono.error(new AppsmithPluginException(
+                log.warn("Failed to send email over SMTP", e);
+                throw new AppsmithPluginException(
                         SMTPPluginError.MAIL_SENDING_FAILED,
                         SMTPErrorMessages.MAIL_SENDING_FAILED_ERROR_MSG,
-                        e.getMessage()));
+                        e.getMessage());
             } catch (IOException e) {
-                return Mono.error(new AppsmithPluginException(
+                throw new AppsmithPluginException(
                         SMTPPluginError.MAIL_SENDING_FAILED,
                         SMTPErrorMessages.UNPARSABLE_EMAIL_BODY_OR_ATTACHMENT_ERROR_MSG,
-                        e.getMessage()));
+                        e.getMessage());
             }
 
-            return Mono.just(result);
+            return result;
+        }
+
+        /**
+         * Seam for tests: {@link Transport#send(Message)} is static and Mockito static mocks are thread-local, which
+         * does not compose with the send running on a bounded-elastic thread.
+         */
+        void sendMessage(MimeMessage message) throws MessagingException {
+            Transport.send(message);
         }
 
         @NotNull MimeBodyPart getMimeBodyPart() {
@@ -209,6 +238,9 @@ public class SmtpPlugin extends BasePlugin {
             Long port = (endpoint.getPort() == null || endpoint.getPort() < 0) ? 25 : endpoint.getPort();
             prop.put("mail.smtp.port", String.valueOf(port));
             prop.put("mail.smtp.ssl.trust", endpoint.getHost());
+            prop.put("mail.smtp.connectiontimeout", String.valueOf(SMTP_CONNECTION_TIMEOUT_MS));
+            prop.put("mail.smtp.timeout", String.valueOf(SMTP_READ_TIMEOUT_MS));
+            prop.put("mail.smtp.writetimeout", String.valueOf(SMTP_WRITE_TIMEOUT_MS));
 
             Session session;
 
@@ -240,13 +272,8 @@ public class SmtpPlugin extends BasePlugin {
         @Override
         public void datasourceDestroy(Session session) {
             log.debug(Thread.currentThread().getName() + ": datasourceDestroy() called for SMTP plugin.");
-            try {
-                if (session != null && session.getTransport() != null) {
-                    session.getTransport().close();
-                }
-            } catch (MessagingException e) {
-                e.printStackTrace();
-            }
+            // A Session holds only configuration. Transports are opened and closed per send/test (getTransport()
+            // returns a new, unconnected instance every call), so there is nothing to release here.
         }
 
         @Override
@@ -273,7 +300,15 @@ public class SmtpPlugin extends BasePlugin {
                         try {
                             Transport transport = connection.getTransport();
                             if (transport != null) {
-                                transport.connect();
+                                try {
+                                    transport.connect();
+                                } finally {
+                                    try {
+                                        transport.close();
+                                    } catch (MessagingException ignored) {
+                                        // the connection is being discarded either way
+                                    }
+                                }
                             }
                             return invalids;
                         } catch (NoSuchProviderException e) {
@@ -286,6 +321,7 @@ public class SmtpPlugin extends BasePlugin {
                         }
                         return invalids;
                     })
+                    .subscribeOn(scheduler)
                     .map(DatasourceTestResult::new);
         }
 

--- a/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
+++ b/app/server/appsmith-plugins/smtpPlugin/src/test/java/com/external/plugins/SmtpPluginTest.java
@@ -17,32 +17,44 @@ import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -429,21 +441,18 @@ public class SmtpPluginTest {
 
         SmtpPlugin.SmtpPluginExecutor spySmtp = spy(pluginExecutor);
 
-        try (MockedStatic<Transport> transportMock = Mockito.mockStatic(Transport.class)) {
-            Session session =
-                    pluginExecutor.datasourceCreate(datasourceConfiguration).block();
+        Session session =
+                pluginExecutor.datasourceCreate(datasourceConfiguration).block();
 
-            when(spySmtp.getMimeMessage(session)).thenReturn(mockMimeMessage);
-            when(spySmtp.getMimeBodyPart()).thenReturn(mockMimeBodyPart);
+        when(spySmtp.getMimeMessage(session)).thenReturn(mockMimeMessage);
+        when(spySmtp.getMimeBodyPart()).thenReturn(mockMimeBodyPart);
+        doNothing().when(spySmtp).sendMessage(any(MimeMessage.class));
 
-            transportMock.when(() -> Transport.send(mockMimeMessage)).thenAnswer((Answer<Void>) invocation -> null);
+        spySmtp.execute(session, datasourceConfiguration, actionConfiguration).block();
+        String ENCODING = "UTF-8";
 
-            spySmtp.execute(session, datasourceConfiguration, actionConfiguration); // test method call
-            String ENCODING = "UTF-8";
-
-            verify(mockMimeMessage).setSubject("This is a test subject", ENCODING);
-            verify(mockMimeBodyPart).setContent(actionConfiguration.getBody(), "text/html; charset=" + ENCODING);
-        }
+        verify(mockMimeMessage).setSubject("This is a test subject", ENCODING);
+        verify(mockMimeBodyPart).setContent(actionConfiguration.getBody(), "text/html; charset=" + ENCODING);
     }
 
     @Test
@@ -457,21 +466,18 @@ public class SmtpPluginTest {
 
         SmtpPlugin.SmtpPluginExecutor spySmtp = spy(pluginExecutor);
 
-        try (MockedStatic<Transport> transportMock = Mockito.mockStatic(Transport.class)) {
-            Session session =
-                    pluginExecutor.datasourceCreate(datasourceConfiguration).block();
+        Session session =
+                pluginExecutor.datasourceCreate(datasourceConfiguration).block();
 
-            when(spySmtp.getMimeMessage(session)).thenReturn(mockMimeMessage);
-            when(spySmtp.getMimeBodyPart()).thenReturn(mockMimeBodyPart);
+        when(spySmtp.getMimeMessage(session)).thenReturn(mockMimeMessage);
+        when(spySmtp.getMimeBodyPart()).thenReturn(mockMimeBodyPart);
+        doNothing().when(spySmtp).sendMessage(any(MimeMessage.class));
 
-            transportMock.when(() -> Transport.send(mockMimeMessage)).thenAnswer((Answer<Void>) invocation -> null);
+        spySmtp.execute(session, datasourceConfiguration, actionConfiguration).block();
+        String ENCODING = "UTF-8";
 
-            spySmtp.execute(session, datasourceConfiguration, actionConfiguration); // test method call
-            String ENCODING = "UTF-8";
-
-            verify(mockMimeMessage).setSubject("This is a test subject", ENCODING);
-            verify(mockMimeBodyPart).setContent(actionConfiguration.getBody(), "text/plain; charset=" + ENCODING);
-        }
+        verify(mockMimeMessage).setSubject("This is a test subject", ENCODING);
+        verify(mockMimeBodyPart).setContent(actionConfiguration.getBody(), "text/plain; charset=" + ENCODING);
     }
 
     @Test
@@ -554,5 +560,160 @@ public class SmtpPluginTest {
                     assertEquals("localhost_25", endpointIdentifier);
                 })
                 .verifyComplete();
+    }
+
+    /**
+     * Plugin execution is invoked from the continuation of Redis-backed lookups in the server, i.e. on a Lettuce
+     * event-loop thread. The blocking SMTP send must therefore never complete on the thread that subscribed.
+     */
+    @Test
+    public void testExecute_doesNotRunOnTheSubscribingThread() throws MessagingException {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        ActionConfiguration actionConfiguration = createActionConfiguration();
+        SmtpPlugin.SmtpPluginExecutor spySmtp = spy(pluginExecutor);
+        AtomicReference<String> sendThread = new AtomicReference<>();
+        doAnswer(invocation -> {
+                    sendThread.set(Thread.currentThread().getName());
+                    return invocation.callRealMethod();
+                })
+                .when(spySmtp)
+                .sendMessage(any(MimeMessage.class));
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            Mono<ActionExecutionResult> resultMono = spySmtp.datasourceCreate(dsConfig)
+                    .flatMap(session -> spySmtp.execute(session, dsConfig, actionConfiguration))
+                    .subscribeOn(caller);
+
+            StepVerifier.create(resultMono)
+                    .assertNext(result -> assertTrue(result.getIsExecutionSuccess()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        assertNotNull(sendThread.get(), "the email was never sent");
+        assertFalse(
+                sendThread.get().startsWith("caller-event-loop"),
+                "SMTP send ran on the subscribing thread: " + sendThread.get());
+    }
+
+    @Test
+    public void testTestDatasource_doesNotRunOnTheSubscribingThread() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            // Target the Session overload directly: the DatasourceConfiguration overload's default wrapper in
+            // PluginExecutor already subscribes on boundedElastic, which would mask a regression here.
+            Mono<DatasourceTestResult> testDatasourceMono = pluginExecutor
+                    .datasourceCreate(dsConfig)
+                    .flatMap(pluginExecutor::testDatasource)
+                    .subscribeOn(caller);
+
+            StepVerifier.create(testDatasourceMono)
+                    .assertNext(result -> {
+                        assertTrue(result.isSuccess());
+                        String thread = Thread.currentThread().getName();
+                        assertFalse(
+                                thread.startsWith("caller-event-loop"),
+                                "SMTP connect completed on the subscribing thread: " + thread);
+                    })
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+    }
+
+    @Test
+    public void testDatasourceCreate_setsBoundedSocketTimeouts() {
+        Session session =
+                pluginExecutor.datasourceCreate(createDatasourceConfiguration()).block();
+        assertNotNull(session);
+        Properties props = session.getProperties();
+
+        for (String key : List.of("mail.smtp.connectiontimeout", "mail.smtp.timeout", "mail.smtp.writetimeout")) {
+            String value = props.getProperty(key);
+            assertNotNull(value, key + " must be set so a stalled SMTP server cannot block forever");
+            assertTrue(Integer.parseInt(value) > 0, key + " must be a positive bound, was " + value);
+        }
+    }
+
+    /**
+     * An SMTP server that accepts the TCP connection but never sends a greeting. Without socket timeouts the
+     * send would block indefinitely; with them it must fail with a plugin error within the configured bound.
+     */
+    @Test
+    public void testExecute_againstUnresponsiveServer_failsWithinTimeout() throws IOException {
+        Queue<Socket> heldConnections = new ConcurrentLinkedQueue<>();
+        try (ServerSocket silentServer = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            Thread acceptor = new Thread(() -> {
+                try {
+                    while (!silentServer.isClosed()) {
+                        heldConnections.add(silentServer.accept());
+                    }
+                } catch (IOException ignored) {
+                    // server closed, stop accepting
+                }
+            });
+            acceptor.setDaemon(true);
+            acceptor.start();
+
+            DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+            dsConfig.setAuthentication(null);
+            dsConfig.setEndpoints(List.of(
+                    new Endpoint(silentServer.getInetAddress().getHostAddress(), (long) silentServer.getLocalPort())));
+            ActionConfiguration actionConfiguration = createActionConfiguration();
+
+            // Subscribe off the test thread so that a regression (blocking the subscriber forever) shows up as a
+            // StepVerifier timeout instead of hanging the whole test JVM.
+            Mono<ActionExecutionResult> resultMono = pluginExecutor
+                    .datasourceCreate(dsConfig)
+                    .map(session -> {
+                        // The production defaults are asserted separately; shrink them here so this test
+                        // exercises the same timeout path in ~2 s instead of 30.
+                        session.getProperties().setProperty("mail.smtp.connectiontimeout", "2000");
+                        session.getProperties().setProperty("mail.smtp.timeout", "2000");
+                        session.getProperties().setProperty("mail.smtp.writetimeout", "2000");
+                        return session;
+                    })
+                    .flatMap(session -> pluginExecutor.execute(session, dsConfig, actionConfiguration))
+                    .subscribeOn(Schedulers.boundedElastic());
+
+            StepVerifier.create(resultMono)
+                    .expectErrorMatches(e -> e instanceof AppsmithPluginException
+                            && SMTPErrorMessages.MAIL_SENDING_FAILED_ERROR_MSG.equals(e.getMessage()))
+                    .verify(Duration.ofSeconds(15));
+        } finally {
+            for (Socket socket : heldConnections) {
+                socket.close();
+            }
+        }
+    }
+
+    @Test
+    public void testDatasource_connection_closesTheTransportItConnects() throws MessagingException {
+        Session mockSession = mock(Session.class);
+        Transport mockTransport = mock(Transport.class);
+        when(mockSession.getTransport()).thenReturn(mockTransport);
+        AtomicReference<String> connectThread = new AtomicReference<>();
+        doAnswer(invocation -> {
+                    connectThread.set(Thread.currentThread().getName());
+                    return null;
+                })
+                .when(mockTransport)
+                .connect();
+
+        Scheduler caller = Schedulers.newSingle("caller-event-loop");
+        try {
+            StepVerifier.create(pluginExecutor.testDatasource(mockSession).subscribeOn(caller))
+                    .assertNext(result -> assertTrue(result.isSuccess()))
+                    .verifyComplete();
+        } finally {
+            caller.dispose();
+        }
+        verify(mockTransport, times(1)).connect();
+        verify(mockTransport, times(1)).close();
+        assertNotNull(connectThread.get(), "connect was never called");
+        assertFalse(
+                connectThread.get().startsWith("caller-event-loop"),
+                "connect ran on the subscribing thread: " + connectThread.get());
     }
 }


### PR DESCRIPTION
## Description

Several plugins performed blocking I/O directly on the thread that subscribed to their reactive chain. Since the server invokes plugin methods from the continuation of shared event-loop threads, a slow or unresponsive external host could stall unrelated requests and the health endpoint instead of failing just that one query.

This PR moves every such call onto the bounded-elastic scheduler (`Mono.fromCallable(...).subscribeOn(...)` / `Mono.using`, the same shape the SQL plugins already use) and bounds connections that had no socket timeouts:

- SMTP: `execute` and `testDatasource`; JavaMail connect/read/write timeouts (10 s / 30 s / 30 s); the test connection is now closed after use
- Redis: the pool borrow in `execute` (via `Mono.using`, so the connection is returned on complete, error, and cancel) and `testDatasource`
- MySQL: `datasourceCreate` — the SSH tunnel now opens as the last blocking step and is closed if the result is discarded; sshj connect/read timeouts (10 s / 30 s) in the shared `SSHUtils`
- AWS Lambda: `trigger` and `testDatasource`
- ArangoDB: `getStructure`, `testDatasource`, `datasourceDestroy`
- DynamoDB and ElasticSearch: `testDatasource` and `datasourceDestroy`

Each changed method has a regression test that fails without its fix: thread assertions capture where the blocking call runs, and unresponsive-server tests verify the new bounds.

Successful operations are unaffected. Operations against an unresponsive host now fail with the plugin's existing error after the socket timeout instead of hanging.

Fixes https://linear.app/appsmith/issue/APP-15827

Addresses https://github.com/appsmithorg/appsmith/security/advisories/GHSA-wg72-v37f-rp8r

## Automation

/ok-to-test tags="@tag.Datasource"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/32910005065>
> Commit: c35d95d425fac761021e22842662526a247065ae
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=32910005065&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Datasource`
> Spec:
> <hr>Wed, 26 Aug 2026 00:06:55 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added bounded connection and socket timeouts for SSH and SMTP operations, preventing indefinite hangs.
  * Improved cleanup of database, search, Redis, SMTP, and SSH resources.
  * Moved blocking connection, execution, and shutdown operations off caller threads to improve responsiveness.
  * Improved Redis cancellation handling, resource reuse, and error reporting.
* **Tests**
  * Added coverage for timeout behavior, asynchronous execution, resource cleanup, cancellation handling, and unresponsive services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->