### PR TITLE
test(server): retarget Firestore emulator image after GCR tag removal

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -88,7 +88,7 @@ public class FirestorePluginTest {
 
     @Container
     public static final FirestoreEmulatorContainer emulator = new FirestoreEmulatorContainer(
-            DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators"));
+            DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators"));
 
     static Firestore firestoreConnection;
 


### PR DESCRIPTION
## Description

Google deleted the pinned Testcontainers image `gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators` (404 / manifest unknown). That crashes `FirestorePluginTest` during container start and fails a server unit-test shard on every PR.

Pin the published replacement `gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators`. Testcontainers 1.20.1 already accepts this image name.

Verified locally: `FirestorePluginTest` — Tests run: 35, Failures: 0, Errors: 0.

Fixes https://linear.app/appsmith/issue/APP-15872

## Testing

- [ ] Client unit tests
- [x] Server unit tests
- [ ] Cypress
- [ ] Playwright
- [ ] Deploy preview
- [ ] Not applicable

Suggested Cypress tags or specs:

Test-only image pin; no runtime behavior change. Cypress skipped.

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Firestore emulator test environment to use the current Google Cloud CLI image, improving test compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->