### PR TITLE
fix: Now Mcp also accepts redis cluster

### DIFF
--- a/app/client/packages/mcp/src/governance/store.test.ts
+++ b/app/client/packages/mcp/src/governance/store.test.ts
@@ -52,4 +52,30 @@ describe("createGovernanceStoreFromEnv", () => {
 
     expect(createGovernanceStoreFromEnv()).toBeDefined();
   });
+
+  it("builds a store for a redis-cluster URL instead of throwing Invalid protocol", () => {
+    // Cloud / ElastiCache cluster mode uses redis-cluster://, which Java RedisConfig rewrites. node-redis
+    // createClient rejects that scheme with TypeError("Invalid protocol") and used to crash MCP startup.
+    process.env.APPSMITH_MONGODB_URI = "mongodb://127.0.0.1:27017/appsmith";
+    process.env.APPSMITH_REDIS_URL =
+      "redis-cluster://:secret@clustercfg.example.cache.amazonaws.com:6379";
+
+    expect(() => createGovernanceStoreFromEnv()).not.toThrow();
+    expect(createGovernanceStoreFromEnv()).toBeDefined();
+  });
+
+  it("builds a store for a rediss URL", () => {
+    process.env.APPSMITH_MONGODB_URI = "mongodb://127.0.0.1:27017/appsmith";
+    process.env.APPSMITH_REDIS_URL = "rediss://:secret@127.0.0.1:6379";
+
+    expect(createGovernanceStoreFromEnv()).toBeDefined();
+  });
+
+  it("skips governance (does not throw) when the Redis URL scheme is unsupported", () => {
+    process.env.APPSMITH_MONGODB_URI = "mongodb://127.0.0.1:27017/appsmith";
+    process.env.APPSMITH_REDIS_URL = "http://127.0.0.1:6379";
+
+    expect(() => createGovernanceStoreFromEnv()).not.toThrow();
+    expect(createGovernanceStoreFromEnv()).toBeUndefined();
+  });
 });

--- a/app/client/packages/mcp/src/governance/store.test.ts
+++ b/app/client/packages/mcp/src/governance/store.test.ts
@@ -1,4 +1,71 @@
-import { createGovernanceStoreFromEnv } from "./store.js";
+import {
+  createGovernanceStoreFromEnv,
+  createRedisClientFromUrl,
+} from "./store.js";
+
+interface RedisClusterTestOptions {
+  rootNodes: Array<{ url?: string }>;
+  defaults?: {
+    username?: string;
+    password?: string;
+    socket?: { tls?: boolean };
+  };
+}
+
+function clusterOptions(redisUrl: string): RedisClusterTestOptions {
+  const client = createRedisClientFromUrl(redisUrl) as unknown as {
+    _options: RedisClusterTestOptions;
+  };
+
+  return client._options;
+}
+
+describe("createRedisClientFromUrl", () => {
+  it("propagates ACL credentials and TLS to every cluster node", () => {
+    expect(
+      clusterOptions(
+        "redis-cluster://appsmith:p%40ssword@clustercfg.example.cache.amazonaws.com:6379",
+      ),
+    ).toMatchObject({
+      rootNodes: [
+        {
+          url: "rediss://clustercfg.example.cache.amazonaws.com:6379",
+        },
+      ],
+      defaults: {
+        username: "appsmith",
+        password: "p@ssword",
+        socket: { tls: true },
+      },
+    });
+  });
+
+  it("secures password-only cluster URLs without forcing an empty ACL username", () => {
+    expect(
+      clusterOptions(
+        "redis-cluster://:secret@clustercfg.example.cache.amazonaws.com:6379",
+      ),
+    ).toMatchObject({
+      rootNodes: [
+        {
+          url: "rediss://clustercfg.example.cache.amazonaws.com:6379",
+        },
+      ],
+      defaults: {
+        password: "secret",
+        socket: { tls: true },
+      },
+    });
+  });
+
+  it("rejects cluster credentials that cannot be safely parsed", () => {
+    expect(
+      createRedisClientFromUrl(
+        "redis-cluster://appsmith:%ZZ@clustercfg.example.cache.amazonaws.com:6379",
+      ),
+    ).toBeUndefined();
+  });
+});
 
 // Unit coverage for the env-driven governance-store factory. MongoClient/redis clients do not open a connection at
 // construction time, so these assertions never touch the network — they only exercise the URL-scheme fail-safe.

