### PR TITLE
fix(security): load Docker environment configuration as data

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,6 +5,13 @@ Each one is named for what it does, and its `on:` block states its triggers.
 
 This README covers only what you cannot infer from the YAML: how to trigger CI by hand.
 
+## Docker configuration and Caddy route tests
+
+The `Caddy route tests` workflow can be run manually from Actions. It includes
+the data-only configuration loader and startup/service-restart boundary tests,
+shell checks, Docker configuration defaults, and Caddy routing tests. The loader
+tests use isolated fixtures without starting Appsmith's databases.
+
 ## Running Cypress on a PR
 
 1. Keep the `## Automation` section from the PR template in your PR description, and

--- a/.github/workflows/caddy-routes-test.yml
+++ b/.github/workflows/caddy-routes-test.yml
@@ -7,19 +7,18 @@ on:
       - release
     paths:
       - .github/workflows/caddy-routes-test.yml
-      - deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
-      - deploy/docker/fs/opt/appsmith/templates/docker.env.sh
+      - deploy/docker/fs/opt/appsmith/**
       - deploy/docker/route-tests/**
       - deploy/docker/tests/**
   pull_request:
-    branches:
-      - release
     paths:
       - .github/workflows/caddy-routes-test.yml
-      - deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs
-      - deploy/docker/fs/opt/appsmith/templates/docker.env.sh
+      - deploy/docker/fs/opt/appsmith/**
       - deploy/docker/route-tests/**
       - deploy/docker/tests/**
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -27,6 +26,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Test configuration parsing and startup boundaries
+        run: python3 deploy/docker/tests/env-loader-test.py
+
+      - name: Check the shared shell loader
+        run: shellcheck deploy/docker/fs/opt/appsmith/load-env.sh
+
+      - name: Check startup shell syntax
+        run: |
+          bash -n deploy/docker/fs/opt/appsmith/load-env.sh
+          bash -n deploy/docker/fs/opt/appsmith/entrypoint.sh
+          bash -n deploy/docker/fs/opt/appsmith/run-with-env.sh
 
       - name: docker.env.sh default frame-ancestors is safe
         run: deploy/docker/tests/docker-env-defaults-test.sh

--- a/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
+++ b/app/client/packages/rts/src/ctl/backup/links/EnvFileLink.ts
@@ -1,6 +1,7 @@
 import type { Link } from ".";
 import type { BackupState } from "../BackupState";
 import fsPromises from "fs/promises";
+import { serializeEnvFile, writeEnvFile } from "../../env-file";
 
 const SECRETS_WARNING = `
 ***************************** IMPORTANT!!! *****************************
@@ -23,19 +24,27 @@ export class EnvFileLink implements Link {
       "/appsmith-stacks/configuration/docker.env",
       { encoding: "utf8" },
     );
-    let cleanedContent = removeSensitiveEnvData(content);
+    const cleanedContent = removeSensitiveEnvData(content);
+    const values: Record<string, string> = {};
 
     if (this.state.isEncryptionEnabled) {
-      cleanedContent +=
-        "\nAPPSMITH_ENCRYPTION_SALT=" +
-        process.env.APPSMITH_ENCRYPTION_SALT +
-        "\nAPPSMITH_ENCRYPTION_PASSWORD=" +
+      values.APPSMITH_ENCRYPTION_SALT = process.env.APPSMITH_ENCRYPTION_SALT;
+      values.APPSMITH_ENCRYPTION_PASSWORD =
         process.env.APPSMITH_ENCRYPTION_PASSWORD;
+
+      if (
+        !values.APPSMITH_ENCRYPTION_SALT ||
+        !values.APPSMITH_ENCRYPTION_PASSWORD
+      ) {
+        throw new Error(
+          "Encryption password and salt are required for an encrypted backup.",
+        );
+      }
     }
 
-    await fsPromises.writeFile(
+    await writeEnvFile(
       this.state.backupRootPath + "/docker.env",
-      cleanedContent,
+      await serializeEnvFile(cleanedContent, values),
     );
     console.log("Exporting docker environment file done.");
   }

--- a/app/client/packages/rts/src/ctl/env-file-writers.test.ts
+++ b/app/client/packages/rts/src/ctl/env-file-writers.test.ts
@@ -1,0 +1,158 @@
+import fs from "fs/promises";
+import path from "path";
+import { spawnSync } from "child_process";
+import { EnvFileLink } from "./backup/links/EnvFileLink";
+import { BackupState } from "./backup/BackupState";
+import * as restore from "./restore";
+import * as utils from "./utils";
+
+// Run the production Python boundary, with only its installed location changed.
+jest.mock("child_process", () => {
+  const actual = jest.requireActual("child_process");
+
+  return {
+    ...actual,
+    execFile: (file, args, ...rest) =>
+      actual.execFile(
+        file,
+        args.map((arg) =>
+          arg === "/opt/appsmith/env-file.py"
+            ? jest
+                .requireActual("path")
+                .resolve(
+                  __dirname,
+                  "../../../../../../deploy/docker/fs/opt/appsmith/env-file.py",
+                )
+            : arg,
+        ),
+        ...rest,
+      ),
+  };
+});
+jest.mock("./utils", () => ({
+  execCommand: jest.fn(),
+  ensureSupervisorIsRunning: jest.fn(),
+  listLocalBackupFiles: jest.fn().mockResolvedValue(["backup.tar.gz"]),
+  getCurrentAppsmithVersion: jest.fn().mockResolvedValue("test"),
+  getDburl: jest.fn().mockReturnValue("mongodb://localhost/appsmith"),
+  getDatabaseNameFromMongoURI: jest.fn().mockReturnValue("appsmith"),
+  stop: jest.fn(),
+  start: jest.fn(),
+}));
+jest.mock("readline-sync", () => ({
+  question: jest.fn().mockReturnValue("0"),
+}));
+
+const parser = path.resolve(
+  __dirname,
+  "../../../../../../deploy/docker/fs/opt/appsmith/env-file.py",
+);
+const originalEnv = process.env;
+let content: string;
+let written: string;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  content = "APPSMITH_INSTANCE_NAME=Appsmith\n";
+  written = "";
+  process.env = {
+    ...originalEnv,
+    APPSMITH_ENCRYPTION_PASSWORD: "a'b\\c $(secret)",
+    APPSMITH_ENCRYPTION_SALT: "salt",
+    APPSMITH_MONGODB_USER: "appsmith",
+    APPSMITH_MONGODB_PASSWORD: "p'ass",
+    APPSMITH_REDIS_URL: "redis://:p'ass@localhost",
+    APPSMITH_REDIS_PASSWORD: "p'ass",
+  };
+  jest
+    .spyOn(fs, "readFile")
+    .mockImplementation(async (file) =>
+      String(file).endsWith("manifest.json")
+        ? JSON.stringify({ appsmithVersion: "test", dbName: "appsmith" })
+        : content,
+    );
+  jest.spyOn(fs, "writeFile").mockImplementation(async (_file, data) => {
+    written = String(data);
+  });
+  jest.spyOn(fs, "rename").mockResolvedValue(undefined);
+  jest.spyOn(fs, "unlink").mockResolvedValue(undefined);
+  jest.spyOn(fs, "mkdtemp").mockResolvedValue("/test-restore");
+  jest.spyOn(fs, "readdir").mockResolvedValue([]);
+  jest.spyOn(fs, "access").mockResolvedValue(undefined);
+  jest.spyOn(fs, "rm").mockResolvedValue(undefined);
+  jest.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+  process.env = originalEnv;
+  process.exitCode = 0;
+});
+
+function expectLiteralPassword() {
+  // Feeding the written file as the content of a merge invokes the real reader.
+  const result = spawnSync("/usr/bin/python3", [parser, "merge", "-"], {
+    input: JSON.stringify({ content: written, values: {} }),
+    encoding: "utf8",
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("APPSMITH_ENCRYPTION_PASSWORD=");
+  const shell = spawnSync(
+    "bash",
+    ["-c", result.stdout + '\nprintf "%s" "$APPSMITH_ENCRYPTION_PASSWORD"'],
+    { encoding: "utf8" },
+  );
+
+  expect(shell.status).toBe(0);
+  expect(shell.stdout).toBe(process.env.APPSMITH_ENCRYPTION_PASSWORD);
+}
+
+test("GHSA-h6hh encrypted backup round-trips literal secrets", async () => {
+  const state = new BackupState([]);
+
+  state.isEncryptionEnabled = true;
+  state.backupRootPath = "/backup";
+  await new EnvFileLink(state).doBackup();
+  expectLiteralPassword();
+});
+
+test("GHSA-h6hh restore round-trips literal secrets", async () => {
+  await restore.run();
+  expect(utils.execCommand).toHaveBeenCalledWith(
+    expect.arrayContaining(["mongorestore"]),
+  );
+  expectLiteralPassword();
+  expect(fs.rename).toHaveBeenCalled();
+  expect(fs.writeFile).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.any(String),
+    expect.objectContaining({ mode: 0o600, flag: "wx" }),
+  );
+});
+
+test.each(["APPSMITH_NAME=${SECRET}", "PATH=bad", "APPSMITH_NAME='unfinished"])(
+  "restore refuses incompatible config before stopping services: %s",
+  async (legacy) => {
+    content = legacy;
+    await restore.run();
+    expect(process.exitCode).toBe(1);
+    expect(utils.stop).not.toHaveBeenCalled();
+    expect(utils.execCommand).not.toHaveBeenCalledWith(
+      expect.arrayContaining(["mongorestore"]),
+    );
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  },
+);
+
+test("restore refuses multiline secrets before changing the database", async () => {
+  process.env.APPSMITH_ENCRYPTION_PASSWORD = "private\nvalue";
+  await restore.run();
+  expect(process.exitCode).toBe(1);
+  expect(utils.stop).not.toHaveBeenCalled();
+  expect(fs.writeFile).not.toHaveBeenCalled();
+  expect(JSON.stringify((console.error as jest.Mock).mock.calls)).not.toContain(
+    "private",
+  );
+});

--- a/app/client/packages/rts/src/ctl/env-file.ts
+++ b/app/client/packages/rts/src/ctl/env-file.ts
@@ -1,0 +1,54 @@
+import { execFile } from "child_process";
+import { randomUUID } from "crypto";
+import fs from "fs/promises";
+
+/** Validate persisted configuration and quote literal overrides using the startup parser. */
+export async function serializeEnvFile(
+  content: string,
+  values: Record<string, string>,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const failure = () =>
+      reject(
+        new Error(
+          "Environment configuration cannot be persisted. Check docker.env for unsupported names, " +
+            "unquoted expressions or malformed assignments, and ensure supplied values contain no control characters. " +
+            "Resolve expressions from a trusted source and single-quote intentional literal expressions. " +
+            "Do not source the file to convert it.",
+        ),
+      );
+    const child = execFile(
+      "/usr/bin/python3",
+      ["/opt/appsmith/env-file.py", "merge", "-"],
+      { timeout: 10000, maxBuffer: 4 * 1024 * 1024, encoding: "utf8" },
+      (error, stdout) => {
+        // Child-process errors can carry stdout/stderr containing secret values.
+        if (error) failure();
+        else resolve(stdout);
+      },
+    );
+
+    child.stdin.on("error", failure);
+    child.stdin.end(JSON.stringify({ content, values }));
+  });
+}
+
+/** Replace only a fully validated file, using a private sibling on the same filesystem. */
+export async function writeEnvFile(file: string, content: string) {
+  const temporary = `${file}.${randomUUID()}.tmp`;
+
+  try {
+    await fs.writeFile(temporary, content, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await fs.rename(temporary, file);
+  } finally {
+    try {
+      await fs.unlink(temporary);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}

--- a/app/client/packages/rts/src/ctl/restore.ts
+++ b/app/client/packages/rts/src/ctl/restore.ts
@@ -4,6 +4,7 @@ import os from "os";
 import readlineSync from "readline-sync";
 import * as utils from "./utils";
 import * as Constants from "./constants";
+import { serializeEnvFile, writeEnvFile } from "./env-file";
 
 const command_args = process.argv.slice(3);
 
@@ -230,28 +231,24 @@ async function restoreDatabase(restoreContentsPath: string, dbUrl: string) {
   console.log("Restoring database completed");
 }
 
-async function restoreDockerEnvFile(
+async function prepareDockerEnvFile(
   restoreContentsPath: string,
-  backupName: string,
   overwriteEncryptionKeys: boolean,
   args: readonly string[],
 ) {
-  console.log("Restoring docker environment file");
-  const dockerEnvFile = "/appsmith-stacks/configuration/docker.env";
-  const updatedbUrl = utils.getDburl();
+  console.log("Validating docker environment file");
   let encryptionPwd = process.env.APPSMITH_ENCRYPTION_PASSWORD;
   let encryptionSalt = process.env.APPSMITH_ENCRYPTION_SALT;
 
-  await utils.execCommand([
-    "cp",
-    dockerEnvFile,
-    dockerEnvFile + "." + backupName,
-  ]);
-
-  let dockerEnvContent = await fsPromises.readFile(
+  const dockerEnvContent = await fsPromises.readFile(
     restoreContentsPath + "/docker.env",
     "utf8",
   );
+  const values: Record<string, string> = {
+    APPSMITH_DB_URL: utils.getDburl(),
+    APPSMITH_MONGODB_USER: process.env.APPSMITH_MONGODB_USER,
+    APPSMITH_MONGODB_PASSWORD: process.env.APPSMITH_MONGODB_PASSWORD,
+  };
 
   if (overwriteEncryptionKeys) {
     if (isNonInteractive(args)) {
@@ -300,43 +297,26 @@ async function restoreDockerEnvFile(
       );
     }
 
-    dockerEnvContent +=
-      "\nAPPSMITH_ENCRYPTION_PASSWORD=" +
-      encryptionPwd +
-      "\nAPPSMITH_ENCRYPTION_SALT=" +
-      encryptionSalt +
-      "\nAPPSMITH_DB_URL=" +
-      utils.getDburl() +
-      "\nAPPSMITH_MONGODB_USER=" +
-      process.env.APPSMITH_MONGODB_USER +
-      "\nAPPSMITH_MONGODB_PASSWORD=" +
-      process.env.APPSMITH_MONGODB_PASSWORD;
-  } else {
-    dockerEnvContent +=
-      "\nAPPSMITH_DB_URL=" +
-      updatedbUrl +
-      "\nAPPSMITH_MONGODB_USER=" +
-      process.env.APPSMITH_MONGODB_USER +
-      "\nAPPSMITH_MONGODB_PASSWORD=" +
-      process.env.APPSMITH_MONGODB_PASSWORD;
+    if (!encryptionPwd || !encryptionSalt) {
+      throw new Error("Encryption password and salt are required for restore.");
+    }
+
+    values.APPSMITH_ENCRYPTION_PASSWORD = encryptionPwd;
+    values.APPSMITH_ENCRYPTION_SALT = encryptionSalt;
   }
 
   // Preserve the restoring instance's Redis configuration. The backup strips
   // these (see `removeSensitiveEnvData`) because the source instance's Redis
   // password does not match the target's embedded Redis `requirepass`.
   if (process.env.APPSMITH_REDIS_URL) {
-    dockerEnvContent +=
-      "\nAPPSMITH_REDIS_URL=" + process.env.APPSMITH_REDIS_URL;
+    values.APPSMITH_REDIS_URL = process.env.APPSMITH_REDIS_URL;
   }
 
   if (process.env.APPSMITH_REDIS_PASSWORD) {
-    dockerEnvContent +=
-      "\nAPPSMITH_REDIS_PASSWORD=" + process.env.APPSMITH_REDIS_PASSWORD;
+    values.APPSMITH_REDIS_PASSWORD = process.env.APPSMITH_REDIS_PASSWORD;
   }
 
-  await fsPromises.writeFile(dockerEnvFile, dockerEnvContent, "utf8");
-
-  console.log("Restoring docker environment file completed");
+  return serializeEnvFile(dockerEnvContent, values);
 }
 
 async function restoreGitStorageArchive(
@@ -492,6 +472,14 @@ export async function run() {
 
       await checkRestoreVersionCompatability(restoreContentsPath, command_args);
 
+      // Validate before stopping services or restoring any data. An incompatible
+      // legacy file must not leave a restored database with unusable credentials.
+      const dockerEnvContent = await prepareDockerEnvFile(
+        restoreContentsPath,
+        overwriteEncryptionKeys,
+        command_args,
+      );
+
       console.log(
         "****************************************************************",
       );
@@ -500,12 +488,12 @@ export async function run() {
       );
       await utils.stop(["backend", "rts"]);
       await restoreDatabase(restoreContentsPath, utils.getDburl());
-      await restoreDockerEnvFile(
-        restoreContentsPath,
-        backupName,
-        overwriteEncryptionKeys,
-        command_args,
-      );
+      await utils.execCommand([
+        "cp",
+        Constants.ENV_PATH,
+        Constants.ENV_PATH + "." + backupName,
+      ]);
+      await writeEnvFile(Constants.ENV_PATH, dockerEnvContent);
       await restoreGitStorageArchive(restoreContentsPath, backupName);
       console.log("Appsmith instance successfully restored.");
       await fsPromises.rm(restoreRootPath, { recursive: true, force: true });

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -102,6 +102,70 @@ In our container, we support to generate a free SSL certificate If you have your
 The container will check the certificate files in the folder `<mounting-directory>/ssl` and use them if they are existed.
 
 *Note: In case of the certificate files have different name from `fullchain.pem` and `privkey.pem`, it will be considered as missing custom certificate and auto-provisioning the certificate by Let's Encrypt*
+## Environment configuration format
+
+`/appsmith-stacks/configuration/docker.env` contains data, not a shell script.
+Use one `NAME=value` assignment per line. Empty values, single and double quotes,
+and concatenated quoted segments are supported. Single quotes preserve their
+contents literally. Outside single quotes, backslashes escape the next character
+(inside double quotes, only backslash, double quote, dollar sign, and backtick).
+Blank lines and full-line comments are ignored. Unquoted, unescaped trailing
+spaces and tabs are ignored and may be followed by an inline `#` comment.
+Quoted or escaped spaces remain part of the value, and `NAME=#abc` preserves
+`#abc`. Quote values containing spaces. Duplicate
+assignments use the last value. LF and CRLF line endings are accepted.
+
+Supported names start with `APPSMITH_`, `MONGO_`, or `KEYCLOAK_` and contain only
+letters, digits, and underscores. The prefixes remain case-sensitive.
+`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` and their lowercase equivalents are supported,
+as are `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_APP_NAME`, `JAVA_OPTS_APPEND`,
+`JGROUPS_DISCOVERY_PROTOCOL`, `FILESTORE_IP_ADDRESS`, `FILE_SHARE_NAME`, and `PORT`.
+Other names are rejected rather than silently ignored. Shell control variables such
+as `PATH`, `BASH_ENV`, and `LD_PRELOAD` cannot be set through this file.
+
+Variable references such as `${PASSWORD}`, commands such as `$(command)`, backticks,
+and semicolons are never evaluated. Unescaped expressions that would require shell
+expansion (including inside double quotes) stop startup with a migration error.
+Supply fully resolved configuration values. Single-quote intentional literal
+expressions, for example `APPSMITH_ENCRYPTION_PASSWORD='literal$(text)'`.
+Malformed assignments, unsupported names, control characters, and unterminated
+quotes stop startup with the line number and, when recognizable, the variable
+name, without printing its value. Quoted multiline values in
+`docker.env` are not supported.
+
+External `APPSMITH_*` and `MONGO_*` environment variables override this file,
+including explicitly empty values. Their values are saved verbatim in a private
+JSON snapshot for service restarts; quotes, newlines, and non-UTF-8 bytes are preserved. Kubernetes
+Secrets and Vault values that are already resolved before container startup do
+not require shell evaluation.
+
+### Impact on existing instances
+
+Fresh installs and upgrades using generated defaults or Admin Settings values
+require no configuration changes. Before upgrading a customized installation,
+replace shell expressions in `docker.env` with their intended literal values and
+remove shell commands or unsupported variable names. Do not source a potentially
+compromised file to perform this conversion.
+
+Preserve the effective encryption password and salt exactly. Changing either can
+make existing encrypted credentials unreadable. Obtain their resolved values from
+a trusted secret store or the running instance before upgrade; do not replace
+an expression with its literal text unless that was already the intended value.
+
+Backup and restore use the same parser to validate configuration and quote literal
+values. Restore validates before stopping services or restoring the database, and
+replaces the environment file atomically. Incompatible legacy backups must be
+corrected before restore. Persisted configuration uses UTF-8 and cannot contain
+multiline values. Backup/restore reject multiline replacement values rather than
+changing them. Tabs are supported; other control characters are not. The external
+snapshot's byte preservation does not guarantee that individual application
+runtimes support non-UTF-8 credentials; use UTF-8 for portable configuration.
+
+The loader does not sanitize or rewrite the persistent file. Rolling back to an
+older image restores that image's shell evaluation behavior, so inspect the file
+before rollback. Removing configuration evaluation prevents stored commands from
+running through this path; it does not recover an already compromised instance.
+
 ## Instance Management Utilities
 
 The image includes an `appsmithctl` command to help with the management and maintenance of your instance. The following subsections describe what's available.

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -2,12 +2,13 @@
 
 # Source the helper script
 source pg-utils.sh
+# shellcheck source=deploy/docker/fs/opt/appsmith/load-env.sh
+source "$(dirname "$0")/load-env.sh" || exit 1
 
 set -e
 
 stacks_path=/appsmith-stacks
 
-export APPSMITH_PG_DATABASE="appsmith"
 export SUPERVISORD_CONF_TARGET="$TMP/supervisor-conf.d/"  # export for use in supervisord.conf
 export MONGODB_TMP_KEY_PATH="$TMP/mongodb-key"  # export for use in supervisor process mongodb.conf
 
@@ -76,8 +77,8 @@ init_env_file() {
     unset APPSMITH_MONGODB_URI
   fi
 
-  # Build an env file with current env variables. We single-quote the values, as well as escaping any single-quote characters.
-  printenv | grep -E '^APPSMITH_|^MONGO_' | sed "s/'/'\\\''/g; s/=/='/; s/$/'/" > "$TMP/pre-define.env"
+  # Preserve externally supplied values verbatim, including embedded newlines.
+  (umask 077; /usr/bin/python3 /opt/appsmith/env-file.py snapshot "$TMP/pre-define.json")
 
   tlog "Initialize .env file"
   if ! [[ -e "$ENV_PATH" ]]; then
@@ -106,6 +107,8 @@ init_env_file() {
     bash "$TEMPLATES_PATH/docker.env.sh" "$default_appsmith_mongodb_user" "$generated_appsmith_mongodb_password" "$generated_appsmith_encryption_password" "$generated_appsmith_encription_salt" "$generated_appsmith_redis_password" > "$ENV_PATH"
   else
     tlog "Configuration file already exists"
+    # Validate before backfills mutate the persistent configuration.
+    /usr/bin/python3 /opt/appsmith/env-file.py validate "$ENV_PATH" || exit 1
     # Backfill APPSMITH_REDIS_PASSWORD for existing installs that don't have it yet.
     # Only inject auth into the Redis URL when it points to the embedded (localhost) Redis.
     if ! grep -q "APPSMITH_REDIS_PASSWORD" "$ENV_PATH"; then
@@ -126,9 +129,7 @@ init_env_file() {
   tlog "Load environment configuration"
 
   # Load the ones in `docker.env` in the stacks folder.
-  set -o allexport
-  . "$ENV_PATH"
-  set +o allexport
+  load_env_file env "$ENV_PATH" || exit 1
 
   if [[ -n "$APPSMITH_MONGODB_URI" ]]; then
     export APPSMITH_DB_URL="$APPSMITH_MONGODB_URI"
@@ -136,9 +137,7 @@ init_env_file() {
   fi
 
   # Load the ones set from outside, should take precedence, and so will overwrite anything from `docker.env` above.
-  set -o allexport
-  . "$TMP/pre-define.env"
-  set +o allexport
+  load_env_file json "$TMP/pre-define.json" || exit 1
 }
 
 init_env_file
@@ -614,14 +613,17 @@ safe_init_postgres() {
 # Example:
 #     create_appsmith_pg_db "/appsmith-stacks/data/postgres/main"
 create_appsmith_pg_db() {
-  POSTGRES_DB_PATH=$1
+  local -r pg_database=appsmith
+  local POSTGRES_DB_PATH=$1
+  local db_exists database_status=0
   # Start the postgres , wait for it to be ready and create a appsmith db
   su postgres -c "env PATH='$PATH' pg_ctl -D $POSTGRES_DB_PATH -l $POSTGRES_DB_PATH/logfile start"
   echo "Waiting for Postgres to start"
   local max_attempts=300
   local attempt=0
 
-  local unix_socket_directory=$(get_unix_socket_directory "$POSTGRES_DB_PATH")
+  local unix_socket_directory
+  unix_socket_directory=$(get_unix_socket_directory "$POSTGRES_DB_PATH")
   echo "Unix socket directory is $unix_socket_directory"
   until su postgres -c "env PATH='$PATH' pg_isready -h $unix_socket_directory"; do
     if (( attempt >= max_attempts )); then
@@ -632,14 +634,24 @@ create_appsmith_pg_db() {
     sleep 1
   done
   # Check if the appsmith DB is present
-  DB_EXISTS=$(su postgres -c "env PATH='$PATH' psql -tAc \"SELECT 1 FROM pg_database WHERE datname='${APPSMITH_PG_DATABASE}'\"")
+  # Forward arguments through a fixed shell command; psql quotes the SQL literal.
+  db_exists=$(su postgres -s /bin/sh -c 'exec "$@"' -- postgres \
+    env "PATH=$PATH" psql -X -v ON_ERROR_STOP=1 -v "pg_database=$pg_database" -tA <<'SQL'
+SELECT 1 FROM pg_database WHERE datname=:'pg_database';
+SQL
+  ) || database_status=$?
 
-  if [[ "$DB_EXISTS" != "1" ]]; then
-    su postgres -c "env PATH='$PATH' psql -c \"CREATE DATABASE ${APPSMITH_PG_DATABASE}\""
-  else
-    echo "Database ${APPSMITH_PG_DATABASE} already exists."
+  if [[ $database_status == 0 ]]; then
+    if [[ "$db_exists" != "1" ]]; then
+      # createdb quotes database identifiers, including embedded punctuation.
+      su postgres -s /bin/sh -c 'exec "$@"' -- postgres \
+        env "PATH=$PATH" createdb -- "$pg_database" || database_status=$?
+    else
+      echo "Database $pg_database already exists."
+    fi
   fi
-  su postgres -c "env PATH='$PATH' pg_ctl -D $POSTGRES_DB_PATH stop"
+  su postgres -c "env PATH='$PATH' pg_ctl -D $POSTGRES_DB_PATH stop" || return
+  return "$database_status"
 }
 
 setup_caddy() {

--- a/deploy/docker/fs/opt/appsmith/env-file.py
+++ b/deploy/docker/fs/opt/appsmith/env-file.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Read Appsmith configuration as data; never evaluate shell expressions."""
+
+import json
+import io
+import os
+import re
+import shlex
+import sys
+
+
+class ConfigError(ValueError):
+    """Value-free configuration diagnostic."""
+
+
+def valid_name(name):
+    # Do not let a configuration file replace PATH, BASH_ENV, LD_PRELOAD,
+    # or the shell loader's own variables.
+    return bool(re.fullmatch(r"(?:APPSMITH_|MONGO_|KEYCLOAK_)[A-Za-z0-9_]+", name)) or name in {
+        "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy",
+        "NEW_RELIC_LICENSE_KEY", "NEW_RELIC_APP_NAME", "JAVA_OPTS_APPEND",
+        "JGROUPS_DISCOVERY_PROTOCOL", "FILESTORE_IP_ADDRESS", "FILE_SHARE_NAME", "PORT",
+    }
+
+
+def parse_value(raw):
+    value = []
+    quote = None
+    i = 0
+    while i < len(raw):
+        char = raw[i]
+        if quote == "'":
+            if char == "'":
+                quote = None
+            else:
+                value.append(char)
+        elif char == quote:
+            quote = None
+        elif char in "\"'" and quote is None:
+            quote = char
+        elif char == "\\":
+            if i + 1 == len(raw):
+                raise ValueError("unterminated escape")
+            following = raw[i + 1]
+            if quote is None or following in '\\"$`':
+                i += 1
+                value.append(following)
+            else:
+                value.append(char)
+        elif quote is None and char in " \t":
+            # Only unescaped whitespace terminates an assignment. Preserve spaces
+            # inside quotes or consumed by the backslash branch above.
+            rest = raw[i:].lstrip(" \t")
+            if rest and not rest.startswith("#"):
+                raise ValueError("quote values containing spaces")
+            break
+        elif char == "`" or (char == "$" and i + 1 < len(raw)
+                             and (raw[i + 1].isalnum() or raw[i + 1] in "_{([*@#?-$!"
+                                  or (quote is None and raw[i + 1] in "\"'"))) or (
+                                 quote is None and char == "~" and (i == 0 or raw[i - 1] == ":")):
+            raise ValueError("shell expression requires migration to a resolved literal; "
+                             "single-quote intentional literal expressions")
+        else:
+            value.append(char)
+        i += 1
+    if quote is not None:
+        raise ValueError("unterminated quote or escape")
+    return "".join(value)
+
+
+def read_env(path):
+    with open(path, encoding="utf-8", newline="") as source:
+        return parse_env(source)
+
+
+def parse_env(source):
+    values = {}
+    for number, line in enumerate(source, 1):
+        line = line.removesuffix("\n").removesuffix("\r")
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        try:
+            name, separator, raw = line.partition("=")
+            if not separator or not valid_name(name):
+                raise ValueError("unsupported variable name or missing assignment")
+            if any(ord(char) < 32 and char != "\t" for char in line) or "\x7f" in line:
+                raise ValueError("control character")
+            values[name] = parse_value(raw)
+        except ValueError as error:
+            # Report only a bounded identifier, never a value or malformed line.
+            identifier = (
+                f" ({name})" if separator and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,127}", name)
+                else ""
+            )
+            raise ConfigError(f"line {number}{identifier}: {error}") from None
+    return values
+
+
+def merge_env():
+    # One shared parser/serializer for backup and restore. Nothing is emitted
+    # until both the original content and replacement values are valid.
+    request = json.load(sys.stdin)
+    if not isinstance(request, dict) or not isinstance(request.get("content"), str) or not isinstance(
+        request.get("values"), dict
+    ):
+        raise ValueError("invalid merge request")
+    values = parse_env(io.StringIO(request["content"]))
+    for name, value in request["values"].items():
+        if not valid_name(name) or not isinstance(value, str) or any(
+            (ord(char) < 32 and char != "\t") or ord(char) == 127 for char in value
+        ):
+            raise ValueError("invalid persisted environment value")
+        values[name] = value
+    output = "".join(f"{name}={shlex.quote(value)}\n" for name, value in values.items())
+    # Includes UTF-8 representability and a round trip through the reader.
+    output.encode("utf-8")
+    if parse_env(io.StringIO(output)) != values:
+        raise ValueError("environment serialization failed")
+    sys.stdout.write(output)
+
+
+def main():
+    mode, path = sys.argv[1:]
+    if mode not in {"snapshot", "json", "env", "validate", "merge"}:
+        raise ValueError("invalid mode")
+    if mode == "merge":
+        merge_env()
+        return
+    if mode == "snapshot":
+        values = {key: value for key, value in os.environ.items()
+                  if key.startswith(("APPSMITH_", "MONGO_"))}
+        if any(not valid_name(key) for key in values):
+            raise ConfigError("externally supplied environment has an unsupported variable name")
+        with open(path, "w", encoding="utf-8") as target:
+            json.dump(values, target)
+        return
+    if mode == "json":
+        with open(path, encoding="utf-8") as source:
+            values = json.load(source)
+        if not isinstance(values, dict) or any(
+            not valid_name(key) or not isinstance(value, str) or "\0" in value
+            for key, value in values.items()
+        ):
+            raise ConfigError("invalid external environment snapshot; check container environment names and values")
+    else:
+        values = read_env(path)
+    if mode != "validate":
+        # Emit only after the entire file has passed validation.
+        for key, value in values.items():
+            sys.stdout.buffer.write(os.fsencode(key) + b"=" + os.fsencode(value) + b"\0")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ConfigError as error:
+        print(f"Unable to load environment configuration: {error}.", file=sys.stderr)
+        sys.exit(1)
+    except (OSError, ValueError, UnicodeError):
+        # json/OS exceptions can include source data; suppress their text.
+        print("Unable to load environment configuration; check file syntax and permissions.", file=sys.stderr)
+        sys.exit(1)

--- a/deploy/docker/fs/opt/appsmith/load-env.sh
+++ b/deploy/docker/fs/opt/appsmith/load-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Parse completely before exporting anything. A failed parser must never launch
+# a service with a partially loaded configuration.
+load_env_file() {
+  local env_loader_output env_loader_assignment
+  local env_loader_status=0
+  env_loader_output=$(mktemp) || return 1
+  if ! /usr/bin/python3 "$(dirname "${BASH_SOURCE[0]}")/env-file.py" "$1" "$2" > "$env_loader_output"; then
+    printf 'Configuration file could not be loaded: %s\n' "$2" >&2
+    rm -f "$env_loader_output"
+    return 1
+  fi
+  while IFS= read -r -d '' env_loader_assignment; do
+    export "${env_loader_assignment?}" || { env_loader_status=1; break; }
+  done < "$env_loader_output"
+  rm -f "$env_loader_output" || return 1
+  return "$env_loader_status"
+}

--- a/deploy/docker/fs/opt/appsmith/run-with-env.sh
+++ b/deploy/docker/fs/opt/appsmith/run-with-env.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+# shellcheck source=deploy/docker/fs/opt/appsmith/load-env.sh
+source "$(dirname "$0")/load-env.sh" || exit 1
+
 ENV_PATH="/appsmith-stacks/configuration/docker.env"
-PRE_DEFINED_ENV_PATH="$TMP/pre-define.env"
+PRE_DEFINED_ENV_PATH="$TMP/pre-define.json"
 tlog 'Load environment configuration'
-set -o allexport
-. "$ENV_PATH"
-. "$PRE_DEFINED_ENV_PATH"
-set +o allexport
+load_env_file env "$ENV_PATH" || exit 1
+load_env_file json "$PRE_DEFINED_ENV_PATH" || exit 1
 
 if [[ -z "${APPSMITH_MAIL_ENABLED}" ]]; then
   unset APPSMITH_MAIL_ENABLED # If this field is empty is might cause application crash

--- a/deploy/docker/tests/env-loader-test.py
+++ b/deploy/docker/tests/env-loader-test.py
@@ -1,0 +1,306 @@
+"""Configuration boundary regressions for GHSA-h6hh-wqxc-5hw9."""
+
+import os
+import json
+import random
+import shlex
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+APP = Path(__file__).resolve().parents[1] / "fs/opt/appsmith"
+
+
+class EnvLoaderTest(unittest.TestCase):
+    def test_ghsa_h6hh_embedded_pg_helper_does_not_evaluate_environment(self):
+        # Exercise the helper independently of startup's environment snapshot.
+        # This is a hardening regression, not evidence of a reachable boot exploit.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            marker = root / "executed"
+            log = root / "commands.jsonl"
+            executable = root / "fake-pg"
+            executable.write_text(
+                '#!/usr/bin/env python3\n'
+                'import json, os, pathlib, sys\n'
+                'name = pathlib.Path(sys.argv[0]).name\n'
+                'query = sys.stdin.read() if name == "psql" else ""\n'
+                'with open(os.environ["COMMAND_LOG"], "a") as log:\n'
+                '    log.write(json.dumps([name, sys.argv[1:], query]) + "\\n")\n'
+                'if name == os.environ.get("FAIL_COMMAND"): sys.exit(7)\n'
+                'if name == "psql": print(os.environ["DB_PRESENT"])\n'
+            )
+            executable.chmod(0o700)
+            for name in ["pg_ctl", "pg_isready", "psql", "createdb"]:
+                (root / name).symlink_to(executable)
+            source = (APP / "entrypoint.sh").read_text()
+            helper = source[source.index("create_appsmith_pg_db() {"):source.index("\nsetup_caddy()")]
+            # Simulate su's shell argument forwarding without switching users.
+            harness = '''
+set -e
+su() {
+  if [[ $2 == -c ]]; then
+    bash -c "$3"
+  else
+    [[ $1 == postgres && $2 == -s && $3 == /bin/sh && $4 == -c && $6 == -- ]]
+    /bin/sh -c "$5" "${@:7}"
+  fi
+}
+get_unix_socket_directory() { printf /tmp; }
+tlog() { :; }
+'''
+            for present, failure in [("", ""), ("1", ""), ("", "psql"), ("", "createdb")]:
+                log.write_text("")
+                result = subprocess.run(["bash", "-c", harness + helper + '\ncreate_appsmith_pg_db "$1"',
+                                         "test", "/tmp/postgres-test-data"], input="", capture_output=True, text=True,
+                                        env=dict(os.environ, PATH=str(root) + os.pathsep + os.environ["PATH"],
+                                                 COMMAND_LOG=str(log), DB_PRESENT=present,
+                                                 FAIL_COMMAND=failure,
+                                                 APPSMITH_PG_DATABASE=f"$(touch {marker})"))
+                self.assertEqual(result.returncode, 7 if failure else 0, result.stderr)
+                self.assertFalse(marker.exists(), "database helper evaluated an environment value")
+                commands = [json.loads(line) for line in log.read_text().splitlines()]
+                query = next(command for command in commands if command[0] == "psql")
+                self.assertIn("pg_database=appsmith", query[1])
+                self.assertIn(":'pg_database'", query[2])
+                creates = [command for command in commands if command[0] == "createdb"]
+                self.assertEqual(len(creates), 0 if present or failure == "psql" else 1)
+                if creates:
+                    self.assertEqual(creates[0][1], ["--", "appsmith"])
+                self.assertEqual(commands[-1][0], "pg_ctl")
+                self.assertEqual(commands[-1][1][-1], "stop")
+            self.assertNotIn("APPSMITH_PG_DATABASE", source)
+
+    def test_shell_serializers_round_trip(self):
+        generator = random.Random(15243)
+        alphabet = "abcXYZ09 '$`\\\";#=(){}[]*!?雪"
+        expected = {}
+        lines = []
+        for number in range(100):
+            value = "".join(generator.choice(alphabet) for _ in range(40))
+            java_quoted = ("'" + value.replace("'", "'\"'\"'") + "'")
+            if java_quoted.startswith("''"):
+                java_quoted = java_quoted[2:]
+            if java_quoted.endswith("''"):
+                java_quoted = java_quoted[:-2]
+            for suffix, raw in [("JAVA", java_quoted), ("SHELL", shlex.quote(value))]:
+                key = f"APPSMITH_TEST_{number}_{suffix}"
+                lines.append(f"{key}={raw}")
+                expected[key] = value
+        result = self.parse("\n".join(lines))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        actual = dict(record.split("=", 1) for record in result.stdout.decode().split("\0")[:-1])
+        self.assertEqual(actual, expected)
+
+    def test_generated_defaults_and_existing_config_through_startup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = (APP / "entrypoint.sh").read_text()
+            startup = source[source.index("init_env_file() {"):source.index("\ninit_env_file\n")]
+            startup = startup.replace("/appsmith-stacks/configuration", str(root / "configuration"))
+            startup = startup.replace("/opt/appsmith/templates", str(APP / "templates"))
+            startup = startup.replace("/opt/appsmith/env-file.py", str(APP / "env-file.py"))
+            command = 'set -e; tlog() { :; }; source "$1";\n' + startup + '\ninit_env_file\n'
+            command += '/usr/bin/python3 -c \'import os; print(os.environ["APPSMITH_BACKUP_CRON_EXPRESSION"])\''
+            environment = {"PATH": os.environ["PATH"], "TMP": str(root)}
+            for _ in range(2):
+                result = subprocess.run(["bash", "-c", command, "test", str(APP / "load-env.sh")],
+                                        env=environment, capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), "0 0 * * *")
+            config = root / "configuration/docker.env"
+            before = config.read_bytes()
+            marker = root / "should-not-execute"
+            config.write_text(before.decode() + f"\nAPPSMITH_INSTANCE_NAME=$(touch {marker})\n")
+            result = subprocess.run(["bash", "-c", command, "test", str(APP / "load-env.sh")],
+                                    env=environment, capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("shell expression", result.stderr)
+            self.assertFalse(marker.exists())
+            self.assertEqual((root / "pre-define.json").stat().st_mode & 0o777, 0o600)
+
+    def parse(self, content):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "docker.env"
+            path.write_bytes(content.encode())
+            return subprocess.run(["/usr/bin/python3", str(APP / "env-file.py"), "env", str(path)],
+                                  capture_output=True)
+
+    def test_writer_and_template_values(self):
+        cases = {
+            "": "",
+            "'hello world'": "hello world",
+            '"0 0 * * *"': "0 0 * * *",
+            "'Sponge-bob'\"'\"'s Instance'": "Sponge-bob's Instance",
+            "'hello'\\''world'": "hello'world",
+            "'$(command); `command` ${VALUE}'": "$(command); `command` ${VALUE}",
+            "rediss://:password@host/db?a=b#fragment": "rediss://:password@host/db?a=b#fragment",
+            "'雪\\path'": "雪\\path",
+            '"escaped\\$dollar"': "escaped$dollar",
+            "'trailing\\'": "trailing\\",
+            "unquoted\\\\": "unquoted\\",
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                result = self.parse(f"APPSMITH_INSTANCE_NAME={raw}\n")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, f"APPSMITH_INSTANCE_NAME={expected}\0".encode())
+
+    def test_comments_crlf_duplicate_and_missing_final_newline(self):
+        result = self.parse("# comment\r\n\r\nAPPSMITH_INSTANCE_NAME=first\r\nAPPSMITH_INSTANCE_NAME=last")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, b"APPSMITH_INSTANCE_NAME=last\0")
+
+    def test_shell_whitespace_and_comment_compatibility(self):
+        for raw, expected in [("true # note", "true"), ("true \t", "true"),
+                              ("#abc", "#abc"), ("'true '", "true "),
+                              (r"value\ #suffix", "value #suffix"),
+                              ('"value " # note', "value ")]:
+            with self.subTest(raw=raw):
+                result = self.parse("APPSMITH_TEST=" + raw)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, f"APPSMITH_TEST={expected}\0".encode())
+
+    def test_known_runtime_names(self):
+        for name in ["NEW_RELIC_LICENSE_KEY", "NEW_RELIC_APP_NAME", "JAVA_OPTS_APPEND",
+                     "JGROUPS_DISCOVERY_PROTOCOL", "FILESTORE_IP_ADDRESS", "FILE_SHARE_NAME", "PORT"]:
+            with self.subTest(name=name):
+                result = self.parse(f"{name}='literal value'")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, f"{name}=literal value\0".encode())
+
+    def test_ghsa_h6hh_expression_migration_is_fail_closed_and_redacted(self):
+        for expression in ['${PASSWORD}', '$PASSWORD', '$(printf secret)', '`printf secret`',
+                           '"${PASSWORD}"', '"$(printf secret)"', '$1', '$?', '~/.secret',
+                           "$'secret\\n'", '$"secret"', '$[1+2]']:
+            result = self.parse("APPSMITH_ENCRYPTION_PASSWORD=" + expression)
+            self.assertNotEqual(result.returncode, 0, expression)
+            self.assertEqual(result.stdout, b"")
+            self.assertIn(b"shell expression", result.stderr)
+            self.assertNotIn(b"secret", result.stderr)
+        for raw in ["'$(printf secret)'", r"\$(printf\ secret)", "'${PASSWORD}'"]:
+            self.assertEqual(self.parse("APPSMITH_ENCRYPTION_PASSWORD=" + raw).returncode, 0)
+
+    def test_snapshot_round_trips_lowercase_names_and_non_utf8_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            snapshot = Path(directory) / "snapshot.json"
+            environment = dict(os.environ, APPSMITH_customFlag="yes", APPSMITH_BYTES="\udcff")
+            result = subprocess.run(["/usr/bin/python3", str(APP / "env-file.py"), "snapshot", str(snapshot)],
+                                    env=environment, capture_output=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            result = subprocess.run(["/usr/bin/python3", str(APP / "env-file.py"), "json", str(snapshot)],
+                                    capture_output=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(b"APPSMITH_customFlag=yes\0", result.stdout)
+            self.assertIn(b"APPSMITH_BYTES=\xff\0", result.stdout)
+
+    def test_merge_serializes_literals_and_validates_before_emitting(self):
+        values = {"APPSMITH_ENCRYPTION_PASSWORD": "'a\\b $(secret) # ;", "APPSMITH_ENCRYPTION_SALT": "salt"}
+        result = subprocess.run(["/usr/bin/python3", str(APP / "env-file.py"), "merge", "-"],
+                                input=json.dumps({"content": "APPSMITH_INSTANCE_NAME=old", "values": values}).encode(),
+                                capture_output=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        parsed = self.parse(result.stdout.decode())
+        self.assertEqual(parsed.returncode, 0, parsed.stderr)
+        self.assertIn(("APPSMITH_ENCRYPTION_PASSWORD=" + values["APPSMITH_ENCRYPTION_PASSWORD"] + "\0").encode(), parsed.stdout)
+        for content, overrides in [("APPSMITH_NAME=${SECRET}", {}), ("PATH=bad", {}),
+                                    ("", {"APPSMITH_ENCRYPTION_PASSWORD": "private\nvalue"})]:
+            result = subprocess.run(["/usr/bin/python3", str(APP / "env-file.py"), "merge", "-"],
+                                    input=json.dumps({"content": content, "values": overrides}).encode(), capture_output=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, b"")
+            self.assertNotIn(b"private", result.stderr)
+
+    def test_invalid_input_is_atomic_and_redacted(self):
+        for invalid in ["command secret", "PATH=secret", "BASH_ENV=secret", "LD_PRELOAD=secret",
+                        "APPSMITH_NAME='secret", "APPSMITH_NAME=secret\0", "APPSMITH_NAME=secret\\"]:
+            with self.subTest(invalid=invalid):
+                result = self.parse("APPSMITH_INSTANCE_NAME=valid\n" + invalid)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, b"")
+                self.assertIn(b"line 2", result.stderr)
+                self.assertNotIn(b"secret", result.stderr)
+
+    def test_diagnostics_identify_variable_without_disclosing_values(self):
+        for name, raw in [("APPSMITH_DB_URL", '"mongodb://private:${PASSWORD}@host"'),
+                          ("MONGODB_PASS", "private"),
+                          ("APPSMITH_ENCRYPTION_PASSWORD", "'private")]:
+            with self.subTest(name=name):
+                result = self.parse(f"# config\n{name}={raw}")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"line 2 ({name}):".encode(), result.stderr)
+                self.assertNotIn(b"private", result.stderr)
+                self.assertNotIn(b"${PASSWORD}", result.stderr)
+                self.assertEqual(result.stdout, b"")
+
+        # Malformed lines must not expose arbitrary text as a variable name.
+        for invalid in ["private", "private data=value", "private\x1b[31m=value",
+                        "private" * 100 + "=value"]:
+            result = self.parse(invalid)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(b"line 1:", result.stderr)
+            self.assertNotIn(b"private", result.stderr)
+            self.assertNotIn(b"\x1b", result.stderr)
+
+    def test_external_snapshot_preserves_values_and_overrides_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            snapshot = root / "pre-define.json"
+            value = "Vault's \\\"secret\\\"\n${REFERENCE}\nAPPSMITH_INJECTED=bad"
+            environment = dict(os.environ, APPSMITH_INSTANCE_NAME=value)
+            subprocess.run(["/usr/bin/python3", str(APP / "env-file.py"), "snapshot", str(snapshot)],
+                           env=environment, check=True)
+            self.assertEqual(json.loads(snapshot.read_text())["APPSMITH_INSTANCE_NAME"], value)
+            config = root / "docker.env"
+            config.write_text("APPSMITH_INSTANCE_NAME=stored\n")
+            result = subprocess.run([
+                "bash", "-euc", 'source "$1"; load_env_file env "$2"; load_env_file json "$3"; '
+                '/usr/bin/python3 -c \'import os; print(repr(os.environ["APPSMITH_INSTANCE_NAME"]))\'',
+                "test", str(APP / "load-env.sh"), str(config), str(snapshot),
+            ], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), repr(value))
+
+    def test_ghsa_h6hh_restart_does_not_execute_configuration(self):
+        # Exercise the production restart wrapper with isolated fixture paths.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            marker = root / "executed"
+            config = root / "docker.env"
+            config.write_text(f"APPSMITH_INSTANCE_NAME=$(touch {marker})\n")
+            (root / "pre-define.env").write_text("")
+            (root / "pre-define.json").write_text("{}")
+            wrapper = (APP / "run-with-env.sh").read_text().replace(
+                "/appsmith-stacks/configuration/docker.env", str(config)
+            ).replace('"$(dirname "$0")/load-env.sh"', f'"{APP}/load-env.sh"')
+            environment = dict(os.environ, TMP=str(root), APPSMITH_GIT_ROOT=str(root / "git"))
+            result = subprocess.run(
+                ["bash", "-c", 'tlog() { :; };\n' + wrapper, "test", "/usr/bin/true"],
+                env=environment, capture_output=True, text=True,
+            )
+            self.assertFalse(marker.exists(), "docker.env executed a shell command")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("shell expression", result.stderr)
+
+    def test_restart_refuses_invalid_file_and_does_not_launch_service(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = root / "docker.env"
+            config.write_text("APPSMITH_INSTANCE_NAME='private-value\n")
+            marker = root / "service-started"
+            wrapper = (APP / "run-with-env.sh").read_text().replace(
+                "/appsmith-stacks/configuration/docker.env", str(config)
+            ).replace('"$(dirname "$0")/load-env.sh"', f'"{APP}/load-env.sh"')
+            result = subprocess.run(
+                ["bash", "-c", 'tlog() { :; };\n' + wrapper, "test", "/usr/bin/touch", str(marker)],
+                env=dict(os.environ, TMP=str(root)), capture_output=True, text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(marker.exists())
+            self.assertNotIn("private-value", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/tests/env-loader-test.py
+++ b/deploy/docker/tests/env-loader-test.py
@@ -103,13 +103,13 @@ tlog() { :; }
             startup = startup.replace("/opt/appsmith/templates", str(APP / "templates"))
             startup = startup.replace("/opt/appsmith/env-file.py", str(APP / "env-file.py"))
             command = 'set -e; tlog() { :; }; source "$1";\n' + startup + '\ninit_env_file\n'
-            command += '/usr/bin/python3 -c \'import os; print(os.environ["APPSMITH_BACKUP_CRON_EXPRESSION"])\''
+            command += '/usr/bin/python3 -c \'import os; print(os.environ["APPSMITH_MONGODB_USER"])\''
             environment = {"PATH": os.environ["PATH"], "TMP": str(root)}
             for _ in range(2):
                 result = subprocess.run(["bash", "-c", command, "test", str(APP / "load-env.sh")],
                                         env=environment, capture_output=True, text=True)
                 self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertEqual(result.stdout.strip(), "0 0 * * *")
+                self.assertEqual(result.stdout.strip(), "appsmith")
             config = root / "configuration/docker.env"
             before = config.read_bytes()
             marker = root / "should-not-execute"


### PR DESCRIPTION
## Description

Treat persisted `docker.env` as data rather than shell code. This is defense-in-depth hardening on top of the existing admin API escaping protections.

Startup and service restarts validate the complete file before loading it. Invalid configuration stops startup with a line number and variable name, without printing values. Resolved external environment values retain precedence.

Backup and restore share the parser and literal-value serializer; restore validates configuration before stopping services or changing the database. Embedded PostgreSQL initialization uses a fixed database name and passes database arguments as data.

Fixes [APP-15243](https://linear.app/appsmith/issue/APP-15243).

### Compatibility example

Previously, a manually edited `docker.env` could reference another variable:

```ini
MONGO_PASS="asdf"
APPSMITH_DB_URL="mongodb://user:${MONGO_PASS}@mongodb.host.company.com/appsmith"
```

The shell expanded `${MONGO_PASS}` to `asdf`. With this change, startup exits with code 1 and logs:

```text
Unable to load environment configuration: line 2 (APPSMITH_DB_URL): shell expression requires migration to a resolved literal; single-quote intentional literal expressions.
```

Supply the resolved value instead, in `docker.env` or through the deployment's environment/secret configuration:

```ini
APPSMITH_DB_URL='mongodb://user:asdf@mongodb.host.company.com/appsmith'
```

Single-quoting the original expression preserves it literally; it does not resolve the reference.

### Impact on existing instances

- **Fresh install:** generated defaults work unchanged.
- **Upgrade from defaults/Admin Settings:** existing generated and quoted values remain supported.
- **Upgrade from customized configuration:** resolve shell expressions and correct unsupported names or malformed assignments before upgrading. Preserve the effective encryption password and salt exactly. Do not source an untrusted file to convert it. Incompatible legacy backups and multiline replacement values must be corrected before restore.
- **Rollback:** the loader does not rewrite `docker.env`; backup/restore output remains shell-quote compatible. Older images resume shell evaluation, so inspect configuration before rollback.

### Draft release note

Customized `docker.env` files must contain resolved values before upgrading. Shell expressions now stop startup with a redacted diagnostic identifying the affected variable. Generated defaults and Admin Settings values need no changes.

## Verification

- 15 parser/startup tests pass locally and in the cached Appsmith Linux runtime; 52 CE backup/restore tests pass.
- Shell syntax, shared-loader ShellCheck, changed-file TypeScript lint, RTS typecheck, Docker defaults, and rate-limit checks pass.
- Loader checks run in the existing Caddy route workflow. CE CI and Cypress will run after the PR is opened.
- Paths checked: startup, supervised restart, external snapshot, backup/restore writers, embedded PostgreSQL initialization, and the existing Java configuration writer.

## Automation

/ok-to-test tags="@tag.All"

### :mag: Cypress test results

## Communication

Should the DevRel and Marketing teams inform users about this change?

- [x] Yes
- [ ] No


<!-- This is an auto-generated comment: Cypress test results  -->
> [!TIP]
> 🟢 🟢 🟢 All cypress tests have passed! 🎉 🎉 🎉
> Workflow run: <https://github.com/appsmithorg/appsmith/actions/runs/34652334073>
> Commit: 60298a57a46011e574478d742dd6baf0ed10e9ca
> <a href="https://internal.appsmith.com/app/cypress-dashboard/rundetails-65890b3c81d7400d08fa9ee5?branch=master&workflowId=34652334073&attempt=1" target="_blank">Cypress dashboard</a>.
> Tags: `@tag.All`
> Spec:
> <hr>Fri, 11 Sep 2026 23:12:03 UTC
<!-- end of auto-generated comment: Cypress test results  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safer Docker environment-file parsing, validation, serialization, and atomic updates.
  - Added support for preserving environment values, including quoted, escaped, multiline, and non-UTF-8 content where supported.
  - Improved startup and restore handling with validation before services or database changes.

- **Bug Fixes**
  - Prevented invalid configuration and shell expressions from being executed.
  - Improved backup and restore handling for encryption credentials and sensitive values.
  - Added sanitized error reporting and safer temporary-file permissions.

- **Documentation**
  - Documented environment-file syntax, validation rules, upgrade considerations, and backup/restore behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->