### PR TITLE
ci: stop CRA warnings failing the external PR compile check

### DIFF
--- a/.github/workflows/external-pr-validation.yml
+++ b/.github/workflows/external-pr-validation.yml
@@ -282,6 +282,10 @@ jobs:
           REACT_APP_ENVIRONMENT: DEVELOPMENT
           REACT_APP_VERSION_EDITION: Community
           NODE_OPTIONS: --max-old-space-size=8192
+          # Without this, the runner's CI=true makes CRA treat the
+          # long-standing CSS chunk-order warnings as a build failure.
+          # Real compile errors still fail the build.
+          CI: "false"
         run: yarn build
 
   result:


### PR DESCRIPTION
## Description

The `ci/compile-client` job in the external PR validation workflow fails on every PR it runs on, regardless of the PR's changes. First seen on #41927 — the workflow's first non-skipped run since it landed in #42061.

**Root cause:** the job runs a plain `yarn build`. GitHub runners set `CI=true`, which makes CRA treat warnings as errors — including the long-standing `mini-css-extract-plugin` CSS chunk-order warnings between design-system packages. The build exits 1 with `Failed to compile` even though there are no real errors.

**Fix:** set `CI=false` on the build step. Warnings now print without failing the job; genuine compile errors still exit non-zero and fail it.

**Alternative considered:** `client-build.yml` tolerates exit code 1 (`yarn build || EXIT_CODE=$?` + fail only if `> 1`). Not used here because CRA also exits 1 on real compile errors, which would make this compile gate pass on broken code.

Failing run: https://github.com/appsmithorg/appsmith/actions/runs/33195260633/job/98930832645

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client build reliability by preventing non-blocking CSS ordering warnings from causing validation failures.
  * Actual compilation errors continue to fail the build as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->