### PR TITLE
fix: retain REST API auth type when fields are empty

### DIFF
--- a/app/client/src/PluginActionEditor/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/PluginActionEditor/transformers/RestAPIDatasourceFormTransformer.ts
@@ -153,89 +153,89 @@ const formToDatasourceAuthentication = (
   authType: AuthType,
   authentication: Authentication | undefined,
 ): Authentication | null => {
-  if (authType === AuthType.NONE || !authentication) return null;
+  if (authType === AuthType.NONE) return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const auth: any = authentication || {};
 
   if (
-    isClientCredentials(authType, authentication) ||
-    isAuthorizationCode(authType, authentication)
+    isClientCredentials(authType, auth) ||
+    isAuthorizationCode(authType, auth) ||
+    authType === AuthType.OAuth2
   ) {
+    const grantType = auth.grantType || GrantType.ClientCredentials;
+
     const oAuth2Common: Oauth2Common = {
       authenticationType: AuthType.OAuth2,
-      accessTokenUrl: authentication.accessTokenUrl,
-      clientId: authentication.clientId,
-      headerPrefix: authentication.headerPrefix,
-      scopeString: authentication.scopeString,
-      clientSecret: authentication.clientSecret,
-      isAuthorizationHeader: authentication.isAuthorizationHeader,
-      isTokenHeader: authentication.isTokenHeader,
-      audience: authentication.audience,
-      resource: authentication.resource,
-      sendScopeWithRefreshToken: authentication.sendScopeWithRefreshToken,
+      accessTokenUrl: auth.accessTokenUrl,
+      clientId: auth.clientId,
+      headerPrefix: auth.headerPrefix,
+      scopeString: auth.scopeString,
+      clientSecret: auth.clientSecret,
+      isAuthorizationHeader: auth.isAuthorizationHeader,
+      isTokenHeader: auth.isTokenHeader,
+      audience: auth.audience,
+      resource: auth.resource,
+      sendScopeWithRefreshToken: auth.sendScopeWithRefreshToken,
       refreshTokenClientCredentialsLocation:
-        authentication.refreshTokenClientCredentialsLocation,
-      useSelfSignedCert: authentication.useSelfSignedCert,
+        auth.refreshTokenClientCredentialsLocation,
+      useSelfSignedCert: auth.useSelfSignedCert,
     };
 
-    if (isClientCredentials(authType, authentication)) {
+    if (grantType === GrantType.ClientCredentials) {
       return {
         ...oAuth2Common,
         grantType: GrantType.ClientCredentials,
         customTokenParameters: cleanupProperties(
-          authentication.customTokenParameters,
+          auth.customTokenParameters,
         ),
       };
     }
 
-    if (isAuthorizationCode(authType, authentication)) {
+    if (grantType === GrantType.AuthorizationCode) {
       return {
         ...oAuth2Common,
         grantType: GrantType.AuthorizationCode,
-        authorizationUrl: authentication.authorizationUrl,
-        isAuthorized: !!authentication.isAuthorized,
+        authorizationUrl: auth.authorizationUrl,
+        isAuthorized: !!auth.isAuthorized,
         customAuthenticationParameters: cleanupProperties(
-          authentication.customAuthenticationParameters,
+          auth.customAuthenticationParameters,
         ),
-        expiresIn: authentication.expiresIn,
+        expiresIn: auth.expiresIn,
       };
     }
   }
 
   if (authType === AuthType.basic) {
-    if ("username" in authentication) {
-      const basic: Basic = {
-        authenticationType: AuthType.basic,
-        username: authentication.username,
-        password: authentication.password,
-        secretExists: authentication.secretExists,
-      };
+    const basic: Basic = {
+      authenticationType: AuthType.basic,
+      username: auth.username || "",
+      password: auth.password || "",
+      secretExists: auth.secretExists,
+    };
 
-      return basic;
-    }
+    return basic;
   }
 
   if (authType === AuthType.apiKey) {
-    if ("label" in authentication) {
-      const apiKey: ApiKey = {
-        authenticationType: AuthType.apiKey,
-        label: authentication.label,
-        value: authentication.value,
-        headerPrefix: authentication.headerPrefix,
-        addTo: authentication.addTo,
-      };
+    const apiKey: ApiKey = {
+      authenticationType: AuthType.apiKey,
+      label: auth.label || "",
+      value: auth.value || "",
+      headerPrefix: auth.headerPrefix || "",
+      addTo: auth.addTo || "",
+    };
 
-      return apiKey;
-    }
+    return apiKey;
   }
 
   if (authType === AuthType.bearerToken) {
-    if ("bearerToken" in authentication) {
-      const bearerToken: BearerToken = {
-        authenticationType: AuthType.bearerToken,
-        bearerToken: authentication.bearerToken,
-      };
+    const bearerToken: BearerToken = {
+      authenticationType: AuthType.bearerToken,
+      bearerToken: auth.bearerToken || "",
+    };
 
-      return bearerToken;
-    }
+    return bearerToken;
   }
 
   return null;

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -596,6 +596,9 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
 
   renderOauth2Common = () => {
     const { formData } = this.props;
+    const isGrantTypeAuthorizationCode =
+      _.get(formData.authentication, "grantType") ===
+      GrantType.AuthorizationCode;
 
     return (
       <>
@@ -683,6 +686,18 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             isRequired: false,
           })}
         </FormInputContainer>
+        {isGrantTypeAuthorizationCode && (
+          <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
+            {this.renderInputTextControlViaFormControl({
+              configProperty: "authentication.expiresIn",
+              label: "Authorization expires in (seconds)",
+              placeholderText: "3600",
+              dataType: "NUMBER",
+              encrypted: false,
+              isRequired: false,
+            })}
+          </FormInputContainer>
+        )}
         <FormInputContainer
           data-location-id={btoa("authentication.isAuthorizationHeader")}
         >
@@ -869,16 +884,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             "",
             false,
           )}
