### PR TITLE
perf: reduce redundant Segment API calls (~35% cut, ~88M calls/month)

### DIFF
--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -654,7 +654,6 @@ export default function* executePluginActionTriggerSaga(
       );
     }
   } else {
-    AnalyticsUtil.logEvent("EXECUTE_ACTION_SUCCESS", actionExecutionAnalytics);
     AppsmithConsole.info({
       logType: LOG_TYPE.ACTION_EXECUTION_SUCCESS,
       text: `Successfully executed in ${payload.duration}(ms)`,
@@ -1261,27 +1260,6 @@ function* executePageLoadAction(
           : ActionExecutionContext.PAGE_LOAD,
       });
     } else {
-      AnalyticsUtil.logEvent("EXECUTE_ACTION_SUCCESS", {
-        type: pageAction.pluginType,
-        name: actionName,
-        pageId: pageId,
-        appMode: appMode,
-        appId: currentApp.id,
-        onPageLoad: true,
-        appName: currentApp.name,
-        environmentId: currentEnvDetails.id,
-        environmentName: currentEnvDetails.name,
-        isExampleApp: currentApp.appIsExample,
-        pluginName: plugin?.name,
-        datasourceId: datasourceId,
-        isMock: !!datasource?.isMock,
-        actionId: pageAction?.id,
-        inputParams: 0,
-        source: !!actionExecutionContext
-          ? actionExecutionContext
-          : ActionExecutionContext.PAGE_LOAD,
-      });
-
       yield take(ReduxActionTypes.SET_EVALUATED_TREE);
     }
   }

--- a/app/client/src/sagas/DebuggerSagas.ts
+++ b/app/client/src/sagas/DebuggerSagas.ts
@@ -651,35 +651,6 @@ function* deleteDebuggerErrorLogsSaga(
       } as LogDebuggerErrorAnalyticsPayload,
       currentDebuggerErrors,
     );
-
-    if (errorMessages) {
-      const currentEnvDetails: { id: string; name: string } = yield select(
-        getCurrentEnvironmentDetails,
-      );
-
-      //errorID has timestamp for 1:1 mapping with new and resolved errors
-      yield all(
-        errorMessages.map((errorMessage) => {
-          return fork(
-            logDebuggerErrorAnalyticsSaga,
-            {
-              ...analyticsPayload,
-              environmentId: currentEnvDetails.id,
-              environmentName: currentEnvDetails.name,
-              eventName: "DEBUGGER_RESOLVED_ERROR_MESSAGE",
-              errorId: generateErrorId(error),
-              errorMessage: errorMessage.message,
-              errorType: errorMessage.type,
-              errorSubType: errorMessage.subType,
-              appMode,
-              source: error.source,
-              logId: error.id,
-            } as LogDebuggerErrorAnalyticsPayload,
-            currentDebuggerErrors,
-          );
-        }),
-      );
-    }
   }
 
   const validErrorIds = validErrorPayloadsToDelete.map((payload) => payload.id);
@@ -811,22 +782,6 @@ function* activeFieldDebuggerErrorHandler(
         errorId: generateErrorId(initialSourceDebuggerError),
       } as LogDebuggerErrorAnalyticsPayload,
       latestDebuggerErrors,
-    );
-
-    yield all(
-      initialSourceDebuggerError.messages?.map((errorMessage) => {
-        return fork(
-          logDebuggerErrorAnalyticsSaga,
-          {
-            ...sourceMetaData,
-            ...envMetaData,
-            eventName: "DEBUGGER_RESOLVED_ERROR_MESSAGE",
-            errorMessage: errorMessage.message,
-            errorId: generateErrorId(initialSourceDebuggerError),
-          } as LogDebuggerErrorAnalyticsPayload,
-          latestDebuggerErrors,
-        );
-      }) || [],
     );
   }
 

