### PR TITLE
ci: converge fork and internal PRs on a single required merge gate

### DIFF
--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -10,10 +10,12 @@ concurrency:
 
 permissions:
   actions: read
+  checks: read
   contents: read
   issues: write
   packages: write
   pull-requests: write
+  statuses: write
 
 jobs:
   file-check:
@@ -766,11 +768,52 @@ jobs:
         if: needs.ci-test-limited-existing-docker-image.result != 'success'
         run: exit 1
 
-  # Publish the single required merge gate (`ci/merge-gate`) for FORK PRs on the
-  # maintainer-approved head SHA. This dispatch is triggered by `/approve-ci`, so
-  # it runs trusted and may hold statuses: write. Internal PRs get ci/merge-gate
-  # from merge-gate.yml instead; the fork-only guard below prevents both paths
-  # from writing the same context on one PR. See merge-gate.yml for the rationale.
+  # Fork PRs: mark the single required gate `pending` as soon as an approved-CI
+  # run starts, so an earlier `success` cannot linger while the same commit is
+  # re-tested. Internal PRs are owned by merge-gate.yml (guarded out below). No
+  # checkout here (no fork code) — the PR number/head come from the trusted
+  # dispatch payload.
+  mark-fork-gate-pending:
+    name: mark-fork-gate-pending
+    if: github.event.action == 'approve-ci-command'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set ci/merge-gate pending for the fork PR
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const { HEAD_SHA, PR_NUMBER } = process.env;
+            const pr = (
+              await github.rest.pulls.get({ owner, repo, pull_number: Number(PR_NUMBER) })
+            ).data;
+            const isFork = !pr.head.repo || pr.head.repo.full_name !== `${owner}/${repo}`;
+            if (!isFork) {
+              core.info(`PR #${PR_NUMBER} is internal; merge-gate.yml owns it. Skipping.`);
+              return;
+            }
+            if (pr.state !== "open" || pr.base.ref !== "release" || pr.head.sha !== HEAD_SHA) {
+              core.info(`PR #${PR_NUMBER} not gatable / head moved; skipping.`);
+              return;
+            }
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: HEAD_SHA,
+              state: "pending",
+              context: "ci/merge-gate",
+              description: "Approved CI running…",
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });
+
+  # Fork PRs: persist the approved Cypress result (`ci/fork-cypress`) on the
+  # approved head SHA, then write the single required `ci/merge-gate`. Uses the
+  # shared gate script, checked out from the trusted base repo (a
+  # repository_dispatch run defaults to the default branch — never fork code).
+  # Internal PRs are owned by merge-gate.yml (guarded out below).
   set-fork-merge-gate:
     name: set-fork-merge-gate
     needs:
@@ -782,15 +825,14 @@ jobs:
       ]
     if: always() && github.event.action == 'approve-ci-command' && needs.file-check.outputs.pr != '0'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: read
-      pull-requests: read
-      statuses: write
     steps:
-      - name: Set ci/merge-gate for the fork PR
+      - name: Checkout base repo (trusted — for the shared gate script only)
+        uses: actions/checkout@v4
+
+      - name: Write ci/merge-gate for the fork PR
         uses: actions/github-script@v7
         env:
+          NODE_PATH: ${{ github.workspace }}/.github/workflows/scripts
           HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
           PR_NUMBER: ${{ needs.file-check.outputs.pr }}
           CYPRESS_LIMITED: ${{ needs.ci-test-limited-result.result }}
@@ -798,76 +840,40 @@ jobs:
           CYPRESS_EXISTING: ${{ needs.ci-test-limited-result-existing.result }}
         with:
           script: |
-            const GATE = "ci/merge-gate";
+            const gate = require("merge-gate.js");
             const { owner, repo } = context.repo;
             const { HEAD_SHA, PR_NUMBER, CYPRESS_LIMITED, CYPRESS_FULL, CYPRESS_EXISTING } = process.env;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
-            // Only fork PRs are gated here; internal PRs are owned by merge-gate.yml.
             const pr = (
               await github.rest.pulls.get({ owner, repo, pull_number: Number(PR_NUMBER) })
             ).data;
