### PR TITLE
fix: Mcp server baseUrl suffix omission

### DIFF
--- a/app/client/packages/mcp/src/gates.test.ts
+++ b/app/client/packages/mcp/src/gates.test.ts
@@ -1,5 +1,6 @@
 import {
   ELICITATION_TIMEOUT_CEILING_MS,
+  apiBaseUrlFromEnv,
   elicitationTimeoutFromEnv,
   gateEnabled,
   parsePositiveInt,
@@ -82,6 +83,31 @@ describe("parsePositiveInt — session cap/TTL env overrides", () => {
       expect(parsePositiveInt(value, 10)).toBe(10);
     },
   );
+});
+
+describe("apiBaseUrlFromEnv — APPSMITH_API_BASE_URL origin for /api/v1 paths", () => {
+  it.each([
+    ["http://127.0.0.1:8080", "http://127.0.0.1:8080"],
+    ["http://127.0.0.1:8080/", "http://127.0.0.1:8080"],
+    ["http://127.0.0.1:8080///", "http://127.0.0.1:8080"],
+    [" http://127.0.0.1:8080/ ", "http://127.0.0.1:8080"],
+    ["http://127.0.0.1:8080/api/v1", "http://127.0.0.1:8080"],
+    ["http://127.0.0.1:8080/api/v1/", "http://127.0.0.1:8080"],
+    ["https://apps.example.com/api/v1/", "https://apps.example.com"],
+    [
+      "https://apps.example.com/appsmith/api/v1/",
+      "https://apps.example.com/appsmith",
+    ],
+    ["HTTPS://apps.example.com/API/V1", "HTTPS://apps.example.com"],
+  ])("normalizes %j to %j", (value, expected) => {
+    expect(apiBaseUrlFromEnv(value)).toBe(expected);
+  });
+
+  it("leaves a non-api/v1 path prefix intact", () => {
+    expect(apiBaseUrlFromEnv("http://127.0.0.1:8080/appsmith")).toBe(
+      "http://127.0.0.1:8080/appsmith",
+    );
+  });
 });
 
 describe("publicOriginFromEnv — APPSMITH_MCP_PUBLIC_ORIGIN parsing (fail-closed)", () => {

--- a/app/client/packages/mcp/src/gates.test.ts
+++ b/app/client/packages/mcp/src/gates.test.ts
@@ -3,6 +3,7 @@ import {
   apiBaseUrlFromEnv,
   elicitationTimeoutFromEnv,
   gateEnabled,
+  gateEnabledUnlessFalse,
   parsePositiveInt,
   publicOriginFromEnv,
   sessionLimitsFromEnv,
@@ -63,6 +64,26 @@ describe("gateEnabled — opt-in gate parsing (data/JS layers)", () => {
 
   it("stays off when the variable is unset", () => {
     expect(gateEnabled(undefined)).toBe(false);
+  });
+});
+
+describe("gateEnabledUnlessFalse — default-on until false", () => {
+  it.each(["false", "FALSE", "False", " false "])(
+    "disables for %j",
+    (value) => {
+      expect(gateEnabledUnlessFalse(value)).toBe(false);
+    },
+  );
+
+  it.each(["0", "off", "no", "disabled", "true", "1", "", "  "])(
+    "stays on for %j",
+    (value) => {
+      expect(gateEnabledUnlessFalse(value)).toBe(true);
+    },
+  );
+
+  it("stays on when the variable is unset", () => {
+    expect(gateEnabledUnlessFalse(undefined)).toBe(true);
   });
 });
 

--- a/app/client/packages/mcp/src/gates.ts
+++ b/app/client/packages/mcp/src/gates.ts
@@ -8,6 +8,12 @@ export function gateEnabled(value: string | undefined): boolean {
   return value !== undefined && /^(1|true|yes|on)$/i.test(value.trim());
 }
 
+// Default-ON counterpart for capabilities whose server-side opt-in flags were removed. Enabled unless the env
+// value is "false" (trim + case-insensitive); "0", "off", blank, and unset all stay enabled.
+export function gateEnabledUnlessFalse(value: string | undefined): boolean {
+  return value === undefined || value.trim().toLowerCase() !== "false";
+}
+
 // Positive-integer env override (session caps, TTLs). Unset, non-numeric, fractional, zero, or negative values fall
 // back to the built-in default rather than failing startup or silently disabling a limit.
 export function parsePositiveInt(

--- a/app/client/packages/mcp/src/gates.ts
+++ b/app/client/packages/mcp/src/gates.ts
@@ -21,6 +21,16 @@ export function parsePositiveInt(
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+// APPSMITH_API_BASE_URL is concatenated with paths that already start with /api/v1. Operators often paste the
+// Appsmith origin including that prefix (and a trailing slash). Strip both so we do not request /api/v1/api/v1/...
+export function apiBaseUrlFromEnv(value: string): string {
+  return value
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\/api\/v1$/i, "")
+    .replace(/\/+$/, "");
+}
+
 // Public origin override for the URLs build_application returns (APPSMITH_MCP_PUBLIC_ORIGIN). Accepts ONLY an
 // absolute http(s) origin — scheme + host + optional port, with no path, query, fragment, or credentials (a bare
 // trailing slash is normalized away). Anything else fails CLOSED to undefined, so URLs degrade to root-relative

--- a/app/client/packages/mcp/src/server.ts
+++ b/app/client/packages/mcp/src/server.ts
@@ -6,6 +6,7 @@ import {
   MCP_SESSION_TTL_MS,
 } from "./app.js";
 import {
+  apiBaseUrlFromEnv,
   elicitationTimeoutFromEnv,
   gateEnabled,
   publicOriginFromEnv,
@@ -18,13 +19,14 @@ import {
 } from "./governance/store.js";
 
 const port = Number(process.env.APPSMITH_MCP_PORT ?? 8092);
-const apiBaseUrl = process.env.APPSMITH_API_BASE_URL ?? "http://127.0.0.1:8080";
+const apiBaseUrl = apiBaseUrlFromEnv(
+  process.env.APPSMITH_API_BASE_URL ?? "http://127.0.0.1:8080",
+);
 
-// The data layer and restricted JS objects are OFF unless explicitly enabled, matching the parent
-// APPSMITH_MCP_ENABLED gate: an admin opts into each capability. Governed/destructive tools additionally require
-// Mongo+Redis, so they only register when that infra is present.
-const dataEnabled = gateEnabled(process.env.APPSMITH_MCP_DATA_ENABLED);
-const jsEnabled = gateEnabled(process.env.APPSMITH_MCP_JS_ENABLED);
+// Temporarily keep these capabilities enabled while their server-side configuration flags are unavailable.
+// Governed/destructive tools still require Mongo+Redis and register only when that infrastructure is present.
+const dataEnabled = true;
+const jsEnabled = true;
 
 // Optional Host-header allowlist (comma-separated hostnames) enforced on /mcp. Unset by default: this service is
 // fronted by Caddy which preserves the original Host, so a default loopback list would reject the proxied public

--- a/app/client/packages/mcp/src/server.ts
+++ b/app/client/packages/mcp/src/server.ts
@@ -9,6 +9,7 @@ import {
   apiBaseUrlFromEnv,
   elicitationTimeoutFromEnv,
   gateEnabled,
+  gateEnabledUnlessFalse,
   publicOriginFromEnv,
   sessionLimitsFromEnv,
 } from "./gates.js";
@@ -23,10 +24,12 @@ const apiBaseUrl = apiBaseUrlFromEnv(
   process.env.APPSMITH_API_BASE_URL ?? "http://127.0.0.1:8080",
 );
 
-// Temporarily keep these capabilities enabled while their server-side configuration flags are unavailable.
-// Governed/destructive tools still require Mongo+Redis and register only when that infrastructure is present.
-const dataEnabled = true;
-const jsEnabled = true;
+// Data and JS stay on unless an operator explicitly sets the env var to "false". Governed/destructive tools
+// still require Mongo+Redis and register only when that infrastructure is present.
+const dataEnabled = gateEnabledUnlessFalse(
+  process.env.APPSMITH_MCP_DATA_ENABLED,
+);
+const jsEnabled = gateEnabledUnlessFalse(process.env.APPSMITH_MCP_JS_ENABLED);
 
 // Optional Host-header allowlist (comma-separated hostnames) enforced on /mcp. Unset by default: this service is
 // fronted by Caddy which preserves the original Host, so a default loopback list would reject the proxied public


### PR DESCRIPTION
## Description
- When server url in the environment is set with suffixes, mcp server parses to remove the extra fields.
- Hotwires JS and Data enabled as it's not controlled using env variables 


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Testing

> [!NOTE]
> **How CI runs on fork PRs — no action needed from you.**
> 1. **Workflow approval.** GitHub holds the first run on fork PRs until a maintainer approves it, so a pause before any check appears is expected.
> 2. **Credential-free checks.** Once approved, format, lint, typecheck, unit tests, cyclic-dependency and compile-only build checks run without repository secrets. Only the checks relevant to what you changed (client / server / RTS) will run, and their logs are safe to debug against.
> 3. **Maintainer-triggered checks.** Cypress, Playwright, Docker builds and deploy previews need secrets, so a maintainer starts them with `/approve-ci`, and `/build-deploy-preview` when hands-on testing is needed. Approval is pinned to one commit — pushing again requires fresh approval.
>
> The `awaiting-maintainer` / `awaiting-contributor` labels show whose turn it is. You do **not** need `ok-to-test` or any slash command. Full detail: [Pull request check states](https://github.com/appsmithorg/appsmith/blob/release/contributions/CodeContributionsGuidelines.md#pull-request-check-states).

Select the validation relevant to this change:

- [ ] Client unit tests
- [ ] Server unit tests
- [ ] Cypress
- [ ] Playwright
- [ ] Deploy preview
- [x] Not applicable

Suggested Cypress tags or specs:


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data and JavaScript capabilities are now enabled by default.
  * API base URLs are handled more reliably, including trailing slashes, `/api/v1` suffixes, whitespace, and nested paths.

* **Bug Fixes**
  * Prevented duplicated API path prefixes when configuring the application API URL.
  * Improved compatibility with API URLs using different capitalization or additional path segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 718fb123f6daec689ad59f31eaa690f246945b6c yet
> <hr>Tue, 08 Sep 2026 18:38:01 UTC
<!-- end of auto-generated comment: Cypress test results  -->
