### PR TITLE
fix: use hardened WebClientUtils builder in AI and Google Sheets plugins

### DIFF
--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
@@ -4,18 +4,17 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ApiKeyAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.util.WebClientUtils;
 import com.external.plugins.constants.AnthropicConstants;
 import com.external.plugins.constants.AnthropicErrorMessages;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ClientHttpRequest;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 
 import java.net.URI;
@@ -69,10 +68,8 @@ public class RequestUtils {
 
     private static WebClient createWebClient() {
         // Initializing webClient to be used for http call
-        WebClient.Builder webClientBuilder = WebClient.builder();
-        return webClientBuilder
+        return WebClientUtils.builder(connectionProvider())
                 .exchangeStrategies(AnthropicConstants.EXCHANGE_STRATEGIES)
-                .clientConnector(new ReactorClientHttpConnector(HttpClient.create(connectionProvider())))
                 .build();
     }
 

--- a/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/utils/RequestUtilsSsrfFilterTest.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/test/java/com/external/plugins/utils/RequestUtilsSsrfFilterTest.java
@@ -1,0 +1,47 @@
+package com.external.plugins.utils;
+
+import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.util.RestrictedHostFilter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class RequestUtilsSsrfFilterTest {
+
+    @BeforeAll
+    public static void enableFilterForThisClass() {
+        RestrictedHostFilter.setSsrfFilterDisabledForTesting(false);
+    }
+
+    @AfterAll
+    public static void restoreSurefireDefault() {
+        RestrictedHostFilter.resetSsrfFilterDisabledForTesting();
+    }
+
+    @Test
+    public void makeRequest_toDisallowedHost_isRejectedBySsrfFilter() {
+        final ApiKeyAuth apiKeyAuth = new ApiKeyAuth();
+        apiKeyAuth.setValue("test-api-key");
+
+        StepVerifier.create(RequestUtils.makeRequest(
+                        HttpMethod.GET,
+                        URI.create("http://169.254.169.254/latest/meta-data"),
+                        apiKeyAuth,
+                        BodyInserters.empty()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(UnknownHostException.class, throwable);
+                    assertEquals(RestrictedHostFilter.HOST_NOT_ALLOWED, throwable.getMessage());
+                })
+                .verify(Duration.ofSeconds(10));
+    }
+}

--- a/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
@@ -4,19 +4,18 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ApiKeyAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.util.WebClientUtils;
 import com.external.plugins.constants.GoogleAIConstants;
 import com.external.plugins.constants.GoogleAIErrorMessages;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ClientHttpRequest;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 
 import java.net.URI;
@@ -77,10 +76,8 @@ public class RequestUtils {
 
     private static WebClient createWebClient() {
         // Initializing webClient to be used for http call
-        WebClient.Builder webClientBuilder = WebClient.builder();
-        return webClientBuilder
+        return WebClientUtils.builder(connectionProvider())
                 .exchangeStrategies(GoogleAIConstants.EXCHANGE_STRATEGIES)
-                .clientConnector(new ReactorClientHttpConnector(HttpClient.create(connectionProvider())))
                 .build();
     }
 

--- a/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/utils/RequestUtilsSsrfFilterTest.java
+++ b/app/server/appsmith-plugins/googleAiPlugin/src/test/java/com/external/plugins/utils/RequestUtilsSsrfFilterTest.java
@@ -1,0 +1,47 @@
+package com.external.plugins.utils;
+
+import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.util.RestrictedHostFilter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class RequestUtilsSsrfFilterTest {
+
+    @BeforeAll
+    public static void enableFilterForThisClass() {
+        RestrictedHostFilter.setSsrfFilterDisabledForTesting(false);
+    }
+
+    @AfterAll
+    public static void restoreSurefireDefault() {
+        RestrictedHostFilter.resetSsrfFilterDisabledForTesting();
+    }
+
+    @Test
+    public void makeRequest_toDisallowedHost_isRejectedBySsrfFilter() {
+        final ApiKeyAuth apiKeyAuth = new ApiKeyAuth();
+        apiKeyAuth.setValue("test-api-key");
+
+        StepVerifier.create(RequestUtils.makeRequest(
+                        HttpMethod.GET,
+                        URI.create("http://169.254.169.254/latest/meta-data"),
+                        apiKeyAuth,
+                        BodyInserters.empty()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(UnknownHostException.class, throwable);
+                    assertEquals(RestrictedHostFilter.HOST_NOT_ALLOWED, throwable.getMessage());
+                })
+                .verify(Duration.ofSeconds(10));
+    }
+}

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
@@ -350,13 +350,12 @@ public class GoogleSheetsPlugin extends BasePlugin {
             final TriggerMethod triggerMethod = GoogleSheetsMethodStrategy.getTriggerMethod(request, objectMapper);
             MethodConfig methodConfig = new MethodConfig(request);
 
-            // Initializing webClient to be used for http call
-            WebClient.Builder webClientBuilder = WebClient.builder();
-
             triggerMethod.validateTriggerMethodRequest(methodConfig);
 
-            WebClient client =
-                    webClientBuilder.exchangeStrategies(EXCHANGE_STRATEGIES).build();
+            // Initializing webClient to be used for http call
+            WebClient client = WebClientUtils.builder()
+                    .exchangeStrategies(EXCHANGE_STRATEGIES)
+                    .build();
 
             // Authentication will already be valid at this point
             final OAuth2 oauth2 = (OAuth2) datasourceConfiguration.getAuthentication();

--- a/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/main/java/com/external/plugins/utils/RequestUtils.java
@@ -5,18 +5,17 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.BearerTokenAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.util.WebClientUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ClientHttpRequest;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 
 import java.net.URI;
@@ -119,10 +118,8 @@ public class RequestUtils {
 
     private static WebClient createWebClient() {
         // Initializing webClient to be used for http call
-        WebClient.Builder webClientBuilder = WebClient.builder();
-        return webClientBuilder
+        return WebClientUtils.builder(connectionProvider())
                 .exchangeStrategies(EXCHANGE_STRATEGIES)
-                .clientConnector(new ReactorClientHttpConnector(HttpClient.create(connectionProvider())))
                 .build();
     }
 

--- a/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/utils/RequestUtilsSsrfFilterTest.java
+++ b/app/server/appsmith-plugins/openAiPlugin/src/test/java/com/external/plugins/utils/RequestUtilsSsrfFilterTest.java
@@ -1,0 +1,47 @@
+package com.external.plugins.utils;
+
+import com.appsmith.external.models.BearerTokenAuth;
+import com.appsmith.util.RestrictedHostFilter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class RequestUtilsSsrfFilterTest {
+
+    @BeforeAll
+    public static void enableFilterForThisClass() {
+        RestrictedHostFilter.setSsrfFilterDisabledForTesting(false);
+    }
+
+    @AfterAll
+    public static void restoreSurefireDefault() {
+        RestrictedHostFilter.resetSsrfFilterDisabledForTesting();
+    }
+
+    @Test
+    public void makeRequest_toDisallowedHost_isRejectedBySsrfFilter() {
+        final BearerTokenAuth bearerTokenAuth = new BearerTokenAuth();
+        bearerTokenAuth.setBearerToken("test-token");
+
+        StepVerifier.create(RequestUtils.makeRequest(
+                        HttpMethod.GET,
+                        URI.create("http://169.254.169.254/latest/meta-data"),
+                        bearerTokenAuth,
+                        BodyInserters.empty()))
+                .expectErrorSatisfies(throwable -> {
+                    assertInstanceOf(UnknownHostException.class, throwable);
+                    assertEquals(RestrictedHostFilter.HOST_NOT_ALLOWED, throwable.getMessage());
+                })
+                .verify(Duration.ofSeconds(10));
+    }
+}


### PR DESCRIPTION
## Description

The Anthropic, OpenAI, and Google AI plugins, and the Google Sheets trigger path, built their outbound HTTP clients with raw `WebClient.builder()`, skipping the SSRF host filter that `WebClientUtils.builder()` wires in for every other outbound client (the Google Sheets execute path in the same file already used the hardened builder).

All request targets in these plugins are fixed provider endpoints, so this is consistency hardening rather than a fix for reachable behavior: it ensures a future configurable endpoint (custom base URL, proxy, OpenAI-compatible gateway) cannot ship without the filter.

Each affected `RequestUtils` gains a regression test asserting that a request to a disallowed host is rejected by the filter with `UnknownHostException: Host not allowed.`. The tests were verified to fail against the previous builder wiring (the unfiltered client attempts a real connection instead).

### Call sites checked (all raw `WebClient.builder()` usages in main code)

Changed:
- `anthropicPlugin` `RequestUtils.createWebClient()`
- `openAiPlugin` `RequestUtils.createWebClient()`
- `googleAiPlugin` `RequestUtils.createWebClient()`
- `googleSheetsPlugin` `triggerWithFlags()`

Deliberately excluded:
- `RTSCallerCEImpl` — its only target is the local RTS process, which the filter blocks by design (documented in the source).
- `appsmithAiPlugin` `RequestUtils` — shares one client between external requests and, in some deployments, the local RTS process; filtering it requires a per-target client split and is out of scope here.

## Impact on existing instances

- Fresh install: no change; all affected request targets are fixed external provider hosts, which the filter allows.
- Upgrade from default: no change, same reasoning.
- Upgrade from customized: none of the affected endpoints are configurable, so there is no customized state to affect. Operators who set `APPSMITH_DISABLE_SSRF_FILTER=true` get the previous unfiltered behavior everywhere, including these clients.
- Rollback: reverts to the unfiltered clients; no persisted state involved.

Linear: https://linear.app/appsmith/issue/APP-15866

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/33426610112>
> Commit: 57410c69b232bd8cbbf22009c41f9ae4734b1ecb
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=33426610112&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 31 Aug 2026 19:43:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection against requests to restricted cloud metadata endpoints across supported AI integrations.
  * Added validation before creating outbound connections for Google Sheets actions.

* **Reliability**
  * Standardized outbound HTTP client setup across Anthropic, Google AI, OpenAI, and Google Sheets integrations.

* **Tests**
  * Added coverage confirming that requests to disallowed metadata hosts are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->