### PR TITLE
feat: add font family control to the RTE toolbar

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
@@ -204,5 +204,43 @@ describe(
         expect(html).to.not.match(/font-family:[^>]*courier[^>]*>nocourier/);
       });
     });
+
+    it("7. Verify picking Arial inside Arial Black text applies Arial to the next insert", function () {
+      cy.window().then((win) => {
+        const editor = getActiveEditor(win);
+
+        editor.focus();
+        editor.selection.select(editor.getBody(), true);
+      });
+      agHelper.GetNClick(locators._richText_FontFamily);
+      agHelper.GetNClick(locators._richText_FontFamilyOption("Arial Black"));
+      cy.window().then((win) => {
+        const editor = getActiveEditor(win);
+
+        expect(editor.getContent().toLowerCase()).to.contain("arial black");
+        editor.selection.select(editor.getBody(), true);
+        editor.selection.collapse(true);
+      });
+      agHelper.GetNClick(locators._richText_FontFamily);
+      agHelper.GetNClick(locators._richText_FontFamilyOption("Arial"));
+      cy.get(locators._richText_FontFamily).should(
+        "have.attr",
+        "aria-label",
+        "Font Arial",
+      );
+      cy.window().then((win) => {
+        const editor = getActiveEditor(win);
+
+        editor.insertContent("ArialNotBlack");
+
+        const html = editor.getContent().toLowerCase();
+
+        expect(html).to.contain("arialnotblack");
+        expect(html).to.not.match(/arial\s*black[^>]*>arialnotblack/);
+        expect(html).to.match(
+          /font-family:\s*['"]?arial['"]?(?!\s*black)[^>]*>arialnotblack/,
+        );
+      });
+    });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
@@ -1,3 +1,4 @@
+import type { TinyMCE } from "tinymce";
 import {
   agHelper,
   locators,
@@ -7,6 +8,22 @@ import {
 import EditorNavigation, {
   EntityType,
 } from "../../../../../support/Pages/EditorNavigation";
+
+declare global {
+  interface Window {
+    tinymce: TinyMCE;
+  }
+}
+
+function getActiveEditor(win: Window) {
+  const editor = win.tinymce.activeEditor;
+
+  if (!editor) {
+    throw new Error("TinyMCE active editor is missing");
+  }
+
+  return editor;
+}
 
 describe(
   "Rich Text Editor widget Tests",
@@ -89,7 +106,7 @@ describe(
       let htmlBefore = "";
 
       cy.window().then((win) => {
-        htmlBefore = win.tinymce.activeEditor.getContent().toLowerCase();
+        htmlBefore = getActiveEditor(win).getContent().toLowerCase();
         expect(htmlBefore).to.not.contain("font-family");
       });
       agHelper.GetNClick(locators._richText_FontFamily);
@@ -104,7 +121,7 @@ describe(
           return agHelper.TypeText($body, "ArialText");
         });
       cy.window().then((win) => {
-        const htmlAfter = win.tinymce.activeEditor.getContent().toLowerCase();
+        const htmlAfter = getActiveEditor(win).getContent().toLowerCase();
 
         expect(htmlAfter).to.not.equal(htmlBefore);
         expect(htmlAfter).to.contain("font-family");
@@ -114,7 +131,7 @@ describe(
 
     it("5. Verify choosing a font with a collapsed caret applies to the next typed text", function () {
       cy.window().then((win) => {
-        const editor = win.tinymce.activeEditor;
+        const editor = getActiveEditor(win);
 
         editor.focus();
         editor.selection.select(editor.getBody(), true);
@@ -129,9 +146,9 @@ describe(
         "Font Georgia",
       );
       cy.window().then((win) => {
-        expect(
-          win.tinymce.activeEditor.getContent().toLowerCase(),
-        ).to.not.contain("georgia");
+        expect(getActiveEditor(win).getContent().toLowerCase()).to.not.contain(
+          "georgia",
+        );
       });
       agHelper
         .GetElement(
@@ -143,7 +160,7 @@ describe(
           return agHelper.TypeText($body, "GeorgiaText");
         });
       cy.window().then((win) => {
-        expect(win.tinymce.activeEditor.getContent().toLowerCase()).to.contain(
+        expect(getActiveEditor(win).getContent().toLowerCase()).to.contain(
           "georgia",
         );
       });
@@ -151,7 +168,7 @@ describe(
 
     it("6. Verify moving the caret after picking a font does not apply it at the new location", function () {
       cy.window().then((win) => {
-        const editor = win.tinymce.activeEditor;
+        const editor = getActiveEditor(win);
 
         editor.focus();
         editor.selection.select(editor.getBody(), true);
@@ -166,7 +183,7 @@ describe(
         "Font Courier New",
       );
       cy.window().then((win) => {
-        const editor = win.tinymce.activeEditor;
+        const editor = getActiveEditor(win);
         const body = editor.getBody();
 
         expect(editor.getContent().toLowerCase()).to.not.contain("courier");
@@ -174,9 +191,17 @@ describe(
         editor.selection.setCursorLocation(body.firstChild || body, 0);
       });
       cy.window().then((win) => {
-        expect(
-          win.tinymce.activeEditor.getContent().toLowerCase(),
-        ).to.not.contain("courier");
+        const editor = getActiveEditor(win);
+
+        // Insert at TinyMCE's caret so a body click cannot clear pending
+        // via mousedown. Caret formats only show up in getContent after
+        // this insert.
+        editor.insertContent("NoCourier");
+
+        const html = editor.getContent().toLowerCase();
+
+        expect(html).to.contain("nocourier");
+        expect(html).to.not.match(/font-family:[^>]*courier[^>]*>nocourier/);
       });
     });
   },

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
@@ -66,6 +66,7 @@ describe(
     });
 
     it("3. Verify applying style in one line should be observed in next line", function () {
+      agHelper.GetNClick(locators._richText_ToolbarOverflow);
       agHelper.GetNClick(locators._richText_Text_Color("Black"));
       agHelper.GetNClick(locators._richText_color("Red"));
       agHelper

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
@@ -25,6 +25,16 @@ function getActiveEditor(win: Window) {
   return editor;
 }
 
+function firstFamily(font: string) {
+  return font.split(",")[0].trim().replace(/['"]/g, "").toLowerCase();
+}
+
+function fontFamilyAtCaret(editor: ReturnType<typeof getActiveEditor>) {
+  return firstFamily(
+    editor.dom.getStyle(editor.selection.getNode(), "font-family", true) || "",
+  );
+}
+
 describe(
   "Rich Text Editor widget Tests",
   { tags: ["@tag.Widget", "@tag.TextEditor", "@tag.Binding"] },
@@ -112,17 +122,12 @@ describe(
       });
       agHelper.GetNClick(locators._richText_FontFamily);
       agHelper.GetNClick(locators._richText_FontFamilyOption("Arial"));
-      agHelper
-        .GetElement(
-          locators._widgetInDeployed("richtexteditorwidget") + " iframe",
-        )
-        .then(($iframe) => {
-          const $body = $iframe.contents().find("body");
-
-          return agHelper.TypeText($body, "ArialText");
-        });
       cy.window().then((win) => {
-        const htmlAfter = getActiveEditor(win).getContent().toLowerCase();
+        const editor = getActiveEditor(win);
+
+        editor.insertContent("ArialText");
+
+        const htmlAfter = editor.getContent().toLowerCase();
 
         expect(htmlAfter).to.not.equal(htmlBefore);
         expect(htmlAfter).to.contain("font-family");
@@ -151,19 +156,11 @@ describe(
           "georgia",
         );
       });
-      agHelper
-        .GetElement(
-          locators._widgetInDeployed("richtexteditorwidget") + " iframe",
-        )
-        .then(($iframe) => {
-          const $body = $iframe.contents().find("body");
-
-          return agHelper.TypeText($body, "GeorgiaText");
-        });
       cy.window().then((win) => {
-        expect(getActiveEditor(win).getContent().toLowerCase()).to.contain(
-          "georgia",
-        );
+        const editor = getActiveEditor(win);
+
+        editor.insertContent("GeorgiaText");
+        expect(editor.getContent().toLowerCase()).to.contain("georgia");
       });
     });
 
@@ -191,18 +188,18 @@ describe(
         // Stay collapsed: select-all would clear pending for a different reason.
         editor.selection.setCursorLocation(body.firstChild || body, 0);
       });
+      cy.get(locators._richText_FontFamily).should(
+        "not.have.attr",
+        "aria-label",
+        "Font Courier New",
+      );
       cy.window().then((win) => {
         const editor = getActiveEditor(win);
 
-        // Insert at TinyMCE's caret so a body click cannot clear pending
-        // via mousedown. Caret formats only show up in getContent after
-        // this insert.
         editor.insertContent("NoCourier");
 
-        const html = editor.getContent().toLowerCase();
-
-        expect(html).to.contain("nocourier");
-        expect(html).to.not.match(/font-family:[^>]*courier[^>]*>nocourier/);
+        expect(editor.getContent().toLowerCase()).to.contain("nocourier");
+        expect(fontFamilyAtCaret(editor)).to.not.match(/courier/);
       });
     });
 
@@ -234,13 +231,8 @@ describe(
 
         editor.insertContent("ArialNotBlack");
 
-        const html = editor.getContent().toLowerCase();
-
-        expect(html).to.contain("arialnotblack");
-        expect(html).to.not.match(/arial\s*black[^>]*>arialnotblack/);
-        expect(html).to.match(
-          /font-family:\s*['"]?arial['"]?(?!\s*black)[^>]*>arialnotblack/,
-        );
+        expect(editor.getContent().toLowerCase()).to.contain("arialnotblack");
+        expect(fontFamilyAtCaret(editor)).to.eq("arial");
       });
     });
   },

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
@@ -264,5 +264,47 @@ describe(
         expect(fontFamilyAtCaret(editor)).to.eq("verdana");
       });
     });
+
+    it("9. Verify picking a font with the caret inside a word does not restyle that word", function () {
+      cy.window().then((win) => {
+        const editor = getActiveEditor(win);
+
+        editor.focus();
+        editor.setContent("<p>Hello World</p>");
+
+        const textNode = editor.getBody().querySelector("p")?.firstChild;
+
+        if (!textNode || textNode.nodeType !== Node.TEXT_NODE) {
+          throw new Error("Expected a text node in the RTE");
+        }
+
+        editor.selection.setCursorLocation(textNode, 2);
+        expect(editor.selection.isCollapsed()).to.eq(true);
+      });
+      agHelper.GetNClick(locators._richText_FontFamily);
+      agHelper.GetNClick(locators._richText_FontFamilyOption("Impact"));
+      cy.get(locators._richText_FontFamily).should(
+        "have.attr",
+        "aria-label",
+        "Font Impact",
+      );
+      cy.window().then((win) => {
+        const html = getActiveEditor(win).getContent().toLowerCase();
+
+        expect(html).to.contain("hello");
+        expect(html).to.not.contain("impact");
+      });
+      cy.window().then((win) => {
+        const editor = getActiveEditor(win);
+
+        editor.insertContent("NEW");
+
+        const html = editor.getContent().toLowerCase();
+
+        expect(html).to.match(/<span[^>]*impact[^>]*>new<\/span>/);
+        expect(html).to.contain("llo world");
+        expect(fontFamilyAtCaret(editor)).to.match(/impact/);
+      });
+    });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
@@ -235,5 +235,34 @@ describe(
         expect(fontFamilyAtCaret(editor)).to.eq("arial");
       });
     });
+
+    it("8. Verify a font picked before typing survives a freshly pushed default text", function () {
+      // A default text the editor has to re-serialize (forced_root_block adds
+      // the <p>), which is what used to leave the react wrapper pushing the
+      // stale value back and wiping the caret format.
+      propPane.UpdatePropertyFieldValue(
+        "Default value",
+        "Default text with no font",
+      );
+      agHelper.GetNClick(locators._richText_FontFamily);
+      agHelper.GetNClick(locators._richText_FontFamilyOption("Verdana"));
+      // Outlast the wrapper's 200ms rollback timer without typing.
+      agHelper.Sleep(600);
+      cy.get(locators._richText_FontFamily).should(
+        "have.attr",
+        "aria-label",
+        "Font Verdana",
+      );
+      cy.window().then((win) => {
+        const editor = getActiveEditor(win);
+
+        editor.insertContent("VerdanaAfterPush");
+
+        expect(editor.getContent().toLowerCase()).to.contain(
+          "verdanaafterpush",
+        );
+        expect(fontFamilyAtCaret(editor)).to.eq("verdana");
+      });
+    });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor3_spec.ts
@@ -84,5 +84,100 @@ describe(
           );
         });
     });
