### PR TITLE
fix: keep form signup toggle label static

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/authentication.test.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication.test.tsx
@@ -1,0 +1,21 @@
+import { FormAuth } from "./authentication";
+
+describe("FormAuth form signup toggle", () => {
+  it("has a label that does not change with the toggle state", () => {
+    const signupSetting = FormAuth.settings?.find(
+      (setting) => setting.id === "isSignupDisabled",
+    );
+
+    expect(signupSetting).toBeDefined();
+    // The toggle text must describe what the setting does, not the current
+    // state — a state-dependent label reads as the option itself changing.
+    expect(signupSetting?.toggleText?.(true)).toEqual(
+      signupSetting?.toggleText?.(false),
+    );
+    // Pin the wording: the label must describe the ON state (open signup).
+    // A static "invited only" label would invert the meaning of the switch.
+    expect(signupSetting?.toggleText?.(false)).toEqual(
+      "Allow all users to signup",
+    );
+  });
+});

--- a/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication.tsx
@@ -61,10 +61,7 @@ export const FormAuth: AdminConfigType = {
       category: SettingCategories.FORM_AUTH,
       controlType: SettingTypes.TOGGLE,
       label: "Form signup",
-      toggleText: (value: boolean) =>
-        value
-          ? "Allow only invited users to signup"
-          : "Allow all users to signup",
+      toggleText: () => "Allow all users to signup",
     },
     {
       id: "emailVerificationEnabled",


### PR DESCRIPTION
## Description

In **Admin Settings → Authentication → Form login**, the signup toggle (`isSignupDisabled`) rendered its label from the current value: "Allow only invited users to signup" when signup is disabled, "Allow all users to signup" when enabled. Because the label restated the current state, toggling the switch appeared to change the option itself — a customer looking for the "invited users" option couldn't find it while it was enabled, and open signup kept adding unintended members (and paid seats) to their org.

This PR makes the label static — **"Allow all users to signup"** — so it describes what the setting does: switch ON = anyone can sign up, switch OFF = only invited users can sign up. This matches the static-label pattern of the sibling toggles on the same page ("Enable form login", "Enable email verification") and keeps the accessible name of the switch stable across activation.

Behavior of the setting itself is unchanged; this is label-only.

### Call sites checked

- `toggleText` is only consumed by `FieldToggleWithToggleText` in `app/client/src/pages/AdminSettings/FormGroup/Toggle.tsx`; `isSignupDisabled` was the only setting supplying a value-dependent one.
- No Cypress spec or locator references either label string (the signup toggle locator is testid-based: `[data-testid='isSignupDisabled']`).
- EE imports `FormAuth` from `ce/` with no override, so this CE-only change flows to EE via the hourly sync (verified it applies cleanly).

### Tests

- New unit test `app/client/src/ce/pages/AdminSettings/config/authentication.test.tsx`: asserts the label is state-independent and pins the exact wording. Verified red against the pre-fix source, green after.
- Full `src/pages/AdminSettings` jest scope passes (13 suites, 39 tests).

Fixes https://linear.app/appsmith/issue/APP-15855

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/33033481965>
> Commit: b7d0192a71859896fdcee5a06e10d988851e9249
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=33033481965&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 27 Aug 2026 03:33:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the signup setting label to consistently display “Allow all users to signup,” regardless of the toggle state.

* **Tests**
  * Added coverage to verify the signup setting label remains consistent when toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->