### PR TITLE
Fix CI failure reporting and pin MCP builds to the approved commit

### DIFF
--- a/.github/workflows/build-client-server-count.yml
+++ b/.github/workflows/build-client-server-count.yml
@@ -207,7 +207,8 @@ jobs:
         if: needs.ci-test-limited.result != 'success'
         uses: actions/setup-node@v4
         with:
-          node-version-file: app/client/package.json
+          # Reporting runs without a repository checkout.
+          node-version: "24"
 
       - name: install pg
         if: needs.ci-test-limited.result != 'success'
@@ -366,7 +367,8 @@ jobs:
         if: needs.ci-test-limited-existing-docker-image.result != 'success'
         uses: actions/setup-node@v4
         with:
-          node-version-file: app/client/package.json
+          # Reporting runs without a repository checkout.
+          node-version: "24"
 
       - name: install pg
         if: needs.ci-test-limited-existing-docker-image.result != 'success'

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -353,6 +353,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{fromJson(needs.file-check.outputs.pr)}}
+      checkout-ref: ${{ needs.file-check.outputs.merge_sha }}
 
   rts-build:
     name: rts-build
@@ -425,7 +426,8 @@ jobs:
         if: needs.ci-test-limited.result != 'success'
         uses: actions/setup-node@v4
         with:
-          node-version-file: app/client/package.json
+          # Reporting runs without a repository checkout.
+          node-version: "24"
 
       - name: install pg
         if: needs.ci-test-limited.result != 'success'
@@ -543,7 +545,8 @@ jobs:
         if: needs.ci-test-full.result != 'success'
         uses: actions/setup-node@v4
         with:
-          node-version-file: app/client/package.json
+          # Reporting runs without a repository checkout.
+          node-version: "24"
 
       - name: install pg
         if: needs.ci-test-full.result != 'success'
@@ -661,7 +664,8 @@ jobs:
         if: needs.ci-test-limited-existing-docker-image.result != 'success'
         uses: actions/setup-node@v4
         with:
-          node-version-file: app/client/package.json
+          # Reporting runs without a repository checkout.
+          node-version: "24"
 
       - name: install pg
         if: needs.ci-test-limited-existing-docker-image.result != 'success'

--- a/.github/workflows/mcp-build.yml
+++ b/.github/workflows/mcp-build.yml
@@ -21,6 +21,11 @@ on:
         description: "Branch to build when pr is 0"
         required: false
         type: string
+      checkout-ref:
+        description: "Immutable commit SHA to checkout for an approved external PR"
+        required: false
+        type: string
+        default: ""
 
   pull_request:
     branches: [release, master]
@@ -44,7 +49,7 @@ jobs:
       github.event_name == 'release'
     steps:
       - name: Checkout the merged pull-request commit
-        if: inputs.pr != 0
+        if: inputs.checkout-ref == '' && inputs.pr != 0
         uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -52,7 +57,7 @@ jobs:
           ref: refs/pull/${{ inputs.pr }}/merge
 
       - name: Checkout the specified branch
-        if: inputs.pr == 0 && inputs.branch != ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch != ''
         uses: actions/checkout@v4
         with:
           fetch-tags: true
@@ -60,11 +65,19 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Checkout the head commit
-        if: inputs.pr == 0 && inputs.branch == ''
+        if: inputs.checkout-ref == '' && inputs.pr == 0 && inputs.branch == ''
         uses: actions/checkout@v4
         with:
           fetch-tags: true
           persist-credentials: false
+
+      - name: Checkout the approved immutable commit
+        if: inputs.checkout-ref != ''
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          persist-credentials: false
+          ref: ${{ inputs.checkout-ref }}
 
       - name: Use Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Cypress failure-reporting jobs referenced app/client/package.json without checking out the repository, causing Node setup to fail before reporting test failures. All five affected jobs now specify Node 24 directly.
The MCP workflow now accepts checkout-ref, and the approved CI pipeline passes its verified merge SHA. This keeps MCP on the same commit as the other build components if the PR changes after approval.
Validation:
- Parsed all 50 workflow YAML files.
- Checked eight MCP checkout combinations.
- Verified all five build jobs receive the approved merge SHA.
- Passed git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Build and reporting workflows now use Node.js 24 consistently, improving predictability across CI runs.
  - Builds can now check out an explicitly approved commit, helping ensure external pull request builds use the intended source revision.
  - Build jobs now pass the selected commit revision consistently through the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->