### PR TITLE
chore: MCP enabled check for all authentication mechanism

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/McpTokenServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/McpTokenServiceCEImpl.java
@@ -21,7 +21,6 @@ import com.appsmith.server.services.OrganizationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.transaction.reactive.TransactionalOperator;
 import org.springframework.util.StringUtils;
@@ -271,7 +270,16 @@ public class McpTokenServiceCEImpl implements McpTokenServiceCE {
         }
 
         return authenticateFromCache(userKey, mcpKeyId)
-                .switchIfEmpty(Mono.defer(() -> authenticateFromStore(userKey, mcpKeyId)));
+                .switchIfEmpty(Mono.defer(() -> authenticateFromStore(userKey, mcpKeyId)))
+                .flatMap(this::requireMcpEnabled);
+    }
+
+    private Mono<User> requireMcpEnabled(User user) {
+        return validateMCPEnabled()
+                .thenReturn(user)
+                .contextWrite(ReactiveSecurityContextHolder.withAuthentication(
+                        UsernamePasswordAuthenticationToken.authenticated(user, null, null)))
+                .contextWrite(context -> context.put(ORGANIZATION_ID, user.getOrganizationId()));
     }
 
     private Mono<User> authenticateFromCache(String userKey, String mcpKeyId) {
@@ -282,15 +290,7 @@ public class McpTokenServiceCEImpl implements McpTokenServiceCE {
                 .get(mcpKeyId)
                 .filter(entry -> McpTokenUtils.matches(userKey, entry.tokenHash()))
                 .filter(entry -> isNotExpired(entry.expiresAt()))
-                .flatMap(entry -> loadEnabledUser(entry.userId()))
-                .flatMap(user -> {
-                    return Mono.just(user)
-                            .contextWrite(ReactiveSecurityContextHolder.withAuthentication((Authentication)
-                                    UsernamePasswordAuthenticationToken.authenticated(user, null, null)))
-                            .contextWrite(context -> context.put(ORGANIZATION_ID, user.getOrganizationId()))
-                            .then(validateMCPEnabled())
-                            .thenReturn(user);
-                });
+                .flatMap(entry -> loadEnabledUser(entry.userId()));
     }
 
     private Mono<User> authenticateFromStore(String userKey, String mcpKeyId) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/McpTokenServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/McpTokenServiceImplTest.java
@@ -476,6 +476,23 @@ class McpTokenServiceImplTest {
     }
 
     @Test
+    void should_throwError_whenMCPDisabledAndStoreHashMatches() {
+        McpTokenResponseDTO generated = createToken("Claude Desktop", 30);
+        when(mcpTokenCache.get(generated.id())).thenReturn(Mono.empty());
+        when(mcpTokenRepository.findByMcpKeyIdAndStatus(generated.id(), McpTokenStatus.ACTIVE))
+                .thenReturn(Flux.just(persistedToken));
+        when(userRepository.findById(user.getId())).thenReturn(Mono.just(user));
+        mcpConfig.setEnabled(false);
+        when(organizationService.getCurrentUserOrganization()).thenReturn(Mono.just(organization));
+
+        StepVerifier.create(service.authenticate(generated.token())).expectErrorSatisfies(error -> {
+            assertThat(error).isInstanceOf(AppsmithException.class);
+            assertThat(((AppsmithException) error).getError().getAppErrorCode())
+                    .isEqualTo(AppsmithError.INTERNAL_SERVER_ERROR.getAppErrorCode());
+        });
+    }
+
+    @Test
     void should_fallBackToStoreAndRefillCache_whenCacheMisses() {
         McpTokenResponseDTO generated = createToken("Claude Desktop", 30);
         when(mcpTokenCache.get(generated.id())).thenReturn(Mono.empty());


### PR DESCRIPTION
## Description
- Now MCP enabled check happens on all authentication runs. 
- Closes the vulnerability of passing mcp enabled check when their is a cache miss

Fixes 

## Testing

> [!NOTE]
> **How CI runs on fork PRs — no action needed from you.**
> 1. **Workflow approval.** GitHub holds the first run on fork PRs until a maintainer approves it, so a pause before any check appears is expected.
> 2. **Credential-free checks.** Once approved, format, lint, typecheck, unit tests, cyclic-dependency and compile-only build checks run without repository secrets. Only the checks relevant to what you changed (client / server / RTS) will run, and their logs are safe to debug against.
> 3. **Maintainer-triggered checks.** Cypress, Playwright, Docker builds and deploy previews need secrets, so a maintainer starts them with `/approve-ci`, and `/build-deploy-preview` when hands-on testing is needed. Approval is pinned to one commit — pushing again requires fresh approval.
>
> The `awaiting-maintainer` / `awaiting-contributor` labels show whose turn it is. You do **not** need `ok-to-test` or any slash command. Full detail: [Pull request check states](https://github.com/appsmithorg/appsmith/blob/release/contributions/CodeContributionsGuidelines.md#pull-request-check-states).

Select the validation relevant to this change:

- [ ] Client unit tests
- [ ] Server unit tests
- [ ] Cypress
- [ ] Playwright
- [ ] Deploy preview
- [ ] Not applicable

Suggested Cypress tags or specs:


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP token authentication consistency across cached and stored-token validation paths.
  * Authentication now correctly rejects tokens when MCP access is disabled, returning an internal server error.
  * Prevented disabled users from being authenticated through cached credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->