### PR TITLE
build(base-image): make apt install resilient to transient mirror failures

### DIFF
--- a/deploy/docker/base.dockerfile
+++ b/deploy/docker/base.dockerfile
@@ -52,6 +52,12 @@ ENV LC_ALL=C.UTF-8
 
 # Install dependency packages
 RUN set -o xtrace \
+  # Make apt resilient to transient Ubuntu-mirror connection failures on the build
+  # host. ubuntu:24.04 ships no retry config (apt default is 0 retries), so a single
+  # dropped connection fails the whole build. This drop-in is build-scoped: it is
+  # removed in the cleanup step below, so the shipped image's apt behavior is
+  # unchanged. Does not rescue a sustained egress outage, only transient blips. APP-15960.
+  && printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-appsmith-retries \
   && apt-get update \
   && apt-get upgrade --yes \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
@@ -64,10 +70,10 @@ RUN set -o xtrace \
   && add-apt-repository -y ppa:git-core/ppa \
   # Install MongoDB v7, PostgreSQL v14
   # Note: MongoDB 7.0 does not publish apt packages for Ubuntu 24.04 (noble) yet, so we use the jammy (22.04) packages — same pattern used for the previous 6.0 install.
-  && curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg \
+  && curl --retry 3 --retry-connrefused --connect-timeout 15 --retry-max-time 60 -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg \
   && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(grep CODENAME /etc/lsb-release | cut -d= -f2)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
-  && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && curl --fail --retry 3 --retry-connrefused --connect-timeout 15 --retry-max-time 60 --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
     mongodb-org-server mongodb-org-mongos mongodb-mongosh \
@@ -87,6 +93,7 @@ RUN set -o xtrace \
     /usr/share/doc \
     /usr/share/man \
     /var/lib/apt/lists/* \
+    /etc/apt/apt.conf.d/80-appsmith-retries \
     /tmp/*
 
 # Install Redis from official image to avoid false positive CVE reports from dpkg-based scanners.


### PR DESCRIPTION
## Description

**TL;DR:** Make the base-image `apt` install resilient to transient Ubuntu-mirror connection failures, so a momentary network blip on the build host doesn't red the whole `Docker Base Image` build.

### Background / root cause

The `Docker Base Image` workflow (`deploy/docker/base.dockerfile`) intermittently fails at the apt dependency-install layer when the builder briefly can't reach the Ubuntu mirrors. Most recent example: appsmith-ee run [34570186320](https://github.com/appsmithorg/appsmith-ee/actions/runs/34570186320) failed twice with `connect (101: Network is unreachable)` (IPv6) and `connection timed out` (IPv4) to `archive.ubuntu.com` / `security.ubuntu.com`. The same base-image build has flaked on apt before (a same-SHA run failed, then passed, on 2026-09-05).

Verified cause: `ubuntu:24.04` ships **no** apt retry configuration — `apt-config dump` shows no `Acquire::Retries` and there is no drop-in in `/etc/apt/apt.conf.d/`, so the compiled default of **0 retries** applies. A single dropped connection fails the build. The two GPG-key `curl` fetches also had no retry, and the PostgreSQL one lacked `--fail` (so an HTTP error body could be piped into `apt-key`).

### Changes (`deploy/docker/base.dockerfile`, apt layer only)

- Add a **build-scoped** apt drop-in before the apt operations: `Acquire::Retries "3"` + `Acquire::http(s)::Timeout "30"`. It is deleted in the same layer's cleanup (`rm -rf`), so the **shipped image's apt behavior is unchanged**.
- Add `--retry 3 --retry-connrefused --connect-timeout 15 --retry-max-time 60` to the MongoDB and PostgreSQL key-fetch curls; add `--fail` to the PostgreSQL one.
- Deliberately **not** done: no `Acquire::ForceIPv4` (IPv4 also timed out in the incident, so it wouldn't help), and no change to the deprecated `apt-key` usage (out of scope).

This matches the retry pattern already used in this file (the Keycloak jar overlay uses `curl --fail --retry 3 --connect-timeout 15`).

### Scope / honest limitation

This reduces flake frequency for **transient** mirror blips. It will **not** rescue a sustained multi-minute total egress outage — retries only help if egress recovers within the retry window. That class of failure is infra, not the Dockerfile.

### Verification

- `ubuntu:24.04` default confirmed: no `Acquire::Retries`, no apt.conf.d retry drop-in → default 0.
- Built the exact RUN structure (comment + `\`-continuation + `printf` drop-in + cleanup) with `docker build`: `apt-config dump` reports `Acquire::Retries "3"`; the drop-in is removed by cleanup (`test ! -f` passes); build prints success. BuildKit strips the inline `#` comment lines before the shell runs (same idiom already in this file).
- All new `curl` flags accepted by `ubuntu:24.04`'s curl (connect failure exit 7 with 3 retries observed; no unknown-option error).

### Impact on existing instances

None. The drop-in is created and deleted within the same build layer, so the produced image is byte-equivalent in apt configuration to before. Fresh install, upgrade-from-default, upgrade-from-customized, and rollback are all unaffected (this only changes how the base image is *built*, not its contents).

### Reviewers / second opinion

Approach independently reviewed by GPT-5.6 sol and reconciled: retries tuned to 3 (not 5), `Acquire::Retries::Delay` dropped as redundant, drop-in build-scoped rather than persisted, `--fail` not duplicated on the mongo curl (already has `-f`), curl retries bounded, IPv4 not forced.

Linear: https://linear.app/appsmith/issue/APP-15960

## Automation

/ok-to-test tags="@tag.All"

> Note: this is a build/base-image change; the meaningful CI gate is the `Docker Base Image` build itself. Full Cypress requires a base-image rebuild + deploy preview.

## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Improved container build reliability with retry and timeout handling for package, signing-key, and Java downloads.
- Added clearer failure handling when signing keys or Java archives cannot be downloaded or processed.
- Ensured temporary download files and package-manager settings are cleaned up after installation, keeping the final image free of build-time artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes https://linear.app/appsmith/issue/APP-15960/base-image-build-make-apt-install-resilient-to-transient-mirror

<!-- This is an auto-generated comment: Cypress test results  -->
> [!WARNING]
> Tests have not run on the HEAD 1d82958a76ab38f7d4b857058abe729a5eec821a yet
> <hr>Wed, 16 Sep 2026 07:48:45 UTC
<!-- end of auto-generated comment: Cypress test results  -->