--- a/app/client/packages/mcp/src/governance/store.ts
+++ b/app/client/packages/mcp/src/governance/store.ts
@@ -262,7 +262,8 @@ function redisScheme(url: string): string | undefined {
 
 // Java RedisConfig accepts redis / rediss / redis-cluster. node-redis createClient only accepts redis:// and
 // rediss:// and throws TypeError("Invalid protocol") on redis-cluster://, which used to crash MCP at startup
-// (Caddy then 502s /mcp). Mirror the Java rewrite for cluster, and skip governance for any other scheme.
+// (Caddy then 502s /mcp). Adapt the cluster scheme for node-redis, securing credentialed URLs below, and skip
+// governance for any other scheme.
 export function createRedisClientFromUrl(
   redisUrl: string,
 ): GovernanceRedis | undefined {
@@ -274,10 +275,42 @@ export function createRedisClientFromUrl(
   }
 
   if (scheme === "redis-cluster") {
-    const standaloneUrl = trimmed.replace(/^redis-cluster:\/\//i, "redis://");
+    let clusterUrl: URL;
+    let username: string;
+    let password: string;
+
+    try {
+      clusterUrl = new URL(trimmed);
+      username = decodeURIComponent(clusterUrl.username);
+      password = decodeURIComponent(clusterUrl.password);
+    } catch {
+      return undefined;
+    }
+
+    const hasCredentials = username.length > 0 || password.length > 0;
+
+    if (!hasCredentials) {
+      return createCluster({
+        rootNodes: [
+          { url: trimmed.replace(/^redis-cluster:\/\//i, "redis://") },
+        ],
+      }) as GovernanceRedis;
+    }
+
+    // Credentials in a root-node URL apply only to topology discovery. Put them in defaults so every discovered
+    // node authenticates, and require TLS for both the root and discovered nodes so credentials are never sent in
+    // cleartext.
+    clusterUrl.protocol = "rediss:";
+    clusterUrl.username = "";
+    clusterUrl.password = "";
 
     return createCluster({
-      rootNodes: [{ url: standaloneUrl }],
+      rootNodes: [{ url: clusterUrl.toString() }],
+      defaults: {
+        ...(username ? { username } : {}),
+        ...(password ? { password } : {}),
+        socket: { tls: true },
+      },
     }) as GovernanceRedis;
   }
 

--- a/app/client/packages/mcp/src/governance/store.ts
+++ b/app/client/packages/mcp/src/governance/store.ts
@@ -77,7 +77,7 @@ const CONSUME_CONFIRMATION_SCRIPT =
 
 // node-redis standalone vs cluster clients share this surface (connect/close/set/get/eval). Keep the store
 // typed to the methods it actually calls so a redis-cluster:// URL can use createCluster without widening to any.
-type GovernanceRedis = {
+interface GovernanceRedis {
   connect(): Promise<unknown>;
   close(): Promise<unknown>;
   set(
@@ -90,7 +90,7 @@ type GovernanceRedis = {
     script: string,
     options: { keys: string[]; arguments: string[] },
   ): Promise<unknown>;
-};
+}
 
 // MCP owns these collections and keys. It never writes Appsmith product documents directly; it only records
 // governance metadata around authorized REST mutations made by the MCP service.

--- a/app/client/packages/mcp/src/governance/store.ts
+++ b/app/client/packages/mcp/src/governance/store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { MongoClient, type Collection } from "mongodb";
-import { createClient, type RedisClientType } from "redis";
+import { createClient, createCluster } from "redis";
 
 export interface McpChangeRecord {
   id: string;
@@ -75,6 +75,23 @@ const RELEASE_LOCK_SCRIPT =
 const CONSUME_CONFIRMATION_SCRIPT =
   "local value = redis.call('get', KEYS[1]); if value then redis.call('del', KEYS[1]); end; return value";
 
+// node-redis standalone vs cluster clients share this surface (connect/close/set/get/eval). Keep the store
+// typed to the methods it actually calls so a redis-cluster:// URL can use createCluster without widening to any.
+type GovernanceRedis = {
+  connect(): Promise<unknown>;
+  close(): Promise<unknown>;
+  set(
+    key: string,
+    value: string,
+    options: { NX: true; PX: number },
+  ): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+  eval(
+    script: string,
+    options: { keys: string[]; arguments: string[] },
+  ): Promise<unknown>;
+};
+
 // MCP owns these collections and keys. It never writes Appsmith product documents directly; it only records
 // governance metadata around authorized REST mutations made by the MCP service.
 export class MongoRedisGovernanceStore implements McpGovernanceStore {
@@ -82,7 +99,7 @@ export class MongoRedisGovernanceStore implements McpGovernanceStore {
 
   constructor(
     private readonly mongo: MongoClient,
-    private readonly redis: RedisClientType,
+    private readonly redis: GovernanceRedis,
     // Defaults to undefined so mongo.db() honours the database named in the connection URI. Hardcoding
     // "appsmith" matches the bundled container but silently diverges on an external/Atlas deployment whose URI
     // names a different database — governance records would land in a stray db outside the operator's backups.
@@ -236,6 +253,37 @@ function isMongoUrl(url: string): boolean {
   return /^mongodb(\+srv)?:\/\//i.test(url.trim());
 }
 
+function redisScheme(url: string): string | undefined {
+  return url
+    .trim()
+    .match(/^([a-z][a-z0-9+.-]*):\/\//i)?.[1]
+    ?.toLowerCase();
+}
+
+// Java RedisConfig accepts redis / rediss / redis-cluster. node-redis createClient only accepts redis:// and
+// rediss:// and throws TypeError("Invalid protocol") on redis-cluster://, which used to crash MCP at startup
+// (Caddy then 502s /mcp). Mirror the Java rewrite for cluster, and skip governance for any other scheme.
+export function createRedisClientFromUrl(
+  redisUrl: string,
+): GovernanceRedis | undefined {
+  const trimmed = redisUrl.trim();
+  const scheme = redisScheme(trimmed);
+
+  if (scheme === "redis" || scheme === "rediss") {
+    return createClient({ url: trimmed }) as GovernanceRedis;
+  }
+
+  if (scheme === "redis-cluster") {
+    const standaloneUrl = trimmed.replace(/^redis-cluster:\/\//i, "redis://");
+
+    return createCluster({
+      rootNodes: [{ url: standaloneUrl }],
+    }) as GovernanceRedis;
+  }
+
+  return undefined;
+}
+
 export function createGovernanceStoreFromEnv():
   | MongoRedisGovernanceStore
   | undefined {
@@ -254,8 +302,16 @@ export function createGovernanceStoreFromEnv():
     return undefined;
   }
 
-  return new MongoRedisGovernanceStore(
-    new MongoClient(mongoUrl),
-    createClient({ url: redisUrl }),
-  );
+  const redis = createRedisClientFromUrl(redisUrl);
+
+  if (!redis) {
+    process.stderr.write(
+      "Appsmith MCP governance disabled: the configured Redis URL is not a redis://, rediss://, or redis-cluster:// URL. " +
+        "Governed tools will be unavailable.\n",
+    );
+
+    return undefined;
+  }
+
+  return new MongoRedisGovernanceStore(new MongoClient(mongoUrl), redis);
 }


### PR DESCRIPTION
## Description
- Now mcp governance accepts redis clusters


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Testing

> [!NOTE]
> **How CI runs on fork PRs — no action needed from you.**
> 1. **Workflow approval.** GitHub holds the first run on fork PRs until a maintainer approves it, so a pause before any check appears is expected.
> 2. **Credential-free checks.** Once approved, format, lint, typecheck, unit tests, cyclic-dependency and compile-only build checks run without repository secrets. Only the checks relevant to what you changed (client / server / RTS) will run, and their logs are safe to debug against.
> 3. **Maintainer-triggered checks.** Cypress, Playwright, Docker builds and deploy previews need secrets, so a maintainer starts them with `/approve-ci`, and `/build-deploy-preview` when hands-on testing is needed. Approval is pinned to one commit — pushing again requires fresh approval.
>
> The `awaiting-maintainer` / `awaiting-contributor` labels show whose turn it is. You do **not** need `ok-to-test` or any slash command. Full detail: [Pull request check states](https://github.com/appsmithorg/appsmith/blob/release/contributions/CodeContributionsGuidelines.md#pull-request-check-states).

Select the validation relevant to this change:

- [ ] Client unit tests
- [ ] Server unit tests
- [ ] Cypress
- [ ] Playwright
- [ ] Deploy preview
- [ ] Not applicable

Suggested Cypress tags or specs:


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Redis standalone, secure, and cluster connection URLs for governance storage.
  - Secure Redis connections can now be configured using encrypted connection URLs.
  - Cluster connections now support authenticated URLs and securely apply credentials to discovered nodes.

- **Bug Fixes**
  - Prevented unsupported Redis URL schemes from causing startup errors.
  - Governance storage now skips initialization gracefully and reports a warning when an unsupported or malformed URL is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 2f684a4910afacac0c11b1a44079511a4f7c14f8 yet
> <hr>Tue, 08 Sep 2026 11:32:14 UTC
<!-- end of auto-generated comment: Cypress test results  -->