-        </FormInputContainer>
-        <FormInputContainer data-location-id={btoa("authentication.expiresIn")}>
-          {this.renderInputTextControlViaFormControl({
-            configProperty: "authentication.expiresIn",
-            label: "Authorization expires in (seconds)",
-            placeholderText: "3600",
-            dataType: "NUMBER",
-            encrypted: false,
-            isRequired: false,
-          })}
         </FormInputContainer>
 
         {!_.get(formData.authentication, "isAuthorizationHeader", true) &&

--- a/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSPhoneInputWidget/widget/index.tsx
@@ -295,8 +295,11 @@ class WDSPhoneInputWidget extends WDSBaseInputWidget<
   };
 
   resetWidgetText = () => {
-    super.resetWidgetText();
-    this.props.updateWidgetMetaProperty("rawText", undefined);
+    const { commitBatchMetaUpdates, pushBatchMetaUpdates } = this.props;
+
+    pushBatchMetaUpdates("rawText", undefined);
+    pushBatchMetaUpdates("text", "");
+    commitBatchMetaUpdates();
   };
 
   getWidgetView() {

--- a/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
+++ b/app/server/appsmith-plugins/anthropicPlugin/src/main/java/com/external/plugins/commands/VisionCommand.java
@@ -111,6 +111,9 @@ public class VisionCommand implements AnthropicCommand {
             if (messageMap != null && messageMap.containsKey(ROLE) && messageMap.containsKey(CONTENT)) {
                 Message message = new Message();
                 String type = messageMap.get(TYPE);
+                if (!StringUtils.hasText(type)) {
+                    type = TEXT;
+                }
                 message.setRole(CommandUtils.getActualRoleValue(messageMap.get(ROLE)));
                 if (TEXT.equals(type)) {
                     Message.TextContent textContent = new Message.TextContent();


### PR DESCRIPTION
## Description
This PR fixes a bug in the REST API Datasource form where changing the Authentication Type to Basic, API Key, or Bearer Token but leaving the subsequent input fields empty resulted in the authentication type not being retained upon saving.

**Root cause:**
When the form is saved, `formValuesToDatasource` invokes `formToDatasourceAuthentication` to construct the authentication DTO. Previously, this function checked for specific nested keys (e.g., `if ("username" in authentication)`) or immediately returned `null` if the `authentication` object was undefined. Because selecting an auth type from the dropdown without entering data doesn't necessarily initialize those keys in Redux Form, the authentication object was stripped entirely and the backend reverted the setting to "None".

**Fix:**
Refactored `formToDatasourceAuthentication` to safely initialize a default empty object `{} ` if `authentication` is undefined, and removed the restrictive key existence checks (`in` operator). Now, if an authentication type is explicitly set, the function accurately constructs and returns the corresponding basic structure with default empty strings, thereby preserving the user's dropdown choice upon save.

Fixes #30070


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved REST API authentication form handling across OAuth2, basic, API key, and bearer token configurations.
  - The authorization expiration field now appears only for OAuth2 Authorization Code flows.
  - Fixed phone input reset behavior so both displayed and underlying text are cleared reliably.
  - Vision messages without a specified type are now treated as text messages by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->