### PR TITLE
fix: stop filing Anvil applications under "AI Agents", rename them "responsive"

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -219,10 +219,17 @@ export const FIXED_APPLICATIONS = () => `Classic Applications`;
 export const AI_AGENTS_APPLICATIONS = () => `AI Agents`;
 export const AI_APPLICATION_CARD_LIST_ZERO_STATE = () =>
   `There are no AI Agents in this workspace.`;
-export const ANVIL_APPLICATIONS = () => `Anvil apps`;
+// User-facing label for the ANVIL layout system is "Responsive" (APP-15954).
+// The internal name stays "Anvil" everywhere — the persisted
+// appPositioning.type == ANVIL enum, LayoutSystemTypes.ANVIL, the feature flags
+// and the module paths are unchanged.
+// Sentence case and "applications" (not "Apps") to match every sibling on the
+// same screen — APPLICATIONS, NEW_APP, APPLICATION_CARD_LIST_ZERO_STATE.
+// "responsive" stays lowercase mid-sentence: it is a descriptor, not a brand.
+export const ANVIL_APPLICATIONS = () => `Responsive applications`;
 export const ANVIL_APPLICATION_CARD_LIST_ZERO_STATE = () =>
-  `There are no Anvil apps in this workspace yet.`;
-export const NEW_ANVIL_APP = () => `Anvil app`;
+  `There are no responsive applications in this workspace.`;
+export const NEW_ANVIL_APP = () => `Responsive application`;
 export const AI_AGENT_AUTH_SUBTITLE = () =>
   `Sign up with any Google account.\n Support for email will be available soon.`;
 

