### PR TITLE
fix: preserve empty array default value on JSONForm reset

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/helper.test.ts
+++ b/app/client/src/widgets/JSONFormWidget/helper.test.ts
@@ -136,6 +136,88 @@ describe(".schemaItemDefaultValue", () => {
     expect(result).toEqual(expectedDefaultValue);
   });
 
+  it("returns empty array when array field default value is an empty array", () => {
+    const schemaItem = {
+      accessor: "profileIds",
+      identifier: "profileIds",
+      originalIdentifier: "profileIds",
+      dataType: DataType.ARRAY,
+      fieldType: FieldType.ARRAY,
+      isVisible: true,
+      defaultValue: [],
+      children: {
+        __array_item__: {
+          identifier: ARRAY_ITEM_KEY,
+          originalIdentifier: ARRAY_ITEM_KEY,
+          dataType: DataType.OBJECT,
+          fieldType: FieldType.OBJECT,
+          defaultValue: undefined,
+          isVisible: true,
+          children: {
+            id: {
+              label: "Id",
+              children: {},
+              dataType: DataType.STRING,
+              defaultValue: undefined,
+              fieldType: FieldType.TEXT_INPUT,
+              accessor: "id",
+              identifier: "id",
+              originalIdentifier: "id",
+              isVisible: true,
+            },
+          },
+        },
+      },
+    } as unknown as SchemaItem;
+
+    const expectedDefaultValue: unknown[] = [];
+
+    const result = schemaItemDefaultValue(schemaItem, "identifier");
+
+    expect(result).toEqual(expectedDefaultValue);
+  });
+
+  it("returns empty array when array field default value is an empty array with accessor keys", () => {
+    const schemaItem = {
+      accessor: "profileIds",
+      identifier: "profileIds",
+      originalIdentifier: "profileIds",
+      dataType: DataType.ARRAY,
+      fieldType: FieldType.ARRAY,
+      isVisible: true,
+      defaultValue: [],
+      children: {
+        __array_item__: {
+          identifier: ARRAY_ITEM_KEY,
+          originalIdentifier: ARRAY_ITEM_KEY,
+          dataType: DataType.OBJECT,
+          fieldType: FieldType.OBJECT,
+          defaultValue: undefined,
+          isVisible: true,
+          children: {
+            id: {
+              label: "Id",
+              children: {},
+              dataType: DataType.STRING,
+              defaultValue: undefined,
+              fieldType: FieldType.TEXT_INPUT,
+              accessor: "profileId",
+              identifier: "id",
+              originalIdentifier: "id",
+              isVisible: true,
+            },
+          },
+        },
+      },
+    } as unknown as SchemaItem;
+
+    const expectedDefaultValue: unknown[] = [];
+
+    const result = schemaItemDefaultValue(schemaItem, "accessor");
+
+    expect(result).toEqual(expectedDefaultValue);
+  });
+
   it("returns merged default value when sub array fields have default value", () => {
     const schemaItem = {
       name: "education",

--- a/app/client/src/widgets/JSONFormWidget/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/helper.ts
@@ -276,6 +276,13 @@ export const schemaItemDefaultValue = (
   }
 
   if (schemaItem.fieldType === FieldType.ARRAY) {
+    if (
+      Array.isArray(schemaItem.defaultValue) &&
+      schemaItem.defaultValue.length === 0
+    ) {
+      return [];
+    }
+
     const defaultArrayValue = processArray(schemaItem.children, toKey);
     let sanitizedDefaultValue: unknown[] = [];
 


### PR DESCRIPTION
## Summary
Fixes #41653. Resetting a JSON Form whose Array field defaults to `[]` created one empty array item, making the form invalid and unsubmittable. Reset now restores the empty default.

## Root cause
`schemaItemDefaultValue()` in `app/client/src/widgets/JSONFormWidget/helper.ts` computes the array default as `lodash.merge(processArray(...), sanitizedDefaultValue)`. `processArray()` always returns a single-item array because the `__array_item__` schema entry always exists, and `lodash.merge([item], [])` keeps `[item]`, so an empty default `[]` becomes `[{}]`. `Form.onReset()` (`component/Form.tsx`) feeds that value into `reset(values, { keepErrors: true })`, producing the phantom array item that fails required/regex validation.

## Changes
* `app/client/src/widgets/JSONFormWidget/helper.ts`: return `[]` when the array schema item's `defaultValue` is an empty array
* `app/client/src/widgets/JSONFormWidget/helper.test.ts`: regression tests for both `identifier` and `accessor` key paths

## Testing
- `jest src/widgets/JSONFormWidget/helper.test.ts` — 17/17 pass
- `jest src/widgets/JSONFormWidget/fields/ArrayField.test.tsx` — 2/2 pass
- `tsc --noEmit` — clean
- `prettier --check` and `eslint` on touched files — clean
- Verified the new tests fail without the fix

Closes #41653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty array defaults in JSON forms are now preserved as empty arrays instead of being populated with unintended values.

- **Tests**
  - Added coverage for empty array defaults using both identifier- and accessor-based field configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->