+
+    it("4. Verify applying a font family from the toolbar writes font-family into the editor HTML", function () {
+      let htmlBefore = "";
+
+      cy.window().then((win) => {
+        htmlBefore = win.tinymce.activeEditor.getContent().toLowerCase();
+        expect(htmlBefore).to.not.contain("font-family");
+      });
+      agHelper.GetNClick(locators._richText_FontFamily);
+      agHelper.GetNClick(locators._richText_FontFamilyOption("Arial"));
+      agHelper
+        .GetElement(
+          locators._widgetInDeployed("richtexteditorwidget") + " iframe",
+        )
+        .then(($iframe) => {
+          const $body = $iframe.contents().find("body");
+
+          return agHelper.TypeText($body, "ArialText");
+        });
+      cy.window().then((win) => {
+        const htmlAfter = win.tinymce.activeEditor.getContent().toLowerCase();
+
+        expect(htmlAfter).to.not.equal(htmlBefore);
+        expect(htmlAfter).to.contain("font-family");
+        expect(htmlAfter).to.contain("arial");
+      });
+    });
+
+    it("5. Verify choosing a font with a collapsed caret applies to the next typed text", function () {
+      cy.window().then((win) => {
+        const editor = win.tinymce.activeEditor;
+
+        editor.focus();
+        editor.selection.select(editor.getBody(), true);
+        editor.selection.collapse(false);
+        expect(editor.getContent().toLowerCase()).to.not.contain("georgia");
+      });
+      agHelper.GetNClick(locators._richText_FontFamily);
+      agHelper.GetNClick(locators._richText_FontFamilyOption("Georgia"));
+      cy.get(locators._richText_FontFamily).should(
+        "have.attr",
+        "aria-label",
+        "Font Georgia",
+      );
+      cy.window().then((win) => {
+        expect(
+          win.tinymce.activeEditor.getContent().toLowerCase(),
+        ).to.not.contain("georgia");
+      });
+      agHelper
+        .GetElement(
+          locators._widgetInDeployed("richtexteditorwidget") + " iframe",
+        )
+        .then(($iframe) => {
+          const $body = $iframe.contents().find("body");
+
+          return agHelper.TypeText($body, "GeorgiaText");
+        });
+      cy.window().then((win) => {
+        expect(win.tinymce.activeEditor.getContent().toLowerCase()).to.contain(
+          "georgia",
+        );
+      });
+    });
+
+    it("6. Verify moving the caret after picking a font does not apply it at the new location", function () {
+      cy.window().then((win) => {
+        const editor = win.tinymce.activeEditor;
+
+        editor.focus();
+        editor.selection.select(editor.getBody(), true);
+        editor.selection.collapse(false);
+        expect(editor.getContent().toLowerCase()).to.not.contain("courier");
+      });
+      agHelper.GetNClick(locators._richText_FontFamily);
+      agHelper.GetNClick(locators._richText_FontFamilyOption("Courier New"));
+      cy.get(locators._richText_FontFamily).should(
+        "have.attr",
+        "aria-label",
+        "Font Courier New",
+      );
+      cy.window().then((win) => {
+        const editor = win.tinymce.activeEditor;
+        const body = editor.getBody();
+
+        expect(editor.getContent().toLowerCase()).to.not.contain("courier");
+        // Stay collapsed: select-all would clear pending for a different reason.
+        editor.selection.setCursorLocation(body.firstChild || body, 0);
+      });
+      cy.window().then((win) => {
+        expect(
+          win.tinymce.activeEditor.getContent().toLowerCase(),
+        ).to.not.contain("courier");
+      });
+    });
   },
 );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_2_spec.js
