### PR TITLE
fix(test): prevent Email_settings stale getAllWorkspaces intercept

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/AdminSettings/Email_settings_Spec.ts
@@ -65,8 +65,7 @@ describe(
     });
 
     it("2. Verify admin setup smtp and test email works", () => {
-      agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
-      agHelper.CypressReload();
+      cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
       const testEmailSubject: string = "Test email from Appsmith";
       const testEmailBody: string =
         "This is a test email from Appsmith, initiated from Admin Settings page. If you are seeing this, your email configuration is working!";
@@ -248,8 +247,6 @@ describe(
     });
 
     it("4. To verify invite workspace email", () => {
-      agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
-      agHelper.CypressReload();
       const inviteEmailSubject: string =
         CURRENT_REPO === REPO.EE
           ? "You’re invited to the workspace"
@@ -257,8 +254,6 @@ describe(
       homePage.LogOutviaAPI();
       agHelper.VisitNAssert("/");
       agHelper.WaitUntilEleAppear(SignupPageLocators.forgetPasswordLink);
-      agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
-      agHelper.CypressReload();
       cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
       agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
       if (CURRENT_REPO === REPO.EE) adminSettings.EnableGAC(false, true);
@@ -325,8 +320,6 @@ describe(
     });
 
     it("5. To verify application invite email with developer right", () => {
-      agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
-      agHelper.CypressReload();
       const inviteEmailSubject: string =
         CURRENT_REPO === REPO.EE
           ? "You're invited to the app"
@@ -428,8 +421,6 @@ describe(
     });
 
     it("6. To verify application invite email with view right", () => {
-      agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
-      agHelper.CypressReload();
       const inviteEmailSubject: string =
         CURRENT_REPO === REPO.EE
           ? "You're invited to the app"
@@ -437,8 +428,8 @@ describe(
       homePage.LogOutviaAPI();
       agHelper.VisitNAssert("/");
       agHelper.WaitUntilEleAppear(SignupPageLocators.forgetPasswordLink);
-      agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
       cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+      agHelper.VisitNAssert(adminSettings.routes.APPLICATIONS);
 
       if (CURRENT_REPO === REPO.EE) adminSettings.EnableGAC(false, true);
       agHelper.GenerateUUID();


### PR DESCRIPTION
## Description

`Email_settings_Spec` failed all Cypress retries in isolation ([run 34177523488](https://github.com/appsmithorg/appsmith/actions/runs/34177523488)). Tests 4 and 6 visited `/applications` while logged out, then `LoginFromAPI` waited on `@getAllWorkspaces` and consumed a 401 body with no `responseMeta`. `processNetworkStatus` then threw `Cannot read properties of undefined (reading 'status')`. `CypressReload()` on that path also mixed `cy.reload()` with `cy.log()` from the global fail handler.

Test 5 already used logout → login page → `LoginFromAPI` → `/applications` and passed every retry. This PR matches that order, drops the redundant reloads, and logs test 2 in explicitly. Prior HTML-body wait (#41893) did not cover this.

Fixes https://linear.app/appsmith/issue/APP-15931

## Testing

- [ ] Client unit tests
- [ ] Server unit tests
- [x] Cypress
- [ ] Playwright
- [ ] Deploy preview
- [ ] Not applicable

Suggested Cypress tags or specs:
`@tag.Email`

## Automation

/ok-to-test tags="@tag.Email"

### :mag: Cypress test results
<!-- leave this section untouched — CI auto-populates it -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34225280782>
> Commit: e90b107e55f8ea1f75dc689ba736c5a2baf404c7
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34225280782&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.Email`
> Spec:
> <hr>Tue, 08 Sep 2026 12:37:23 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined automated coverage for admin email settings.
  * Removed redundant navigation and page reload steps from several test scenarios.
  * Updated login and navigation sequencing to make test execution more direct and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->