### PR TITLE
ci: enforce strict client builds; suppress CSS order false positives

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -170,7 +170,6 @@ jobs:
       # We burn React environment & the Segment analytics key into the build itself.
       # Pylon: REACT_APP_* is required for CRA to embed values; secret name matches github-release.yml.
       # This is to ensure that we don't need to configure it in each installation.
-      # Client build fails only on errors (EXIT_CODE > 1); warnings (EXIT_CODE <= 1) don’t affect it.
       - name: Create the bundle
         if: steps.changed-files-specific.outputs.any_changed == 'true' ||  github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         run: |
@@ -189,11 +188,7 @@ jobs:
           REACT_APP_PYLON_APP_ID=${{ secrets.APPSMITH_PYLON_APP_ID }} \
           SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
           REACT_APP_VERSION_EDITION="Community" \
-          yarn build || EXIT_CODE=$?
-
-          if [ -n "$EXIT_CODE" ] && [ "$EXIT_CODE" -gt 1 ]; then
-            exit $EXIT_CODE
-          fi
+          yarn build
 
       # Saving the cache to use it in subsequent runs
       - name: Save Yarn cache

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -83,12 +83,7 @@ jobs:
           REACT_APP_PYLON_APP_ID: "${{ secrets.APPSMITH_PYLON_APP_ID }}"
           REACT_APP_VERSION_EDITION: "Community"
         run: |
-          yarn build || EXIT_CODE=$?
-
-          if [ -n "$EXIT_CODE" ] && [ "$EXIT_CODE" -gt 1 ]; then
-            exit $EXIT_CODE
-          fi
-
+          yarn build
           ls -l build
 
       - name: Pack the client build directory

--- a/app/client/config/webpack.config.js
+++ b/app/client/config/webpack.config.js
@@ -722,6 +722,14 @@ module.exports = function (webpackEnv) {
           // both options are optional
           filename: "static/css/[name].[contenthash:8].css",
           chunkFilename: "static/css/[name].[contenthash:8].chunk.css",
+          // Lazy chunks import WDS/anvil CSS modules and the widgets-old/ads
+          // tooltip+dropdown stylesheets in inconsistent relative orders, so
+          // no total CSS order exists and webpack warns "Conflicting order".
+          // The conflicting families share no selectors (WDS modules are
+          // hash-scoped; the legacy files only target .rc-tooltip*,
+          // .bp3-popover*, .ads-v2-tooltip, .ds--dropdown-popover), so the
+          // order is irrelevant and the warning is a false positive.
+          ignoreOrder: true,
         }),
       // Generate an asset manifest file with the following content:
       // - "files" key: Mapping of all asset filenames to their corresponding


### PR DESCRIPTION
## Description

**TL;DR:** Suppress the false-positive `mini-css-extract-plugin` "Conflicting order" warnings at the source (`ignoreOrder: true`) and remove the lenient exit-code hacks from the internal build workflows, so every client build pipeline — including the credential-free external contributor one — enforces the same strict warnings-as-errors gate.

The `ci/compile-client` job in the external PR validation workflow fails on every PR it runs on ([first non-skipped run](https://github.com/appsmithorg/appsmith/actions/runs/33195260633/job/99538630956?pr=41927), on #41927). GitHub runners set `CI=true`, which makes CRA treat webpack warnings as errors — and the build emits 29+ long-standing `mini-css-extract-plugin` "Conflicting order" warnings, so a plain `yarn build` exits 1 with `Failed to compile` despite no real errors. The internal pipelines (`client-build.yml`, `github-release.yml`) dodged this with `yarn build || EXIT_CODE=$?` + fail-only-if-`> 1` — which also masks **real** compile errors, since CRA exits 1 for those too.

**Why the warnings are false positives (verified):** every conflict is the same shape — WDS/anvil CSS modules vs the same three legacy stylesheets (`ads/src/Tooltip/Tooltip.css`, `widgets-old/src/Dropdown/styles.css`, `widgets-old/src/Tooltip/styles.module.css`) inside a shared async CSS chunk. Lazy routes import the two families in inconsistent relative orders, so no total CSS order exists by construction. The families share **zero selectors** (WDS modules are hash-scoped; the legacy files only target `.rc-tooltip*`, `.bp3-popover*`, `.ads-v2-tooltip`, `.ds--dropdown-popover`), so the order provably cannot affect rendering. Entry-hoisting the three files was tried and does not dedupe them out of the shared chunk.

**Changes:**
- `app/client/config/webpack.config.js`: `ignoreOrder: true` on `MiniCssExtractPlugin` (production-only instantiation; diagnostic suppression only, emitted CSS unchanged)
- `.github/workflows/client-build.yml` and `.github/workflows/github-release.yml`: drop the `EXIT_CODE > 1` tolerance — any nonzero build exit now fails, closing the gap where real compile errors could ship

Replaces #42171 (which only set `CI=false` on the external workflow, leaving the warnings and the internal hacks in place).

Follow-up tracked in [APP-15869](https://linear.app/appsmith/issue/APP-15869/client-builds-fail-on-mini-css-extract-conflicting-order-warnings-in) for EE (mirror `ignoreOrder` + drop the EE workflow hacks after one strict EE build is verified) and for the long-term real fix (migrating the three legacy stylesheets to scoped CSS modules, after which `ignoreOrder` can be dropped).

Fixes https://github.com/appsmithorg/appsmith-ee/issues/9599

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/33460764320>
> Commit: 932d7de6296c444b54ae00f0fb697028642857af
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=33460764320&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 01 Sep 2026 13:02:10 UTC
<!-- end of auto-generated comment: Cypress test results  -->

## Testing

Ran a strict local production build matching the CI invocation (`CI=true REACT_APP_ENVIRONMENT=DEVELOPMENT REACT_APP_VERSION_EDITION=Community yarn build`): `Compiled successfully`, zero "Conflicting order" warnings, exit 0. YAML lint passes on all touched workflows. The first post-merge `client-build` run on `release` confirms the PRODUCTION-env path.

Select the validation relevant to this change:

- [ ] Client unit tests
- [ ] Server unit tests
- [ ] Cypress
- [ ] Playwright
- [ ] Deploy preview
- [x] Not applicable

Suggested Cypress tags or specs:


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build Improvements**
  - Production builds now fail consistently when any build error occurs, improving release reliability.
  - Resolved misleading CSS ordering warnings during production bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
