### PR TITLE
fix: Moved expires_in field after scope in OAuth2 DatasourceForm

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -596,6 +596,9 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
 
   renderOauth2Common = () => {
     const { formData } = this.props;
+    const isGrantTypeAuthorizationCode =
+      _.get(formData.authentication, "grantType") ===
+      GrantType.AuthorizationCode;
 
     return (
       <>
@@ -683,6 +686,18 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        {isGrantTypeAuthorizationCode && (
+          <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+            {this.renderInputTextControlViaFormControl({
+              configProperty: "authentication.expiresIn",
+              label: "Authorization expires in (seconds)",
+              placeholderText: "3600",
+              dataType: "NUMBER",
+              encrypted: false,
+              isRequired: false,
+            })}
+          </FormInputContainer>
+        )}
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +884,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&


### PR DESCRIPTION
## Description
This PR moves the `expires_in` field right after the `scope` field in the OAuth2 datasource configuration form.

Previously, `expires_in` was placed at the very end of the form, which made it easy to miss since it was disconnected from the rest of the auth settings. Grouping them together improves the UX when setting up OAuth2.

Fixes #31059

## Type of change
- UI/UX enhancement

## How Has This Been Tested?
- Tested locally to ensure the `expiresIn` input correctly appears below the scope input only when the Authorization Code grant type is selected.