--- a/app/client/src/widgets/CustomWidget/widget/index.tsx
+++ b/app/client/src/widgets/CustomWidget/widget/index.tsx
@@ -46,6 +46,10 @@ const StyledLink = styled(Link)`
 class CustomWidget extends BaseWidget<CustomWidgetProps, WidgetState> {
   static type = "CUSTOM_WIDGET";
 
+  private modelUpdateCount = 0;
+  private modelUpdateLastEmitTime = 0;
+  private static MODEL_UPDATE_THROTTLE_MS = 60000;
+
   static getConfig() {
     return {
       name: "Custom",
@@ -421,9 +425,20 @@ class CustomWidget extends BaseWidget<CustomWidgetProps, WidgetState> {
       ...data,
     });
 
-    AnalyticsUtil.logEvent("CUSTOM_WIDGET_API_UPDATE_MODEL", {
-      widgetId: this.props.widgetId,
-    });
+    this.modelUpdateCount++;
+    const now = Date.now();
+
+    if (
+      now - this.modelUpdateLastEmitTime >=
+      CustomWidget.MODEL_UPDATE_THROTTLE_MS
+    ) {
+      AnalyticsUtil.logEvent("CUSTOM_WIDGET_API_UPDATE_MODEL", {
+        widgetId: this.props.widgetId,
+        updateCount: this.modelUpdateCount,
+      });
+      this.modelUpdateCount = 0;
+      this.modelUpdateLastEmitTime = now;
+    }
   };
 
   getRenderMode = () => {

--- a/app/client/src/widgets/wds/WDSCustomWidget/widget/index.tsx
+++ b/app/client/src/widgets/wds/WDSCustomWidget/widget/index.tsx
@@ -36,6 +36,10 @@ export class WDSCustomWidget extends BaseWidget<
 > {
   static type = "WDS_CUSTOM_WIDGET";
 
+  private modelUpdateCount = 0;
+  private modelUpdateLastEmitTime = 0;
+  private static MODEL_UPDATE_THROTTLE_MS = 60000;
+
   static getConfig() {
     return config.metaConfig;
   }
@@ -102,9 +106,20 @@ export class WDSCustomWidget extends BaseWidget<
       ...data,
     });
 
-    AnalyticsUtil.logEvent("CUSTOM_WIDGET_API_UPDATE_MODEL", {
-      widgetId: this.props.widgetId,
-    });
+    this.modelUpdateCount++;
+    const now = Date.now();
+
+    if (
+      now - this.modelUpdateLastEmitTime >=
+      WDSCustomWidget.MODEL_UPDATE_THROTTLE_MS
+    ) {
+      AnalyticsUtil.logEvent("CUSTOM_WIDGET_API_UPDATE_MODEL", {
+        widgetId: this.props.widgetId,
+        updateCount: this.modelUpdateCount,
+      });
+      this.modelUpdateCount = 0;
+      this.modelUpdateLastEmitTime = now;
+    }
   };
 
   getRenderMode = () => {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.solutions.ce;
 
-import com.appsmith.external.constants.AnalyticsEvents;
 import com.appsmith.external.datatypes.ClientDataType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.dtos.ParamProperty;
@@ -21,23 +20,17 @@ import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.applications.base.ApplicationService;
 import com.appsmith.server.configurations.CommonConfig;
-import com.appsmith.server.constants.Constraint;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.datasources.base.DatasourceService;
 import com.appsmith.server.datasourcestorages.base.DatasourceStorageService;
-import com.appsmith.server.domains.Application;
-import com.appsmith.server.domains.ApplicationMode;
 import com.appsmith.server.domains.DatasourceContext;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.Plugin;
-import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.ExecuteActionMetaDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.featureflags.CachedFeatures;
 import com.appsmith.server.helpers.ActionExecutionSolutionHelper;
-import com.appsmith.server.helpers.DatasourceAnalyticsUtils;
-import com.appsmith.server.helpers.DateUtils;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.newactions.base.NewActionService;
 import com.appsmith.server.newpages.base.NewPageService;
@@ -92,7 +85,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.appsmith.external.constants.CommonFieldName.REDACTED_DATA;
 import static com.appsmith.external.constants.spans.ActionSpan.ACTION_EXECUTION_CACHED_DATASOURCE;
 import static com.appsmith.external.constants.spans.ActionSpan.ACTION_EXECUTION_DATASOURCE_CONTEXT;
 import static com.appsmith.external.constants.spans.ActionSpan.ACTION_EXECUTION_EDITOR_CONFIG;
@@ -1191,143 +1183,7 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
             request.setProperties(stringProperties);
         }
 
-        return Mono.justOrEmpty(actionDTO.getApplicationId())
-                .flatMap(applicationService::findById)
-                .defaultIfEmpty(new Application())
-                .flatMap(application -> Mono.zip(
-                        Mono.just(application),
-                        sessionUserService.getCurrentUser(),
-                        newPageService.getNameByPageId(actionDTO.getPageId(), executeActionDto.getViewMode()),
-                        pluginService.getByIdWithoutPermissionCheck(actionDTO.getPluginId()),
-                        datasourceStorageService.getEnvironmentNameFromEnvironmentIdForAnalytics(
-                                datasourceStorage.getEnvironmentId())))
-                .flatMap(tuple -> {
-                    final Application application = tuple.getT1();
-                    final User user = tuple.getT2();
-                    final String pageName = tuple.getT3();
-                    final Plugin plugin = tuple.getT4();
-                    final String environmentName = tuple.getT5();
-
-                    final PluginType pluginType = actionDTO.getPluginType();
-                    final String appMode = TRUE.equals(executeActionDto.getViewMode())
-                            ? ApplicationMode.PUBLISHED.toString()
-                            : ApplicationMode.EDIT.toString();
-
-                    final Map<String, Object> data = new HashMap<>();
-                    data.put("username", user.getUsername());
-                    data.put("type", pluginType);
-                    data.put("pluginName", plugin.getName());
-                    data.put("name", actionDTO.getName());
-
-                    Map<String, Object> datasourceInfo = new HashMap<>();
-                    datasourceInfo.put("name", datasourceStorage.getName());
-                    data.put("datasource", datasourceInfo);
-
-                    data.put("workspaceId", application.getWorkspaceId());
-                    data.put("appId", actionDTO.getApplicationId());
-                    data.put(FieldName.APP_MODE, appMode);
-                    data.put("appName", application.getName());
-                    data.put("isExampleApp", application.getAppIsExample());
-
-                    String dsCreatedAt = "";
-                    if (datasourceStorage.getCreatedAt() != null) {
-                        dsCreatedAt = DateUtils.ISO_FORMATTER.format(datasourceStorage.getCreatedAt());
-                    }
-                    List<Param> paramsList = executeActionDto.getParams();
-                    if (paramsList == null) {
-                        paramsList = new ArrayList<>();
-                    }
-                    List<String> executionParams =
-                            paramsList.stream().map(param -> param.getValue()).collect(Collectors.toList());
-
-                    data.put("request", request);
-                    data.put(
-                            "isSuccessfulExecution",
-                            ObjectUtils.defaultIfNull(actionExecutionResult.getIsExecutionSuccess(), false));
-                    data.put("statusCode", ObjectUtils.defaultIfNull(actionExecutionResult.getStatusCode(), ""));
-                    data.put("timeElapsed", timeElapsed);
-                    data.put("actionCreated", DateUtils.ISO_FORMATTER.format(actionDTO.getCreatedAt()));
-                    data.put("actionId", ObjectUtils.defaultIfNull(actionDTO.getId(), ""));
-                    data.put(
-                            FieldName.ACTION_EXECUTION_REQUEST_PARAMS_SIZE,
-                            executeActionDto.getTotalReadableByteCount());
-                    data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_COUNT, executionParams.size());
-
-                    setContextSpecificProperties(data, actionDTO, pageName);
-
-                    ActionExecutionResult.PluginErrorDetails pluginErrorDetails =
-                            actionExecutionResult.getPluginErrorDetails();
-                    data.put("pluginErrorDetails", ObjectUtils.defaultIfNull(pluginErrorDetails, ""));
-                    if (pluginErrorDetails != null) {
-                        data.put("appsmithErrorCode", pluginErrorDetails.getAppsmithErrorCode());
-                        data.put("appsmithErrorMessage", pluginErrorDetails.getAppsmithErrorMessage());
-                        data.put("errorType", pluginErrorDetails.getErrorType());
-                    }
-
-                    data.putAll(DatasourceAnalyticsUtils.getAnalyticsPropertiesWithStorageOnActionExecution(
-                            datasourceStorage, dsCreatedAt, environmentName));
-
-                    // Add the error message in case of erroneous execution
-                    if (FALSE.equals(actionExecutionResult.getIsExecutionSuccess())) {
-                        String errorJson;
-                        try {
-                            errorJson = objectMapper.writeValueAsString(actionExecutionResult.getBody());
-                        } catch (JsonProcessingException e) {
-                            log.warn("Unable to serialize action execution error result to JSON.", e);
-                            errorJson = "\"Failed to serialize error data to JSON.\"";
-                        }
-                        data.put("error", errorJson);
-                    }
-
-                    if (actionExecutionResult.getStatusCode() != null) {
-                        data.put("statusCode", actionExecutionResult.getStatusCode());
-                    }
-
-                    String executionRequestQuery = "";
-                    if (actionExecutionResult.getRequest() != null
-                            && actionExecutionResult.getRequest().getQuery() != null) {
-                        executionRequestQuery =
-                                actionExecutionResult.getRequest().getQuery();
-                    }
-
-                    final Map<String, Object> eventData = new HashMap<>();
-                    eventData.put(FieldName.ACTION, actionDTO);
-                    eventData.put(FieldName.DATASOURCE, datasourceStorage);
-                    eventData.put(FieldName.APP_MODE, appMode);
-                    eventData.put(FieldName.ACTION_EXECUTION_RESULT, actionExecutionResult);
-                    eventData.put(FieldName.ACTION_EXECUTION_TIME, timeElapsed);
-                    eventData.put(FieldName.ACTION_EXECUTION_QUERY, executionRequestQuery);
-                    eventData.put(FieldName.APPLICATION, application);
-                    eventData.put(FieldName.PLUGIN, plugin);
-
-                    if (executeActionDto.getTotalReadableByteCount() <= Constraint.MAX_ANALYTICS_SIZE_BYTES) {
-                        // Only send params info if total size is less than 5 MB
-                        eventData.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS, executionParams);
-                    } else {
-                        eventData.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS, REDACTED_DATA);
-                    }
-                    if (executeActionDto != null) {
-                        // Remove the value from the executeActionDto.params before sending to mixpanel as it contains
-                        // user submitted data
-                        if (executeActionDto.getParams() != null) {
-                            executeActionDto.getParams().forEach(param -> param.setValue(REDACTED_DATA));
-                        }
-                        data.put(FieldName.ACTION_EXECUTION_REQUEST_PARAMS_VALUE_MAP, executeActionDto.getParams());
-                        data.put(
-                                FieldName.ACTION_EXECUTION_INVERT_PARAMETER_MAP,
-                                executeActionDto.getInvertParameterMap());
-                    }
-                    data.put(FieldName.ACTION_CONFIGURATION, rawActionConfiguration);
-                    data.put(FieldName.EVENT_DATA, eventData);
-                    data.put(FieldName.ACTION_CONFIGURATION_RUN_BEHAVIOUR, actionDTO.getRunBehaviour());
-                    return analyticsService
-                            .sendObjectEvent(AnalyticsEvents.EXECUTE_ACTION, actionDTO, data)
-                            .thenReturn(request);
-                })
-                .onErrorResume(error -> {
-                    log.warn("Error sending action execution data point", error);
-                    return Mono.just(request);
-                });
+        return Mono.just(request);
     }
 
     protected void setContextSpecificProperties(Map<String, Object> data, ActionDTO actionDTO, String contextName) {


### PR DESCRIPTION
## Summary

Reduces Segment API call volume by ~48% on EE (~4M calls/day, ~120M/month) by removing redundant and disabled analytics events. 5 files changed, +37 / -218.

### Commit 1: Remove redundant client-side events (~2.93M/day)

**1. Remove `EXECUTE_ACTION_SUCCESS` from plugin action paths** (~1.35M/day)

The client `EXECUTE_ACTION_SUCCESS` carried identical properties to the preceding `EXECUTE_ACTION` — same action/plugin/datasource/app identity, zero additional data. Removed from 2 call sites in `PluginActionSaga.ts`.

**NOT touched:**
- `EXECUTE_ACTION` (client, pre-execution intent) — still fires
- `EXECUTE_ACTION_FAILURE` (client, captures network/timeout/CORS errors that never reach the server) — still fires
- JS expression SUCCESS/FAILURE in `analyticsSaga.ts` — no server equivalent, still fires

**2. Remove `DEBUGGER_RESOLVED_ERROR_MESSAGE` fan-out where parent already fires** (~1.08M/day)

On complete error deletion, both `DEBUGGER_RESOLVED_ERROR` (with `errorMessages[]` array) and N × `DEBUGGER_RESOLVED_ERROR_MESSAGE` fired in parallel. Removed the per-message fan-out since the parent already contains all message data. Partial-resolution paths where only `_MESSAGE` fires (the only record) are preserved.

**3. Throttle `CUSTOM_WIDGET_API_UPDATE_MODEL` with count aggregation** (~500k+/day)

Previously fired per `appsmith.model.key = value` call. Now emits once per widget per 60s with `{ widgetId, updateCount }`.

### Commit 2: Remove server-side `execute_ACTION_TRIGGERED` (~1.03M/day)

**This is the richest execution analytics event** — it carries `timeElapsed`, `statusCode`, `isSuccessfulExecution`, query text, error details, datasource metadata, and request params that no other event has.

**Why it is safe to remove NOW:** The Segment warehouse sync for this event has already been turned off. The event was costing ~1.03M API calls/day (~31M/month) with no downstream consumer. The data was already not flowing anywhere.

**What is lost:** Execution outcome analytics — latency, success/failure rates, status codes, error details, query text. These are **not available from any remaining event**. The client `EXECUTE_ACTION` only captures intent (pre-execution), not outcome.

**Reversibility:** Re-enabling is a one-commit revert if execution analytics are needed again.

### Impact on Segment cost

**API calls (throughput):**

| Change | Saved/day (EE) | Saved/month |
|---|---|---|
| Remove `EXECUTE_ACTION_SUCCESS` | ~1.35M | ~41M |
| Remove debugger `_MESSAGE` fan-out | ~1.08M | ~32M |
| Throttle custom widget | ~500k+ | ~15M |
| Remove `execute_ACTION_TRIGGERED` (server) | ~1.03M | ~31M |
| **Total** | **~3.96M/day (~48% of EE)** | **~119M/month** |

CE source sees a proportional cut. Combined workspace savings estimated at ~119M+ API calls/month.

**MTU:** No impact — same userIds, no identity changes.

**Throughput ratio:** August was 644 calls/MTU (limit: 1,000). After this PR, projected ratio drops to ~350-400 — well within limits even if the MTU plan is downsized.

### What still fires after this PR (per plugin query execution)

| Event | Side | What it captures |
|---|---|---|
| `EXECUTE_ACTION` | Client | Intent — action/plugin/datasource identity, app context. Fires before HTTP call. |
| `EXECUTE_ACTION_FAILURE` | Client | Only on failure — error details for network/timeout/CORS failures. |
| ~~`EXECUTE_ACTION_SUCCESS`~~ | ~~Client~~ | **Removed** — identical properties to EXECUTE_ACTION, zero additional data. |
| ~~`execute_ACTION_TRIGGERED`~~ | ~~Server~~ | **Removed** — richest event but warehouse sync already off. No downstream consumer. |

### Warehouse impact

- `execute_action_success` — stops receiving plugin-action rows (JS expression SUCCESS still flows)
- `execute_action_triggered` — stops receiving rows (warehouse sync was already off)
- `debugger_resolved_error_message` — receives fewer rows (only partial resolutions; full-deletion data in parent)
- `custom_widget_api_update_model` — fewer rows, now includes `update_count`

### Linear

https://linear.app/appsmith/issue/APP-15946

### Slack thread

https://theappsmith.slack.com/archives/C0B02MW6JMS/p1788271277313719

### Automation

/ok-to-test tags="@tag.Sanity"

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD be5a057c1d88ea49f25032ce6a1c466e2036ca8b yet
> <hr>Wed, 16 Sep 2026 12:56:31 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Removed individual success and error-resolution event emissions while retaining aggregate tracking.
  * Improved model-update tracking so pending counts are recorded after activity stops and when widgets are closed.
  * Simplified action execution analytics handling and reduced unnecessary contextual data collection.

* **Reliability**
  * Ensured pending tracking updates are cleared and finalized consistently during widget lifecycle changes.
  * Preserved accurate tracking when updates stop unexpectedly or widgets are unmounted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->