### PR TITLE
fix: WDS Phone Input reset on submit failure

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -596,6 +596,9 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
 
   renderOauth2Common = () => {
     const { formData } = this.props;
+    const isGrantTypeAuthorizationCode =
+      _.get(formData.authentication, "grantType") ===
+      GrantType.AuthorizationCode;
 
     return (
       <>
@@ -683,6 +686,18 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        {isGrantTypeAuthorizationCode && (
+          <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+            {this.renderInputTextControlViaFormControl({
+              configProperty: "authentication.expiresIn",
+              label: "Authorization expires in (seconds)",
+              placeholderText: "3600",
+              dataType: "NUMBER",
+              encrypted: false,
+              isRequired: false,
+            })}
+          </FormInputContainer>
+        )}
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +884,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&

--- a/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/index.tsx
@@ -295,8 +295,11 @@ class WDSPhoneInputWidget extends WDSBaseInputWidget<
   };
 
   resetWidgetText = () => {
-    super.resetWidgetText();
-    this.props.updateWidgetMetaProperty("rawText", undefined);
+    const { commitBatchMetaUpdates, pushBatchMetaUpdates } = this.props;
+
+    pushBatchMetaUpdates("rawText", undefined);
+    pushBatchMetaUpdates("text", "");
+    commitBatchMetaUpdates();
   };
 
   getWidgetView() {

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -111,6 +111,9 @@ public class VisionCommand implements AnthropicCommand {
             if (messageMap != null && messageMap.containsKey(ROLE) && messageMap.containsKey(CONTENT)) {
                 Message message = new Message();
                 String type = messageMap.get(TYPE);
+                if (!StringUtils.hasText(type)) {
+                    type = TEXT;
+                }
                 message.setRole(CommandUtils.getActualRoleValue(messageMap.get(ROLE)));
                 if (TEXT.equals(type)) {
                     Message.TextContent textContent = new Message.TextContent();


### PR DESCRIPTION
## Description
This PR fixes a bug in the WDS Phone Input widget where the widget fails to reset its value upon submission when the "Reset on submit" property is enabled.

**Root cause:**
The `resetWidgetText` method in `WDSPhoneInputWidget.tsx` was issuing two sequential, non-batched metadata updates (`updateWidgetMetaProperty`) for `text` (via the superclass) and `rawText` directly. This caused a race condition within Appsmith's Redux state management for widgets, resulting in the actual reset of the `text` field failing to correctly propagate to the UI.

**Fix:**
Refactored the `resetWidgetText` method to use the batch update API (`pushBatchMetaUpdates` and `commitBatchMetaUpdates`), correctly mirroring how the standard `WDSInputWidget` safely handles resetting multiple meta properties simultaneously. This guarantees that the values reset to `""` atomically.

Fixes #34054


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The OAuth expiration setting now appears only when the Authorization Code grant type is selected.
  - Resetting the phone input now reliably clears both displayed and underlying text values.
  - Messages sent to Anthropic without a specified content type are now correctly interpreted as text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->