-            if (pr.head.repo.full_name === `${owner}/${repo}`) {
+
+            // Only fork PRs are gated here; internal PRs are owned by merge-gate.yml.
+            if (!gate.isFork(pr, owner, repo)) {
               core.info(`PR #${PR_NUMBER} is internal; merge-gate.yml owns its status. Skipping.`);
               return;
             }
 
-            // Exactly one of the three Cypress result jobs runs per invocation;
-            // the others report 'skipped'. Cypress is green only if the one that
-            // actually ran succeeded.
-            const cypressRuns = [CYPRESS_LIMITED, CYPRESS_FULL, CYPRESS_EXISTING].filter(
-              (r) => r !== "skipped",
-            );
-            const cypress =
-              cypressRuns.length === 0
-                ? "pending"
-                : cypressRuns.every((r) => r === "success")
-                  ? "success"
-                  : "failure";
-
-            // Credential-free validation (external-ci-result) runs in a separate
-            // workflow on the same head SHA; read its latest conclusion.
-            const checks = await github.paginate(github.rest.checks.listForRef, {
-              owner,
-              repo,
-              ref: HEAD_SHA,
-              per_page: 100,
-            });
-            const ext = checks
-              .filter((c) => c.name === "external-ci-result")
-              .sort((a, b) => new Date(b.started_at ?? 0) - new Date(a.started_at ?? 0))[0];
-            let credFree = "pending";
-            if (ext && ext.status === "completed") {
-              credFree =
-                ext.conclusion === "success"
-                  ? "success"
-                  : ext.conclusion === "skipped" || ext.conclusion === "neutral"
-                    ? "pending"
-                    : "failure";
-            }
-
-            const parts = { "external-ci-result": credFree, "approved Cypress": cypress };
-            const failed = Object.entries(parts).filter(([, v]) => v === "failure").map(([k]) => k);
-            const pending = Object.entries(parts).filter(([, v]) => v === "pending").map(([k]) => k);
-
-            let state, description;
-            if (failed.length) {
-              state = "failure";
-              description = `Failed: ${failed.join(", ")}`.slice(0, 140);
-            } else if (pending.length) {
-              state = "pending";
-              description = `Waiting: ${pending.join(", ")}`.slice(0, 140);
-            } else {
-              state = "success";
-              description = "Credential-free + approved Cypress passed";
-            }
-
-            core.info(`Setting ${GATE}=${state} on ${HEAD_SHA} for fork PR #${PR_NUMBER} (${description})`);
-            await github.rest.repos.createCommitStatus({
+            // Persist the approved Cypress result on the approved head SHA, then
+            // compute the gate from external-ci-result + that result. Passing the
+            // just-computed state avoids a read-after-write race on the status.
+            const forkCypressState = await gate.publishForkCypress({
+              github,
               owner,
               repo,
               sha: HEAD_SHA,
-              state,
-              context: GATE,
-              description,
-              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+              results: [CYPRESS_LIMITED, CYPRESS_FULL, CYPRESS_EXISTING],
+              runUrl,
+            });
+
+            await gate.evaluate({
+              github,
+              core,
+              owner,
+              repo,
+              sha: HEAD_SHA,
+              pr,
+              forkCypressState,
+              runUrl,
             });

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -765,3 +765,109 @@ jobs:
       - name: Check ci-test-limited-existing-docker-image set status
         if: needs.ci-test-limited-existing-docker-image.result != 'success'
         run: exit 1
+
+  # Publish the single required merge gate (`ci/merge-gate`) for FORK PRs on the
+  # maintainer-approved head SHA. This dispatch is triggered by `/approve-ci`, so
+  # it runs trusted and may hold statuses: write. Internal PRs get ci/merge-gate
+  # from merge-gate.yml instead; the fork-only guard below prevents both paths
+  # from writing the same context on one PR. See merge-gate.yml for the rationale.
+  set-fork-merge-gate:
+    name: set-fork-merge-gate
+    needs:
+      [
+        file-check,
+        ci-test-limited-result,
+        ci-test-full-result,
+        ci-test-limited-result-existing,
+      ]
+    if: always() && github.event.action == 'approve-ci-command' && needs.file-check.outputs.pr != '0'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Set ci/merge-gate for the fork PR
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+          PR_NUMBER: ${{ needs.file-check.outputs.pr }}
+          CYPRESS_LIMITED: ${{ needs.ci-test-limited-result.result }}
+          CYPRESS_FULL: ${{ needs.ci-test-full-result.result }}
+          CYPRESS_EXISTING: ${{ needs.ci-test-limited-result-existing.result }}
+        with:
+          script: |
+            const GATE = "ci/merge-gate";
+            const { owner, repo } = context.repo;
+            const { HEAD_SHA, PR_NUMBER, CYPRESS_LIMITED, CYPRESS_FULL, CYPRESS_EXISTING } = process.env;
+
+            // Only fork PRs are gated here; internal PRs are owned by merge-gate.yml.
+            const pr = (
+              await github.rest.pulls.get({ owner, repo, pull_number: Number(PR_NUMBER) })
+            ).data;
+            if (pr.head.repo.full_name === `${owner}/${repo}`) {
+              core.info(`PR #${PR_NUMBER} is internal; merge-gate.yml owns its status. Skipping.`);
+              return;
+            }
+
+            // Exactly one of the three Cypress result jobs runs per invocation;
+            // the others report 'skipped'. Cypress is green only if the one that
+            // actually ran succeeded.
+            const cypressRuns = [CYPRESS_LIMITED, CYPRESS_FULL, CYPRESS_EXISTING].filter(
+              (r) => r !== "skipped",
+            );
+            const cypress =
+              cypressRuns.length === 0
+                ? "pending"
+                : cypressRuns.every((r) => r === "success")
+                  ? "success"
+                  : "failure";
+
+            // Credential-free validation (external-ci-result) runs in a separate
+            // workflow on the same head SHA; read its latest conclusion.
+            const checks = await github.paginate(github.rest.checks.listForRef, {
+              owner,
+              repo,
+              ref: HEAD_SHA,
+              per_page: 100,
+            });
+            const ext = checks
+              .filter((c) => c.name === "external-ci-result")
+              .sort((a, b) => new Date(b.started_at ?? 0) - new Date(a.started_at ?? 0))[0];
+            let credFree = "pending";
+            if (ext && ext.status === "completed") {
+              credFree =
+                ext.conclusion === "success"
+                  ? "success"
+                  : ext.conclusion === "skipped" || ext.conclusion === "neutral"
+                    ? "pending"
+                    : "failure";
+            }
+
+            const parts = { "external-ci-result": credFree, "approved Cypress": cypress };
+            const failed = Object.entries(parts).filter(([, v]) => v === "failure").map(([k]) => k);
+            const pending = Object.entries(parts).filter(([, v]) => v === "pending").map(([k]) => k);
+
+            let state, description;
+            if (failed.length) {
+              state = "failure";
+              description = `Failed: ${failed.join(", ")}`.slice(0, 140);
+            } else if (pending.length) {
+              state = "pending";
+              description = `Waiting: ${pending.join(", ")}`.slice(0, 140);
+            } else {
+              state = "success";
+              description = "Credential-free + approved Cypress passed";
+            }
+
+            core.info(`Setting ${GATE}=${state} on ${HEAD_SHA} for fork PR #${PR_NUMBER} (${description})`);
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: HEAD_SHA,
+              state,
+              context: GATE,
+              description,
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,141 @@
+name: Merge gate
+
+# Single required status context (`ci/merge-gate`) that both internal and fork
+# PRs to `release` can satisfy. Branch protection on `release` requires
+# `ci/merge-gate`; the per-flow checks it aggregates (qc-result,
+# `perform-test / ci-test-result`, external-ci-result, approved Cypress) are no
+# longer individually required — each PR type only ever produces one of the two
+# sets, and a raw required context that is skipped/absent on the other type
+# stays "Expected" forever and blocks the merge (this is exactly the bug that
+# left fork PRs unmergeable after the external-contributor flow shipped).
+#
+# Ownership of the write is split by which flow knows the PR head SHA:
+#   - Internal PRs: THIS workflow, triggered by the internal PR workflows'
+#     completion (their head_sha is the PR head).
+#   - Fork PRs: build-client-server.yml sets `ci/merge-gate` on `/approve-ci`,
+#     where the approved head SHA is known. This workflow skips forks.
+# A PR is exactly one of the two, so the context is written by exactly one path
+# and the two setters never race.
+#
+# Security: this workflow never checks out or runs PR code — it only calls the
+# GitHub API — and runs from the default branch in the base-repo context, so
+# holding `statuses: write` is safe even when the associated PR is from a fork.
+
+on:
+  workflow_run:
+    workflows:
+      - "Quality checks"
+      - "PR Automation test suite"
+    types: [completed]
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  # Serialize evaluations per head SHA so concurrent triggers don't race on the
+  # commit-status write; queue rather than cancel so the latest state wins.
+  group: merge-gate-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate internal merge gate
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const GATE = "ci/merge-gate";
+            const { owner, repo } = context.repo;
+            const sha = process.env.HEAD_SHA;
+            if (!sha) {
+              core.info("No head SHA on the triggering run; skipping.");
+              return;
+            }
+
+            // Resolve the open PR whose head is this SHA.
+            const assoc = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              { owner, repo, commit_sha: sha, per_page: 100 },
+            );
+            const pr =
+              assoc.find((p) => p.state === "open" && p.head.sha === sha) ??
+              assoc.find((p) => p.state === "open");
+            if (!pr) {
+              core.info(`No open PR found for ${sha}; skipping.`);
+              return;
+            }
+
+            // Only gate PRs targeting release — the branch whose protection
+            // requires ci/merge-gate.
+            if (pr.base.ref !== "release") {
+              core.info(`PR #${pr.number} targets ${pr.base.ref}, not release; skipping.`);
+              return;
+            }
+
+            // Fork PRs get ci/merge-gate from build-client-server.yml on
+            // /approve-ci; this workflow owns internal PRs only.
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.info(`PR #${pr.number} is a fork; build-client-server.yml owns its status. Skipping.`);
+              return;
+            }
+
+            // Read the latest run of each required internal check on the head SHA.
+            const checks = await github.paginate(github.rest.checks.listForRef, {
+              owner,
+              repo,
+              ref: sha,
+              per_page: 100,
+            });
+            const latest = new Map();
+            for (const c of checks) {
+              const prev = latest.get(c.name);
+              if (!prev || new Date(c.started_at ?? 0) >= new Date(prev.started_at ?? 0)) {
+                latest.set(c.name, c);
+              }
+            }
+            // A skipped/neutral required check means "not satisfied yet" (e.g. an
+            // internal PR without ok-to-test never ran Cypress) — treat as
+            // pending so the gate blocks, matching pre-existing behavior.
+            const outcome = (name) => {
+              const c = latest.get(name);
+              if (!c || c.status !== "completed") return "pending";
+              if (c.conclusion === "success") return "success";
+              if (c.conclusion === "skipped" || c.conclusion === "neutral") return "pending";
+              return "failure";
+            };
+
+            const parts = {
+              "qc-result": outcome("qc-result"),
+              "perform-test / ci-test-result": outcome("perform-test / ci-test-result"),
+            };
+            const failed = Object.entries(parts).filter(([, v]) => v === "failure").map(([k]) => k);
+            const pending = Object.entries(parts).filter(([, v]) => v === "pending").map(([k]) => k);
+
+            let state, description;
+            if (failed.length) {
+              state = "failure";
+              description = `Failed: ${failed.join(", ")}`.slice(0, 140);
+            } else if (pending.length) {
+              state = "pending";
+              description = `Waiting: ${pending.join(", ")}`.slice(0, 140);
+            } else {
+              state = "success";
+              description = "Quality checks + Cypress passed";
+            }
+
+            core.info(`Setting ${GATE}=${state} on ${sha} for internal PR #${pr.number} (${description})`);
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha,
+              state,
+              context: GATE,
+              description,
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -2,31 +2,33 @@ name: Merge gate
 
 # Single required status context (`ci/merge-gate`) that both internal and fork
 # PRs to `release` can satisfy. Branch protection on `release` requires
-# `ci/merge-gate`; the per-flow checks it aggregates (qc-result,
-# `perform-test / ci-test-result`, external-ci-result, approved Cypress) are no
-# longer individually required — each PR type only ever produces one of the two
-# sets, and a raw required context that is skipped/absent on the other type
-# stays "Expected" forever and blocks the merge (this is exactly the bug that
-# left fork PRs unmergeable after the external-contributor flow shipped).
+# `ci/merge-gate`; the per-flow checks it aggregates (`qc-result`,
+# `perform-test / ci-test-result`, `external-ci-result`, approved Cypress) are
+# no longer individually required — each PR type only ever produces one of the
+# two sets, and a raw required context that is skipped/absent on the other type
+# stays "Expected" forever and blocks the merge (the bug this fixes).
 #
-# Ownership of the write is split by which flow knows the PR head SHA:
-#   - Internal PRs: THIS workflow, triggered by the internal PR workflows'
-#     completion (their head_sha is the PR head).
-#   - Fork PRs: build-client-server.yml sets `ci/merge-gate` on `/approve-ci`,
-#     where the approved head SHA is known. This workflow skips forks.
-# A PR is exactly one of the two, so the context is written by exactly one path
-# and the two setters never race.
+# This workflow recomputes the gate for the PR associated with a feeding
+# workflow's run, on both rerun start (`in_progress`) and `completed`:
+#   - `in_progress` forces the feeding workflow's own input to `pending`, so an
+#     earlier success cannot linger while that workflow re-runs on the same SHA.
+#   - `completed` reads the head SHA's checks/statuses and writes success /
+#     failure / pending (fail-closed: skipped/neutral/absent => pending).
+# It owns internal PRs outright and recomputes the fork credential-free side;
+# the fork Cypress side is written by build-client-server.yml on `/approve-ci`.
 #
-# Security: this workflow never checks out or runs PR code — it only calls the
-# GitHub API — and runs from the default branch in the base-repo context, so
-# holding `statuses: write` is safe even when the associated PR is from a fork.
+# Security: it never checks out or runs PR code — it only checks out the base
+# repo for the shared script and calls the GitHub API — and runs from the
+# default branch in the base-repo context, so holding `statuses: write` is safe
+# even when the associated PR is from a fork.
 
 on:
   workflow_run:
     workflows:
       - "Quality checks"
       - "PR Automation test suite"
-    types: [completed]
+      - "External PR credential-free validation"
+    types: [in_progress, completed]
 
 permissions:
   contents: read
@@ -36,7 +38,7 @@ permissions:
 
 concurrency:
   # Serialize evaluations per head SHA so concurrent triggers don't race on the
-  # commit-status write; queue rather than cancel so the latest state wins.
+  # status write; queue rather than cancel so the latest state always wins.
   group: merge-gate-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false
 
@@ -44,98 +46,32 @@ jobs:
   evaluate:
     runs-on: ubuntu-latest
     steps:
-      - name: Evaluate internal merge gate
+      - name: Checkout base repo (trusted — for the shared gate script only)
+        uses: actions/checkout@v4
+
+      - name: Evaluate merge gate
         uses: actions/github-script@v7
         env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          NODE_PATH: ${{ github.workspace }}/.github/workflows/scripts
         with:
           script: |
-            const GATE = "ci/merge-gate";
+            const gate = require("merge-gate.js");
             const { owner, repo } = context.repo;
-            const sha = process.env.HEAD_SHA;
-            if (!sha) {
-              core.info("No head SHA on the triggering run; skipping.");
-              return;
-            }
+            const run = context.payload.workflow_run;
+            const sha = run.head_sha;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
-            // Resolve the open PR whose head is this SHA.
-            const assoc = await github.paginate(
-              github.rest.repos.listPullRequestsAssociatedWithCommit,
-              { owner, repo, commit_sha: sha, per_page: 100 },
-            );
-            const pr =
-              assoc.find((p) => p.state === "open" && p.head.sha === sha) ??
-              assoc.find((p) => p.state === "open");
+            const pr = await gate.resolvePr({ github, owner, repo, sha, workflowRun: run });
             if (!pr) {
-              core.info(`No open PR found for ${sha}; skipping.`);
+              core.info(`No unique open PR found for ${sha}; skipping.`);
               return;
             }
 
-            // Only gate PRs targeting release — the branch whose protection
-            // requires ci/merge-gate.
-            if (pr.base.ref !== "release") {
-              core.info(`PR #${pr.number} targets ${pr.base.ref}, not release; skipping.`);
-              return;
+            // A rerun that just started means its result is in flight — force
+            // that input to `pending` so an existing success can't linger.
+            const pendingChecks = new Set();
+            if (run.status === "in_progress" && gate.WORKFLOW_TO_CHECK[run.name]) {
+              pendingChecks.add(gate.WORKFLOW_TO_CHECK[run.name]);
             }
 
-            // Fork PRs get ci/merge-gate from build-client-server.yml on
-            // /approve-ci; this workflow owns internal PRs only.
-            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-              core.info(`PR #${pr.number} is a fork; build-client-server.yml owns its status. Skipping.`);
-              return;
-            }
-
-            // Read the latest run of each required internal check on the head SHA.
-            const checks = await github.paginate(github.rest.checks.listForRef, {
-              owner,
-              repo,
-              ref: sha,
-              per_page: 100,
-            });
-            const latest = new Map();
-            for (const c of checks) {
-              const prev = latest.get(c.name);
-              if (!prev || new Date(c.started_at ?? 0) >= new Date(prev.started_at ?? 0)) {
-                latest.set(c.name, c);
-              }
-            }
-            // A skipped/neutral required check means "not satisfied yet" (e.g. an
-            // internal PR without ok-to-test never ran Cypress) — treat as
-            // pending so the gate blocks, matching pre-existing behavior.
-            const outcome = (name) => {
-              const c = latest.get(name);
-              if (!c || c.status !== "completed") return "pending";
-              if (c.conclusion === "success") return "success";
-              if (c.conclusion === "skipped" || c.conclusion === "neutral") return "pending";
-              return "failure";
-            };
-
-            const parts = {
-              "qc-result": outcome("qc-result"),
-              "perform-test / ci-test-result": outcome("perform-test / ci-test-result"),
-            };
-            const failed = Object.entries(parts).filter(([, v]) => v === "failure").map(([k]) => k);
-            const pending = Object.entries(parts).filter(([, v]) => v === "pending").map(([k]) => k);
-
-            let state, description;
-            if (failed.length) {
-              state = "failure";
-              description = `Failed: ${failed.join(", ")}`.slice(0, 140);
-            } else if (pending.length) {
-              state = "pending";
-              description = `Waiting: ${pending.join(", ")}`.slice(0, 140);
-            } else {
-              state = "success";
-              description = "Quality checks + Cypress passed";
-            }
-
-            core.info(`Setting ${GATE}=${state} on ${sha} for internal PR #${pr.number} (${description})`);
-            await github.rest.repos.createCommitStatus({
-              owner,
-              repo,
-              sha,
-              state,
-              context: GATE,
-              description,
-              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
-            });
+            await gate.evaluate({ github, core, owner, repo, sha, pr, pendingChecks, runUrl });

--- a/.github/workflows/scripts/merge-gate.js
+++ b/.github/workflows/scripts/merge-gate.js
@@ -1,0 +1,241 @@
+"use strict";
+
+// Shared logic for the single required `ci/merge-gate` status.
+//
+// The gate is written on a PR's HEAD commit SHA and reflects whether the
+// checks that actually apply to that PR type are green:
+//   - internal PR: `qc-result` AND `perform-test / ci-test-result`
+//   - fork PR:     `external-ci-result` AND the approved Cypress result
+//                  (persisted as the `ci/fork-cypress` commit status)
+//
+// It is invoked from two places so exactly one writes per PR:
+//   - merge-gate.yml (workflow_run) — recomputes on every completion / rerun
+//     start of the feeding workflows; owns internal PRs and recomputes the fork
+//     credential-free side.
+//   - build-client-server.yml (/approve-ci dispatch) — persists ci/fork-cypress
+//     and writes the gate for fork PRs, where the approved head SHA is known.
+//
+// Fail-closed everywhere: anything not proven green (skipped, neutral, missing,
+// in-flight) maps to `pending`, never `success`.
+
+const GATE = "ci/merge-gate";
+const FORK_CYPRESS = "ci/fork-cypress";
+
+// Feeding workflow name -> the check-run context it produces. Used to force an
+// input to `pending` while that workflow is re-running (workflow_run
+// `in_progress`), so an earlier success cannot linger during a rerun.
+const WORKFLOW_TO_CHECK = {
+  "Quality checks": "qc-result",
+  "PR Automation test suite": "perform-test / ci-test-result",
+  "External PR credential-free validation": "external-ci-result",
+};
+
+// A deleted fork leaves head.repo === null; treat a missing head.repo as a fork.
+function isFork(pr, owner, repo) {
+  return !pr.head.repo || pr.head.repo.full_name !== `${owner}/${repo}`;
+}
+
+// Only gate open PRs that target `release` and whose current head is the SHA we
+// are about to write on. This prevents stale writes (head advanced) and reuse
+// of results from a different merge commit after a base retarget.
+function isGatable(pr, sha) {
+  return Boolean(
+    pr &&
+      pr.state === "open" &&
+      pr.base &&
+      pr.base.ref === "release" &&
+      pr.head &&
+      pr.head.sha === sha,
+  );
+}
+
+function latestChecks(checkRuns) {
+  const map = new Map();
+  const ts = (c) => new Date(c.started_at || c.completed_at || 0).getTime();
+  for (const c of checkRuns) {
+    const prev = map.get(c.name);
+    if (!prev || ts(c) >= ts(prev)) map.set(c.name, c);
+  }
+  return map;
+}
+
+// listCommitStatusesForRef returns newest-first, so the first per context wins.
+function latestStatuses(statuses) {
+  const map = new Map();
+  for (const s of statuses) if (!map.has(s.context)) map.set(s.context, s);
+  return map;
+}
+
+// Pure decision so it can be unit-tested without the API.
+function decide({ fork, checkRuns, statuses, pendingChecks, forkCypressState }) {
+  const checksByName = latestChecks(checkRuns || []);
+  const statusesByCtx = latestStatuses(statuses || []);
+  const forced = pendingChecks || new Set();
+
+  const checkOutcome = (name) => {
+    if (forced.has(name)) return "pending";
+    const c = checksByName.get(name);
+    if (!c || c.status !== "completed") return "pending";
+    if (c.conclusion === "success") return "success";
+    // skipped / neutral are NOT a pass — keep the gate closed.
+    if (c.conclusion === "skipped" || c.conclusion === "neutral") return "pending";
+    return "failure";
+  };
+  const statusOutcome = (ctx, override) => {
+    if (override) return override;
+    const s = statusesByCtx.get(ctx);
+    if (!s) return "pending";
+    if (s.state === "success") return "success";
+    if (s.state === "pending") return "pending";
+    return "failure";
+  };
+
+  const parts = fork
+    ? [
+        ["external-ci-result", checkOutcome("external-ci-result")],
+        ["approved Cypress", statusOutcome(FORK_CYPRESS, forkCypressState)],
+      ]
+    : [
+        ["qc-result", checkOutcome("qc-result")],
+        ["perform-test / ci-test-result", checkOutcome("perform-test / ci-test-result")],
+      ];
+
+  const failed = parts.filter(([, v]) => v === "failure").map(([k]) => k);
+  const pending = parts.filter(([, v]) => v === "pending").map(([k]) => k);
+
+  if (failed.length) {
+    return { state: "failure", description: `Failed: ${failed.join(", ")}`.slice(0, 140) };
+  }
+  if (pending.length) {
+    return { state: "pending", description: `Waiting: ${pending.join(", ")}`.slice(0, 140) };
+  }
+  return {
+    state: "success",
+    description: (fork
+      ? "Credential-free + approved Cypress passed"
+      : "Quality checks + Cypress passed"
+    ).slice(0, 140),
+  };
+}
+
+// Exactly one of the three fork Cypress result jobs runs per invocation; 0 or
+// >1 is unexpected and fails closed.
+function forkCypressStateFromResults(results) {
+  const ran = (results || []).filter((r) => r && r !== "skipped");
+  if (ran.length !== 1) return "failure";
+  return ran[0] === "success" ? "success" : "failure";
+}
+
+// Resolve the unique open PR whose head is `sha`. No arbitrary fallback: a
+// non-unique / no match returns null so we never gate the wrong PR.
+async function resolvePr({ github, owner, repo, sha, workflowRun }) {
+  const uniqueBySha = (arr) => {
+    const m = (arr || []).filter((p) => p.head && p.head.sha === sha);
+    return m.length === 1 ? m[0] : null;
+  };
+
+  // 1) Same-repo PRs are attached to the run.
+  const fromRun = uniqueBySha(workflowRun && workflowRun.pull_requests);
+  if (fromRun) {
+    return (await github.rest.pulls.get({ owner, repo, pull_number: fromRun.number })).data;
+  }
+
+  // 2) Fork PRs: workflow_run.pull_requests is empty, so query by head owner:branch.
+  const headOwner =
+    workflowRun &&
+    workflowRun.head_repository &&
+    workflowRun.head_repository.owner &&
+    workflowRun.head_repository.owner.login;
+  const headBranch = workflowRun && workflowRun.head_branch;
+  if (headOwner && headBranch) {
+    const list = await github.paginate(github.rest.pulls.list, {
+      owner,
+      repo,
+      state: "open",
+      head: `${headOwner}:${headBranch}`,
+      per_page: 100,
+    });
+    const m = uniqueBySha(list);
+    if (m) return m;
+  }
+
+  // 3) Last resort: commit association, exact single SHA match only.
+  const assoc = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+    owner,
+    repo,
+    commit_sha: sha,
+    per_page: 100,
+  });
+  return uniqueBySha(assoc);
+}
+
+async function readRef({ github, owner, repo, sha }) {
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: sha,
+    per_page: 100,
+  });
+  const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+    owner,
+    repo,
+    ref: sha,
+    per_page: 100,
+  });
+  return { checkRuns, statuses };
+}
+
+async function writeGate({ github, owner, repo, sha, state, description, runUrl }) {
+  await github.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context: GATE,
+    description,
+    target_url: runUrl,
+  });
+}
+
+async function publishForkCypress({ github, owner, repo, sha, results, runUrl }) {
+  const state = forkCypressStateFromResults(results);
+  await github.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context: FORK_CYPRESS,
+    description: state === "success" ? "Approved Cypress passed" : "Approved Cypress not green",
+    target_url: runUrl,
+  });
+  return state;
+}
+
+// Caller supplies the resolved PR. Writes ci/merge-gate on `sha`.
+async function evaluate({ github, core, owner, repo, sha, pr, pendingChecks, forkCypressState, runUrl }) {
+  if (!isGatable(pr, sha)) {
+    if (core && core.info) core.info(`PR not gatable for ${sha} (open + base=release + head==sha); skipping.`);
+    return null;
+  }
+  const fork = isFork(pr, owner, repo);
+  const { checkRuns, statuses } = await readRef({ github, owner, repo, sha });
+  const { state, description } = decide({ fork, checkRuns, statuses, pendingChecks, forkCypressState });
+  await writeGate({ github, owner, repo, sha, state, description, runUrl });
+  if (core && core.info) core.info(`ci/merge-gate=${state} on ${sha} (fork=${fork}) — ${description}`);
+  return state;
+}
+
+module.exports = {
+  GATE,
+  FORK_CYPRESS,
+  WORKFLOW_TO_CHECK,
+  isFork,
+  isGatable,
+  decide,
+  forkCypressStateFromResults,
+  resolvePr,
+  readRef,
+  writeGate,
+  publishForkCypress,
+  evaluate,
+};


