### PR TITLE
fix(interfaces): validate WHERE clause column names in UQI filtering

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -144,6 +144,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
         validateProjectionColumns(uqiDataFilterParams.getProjectionColumns(), schema);
         validateSortByColumns(uqiDataFilterParams.getSortBy(), schema);
+        validateConditionColumns(uqiDataFilterParams.getCondition(), schema);
 
         String tableName = generateTable(schema);
         try {
@@ -867,6 +868,30 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
         return true;
     }
 
+    public void validateConditionColumns(Condition condition, Map<String, DataType> schema) {
+        if (condition == null) {
+            return;
+        }
+
+        ConditionalOperator operator = condition.getOperator();
+        if (operator == ConditionalOperator.AND || operator == ConditionalOperator.OR) {
+            Object value = condition.getValue();
+            if (value instanceof List) {
+                List<Condition> childConditions = (List<Condition>) value;
+                for (Condition child : childConditions) {
+                    validateConditionColumns(child, schema);
+                }
+            }
+        } else {
+            String path = condition.getPath();
+            if (StringUtils.isNotEmpty(path) && !schema.containsKey(path)) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                        path + " not found in the known column names :" + schema.keySet());
+            }
+        }
+    }
+
     public String generateLogicalExpression(
             List<Condition> conditions,
             List<PreparedStatementValueDTO> values,
@@ -898,9 +923,10 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                     sb.append(" " + logicOp);
                 }
                 if (StringUtils.isNotEmpty(path)) {
+                    String escapedPath = path.replace("\"", "\"\"");
                     if (value == null || value.equals(StringUtils.EMPTY)) {
                         sb.append(" ( ");
-                        sb.append("\"" + path + "\"");
+                        sb.append("\"" + escapedPath + "\"");
                         sb.append(" ");
                         if (Set.of(
                                         ConditionalOperator.EQ,
@@ -926,7 +952,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                                     operator + " is not supported currently for filtering.");
                         }
                         sb.append(" ( ");
-                        sb.append("\"" + path + "\"");
+                        sb.append("\"" + escapedPath + "\"");
                         sb.append(" ");
                         sb.append(sqlOp);
                         sb.append(" ");

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -2,6 +2,7 @@ package com.appsmith.external.services;
 
 import com.appsmith.external.constants.ConditionalOperator;
 import com.appsmith.external.constants.DataType;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
 import com.appsmith.external.models.UQIDataFilterParams;
@@ -1503,5 +1504,69 @@ public class FilterDataServiceTest {
         ArrayNode result =
                 filterDataService.filterDataNew(items, new UQIDataFilterParams(null, List.of("id"), null, null));
         assertEquals(2, result.size());
+    }
+
+    private Condition whereClause(Map<String, Object>... children) {
+        return parseWhereClause(Map.of("condition", "AND", "children", List.of(children)));
+    }
+
+    private void assertUnknownColumnRejected(Condition condition, String columnName) throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+
+        AppsmithPluginException exception = assertThrows(
+                AppsmithPluginException.class,
+                () -> filterDataService.filterDataNew(items, new UQIDataFilterParams(condition, null, null, null)));
+
+        assertEquals(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, exception.getError());
+        assertThat(exception.getMessage()).startsWith(columnName + " not found in the known column names");
+    }
+
+    @Test
+    public void testWhereWithUnknownColumn_throwsException() throws IOException {
+        Condition condition = whereClause(Map.of("condition", "EQ", "key", "unknownColumn", "value", "1"));
+
+        assertUnknownColumnRejected(condition, "unknownColumn");
+    }
+
+    @Test
+    public void testWhereWithUnknownColumnInNestedGroup_throwsException() throws IOException {
+        Condition condition = whereClause(
+                Map.of("condition", "EQ", "key", "id", "value", "1"),
+                Map.of(
+                        "condition",
+                        "OR",
+                        "children",
+                        List.of(Map.of("condition", "EQ", "key", "unknownColumn", "value", ""))));
+
+        assertUnknownColumnRejected(condition, "unknownColumn");
+    }
+
+    @Test
+    public void testWhereWithColumnNameContainingQuote_throwsException() throws IOException {
+        Condition condition = whereClause(Map.of("condition", "EQ", "key", "na\"me", "value", ""));
+
+        assertUnknownColumnRejected(condition, "na\"me");
+    }
+
+    @Test
+    public void testWhereWithKnownColumn_filtersRows() throws IOException {
+        ArrayNode items = (ArrayNode) objectMapper.readTree(SIMPLE_DATA);
+        Condition condition = whereClause(Map.of("condition", "EQ", "key", "id", "value", "1"));
+
+        ArrayNode result = filterDataService.filterDataNew(items, new UQIDataFilterParams(condition, null, null, null));
+
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).get("id").asInt());
+    }
+
+    @Test
+    public void testGenerateLogicalExpression_quotesColumnNameContainingQuote() {
+        Map<String, DataType> schema = Map.of("na\"me", DataType.STRING);
+        Condition condition = whereClause(Map.of("condition", "EQ", "key", "na\"me", "value", "Alice"));
+
+        String expression = filterDataService.generateLogicalExpression(
+                (List<Condition>) condition.getValue(), new ArrayList<>(), schema, condition.getOperator());
+
+        assertThat(expression).isEqualTo(" ( \"na\"\"me\" = ? ) ");
     }
 }


### PR DESCRIPTION
## Description

Hardens column handling in the WHERE clause of UQI in-memory filtering (used by the Google Sheets and Amazon S3 plugins).

- `FilterDataServiceCE.filterDataNew()` checks every column referenced in the WHERE condition, including nested AND/OR groups, against the columns present in the data before building the query. Unknown columns return a validation error.
- Quote characters in column identifiers are escaped in the generated filter expression.

Advisory: [GHSA-cm7r-f7h3-q33p](https://github.com/appsmithorg/appsmith/security/advisories/GHSA-cm7r-f7h3-q33p)
Part of https://linear.app/appsmith/issue/APP-15874

## Testing

- [x] Server unit tests

New tests in `FilterDataServiceTest`:
- `testWhereWithUnknownColumn_throwsException`
- `testWhereWithUnknownColumnInNestedGroup_throwsException`
- `testWhereWithColumnNameContainingQuote_throwsException`
- `testWhereWithKnownColumn_filtersRows`
- `testGenerateLogicalExpression_quotesColumnNameContainingQuote`

## Impact on existing instances

- Working queries: no change.
- A WHERE condition on a column that isn't in the data already failed; it now fails before the query is built, with `<column> not found in the known column names`, instead of an in-memory database error.
- Rollback: restores the previous behavior.

## Automation

/ok-to-test tags="@tag.All"

## Communication
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34604046075>
> Commit: 5633f1536a42d2f1a8da3f64b24470cf10ff0e0d
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34604046075&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 11 Sep 2026 14:25:05 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filtering now rejects conditions that reference unknown or invalid column paths.
  * Nested `AND` and `OR` conditions are validated consistently.
  * Column names containing quotation marks are handled safely when generating filter queries.
  * Valid filters continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->