--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -8,8 +8,6 @@ import {
 } from "ee/actions/workspaceActions";
 import type { UpdateApplicationPayload } from "ee/api/ApplicationApi";
 import {
-  AI_AGENTS_APPLICATIONS,
-  AI_APPLICATION_CARD_LIST_ZERO_STATE,
   ANVIL_APPLICATIONS,
   ANVIL_APPLICATION_CARD_LIST_ZERO_STATE,
   APPLICATIONS,
@@ -1088,11 +1086,9 @@ export function ApplicationsSection(props: any) {
                   applications={anvilApplications}
                   canInviteToWorkspace={canInviteToWorkspace}
                   deleteApplication={deleteApplication}
-                  emptyStateMessage={
-                    isAiAgentFlowEnabled
-                      ? createMessage(AI_APPLICATION_CARD_LIST_ZERO_STATE)
-                      : createMessage(ANVIL_APPLICATION_CARD_LIST_ZERO_STATE)
-                  }
+                  emptyStateMessage={createMessage(
+                    ANVIL_APPLICATION_CARD_LIST_ZERO_STATE,
+                  )}
                   enableImportExport={enableImportExport}
                   hasCreateNewApplicationPermission={
                     hasCreateNewApplicationPermission
@@ -1100,11 +1096,20 @@ export function ApplicationsSection(props: any) {
                   hasManageWorkspacePermissions={hasManageWorkspacePermissions}
                   isMobile={isMobile}
                   onClickAddNewButton={onClickAddNewAppButton}
-                  title={createMessage(
-                    isAiAgentFlowEnabled
-                      ? AI_AGENTS_APPLICATIONS
-                      : ANVIL_APPLICATIONS,
-                  )}
+                  // This list holds ANVIL-layout applications, so it is titled
+                  // for them regardless of the AI-agent flag — they were never
+                  // AI agents, they were only filed under that heading because
+                  // the flag was on (APP-15954).
+                  //
+                  // NOTE: the render gate on this block is NOT correct and is
+                  // not fixed here. `isAnvilEnabled` resolves via
+                  // getIsAnvilLayoutEnabled, which reads the RETIRED
+                  // release_anvil_enabled flag — never served, so always false in
+                  // production. The gate therefore collapses to
+                  // isAiAgentFlowEnabled alone, and an org licensed for Anvil but
+                  // without the AI-agent flag never sees this section at all.
+                  // Tracked separately; see APP-15950.
+                  title={createMessage(ANVIL_APPLICATIONS)}
                   titleTag={PreviewTag}
                   updateApplicationDispatch={updateApplicationDispatch}
                   workspaceId={activeWorkspace.id}

--- a/app/client/src/ce/pages/Applications/tests/ApplicationsSection.test.tsx
+++ b/app/client/src/ce/pages/Applications/tests/ApplicationsSection.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { ThemeProvider } from "styled-components";
+import "@testing-library/jest-dom";
+
+import store from "store";
+import { lightTheme } from "selectors/themeSelectors";
+import { LayoutSystemTypes } from "layoutSystems/types";
+import { PERMISSION_TYPE } from "ee/utils/permissionHelpers";
+import type { ApplicationPayload } from "entities/Application";
+import type { Workspace } from "ee/constants/workspaceConstants";
+import { ApplicationsSection } from "../index";
+
+// Force the AI-agent FLOW flag (license_ai_agent_enabled) ON. This is the exact
+// state that produced APP-15954: with the flag on, the ANVIL application list
+// was titled "AI Agents". The INSTANCE flag is left real — it gates the sibling
+// classic-application list, which this file does not exercise.
+jest.mock("ee/selectors/aiAgentSelectors", () => ({
+  __esModule: true,
+  ...jest.requireActual("ee/selectors/aiAgentSelectors"),
+  getIsAiAgentFlowEnabled: jest.fn(() => true),
+}));
+
+// Keep the retired Anvil layout flag OFF so the AI-agent flag is the *only*
+// thing rendering the ANVIL list. That is the reported configuration, and it
+// means the assertions below cannot be satisfied by an unrelated code path.
+jest.mock("layoutSystems/anvil/integrations/selectors", () => ({
+  __esModule: true,
+  ...jest.requireActual("layoutSystems/anvil/integrations/selectors"),
+  getIsAnvilLayoutEnabled: jest.fn(() => false),
+}));
+
+// Everything below is page chrome that has nothing to do with the title
+// decision under test. ApplicationCardList and CardList are deliberately NOT
+// mocked: the heading has to be produced by the real render chain, otherwise
+// this asserts the stub instead of the product.
+jest.mock("ee/pages/Applications/WorkspaceAction", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("ee/pages/Applications/WorkspaceMenu", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("ee/pages/Applications/PackageCardList", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("ee/pages/Applications/WorkflowCardList", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("pages/common/ImportModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("pages/common/SharedUserList", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("pages/Editor/gitSync/ReconnectDatasourceModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock(
+  "../CreateNewAppFromTemplateModal/CreateNewAppFromTemplatesWrapper",
+  () => ({
+    __esModule: true,
+    default: () => null,
+  }),
+);
+// ce/pages/Applications/ApplicationCardList imports NoAppsFound back out of
+// ee/pages/Applications, which re-exports this very module — a require cycle
+// that jest cannot resolve. Stubbing the barrel breaks it, exactly as
+// ee/pages/Applications/PackageCardList.test.tsx does.
+jest.mock("ee/pages/Applications", () => ({
+  __esModule: true,
+  // TODO: Fix this the next time the file is edited
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  NoAppsFound: ({ children }: any) => <div>{children}</div>,
+}));
+jest.mock("pages/Applications/ApplicationCard", () => ({
+  __esModule: true,
+  // TODO: Fix this the next time the file is edited
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: ({ application }: any) => <div>{application.name}</div>,
+}));
+
+const WORKSPACE_ID = "test-workspace";
+
+const workspace = {
+  id: WORKSPACE_ID,
+  name: "Test Workspace",
+  userPermissions: [
+    PERMISSION_TYPE.MANAGE_WORKSPACE,
+    PERMISSION_TYPE.CREATE_APPLICATION,
+  ],
+} as unknown as Workspace;
+
+const anvilApplication = {
+  id: "anvil-app-1",
+  name: "Anvil App 1",
+  workspaceId: WORKSPACE_ID,
+  applicationDetail: {
+    appPositioning: { type: LayoutSystemTypes.ANVIL },
+  },
+} as unknown as ApplicationPayload;
+
+const classicApplication = {
+  id: "classic-app-1",
+  name: "Classic App 1",
+  workspaceId: WORKSPACE_ID,
+  applicationDetail: {
+    appPositioning: { type: LayoutSystemTypes.FIXED },
+  },
+} as unknown as ApplicationPayload;
+
+const NO_PACKAGES: never[] = [];
+const NO_WORKFLOWS: never[] = [];
+const WORKSPACES = [workspace];
+
+const renderApplicationsSection = (applications: ApplicationPayload[]) =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <Provider store={store}>
+        <ApplicationsSection
+          activeWorkspaceId={WORKSPACE_ID}
+          applications={applications}
+          packages={NO_PACKAGES}
+          workflows={NO_WORKFLOWS}
+          workspaces={WORKSPACES}
+        />
+      </Provider>
+    </ThemeProvider>,
+  );
+
+describe("ApplicationsSection - ANVIL application list heading (APP-15954)", () => {
+  it("titles the ANVIL application list 'Responsive applications', not 'AI Agents', when the AI-agent flow flag is on", () => {
+    renderApplicationsSection([anvilApplication, classicApplication]);
+
+    // The ANVIL application is listed...
+    expect(screen.getByText("Anvil App 1")).toBeInTheDocument();
+    // ...under the responsive heading...
+    expect(screen.getByText("Responsive applications")).toBeInTheDocument();
+    // ...and never under the AI Agents heading, which is what users reported.
+    expect(screen.queryByText("AI Agents")).not.toBeInTheDocument();
+  });
+
+  it("uses the responsive empty-state copy when the workspace has no ANVIL applications", () => {
+    renderApplicationsSection([classicApplication]);
+
+    expect(
+      screen.getByText(
+        "There are no responsive applications in this workspace.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("There are no AI Agents in this workspace."),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Two user-facing problems on the workspace applications screen.

**1. ANVIL applications were filed under an "AI Agents" heading.**

`ApplicationsSection` renders a single `anvilApplications` card list whose title was picked by a ternary:

```tsx
title={createMessage(
  isAiAgentFlowEnabled ? AI_AGENTS_APPLICATIONS : ANVIL_APPLICATIONS,
)}
```

With `license_ai_agent_enabled` on, every ANVIL application was filed under a heading calling it an AI agent. They are not AI agents — they are ANVIL-layout applications that happen to share the list. The `emptyStateMessage` directly above used the same ternary. Both are removed; the heading and empty state are now unconditional.

**2. The user-facing name for the ANVIL layout system becomes "responsive".**

| Constant | Was | Now |
|---|---|---|
| `ANVIL_APPLICATIONS` | `Anvil apps` | `Responsive applications` |
| `NEW_ANVIL_APP` | `Anvil app` | `Responsive application` |
| `ANVIL_APPLICATION_CARD_LIST_ZERO_STATE` | `There are no Anvil apps in this workspace yet.` | `There are no responsive applications in this workspace.` |

Sentence case and "applications" rather than "apps", to match every sibling rendered on the same screen — `APPLICATIONS`, `NEW_APP`, `APPLICATION_CARD_LIST_ZERO_STATE`. "responsive" stays lowercase mid-sentence because it is a descriptor, not a brand name.

Note `FIXED_APPLICATIONS` ("Classic Applications") is **dead code** — defined but referenced nowhere — so it is not the title-cased counterweight it appears to be. The headings that actually render are "Applications", this one, "Packages" and "Workflows".

Fixes https://linear.app/appsmith/issue/APP-15954

## Scope — user-facing strings only

The **internal** name stays "Anvil" everywhere: the persisted `appPositioning.type == ANVIL` enum, `LayoutSystemTypes.ANVIL`, the feature flags, module paths and every `data-testid`. Renaming the persisted enum would require a migration and would silently un-gate every existing Anvil application, since the paid-entitlement gate keys on that literal value.

## Testing

Adds `ce/pages/Applications/tests/ApplicationsSection.test.tsx` — two tests, both verified **red against pre-fix source**:

```text
✕ titles the ANVIL application list 'Responsive applications', not 'AI Agents', …
✕ uses the responsive empty-state copy when the workspace has no ANVIL applications

TestingLibraryElementError: Unable to find an element with the text: Responsive applications.
```
with the printed DOM showing the heading as `AI Agents` and the zero state as `There are no AI Agents in this workspace.`

It renders `ApplicationsSection` deliberately, **not** `ApplicationCardList` — that component forwards `title` verbatim to `CardList`, so a test there would prove only "the component renders the title it was handed" and would pass both before and after the fix. The decision being fixed lives in `ApplicationsSection`.

Reverting *only* the ternary while leaving the string rename applied isolates the mis-filing decision from the rename.

## Known issue, deliberately not fixed here

The render gate on that block is wrong, and this PR does not change it. `isAnvilEnabled` resolves through `getIsAnvilLayoutEnabled`, which reads the **retired** `release_anvil_enabled` flag — no longer in the server's `FeatureFlagEnum`, so never served, and defaulted to `false`. The gate therefore collapses to `isAiAgentFlowEnabled` alone.

Consequence: an organization licensed for Anvil **without** the AI-agent flag never renders this section at all, and because `anvilApplications` is partitioned out of `nonAnvilApplications`, its applications appear in neither list. That is pre-existing, is a behaviour change to fix, and needs its own test — so it is tracked separately rather than folded in here.

`getIsAnvilLayoutEnabled`'s JSDoc also claims it is `@deprecated DEAD / RETIRED (M5)` with "ZERO production callers", which is false — `ApplicationsSection` is a live caller. Worth correcting alongside that fix.

## Impact on existing instances

Label-only. No schema change, no migration, no persisted-data change, no flag change. Existing applications are unaffected functionally; ANVIL ones move from an "AI Agents" heading to "Responsive applications". Rollback is a revert.

Companion EE change (removing the unused **AI Agent** create-menu item, and renaming the EE license-gate copy and instance-setting label) ships separately in `appsmith-ee` and depends on this landing first, since the create-menu label lives in this file.

## Automation

/ok-to-test tags="@tag.All"


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34511756341>
> Commit: 9212b4738f30240a21dc24e22422845ff08c1329
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34511756341&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Thu, 10 Sep 2026 19:07:42 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated application labels to use “Responsive” terminology, including “Responsive applications” and “Responsive application.”
  - Standardized application list headings and empty states to display responsive application messaging consistently.
  - Corrected a display issue where AI-agent labels could appear for responsive applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->