@@ -118,7 +118,7 @@ describe(
       // Set the content inside RTE widget by typing
       setRTEContent(`${testString} {enter} ${testString} 1`);
 
-      cy.get(".tox-tbtn--bespoke").click({ force: true });
+      cy.get(locators._richText_TitleBlock).click({ force: true });
       cy.contains("Heading 1").click({ force: true });
 
       cy.window().then((win) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_2_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/RTE/RichTextEditor_2_spec.js
@@ -144,7 +144,7 @@ describe(
     });
 
     it("6. Check if able to add an emoji through toolbar", () => {
-      cy.get('[aria-label="Reveal or hide additional toolbar items"]').click({
+      cy.get(locators._richText_ToolbarOverflow).click({
         force: true,
       });
       cy.get('[aria-label="Emojis"]').click({ force: true });

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -49,8 +49,11 @@ export class CommonLocators {
     )}`;
   _textWidget = ".t--draggable-textwidget .t--text-widget-container span";
   _tableWidget = ".t--widget-tablewidgetv2";
+  _tabWidget = (tabNumber: string) => `.t--tabid-tab${tabNumber}`;
   _inputWidget = ".t--draggable-inputwidgetv2 input";
   _publishButton = ".t--application-publish-btn";
+  _deployPopup = ".t--deploy-popup-option-trigger";
+  _currentDeployPreview = ".t--current-deployed-preview-btn";
   _widgetInCanvas = (widgetType: string) => `.t--draggable-${widgetType}`;
   _widgetInDeployed = (widgetType: string) => `.t--widget-${widgetType}`;
   _widgetInputSelector = (widgetType: string) =>
@@ -64,6 +67,7 @@ export class CommonLocators {
   _textAreainputWidgetv2InDeployed =
     this._widgetInDeployed("inputwidgetv2") + " textarea";
   _imageWidget = ".t--draggable-imagewidget";
+  _imageWidgetInDeployed = ".t--widget-imagewidget";
   _backToEditor = ".t--back-to-editor";
   _toastMsg = "div.Toastify__toast";
   _toastContainer = "div.Toastify__toast-container";
@@ -201,6 +205,7 @@ export class CommonLocators {
   _jsonToggle = (fieldName: string) =>
     `//p[text()='${fieldName}']/parent::div//following-sibling::div//input[@type='checkbox']`;
   _deployedPage = `.t--page-switch-tab`;
+  _navigationMenuItem = "[data-testid='t--pages-switcher']";
   _hints = "ul.CodeMirror-hints li";
   _hints_apis = "ul.CodeMirror-hints li.Codemirror-commands-apis";
   _tern_doc = ".t--tern-doc";
@@ -322,6 +327,8 @@ export class CommonLocators {
   _richText_FontFamily = "[data-mce-name='fontfamily']";
   _richText_FontFamilyOption = (font: string) =>
     `.tox-collection__item[aria-label="${font}"]`;
+  _richText_ToolbarOverflow =
+    '[aria-label="Reveal or hide additional toolbar items"]';
   _richText_Text_Color = (color: string) =>
     `[aria-label="Text color ${color}"] .tox-split-button__chevron`;
   _richText_color = (value: string) =>
@@ -356,6 +363,7 @@ export class CommonLocators {
   _entityItem = "[data-testid='t--entity-item-Api1']";
   _rowData = "[data-colindex='0'][data-rowindex='0']";
   _visualNonIdeaState = ".bp3-non-ideal-state";
+  _mongoDBConnectionInfo = "input[name='APPSMITH_DB_CONNECTION_INFO']";
   _editorTab = ".editor-tab";
   _entityTestId = (entity: string) =>
     `[data-testid="t--entity-item-${entity}"]`;
@@ -364,5 +372,8 @@ export class CommonLocators {
   _dropdownActiveOption = ".rc-select-dropdown .rc-select-item-option-active";
   _rcVirtualListHolder = ".rc-virtual-list-holder";
   _homeIcon = "[data-testid='t--default-home-icon']";
+  _appsmithLogo = ".t--appsmith-logo";
   _widget = (widgetName: string) => `.t--widget-${widgetName}`;
+  _settingPaneWrapper = "[role='table']";
+  _tableOverlayConnectData = ".t--cypress-table-overlay-connectdata";
 }

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -318,6 +318,10 @@ export class CommonLocators {
   _richText_TitleBlock = "[aria-label='Block Paragraph']";
   _richText_Heading = "[aria-label='Heading 1']";
   _richText_Label_Text = ".tox-tbtn__select-label";
+  // TinyMCE 7.9.3: data-mce-name is stable; aria-label is "Font {current}" (default "Font System Font")
+  _richText_FontFamily = "[data-mce-name='fontfamily']";
+  _richText_FontFamilyOption = (font: string) =>
+    `.tox-collection__item[aria-label="${font}"]`;
   _richText_Text_Color = (color: string) =>
     `[aria-label="Text color ${color}"] .tox-split-button__chevron`;
   _richText_color = (value: string) =>

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -323,7 +323,7 @@ export class CommonLocators {
   _richText_TitleBlock = "[aria-label='Block Paragraph']";
   _richText_Heading = "[aria-label='Heading 1']";
   _richText_Label_Text = ".tox-tbtn__select-label";
-  // TinyMCE 7.9.3: data-mce-name is stable; aria-label is "Font {current}" (default "Font System Font")
+  // TinyMCE 7.9.3: data-mce-name is stable; aria-label is "Font {current}" (default "Font Default")
   _richText_FontFamily = "[data-mce-name='fontfamily']";
   _richText_FontFamilyOption = (font: string) =>
     `.tox-collection__item[aria-label="${font}"]`;

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -568,9 +568,8 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
 
                   return {
                     block,
-                    offset: probe
-                      .toString()
-                      .replace(/[\uFEFF\u200B]/g, "").length,
+                    offset: probe.toString().replace(/[\uFEFF\u200B]/g, "")
+                      .length,
                   };
                 } catch {
                   return null;

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -331,8 +331,39 @@ export interface RichtextEditorComponentProps {
   onValueChange: (valueAsString: string) => void;
 }
 
-function titleForFontFamilyFormat(formats: string, format: string): string {
-  for (const entry of formats.split(";")) {
+const FONT_CARET_NAVIGATION_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
+
+// TinyMCE 7.9.3 default minus Symbol/Webdings/Wingdings, plus Default
+// mapped to the iframe UA serif (Times) so existing apps keep the same
+// look and the dropdown has a real selected option.
+const fontFamilyFormats =
+  "Default=times,times new roman,serif;" +
+  "Andale Mono=andale mono,monospace;" +
+  "Arial=arial,helvetica,sans-serif;" +
+  "Arial Black=arial black,sans-serif;" +
+  "Book Antiqua=book antiqua,palatino,serif;" +
+  "Comic Sans MS=comic sans ms,sans-serif;" +
+  "Courier New=courier new,courier,monospace;" +
+  "Georgia=georgia,palatino,serif;" +
+  "Helvetica=helvetica,arial,sans-serif;" +
+  "Impact=impact,sans-serif;" +
+  "Tahoma=tahoma,arial,helvetica,sans-serif;" +
+  "Terminal=terminal,monaco,monospace;" +
+  "Times New Roman=times new roman,times,serif;" +
+  "Trebuchet MS=trebuchet ms,geneva,sans-serif;" +
+  "Verdana=verdana,geneva,sans-serif";
+
+function titleForFontFamilyFormat(format: string): string {
+  for (const entry of fontFamilyFormats.split(";")) {
     const separator = entry.indexOf("=");
 
     if (separator === -1) {
@@ -346,17 +377,6 @@ function titleForFontFamilyFormat(formats: string, format: string): string {
 
   return format.split(",")[0]?.trim() ?? format;
 }
-
-const FONT_CARET_NAVIGATION_KEYS = new Set([
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowUp",
-  "ArrowDown",
-  "Home",
-  "End",
-  "PageUp",
-  "PageDown",
-]);
 
 function RichtextEditorComponent(props: RichtextEditorComponentProps) {
   const {
@@ -378,26 +398,6 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
 
   const toolbarConfig =
     "insertfile undo redo | blocks | fontfamily | bold italic underline backcolor forecolor | lineheight | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | removeformat | table | preview media | emoticons | code | help";
-
-  // TinyMCE 7.9.3 default minus Symbol/Webdings/Wingdings, plus Default
-  // mapped to the iframe UA serif (Times) so existing apps keep the same
-  // look and the dropdown has a real selected option.
-  const fontFamilyFormats =
-    "Default=times,times new roman,serif;" +
-    "Andale Mono=andale mono,monospace;" +
-    "Arial=arial,helvetica,sans-serif;" +
-    "Arial Black=arial black,sans-serif;" +
-    "Book Antiqua=book antiqua,palatino,serif;" +
-    "Comic Sans MS=comic sans ms,sans-serif;" +
-    "Courier New=courier new,courier,monospace;" +
-    "Georgia=georgia,palatino,serif;" +
-    "Helvetica=helvetica,arial,sans-serif;" +
-    "Impact=impact,sans-serif;" +
-    "Tahoma=tahoma,arial,helvetica,sans-serif;" +
-    "Terminal=terminal,monaco,monospace;" +
-    "Times New Roman=times new roman,times,serif;" +
-    "Trebuchet MS=trebuchet ms,geneva,sans-serif;" +
-    "Verdana=verdana,geneva,sans-serif";
 
   const handleEditorChange = useCallback(
     // TODO: Fix this the next time the file is edited
@@ -651,10 +651,7 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                 }
 
                 pendingFontFamily = String(event.value);
-                pendingFontTitle = titleForFontFamilyFormat(
-                  fontFamilyFormats,
-                  pendingFontFamily,
-                );
+                pendingFontTitle = titleForFontFamilyFormat(pendingFontFamily);
                 pendingCaretOffset = collapsedTextOffset();
               });
               editor.on("NodeChange", () => {

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -368,6 +368,50 @@ function titleForFontFamilyFormat(format: string): string {
   return format.split(",")[0]?.trim() ?? format;
 }
 
+const WORD_CHAR = /[^\s\u00a0\u00ad\u200b\ufeff]/;
+
+/**
+ * TinyMCE's formatter expands a collapsed caret in the middle of a word
+ * to that word before applying an inline format. Collapsed FontName is a
+ * caret format for the next typed characters, so split the text node at
+ * the caret first — TinyMCE then takes its caret-container path instead
+ * of wrapping the existing word.
+ */
+function splitCollapsedCaretIfInsideWord(editor: TinyMCEEditor) {
+  if (!editor.selection.isCollapsed()) {
+    return;
+  }
+
+  try {
+    const rng = editor.selection.getRng();
+    const node = rng.startContainer;
+
+    if (node.nodeType !== Node.TEXT_NODE) {
+      return;
+    }
+
+    const offset = rng.startOffset;
+    const text = node.nodeValue ?? "";
+
+    if (offset <= 0 || offset >= text.length) {
+      return;
+    }
+
+    if (
+      !WORD_CHAR.test(text.charAt(offset - 1)) ||
+      !WORD_CHAR.test(text.charAt(offset))
+    ) {
+      return;
+    }
+
+    const after = (node as Text).splitText(offset);
+
+    editor.selection.setCursorLocation(after, 0);
+  } catch {
+    // Leave the range as-is so FontName still runs.
+  }
+}
+
 function RichtextEditorComponent(props: RichtextEditorComponentProps) {
   const {
     compactMode,
@@ -719,6 +763,7 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
 
                 if (!pendingFontIsActive()) {
                   applyingPendingFont = true;
+                  splitCollapsedCaretIfInsideWord(editor);
                   editor.formatter.apply("fontname", {
                     value: pendingFontFamily,
                   });
@@ -733,6 +778,7 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                   return;
                 }
 
+                splitCollapsedCaretIfInsideWord(editor);
                 pendingFontFamily = String(event.value);
                 pendingFontTitle = titleForFontFamilyFormat(pendingFontFamily);
                 pendingCaret = collapsedCaretInBlock();

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -331,6 +331,33 @@ export interface RichtextEditorComponentProps {
   onValueChange: (valueAsString: string) => void;
 }
 
+function titleForFontFamilyFormat(formats: string, format: string): string {
+  for (const entry of formats.split(";")) {
+    const separator = entry.indexOf("=");
+
+    if (separator === -1) {
+      continue;
+    }
+
+    if (entry.slice(separator + 1).trim() === format) {
+      return entry.slice(0, separator).trim();
+    }
+  }
+
+  return format.split(",")[0]?.trim() ?? format;
+}
+
+const FONT_CARET_NAVIGATION_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
+
 function RichtextEditorComponent(props: RichtextEditorComponentProps) {
   const {
     compactMode,
@@ -350,7 +377,27 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
   const initialRender = useRef(true);
 
   const toolbarConfig =
-    "insertfile undo redo | blocks | bold italic underline backcolor forecolor | lineheight | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | removeformat | table | preview media | emoticons | code | help";
+    "insertfile undo redo | blocks | fontfamily | bold italic underline backcolor forecolor | lineheight | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | removeformat | table | preview media | emoticons | code | help";
+
+  // TinyMCE 7.9.3 default minus Symbol/Webdings/Wingdings, plus Default
+  // mapped to the iframe UA serif (Times) so existing apps keep the same
+  // look and the dropdown has a real selected option.
+  const fontFamilyFormats =
+    "Default=times,times new roman,serif;" +
+    "Andale Mono=andale mono,monospace;" +
+    "Arial=arial,helvetica,sans-serif;" +
+    "Arial Black=arial black,sans-serif;" +
+    "Book Antiqua=book antiqua,palatino,serif;" +
+    "Comic Sans MS=comic sans ms,sans-serif;" +
+    "Courier New=courier new,courier,monospace;" +
+    "Georgia=georgia,palatino,serif;" +
+    "Helvetica=helvetica,arial,sans-serif;" +
+    "Impact=impact,sans-serif;" +
+    "Tahoma=tahoma,arial,helvetica,sans-serif;" +
+    "Terminal=terminal,monaco,monospace;" +
+    "Times New Roman=times new roman,times,serif;" +
+    "Trebuchet MS=trebuchet ms,geneva,sans-serif;" +
+    "Verdana=verdana,geneva,sans-serif";
 
   const handleEditorChange = useCallback(
     // TODO: Fix this the next time the file is edited
@@ -429,6 +476,7 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
             forced_root_block: "p",
             branding: false,
             resize: false,
+            font_family_formats: fontFamilyFormats,
             browser_spellcheck: true,
             convert_unsafe_embeds: true,
             sandbox_iframes: true,
@@ -493,11 +541,140 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                     : [];
                 },
               });
+              // Collapsed FontName is a caret format. Closing the toolbar menu
+              // restores the pre-menu bookmark (Times) and NodeChange then
+              // overwrites the dropdown. Keep the pick as pending only while
+              // the caret stays at that same text offset — a click, arrow
+              // key, or programmatic move must drop it so we do not restyle
+              // an unrelated location.
+              let pendingFontFamily: string | null = null;
+              let pendingFontTitle: string | null = null;
+              let pendingCaretOffset: number | null = null;
+              let applyingPendingFont = false;
+
+              const firstFamily = (font: string) =>
+                font.split(",")[0].trim().replace(/['"]/g, "").toLowerCase();
+
+              const collapsedTextOffset = () => {
+                const rng = editor.selection.getRng();
+                const body = editor.getBody();
+
+                if (!body) {
+                  return 0;
+                }
+
+                try {
+                  const probe = rng.cloneRange();
+
+                  probe.selectNodeContents(body);
+                  probe.setEnd(rng.startContainer, rng.startOffset);
+
+                  return probe.toString().replace(/[\uFEFF\u200B]/g, "").length;
+                } catch {
+                  return pendingCaretOffset ?? 0;
+                }
+              };
+
+              const clearPendingFont = () => {
+                pendingFontFamily = null;
+                pendingFontTitle = null;
+                pendingCaretOffset = null;
+              };
+
+              const pendingFontIsActive = () => {
+                if (!pendingFontFamily) {
+                  return true;
+                }
+
+                const current = (
+                  editor.queryCommandValue("FontName") || ""
+                ).toLowerCase();
+
+                return current.includes(firstFamily(pendingFontFamily));
+              };
+
+              const paintPendingFontLabel = () => {
+                if (!pendingFontTitle) {
+                  return;
+                }
+
+                const button = editor
+                  .getContainer()
+                  ?.querySelector("[data-mce-name='fontfamily']");
+                const label = button?.querySelector(".tox-tbtn__select-label");
+
+                if (label) {
+                  label.textContent = pendingFontTitle;
+                }
+
+                button?.setAttribute("aria-label", `Font ${pendingFontTitle}`);
+              };
+
+              const ensurePendingFont = () => {
+                if (
+                  applyingPendingFont ||
+                  editor.removed ||
+                  !pendingFontFamily
+                ) {
+                  return;
+                }
+
+                if (!editor.selection.isCollapsed()) {
+                  clearPendingFont();
+
+                  return;
+                }
+
+                if (
+                  pendingCaretOffset !== null &&
+                  collapsedTextOffset() !== pendingCaretOffset
+                ) {
+                  clearPendingFont();
+
+                  return;
+                }
+
+                if (!pendingFontIsActive()) {
+                  applyingPendingFont = true;
+                  editor.formatter.apply("fontname", {
+                    value: pendingFontFamily,
+                  });
+                  applyingPendingFont = false;
+                }
+
+                paintPendingFontLabel();
+              };
+
+              editor.on("BeforeExecCommand", (event) => {
+                if (event.command !== "FontName" || !event.value) {
+                  return;
+                }
+
+                pendingFontFamily = String(event.value);
+                pendingFontTitle = titleForFontFamilyFormat(
+                  fontFamilyFormats,
+                  pendingFontFamily,
+                );
+                pendingCaretOffset = collapsedTextOffset();
+              });
+              editor.on("NodeChange", () => {
+                setTimeout(ensurePendingFont, 0);
+              });
+              editor.on("mousedown", clearPendingFont);
+              editor.on("keydown", (event) => {
+                if (FONT_CARET_NAVIGATION_KEYS.has(event.key)) {
+                  clearPendingFont();
+                }
+              });
             },
           }}
           key={`editor_${props.isToolbarHidden}_${props.isDisabled}`}
           licenseKey="gpl"
           onEditorChange={handleEditorChange}
+          // Local `value` is not a veto. tinymce-react's rollback would
+          // setContent() 200ms later and wipe caret formats; WDS RTE
+          // disables it for the same contract.
+          rollback={false}
           toolbar={props.isToolbarHidden ? false : toolbarConfig}
           value={editorValue}
         />

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -331,17 +331,6 @@ export interface RichtextEditorComponentProps {
   onValueChange: (valueAsString: string) => void;
 }
 
-const FONT_CARET_NAVIGATION_KEYS = new Set([
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowUp",
-  "ArrowDown",
-  "Home",
-  "End",
-  "PageUp",
-  "PageDown",
-]);
-
 // TinyMCE 7.9.3 default minus Symbol/Webdings/Wingdings, plus Default
 // mapped to the iframe UA serif (Times) so existing apps keep the same
 // look and the dropdown has a real selected option.
@@ -405,15 +394,13 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
     (newValue: string, editor: any) => {
       // avoid updating value, when there is no actual change.
       if (newValue !== editorValue) {
-        const isFocused = editor.hasFocus();
+        setEditorValue(newValue);
 
         /**
-         * only change call the props.onValueChange when the editor is in focus.
+         * only call props.onValueChange when the editor is in focus.
          * This prevents props.onValueChange from getting called whenever the defaultText is changed.
          */
-        //
-        if (isFocused) {
-          setEditorValue(newValue);
+        if (editor.hasFocus()) {
           props.onValueChange(newValue);
         }
       }
@@ -544,9 +531,9 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
               // Collapsed FontName is a caret format. Closing the toolbar menu
               // restores the pre-menu bookmark (Times) and NodeChange then
               // overwrites the dropdown. Keep the pick as pending only while
-              // the caret stays at that same text offset — a click, arrow
-              // key, or programmatic move must drop it so we do not restyle
-              // an unrelated location.
+              // the caret stays at that same text offset — a click or
+              // programmatic move must drop it so we do not restyle an
+              // unrelated location.
               let pendingFontFamily: string | null = null;
               let pendingFontTitle: string | null = null;
               let pendingCaretOffset: number | null = null;
@@ -555,12 +542,12 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
               const firstFamily = (font: string) =>
                 font.split(",")[0].trim().replace(/['"]/g, "").toLowerCase();
 
-              const collapsedTextOffset = () => {
+              const collapsedTextOffset = (): number | null => {
                 const rng = editor.selection.getRng();
                 const body = editor.getBody();
 
                 if (!body) {
-                  return 0;
+                  return null;
                 }
 
                 try {
@@ -571,7 +558,7 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
 
                   return probe.toString().replace(/[\uFEFF\u200B]/g, "").length;
                 } catch {
-                  return pendingCaretOffset ?? 0;
+                  return null;
                 }
               };
 
@@ -624,9 +611,12 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                   return;
                 }
 
+                const caretOffset = collapsedTextOffset();
+
                 if (
-                  pendingCaretOffset !== null &&
-                  collapsedTextOffset() !== pendingCaretOffset
+                  caretOffset === null ||
+                  (pendingCaretOffset !== null &&
+                    caretOffset !== pendingCaretOffset)
                 ) {
                   clearPendingFont();
 
@@ -652,25 +642,20 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                 pendingFontFamily = String(event.value);
                 pendingFontTitle = titleForFontFamilyFormat(pendingFontFamily);
                 pendingCaretOffset = collapsedTextOffset();
+
+                if (pendingCaretOffset === null) {
+                  clearPendingFont();
+                }
               });
               editor.on("NodeChange", () => {
                 setTimeout(ensurePendingFont, 0);
               });
               editor.on("mousedown", clearPendingFont);
-              editor.on("keydown", (event) => {
-                if (FONT_CARET_NAVIGATION_KEYS.has(event.key)) {
-                  clearPendingFont();
-                }
-              });
             },
           }}
           key={`editor_${props.isToolbarHidden}_${props.isDisabled}`}
           licenseKey="gpl"
           onEditorChange={handleEditorChange}
-          // Local `value` is not a veto. tinymce-react's rollback would
-          // setContent() 200ms later and wipe caret formats; WDS RTE
-          // disables it for the same contract.
-          rollback={false}
           toolbar={props.isToolbarHidden ? false : toolbarConfig}
           value={editorValue}
         />

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -394,13 +394,15 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
     (newValue: string, editor: any) => {
       // avoid updating value, when there is no actual change.
       if (newValue !== editorValue) {
-        setEditorValue(newValue);
+        const isFocused = editor.hasFocus();
 
         /**
-         * only call props.onValueChange when the editor is in focus.
+         * only change call the props.onValueChange when the editor is in focus.
          * This prevents props.onValueChange from getting called whenever the defaultText is changed.
          */
-        if (editor.hasFocus()) {
+        //
+        if (isFocused) {
+          setEditorValue(newValue);
           props.onValueChange(newValue);
         }
       }
@@ -531,19 +533,22 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
               // Collapsed FontName is a caret format. Closing the toolbar menu
               // restores the pre-menu bookmark (Times) and NodeChange then
               // overwrites the dropdown. Keep the pick as pending only while
-              // the caret stays at that same text offset — a click or
-              // programmatic move must drop it so we do not restyle an
-              // unrelated location.
+              // the caret stays in the same block at the same text offset —
+              // a click outside this editor, or a move, must drop it so we
+              // do not restyle an unrelated location.
               let pendingFontFamily: string | null = null;
               let pendingFontTitle: string | null = null;
-              let pendingCaretOffset: number | null = null;
+              let pendingCaret: { block: Node; offset: number } | null = null;
               let applyingPendingFont = false;
+              let pendingFontTimer: ReturnType<typeof setTimeout> | undefined;
 
               const firstFamily = (font: string) =>
                 font.split(",")[0].trim().replace(/['"]/g, "").toLowerCase();
 
-              const collapsedTextOffset = (): number | null => {
-                const rng = editor.selection.getRng();
+              const collapsedCaretInBlock = (): {
+                block: Node;
+                offset: number;
+              } | null => {
                 const body = editor.getBody();
 
                 if (!body) {
@@ -551,12 +556,22 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                 }
 
                 try {
+                  const rng = editor.selection.getRng();
+                  const block =
+                    editor.dom.getParent(rng.startContainer, (node) =>
+                      editor.dom.isBlock(node),
+                    ) || body;
                   const probe = rng.cloneRange();
 
-                  probe.selectNodeContents(body);
+                  probe.selectNodeContents(block);
                   probe.setEnd(rng.startContainer, rng.startOffset);
 
-                  return probe.toString().replace(/[\uFEFF\u200B]/g, "").length;
+                  return {
+                    block,
+                    offset: probe
+                      .toString()
+                      .replace(/[\uFEFF\u200B]/g, "").length,
+                  };
                 } catch {
                   return null;
                 }
@@ -565,7 +580,36 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
               const clearPendingFont = () => {
                 pendingFontFamily = null;
                 pendingFontTitle = null;
-                pendingCaretOffset = null;
+                pendingCaret = null;
+              };
+
+              const isThisEditorChrome = (target: EventTarget | null) => {
+                if (!(target instanceof Node)) {
+                  return false;
+                }
+
+                const container = editor.getContainer();
+
+                if (container?.contains(target)) {
+                  return true;
+                }
+
+                const element =
+                  target instanceof Element ? target : target.parentElement;
+
+                return Boolean(
+                  element?.closest(
+                    ".tox-silver-sink, .tox-menu, .tox-dialog, .tox-selected-menu",
+                  ),
+                );
+              };
+
+              const onPageMouseDown = (event: MouseEvent) => {
+                if (!pendingFontFamily || isThisEditorChrome(event.target)) {
+                  return;
+                }
+
+                clearPendingFont();
               };
 
               const pendingFontIsActive = () => {
@@ -611,12 +655,13 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                   return;
                 }
 
-                const caretOffset = collapsedTextOffset();
+                const caret = collapsedCaretInBlock();
 
                 if (
-                  caretOffset === null ||
-                  (pendingCaretOffset !== null &&
-                    caretOffset !== pendingCaretOffset)
+                  caret === null ||
+                  (pendingCaret !== null &&
+                    (caret.block !== pendingCaret.block ||
+                      caret.offset !== pendingCaret.offset))
                 ) {
                   clearPendingFont();
 
@@ -641,16 +686,36 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
 
                 pendingFontFamily = String(event.value);
                 pendingFontTitle = titleForFontFamilyFormat(pendingFontFamily);
-                pendingCaretOffset = collapsedTextOffset();
+                pendingCaret = collapsedCaretInBlock();
 
-                if (pendingCaretOffset === null) {
+                if (pendingCaret === null) {
                   clearPendingFont();
                 }
               });
               editor.on("NodeChange", () => {
-                setTimeout(ensurePendingFont, 0);
+                if (pendingFontTimer !== undefined) {
+                  clearTimeout(pendingFontTimer);
+                }
+
+                pendingFontTimer = setTimeout(() => {
+                  pendingFontTimer = undefined;
+                  ensurePendingFont();
+                }, 0);
               });
               editor.on("mousedown", clearPendingFont);
+              editor.on("deactivate", clearPendingFont);
+              document.addEventListener("mousedown", onPageMouseDown, true);
+              editor.on("remove", () => {
+                if (pendingFontTimer !== undefined) {
+                  clearTimeout(pendingFontTimer);
+                }
+
+                document.removeEventListener(
+                  "mousedown",
+                  onPageMouseDown,
+                  true,
+                );
+              });
             },
           }}
           key={`editor_${props.isToolbarHidden}_${props.isDisabled}`}

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -586,11 +586,10 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
                   return true;
                 }
 
-                const current = (
-                  editor.queryCommandValue("FontName") || ""
-                ).toLowerCase();
-
-                return current.includes(firstFamily(pendingFontFamily));
+                return (
+                  firstFamily(editor.queryCommandValue("FontName") || "") ===
+                  firstFamily(pendingFontFamily)
+                );
               };
 
               const paintPendingFontLabel = () => {

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -25,6 +25,7 @@ import "tinymce/plugins/help/js/i18n/keynav/en.js";
 import React, { useRef, useCallback, useEffect, useState } from "react";
 import styled, { createGlobalStyle } from "styled-components";
 import { Editor } from "@tinymce/tinymce-react";
+import type { Editor as TinyMCEEditor } from "tinymce";
 import type { LabelPosition } from "components/constants";
 import type { Alignment } from "@blueprintjs/core";
 import type { TextSize } from "constants/WidgetConstants";
@@ -384,6 +385,8 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
 
   const [editorValue, setEditorValue] = useState<string>(props.value as string);
   const initialRender = useRef(true);
+  const editorRef = useRef<TinyMCEEditor | null>(null);
+  const pushedValueToEditor = useRef(false);
 
   const toolbarConfig =
     "insertfile undo redo | blocks | fontfamily | bold italic underline backcolor forecolor | lineheight | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | removeformat | table | preview media | emoticons | code | help";
@@ -410,10 +413,57 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
     [props.onValueChange, editorValue],
   );
 
+  /**
+   * TinyMCE re-serializes whatever it is handed — `forced_root_block` alone
+   * wraps a bare `defaultText` in a `<p>` — so the string we hold and the
+   * editor's own content do not match until a focused edit syncs them. The
+   * react wrapper reads that mismatch as "the consumer rejected this
+   * content" and keeps pushing our value back through `setContent`, on the
+   * 200ms rollback timer and again on every render, which wipes any
+   * caret-only format the user set before typing — a font picked from the
+   * toolbar, for example. Adopting the editor's serialization of the value
+   * we already gave it keeps the two in step. Nothing is committed to the
+   * widget, so `defaultText` stays the source of truth for `text` and for
+   * `resetWidget`, and content set by anyone else is still rolled back.
+   */
+  const adoptEditorSerialization = useCallback(() => {
+    const editor = editorRef.current;
+
+    if (!editor || editor.removed) {
+      return;
+    }
+
+    const serialized = editor.getContent();
+
+    setEditorValue((current) =>
+      current === serialized ? current : serialized,
+    );
+  }, []);
+
+  const handleInit = useCallback(
+    (_event: unknown, editor: TinyMCEEditor) => {
+      editorRef.current = editor;
+      adoptEditorSerialization();
+    },
+    [adoptEditorSerialization],
+  );
+
+  // Runs in the commit that pushed a new value into the editor, after the
+  // wrapper's own componentDidUpdate has called setContent with it.
+  useEffect(() => {
+    if (!pushedValueToEditor.current) {
+      return;
+    }
+
+    pushedValueToEditor.current = false;
+    adoptEditorSerialization();
+  }, [editorValue, adoptEditorSerialization]);
+
   // As this useEffect sets the initialRender.current value as false and order of hooks matter,
   // we should always keep this useEffect logic at last part of component before return to make sure, initialRender.current value is consumed as expected in the component.
   useEffect(() => {
     if (!initialRender.current && editorValue !== props.value) {
+      pushedValueToEditor.current = true;
       setEditorValue(props.value as string);
     } else {
       initialRender.current = false;
@@ -720,6 +770,7 @@ function RichtextEditorComponent(props: RichtextEditorComponentProps) {
           key={`editor_${props.isToolbarHidden}_${props.isDisabled}`}
           licenseKey="gpl"
           onEditorChange={handleEditorChange}
+          onInit={handleInit}
           toolbar={props.isToolbarHidden ? false : toolbarConfig}
           value={editorValue}
         />


### PR DESCRIPTION
## Description
Add TinyMCE's built-in Font Family control to the classic Rich Text Editor toolbar. The list is TinyMCE's web-safe fonts, minus dingbats, with **Default** mapped to the existing Times look so current apps do not restyle.
A collapsed caret applies the font to the next typed text, not the current paragraph. Moving the caret (click, arrows, Home/End) drops that pending pick so it is not applied at an unrelated location.


Fixes https://github.com/appsmithorg/appsmith-ee/issues/6266

## Testing

> [!NOTE]
> **How CI runs on fork PRs — no action needed from you.**
> 1. **Workflow approval.** GitHub holds the first run on fork PRs until a maintainer approves it, so a pause before any check appears is expected.
> 2. **Credential-free checks.** Once approved, format, lint, typecheck, unit tests, cyclic-dependency and compile-only build checks run without repository secrets. Only the checks relevant to what you changed (client / server / RTS) will run, and their logs are safe to debug against.
> 3. **Maintainer-triggered checks.** Cypress, Playwright, Docker builds and deploy previews need secrets, so a maintainer starts them with `/approve-ci`, and `/build-deploy-preview` when hands-on testing is needed. Approval is pinned to one commit — pushing again requires fresh approval.
>
> The `awaiting-maintainer` / `awaiting-contributor` labels show whose turn it is. You do **not** need `ok-to-test` or any slash command. Full detail: [Pull request check states](https://github.com/appsmithorg/appsmith/blob/release/contributions/CodeContributionsGuidelines.md#pull-request-check-states).

Select the validation relevant to this change:

- [ ] Client unit tests
- [ ] Server unit tests
- [x] Cypress
- [ ] Playwright
- [x] Deploy preview
- [ ] Not applicable

## Automation
/ok-to-test tags="@tag.All"

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/35105907643>
> Commit: e395170c663f88f936fbac5008f03ab28a9ec9aa
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=35105907643&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Wed, 16 Sep 2026 15:08:34 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable font-family dropdown to the Rich Text Editor.
  - Includes a “Default” option and a curated selection of font families.
  - Font selections apply to highlighted text and newly entered text at the cursor.

- **Bug Fixes**
  - Improved font formatting when moving or navigating the cursor.
  - Prevented unintended font application at new cursor positions.
  - Improved consistency when opening font-size and additional toolbar controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->