### PR TITLE
fix: move OAuth2 expiry field next to scopes

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -683,6 +683,21 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        {_.get(formData.authentication, "grantType") ===
+          GrantType.AuthorizationCode && (
+          <FormInputContainer
+            data-location-id={btoa("authentication.expiresIn")}
+          >
+            {this.renderInputTextControlViaFormControl({
+              configProperty: "authentication.expiresIn",
+              label: "Authorization expires in (seconds)",
+              placeholderText: "3600",
+              dataType: "NUMBER",
+              encrypted: false,
+              isRequired: false,
+            })}
+          </FormInputContainer>
+        )}
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -870,17 +885,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             false,
           )}
         </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
-        </FormInputContainer>
-
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&
           this.renderOauth2CommonAdvanced()}
       </>


### PR DESCRIPTION
## Description

Moves the **Authorization expires in (seconds)** field directly after **Scope(s)** in the authenticated API OAuth2 form, so related authentication settings stay adjacent and easier to discover.

The field remains limited to the Authorization Code grant type, preserving the existing behavior for Client Credentials.

Fixes #31059

## Testing

- [x] Prettier check for the changed file
- [x] ESLint for the changed file (0 errors; pre-existing warnings only)
- [x] TypeScript typecheck with `tsc --noEmit --pretty false`
- [x] Structural check confirming `scopeString` → `expiresIn` → `isAuthorizationHeader` and a single `expiresIn` field

## Communication

Should the DevRel and Marketing teams inform users about this change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 settings by displaying the expiration duration in the appropriate shared settings area.
  * The expiration duration is now shown only when the Authorization Code grant type is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->