### PR TITLE
fix(deps): bump netty-handler 4.1.136 → 4.1.137 for CVE-2026-75595

### DIFF
--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -45,8 +45,9 @@
         <mockito.version>4.4.0</mockito.version>
         <mockwebserver.version>5.0.0-alpha.2</mockwebserver.version>
         <!-- Pinned above the Spring Boot BOM default for CVE-2026-42583/42579/42584/42587/33870/33871/44249/45416/50010/45674/47691
-             and CVE-2026-55831/55833/55851/56745/56746/59898/59899/59900/59901/59919/59921 -->
-        <netty.version>4.1.136.Final</netty.version>
+             and CVE-2026-55831/55833/55851/56745/56746/59898/59899/59900/59901/59919/59921
+             and CVE-2026-75595 (SNI routing bypass via fragmented TLS ClientHello) -->
+        <netty.version>4.1.137.Final</netty.version>
         <okhttp3.version>4.12.0</okhttp3.version>
         <org.pf4j.version>3.15.0</org.pf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Description

Bumps `io.netty:netty-handler` from **4.1.136.Final** to **4.1.137.Final** to
fix [CVE-2026-75595](https://nvd.nist.gov/vuln/detail/cve-2026-75595)
([GHSA-c4c3-7fpv-j4q5](https://github.com/netty/netty/security/advisories/GHSA-c4c3-7fpv-j4q5)).

**What is CVE-2026-75595?**
A fragmented TLS ClientHello whose handshake header spans records triggers an
`IndexOutOfBoundsException` in `SslClientHelloHandler#decode`, causing Netty to
fall back to the default `SslContext` instead of the SNI-specific one. In
deployments relying solely on per-SNI mTLS selection, this lets an
unauthenticated client bypass the mTLS requirement.

**Practical exploitability in Appsmith:** Very low. TLS termination happens at
Caddy, not inside the Java server. Appsmith does not use Netty's
`SslClientHelloHandler` for SNI-based mTLS routing. The bump removes the scanner
finding.

**What this fixes (5 of 6 scanner findings):**
- `server.jar` (BOOT-INF/lib/netty-handler)
- `awsLambdaPlugin-v2.4.jar`
- `dynamoPlugin-v2.4.jar`
- `firestorePlugin-v2.4.jar`
- `mysqlPlugin-v2.4.jar`

**Not covered here:** `/opt/keycloak/lib/…/netty-handler-4.1.136.Final.jar` —
Keycloak is EE-only (not present in CE base.dockerfile). That fix will be a
separate EE-only change (Keycloak version bump or JAR overlay).

**Regression risk:** Minimal. This is a patch bump (136→137) within the 4.1.x
series. The fix touches only the TLS ClientHello parser
(`SslClientHelloHandler#decode`). No HTTP, codec, or transport API changes.
Spring Boot 3.5.16 is compatible.

## Impact on existing instances
- **Fresh install:** gets 4.1.137 — no action needed.
- **Upgrade from default:** gets 4.1.137 — transparent, no config changes.
- **Upgrade from customized:** no user-facing config related to netty version.
- **Rollback:** reverts to 4.1.136 — re-exposes the CVE but no functional breakage.

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results
<!-- leave this section untouched — CI auto-populates it -->

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34449300280>
> Commit: ba35b620964ba388b096651d5222ed764d97c75e
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34449300280&attempt=2" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 10 Sep 2026 08:36:02 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the server’s Netty dependency to version 4.1.137.Final.
  * Added a security reference for CVE-2026-75595.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->