### PR TITLE
fix: handle empty branch set in git.sh branch store upload

### DIFF
--- a/app/server/appsmith-git/src/main/resources/git.sh
+++ b/app/server/appsmith-git/src/main/resources/git.sh
@@ -82,12 +82,24 @@ upload_branches_to_redis_hash() {
     local redis_url="$2"
     local key_value_pair_key="$3"
 
-    local branches=$(git -C "$directory_path" for-each-ref --format='"%(refname:short)" %(objectname:short)' refs/heads/)
+    # Branch names cannot contain whitespace, so each line splits cleanly into name and sha.
+    local branch_args=()
+    local branch_name branch_sha
+    while read -r branch_name branch_sha; do
+        if [[ -n "$branch_name" && -n "$branch_sha" ]]; then
+            branch_args+=("$branch_name" "$branch_sha")
+        fi
+    done < <(git -C "$directory_path" for-each-ref --format='%(refname:short) %(objectname:short)' refs/heads/)
 
-    log_info "Preparing to upload branch store. Current branches: $branches"
+    log_info "Preparing to upload branch store. Current branches: ${branch_args[*]:-}"
 
     redis-exec "$redis_url" DEL "$key_value_pair_key"
-    redis-exec "$redis_url" HSET "$key_value_pair_key" $branches
+
+    if [[ ${#branch_args[@]} -gt 0 ]]; then
+        redis-exec "$redis_url" HSET "$key_value_pair_key" "${branch_args[@]}"
+    else
+        log_warn "No local branches found in $directory_path; skipping branch store upload"
+    fi
 }
 
 # Removes cached repository artifact and branch store from Redis.

--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/service/GitBranchStoreUploadTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/service/GitBranchStoreUploadTest.java
@@ -1,0 +1,123 @@
+package com.appsmith.git.service;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@code upload_branches_to_redis_hash} in {@code git.sh}.
+ *
+ * <p>The Redis dependency is stubbed by overriding the {@code redis-exec} function after sourcing
+ * the script, recording every invocation to a log file that the assertions inspect.
+ */
+public class GitBranchStoreUploadTest {
+
+    private static final String BRANCH_STORE_KEY = "test_branch_store";
+
+    private static Path gitShPath;
+
+    @BeforeAll
+    static void locateGitScript() throws Exception {
+        var resource = GitBranchStoreUploadTest.class.getClassLoader().getResource("git.sh");
+        assertThat(resource).as("git.sh on classpath").isNotNull();
+        gitShPath = Paths.get(resource.toURI());
+    }
+
+    @Test
+    @DisplayName("skips HSET entirely when the repository has no local branches")
+    void skipsHsetForEmptyBranchSet(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("empty-repo");
+        Files.createDirectories(repo);
+        runGit(repo, "init", "-b", "main");
+
+        Path callLog = tempDir.resolve("redis-calls.log");
+        int exitCode = runUploadBranches(repo, callLog);
+        List<String> calls = readCalls(callLog);
+
+        assertThat(exitCode).isZero();
+        assertThat(calls).anyMatch(call -> call.startsWith("DEL " + BRANCH_STORE_KEY));
+        assertThat(calls).noneMatch(call -> call.contains("HSET"));
+    }
+
+    @Test
+    @DisplayName("uploads branch/sha pairs without literal quote characters")
+    void uploadsUnquotedBranchShaPairs(@TempDir Path tempDir) throws Exception {
+        Path repo = tempDir.resolve("repo-with-branches");
+        initRepositoryWithCommit(repo);
+        runGit(repo, "branch", "feature");
+
+        Path callLog = tempDir.resolve("redis-calls.log");
+        int exitCode = runUploadBranches(repo, callLog);
+        List<String> calls = readCalls(callLog);
+
+        assertThat(exitCode).isZero();
+        assertThat(calls).anyMatch(call -> call.startsWith("DEL " + BRANCH_STORE_KEY));
+
+        List<String> hsetCalls =
+                calls.stream().filter(call -> call.startsWith("HSET ")).toList();
+        assertThat(hsetCalls).hasSize(1);
+
+        String hset = hsetCalls.get(0);
+        assertThat(hset).doesNotContain("\"");
+        assertThat(hset).matches("^HSET " + BRANCH_STORE_KEY + "( \\S+ [0-9a-f]{4,40}){2}$");
+        assertThat(hset).contains(" main ").contains(" feature ");
+    }
+
+    private static void initRepositoryWithCommit(Path repo) throws IOException, InterruptedException {
+        Files.createDirectories(repo);
+        runGit(repo, "init", "-b", "main");
+        runGit(
+                repo,
+                "-c",
+                "user.email=test@appsmith.com",
+                "-c",
+                "user.name=Test User",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init");
+    }
+
+    private static void runGit(Path repo, String... args) throws IOException, InterruptedException {
+        String[] command = new String[args.length + 3];
+        command[0] = "git";
+        command[1] = "-C";
+        command[2] = repo.toAbsolutePath().toString();
+        System.arraycopy(args, 0, command, 3, args.length);
+
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        int exitCode = process.waitFor(30, TimeUnit.SECONDS) ? process.exitValue() : -1;
+        assertThat(exitCode).as("git %s", String.join(" ", args)).isZero();
+    }
+
+    private static int runUploadBranches(Path repo, Path callLog) throws IOException, InterruptedException {
+        String script = String.format(
+                "source '%s'%n" + "redis-exec() { printf '%%s\\n' \"${*:2}\" >> '%s'; }%n"
+                        + "upload_branches_to_redis_hash '%s' 'redis://stub:6379' '%s'",
+                gitShPath.toAbsolutePath(), callLog.toAbsolutePath(), repo.toAbsolutePath(), BRANCH_STORE_KEY);
+
+        Process process =
+                new ProcessBuilder("bash", "-c", script).redirectErrorStream(true).start();
+
+        if (!process.waitFor(30, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            return -1;
+        }
+
+        return process.exitValue();
+    }
+
+    private static List<String> readCalls(Path callLog) throws IOException {
+        return Files.exists(callLog) ? Files.readAllLines(callLog) : List.of();
+    }
+}

--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/service/GitBranchStoreUploadTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/service/GitBranchStoreUploadTest.java
@@ -106,8 +106,9 @@ public class GitBranchStoreUploadTest {
                         + "upload_branches_to_redis_hash '%s' 'redis://stub:6379' '%s'",
                 gitShPath.toAbsolutePath(), callLog.toAbsolutePath(), repo.toAbsolutePath(), BRANCH_STORE_KEY);
 
-        Process process =
-                new ProcessBuilder("bash", "-c", script).redirectErrorStream(true).start();
+        Process process = new ProcessBuilder("bash", "-c", script)
+                .redirectErrorStream(true)
+                .start();
 
         if (!process.waitFor(30, TimeUnit.SECONDS)) {
             process.destroyForcibly();


### PR DESCRIPTION
## Description

`upload_branches_to_redis_hash` in `app/server/appsmith-git/src/main/resources/git.sh` relied on unquoted word-splitting of a single string, with two defects:

1. When a repository has no local branches (`refs/heads/` empty), it issued a zero-argument `HSET`, which Redis rejects with `ERR wrong number of arguments`. redis-cli (without `-e`) exits 0 on error replies, so the failure was silently swallowed and the branch store was left unpopulated after the preceding `DEL`.
2. The `for-each-ref` format wrapped branch names in literal quote characters, which were stored verbatim in the Redis hash and had to be stripped with `sed 's/\"//g'` by both readers.

This change builds the branch/sha pairs as a bash array (git refnames cannot contain whitespace, so each line splits cleanly), skips the `HSET` with a warning when the set is empty (the `DEL` still runs so a stale store is cleared), and drops the literal quotes from the format.

**Call sites checked:** `upload_branches_to_redis_hash` has a single caller (`git_upload`) and this is the only `HSET` in the script. The readers (`verify_cached_branch_store`, `git_checkout_from_branch_store`) already tolerate an empty/missing branch store, and their quote-strip `sed` is deliberately retained so stores written by older code remain readable during rolling upgrades (entries expire via the 24h TTL). Values written by this version are unaffected by the strip.

**Impact on existing instances:** none beyond the fix itself. Applies only to Redis-backed git (`isGitInMemory`). Fresh install / upgrade / rollback all safe: new writer output is readable by old readers (unquoted values pass through the sed strip unchanged), and old writer output remains readable by the unchanged readers.

**Testing:** new `GitBranchStoreUploadTest` (pattern of `GitRepoSanityCheckTest`: sources `git.sh`, stubs `redis-exec` as a call recorder). Both tests were observed failing against the pre-fix script — zero-arg `HSET` recorded on an empty repo; quoted branch names recorded otherwise — and pass with the fix. Full `appsmith-git` module: 77/77.

Fixes https://linear.app/appsmith/issue/APP-15865

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/33429479116>
> Commit: 60bc68955bbf623f3a65a6e78d089a057295ba73
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=33429479116&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 31 Aug 2026 20:17:06 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch synchronization for repositories with branch names or commit IDs requiring safe handling.
  * Empty repositories now clear existing branch data without attempting an invalid empty upload.
  * Added a warning when no branches are available for upload.

* **Tests**
  * Added coverage for empty repositories and repositories containing branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Reported by @MinhHK68