### PR DESCRIPTION
## Problem

External-contributor (fork) PRs to `release` can pass every check, be reviewed, and be DP-validated, yet stay `mergeStateStatus: BLOCKED`. Example: #41927.

`release` branch protection requires status contexts by **exact name** — `mergefreeze`, `qc-result`, `perform-test / ci-test-result`. The external-contributor flow (#42061) gates the internal jobs off for forks (`head.repo.full_name == github.repository`) and instead emits `external-ci-result` (credential-free) plus `ci-test-*-result` from the `/approve-ci` dispatch. So on a fork PR `qc-result` is skipped and `perform-test / ci-test-result` is never created → GitHub keeps a required context in "Expected" forever → merge blocked. (The rollup looks green because it only aggregates checks that ran.)

## Fix

One required status context, **`ci/merge-gate`**, written on the PR head SHA, computed by shared logic in `.github/workflows/scripts/merge-gate.js`. Two entry points, so exactly one writes per PR (a PR is either internal or fork):

- **Internal PRs** — `merge-gate.yml`, triggered by `workflow_run` of `Quality checks` + `PR Automation test suite`. Requires `qc-result` + `perform-test / ci-test-result` green.
- **Fork PRs** — `build-client-server.yml` on the trusted `/approve-ci` dispatch. Requires `external-ci-result` + the approved Cypress result green. The Cypress result is persisted as the `ci/fork-cypress` commit status so it survives and can be re-read.

`merge-gate.yml` also feeds the fork side: it listens to `External PR credential-free validation` too, so a credential-free rerun recomputes the gate.

**Fail-closed by construction:** anything not proven green — skipped, neutral, missing, or in-flight — maps to `pending`, never `success`.

### Correctness hardening (from GPT-5.6 Sol review — all findings addressed)

- **Recompute on both fork inputs.** Credential-free completion/rerun recomputes via `merge-gate.yml`; Cypress completion recomputes via `build-client-server.yml`. No stale `success` when credential-free re-runs and fails; no stuck `pending` if credential-free finishes after Cypress.
- **Rerun → `pending`.** `merge-gate.yml` triggers on `in_progress` and forces the re-running workflow's own input to `pending`, so an earlier `success` can't linger during a same-SHA rerun. Fork side: an early `mark-fork-gate-pending` job sets `pending` when `/approve-ci` starts.
- **Validated write.** Both entry points require the PR to be open, `base == release`, and `head.sha == the SHA being written` — blocks stale writes and reuse of results after a base retarget.
- **Robust PR resolution, no arbitrary fallback.** Resolve via `workflow_run.pull_requests` → head `owner:branch` (forks are absent from `pull_requests`) → commit association, requiring a **unique** exact-SHA match. A `null` `head.repo` (deleted fork) is treated as a fork.
- **Exactly one Cypress result.** `ci/fork-cypress` is `success` only if exactly one of the three result jobs ran and passed; 0 or >1 fails closed.

## Companion step — branch protection (admin, after merge + live validation)

This PR cannot change branch protection. On `release` only:
- **Add** `ci/merge-gate`; **keep** `mergefreeze`; **remove** `qc-result`, `perform-test / ci-test-result`.

Scope: `release` only. `master` takes internal promotion PRs (no forks); `pg` is dead; `appsmith-ee` is private and takes no fork PRs.

### Rollout order (important — no backfill)

`ci/merge-gate` is only written when a feeding workflow runs; existing open PRs won't have it until retriggered. So:
1. Merge this PR (puts `merge-gate.yml` + the script on the default branch, where `workflow_run` activates).
2. Confirm `ci/merge-gate` reports correctly on **one live internal PR** and, after re-running `/approve-ci`, on **fork PR #41927**.
3. **Retrigger every in-flight PR** (push or re-run its workflows; re-`/approve-ci` forks) so they acquire `ci/merge-gate`.
4. Only then flip branch protection.

## Verification

- `actionlint`: clean on `merge-gate.yml`; no new findings on `build-client-server.yml` (all reported items pre-existing).
- Shared decision logic dry-run against the **actual module** — **28/28**: internal green/pending/failure, skipped→pending, rerun→pending (in-flight override), fork success/failure, **stale-success closed** (ext fail + Cypress pass → failure), Cypress read from persisted status, exactly-one-Cypress, `isFork`/`isGatable` guards, and resolver (pull_requests / owner:branch / association, ambiguous→null).
- **CE→EE sync verified safe:** CE and EE `build-client-server.yml` differ by one line (runner) far from the appended jobs → clean apply; all `needs` job names exist in EE; EE workflow names match `merge-gate.yml`'s triggers; `ci/merge-gate` is not in EE's required set, so it is inert/harmless there (EE takes no fork PRs).
- **Cannot be exercised on this PR:** `workflow_run` workflows only run from the default branch, so `merge-gate.yml` activates only after merge — hence the staged rollout. Live-validate the internal rerun transition and both fork completion orders before flipping protection.

## Impact on existing / in-flight PRs

- Internal PRs: `ci/merge-gate` green once `qc-result` + `perform-test / ci-test-result` are green — same effective bar as today.
- Fork PRs (e.g. #41927): unblock once credential-free + approved Cypress pass.
- Rollback: restore the previous required contexts on `release`, delete `merge-gate.yml` + `scripts/merge-gate.js` + the two `build-client-server.yml` jobs. CI-only, no runtime/instance impact.

This is a CI-workflow-only change, so the Cypress suite is intentionally not run (per `AGENTS.md`).

---

Linear: https://linear.app/appsmith/issue/APP-15921
Fixes https://linear.app/appsmith/issue/APP-15921/fork-prs-cant-merge-branch-protection-requires-internal-only-checks
Slack thread: https://theappsmith.slack.com/archives/C09NG5BJ18S/p1788529352417229


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34124266993>
> Commit: e26b44a78d5d25ecc3ba45c3b8e427a7c8b59531
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34124266993&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Mon, 07 Sep 2026 14:34:08 UTC
<!-- end of auto-generated comment: Cypress test results  -->


## Automation
/ok-to-test tags="@tag.All"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request validation for changes originating from forks.
  * Merge checks now accurately reflect pending, failed, skipped, or incomplete quality and test results.
  * Cypress validation results are included in the final merge decision for fork-based pull requests.

* **Chores**
  * Added automated coordination of quality, internal testing, external validation, and merge-status reporting.
  * Prevents outdated or invalid pull request results from being used for merge decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->