### PR TITLE
ci: run docker image workflow cron once daily at 07:00 IST

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -4,9 +4,9 @@ run-name: >
   ${{ github.workflow }} with TED:${{ inputs.ted_tag || 'latest' }}
 
 on:
-  # This workflow will run everyday at 7:00AM, 11:00AM and 3:00PM IST on weekdays
+  # This workflow will run at 7:00AM IST on weekdays
   schedule:
-    - cron: "30 1-11/4 * * 1-5"
+    - cron: "30 1 * * 1-5"
   # This line enables manual triggering of this workflow.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Description

Reduce the weekday schedule for `Test, build and push Docker Image` from three runs (07:00, 11:00, 15:00 IST) to a single 07:00 IST run.

- Before: `30 1-11/4 * * 1-5` → 01:30, 05:30, 09:30 UTC
- After: `30 1 * * 1-5` → 01:30 UTC = 07:00 IST, weekdays

CE-only change. The hourly sync will carry the same cron into EE. GitHub scheduled workflows run from the default branch (`release`).

### Why a single 07:00 IST run

- Each TBP is a full Cypress suite (~60 shards). Typical duration is ~67 min (CE) / ~79 min (EE); retries stretch to 3–5 hours. Three weekday runs are expensive for little extra signal.
- Scheduled TBP failure rate is high (CE ~33%, EE ~45% in recent runs). Later slots often contradict the morning result, which is flake, not additional coverage.
- The 11:00 IST slot starts in the same window as auto-promotion (`30 5 * * 1-5` = 11:00 IST). GitHub often delays TBP until 11:10–11:47, so it is still running when promotion needs a completed SHA-matching run.
- A flaky 11:00 run on the same SHA can become the latest completed TBP and block promotion of an already-green 07:00 run.
- The 15:00 IST run is after promotion and cannot unblock that day's promotion.

Fixes https://linear.app/appsmith/issue/APP-15858

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated build check schedule to run once each weekday morning instead of three times daily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->