### PR TITLE
chore: Removed mcp server url settings from admin settings

### DIFF
--- a/app/client/src/ce/api/OrganizationApi.ts
+++ b/app/client/src/ce/api/OrganizationApi.ts
@@ -16,6 +16,7 @@ export type UpdateOrganizationConfigResponse = ApiResponse<{
 export interface UpdateOrganizationConfigRequest {
   organizationConfiguration: Record<string, string>;
   needsRefresh?: boolean;
+  needsRestart?: boolean;
   isOnlyOrganizationSettings?: boolean;
   apiConfig?: AxiosRequestConfig;
 }

--- a/app/client/src/ce/pages/AdminSettings/config/mcpServer.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/mcpServer.ts
@@ -49,5 +49,6 @@ export const getMcpServerConfig = (
     : {
         ...config,
         categoryType: CategoryType.INSTANCE,
+        needsRestart: true,
       };
 };

--- a/app/client/src/ce/pages/AdminSettings/config/mcpServer.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/mcpServer.ts
@@ -6,17 +6,8 @@ import {
   CategoryType,
   SettingCategories,
   SettingTypes,
-  SettingSubtype,
 } from "ee/pages/AdminSettings/config/types";
-import { getDefaultMcpServerUrl } from "ee/constants/mcp";
 import McpKeysPage from "pages/AdminSettings/Profile/McpKeysPage";
-
-const isMcpServerOff = (
-  // TODO: Fix this the next time the file is edited
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  values?: Record<string, any>,
-) =>
-  values?.mcpConfig?.enabled !== true && values?.["mcpConfig.enabled"] !== true;
 
 export const MCP_ENABLED_SETTING: Setting = {
   id: "mcpConfig.enabled",
@@ -29,55 +20,6 @@ export const MCP_ENABLED_SETTING: Setting = {
     "* Agents authenticate with per-user MCP keys (Settings → MCP Keys) and act with that user's permissions. Disabled by default — turning this on exposes the /mcp endpoint and lets users create MCP keys. Turning it off removes the endpoint, blocks new keys, and rejects existing ones.",
   defaultValue: false,
 };
-
-export const MCP_DATA_ENABLED_SETTING: Setting = {
-  id: "mcpConfig.dataEnabled",
-  name: "mcpConfig.dataEnabled",
-  category: SettingCategories.MCP_SERVER,
-  controlType: SettingTypes.TOGGLE,
-  label: "MCP data tools",
-  text: "Let agents work with datasources and queries (create datasources/queries, run read-only actions)",
-  helpText:
-    "* Disabled by default. Requires the MCP server above. All operations run under the connecting user's existing permissions; credentials are never exposed to agents.",
-  defaultValue: false,
-  isDisabled: isMcpServerOff,
-};
-
-export const MCP_SERVER_URL_SETTING: Setting = {
-  id: "mcpConfig.serverUrl",
-  name: "mcpConfig.serverUrl",
-  category: SettingCategories.MCP_SERVER,
-  controlType: SettingTypes.TEXTINPUT,
-  controlSubType: SettingSubtype.TEXT,
-  label: "MCP server URL",
-  subText: "MCP server URL which MCP clients should use to reach this instance",
-  placeholder: getDefaultMcpServerUrl(),
-  helpText:
-    "* URL MCP clients should use to reach this instance. Leave blank to use the default (this origin + /mcp). Set a custom value if Appsmith is behind a reverse proxy or a different public hostname.",
-  isDisabled: isMcpServerOff,
-
-  validate: (value: string) => {
-    if (value === undefined || value === "") {
-      return;
-    }
-
-    try {
-      const url = new URL(value);
-
-      if (url.protocol !== "http:" && url.protocol !== "https:") {
-        return "Enter an http(s) URL.";
-      }
-    } catch {
-      return "Enter a valid URL.";
-    }
-  },
-};
-
-const instanceSettings = [
-  MCP_ENABLED_SETTING,
-  MCP_DATA_ENABLED_SETTING,
-  MCP_SERVER_URL_SETTING,
-];
 
 export const mcpKeys: AdminConfigType = {
   icon: "robot-2",
@@ -96,17 +38,16 @@ export const config: AdminConfigType = {
   controlType: SettingTypes.GROUP,
   title: "MCP Server (BETA)",
   canSave: true,
-  settings: [MCP_ENABLED_SETTING, MCP_DATA_ENABLED_SETTING],
+  settings: [MCP_ENABLED_SETTING],
 };
 
 export const getMcpServerConfig = (
   isMultiOrgEnabled: boolean,
 ): AdminConfigType => {
   return isMultiOrgEnabled
-    ? { ...config, settings: [MCP_ENABLED_SETTING] }
+    ? config
     : {
         ...config,
         categoryType: CategoryType.INSTANCE,
-        settings: instanceSettings,
       };
 };

--- a/app/client/src/ce/pages/AdminSettings/config/types.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/types.ts
@@ -120,6 +120,7 @@ export interface Category {
   subText?: string;
   isConnected?: boolean;
   needsRefresh?: boolean;
+  needsRestart?: boolean;
   children?: Category[];
   icon?: string;
   categoryType: string;
@@ -168,6 +169,7 @@ export interface AdminConfigType {
   canSave: boolean;
   isConnected?: boolean;
   needsRefresh?: boolean;
+  needsRestart?: boolean;
   icon?: string;
   categoryType: CategoryType;
   isEnterprise?: boolean;

--- a/app/client/src/ce/sagas/organizationSagas.tsx
+++ b/app/client/src/ce/sagas/organizationSagas.tsx
@@ -143,6 +143,12 @@ export function* updateOrganizationConfigSaga(
       if (action.payload.needsRefresh) {
         location.reload();
       }
+
+      if (action.payload.needsRestart) {
+        yield put({
+          type: ReduxActionTypes.RESTART_SERVER_POLL,
+        });
+      }
     }
   } catch (error) {
     const errorObj = error as APIResponseError;

--- a/app/client/src/ce/utils/adminSettingsHelpers.test.ts
+++ b/app/client/src/ce/utils/adminSettingsHelpers.test.ts
@@ -7,30 +7,22 @@ import {
 describe("MCP org config form mapping", () => {
   it("treats nested mcpConfig form fields as organization settings", () => {
     expect(isOrganizationConfig("mcpConfig.enabled")).toBe(true);
-    expect(isOrganizationConfig("mcpConfig.dataEnabled")).toBe(true);
-    expect(isOrganizationConfig("mcpConfig.serverUrl")).toBe(true);
     expect(isOrganizationConfig("APPSMITH_MCP_ENABLED")).toBe(false);
   });
 
-  it("flattens mcpConfig onto dotted form keys and fail-closes missing flags", () => {
+  it("flattens mcpConfig.enabled onto dotted form keys and fail-closes missing flags", () => {
     expect(
       flattenOrganizationConfigForSettingsForm({
         instanceName: "Appsmith",
         mcpConfig: {
           enabled: true,
-          dataEnabled: false,
-          serverUrl: "https://appsmith.example/mcp",
         },
       }),
     ).toEqual({
       instanceName: "Appsmith",
       "mcpConfig.enabled": true,
-      "mcpConfig.dataEnabled": false,
-      "mcpConfig.serverUrl": "https://appsmith.example/mcp",
       mcpConfig: {
         enabled: true,
-        dataEnabled: false,
-        serverUrl: "https://appsmith.example/mcp",
       },
     });
   });
@@ -38,12 +30,12 @@ describe("MCP org config form mapping", () => {
   it("nests only changed mcpConfig fields on save", () => {
     expect(
       nestOrganizationConfigFromSettingsForm({
-        "mcpConfig.dataEnabled": true,
+        "mcpConfig.enabled": true,
         hideWatermark: true,
       }),
     ).toEqual({
       hideWatermark: true,
-      mcpConfig: { dataEnabled: true },
+      mcpConfig: { enabled: true },
     });
   });
 });

--- a/app/client/src/ce/utils/adminSettingsHelpers.ts
+++ b/app/client/src/ce/utils/adminSettingsHelpers.ts
@@ -88,20 +88,12 @@ export const flattenOrganizationConfigForSettingsForm = (
       if (mcpConfig && typeof mcpConfig === "object") {
         const mcp = mcpConfig as Record<string, unknown>;
         const enabled = mcp.enabled === true;
-        const dataEnabled = mcp.dataEnabled === true;
 
         // Nested paths first: redux-form Field names like "mcpConfig.enabled" use lodash path get.
         // Dotted keys second: settingsMap / settingsConfig[id] lookups. lodash.set skips nesting
         // when the dotted own-property already exists.
         set(configs, "mcpConfig.enabled", enabled);
-        set(configs, "mcpConfig.dataEnabled", dataEnabled);
         configs["mcpConfig.enabled"] = enabled;
-        configs["mcpConfig.dataEnabled"] = dataEnabled;
-
-        if (typeof mcp.serverUrl === "string") {
-          set(configs, "mcpConfig.serverUrl", mcp.serverUrl);
-          configs["mcpConfig.serverUrl"] = mcp.serverUrl;
-        }
       }
 
       return;

--- a/app/client/src/pages/AdminSettings/SaveSettings.tsx
+++ b/app/client/src/pages/AdminSettings/SaveSettings.tsx
@@ -34,6 +34,7 @@ interface SaveAdminSettingsProps {
   isOnlyOrganizationConfig?: boolean;
   isSaving?: boolean;
   needsRefresh?: boolean;
+  needsRestart?: boolean;
   onSave?: () => void;
   onClear?: () => void;
   settings: Record<string, string>;
@@ -46,6 +47,7 @@ const saveAdminSettings = (props: SaveAdminSettingsProps) => {
     isOnlyOrganizationConfig = false,
     isSaving,
     needsRefresh = false,
+    needsRestart = false,
     onClear,
     onSave,
     settings,
@@ -58,9 +60,10 @@ const saveAdminSettings = (props: SaveAdminSettingsProps) => {
   if (needsRefresh) {
     saveButtonText = SAVE_AND_REFRESH_BUTTON;
   } else if (
-    isOnlyOrganizationConfig ||
-    (updatedOrganizationSettings?.length === Object.keys(settings).length &&
-      updatedOrganizationSettings?.length !== 0)
+    !needsRestart &&
+    (isOnlyOrganizationConfig ||
+      (updatedOrganizationSettings?.length === Object.keys(settings).length &&
+        updatedOrganizationSettings?.length !== 0))
   ) {
     saveButtonText = SAVE_BUTTON;
   }

--- a/app/client/src/pages/AdminSettings/SettingsForm.tsx
+++ b/app/client/src/pages/AdminSettings/SettingsForm.tsx
@@ -129,6 +129,7 @@ export function SettingsForm(
           organizationConfiguration: config,
           isOnlyOrganizationSettings: !isEnvAndOrganizationSettings,
           needsRefresh: details?.needsRefresh,
+          needsRestart: details?.needsRestart,
         }),
       );
 
@@ -313,6 +314,7 @@ export function SettingsForm(
             isOnlyOrganizationConfig={isOnlyOrganizationConfig}
             isSaving={props.isSaving}
             needsRefresh={details?.needsRefresh}
+            needsRestart={details?.needsRestart}
             onClear={onClear}
             onSave={onSave}
             settings={props.settings}

--- a/app/client/src/pages/AdminSettings/config/ConfigFactory.ts
+++ b/app/client/src/pages/AdminSettings/config/ConfigFactory.ts
@@ -47,6 +47,7 @@ export class ConfigFactory {
       categoryType: config.categoryType,
       isEnterprise: config.isEnterprise,
       needsRefresh: config.needsRefresh,
+      needsRestart: config.needsRestart,
       isFeatureEnabled: config.isFeatureEnabled,
       children: config?.children?.map((child) =>
         ConfigFactory.getCategory(child),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/McpConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/McpConfig.java
@@ -6,27 +6,21 @@ import org.apache.commons.lang3.ObjectUtils;
 import java.io.Serializable;
 
 /**
- * Organization-owned MCP policy. All admin-facing MCP switches live here; the only remaining env var is
+ * Organization-owned MCP policy. The only admin-facing switch is {@code enabled}; the only remaining env var is
  * {@code APPSMITH_MCP_INTERNAL_SECRET} (install-time, never persisted on the organization).
  *
- * <p>Every flag is boxed. {@code null} and {@code false} both mean off — only {@link Boolean#TRUE} enables a
- * capability. Token lifetime is per-key ({@code keySpanDays}), not an org setting.
+ * <p>{@code enabled} is boxed. {@code null} and {@code false} both mean off — only {@link Boolean#TRUE} enables MCP.
+ * Token lifetime is per-key ({@code keySpanDays}), not an org setting.
  */
 @Data
 public class McpConfig implements Serializable {
 
     private Boolean enabled;
 
-    private Boolean dataEnabled;
-
-    private String serverUrl;
-
     public void copyNonSensitiveValues(McpConfig source) {
         if (source == null) {
             return;
         }
         enabled = ObjectUtils.defaultIfNull(source.getEnabled(), enabled);
-        dataEnabled = ObjectUtils.defaultIfNull(source.getDataEnabled(), dataEnabled);
-        serverUrl = ObjectUtils.defaultIfNull(source.getServerUrl(), serverUrl);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/McpOrganizationConfigurationHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/McpOrganizationConfigurationHelper.java
@@ -1,43 +1,15 @@
 package com.appsmith.server.helpers.ce;
 
 import com.appsmith.server.domains.McpConfig;
-import com.appsmith.server.exceptions.AppsmithError;
-import com.appsmith.server.exceptions.AppsmithException;
-import org.springframework.util.StringUtils;
-
-import java.net.URI;
-import java.net.URISyntaxException;
 
 import static java.lang.Boolean.TRUE;
 
 /**
- * Validates organization MCP policy updates. Instance-only fields ({@code dataEnabled}, {@code serverUrl})
- * are accepted only on single-org deployments.
+ * Interprets organization MCP policy updates. The only admin-facing switch is {@code enabled}.
  */
 public final class McpOrganizationConfigurationHelper {
 
     private McpOrganizationConfigurationHelper() {}
-
-    public static void validate(McpConfig incoming, McpConfig existing, boolean isMultiOrg) {
-        if (incoming == null) {
-            return;
-        }
-
-        if (isMultiOrg) {
-            if (incoming.getDataEnabled() != null || incoming.getServerUrl() != null) {
-                throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "mcpConfig");
-            }
-        }
-
-        if (StringUtils.hasText(incoming.getServerUrl())) {
-            validateServerUrl(incoming.getServerUrl());
-        }
-
-        boolean enabled = isEnabled(incoming, existing);
-        if (TRUE.equals(incoming.getDataEnabled()) && !enabled) {
-            throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "mcpConfig.dataEnabled");
-        }
-    }
 
     public static boolean isEnabled(McpConfig incoming, McpConfig existing) {
         if (incoming != null && incoming.getEnabled() != null) {
@@ -52,19 +24,5 @@ public final class McpOrganizationConfigurationHelper {
 
     public static boolean isExplicitDisable(McpConfig incoming) {
         return incoming != null && incoming.getEnabled() != null && !TRUE.equals(incoming.getEnabled());
-    }
-
-    static void validateServerUrl(String serverUrl) {
-        final URI uri;
-        try {
-            uri = new URI(serverUrl);
-        } catch (URISyntaxException e) {
-            throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "mcpConfig.serverUrl");
-        }
-        if (uri.getScheme() == null
-                || uri.getHost() == null
-                || (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme()))) {
-            throw new AppsmithException(AppsmithError.INVALID_PARAMETER, "mcpConfig.serverUrl");
-        }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -123,11 +123,9 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
                     OrganizationConfiguration snapshotOldConfig = oldOrganizationConfiguration;
                     Mono<Boolean> isMultiOrgMono =
                             organizationConfiguration.getMcpConfig() == null ? Mono.just(false) : isMultiOrgInstance();
-                    return envMono.then(isMultiOrgMono).flatMap(isMultiOrg -> {
-                        McpOrganizationConfigurationHelper.validate(
-                                organizationConfiguration.getMcpConfig(), snapshotOldConfig.getMcpConfig(), isMultiOrg);
-                        return Mono.zip(Mono.just(snapshotOldConfig), Mono.just(organization), Mono.just(isMultiOrg));
-                    });
+                    return envMono.then(isMultiOrgMono)
+                            .flatMap(isMultiOrg -> Mono.zip(
+                                    Mono.just(snapshotOldConfig), Mono.just(organization), Mono.just(isMultiOrg)));
                 })
                 .flatMap(tuple3 -> {
                     Organization organization = tuple3.getT2();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
@@ -45,9 +45,9 @@ public interface EnvManagerCE {
     Mono<Boolean> sendTestEmail(TestEmailConfigRequestDTO requestDTO);
 
     /**
-     * Writes {@code APPSMITH_MCP_INTERNAL_SECRET} to the env file without ACL or organization-config fan-out.
-     * An empty value unsets the variable. Does not require a restart; callers must also update
-     * {@code CommonConfig#mcpInternalSecret} for the running process.
+     * Writes {@code APPSMITH_MCP_INTERNAL_SECRET} to the env file without ACL or organization-config fan-out, then
+     * restarts the instance so the MCP process re-reads the secret. An empty value unsets the variable. Callers must
+     * also update {@code CommonConfig#mcpInternalSecret} for the current process until the restart completes.
      */
     Mono<Void> persistMcpInternalSecret(String secret);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCE.java
@@ -45,9 +45,9 @@ public interface EnvManagerCE {
     Mono<Boolean> sendTestEmail(TestEmailConfigRequestDTO requestDTO);
 
     /**
-     * Writes {@code APPSMITH_MCP_INTERNAL_SECRET} to the env file without ACL or organization-config fan-out, then
-     * restarts the instance so the MCP process re-reads the secret. An empty value unsets the variable. Callers must
-     * also update {@code CommonConfig#mcpInternalSecret} for the current process until the restart completes.
+     * Writes {@code APPSMITH_MCP_INTERNAL_SECRET} to the env file without ACL or organization-config fan-out.
+     * An empty value unsets the variable. Does not restart; the client Save and Restart flow applies the secret.
+     * Callers must also update {@code CommonConfig#mcpInternalSecret} for the running process.
      */
     Mono<Void> persistMcpInternalSecret(String secret);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -557,12 +557,10 @@ public class EnvManagerCEImpl implements EnvManagerCE {
         }
         Map<String, String> changes = new HashMap<>();
         changes.put(APPSMITH_MCP_INTERNAL_SECRET.name(), secret == null ? "" : secret);
-        return applyChangesToEnvFileWithoutAclCheck(changes)
-                .flatMap(ignored -> restartWithoutAclCheck())
-                .onErrorResume(error -> {
-                    log.error("Unable to persist APPSMITH_MCP_INTERNAL_SECRET to the env file or restart", error);
-                    return Mono.empty();
-                });
+        return applyChangesToEnvFileWithoutAclCheck(changes).then().onErrorResume(error -> {
+            log.error("Unable to persist APPSMITH_MCP_INTERNAL_SECRET to the env file", error);
+            return Mono.empty();
+        });
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -557,10 +557,12 @@ public class EnvManagerCEImpl implements EnvManagerCE {
         }
         Map<String, String> changes = new HashMap<>();
         changes.put(APPSMITH_MCP_INTERNAL_SECRET.name(), secret == null ? "" : secret);
-        return applyChangesToEnvFileWithoutAclCheck(changes).then().onErrorResume(error -> {
-            log.error("Unable to persist APPSMITH_MCP_INTERNAL_SECRET to the env file", error);
-            return Mono.empty();
-        });
+        return applyChangesToEnvFileWithoutAclCheck(changes)
+                .flatMap(ignored -> restartWithoutAclCheck())
+                .onErrorResume(error -> {
+                    log.error("Unable to persist APPSMITH_MCP_INTERNAL_SECRET to the env file or restart", error);
+                    return Mono.empty();
+                });
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/domains/McpConfigTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/domains/McpConfigTest.java
@@ -10,17 +10,11 @@ class McpConfigTest {
     void copyNonSensitiveValues_mergesNonNullFieldsAndLeavesUnsetSiblings() {
         McpConfig existing = new McpConfig();
         existing.setEnabled(true);
-        existing.setDataEnabled(true);
-        existing.setServerUrl("https://appsmith.example/mcp");
 
         McpConfig patch = new McpConfig();
-        patch.setDataEnabled(false);
-
+        patch.setEnabled(false);
         existing.copyNonSensitiveValues(patch);
-
-        assertThat(existing.getEnabled()).isTrue();
-        assertThat(existing.getDataEnabled()).isFalse();
-        assertThat(existing.getServerUrl()).isEqualTo("https://appsmith.example/mcp");
+        assertThat(existing.getEnabled()).isFalse();
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/McpOrganizationConfigurationHelperTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/McpOrganizationConfigurationHelperTest.java
@@ -1,79 +1,11 @@
 package com.appsmith.server.helpers.ce;
 
 import com.appsmith.server.domains.McpConfig;
-import com.appsmith.server.exceptions.AppsmithException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class McpOrganizationConfigurationHelperTest {
-
-    @Test
-    void acceptsSingleOrgFieldsWhenMcpIsEnabled() {
-        McpConfig incoming = new McpConfig();
-        incoming.setEnabled(true);
-        incoming.setDataEnabled(true);
-        incoming.setServerUrl("https://appsmith.example/mcp");
-
-        McpOrganizationConfigurationHelper.validate(incoming, null, false);
-        assertThat(McpOrganizationConfigurationHelper.isEnabled(incoming, null)).isTrue();
-    }
-
-    @Test
-    void rejectsInvalidServerUrl() {
-        McpConfig incoming = new McpConfig();
-        incoming.setEnabled(true);
-        incoming.setServerUrl("not-a-url");
-
-        assertThatThrownBy(() -> McpOrganizationConfigurationHelper.validate(incoming, null, false))
-                .isInstanceOf(AppsmithException.class)
-                .hasMessageContaining("mcpConfig.serverUrl");
-    }
-
-    @Test
-    void rejectsNonHttpServerUrl() {
-        McpConfig incoming = new McpConfig();
-        incoming.setEnabled(true);
-        incoming.setServerUrl("ftp://appsmith.example/mcp");
-
-        assertThatThrownBy(() -> McpOrganizationConfigurationHelper.validate(incoming, null, false))
-                .isInstanceOf(AppsmithException.class)
-                .hasMessageContaining("mcpConfig.serverUrl");
-    }
-
-    @Test
-    void rejectsDataEnabledWhenMcpIsOff() {
-        McpConfig incoming = new McpConfig();
-        incoming.setDataEnabled(true);
-
-        assertThatThrownBy(() -> McpOrganizationConfigurationHelper.validate(incoming, null, false))
-                .isInstanceOf(AppsmithException.class)
-                .hasMessageContaining("mcpConfig.dataEnabled");
-    }
-
-    @Test
-    void rejectsInstanceFieldsOnMultiOrg() {
-        McpConfig incoming = new McpConfig();
-        incoming.setEnabled(true);
-        incoming.setServerUrl("https://appsmith.example/mcp");
-
-        assertThatThrownBy(() -> McpOrganizationConfigurationHelper.validate(incoming, null, true))
-                .isInstanceOf(AppsmithException.class)
-                .hasMessageContaining("mcpConfig");
-    }
-
-    @Test
-    void allowsEnableOnlyOnMultiOrg() {
-        McpConfig incoming = new McpConfig();
-        incoming.setEnabled(true);
-
-        McpOrganizationConfigurationHelper.validate(incoming, null, true);
-        assertThat(McpOrganizationConfigurationHelper.isExplicitEnable(incoming))
-                .isTrue();
-        assertThat(McpOrganizationConfigurationHelper.isExplicitDisable(incoming))
-                .isFalse();
-    }
 
     @Test
     void treatsIncomingEnabledTrueAsExplicitEnable() {
@@ -82,6 +14,8 @@ class McpOrganizationConfigurationHelperTest {
 
         assertThat(McpOrganizationConfigurationHelper.isExplicitEnable(incoming))
                 .isTrue();
+        assertThat(McpOrganizationConfigurationHelper.isExplicitDisable(incoming))
+                .isFalse();
         assertThat(McpOrganizationConfigurationHelper.isExplicitEnable(null)).isFalse();
         assertThat(McpOrganizationConfigurationHelper.isExplicitEnable(new McpConfig()))
                 .isFalse();
@@ -98,6 +32,17 @@ class McpOrganizationConfigurationHelperTest {
                 .isFalse();
         assertThat(McpOrganizationConfigurationHelper.isEnabled(incoming, enabledConfig()))
                 .isFalse();
+    }
+
+    @Test
+    void isEnabled_fallsBackToExistingWhenIncomingEnabledIsUnset() {
+        McpConfig incoming = new McpConfig();
+
+        assertThat(McpOrganizationConfigurationHelper.isEnabled(incoming, enabledConfig()))
+                .isTrue();
+        assertThat(McpOrganizationConfigurationHelper.isEnabled(incoming, null)).isFalse();
+        assertThat(McpOrganizationConfigurationHelper.isEnabled(null, enabledConfig()))
+                .isTrue();
     }
 
     private static McpConfig enabledConfig() {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/OrganizationServiceCETest.java
@@ -655,7 +655,7 @@ class OrganizationServiceCETest {
 
     @Test
     @WithUserDetails("api_user")
-    void updateOrganizationConfiguration_mcpFieldChangeWithoutExplicitEnabled_doesNotTouchInternalSecret() {
+    void updateOrganizationConfiguration_mcpUpdateWithoutExplicitEnabled_doesNotTouchInternalSecret() {
         commonConfig.setMcpInternalSecret("");
         McpConfig enable = new McpConfig();
         enable.setEnabled(TRUE);
@@ -667,58 +667,22 @@ class OrganizationServiceCETest {
         assertThat(secretAfterEnable).isNotBlank();
         clearInvocations(envManager);
 
-        McpConfig dataOnly = new McpConfig();
-        dataOnly.setDataEnabled(TRUE);
-        OrganizationConfiguration dataChanges = new OrganizationConfiguration();
-        dataChanges.setMcpConfig(dataOnly);
+        McpConfig unsetEnabled = new McpConfig();
+        OrganizationConfiguration unsetChanges = new OrganizationConfiguration();
+        unsetChanges.setMcpConfig(unsetEnabled);
 
-        StepVerifier.create(organizationService.updateOrganizationConfiguration(dataChanges))
+        StepVerifier.create(organizationService.updateOrganizationConfiguration(unsetChanges))
                 .assertNext(organization -> {
                     assertThat(organization
                                     .getOrganizationConfiguration()
                                     .getMcpConfig()
-                                    .getDataEnabled())
+                                    .getEnabled())
                             .isTrue();
                     assertThat(commonConfig.getMcpInternalSecret()).isEqualTo(secretAfterEnable);
                 })
                 .verifyComplete();
 
         verify(envManager, never()).persistMcpInternalSecret(anyString());
-    }
-
-    @Test
-    @WithUserDetails("api_user")
-    void updateOrganizationConfiguration_invalidMcpServerUrl_returnsError() {
-        McpConfig mcpConfig = new McpConfig();
-        mcpConfig.setEnabled(TRUE);
-        mcpConfig.setServerUrl("not-a-url");
-        final OrganizationConfiguration changes = new OrganizationConfiguration();
-        changes.setMcpConfig(mcpConfig);
-
-        StepVerifier.create(organizationService.updateOrganizationConfiguration(changes))
-                .expectErrorMatches(error -> {
-                    assertThat(error).isInstanceOf(AppsmithException.class);
-                    assertThat(error.getMessage()).contains("mcpConfig.serverUrl");
-                    return true;
-                })
-                .verify();
-    }
-
-    @Test
-    @WithUserDetails("api_user")
-    void updateOrganizationConfiguration_dataEnabledWithoutMcp_returnsError() {
-        McpConfig mcpConfig = new McpConfig();
-        mcpConfig.setDataEnabled(TRUE);
-        final OrganizationConfiguration changes = new OrganizationConfiguration();
-        changes.setMcpConfig(mcpConfig);
-
-        StepVerifier.create(organizationService.updateOrganizationConfiguration(changes))
-                .expectErrorMatches(error -> {
-                    assertThat(error).isInstanceOf(AppsmithException.class);
-                    assertThat(error.getMessage()).contains("mcpConfig.dataEnabled");
-                    return true;
-                })
-                .verify();
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -902,5 +902,44 @@ public class EnvManagerTest {
 
         StepVerifier.create(envManager.persistMcpInternalSecret("generated-secret"))
                 .verifyComplete();
+
+        Mockito.verify(envManager, Mockito.never()).restartWithoutAclCheck();
+    }
+
+    @Test
+    public void persistMcpInternalSecret_writesThenRestarts(@TempDir Path tempDir) throws IOException {
+        Path envFile = tempDir.resolve("docker.env");
+        Files.writeString(envFile, "APPSMITH_INSTANCE_NAME='third value'\n");
+        Mockito.when(commonConfig.getEnvFilePath()).thenReturn(envFile.toString());
+        Mockito.doReturn(Mono.empty()).when(envManager).restartWithoutAclCheck();
+
+        StepVerifier.create(envManager.persistMcpInternalSecret("generated-secret"))
+                .verifyComplete();
+
+        assertThat(Files.readString(envFile)).contains("APPSMITH_MCP_INTERNAL_SECRET=generated-secret");
+        Mockito.verify(envManager).restartWithoutAclCheck();
+    }
+
+    @Test
+    public void persistMcpInternalSecret_emptySecret_unsetsAndRestarts(@TempDir Path tempDir) throws IOException {
+        Path envFile = tempDir.resolve("docker.env");
+        Files.writeString(envFile, "APPSMITH_MCP_INTERNAL_SECRET=existing-secret\n");
+        Mockito.when(commonConfig.getEnvFilePath()).thenReturn(envFile.toString());
+        Mockito.doReturn(Mono.empty()).when(envManager).restartWithoutAclCheck();
+
+        StepVerifier.create(envManager.persistMcpInternalSecret("")).verifyComplete();
+
+        assertThat(Files.readString(envFile)).doesNotContain("existing-secret");
+        Mockito.verify(envManager).restartWithoutAclCheck();
+    }
+
+    @Test
+    public void persistMcpInternalSecret_missingEnvFile_doesNotRestart() {
+        Mockito.when(commonConfig.getEnvFilePath()).thenReturn("/no/such/appsmith/docker.env");
+
+        StepVerifier.create(envManager.persistMcpInternalSecret("generated-secret"))
+                .verifyComplete();
+
+        Mockito.verify(envManager, Mockito.never()).restartWithoutAclCheck();
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -902,44 +902,30 @@ public class EnvManagerTest {
 
         StepVerifier.create(envManager.persistMcpInternalSecret("generated-secret"))
                 .verifyComplete();
-
-        Mockito.verify(envManager, Mockito.never()).restartWithoutAclCheck();
     }
 
     @Test
-    public void persistMcpInternalSecret_writesThenRestarts(@TempDir Path tempDir) throws IOException {
+    public void persistMcpInternalSecret_writesWithoutRestart(@TempDir Path tempDir) throws IOException {
         Path envFile = tempDir.resolve("docker.env");
         Files.writeString(envFile, "APPSMITH_INSTANCE_NAME='third value'\n");
         Mockito.when(commonConfig.getEnvFilePath()).thenReturn(envFile.toString());
-        Mockito.doReturn(Mono.empty()).when(envManager).restartWithoutAclCheck();
 
         StepVerifier.create(envManager.persistMcpInternalSecret("generated-secret"))
                 .verifyComplete();
 
         assertThat(Files.readString(envFile)).contains("APPSMITH_MCP_INTERNAL_SECRET=generated-secret");
-        Mockito.verify(envManager).restartWithoutAclCheck();
+        Mockito.verify(envManager, Mockito.never()).restartWithoutAclCheck();
     }
 
     @Test
-    public void persistMcpInternalSecret_emptySecret_unsetsAndRestarts(@TempDir Path tempDir) throws IOException {
+    public void persistMcpInternalSecret_emptySecret_unsetsWithoutRestart(@TempDir Path tempDir) throws IOException {
         Path envFile = tempDir.resolve("docker.env");
         Files.writeString(envFile, "APPSMITH_MCP_INTERNAL_SECRET=existing-secret\n");
         Mockito.when(commonConfig.getEnvFilePath()).thenReturn(envFile.toString());
-        Mockito.doReturn(Mono.empty()).when(envManager).restartWithoutAclCheck();
 
         StepVerifier.create(envManager.persistMcpInternalSecret("")).verifyComplete();
 
         assertThat(Files.readString(envFile)).doesNotContain("existing-secret");
-        Mockito.verify(envManager).restartWithoutAclCheck();
-    }
-
-    @Test
-    public void persistMcpInternalSecret_missingEnvFile_doesNotRestart() {
-        Mockito.when(commonConfig.getEnvFilePath()).thenReturn("/no/such/appsmith/docker.env");
-
-        StepVerifier.create(envManager.persistMcpInternalSecret("generated-secret"))
-                .verifyComplete();
-
         Mockito.verify(envManager, Mockito.never()).restartWithoutAclCheck();
     }
 }


### PR DESCRIPTION
## Description
- Removed peripheral settings from MCP settings
- Now mcp toggle will require restart on single org instances


Fixes  https://linear.app/appsmith/issue/APP-15928/mcp-settings-toggle-should-require-a-restart-for-mcp-server-to-source

## Automation
/ok-to-test tags="@tag.All"

## Testing

> [!NOTE]
> **How CI runs on fork PRs — no action needed from you.**
> 1. **Workflow approval.** GitHub holds the first run on fork PRs until a maintainer approves it, so a pause before any check appears is expected.
> 2. **Credential-free checks.** Once approved, format, lint, typecheck, unit tests, cyclic-dependency and compile-only build checks run without repository secrets. Only the checks relevant to what you changed (client / server / RTS) will run, and their logs are safe to debug against.
> 3. **Maintainer-triggered checks.** Cypress, Playwright, Docker builds and deploy previews need secrets, so a maintainer starts them with `/approve-ci`, and `/build-deploy-preview` when hands-on testing is needed. Approval is pinned to one commit — pushing again requires fresh approval.
>
> The `awaiting-maintainer` / `awaiting-contributor` labels show whose turn it is. You do **not** need `ok-to-test` or any slash command. Full detail: [Pull request check states](https://github.com/appsmithorg/appsmith/blob/release/contributions/CodeContributionsGuidelines.md#pull-request-check-states).

Select the validation relevant to this change:

- [ ] Client unit tests
- [ ] Server unit tests
- [ ] Cypress
- [ ] Playwright
- [ ] Deploy preview
- [ ] Not applicable

Suggested Cypress tags or specs:


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34195617186>
> Commit: 584a55ccc133d2f1741daf2bb2b78eb0b015336d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34195617186&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Tue, 08 Sep 2026 07:42:19 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP administration now exposes a single setting to enable or disable MCP.
  - Changes requiring a server restart are clearly identified, and the Save and Restart action remains available.
  - Organization configuration updates can automatically start restart-status polling.

- **Bug Fixes**
  - Improved handling of MCP configuration updates that require a restart.
  - MCP internal secret changes no longer trigger an immediate server restart; they are applied through the Save and Restart flow.

- **Tests**
  - Updated coverage for simplified MCP settings and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->