### PR TITLE
ci: pin the mongo sidecar image to 7.0

### DIFF
--- a/.github/workflows/ci-test-custom-script.yml
+++ b/.github/workflows/ci-test-custom-script.yml
@@ -62,7 +62,7 @@ jobs:
           # Opens tcp port 6379 on the host and service container
           - 6379:6379
       mongo:
-        image: mongo
+        image: mongo:7.0
         ports:
           - 27017:27017
 

--- a/.github/workflows/ci-test-hosted.yml
+++ b/.github/workflows/ci-test-hosted.yml
@@ -42,7 +42,7 @@ jobs:
           # Opens tcp port 6379 on the host and service container
           - 6379:6379
       mongo:
-        image: mongo
+        image: mongo:7.0
         ports:
           - 27017:27017
 

--- a/.github/workflows/ci-test-limited-with-count.yml
+++ b/.github/workflows/ci-test-limited-with-count.yml
@@ -80,7 +80,7 @@ jobs:
           # Opens tcp port 6379 on the host and service container
           - 6379:6379
       mongo:
-        image: mongo
+        image: mongo:7.0
         ports:
           - 27017:27017
 

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -56,7 +56,7 @@ jobs:
         ports:
           - 6379:6379
       mongo:
-        image: mongo
+        image: mongo:7.0
         ports:
           - 27017:27017
 

--- a/.github/workflows/ci-test-playwright.yml
+++ b/.github/workflows/ci-test-playwright.yml
@@ -53,7 +53,7 @@ jobs:
         ports:
           - 6379:6379
       mongo:
-        image: mongo
+        image: mongo:7.0
         ports:
           - 27017:27017
 

--- a/.github/workflows/external-pr-validation.yml
+++ b/.github/workflows/external-pr-validation.yml
@@ -115,7 +115,7 @@ jobs:
         ports:
           - 6379:6379
       mongo:
-        image: mongo
+        image: mongo:7.0
         ports:
           - 27017:27017
     defaults:


### PR DESCRIPTION
## Description

Every Cypress shard scheduled on a refreshed GitHub runner currently fails during setup: the `mongo` sidecar (unpinned, so `mongo:latest` = 8.x) refuses to start with

```text
MongoDB cannot start: Linux kernel versions 6.19 and newer has a known incompatibility with this version of MongoDB. See https://jira.mongodb.org/browse/SERVER-121912
```

The incompatibility is between MongoDB 8.x's bundled TCMalloc and Linux kernels 6.19–7.0.13; the refreshed runner image carries an affected kernel, so shards fail or pass depending on which runner they land on (observed: 42 of ~60 shards failing on appsmith-ee#9672). MongoDB refuses to start by design; the resolution on affected hosts is a kernel ≥7.0.14, which we don't control on hosted runners.

This pins the sidecar to `mongo:7.0`, which does not bundle the affected allocator and is well within the supported range (server minimum is 5.0). All six workflows that declared the unpinned image are updated: `ci-test-hosted`, `ci-test-playwright`, `ci-test-custom-script`, `ci-test-limited`, `ci-test-limited-with-count`, `external-pr-validation`.

Revisit the pin when a MongoDB 8.x image ships with the re-vendored allocator or the runner kernels move past 7.0.13.

## Automation

CI-workflow-only change; the Cypress suite is what this fixes, and it cannot run to green from an unmerged workflow-only branch on affected runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized automated testing environments on MongoDB 7.0.
  * Improved consistency and predictability across continuous integration and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->